### PR TITLE
Fix make run #2: address jar dependency locations in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,9 @@ VERSION := $(shell sed -n 's:.*<version>\(.*\)</version>.*:\1:p' pom.xml | head 
 ifeq ($(strip $(VERSION)),)
   VERSION := 0.1.0-SNAPSHOT
 endif
-PROTO_JAR := core/proto/target/floecat-proto-$(VERSION).jar
-TEST_SUPPORT_JAR := core/storage-spi/target/floecat-storage-spi-$(VERSION)-tests.jar
+REPO_DIR := ~/.m2/repository/ai/floedb/floecat
+PROTO_JAR := $(REPO_DIR)/floecat-proto/$(VERSION)/floecat-proto-$(VERSION).jar
+TEST_SUPPORT_JAR := $(REPO_DIR)/floecat-storage-spi/$(VERSION)/floecat-storage-spi-$(VERSION)-tests.jar
 
 # ---------- CLI isolation toggle ----------
 CLI_ISOLATED ?= 1
@@ -226,7 +227,7 @@ $(PROTO_JAR): core/proto/pom.xml $(shell find core/proto -type f -name '*.proto'
 	$(MVN) -q -f core/proto/pom.xml -DskipTests install
 	@test -f "$@" || { echo "ERROR: expected $@ not found"; exit 1; }
 
-$(TEST_SUPPORT_JAR):
+$(TEST_SUPPORT_JAR): $(shell find core/storage-spi/src/test -type f -name '*.java' -o -name '*.properties')
 	@echo "==> [BUILD] storage-spi test-jar (for test scope deps)"
 	$(MVN) -q -f ./pom.xml -DskipTests -DskipUTs=true -DskipITs=true -pl core/storage-spi -am install
 


### PR DESCRIPTION
Fixes #91

Move the jar dependency to the .m2 repository, not the local built artifacts. This allows the "make build" to continue to use "mvn package", but handle the inner jar dependencies needing the jars to source from the .m2 repo.

Add proper dependency on test support jar.