### PR TITLE
bug: Change UUIDs to be randomly generated for resources

### DIFF
--- a/docs/iceberg-rest-gateway.md
+++ b/docs/iceberg-rest-gateway.md
@@ -149,17 +149,24 @@ LOAD aws;
 INSTALL iceberg;
 LOAD iceberg;
 
+CREATE OR REPLACE SECRET floe_secret (
+  TYPE s3,
+  KEY_ID '<access-key>',
+  SECRET '<secret-key>',
+  SCOPE 's3://<bucket>/',
+  REGION '<AWS region>'
+);
+
 ATTACH 'analytics' AS iceberg_floecat
   (TYPE iceberg,
    ENDPOINT 'http://localhost:9200/',
-   AUTHORIZATION_TYPE none);
+   AUTHORIZATION_TYPE none,
+   ACCESS_DELEGATION_MODE 'none');
 
-CREATE TABLE iceberg_floecat.sales.quark_events (event_id INTEGER);
-INSERT INTO iceberg_floecat.sales.quark_events VALUES (1), (2), (3), (4);
-SELECT * FROM iceberg_floecat.sales.quark_events;
+CREATE TABLE iceberg_floecat.core.quark_events (event_id INTEGER);
+INSERT INTO iceberg_floecat.core.quark_events VALUES (1), (2), (3), (4);
+SELECT * FROM iceberg_floecat.core.quark_events;
 ```
-
-Ensure `application.properties` provides `floecat.gateway.default-prefix`, storage location, region, and credentials. The gateway injects matching `write.metadata.path`/credentials into load responses so DuckDB reads/writes manifests to the same bucket.
 
 ### Trino
 

--- a/service/src/main/java/ai/floedb/floecat/service/common/AccountIds.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/AccountIds.java
@@ -1,0 +1,15 @@
+package ai.floedb.floecat.service.common;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public final class AccountIds {
+  private AccountIds() {}
+
+  public static String deterministicAccountId(String displayName) {
+    if (displayName == null) {
+      displayName = "";
+    }
+    return UUID.nameUUIDFromBytes((displayName).getBytes(StandardCharsets.UTF_8)).toString();
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
@@ -3,6 +3,7 @@ package ai.floedb.floecat.service.context.impl;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.common.AccountIds;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.impl.QueryContext;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
@@ -209,7 +210,7 @@ public class InboundContextInterceptor implements ServerInterceptor {
   }
 
   private static PrincipalContext devContext() {
-    var id = UUID.nameUUIDFromBytes("/account:t-0001".getBytes()).toString();
+    var id = AccountIds.deterministicAccountId("/account:t-0001");
     var rid =
         ResourceId.newBuilder().setAccountId(id).setId(id).setKind(ResourceKind.RK_ACCOUNT).build();
     return PrincipalContext.newBuilder()

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImpl.java
@@ -310,29 +310,34 @@ public class TableStatisticsServiceImpl extends BaseServiceImpl implements Table
                   }
 
                   var result =
-                      MutationOps.createProto(
-                          accountId,
-                          "PutTableStats",
-                          idempotencyKey,
-                          () -> fingerprint,
-                          () -> {
-                            stats.putTableStats(
-                                request.getTableId(), request.getSnapshotId(), request.getStats());
-                            return new IdempotencyGuard.CreateResult<>(
-                                request.getStats(), request.getTableId());
-                          },
-                          ignored ->
-                              stats.metaForTableStats(
-                                  request.getTableId(), request.getSnapshotId(), tsNow),
-                          idempotencyStore,
-                          tsNow,
-                          idempotencyTtlSeconds(),
-                          this::correlationId,
-                          TableStats::parseFrom,
-                          rec ->
-                              stats
-                                  .getTableStats(request.getTableId(), request.getSnapshotId())
-                                  .isPresent());
+                      runIdempotentCreate(
+                          () ->
+                              MutationOps.createProto(
+                                  accountId,
+                                  "PutTableStats",
+                                  idempotencyKey,
+                                  () -> fingerprint,
+                                  () -> {
+                                    stats.putTableStats(
+                                        request.getTableId(),
+                                        request.getSnapshotId(),
+                                        request.getStats());
+                                    return new IdempotencyGuard.CreateResult<>(
+                                        request.getStats(), request.getTableId());
+                                  },
+                                  ignored ->
+                                      stats.metaForTableStats(
+                                          request.getTableId(), request.getSnapshotId(), tsNow),
+                                  idempotencyStore,
+                                  tsNow,
+                                  idempotencyTtlSeconds(),
+                                  this::correlationId,
+                                  TableStats::parseFrom,
+                                  rec ->
+                                      stats
+                                          .getTableStats(
+                                              request.getTableId(), request.getSnapshotId())
+                                          .isPresent()));
 
                   return PutTableStatsResponse.newBuilder()
                       .setStats(request.getStats())
@@ -490,26 +495,29 @@ public class TableStatisticsServiceImpl extends BaseServiceImpl implements Table
         continue;
       }
 
-      MutationOps.createProto(
-          accountId,
-          "PutColumnStats",
-          next.idempotencyKey(),
-          () -> fingerprint,
-          () -> {
-            stats.putColumnStats(next.tableId(), next.snapshotId(), columnStats);
-            return new IdempotencyGuard.CreateResult<>(columnStats, next.tableId());
-          },
-          cs ->
-              stats.metaForColumnStats(next.tableId(), next.snapshotId(), cs.getColumnId(), tsNow),
-          idempotencyStore,
-          tsNow,
-          idempotencyTtlSeconds(),
-          this::correlationId,
-          ColumnStats::parseFrom,
-          rec ->
-              stats
-                  .getColumnStats(next.tableId(), next.snapshotId(), raw.getColumnId())
-                  .isPresent());
+      runIdempotentCreate(
+          () ->
+              MutationOps.createProto(
+                  accountId,
+                  "PutColumnStats",
+                  next.idempotencyKey(),
+                  () -> fingerprint,
+                  () -> {
+                    stats.putColumnStats(next.tableId(), next.snapshotId(), columnStats);
+                    return new IdempotencyGuard.CreateResult<>(columnStats, next.tableId());
+                  },
+                  cs ->
+                      stats.metaForColumnStats(
+                          next.tableId(), next.snapshotId(), cs.getColumnId(), tsNow),
+                  idempotencyStore,
+                  tsNow,
+                  idempotencyTtlSeconds(),
+                  this::correlationId,
+                  ColumnStats::parseFrom,
+                  rec ->
+                      stats
+                          .getColumnStats(next.tableId(), next.snapshotId(), raw.getColumnId())
+                          .isPresent()));
 
       upserted.incrementAndGet();
     }
@@ -542,27 +550,29 @@ public class TableStatisticsServiceImpl extends BaseServiceImpl implements Table
         continue;
       }
 
-      MutationOps.createProto(
-          accountId,
-          "PutFileColumnStats",
-          next.idempotencyKey(),
-          () -> fingerprint,
-          () -> {
-            stats.putFileColumnStats(next.tableId(), next.snapshotId(), fileStats);
-            return new IdempotencyGuard.CreateResult<>(fileStats, next.tableId());
-          },
-          fs ->
-              stats.metaForFileColumnStats(
-                  next.tableId(), next.snapshotId(), fs.getFilePath(), tsNow),
-          idempotencyStore,
-          tsNow,
-          idempotencyTtlSeconds(),
-          this::correlationId,
-          FileColumnStats::parseFrom,
-          rec ->
-              stats
-                  .getFileColumnStats(next.tableId(), next.snapshotId(), raw.getFilePath())
-                  .isPresent());
+      runIdempotentCreate(
+          () ->
+              MutationOps.createProto(
+                  accountId,
+                  "PutFileColumnStats",
+                  next.idempotencyKey(),
+                  () -> fingerprint,
+                  () -> {
+                    stats.putFileColumnStats(next.tableId(), next.snapshotId(), fileStats);
+                    return new IdempotencyGuard.CreateResult<>(fileStats, next.tableId());
+                  },
+                  fs ->
+                      stats.metaForFileColumnStats(
+                          next.tableId(), next.snapshotId(), fs.getFilePath(), tsNow),
+                  idempotencyStore,
+                  tsNow,
+                  idempotencyTtlSeconds(),
+                  this::correlationId,
+                  FileColumnStats::parseFrom,
+                  rec ->
+                      stats
+                          .getFileColumnStats(next.tableId(), next.snapshotId(), raw.getFilePath())
+                          .isPresent()));
 
       upserted.incrementAndGet();
     }

--- a/service/src/test/java/ai/floedb/floecat/service/util/TestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/util/TestSupport.java
@@ -14,6 +14,7 @@ import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorSpec;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
 import ai.floedb.floecat.connector.rpc.CreateConnectorRequest;
+import ai.floedb.floecat.service.common.AccountIds;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.storage.BlobStore;
 import ai.floedb.floecat.storage.PointerStore;
@@ -26,7 +27,6 @@ import io.grpc.protobuf.StatusProto;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 public final class TestSupport {
   private TestSupport() {}
@@ -46,7 +46,7 @@ public final class TestSupport {
   }
 
   public static ResourceId createAccountId(String tid) {
-    String tidUUID = UUID.nameUUIDFromBytes(("/account:" + tid).getBytes()).toString();
+    String tidUUID = AccountIds.deterministicAccountId("/account:" + tid);
     ResourceId accountId =
         ResourceId.newBuilder()
             .setAccountId(tidUUID)


### PR DESCRIPTION
This change is required to ensure we don't get resource collisions when a table is moved to another namespace and a table with the same name is created in the same namespace. UUIDs go from being deterministically generated based on the FQ name, to randomly generated.

We also fix a package name issue with SnapshotServiceImpl.