### PR TITLE
Introduce EngineContext and normalize engine-scoped system catalogs end-to-end

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/hint/SystemCatalogHintProvider.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/hint/SystemCatalogHintProvider.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.metagraph.model.*;
 import ai.floedb.floecat.systemcatalog.def.*;
 import ai.floedb.floecat.systemcatalog.engine.EngineSpecificRule;
 import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
+import ai.floedb.floecat.systemcatalog.util.EngineContext;
 import java.util.*;
 
 /* Publishes per-object builtin metadata as engine hints. */
@@ -103,7 +104,11 @@ public class SystemCatalogHintProvider implements EngineHintProvider {
       return null;
     }
 
-    var nodes = nodeRegistry.nodesFor(engineKey.engineKind(), engineKey.engineVersion());
+    EngineContext ctx =
+        engineKey == null
+            ? EngineContext.empty()
+            : EngineContext.of(engineKey.engineKind(), engineKey.engineVersion());
+    var nodes = nodeRegistry.nodesFor(ctx);
 
     List<? extends SystemObjectDef> defs =
         switch (node.kind()) {
@@ -116,7 +121,7 @@ public class SystemCatalogHintProvider implements EngineHintProvider {
           default -> List.of();
         };
 
-    String engineKind = engineKey.engineKind();
+    String engineKind = ctx.normalizedKind();
 
     @SuppressWarnings("unchecked")
     List<SystemObjectDef> candidates =

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/provider/StaticSystemCatalogProvider.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/provider/StaticSystemCatalogProvider.java
@@ -18,9 +18,9 @@ package ai.floedb.floecat.systemcatalog.provider;
 
 import ai.floedb.floecat.systemcatalog.registry.SystemCatalogData;
 import ai.floedb.floecat.systemcatalog.registry.SystemEngineCatalog;
+import ai.floedb.floecat.systemcatalog.util.EngineContextNormalizer;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 /** Test-only provider for supplying fixed builtin catalogs. */
@@ -29,7 +29,8 @@ public final class StaticSystemCatalogProvider implements SystemCatalogProvider 
   private final Map<String, SystemCatalogData> catalogs = new HashMap<>();
 
   public StaticSystemCatalogProvider(Map<String, SystemCatalogData> input) {
-    input.forEach((kind, data) -> catalogs.put(kind.toLowerCase(Locale.ROOT), data));
+    input.forEach(
+        (kind, data) -> catalogs.put(EngineContextNormalizer.normalizeEngineKind(kind), data));
   }
 
   @Override
@@ -39,10 +40,8 @@ public final class StaticSystemCatalogProvider implements SystemCatalogProvider 
 
   @Override
   public SystemEngineCatalog load(String engineKind) {
-    SystemCatalogData data = catalogs.get(engineKind.toLowerCase(Locale.ROOT));
-    if (data != null) {
-      return SystemEngineCatalog.from(engineKind, data);
-    }
-    return SystemEngineCatalog.from(engineKind, SystemCatalogData.empty());
+    String normalized = EngineContextNormalizer.normalizeEngineKind(engineKind);
+    SystemCatalogData data = catalogs.get(normalized);
+    return SystemEngineCatalog.from(normalized, data != null ? data : SystemCatalogData.empty());
   }
 }

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/registry/SystemDefinitionRegistry.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/registry/SystemDefinitionRegistry.java
@@ -17,8 +17,8 @@
 package ai.floedb.floecat.systemcatalog.registry;
 
 import ai.floedb.floecat.systemcatalog.provider.SystemCatalogProvider;
+import ai.floedb.floecat.systemcatalog.util.EngineContext;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -36,9 +36,10 @@ public final class SystemDefinitionRegistry {
     this.provider = Objects.requireNonNull(provider);
   }
 
