### PR TITLE
SystemCatalog: make ResourceIds stable and overload-safe (functions/operators/aggregates/casts/collations)

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/SignatureUtil.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/SignatureUtil.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.systemcatalog.util;
+
+import static ai.floedb.floecat.systemcatalog.util.NameRefUtil.canonical;
+
+import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.systemcatalog.def.SystemAggregateDef;
+import ai.floedb.floecat.systemcatalog.def.SystemCastDef;
+import ai.floedb.floecat.systemcatalog.def.SystemCollationDef;
+import ai.floedb.floecat.systemcatalog.def.SystemFunctionDef;
+import ai.floedb.floecat.systemcatalog.def.SystemObjectDef;
+import ai.floedb.floecat.systemcatalog.def.SystemOperatorDef;
+import ai.floedb.floecat.systemcatalog.def.SystemTypeDef;
+import java.util.List;
+
+/**
+ * Canonical signature helpers for system catalog objects.
+ *
+ * <p>Design goals:
+ *
+ * <ul>
+ *   <li>Deterministic and stable across JVM runs
+ *   <li>Readable in logs and error messages
+ *   <li>These signatures feed `ResourceId` id strings and drive duplicate detection.
+ * </ul>
+ */
+public final class SignatureUtil {
+
+  private SignatureUtil() {}
+
+  // ----------------------------------------------------------------------
+  // Helpers
+  // ----------------------------------------------------------------------
+
+  /** Comma-joins argument type names using {@link #canonical(NameRef)}. */
+  public static String args(List<NameRef> argTypes) {
+    if (argTypes == null || argTypes.isEmpty()) {
+      return "";
+    }
+    StringBuilder b = new StringBuilder();
+    for (int i = 0; i < argTypes.size(); i++) {
+      b.append(canonical(argTypes.get(i)));
+      if (i + 1 < argTypes.size()) {
+        b.append(",");
+      }
+    }
+    return b.toString();
+  }
+
+  /**
+   * Returns the stable identity string for the given system object.
+   *
+   * <p>This string is used as the ResourceId suffix when identifiers can be overloaded. It switches
+   * between a canonical name and a full signature depending on the type.
+   */
+  public static String identityString(SystemObjectDef def) {
+    String suffix;
+    if (def == null) {
+      suffix = "";
+    } else if (def instanceof SystemFunctionDef fn) {
+      suffix = SignatureUtil.functionSignature(fn);
+    } else if (def instanceof SystemOperatorDef op) {
+      suffix = SignatureUtil.operatorSignature(op);
+    } else if (def instanceof SystemAggregateDef agg) {
+      suffix = SignatureUtil.aggregateSignature(agg);
+    } else if (def instanceof SystemCastDef cast) {
+      suffix = SignatureUtil.castSignature(cast);
+    } else if (def instanceof SystemCollationDef collation) {
+      suffix = SignatureUtil.collationSignature(collation);
+    } else if (def instanceof SystemTypeDef typeName) {
+      suffix = SignatureUtil.typeSignature(typeName);
+    } else {
+      suffix = canonical(def.name()); // Fallback to name only
+    }
+    return suffix;
+  }
+
+  // ----------------------------------------------------------------------
+  // Functions
+  // ----------------------------------------------------------------------
+
+  /**
+   * Canonical function signature (name + argument types).
+   *
+   * <p>Used for ResourceId suffixes and duplicate tracking; format: {@code name(arg1,arg2)}.
+   */
+  public static String functionSignature(SystemFunctionDef fn) {
+    if (fn == null) return "";
+    return canonical(fn.name()) + "(" + args(fn.argumentTypes()) + ")";
+  }
+
+  // ----------------------------------------------------------------------
+  // Operators
+  // ----------------------------------------------------------------------
+
+  /**
+   * Canonical operator signature (name + operand types + return type).
+   *
+   * <p>Format: {@code name(left,right)->returnType}. Used for identity strings and duplicate
+   * checks.
+   *
+   * <p>Note: left may be blank for unary operators.
+   */
+  public static String operatorSignature(SystemOperatorDef op) {
+    if (op == null) return "";
+    return canonical(op.name())
+        + "("
+        + canonical(op.leftType())
+        + ","
+        + canonical(op.rightType())
+        + ")->"
+        + canonical(op.returnType());
+  }
+
+  // ----------------------------------------------------------------------
+  // Aggregates
+  // ----------------------------------------------------------------------
+
+  /**
+   * Canonical aggregate signature (name + argument types + return + state type).
+   *
+   * <p>Format: {@code name(arg1,arg2)->returnType[stateType]} and used for ResourceId suffixes.
+   */
+  public static String aggregateSignature(SystemAggregateDef agg) {
+    if (agg == null) return "";
+    return canonical(agg.name())
+        + "("
+        + args(agg.argumentTypes())
+        + ")->"
+        + canonical(agg.returnType())
+        + "["
+        + canonical(agg.stateType())
+        + "]";
+  }
+
+  // ----------------------------------------------------------------------
+  // Casts
+  // ----------------------------------------------------------------------
+
+  /**
+   * Canonical cast signature (source + target types).
+   *
+   * <p>Format: {@code sourceType->targetType}. Cast method is not part of identity.
+   */
+  public static String castSignature(SystemCastDef cast) {
+    if (cast == null) return "";
+    return canonical(cast.sourceType()) + "->" + canonical(cast.targetType());
+  }
+
+  // ----------------------------------------------------------------------
+  // Collations
+  // ----------------------------------------------------------------------
+  /**
+   * Canonical collation signature.
+   *
+   * <p>Format: {@code name.locale}
+   */
+  public static String collationSignature(SystemCollationDef collation) {
+    if (collation == null) return "";
+    return canonical(collation.name()) + "." + collation.locale();
+  }
+
+  // ----------------------------------------------------------------------
+  // Types
+  // ----------------------------------------------------------------------
+
+  /**
+   * Canonical type signature.
+   *
+   * <p>Format: {@code name}
+   */
+  public static String typeSignature(SystemTypeDef typeName) {
+    return canonical(typeName.name());
+  }
+}

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/validation/SystemCatalogValidator.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/validation/SystemCatalogValidator.java
@@ -28,6 +28,7 @@ import ai.floedb.floecat.systemcatalog.def.SystemViewDef;
 import ai.floedb.floecat.systemcatalog.engine.EngineSpecificRule;
 import ai.floedb.floecat.systemcatalog.engine.VersionIntervals;
 import ai.floedb.floecat.systemcatalog.registry.SystemCatalogData;
