### PR TITLE
Session token validation (external IDP/JWT token integration)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,17 @@
       "vmArgs": [
         "-Xmx1g",
 
+        "-Djava.util.logging.manager=org.jboss.logmanager.LogManager",
+        "--add-reads=org.apache.arrow.flight.core=ALL-UNNAMED",
+        "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED"
+      ]
+    },
+    {
+      "name": "quarkusKVTestConfiguration",
+      "vmArgs": [
+        "-Xmx1g",
+
         "-Dfloecat.fileio.override.io-impl=org.apache.iceberg.aws.s3.S3FileIO",
         "-Dfloecat.fileio.override.s3.endpoint=http://localhost:4566",
         "-Dfloecat.fileio.override.s3.region=us-east-1",
@@ -29,7 +40,7 @@
         "-Dfloecat.kv.ttl-enabled=true",
         "-Dfloecat.blob=s3",
         "-Dfloecat.blob.s3.bucket=floecat-dev",
-                
+
         "-Dfloecat.fileio.override.aws.dynamodb.endpoint-override=http://localhost:4566",
         "-Dfloecat.fixtures.use-aws-s3=true",
         "-Daws.requestChecksumCalculation=when_required",

--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ catalogs, namespaces, tables, and snapshots.
 
 All additional component docs live under [`docs/`](docs).
 
+## External Session Header
+
+The `floecat` service can accept an external session header carrying a JWT. This is validated by Quarkus OIDC and used to authenticate gRPC calls.
+
+Configuration (service `application.properties`):
+- `floecat.interceptor.session.header=x-floe-session` to enable the header.
+- `floecat.interceptor.validate.account=false` to skip account lookup when the caller supplies a trusted account id.
+- `quarkus.oidc.auth-server-url=...` and `quarkus.oidc.client-id=...` to validate with an issuer URL.
+- `quarkus.oidc.public-key=...` to validate locally with a public key (tests/dev).
+- `quarkus.oidc.client_id=...` to set the `aud` claim value expected.
+
+Environment equivalents:
+- FLOECAT_INTERCEPTOR_SESSION_HEADER
+- FLOECAT_INTERCEPTOR_VALIDATE_ACCOUNT
+- QUARKUS_OIDC_AUTH_SERVER_URL
+- QUARKUS_OIDC_PUBLIC_KEY
+- QUARKUS_OIDC_CLIENT_ID
+
+Further documentation on integration to external OpenID Connect IDPs can be found here:
+https://quarkus.io/guides/security-oidc-configuration-properties-reference
+
 ## Contributing
 
 Floecat enforces branch protections and CI. Preferred workflow:

--- a/protocol-gateway/iceberg-rest/src/test/resources/application.properties
+++ b/protocol-gateway/iceberg-rest/src/test/resources/application.properties
@@ -17,3 +17,9 @@ quarkus.scheduler.enabled=false
 quarkus.http.access-log.enabled=false
 quarkus.log.category."io.quarkus".level=WARN
 quarkus.log.category."io.quarkus".min-level=WARN
+
+# For oidc behavior in tests.
+quarkus.keycloak.devservices.enabled=false
+quarkus.oidc.devservices.enabled=false
+quarkus.oidc.discovery-enabled=false
+quarkus.oidc.tenant-enabled=false

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -52,6 +52,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-grpc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-oidc</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -77,6 +81,7 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-logging-json</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-jib</artifactId>
@@ -102,6 +107,11 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.27.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-jwt-build</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -137,3 +137,17 @@ floecat.stats.batch.max-scan-pages=${FLOECAT_STATS_BATCH_MAX_SCAN_PAGES:5}
 
 %dev.quarkus.log.console.json.enabled=false
 %test.quarkus.log.console.json.enabled=false
+
+## Session header validation (external JWT)
+# floecat.interceptor.session.header=x-floe-session
+# Example header: x-floe-session: eyJhbGciOi...
+#
+# Option A: validate with an issuer URL (production/staging)
+# quarkus.oidc.auth-server-url=https://issuer.example.com/realms/floedb
+#
+# Option B: validate locally with a public key (tests/dev)
+# quarkus.oidc.public-key=MIIBIjANBgkqhkiG9w0B...
+#
+# Audience validation (aud claim)
+# quarkus.oidc.client-id=floecat-service
+#

--- a/service/src/test/java/ai/floedb/floecat/service/it/AccountSessionHeaderIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/AccountSessionHeaderIT.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.floedb.floecat.account.rpc.AccountServiceGrpc;
+import ai.floedb.floecat.account.rpc.ListAccountsRequest;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
+import ai.floedb.floecat.service.it.profiles.OidcSessionHeaderProfile;
+import ai.floedb.floecat.service.it.util.TestKeyPair;
+import ai.floedb.floecat.service.util.TestDataResetter;
+import ai.floedb.floecat.service.util.TestSupport;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.jwt.build.Jwt;
+import jakarta.inject.Inject;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(OidcSessionHeaderProfile.class)
+class AccountSessionHeaderIT {
+
+  private static final Metadata.Key<byte[]> PRINCIPAL_BIN =
+      Metadata.Key.of("x-principal-bin", Metadata.BINARY_BYTE_MARSHALLER);
+  private static final Metadata.Key<String> SESSION_HEADER =
+      Metadata.Key.of("x-floe-session", Metadata.ASCII_STRING_MARSHALLER);
+
+  @GrpcClient("floecat")
+  AccountServiceGrpc.AccountServiceBlockingStub accounts;
+
+  @Inject TestDataResetter resetter;
+  @Inject SeedRunner seeder;
+
+  @BeforeEach
+  void resetStores() {
+    resetter.wipeAll();
+    seeder.seedData();
+  }
+
+  @Test
+  void listAccountsAcceptsSessionHeaderJwt() throws Exception {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+    metadata.put(SESSION_HEADER, sessionJwt());
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    var response = stub.listAccounts(ListAccountsRequest.getDefaultInstance());
+
+    assertFalse(response.getAccountsList().isEmpty());
+  }
+
+  @Test
+  void listAccountsRejectsMissingSessionHeader() {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listAccountsRejectsWrongSessionHeaderName() {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+    metadata.put(
+        Metadata.Key.of("x-floe-session-typo", Metadata.ASCII_STRING_MARSHALLER),
+        "eyJhbGciOiJIUzI1NiJ9");
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listAccountsRejectsMissingPrincipalHeader() throws Exception {
+    Metadata metadata = new Metadata();
+    metadata.put(SESSION_HEADER, sessionJwt());
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listAccountsRejectsMalformedJwt() {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+    metadata.put(SESSION_HEADER, "not-a-jwt");
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listAccountsRejectsMissingAudience() throws Exception {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+    metadata.put(SESSION_HEADER, sessionJwtWithKeyAndAudience(TestKeyPair.privateKey(), null));
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listAccountsRejectsInvalidSignature() throws Exception {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+    metadata.put(SESSION_HEADER, sessionJwtWithKey(generatePrivateKey()));
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listAccountsRejectsWrongAudience() throws Exception {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+    metadata.put(
+        SESSION_HEADER, sessionJwtWithKeyAndAudience(TestKeyPair.privateKey(), "wrong-audience"));
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listAccountsRejectsInvalidExpiration() throws Exception {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+    metadata.put(
+        SESSION_HEADER, sessionJwtWithKeyAndTiming(TestKeyPair.privateKey(), -300, -600, 0));
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listAccountsRejectsExpiredToken() throws Exception {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+    metadata.put(
+        SESSION_HEADER, sessionJwtWithKeyAndTiming(TestKeyPair.privateKey(), -3600, -300, 0));
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listAccountsRejectsTokenNotYetValid() throws Exception {
+    Metadata metadata = new Metadata();
+    metadata.put(PRINCIPAL_BIN, principal().toByteArray());
+    metadata.put(
+        SESSION_HEADER, sessionJwtWithKeyAndTiming(TestKeyPair.privateKey(), 0, 3600, 300));
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  private static PrincipalContext principal() {
+    ResourceId accountId = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT);
+    return PrincipalContext.newBuilder()
+        .setAccountId(accountId.getId())
+        .setSubject("it-user")
+        .addPermissions("account.read")
+        .build();
+  }
+
+  private static String sessionJwt() throws Exception {
+    return sessionJwtWithKey(TestKeyPair.privateKey());
+  }
+
+  private static String sessionJwtWithKey(PrivateKey privateKey) throws Exception {
+    return sessionJwtWithKeyAndAudience(privateKey, "floecat-client");
+  }
+
+  private static String sessionJwtWithKeyAndAudience(PrivateKey privateKey, String audience)
+      throws Exception {
+    return sessionJwtWithKeyAndTiming(privateKey, audience, 0, 7L * 365 * 24 * 3600, 0);
+  }
+
+  private static String sessionJwtWithKeyAndTiming(
+      PrivateKey privateKey,
+      long issuedAtOffsetSeconds,
+      long expiresInSeconds,
+      long notBeforeOffset)
+      throws Exception {
+    return sessionJwtWithKeyAndTiming(
+        privateKey, "floecat-client", issuedAtOffsetSeconds, expiresInSeconds, notBeforeOffset);
+  }
+
+  private static String sessionJwtWithKeyAndTiming(
+      PrivateKey privateKey,
+      String audience,
+      long issuedAtOffsetSeconds,
+      long expiresInSeconds,
+      long notBeforeOffset)
+      throws Exception {
+    var now = Instant.now();
+    var builder =
+        Jwt.claims()
+            .issuer("https://floecat.test")
+            .subject("it-user")
+            .issuedAt(now.plusSeconds(issuedAtOffsetSeconds))
+            .expiresAt(now.plusSeconds(expiresInSeconds));
+    if (audience != null) {
+      builder.audience(audience);
+    }
+    if (notBeforeOffset != 0) {
+      builder.claim("nbf", now.plusSeconds(notBeforeOffset).getEpochSecond());
+    }
+    return builder.sign(privateKey);
+  }
+
+  private static PrivateKey generatePrivateKey() throws Exception {
+    KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+    generator.initialize(2048);
+    return generator.generateKeyPair().getPrivate();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/it/profiles/OidcSessionHeaderProfile.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/profiles/OidcSessionHeaderProfile.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.it.profiles;
+
+import ai.floedb.floecat.service.it.util.TestKeyPair;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+public class OidcSessionHeaderProfile implements QuarkusTestProfile {
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return Map.of(
+        "quarkus.oidc.enabled", "true",
+        "quarkus.oidc.tenant-enabled", "true",
+        "quarkus.oidc.token.audience", "floecat-client",
+        "floecat.interceptor.allow.dev-context", "false",
+        "floecat.interceptor.validate.account", "false",
+        "floecat.interceptor.session.header", "x-floe-session",
+        "quarkus.oidc.public-key", TestKeyPair.publicKeyBase64());
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/it/util/TestKeyPair.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/util/TestKeyPair.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.it.util;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.util.Base64;
+
+public final class TestKeyPair {
+  private static final KeyPair KEY_PAIR = generateKeyPair();
+
+  private TestKeyPair() {}
+
+  public static PrivateKey privateKey() {
+    return KEY_PAIR.getPrivate();
+  }
+
+  public static String publicKeyBase64() {
+    return Base64.getEncoder().encodeToString(KEY_PAIR.getPublic().getEncoded());
+  }
+
+  private static KeyPair generateKeyPair() {
+    try {
+      KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+      generator.initialize(2048);
+      return generator.generateKeyPair();
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to generate test RSA keypair", e);
+    }
+  }
+}

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -59,3 +59,9 @@ quarkus.log.console.json.enabled=false
 
 floecat.fileio.override.s3.secret-access-key=test
 floecat.fileio.override.s3.access-key-id=test
+
+# For oidc behavior in tests.
+quarkus.keycloak.devservices.enabled=false
+quarkus.oidc.devservices.enabled=false
+quarkus.oidc.discovery-enabled=false
+quarkus.oidc.tenant-enabled=false


### PR DESCRIPTION
* Session token validation

  - Add quarkus-oidc extension
  - Add token validation if header is set
  - Add config flag to disable dev-context fallback when
    principal/query headers are missing
  - Adjust default test configurations to disable loading of quarkus
    development oidc/keycloak service (which would require docker)
  - Add integration tests for
      - passing token
      - passing token with invalid aud claim
      - passing token with missing aud claim
      - passing token with invalid session header name
      - passing token with missing session header
      - passing token with missing principal header
      - passing malformed JWT
      - passing expired token
      - passing token with exp is before iat
      - passing token not yet valid (nbf)
      - passing token with invalid JWT private key signer
  - Update README.md to include basic guidance on setup of external
    OIDC token integration and pointer to external docs for configuration.
  - Update vs.code test run configuration to allow wider
    use for debugging all unit tests (not just KV-related ones)