-  public SystemEngineCatalog catalog(String engineKind) {
-    String key = engineKind.toLowerCase(Locale.ROOT);
-    return cache.computeIfAbsent(key, provider::load);
+  public SystemEngineCatalog catalog(EngineContext ctx) {
+    EngineContext canonical = ctx == null ? EngineContext.empty() : ctx;
+    String normalizedKind = canonical.normalizedKind();
+    return cache.computeIfAbsent(normalizedKind, ignored -> provider.load(normalizedKind));
   }
 
   /** Test-only: clears catalog cache. */

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/EngineCatalogNames.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/EngineCatalogNames.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.systemcatalog.util;
+
+/** Shared catalog names used across the system-catalog layers. */
+public final class EngineCatalogNames {
+
+  /**
+   * The canonical catalog that represents Floecat-internal objects when no engine header is sent.
+   */
+  public static final String FLOECAT_DEFAULT_CATALOG = "floecat_internal";
+
+  private EngineCatalogNames() {}
+}

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/EngineContext.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/EngineContext.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.systemcatalog.util;
+
+import java.util.Objects;
+
+/** Shared representation of the engine context (kind + version + normalized helpers). */
+public final class EngineContext {
+
+  private static final EngineContext EMPTY =
+      new EngineContext("", "", EngineCatalogNames.FLOECAT_DEFAULT_CATALOG, "", false);
+
+  private final String engineKind;
+  private final String engineVersion;
+  private final String normalizedKind;
+  private final String normalizedVersion;
+  private final boolean hasEngineKind;
+
+  private EngineContext(
+      String engineKind,
+      String engineVersion,
+      String normalizedKind,
+      String normalizedVersion,
+      boolean hasEngineKind) {
+    this.engineKind = Objects.requireNonNull(engineKind, "engineKind");
+    this.engineVersion = Objects.requireNonNull(engineVersion, "engineVersion");
+    this.normalizedKind = Objects.requireNonNull(normalizedKind, "normalizedKind");
+    this.normalizedVersion = Objects.requireNonNull(normalizedVersion, "normalizedVersion");
+    this.hasEngineKind = hasEngineKind;
+  }
+
+  public static EngineContext of(String engineKind, String engineVersion) {
+    String kind = engineKind == null ? "" : engineKind.trim();
+    String version = engineVersion == null ? "" : engineVersion.trim();
+    boolean hasKind = !kind.isEmpty();
+    String normalizedKind =
+        hasKind
+            ? EngineContextNormalizer.normalizeEngineKind(kind)
+            : EngineCatalogNames.FLOECAT_DEFAULT_CATALOG;
+    if (!hasKind) {
+      version = "";
+    }
+    String normalizedVersion = EngineContextNormalizer.normalizeEngineVersion(version);
+    if (!hasKind && version.isEmpty()) {
+      return EMPTY;
+    }
+    return new EngineContext(kind, version, normalizedKind, normalizedVersion, hasKind);
+  }
+
+  public static EngineContext empty() {
+    return EMPTY;
+  }
+
+  public String engineKind() {
+    return engineKind;
+  }
+
+  public String engineVersion() {
+    return engineVersion;
+  }
+
+  public String normalizedKind() {
+    return normalizedKind;
+  }
+
+  public String normalizedVersion() {
+    return normalizedVersion;
+  }
+
+  public boolean hasEngineKind() {
+    return hasEngineKind;
+  }
+}

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/EngineContextNormalizer.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/EngineContextNormalizer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.systemcatalog.util;
+
+import java.util.Locale;
+
+/** Shared helper for normalizing engine contexts across the catalog layer. */
+public final class EngineContextNormalizer {
+
+  private EngineContextNormalizer() {}
+
+  public static String normalizeEngineKind(String engineKind) {
+    if (engineKind == null) {
+      return "";
+    }
+    String trimmed = engineKind.trim();
+    if (trimmed.isEmpty()) {
+      return "";
+    }
+    return trimmed.toLowerCase(Locale.ROOT);
+  }
+
+  public static String normalizeEngineVersion(String engineVersion) {
+    if (engineVersion == null) {
+      return "";
+    }
+    String trimmed = engineVersion.trim();
+    return trimmed.isEmpty() ? "" : trimmed;
+  }
+}

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/provider/ServiceLoaderSystemCatalogProviderTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/provider/ServiceLoaderSystemCatalogProviderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import ai.floedb.floecat.systemcatalog.def.SystemNamespaceDef;
 import ai.floedb.floecat.systemcatalog.registry.SystemEngineCatalog;
+import ai.floedb.floecat.systemcatalog.util.EngineCatalogNames;
 import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,19 @@ class ServiceLoaderSystemCatalogProviderTest {
 
     assertThat(catalog.tables()).isNotEmpty();
     assertThat(catalog.functions()).isEmpty();
+  }
+
+  @Test
+  void load_blankEngineKindDefaultsToFloecatCatalogWithoutDecorator() {
+    ServiceLoaderSystemCatalogProvider provider = new ServiceLoaderSystemCatalogProvider();
+
+    SystemEngineCatalog catalog = provider.load(" ");
+
+    assertThat(catalog.engineKind()).isEqualTo(EngineCatalogNames.FLOECAT_DEFAULT_CATALOG);
+    assertThat(catalog.namespaces())
+        .contains(
+            new SystemNamespaceDef(
+                NameRefUtil.name("information_schema"), "information_schema", List.of()));
   }
 
   @Test

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/util/EngineContextTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/util/EngineContextTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.systemcatalog.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+final class EngineContextTest {
+
+  @Test
+  void blankKindAppearsAsInternalDefault() {
+    EngineContext ctx = EngineContext.of(" ", "16.0");
+
+    assertThat(ctx.hasEngineKind()).isFalse();
+    assertThat(ctx.normalizedKind()).isEqualTo(EngineCatalogNames.FLOECAT_DEFAULT_CATALOG);
+    assertThat(ctx.normalizedVersion()).isEmpty();
+    assertThat(ctx.engineVersion()).isEmpty();
+  }
+
+  @Test
+  void normalizedKindIsTrimmedLowercase() {
+    EngineContext ctx = EngineContext.of(" PG ", "16.0");
+
+    assertThat(ctx.hasEngineKind()).isTrue();
+    assertThat(ctx.normalizedKind()).isEqualTo("pg");
+    assertThat(ctx.engineVersion()).isEqualTo("16.0");
+  }
+}

--- a/extensions/floedb/src/main/java/ai/floedb/floecat/extensions/floedb/FloeCatalogExtension.java
+++ b/extensions/floedb/src/main/java/ai/floedb/floecat/extensions/floedb/FloeCatalogExtension.java
@@ -27,6 +27,7 @@ import ai.floedb.floecat.systemcatalog.registry.SystemCatalogData;
 import ai.floedb.floecat.systemcatalog.registry.SystemCatalogProtoMapper;
 import ai.floedb.floecat.systemcatalog.spi.EngineSystemCatalogExtension;
 import ai.floedb.floecat.systemcatalog.spi.scanner.SystemObjectScanner;
+import ai.floedb.floecat.systemcatalog.util.EngineContextNormalizer;
 import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.TextFormat;
@@ -218,7 +219,8 @@ public abstract class FloeCatalogExtension implements EngineSystemCatalogExtensi
 
   @Override
   public boolean supportsEngine(String engineKind) {
-    return engineKind != null && engineKind.equalsIgnoreCase(engineKind());
+    return EngineContextNormalizer.normalizeEngineKind(engineKind)
+        .equals(EngineContextNormalizer.normalizeEngineKind(this.engineKind()));
   }
 
   @Override

--- a/extensions/floedb/src/main/java/ai/floedb/floecat/extensions/floedb/pgcatalog/PgCatalogProvider.java
+++ b/extensions/floedb/src/main/java/ai/floedb/floecat/extensions/floedb/pgcatalog/PgCatalogProvider.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.systemcatalog.def.SystemTableDef;
 import ai.floedb.floecat.systemcatalog.engine.EngineSpecificRule;
 import ai.floedb.floecat.systemcatalog.provider.SystemObjectScannerProvider;
 import ai.floedb.floecat.systemcatalog.spi.scanner.SystemObjectScanner;
+import ai.floedb.floecat.systemcatalog.util.EngineContextNormalizer;
 import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +113,8 @@ public final class PgCatalogProvider implements SystemObjectScannerProvider {
 
   @Override
   public boolean supportsEngine(String engineKind) {
-    return engineKind != null && SUPPORTED_ENGINES.contains(engineKind.toLowerCase());
+    String normalized = EngineContextNormalizer.normalizeEngineKind(engineKind);
+    return SUPPORTED_ENGINES.contains(normalized);
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/BuiltinCatalogServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/BuiltinCatalogServiceImpl.java
@@ -21,15 +21,15 @@ import ai.floedb.floecat.query.rpc.BuiltinRegistry;
 import ai.floedb.floecat.query.rpc.GetBuiltinCatalogRequest;
 import ai.floedb.floecat.query.rpc.GetBuiltinCatalogResponse;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
-import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.EngineContextProvider;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
 import ai.floedb.floecat.systemcatalog.registry.SystemCatalogProtoMapper;
+import ai.floedb.floecat.systemcatalog.util.EngineContext;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * gRPC endpoint exposed to planners so they can fetch builtin metadata once per engine version.
@@ -40,22 +40,23 @@ import java.util.Optional;
 public class BuiltinCatalogServiceImpl extends BaseServiceImpl implements BuiltinCatalogService {
 
   @Inject SystemNodeRegistry nodeRegistry;
+  @Inject EngineContextProvider engineContextProvider;
 
   @Override
   public Uni<GetBuiltinCatalogResponse> getBuiltinCatalog(GetBuiltinCatalogRequest request) {
     return mapFailures(
         run(
             () -> {
-              String engineVersion = InboundContextInterceptor.ENGINE_VERSION_KEY.get();
-              if (engineVersion == null || engineVersion.isBlank()) {
+              EngineContext ctx = engineContextProvider.engineContext();
+              String engineVersion = ctx.engineVersion();
+              if (engineVersion.isBlank()) {
                 throw GrpcErrors.invalidArgument(
                     correlationId(),
                     "builtin.engine_version.required",
                     Map.of("header", "x-engine-version"));
               }
 
-              String engineKind =
-                  Optional.ofNullable(InboundContextInterceptor.ENGINE_KIND_KEY.get()).orElse("");
+              String engineKind = ctx.engineKind();
               if (engineKind.isBlank()) {
                 throw GrpcErrors.invalidArgument(
                     correlationId(),
@@ -63,14 +64,14 @@ public class BuiltinCatalogServiceImpl extends BaseServiceImpl implements Builti
                     Map.of("header", "x-engine-kind"));
               }
 
-              BuiltinRegistry registry = fetchBuiltinCatalog(engineKind, engineVersion);
+              BuiltinRegistry registry = fetchBuiltinCatalog(ctx);
               return GetBuiltinCatalogResponse.newBuilder().setRegistry(registry).build();
             }),
         correlationId());
   }
 
-  private BuiltinRegistry fetchBuiltinCatalog(String engineKind, String engineVersion) {
-    var nodes = nodeRegistry.nodesFor(engineKind, engineVersion);
+  private BuiltinRegistry fetchBuiltinCatalog(EngineContext ctx) {
+    var nodes = nodeRegistry.nodesFor(ctx);
     return SystemCatalogProtoMapper.toProto(nodes.toCatalogData());
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
@@ -17,20 +17,41 @@
 package ai.floedb.floecat.service.context;
 
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.systemcatalog.util.EngineContext;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Optional;
 
 @ApplicationScoped
 public final class EngineContextProvider {
 
   public String engineKind() {
-    return InboundContextInterceptor.ENGINE_KIND_KEY.get();
+    return engineContext().engineKind();
   }
 
   public String engineVersion() {
-    return InboundContextInterceptor.ENGINE_VERSION_KEY.get();
+    return engineContext().engineVersion();
+  }
+
+  public String normalizedKind() {
+    return engineContext().normalizedKind();
+  }
+
+  public String normalizedVersion() {
+    return engineContext().normalizedVersion();
   }
 
   public boolean isPresent() {
-    return engineKind() != null && !engineKind().isBlank();
+    return engineContext().hasEngineKind();
+  }
+
+  public EngineContext engineContext() {
+    EngineContext ctx = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
+    if (ctx != null) {
+      return ctx;
+    }
+    String kind = Optional.ofNullable(InboundContextInterceptor.ENGINE_KIND_KEY.get()).orElse("");
+    String version =
+        Optional.ofNullable(InboundContextInterceptor.ENGINE_VERSION_KEY.get()).orElse("");
+    return EngineContext.of(kind, version);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -35,6 +35,7 @@ import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.query.resolver.LogicalSchemaMapper;
 import ai.floedb.floecat.systemcatalog.graph.model.SystemTableNode;
 import ai.floedb.floecat.systemcatalog.spi.scanner.CatalogOverlay;
+import ai.floedb.floecat.systemcatalog.util.EngineContext;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -83,7 +84,8 @@ public final class MetaGraph implements CatalogOverlay {
    */
   @Override
   public Optional<GraphNode> resolve(ResourceId id) {
-    Optional<GraphNode> sys = systemGraph.resolve(id, engine.engineKind(), engine.engineVersion());
+    EngineContext ctx = engine.engineContext();
+    Optional<GraphNode> sys = systemGraph.resolve(id, ctx);
     if (sys.isPresent()) {
       return sys;
     }
@@ -101,9 +103,9 @@ public final class MetaGraph implements CatalogOverlay {
    */
   @Override
   public List<GraphNode> listRelations(ResourceId catalogId) {
+    EngineContext ctx = engine.engineContext();
     return mergeLists(
-        () -> systemGraph.listRelations(catalogId, engine.engineKind(), engine.engineVersion()),
-        () -> userGraph.listRelations(catalogId));
+        () -> systemGraph.listRelations(catalogId, ctx), () -> userGraph.listRelations(catalogId));
   }
 
   /**
@@ -118,10 +120,9 @@ public final class MetaGraph implements CatalogOverlay {
    */
   @Override
   public List<GraphNode> listRelationsInNamespace(ResourceId catalogId, ResourceId namespaceId) {
+    EngineContext ctx = engine.engineContext();
     return mergeLists(
-        () ->
-            systemGraph.listRelationsInNamespace(
-                catalogId, namespaceId, engine.engineKind(), engine.engineVersion()),
+        () -> systemGraph.listRelationsInNamespace(catalogId, namespaceId, ctx),
         () -> userGraph.listRelationsInNamespace(catalogId, namespaceId));
   }
 
@@ -136,8 +137,9 @@ public final class MetaGraph implements CatalogOverlay {
    */
   @Override
   public List<FunctionNode> listFunctions(ResourceId catalogId, ResourceId namespaceId) {
+    EngineContext ctx = engine.engineContext();
     return mergeLists(
-        () -> systemGraph.listFunctions(namespaceId, engine.engineKind(), engine.engineVersion()),
+        () -> systemGraph.listFunctions(namespaceId, ctx),
         () -> userGraph.listFunctions(namespaceId));
   }
 
@@ -151,15 +153,16 @@ public final class MetaGraph implements CatalogOverlay {
    */
   @Override
   public List<TypeNode> listTypes(ResourceId catalogId) {
+    EngineContext ctx = engine.engineContext();
     return mergeLists(
-        () -> systemGraph.listTypes(catalogId, engine.engineKind(), engine.engineVersion()),
-        () -> userGraph.listTypes(catalogId));
+        () -> systemGraph.listTypes(catalogId, ctx), () -> userGraph.listTypes(catalogId));
   }
 
   @Override
   public List<NamespaceNode> listNamespaces(ResourceId catalogId) {
+    EngineContext ctx = engine.engineContext();
     return mergeLists(
-        () -> systemGraph.listNamespaces(catalogId, engine.engineKind(), engine.engineVersion()),
+        () -> systemGraph.listNamespaces(catalogId, ctx),
         () -> userGraph.listNamespaces(catalogId));
   }
 
@@ -191,10 +194,11 @@ public final class MetaGraph implements CatalogOverlay {
    */
   @Override
   public ResourceId resolveNamespace(String correlationId, NameRef ref) {
+    EngineContext ctx = engine.engineContext();
     return resolveWithAmbiguityCheck(
         correlationId,
         ref,
-        () -> systemGraph.resolveNamespace(ref, engine.engineKind(), engine.engineVersion()),
+        () -> systemGraph.resolveNamespace(ref, ctx),
         () -> userGraph.tryResolveNamespace(correlationId, ref),
         "namespace");
   }
@@ -212,10 +216,11 @@ public final class MetaGraph implements CatalogOverlay {
    */
   @Override
   public ResourceId resolveTable(String correlationId, NameRef ref) {
+    EngineContext ctx = engine.engineContext();
     return resolveWithAmbiguityCheck(
         correlationId,
         ref,
-        () -> systemGraph.resolveTable(ref, engine.engineKind(), engine.engineVersion()),
+        () -> systemGraph.resolveTable(ref, ctx),
         () -> userGraph.tryResolveTable(correlationId, ref),
         "table");
   }
@@ -233,10 +238,11 @@ public final class MetaGraph implements CatalogOverlay {
    */
   @Override
   public ResourceId resolveView(String correlationId, NameRef ref) {
+    EngineContext ctx = engine.engineContext();
     return resolveWithAmbiguityCheck(
         correlationId,
         ref,
-        () -> systemGraph.resolveView(ref, engine.engineKind(), engine.engineVersion()),
+        () -> systemGraph.resolveView(ref, ctx),
         () -> userGraph.tryResolveView(correlationId, ref),
         "view");
   }
@@ -254,10 +260,11 @@ public final class MetaGraph implements CatalogOverlay {
    */
   @Override
   public ResourceId resolveName(String correlationId, NameRef ref) {
+    EngineContext ctx = engine.engineContext();
     return resolveWithAmbiguityCheck(
         correlationId,
         ref,
-        () -> systemGraph.resolveName(ref, engine.engineKind(), engine.engineVersion()),
+        () -> systemGraph.resolveName(ref, ctx),
         () -> userGraph.tryResolveName(correlationId, ref),
         "table");
   }
@@ -372,7 +379,8 @@ public final class MetaGraph implements CatalogOverlay {
     if (user.isPresent()) {
       return user;
     }
-    return systemGraph.namespaceName(id, engine.engineKind(), engine.engineVersion());
+    EngineContext ctx = engine.engineContext();
+    return systemGraph.namespaceName(id, ctx);
   }
 
   /**
@@ -389,7 +397,8 @@ public final class MetaGraph implements CatalogOverlay {
     if (user.isPresent()) {
       return user;
     }
-    return systemGraph.tableName(id, engine.engineKind(), engine.engineVersion());
+    EngineContext ctx = engine.engineContext();
+    return systemGraph.tableName(id, ctx);
   }
 
   /**
@@ -406,7 +415,8 @@ public final class MetaGraph implements CatalogOverlay {
     if (user.isPresent()) {
       return user;
     }
-    return systemGraph.viewName(id, engine.engineKind(), engine.engineVersion());
+    EngineContext ctx = engine.engineContext();
+    return systemGraph.viewName(id, ctx);
   }
 
   /**
@@ -423,7 +433,8 @@ public final class MetaGraph implements CatalogOverlay {
     if (user.isPresent()) {
       return user;
     }
-    return systemGraph.catalog(id, engine.engineKind(), engine.engineVersion());
+    EngineContext ctx = engine.engineContext();
+    return systemGraph.catalog(id, ctx);
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/SystemScannerResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/SystemScannerResolver.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.systemcatalog.graph.model.SystemTableNode;
 import ai.floedb.floecat.systemcatalog.provider.SystemObjectScannerProvider;
 import ai.floedb.floecat.systemcatalog.spi.scanner.CatalogOverlay;
 import ai.floedb.floecat.systemcatalog.spi.scanner.SystemObjectScanner;
+import ai.floedb.floecat.systemcatalog.util.EngineContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
@@ -55,8 +56,9 @@ public final class SystemScannerResolver {
           correlationId, "system.scan.missing_scanner", Map.of("table_id", tableId.getId()));
     }
 
-    String engineKind = engine.engineKind();
-    String engineVersion = engine.engineVersion();
+    EngineContext ctx = engine.engineContext();
+    String engineKind = ctx.normalizedKind();
+    String engineVersion = ctx.normalizedVersion();
 
     for (var provider : providers) {
       if (!provider.supportsEngine(engineKind)) {
@@ -74,8 +76,6 @@ public final class SystemScannerResolver {
         correlationId,
         "system.scan.scanner_not_found",
         Map.of(
-            "scanner_id", scannerId,
-            "engine_kind", engineKind,
-            "engine_version", engineVersion));
+            "scanner_id", scannerId, "engine_kind", engineKind, "engine_version", engineVersion));
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptorTest.java
@@ -18,82 +18,99 @@ package ai.floedb.floecat.service.context.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.protobuf.Empty;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
-import io.grpc.ClientInterceptors;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.Status;
-import io.grpc.stub.MetadataUtils;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
-class OutboundContextClientInterceptorTest {
+final class OutboundContextClientInterceptorTest {
 
-  private static final MethodDescriptor<Empty, Empty> METHOD =
-      MethodDescriptor.<Empty, Empty>newBuilder()
-          .setType(MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(MethodDescriptor.generateFullMethodName("test", "Method"))
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(Empty.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(Empty.getDefaultInstance()))
-          .build();
+  private static final Metadata.Key<String> ENGINE_KIND_KEY =
+      Metadata.Key.of("x-engine-kind", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> ENGINE_VERSION_KEY =
+      Metadata.Key.of("x-engine-version", Metadata.ASCII_STRING_MARSHALLER);
 
-  /** Ensures the client interceptor copies x-engine-version onto outbound calls. */
   @Test
-  void injectsEngineVersionHeader() {
-    var interceptor = new OutboundContextClientInterceptor();
-    var captured = new AtomicReference<Metadata>();
+  void doesNotEmitEmptyEngineHeadersWhenContextMissing() {
+    OutboundContextClientInterceptor interceptor = new OutboundContextClientInterceptor();
+    AtomicReference<Metadata> captured = new AtomicReference<>();
 
-    Channel baseChannel =
-        new Channel() {
-          @Override
-          public String authority() {
-            return "test";
-          }
+    MethodDescriptor<String, String> method =
+        MethodDescriptor.<String, String>newBuilder()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName("test/empty")
+            .setRequestMarshaller(new StringMarshaller())
+            .setResponseMarshaller(new StringMarshaller())
+            .build();
 
-          @Override
-          public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
-              MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions) {
-            return new ClientCall<ReqT, RespT>() {
-              @Override
-              public void start(Listener<RespT> responseListener, Metadata headers) {
-                captured.set(headers);
-                responseListener.onClose(Status.OK, new Metadata());
-              }
+    ClientCall<String, String> call =
+        interceptor.interceptCall(method, CallOptions.DEFAULT, new TestChannel(captured));
+    call.start(new ClientCall.Listener<>() {}, new Metadata());
 
-              @Override
-              public void request(int numMessages) {}
+    Metadata headers = captured.get();
+    assertThat(headers.get(ENGINE_KIND_KEY)).isNull();
+    assertThat(headers.get(ENGINE_VERSION_KEY)).isNull();
+  }
 
-              @Override
-              public void cancel(String message, Throwable cause) {}
+  private static final class TestChannel extends Channel {
+    private final AtomicReference<Metadata> captured;
 
-              @Override
-              public void halfClose() {}
+    private TestChannel(AtomicReference<Metadata> captured) {
+      this.captured = captured;
+    }
 
-              @Override
-              public void sendMessage(ReqT message) {}
-            };
-          }
-        };
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions) {
+      return new ClientCall<>() {
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+          captured.set(headers);
+        }
 
-    var ctx =
-        io.grpc.Context.current().withValue(InboundContextInterceptor.ENGINE_VERSION_KEY, "16.0");
+        @Override
+        public void request(int numMessages) {}
 
-    Channel intercepted =
-        ClientInterceptors.intercept(
-            baseChannel, MetadataUtils.newAttachHeadersInterceptor(new Metadata()), interceptor);
+        @Override
+        public void cancel(String message, Throwable cause) {}
 
-    ctx.run(
-        () -> {
-          ClientCall<Empty, Empty> call = intercepted.newCall(METHOD, CallOptions.DEFAULT);
-          call.start(new ClientCall.Listener<>() {}, new Metadata());
-        });
+        @Override
+        public void halfClose() {}
 
-    assertThat(captured.get()).isNotNull();
-    Metadata.Key<String> key =
-        Metadata.Key.of("x-engine-version", Metadata.ASCII_STRING_MARSHALLER);
-    assertThat(captured.get().get(key)).isEqualTo("16.0");
+        @Override
+        public void sendMessage(ReqT message) {}
+      };
+    }
+
+    @Override
+    public String authority() {
+      return "test";
+    }
+  }
+
+  private static final class StringMarshaller implements MethodDescriptor.Marshaller<String> {
+    @Override
+    public InputStream stream(String value) {
+      return new ByteArrayInputStream(
+          value != null ? value.getBytes(StandardCharsets.UTF_8) : new byte[0]);
+    }
+
+    @Override
+    public String parse(InputStream stream) {
+      try (stream) {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        stream.transferTo(buffer);
+        return buffer.toString(StandardCharsets.UTF_8);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/it/QuerySystemScanServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QuerySystemScanServiceIT.java
@@ -33,6 +33,7 @@ import ai.floedb.floecat.system.rpc.QuerySystemScanServiceGrpc;
 import ai.floedb.floecat.system.rpc.ScanSystemTableChunk;
 import ai.floedb.floecat.system.rpc.ScanSystemTableRequest;
 import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
+import ai.floedb.floecat.systemcatalog.util.EngineCatalogNames;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -86,7 +87,7 @@ public class QuerySystemScanServiceIT {
   private static ResourceId systemTable(String engineKind, String schema, String table) {
     String kind =
         (engineKind == null || engineKind.isBlank())
-            ? SystemNodeRegistry.FLOECAT_DEFAULT_CATALOG
+            ? EngineCatalogNames.FLOECAT_DEFAULT_CATALOG
             : engineKind;
     return ResourceId.newBuilder()
         .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeSystemNodeRegistry.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeSystemNodeRegistry.java
@@ -21,9 +21,10 @@ import ai.floedb.floecat.systemcatalog.provider.SystemCatalogProvider;
 import ai.floedb.floecat.systemcatalog.registry.SystemCatalogData;
 import ai.floedb.floecat.systemcatalog.registry.SystemDefinitionRegistry;
 import ai.floedb.floecat.systemcatalog.registry.SystemEngineCatalog;
+import ai.floedb.floecat.systemcatalog.util.EngineCatalogNames;
+import ai.floedb.floecat.systemcatalog.util.EngineContextNormalizer;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -64,13 +65,17 @@ public final class FakeSystemNodeRegistry extends SystemNodeRegistry {
     private final Map<String, SystemEngineCatalog> catalogs = new HashMap<>();
 
     void register(String engineKind, SystemCatalogData data) {
-      String key = engineKind.toLowerCase(Locale.ROOT);
+      String key = EngineContextNormalizer.normalizeEngineKind(engineKind);
       catalogs.put(key, SystemEngineCatalog.from(key, data));
     }
 
     @Override
     public SystemEngineCatalog load(String engineKind) {
-      SystemEngineCatalog catalog = catalogs.get(engineKind.toLowerCase(Locale.ROOT));
+      String key = EngineContextNormalizer.normalizeEngineKind(engineKind);
+      if (key.isBlank()) {
+        key = EngineCatalogNames.FLOECAT_DEFAULT_CATALOG;
+      }
+      SystemEngineCatalog catalog = catalogs.get(key);
       if (catalog == null) {
         throw new IllegalStateException(
             "No fake system catalog registered for engine: " + engineKind);


### PR DESCRIPTION
# Introduce EngineContext and normalize engine-scoped system catalogs end-to-end

- Introduces EngineContext, EngineContextNormalizer, and shared catalog names to centralize engine kind/version normalization.
- Makes system catalog resolution and SystemGraph snapshots keyed by normalized engine context.
- Ensures default behavior without engine headers resolves to floecat_internal (information_schema + internal overrides).
- Updates service context plumbing to store EngineContext in inbound gRPC Context and reuse it across metagraph/system graph lookups.
- Adds/updates tests for normalization, default catalog behavior, and context propagation.

No changes in behaviour, this is only for ease of use.