+import ai.floedb.floecat.systemcatalog.util.SignatureUtil;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -253,7 +254,7 @@ public final class SystemCatalogValidator {
       }
 
       String fnCtx = objectCtx("function", name);
-      String signature = functionSignature(fn);
+      String signature = SignatureUtil.functionSignature(fn);
       if (!signatures.add(signature)) {
         err(issues, Codes.Function.DUPLICATE, fnCtx, null, signature);
       }
@@ -316,7 +317,7 @@ public final class SystemCatalogValidator {
       }
 
       String opCtx = objectCtx("operator", name);
-      String signature = operatorSignature(op);
+      String signature = SignatureUtil.operatorSignature(op);
       if (!signatures.add(signature)) {
         err(issues, Codes.Operator.DUPLICATE, opCtx, null, signature);
       }
@@ -424,7 +425,7 @@ public final class SystemCatalogValidator {
       }
 
       if (src != null && !isBlank(src.getName()) && tgt != null && !isBlank(tgt.getName())) {
-        String mapping = castSignature(src, tgt);
+        String mapping = SignatureUtil.castSignature(cast);
         if (!mappings.add(mapping)) {
           err(issues, Codes.Cast.DUPLICATE, castCtx, null, mapping);
         }
@@ -492,7 +493,7 @@ public final class SystemCatalogValidator {
 
       String aggCtx = objectCtx("aggregate", name);
 
-      String signature = aggregateSignature(agg);
+      String signature = SignatureUtil.aggregateSignature(agg);
       if (!signatures.add(signature)) {
         err(issues, Codes.Aggregate.DUPLICATE, aggCtx, null, signature);
       }
@@ -826,53 +827,6 @@ public final class SystemCatalogValidator {
       return objectCtx(kind, name);
     }
     return objectCtx(kind, name) + "." + fieldPath;
-  }
-
-  private static String operatorSignature(SystemOperatorDef op) {
-    return formatName(op.name())
-        + "("
-        + formatName(op.leftType())
-        + ","
-        + formatName(op.rightType())
-        + ")";
-  }
-
-  private static String castSignature(NameRef src, NameRef tgt) {
-    return formatName(src) + "->" + formatName(tgt);
-  }
-
-  private static String aggregateSignature(SystemAggregateDef agg) {
-    StringBuilder b = new StringBuilder();
-    b.append(formatName(agg.name())).append("(");
-    List<NameRef> args = agg.argumentTypes();
-    if (args != null) {
-      for (int i = 0; i < args.size(); i++) {
-        b.append(formatName(args.get(i)));
-        if (i + 1 < args.size()) {
-          b.append(",");
-        }
-      }
-    }
-    b.append(")");
-    b.append("->").append(formatName(agg.returnType()));
-    b.append("[").append(formatName(agg.stateType())).append("]");
-    return b.toString();
-  }
-
-  private static String functionSignature(SystemFunctionDef fn) {
-    StringBuilder b = new StringBuilder();
-    b.append(formatName(fn.name())).append("(");
-    List<NameRef> args = fn.argumentTypes();
-    if (args != null) {
-      for (int i = 0; i < args.size(); i++) {
-        b.append(formatName(args.get(i)));
-        if (i + 1 < args.size()) {
-          b.append(",");
-        }
-      }
-    }
-    b.append(")->").append(formatName(fn.returnType()));
-    return b.toString();
   }
 
   private static String collationSignature(SystemCollationDef coll) {

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/graph/model/AggregateHintProviderTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/graph/model/AggregateHintProviderTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import ai.floedb.floecat.metagraph.model.EngineKey;
 import ai.floedb.floecat.systemcatalog.def.SystemAggregateDef;
 import ai.floedb.floecat.systemcatalog.engine.EngineSpecificRule;
+import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
 import ai.floedb.floecat.systemcatalog.registry.SystemCatalogData;
 import ai.floedb.floecat.systemcatalog.utils.BuiltinTestSupport;
 import java.util.List;
@@ -66,10 +67,14 @@ class AggregateHintProviderTest {
     var provider = BuiltinTestSupport.providerFrom(ENGINE, catalog);
     var key = new EngineKey(ENGINE, "16.0");
 
-    var node = BuiltinTestSupport.aggregateNode(ENGINE, "pg.sum", List.of("pg.int4"), "pg.int4");
+    var node =
+        BuiltinTestSupport.aggregateNode(
+            ENGINE, "pg.sum", List.of("pg.int4"), "pg.state", "pg.int4");
 
     var result = provider.compute(node, key, AGG_PAYLOAD_TYPE, "cid").orElseThrow();
     var payload = result.payload();
+    var def = catalog.aggregates().get(0);
+    assertThat(node.id()).isEqualTo(SystemNodeRegistry.resourceId(ENGINE, def));
     assertThat(result.payloadType()).isEqualTo(AGG_PAYLOAD_TYPE);
     assertThat(new String(payload)).contains("aggfinalextra");
     assertThat(result.metadata()).containsEntry("oid", "6006");

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/graph/model/CastHintProviderTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/graph/model/CastHintProviderTest.java
@@ -61,7 +61,9 @@ class CastHintProviderTest {
     var provider = BuiltinTestSupport.providerFrom(ENGINE, catalog);
     var key = new EngineKey(ENGINE, "16.0");
 
-    var node = BuiltinTestSupport.castNode(ENGINE, "pg.cast", "pg.int4", "pg.text", "explicit");
+    var node =
+        BuiltinTestSupport.castNode(
+            ENGINE, "pg.cast", "pg.int4", "pg.text", SystemCastMethod.EXPLICIT);
 
     var result = provider.compute(node, key, CAST_PAYLOAD_TYPE, "cid").orElseThrow();
     assertThat(result.payloadType()).isEqualTo(CAST_PAYLOAD_TYPE);

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/graph/model/CollationHintProviderTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/graph/model/CollationHintProviderTest.java
@@ -51,7 +51,7 @@ class CollationHintProviderTest {
             List.of(),
             List.of(),
             List.of(
-                new SystemCollationDef(BuiltinTestSupport.nr("pg.en_US"), "en-US", List.of(rule))),
+                new SystemCollationDef(BuiltinTestSupport.nr("pg.en_US"), "en_US", List.of(rule))),
             List.of(),
             List.of(),
             List.of(),
@@ -61,7 +61,7 @@ class CollationHintProviderTest {
     var provider = BuiltinTestSupport.providerFrom(ENGINE, catalog);
     var key = new EngineKey(ENGINE, "16.0");
 
-    var node = BuiltinTestSupport.collationNode(ENGINE, "pg.en_US");
+    var node = BuiltinTestSupport.collationNode(ENGINE, "pg.en_US", "en_US");
 
     var result = provider.compute(node, key, COLLATION_PAYLOAD_TYPE, "cid").orElseThrow();
     assertThat(result.payloadType()).isEqualTo(COLLATION_PAYLOAD_TYPE);

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/validation/SystemCatalogValidatorTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/validation/SystemCatalogValidatorTest.java
@@ -216,7 +216,34 @@ final class SystemCatalogValidatorTest {
     ValidationIssue dup = findFirst(issues, "function.duplicate");
     assertThat(dup).isNotNull();
     assertThat(dup.ctx()).isEqualTo("function:f");
-    assertThat(dup.args()).containsExactly("f(int)->int");
+    assertThat(dup.args()).containsExactly("f(int)");
+
+    // functions that only differ by return type still conflict
+    var fIntReturn =
+        new SystemFunctionDef(
+            name("f"), List.of(name("int")), name("int"), false, false, List.of());
+    var fTextReturn =
+        new SystemFunctionDef(
+            name("f"), List.of(name("int")), name("text"), false, false, List.of());
+
+    catalog =
+        new SystemCatalogData(
+            List.of(fIntReturn, fTextReturn),
+            List.of(),
+            List.of(type("int"), type("text")),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
+
+    issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("function.duplicate");
+    dup = findFirst(issues, "function.duplicate");
+    assertThat(dup).isNotNull();
+    assertThat(dup.args()).containsExactly("f(int)");
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
# SystemCatalog: make ResourceIds stable and overload-safe

SystemNodeRegistry previously generated ResourceIds from name only for overloadable objects (functions/operators/aggregates/…), so overloads collapsed to the same id and the graph builder attempted to merge distinct nodes.

## Key changes 
- Introduces SignatureUtil to produce deterministic canonical identity strings for system objects.
       - Functions: name(argTypes…)
       - Operators: name(left,right)->return
       - Aggregates: name(args…)->return[state]
       - Casts: source->target 
       - Collations: name.locale
       - Types: name
- Adds a single entrypoint SystemNodeRegistry.resourceId(engineKind, SystemObjectDef) so all node ids are computed consistently.
- Updates SystemCatalogHintProvider to match definitions by ResourceId equality (id is now the identity), then selects the appropriate engine-specific rule.

Fixes eng-floe/floecat/issues/115
