### PR TITLE
add slf4j packages into storage/aws as otherwise using the sdk might fail

### DIFF
--- a/storage/aws/pom.xml
+++ b/storage/aws/pom.xml
@@ -117,6 +117,14 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
     </dependency>
+
+    <!-- Logging (AWS SDK uses slf4j) -->
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.3.5</version>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Adding slf4j packages in the storage/aws dependencies, to prevent some issue with SdkTlsSocketFactory not initializing properly.

fixes #106 