### PR TITLE
Catalog bundle: add best-effort stats provider and decoration

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/spi/scanner/StatsProvider.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/spi/scanner/StatsProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.systemcatalog.spi.scanner;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import java.util.Optional;
+
+/** Shared provider that surfaces table/column stats to metadata consumers. */
+public interface StatsProvider {
+
+  default Optional<TableStatsView> tableStats(ResourceId tableId) {
+    return Optional.empty();
+  }
+
+  default Optional<ColumnStatsView> columnStats(ResourceId tableId, int columnId) {
+    return Optional.empty();
+  }
+
+  StatsProvider NONE = new StatsProvider() {};
+
+  interface TableStatsView {
+    ResourceId tableId();
+
+    long snapshotId();
+
+    long rowCount();
+
+    long totalSizeBytes();
+  }
+
+  interface ColumnStatsView {
+    ResourceId tableId();
+
+    int columnId();
+
+    String columnName();
+
+    long valueCount();
+
+    long nullCount();
+  }
+}

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/spi/scanner/SystemObjectScanContext.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/spi/scanner/SystemObjectScanContext.java
@@ -39,13 +39,23 @@ public record SystemObjectScanContext(
     CatalogOverlay graph,
     NameRef name,
     ResourceId queryDefaultCatalogId,
-    EngineContext engineContext)
+    EngineContext engineContext,
+    StatsProvider statsProvider)
     implements MetadataResolutionContext {
 
   public SystemObjectScanContext {
     Objects.requireNonNull(graph, "graph");
     Objects.requireNonNull(queryDefaultCatalogId, "queryDefaultCatalogId");
     engineContext = engineContext == null ? EngineContext.empty() : engineContext;
+    statsProvider = statsProvider == null ? StatsProvider.NONE : statsProvider;
+  }
+
+  public SystemObjectScanContext(
+      CatalogOverlay graph,
+      NameRef name,
+      ResourceId queryDefaultCatalogId,
+      EngineContext engineContext) {
+    this(graph, name, queryDefaultCatalogId, engineContext, StatsProvider.NONE);
   }
 
   public GraphNode resolve(ResourceId id) {
@@ -97,5 +107,10 @@ public record SystemObjectScanContext(
 
   public List<TypeNode> listTypes() {
     return graph.listTypes(queryDefaultCatalogId);
+  }
+
+  @Override
+  public StatsProvider statsProvider() {
+    return statsProvider;
   }
 }

--- a/core/proto/src/main/proto/query/catalog_bundle.proto
+++ b/core/proto/src/main/proto/query/catalog_bundle.proto
@@ -161,8 +161,15 @@ message RelationInfo {
   repeated ColumnInfo columns = 4;
   // Optional view definition for relations of kind VIEW.
   ViewDefinition view_definition = 5;
+  // Optional table-level statistics from a cached catalog snapshot.
+  RelationStats stats = 6;
   // Optional engine-specific metadata.
   repeated ai.floedb.floecat.query.EngineSpecific engine_specific = 99;
+}
+
+message RelationStats {
+  int64 row_count = 1;
+  int64 total_size_bytes = 2;
 }
 
 message ColumnInfo {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import ai.floedb.floecat.catalog.rpc.ColumnStats;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.query.rpc.RelationStats;
+import ai.floedb.floecat.service.query.QueryContextStore;
+import ai.floedb.floecat.service.query.impl.QueryContext;
+import ai.floedb.floecat.service.repo.impl.StatsRepository;
+import ai.floedb.floecat.systemcatalog.spi.scanner.StatsProvider;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public final class StatsProviderFactory {
+
+  private static final Logger LOG = Logger.getLogger(StatsProviderFactory.class);
+
+  private final StatsRepository repository;
+  private final QueryContextStore queryStore;
+
+  private record TableKey(String accountId, String relationId, int kindValue, long snapshotId) {}
+
+  @Inject
+  public StatsProviderFactory(StatsRepository repository, QueryContextStore queryStore) {
+    this.repository = repository;
+    this.queryStore = queryStore;
+  }
+
+  public StatsProvider forQuery(QueryContext ctx, String correlationId) {
+    return new CachedStatsProvider(repository, queryStore, ctx, correlationId);
+  }
+
+  private static final class CachedStatsProvider implements StatsProvider {
+
+    private final StatsRepository repository;
+    private final QueryContextStore queryStore;
+    private final QueryContext initialCtx;
+    private final String queryId;
+    private final String correlationId;
+    private final ConcurrentMap<TableKey, Optional<StatsProvider.TableStatsView>> tableCache =
+        new ConcurrentHashMap<>();
+
+    private CachedStatsProvider(
+        StatsRepository repository,
+        QueryContextStore queryStore,
+        QueryContext ctx,
+        String correlationId) {
+      this.repository = repository;
+      this.queryStore = queryStore;
+      this.initialCtx = ctx;
+      this.queryId = ctx.getQueryId();
+      this.correlationId = correlationId;
+    }
+
+    @Override
+    public Optional<StatsProvider.TableStatsView> tableStats(ResourceId tableId) {
+      return liveContext()
+          .findSnapshotPin(tableId, correlationId)
+          .flatMap(
+              pin -> {
+                long snapshotId = pin.getSnapshotId();
+                TableKey key =
+                    new TableKey(
+                        tableId.getAccountId(),
+                        tableId.getId(),
+                        tableId.getKindValue(),
+                        snapshotId);
+                return tableCache.computeIfAbsent(key, k -> safeTableStats(tableId, snapshotId));
+              });
+    }
+
+    @Override
+    public Optional<StatsProvider.ColumnStatsView> columnStats(ResourceId tableId, int columnId) {
+      return liveContext()
+          .findSnapshotPin(tableId, correlationId)
+          .flatMap(pin -> safeColumnStats(tableId, pin.getSnapshotId(), columnId));
+    }
+
+    private QueryContext liveContext() {
+      return queryStore.get(queryId).orElse(initialCtx);
+    }
+
+    private Optional<StatsProvider.TableStatsView> safeTableStats(
+        ResourceId tableId, long snapshotId) {
+      try {
+        return repository
+            .getTableStatsView(tableId, snapshotId)
+            .map(StatsProviderFactory::toTableStatsView);
+      } catch (RuntimeException e) {
+        LOG.debugf(e, "table stats lookup failed for %s snapshot %s", tableId, snapshotId);
+        return Optional.empty();
+      }
+    }
+
+    private Optional<StatsProvider.ColumnStatsView> safeColumnStats(
+        ResourceId tableId, long snapshotId, int columnId) {
+      try {
+        return repository
+            .getColumnStats(tableId, snapshotId, columnId)
+            .map(StatsProviderFactory::toColumnStatsView);
+      } catch (RuntimeException e) {
+        LOG.debugf(
+            e,
+            "column stats lookup failed for %s column %s snapshot %s",
+            tableId,
+            columnId,
+            snapshotId);
+        return Optional.empty();
+      }
+    }
+  }
+
+  private static StatsProvider.TableStatsView toTableStatsView(
+      StatsRepository.TableStatsView stats) {
+    return new TableStatsViewImpl(
+        stats.tableId(), stats.snapshotId(), stats.rowCount(), stats.totalSizeBytes());
+  }
+
+  private static StatsProvider.ColumnStatsView toColumnStatsView(ColumnStats stats) {
+    return new ColumnStatsViewImpl(
+        stats.getTableId(),
+        stats.getColumnId(),
+        stats.getColumnName(),
+        stats.getValueCount(),
+        stats.getNullCount());
+  }
+
+  private static final class TableStatsViewImpl implements StatsProvider.TableStatsView {
+    private final ResourceId tableId;
+    private final long snapshotId;
+    private final long rowCount;
+    private final long totalSizeBytes;
+
+    private TableStatsViewImpl(
+        ResourceId tableId, long snapshotId, long rowCount, long totalSizeBytes) {
+      this.tableId = tableId;
+      this.snapshotId = snapshotId;
+      this.rowCount = rowCount;
+      this.totalSizeBytes = totalSizeBytes;
+    }
+
+    @Override
+    public ResourceId tableId() {
+      return tableId;
+    }
+
+    @Override
+    public long snapshotId() {
+      return snapshotId;
+    }
+
+    @Override
+    public long rowCount() {
+      return rowCount;
+    }
+
+    @Override
+    public long totalSizeBytes() {
+      return totalSizeBytes;
+    }
+  }
+
+  private static final class ColumnStatsViewImpl implements StatsProvider.ColumnStatsView {
+    private final ResourceId tableId;
+    private final int columnId;
+    private final String columnName;
+    private final long valueCount;
+    private final long nullCount;
+
+    private ColumnStatsViewImpl(
+        ResourceId tableId, int columnId, String columnName, long valueCount, long nullCount) {
+      this.tableId = tableId;
+      this.columnId = columnId;
+      this.columnName = columnName;
+      this.valueCount = valueCount;
+      this.nullCount = nullCount;
+    }
+
+    @Override
+    public ResourceId tableId() {
+      return tableId;
+    }
+
+    @Override
+    public int columnId() {
+      return columnId;
+    }
+
+    @Override
+    public String columnName() {
+      return columnName;
+    }
+
+    @Override
+    public long valueCount() {
+      return valueCount;
+    }
+
+    @Override
+    public long nullCount() {
+      return nullCount;
+    }
+  }
+
+  static RelationStats toRelationStats(StatsProvider.TableStatsView stats) {
+    return RelationStats.newBuilder()
+        .setRowCount(stats.rowCount())
+        .setTotalSizeBytes(stats.totalSizeBytes())
+        .build();
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -82,6 +82,10 @@ public class StatsRepository {
         new TableStatsKey(tableId.getAccountId(), tableId.getId(), snapshotId, ""));
   }
 
+  public Optional<TableStatsView> getTableStatsView(ResourceId tableId, long snapshotId) {
+    return getTableStats(tableId, snapshotId).map(StatsRepository::tableStatsView);
+  }
+
   public boolean deleteTableStats(ResourceId tableId, long snapshotId) {
     return tableStatsRepo.delete(
         new TableStatsKey(tableId.getAccountId(), tableId.getId(), snapshotId, ""));
@@ -266,5 +270,41 @@ public class StatsRepository {
       ResourceId tableId, long snapshotId, String filePath) {
     return fileStatsRepo.metaForSafe(
         new FileColumnStatsKey(tableId.getAccountId(), tableId.getId(), snapshotId, filePath, ""));
+  }
+
+  private static TableStatsView tableStatsView(TableStats stats) {
+    return new TableStatsView(
+        stats.getTableId(), stats.getSnapshotId(), stats.getRowCount(), stats.getTotalSizeBytes());
+  }
+
+  public static final class TableStatsView {
+    private final ResourceId tableId;
+    private final long snapshotId;
+    private final long rowCount;
+    private final long totalSizeBytes;
+
+    private TableStatsView(
+        ResourceId tableId, long snapshotId, long rowCount, long totalSizeBytes) {
+      this.tableId = tableId;
+      this.snapshotId = snapshotId;
+      this.rowCount = rowCount;
+      this.totalSizeBytes = totalSizeBytes;
+    }
+
+    public ResourceId tableId() {
+      return tableId;
+    }
+
+    public long snapshotId() {
+      return snapshotId;
+    }
+
+    public long rowCount() {
+      return rowCount;
+    }
+
+    public long totalSizeBytes() {
+      return totalSizeBytes;
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/CatalogBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/CatalogBundleServiceTest.java
@@ -18,14 +18,19 @@ package ai.floedb.floecat.service.query.catalog;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ai.floedb.floecat.catalog.rpc.TableStats;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.query.rpc.CatalogBundleChunk;
+import ai.floedb.floecat.query.rpc.Origin;
+import ai.floedb.floecat.query.rpc.RelationInfo;
 import ai.floedb.floecat.query.rpc.RelationResolution;
 import ai.floedb.floecat.query.rpc.ResolutionStatus;
+import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TableReferenceCandidate;
 import ai.floedb.floecat.service.context.EngineContextProvider;
@@ -36,11 +41,18 @@ import ai.floedb.floecat.service.query.catalog.testsupport.CatalogBundleTestSupp
 import ai.floedb.floecat.service.query.catalog.testsupport.CatalogBundleTestSupport.TestQueryContextStore;
 import ai.floedb.floecat.service.query.catalog.testsupport.CatalogBundleTestSupport.TestQueryInputResolver;
 import ai.floedb.floecat.service.query.impl.QueryContext;
+import ai.floedb.floecat.service.query.resolver.QueryInputResolver;
+import ai.floedb.floecat.service.query.resolver.QueryInputResolver.ResolutionResult;
+import ai.floedb.floecat.service.repo.impl.StatsRepository;
+import ai.floedb.floecat.storage.InMemoryBlobStore;
+import ai.floedb.floecat.storage.InMemoryPointerStore;
 import ai.floedb.floecat.systemcatalog.spi.decorator.ColumnDecoration;
 import ai.floedb.floecat.systemcatalog.spi.decorator.EngineMetadataDecorator;
 import ai.floedb.floecat.systemcatalog.spi.decorator.EngineMetadataDecoratorProvider;
 import ai.floedb.floecat.systemcatalog.util.EngineContext;
+import com.google.protobuf.Timestamp;
 import io.grpc.Context;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -70,9 +82,24 @@ class CatalogBundleServiceTest {
           .setKind(ResourceKind.RK_TABLE)
           .build();
 
+  private static final ResourceId SYSTEM_TABLE =
+      ResourceId.newBuilder()
+          .setAccountId("sys")
+          .setId("SYSTEM_TABLE")
+          .setKind(ResourceKind.RK_TABLE)
+          .build();
+
+  private static final long TABLE_A_SNAPSHOT_ID = 123L;
+  private static final SnapshotPin TABLE_A_PIN =
+      SnapshotPin.newBuilder().setTableId(TABLE_A).setSnapshotId(TABLE_A_SNAPSHOT_ID).build();
+  private static final SnapshotSet INITIAL_SNAPSHOT =
+      SnapshotSet.newBuilder().addPins(TABLE_A_PIN).build();
+
   private final FakeCatalogOverlay overlay = new FakeCatalogOverlay();
   private final EngineMetadataDecoratorProvider decoratorProvider = ctx -> Optional.empty();
   private final EngineContextProvider engineContextProvider = new EngineContextProvider();
+  private StatsRepository statsRepository;
+  private StatsProviderFactory statsFactory;
   private TestQueryInputResolver resolver;
   private TestQueryContextStore queryStore;
   private CatalogBundleService service;
@@ -86,7 +113,7 @@ class CatalogBundleServiceTest {
                   .setSubject("tester")
                   .setCorrelationId("cid")
                   .build())
-          .snapshotSet(new byte[0])
+          .snapshotSet(INITIAL_SNAPSHOT.toByteArray())
           .createdAtMs(1)
           .expiresAtMs(1000)
           .state(QueryContext.State.ACTIVE)
@@ -109,9 +136,17 @@ class CatalogBundleServiceTest {
         NameRef.newBuilder().setCatalog("cat").setName("b").build());
     overlay.registerCatalog(DEFAULT_CATALOG, "cat");
     queryStore.seed(ctx);
+    statsRepository = new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    statsFactory = new StatsProviderFactory(statsRepository, queryStore);
     service =
         new CatalogBundleService(
-            overlay, resolver, queryStore, decoratorProvider, engineContextProvider, false);
+            overlay,
+            resolver,
+            queryStore,
+            statsFactory,
+            decoratorProvider,
+            engineContextProvider,
+            false);
   }
 
   @Test
@@ -152,6 +187,271 @@ class CatalogBundleServiceTest {
         .containsExactly(
             List.of(QueryInput.newBuilder().setTableId(TABLE_A).build()),
             List.of(QueryInput.newBuilder().setTableId(TABLE_B).build()));
+  }
+
+  @Test
+  void relationIncludesStatsWhenPinned() {
+    TableStats stats =
+        TableStats.newBuilder()
+            .setTableId(TABLE_A)
+            .setSnapshotId(TABLE_A_SNAPSHOT_ID)
+            .setRowCount(22)
+            .build();
+    statsRepository.putTableStats(TABLE_A, TABLE_A_SNAPSHOT_ID, stats);
+
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<CatalogBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    RelationResolution resolution = chunks.get(1).getResolutions().getItems(0);
+    RelationInfo relation = resolution.getRelation();
+    assertThat(relation.hasStats()).isTrue();
+    assertThat(relation.getStats().getRowCount()).isEqualTo(stats.getRowCount());
+    assertThat(relation.getStats().getTotalSizeBytes()).isEqualTo(0L);
+  }
+
+  @Test
+  void statsAvailableWhenPinAddedDuringBundle() {
+    QueryContext noPinCtx =
+        QueryContext.builder()
+            .queryId("q-no-pin")
+            .principal(ctx.getPrincipal())
+            .snapshotSet(SnapshotSet.getDefaultInstance().toByteArray())
+            .createdAtMs(ctx.getCreatedAtMs())
+            .expiresAtMs(ctx.getExpiresAtMs())
+            .state(QueryContext.State.ACTIVE)
+            .version(1)
+            .queryDefaultCatalogId(DEFAULT_CATALOG)
+            .build();
+
+    TestQueryInputResolver deterministicResolver = new TestQueryInputResolver(99);
+    TestQueryContextStore localStore = new TestQueryContextStore();
+    localStore.seed(noPinCtx);
+    StatsRepository localStatsRepository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    StatsProviderFactory localStatsFactory =
+        new StatsProviderFactory(localStatsRepository, localStore);
+    CatalogBundleService localService =
+        new CatalogBundleService(
+            overlay,
+            deterministicResolver,
+            localStore,
+            localStatsFactory,
+            decoratorProvider,
+            engineContextProvider,
+            false);
+
+    long expectedSnapshotId = 99L;
+    TableStats stats =
+        TableStats.newBuilder()
+            .setTableId(TABLE_A)
+            .setSnapshotId(expectedSnapshotId)
+            .setRowCount(42)
+            .setTotalSizeBytes(99L)
+            .build();
+    localStatsRepository.putTableStats(TABLE_A, expectedSnapshotId, stats);
+
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<CatalogBundleChunk> chunks =
+        localService.stream("cid", noPinCtx, List.of(candidate))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely();
+
+    RelationInfo relation = chunks.get(1).getResolutions().getItems(0).getRelation();
+    assertThat(relation.hasStats()).isTrue();
+    assertThat(relation.getStats().getRowCount()).isEqualTo(stats.getRowCount());
+    assertThat(relation.getStats().getTotalSizeBytes()).isEqualTo(stats.getTotalSizeBytes());
+    assertThat(localStore.updateCount()).isEqualTo(1);
+  }
+
+  @Test
+  void chunkUpdateHappensOncePerChunk() {
+    int chunkSize = 25;
+    int totalCandidates = chunkSize + 1;
+    List<TableReferenceCandidate> candidates = new ArrayList<>(totalCandidates);
+    for (int i = 0; i < totalCandidates; i++) {
+      candidates.add(
+          TableReferenceCandidate.newBuilder()
+              .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+              .build());
+    }
+
+    QueryContext chunkCtx =
+        QueryContext.builder()
+            .queryId("q-chunk")
+            .principal(ctx.getPrincipal())
+            .snapshotSet(SnapshotSet.getDefaultInstance().toByteArray())
+            .createdAtMs(ctx.getCreatedAtMs())
+            .expiresAtMs(ctx.getExpiresAtMs())
+            .state(QueryContext.State.ACTIVE)
+            .version(1)
+            .queryDefaultCatalogId(DEFAULT_CATALOG)
+            .build();
+    queryStore.seed(chunkCtx);
+    List<CatalogBundleChunk> chunks =
+        service.stream("cid", chunkCtx, candidates).collect().asList().await().indefinitely();
+
+    assertThat(
+            chunks.stream()
+                .filter(CatalogBundleChunk::hasResolutions)
+                .mapToInt(chunk -> chunk.getResolutions().getItemsCount())
+                .sum())
+        .isEqualTo(totalCandidates);
+    assertThat(queryStore.updateCount()).isGreaterThan(0);
+    assertThat(queryStore.updateCount()).isLessThan(totalCandidates);
+  }
+
+  @Test
+  void commitSkippedWhenPinsEmpty() {
+    QueryInputResolver emptyResolver =
+        new QueryInputResolver() {
+          @Override
+          public ResolutionResult resolveInputs(
+              String correlationId, List<QueryInput> inputs, Optional<Timestamp> asOfDefault) {
+            return new ResolutionResult(
+                List.of(inputs.get(0).getTableId()), SnapshotSet.getDefaultInstance(), null);
+          }
+        };
+    service =
+        new CatalogBundleService(
+            overlay,
+            emptyResolver,
+            queryStore,
+            statsFactory,
+            decoratorProvider,
+            engineContextProvider,
+            false);
+
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<CatalogBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    RelationResolution resolution = chunks.get(1).getResolutions().getItems(0);
+    assertThat(resolution.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(resolution.getRelation().hasStats()).isFalse();
+    assertThat(queryStore.updateCount()).isEqualTo(0);
+  }
+
+  @Test
+  void errorAndNotFoundOrderingUnchanged() {
+    ResourceId missingTable =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("missing")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    TableReferenceCandidate missing =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(missingTable))
+            .build();
+    TableReferenceCandidate found =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<CatalogBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(missing, found))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely();
+
+    RelationResolution first = chunks.get(1).getResolutions().getItems(0);
+    RelationResolution second = chunks.get(1).getResolutions().getItems(1);
+    assertThat(first.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_NOT_FOUND);
+    assertThat(second.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(second.getRelation().getRelationId()).isEqualTo(TABLE_A);
+  }
+
+  @Test
+  void relationStillResolvesWhenStatsMissing() {
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<CatalogBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    RelationResolution resolution = chunks.get(1).getResolutions().getItems(0);
+    assertThat(resolution.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    RelationInfo relation = resolution.getRelation();
+
+    assertThat(relation.getRelationId()).isEqualTo(TABLE_A);
+    assertThat(relation.hasStats()).isFalse();
+  }
+
+  @Test
+  void relationIncludesTotalSizeWhenProvided() {
+    long totalSize = 5_000L;
+    TableStats stats =
+        TableStats.newBuilder()
+            .setTableId(TABLE_A)
+            .setSnapshotId(TABLE_A_SNAPSHOT_ID)
+            .setRowCount(22)
+            .setTotalSizeBytes(totalSize)
+            .build();
+    statsRepository.putTableStats(TABLE_A, TABLE_A_SNAPSHOT_ID, stats);
+
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<CatalogBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    RelationResolution resolution = chunks.get(1).getResolutions().getItems(0);
+    RelationInfo relation = resolution.getRelation();
+
+    assertThat(relation.hasStats()).isTrue();
+    assertThat(relation.getStats().getTotalSizeBytes()).isEqualTo(totalSize);
+  }
+
+  @Test
+  void systemTableStatsAreSkippedWhenUnpinned() {
+    overlay.registerTable(
+        SYSTEM_TABLE,
+        CatalogBundleTestSupport.schemaFor("sys_id"),
+        NameRef.newBuilder().setCatalog("sys").setName("system_table").build(),
+        GraphNodeOrigin.SYSTEM);
+
+    TableStats stats =
+        TableStats.newBuilder().setTableId(SYSTEM_TABLE).setSnapshotId(999L).setRowCount(5).build();
+    statsRepository.putTableStats(SYSTEM_TABLE, 999L, stats);
+
+    TableReferenceCandidate systemCandidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(SYSTEM_TABLE))
+            .build();
+
+    List<CatalogBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(systemCandidate))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely();
+
+    RelationResolution resolution = chunks.get(1).getResolutions().getItems(0);
+    RelationInfo relation = resolution.getRelation();
+
+    assertThat(relation.getRelationId()).isEqualTo(SYSTEM_TABLE);
+    assertThat(relation.getOrigin()).isEqualTo(Origin.ORIGIN_BUILTIN);
+    assertThat(relation.hasStats()).isFalse();
   }
 
   @Test
@@ -260,7 +560,7 @@ class CatalogBundleServiceTest {
         ctx -> Optional.of(new CountingDecorator(columnDecorations));
     CatalogBundleService decoratedService =
         new CatalogBundleService(
-            overlay, resolver, queryStore, provider, engineContextProvider, true);
+            overlay, resolver, queryStore, statsFactory, provider, engineContextProvider, true);
 
     TableReferenceCandidate candidate =
         TableReferenceCandidate.newBuilder()
@@ -283,7 +583,7 @@ class CatalogBundleServiceTest {
         ctx -> Optional.of(new CountingDecorator(columnDecorations));
     CatalogBundleService decoratedService =
         new CatalogBundleService(
-            overlay, resolver, queryStore, provider, engineContextProvider, true);
+            overlay, resolver, queryStore, statsFactory, provider, engineContextProvider, true);
 
     TableReferenceCandidate candidate =
         TableReferenceCandidate.newBuilder()

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.catalog.rpc.ColumnStats;
+import ai.floedb.floecat.catalog.rpc.TableStats;
+import ai.floedb.floecat.catalog.rpc.UpstreamStamp;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.query.rpc.SnapshotPin;
+import ai.floedb.floecat.query.rpc.SnapshotSet;
+import ai.floedb.floecat.service.query.catalog.testsupport.CatalogBundleTestSupport;
+import ai.floedb.floecat.service.query.impl.QueryContext;
+import ai.floedb.floecat.service.repo.impl.StatsRepository;
+import ai.floedb.floecat.storage.InMemoryBlobStore;
+import ai.floedb.floecat.storage.InMemoryPointerStore;
+import com.google.protobuf.Timestamp;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class StatsProviderFactoryTest {
+
+  private static final ResourceId CATALOG =
+      ResourceId.newBuilder()
+          .setAccountId("acct")
+          .setId("catalog")
+          .setKind(ResourceKind.RK_CATALOG)
+          .build();
+
+  private static final ResourceId TABLE =
+      ResourceId.newBuilder()
+          .setAccountId("acct")
+          .setId("users")
+          .setKind(ResourceKind.RK_TABLE)
+          .build();
+
+  @Test
+  void tableStatsAreOptionalWhenMissing() {
+    CountingStatsRepository repository = new CountingStatsRepository();
+    CatalogBundleTestSupport.TestQueryContextStore store =
+        new CatalogBundleTestSupport.TestQueryContextStore();
+    StatsProviderFactory factory = new StatsProviderFactory(repository, store);
+    QueryContext ctx = queryContextWithoutPin();
+    store.seed(ctx);
+    var provider = factory.forQuery(ctx, "corr");
+
+    assertTrue(provider.tableStats(TABLE).isEmpty());
+    assertEquals(0, repository.tableStatsCalls());
+  }
+
+  @Test
+  void cachesTableStatsPerSnapshot() {
+    CountingStatsRepository repository = new CountingStatsRepository();
+    CatalogBundleTestSupport.TestQueryContextStore store =
+        new CatalogBundleTestSupport.TestQueryContextStore();
+    StatsProviderFactory factory = new StatsProviderFactory(repository, store);
+    long snapshotId = 10L;
+    long fetchedAtMs = 10_123L;
+    TableStats stats =
+        TableStats.newBuilder()
+            .setTableId(TABLE)
+            .setSnapshotId(snapshotId)
+            .setRowCount(5)
+            .setTotalSizeBytes(7_777)
+            .setUpstream(
+                UpstreamStamp.newBuilder()
+                    .setFetchedAt(
+                        Timestamp.newBuilder()
+                            .setSeconds(fetchedAtMs / 1000)
+                            .setNanos((int) ((fetchedAtMs % 1000) * 1_000_000))
+                            .build())
+                    .build())
+            .build();
+    repository.putTableStats(TABLE, snapshotId, stats);
+
+    QueryContext ctx = queryContextWithPin(snapshotId);
+    store.seed(ctx);
+    var provider = factory.forQuery(ctx, "corr");
+    var view = provider.tableStats(TABLE).orElseThrow();
+    assertEquals(stats.getRowCount(), view.rowCount());
+    assertEquals(stats.getTotalSizeBytes(), view.totalSizeBytes());
+    assertEquals(stats.getSnapshotId(), view.snapshotId());
+    assertEquals(1, repository.tableStatsCalls());
+
+    long newSnapshot = snapshotId + 1;
+    TableStats otherStats =
+        TableStats.newBuilder()
+            .setTableId(TABLE)
+            .setSnapshotId(newSnapshot)
+            .setRowCount(7)
+            .setTotalSizeBytes(9)
+            .build();
+    repository.putTableStats(TABLE, newSnapshot, otherStats);
+
+    QueryContext otherCtx = queryContextWithPin(newSnapshot);
+    store.seed(otherCtx);
+    var freshProvider = factory.forQuery(otherCtx, "corr");
+    var freshView = freshProvider.tableStats(TABLE).orElseThrow();
+    assertEquals(otherStats.getRowCount(), freshView.rowCount());
+    assertEquals(otherStats.getTotalSizeBytes(), freshView.totalSizeBytes());
+    assertEquals(2, repository.tableStatsCalls());
+  }
+
+  @Test
+  void totalSizeBytesIsOptionalWhenUnset() {
+    CountingStatsRepository repository = new CountingStatsRepository();
+    CatalogBundleTestSupport.TestQueryContextStore store =
+        new CatalogBundleTestSupport.TestQueryContextStore();
+    StatsProviderFactory factory = new StatsProviderFactory(repository, store);
+    long snapshotId = 33L;
+    TableStats stats =
+        TableStats.newBuilder().setTableId(TABLE).setSnapshotId(snapshotId).setRowCount(11).build();
+    repository.putTableStats(TABLE, snapshotId, stats);
+
+    QueryContext ctx = queryContextWithPin(snapshotId);
+    store.seed(ctx);
+    var provider = factory.forQuery(ctx, "corr");
+    var view = provider.tableStats(TABLE).orElseThrow();
+    assertEquals(stats.getRowCount(), view.rowCount());
+    assertEquals(0, view.totalSizeBytes());
+  }
+
+  @Test
+  void columnStatsBestEffortWithoutPin() {
+    CountingStatsRepository repository = new CountingStatsRepository();
+    CatalogBundleTestSupport.TestQueryContextStore store =
+        new CatalogBundleTestSupport.TestQueryContextStore();
+    StatsProviderFactory factory = new StatsProviderFactory(repository, store);
+    long snapshotId = 22L;
+    int columnId = 1;
+    ColumnStats stats =
+        ColumnStats.newBuilder()
+            .setTableId(TABLE)
+            .setSnapshotId(snapshotId)
+            .setColumnId(columnId)
+            .setColumnName("col")
+            .setValueCount(77)
+            .setNullCount(2)
+            .setUpstream(
+                UpstreamStamp.newBuilder()
+                    .setFetchedAt(Timestamp.newBuilder().setSeconds(1).build())
+                    .build())
+            .build();
+    repository.putColumnStats(TABLE, snapshotId, stats);
+
+    QueryContext ctx = queryContextWithPin(snapshotId);
+    store.seed(ctx);
+    var provider = factory.forQuery(ctx, "corr");
+    var view = provider.columnStats(TABLE, columnId).orElseThrow();
+    assertEquals(TABLE, view.tableId());
+    assertEquals(columnId, view.columnId());
+    assertEquals("col", view.columnName());
+    assertEquals(77, view.valueCount());
+    assertEquals(2, view.nullCount());
+    provider.columnStats(TABLE, columnId);
+    assertEquals(2, repository.columnStatsCalls());
+
+    var missingProvider = factory.forQuery(queryContextWithoutPin(), "corr");
+    assertTrue(missingProvider.columnStats(TABLE, columnId).isEmpty());
+  }
+
+  @Test
+  void statsAppearWhenPinAddedDuringBundle() {
+    CountingStatsRepository repository = new CountingStatsRepository();
+    CatalogBundleTestSupport.TestQueryContextStore store =
+        new CatalogBundleTestSupport.TestQueryContextStore();
+    StatsProviderFactory factory = new StatsProviderFactory(repository, store);
+    long snapshotId = 66L;
+    TableStats stats =
+        TableStats.newBuilder()
+            .setTableId(TABLE)
+            .setSnapshotId(snapshotId)
+            .setRowCount(12)
+            .setTotalSizeBytes(34)
+            .build();
+    repository.putTableStats(TABLE, snapshotId, stats);
+
+    QueryContext ctx = queryContextWithoutPin();
+    store.seed(ctx);
+    var provider = factory.forQuery(ctx, "corr");
+
+    assertTrue(provider.tableStats(TABLE).isEmpty());
+    assertEquals(0, repository.tableStatsCalls());
+
+    QueryContext pinned = queryContextWithPin(ctx.getQueryId(), snapshotId);
+    store.replace(pinned);
+    var view = provider.tableStats(TABLE).orElseThrow();
+    assertEquals(stats.getRowCount(), view.rowCount());
+    assertEquals(stats.getTotalSizeBytes(), view.totalSizeBytes());
+    assertEquals(snapshotId, view.snapshotId());
+    assertEquals(1, repository.tableStatsCalls());
+  }
+
+  private static QueryContext queryContextWithPin(long snapshotId) {
+    return queryContextWithPin("query-" + snapshotId, snapshotId);
+  }
+
+  private static QueryContext queryContextWithPin(String queryId, long snapshotId) {
+    SnapshotPin pin = SnapshotPin.newBuilder().setTableId(TABLE).setSnapshotId(snapshotId).build();
+    SnapshotSet set = SnapshotSet.newBuilder().addPins(pin).build();
+    PrincipalContext principal =
+        PrincipalContext.newBuilder()
+            .setAccountId(TABLE.getAccountId())
+            .setSubject("tester")
+            .build();
+
+    return QueryContext.builder()
+        .queryId(queryId)
+        .principal(principal)
+        .snapshotSet(set.toByteArray())
+        .createdAtMs(1)
+        .expiresAtMs(1_000)
+        .state(QueryContext.State.ACTIVE)
+        .version(1)
+        .queryDefaultCatalogId(CATALOG)
+        .build();
+  }
+
+  private static QueryContext queryContextWithoutPin() {
+    PrincipalContext principal =
+        PrincipalContext.newBuilder()
+            .setAccountId(TABLE.getAccountId())
+            .setSubject("tester")
+            .build();
+
+    return QueryContext.builder()
+        .queryId("query-no-pin")
+        .principal(principal)
+        .createdAtMs(1)
+        .expiresAtMs(1_000)
+        .state(QueryContext.State.ACTIVE)
+        .version(1)
+        .queryDefaultCatalogId(CATALOG)
+        .build();
+  }
+
+  private static final class CountingStatsRepository extends StatsRepository {
+
+    private int tableStatsCalls;
+    private int columnStatsCalls;
+
+    private CountingStatsRepository() {
+      super(new InMemoryPointerStore(), new InMemoryBlobStore());
+    }
+
+    @Override
+    public Optional<ColumnStats> getColumnStats(ResourceId tableId, long snapshotId, int columnId) {
+      columnStatsCalls++;
+      return super.getColumnStats(tableId, snapshotId, columnId);
+    }
+
+    @Override
+    public Optional<StatsRepository.TableStatsView> getTableStatsView(
+        ResourceId tableId, long snapshotId) {
+      tableStatsCalls++;
+      return super.getTableStatsView(tableId, snapshotId);
+    }
+
+    private int tableStatsCalls() {
+      return tableStatsCalls;
+    }
+
+    private int columnStatsCalls() {
+      return columnStatsCalls;
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/CatalogBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/CatalogBundleTestSupport.java
@@ -80,7 +80,15 @@ public final class CatalogBundleTestSupport {
 
     public void registerTable(
         ResourceId id, List<ai.floedb.floecat.query.rpc.SchemaColumn> schema, NameRef name) {
-      nodes.put(id.getId(), new SimpleGraphNode(id));
+      registerTable(id, schema, name, GraphNodeOrigin.USER);
+    }
+
+    public void registerTable(
+        ResourceId id,
+        List<ai.floedb.floecat.query.rpc.SchemaColumn> schema,
+        NameRef name,
+        GraphNodeOrigin origin) {
+      nodes.put(id.getId(), new SimpleGraphNode(id, origin));
       schemas.put(id.getId(), schema);
       names.put(id.getId(), name);
     }
@@ -242,9 +250,11 @@ public final class CatalogBundleTestSupport {
 
   private static final class SimpleGraphNode implements GraphNode {
     private final ResourceId id;
+    private final GraphNodeOrigin origin;
 
-    private SimpleGraphNode(ResourceId id) {
+    private SimpleGraphNode(ResourceId id, GraphNodeOrigin origin) {
       this.id = id;
+      this.origin = origin;
     }
 
     @Override
@@ -274,7 +284,7 @@ public final class CatalogBundleTestSupport {
 
     @Override
     public GraphNodeOrigin origin() {
-      return GraphNodeOrigin.USER;
+      return origin;
     }
 
     @Override
@@ -286,6 +296,12 @@ public final class CatalogBundleTestSupport {
   public static final class TestQueryInputResolver extends QueryInputResolver {
     private final List<List<QueryInput>> calls = new ArrayList<>();
     private int nextSnapshotId = 1;
+
+    public TestQueryInputResolver() {}
+
+    public TestQueryInputResolver(int nextSnapshotId) {
+      this.nextSnapshotId = nextSnapshotId;
+    }
 
     public List<List<QueryInput>> recordedInputs() {
       return new ArrayList<>(calls);


### PR DESCRIPTION
# Catalog bundle: add best-effort stats provider and decoration

## Summary

This PR introduces best-effort relation statistics plumbing that can be consumed consistently by both:
- Catalog bundle RPC responses (RelationInfo.stats)
- System table scanners (via MetadataResolutionContext.statsProvider())

Stats are only returned when available for a pinned snapshot and must be treated as decorative hints.
 
---

## Key changes

### New StatsProvider SPI
- Added to MetadataResolutionContext with default StatsProvider.NONE
- Exposed through SystemObjectScanContext

### Catalog bundle proto extension
- Add RelationInfo.stats (optional wrapper)
- Add RelationStats { row_count, total_size_bytes }

### Service implementation
- New StatsProviderFactory backed by StatsRepository
- Stats lookup is gated by QueryContext pins (no implicit pinning)
- Cached per (tableId, snapshotId) to avoid repeated repository hits
- Best-effort behavior: failures return empty Optionals and do not impact correctness

### CatalogBundleService refactor
- Ensure chunk pins are committed before building RelationInfo
- Allows stats decoration even when the table is pinned during the same bundle call

### Perf improvement
- Memoize parsing of SnapshotSet inside immutable QueryContext

---

## Behaviour notes
- Stats are best-effort only
- No new pinning behavior
- No correctness dependence on stats
- System tables/views/unpinned tables will generally not have stats (RelationInfo.stats unset)
