### PR TITLE
Fix "make run" to handle more floecat jar dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ $(PROTO_JAR): core/proto/pom.xml $(shell find core/proto -type f -name '*.proto'
 	$(MVN) -q -f core/proto/pom.xml -DskipTests install
 	@test -f "$@" || { echo "ERROR: expected $@ not found"; exit 1; }
 
- $(TEST_SUPPORT_JAR):
+$(TEST_SUPPORT_JAR):
 	@echo "==> [BUILD] storage-spi test-jar (for test scope deps)"
 	$(MVN) -q -f ./pom.xml -DskipTests -DskipUTs=true -DskipITs=true -pl core/storage-spi -am install
 


### PR DESCRIPTION
Like the proto jar dependency which is special-cased, we now have other inner project dependencies which cannot be skipped when invoking "make run" and the brethren make targets.  Instead of blanket running "mvn install", we'll just add another special case.