### PR TITLE
# Propagate engine hints into system graph nodes and improve LogicalType parsing

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/engine/EngineHintsMapper.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/engine/EngineHintsMapper.java
@@ -23,9 +23,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import org.jboss.logging.Logger;
 
 /** Utility that converts engine-specific rules to metagraph hint maps. */
 public final class EngineHintsMapper {
+
+  private static final Logger LOG = Logger.getLogger(EngineHintsMapper.class);
 
   private EngineHintsMapper() {}
 
@@ -55,18 +58,9 @@ public final class EngineHintsMapper {
       String normalizedVersion = engineVersion == null ? "" : engineVersion;
       EngineHintKey key = new EngineHintKey(normalizedKind, normalizedVersion, rule.payloadType());
       if (hints.containsKey(key)) {
-        throw new IllegalStateException(
-            "Duplicate engine hint for "
-                + key
-                + " (payload="
-                + rule.payloadType()
-                + ", engine="
-                + key.engineKind()
-                + ":"
-                + key.engineVersion()
-                + ", context="
-                + (objectContext == null || objectContext.isBlank() ? "<unknown>" : objectContext)
-                + ")");
+        LOG.warnf(
+            "Duplicate engine hint for %s in %s; overwriting previous value",
+            key, (objectContext == null || objectContext.isBlank()) ? "<unknown>" : objectContext);
       }
       hints.put(key, hint);
     }

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/graph/SystemNodeRegistry.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/graph/SystemNodeRegistry.java
@@ -175,7 +175,9 @@ public class SystemNodeRegistry {
             .toList();
     List<FunctionNode> functionNodes =
         functionDefs.stream()
-            .map(def -> toFunctionNode(normalizedKind, version, def, namespaceIds))
+            .map(
+                def ->
+                    toFunctionNode(normalizedKind, normalizedVersion, version, def, namespaceIds))
             .toList();
 
     // --- Operators ---
@@ -185,7 +187,9 @@ public class SystemNodeRegistry {
             .map(def -> withOperatorRules(def, normalizedKind, normalizedVersion))
             .toList();
     List<OperatorNode> operatorNodes =
-        operatorDefs.stream().map(def -> toOperatorNode(normalizedKind, version, def)).toList();
+        operatorDefs.stream()
+            .map(def -> toOperatorNode(normalizedKind, normalizedVersion, version, def))
+            .toList();
 
     // --- Types ---
     List<SystemTypeDef> typeDefs =
@@ -194,7 +198,9 @@ public class SystemNodeRegistry {
             .map(def -> withTypeRules(def, normalizedKind, normalizedVersion))
             .toList();
     List<TypeNode> typeNodes =
-        typeDefs.stream().map(def -> toTypeNode(normalizedKind, version, def)).toList();
+        typeDefs.stream()
+            .map(def -> toTypeNode(normalizedKind, normalizedVersion, version, def))
+            .toList();
 
     // --- Casts ---
     List<SystemCastDef> castDefs =
@@ -203,7 +209,9 @@ public class SystemNodeRegistry {
             .map(def -> withCastRules(def, normalizedKind, normalizedVersion))
             .toList();
     List<CastNode> castNodes =
-        castDefs.stream().map(def -> toCastNode(normalizedKind, version, def)).toList();
+        castDefs.stream()
+            .map(def -> toCastNode(normalizedKind, normalizedVersion, version, def))
+            .toList();
 
     // --- Collations ---
     List<SystemCollationDef> collationDefs =
@@ -212,7 +220,9 @@ public class SystemNodeRegistry {
             .map(def -> withCollationRules(def, normalizedKind, normalizedVersion))
             .toList();
     List<CollationNode> collationNodes =
-        collationDefs.stream().map(def -> toCollationNode(normalizedKind, version, def)).toList();
+        collationDefs.stream()
+            .map(def -> toCollationNode(normalizedKind, normalizedVersion, version, def))
+            .toList();
 
     // --- Aggregates ---
     List<SystemAggregateDef> aggregateDefs =
@@ -221,7 +231,9 @@ public class SystemNodeRegistry {
             .map(def -> withAggregateRules(def, normalizedKind, normalizedVersion))
             .toList();
     List<AggregateNode> aggregateNodes =
-        aggregateDefs.stream().map(def -> toAggregateNode(normalizedKind, version, def)).toList();
+        aggregateDefs.stream()
+            .map(def -> toAggregateNode(normalizedKind, normalizedVersion, version, def))
+            .toList();
 
     // --- Tables ---
     List<SystemTableDef> tableDefs =
@@ -609,12 +621,15 @@ public class SystemNodeRegistry {
 
   private FunctionNode toFunctionNode(
       String engineKind,
+      String engineVersion,
       long version,
       SystemFunctionDef def,
       Map<String, ResourceId> namespaceIds) {
 
     ResourceId nsId = findNamespaceId(def.name(), namespaceIds).orElse(null);
 
+    Map<EngineHintKey, EngineHint> hints =
+        EngineHintsMapper.toHints(engineKind, engineVersion, def.engineSpecific());
     return new FunctionNode(
         resourceId(engineKind, def),
         version,
@@ -628,10 +643,13 @@ public class SystemNodeRegistry {
         resourceId(engineKind, ResourceKind.RK_TYPE, def.returnType()),
         def.isAggregate(),
         def.isWindow(),
-        Map.of());
+        hints);
   }
 
-  private OperatorNode toOperatorNode(String engineKind, long version, SystemOperatorDef def) {
+  private OperatorNode toOperatorNode(
+      String engineKind, String engineVersion, long version, SystemOperatorDef def) {
+    Map<EngineHintKey, EngineHint> hints =
+        EngineHintsMapper.toHints(engineKind, engineVersion, def.engineSpecific());
 
     return new OperatorNode(
         resourceId(engineKind, def),
@@ -644,10 +662,13 @@ public class SystemNodeRegistry {
         resourceId(engineKind, ResourceKind.RK_TYPE, def.returnType()),
         def.isCommutative(),
         def.isAssociative(),
-        Map.of());
+        hints);
   }
 
-  private TypeNode toTypeNode(String engineKind, long version, SystemTypeDef def) {
+  private TypeNode toTypeNode(
+      String engineKind, String engineVersion, long version, SystemTypeDef def) {
+    Map<EngineHintKey, EngineHint> hints =
+        EngineHintsMapper.toHints(engineKind, engineVersion, def.engineSpecific());
     return new TypeNode(
         resourceId(engineKind, def),
         version,
@@ -659,10 +680,13 @@ public class SystemNodeRegistry {
         def.elementType() == null
             ? null
             : resourceId(engineKind, ResourceKind.RK_TYPE, def.elementType()),
-        Map.of());
+        hints);
   }
 
-  private CastNode toCastNode(String engineKind, long version, SystemCastDef def) {
+  private CastNode toCastNode(
+      String engineKind, String engineVersion, long version, SystemCastDef def) {
+    Map<EngineHintKey, EngineHint> hints =
+        EngineHintsMapper.toHints(engineKind, engineVersion, def.engineSpecific());
     return new CastNode(
         resourceId(engineKind, def),
         version,
@@ -671,10 +695,13 @@ public class SystemNodeRegistry {
         resourceId(engineKind, ResourceKind.RK_TYPE, def.sourceType()),
         resourceId(engineKind, ResourceKind.RK_TYPE, def.targetType()),
         def.method().wireValue(),
-        Map.of());
+        hints);
   }
 
-  private CollationNode toCollationNode(String engineKind, long version, SystemCollationDef def) {
+  private CollationNode toCollationNode(
+      String engineKind, String engineVersion, long version, SystemCollationDef def) {
+    Map<EngineHintKey, EngineHint> hints =
+        EngineHintsMapper.toHints(engineKind, engineVersion, def.engineSpecific());
 
     return new CollationNode(
         resourceId(engineKind, def),
@@ -683,10 +710,13 @@ public class SystemNodeRegistry {
         engineKind,
         safeName(def.name()),
         def.locale(),
-        Map.of());
+        hints);
   }
 
-  private AggregateNode toAggregateNode(String engineKind, long version, SystemAggregateDef def) {
+  private AggregateNode toAggregateNode(
+      String engineKind, String engineVersion, long version, SystemAggregateDef def) {
+    Map<EngineHintKey, EngineHint> hints =
+        EngineHintsMapper.toHints(engineKind, engineVersion, def.engineSpecific());
 
     return new AggregateNode(
         resourceId(engineKind, def),
@@ -699,7 +729,7 @@ public class SystemNodeRegistry {
             .toList(),
         resourceId(engineKind, ResourceKind.RK_TYPE, def.stateType()),
         resourceId(engineKind, ResourceKind.RK_TYPE, def.returnType()),
-        Map.of());
+        hints);
   }
 
   // =======================================================================

--- a/core/types/src/main/java/ai/floedb/floecat/types/LogicalKind.java
+++ b/core/types/src/main/java/ai/floedb/floecat/types/LogicalKind.java
@@ -16,6 +16,16 @@
 
 package ai.floedb.floecat.types;
 
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Canonical logical type kinds shared across table formats (e.g. Iceberg, Delta) and SQL-facing
+ * components.
+ *
+ * <p>This enum represents only the logical category. Type parameters (precision, scale, timezone,
+ * length, etc.) are handled outside of this enum.
+ */
 public enum LogicalKind {
   BOOLEAN,
   INT16,
@@ -29,5 +39,58 @@ public enum LogicalKind {
   STRING,
   BINARY,
   UUID,
-  DECIMAL
+  DECIMAL;
+
+  private static final Map<String, LogicalKind> ALIASES =
+      Map.ofEntries(
+          Map.entry("INTEGER", INT32),
+          Map.entry("INT", INT32),
+          Map.entry("SMALLINT", INT16),
+          Map.entry("BIGINT", INT64),
+          Map.entry("FLOAT", FLOAT32),
+          Map.entry("REAL", FLOAT32),
+          Map.entry("DOUBLE", FLOAT64),
+          Map.entry("BOOLEAN", BOOLEAN),
+          Map.entry("BOOL", BOOLEAN),
+          Map.entry("VARCHAR", STRING),
+          Map.entry("CHAR", STRING),
+          Map.entry("CHARACTER", STRING),
+          Map.entry("TEXT", STRING),
+          Map.entry("STRING", STRING),
+          Map.entry("VARBINARY", BINARY),
+          Map.entry("BINARY", BINARY),
+          Map.entry("UUID", UUID),
+          Map.entry("DECIMAL", DECIMAL),
+          Map.entry("NUMERIC", DECIMAL));
+
+  public static LogicalKind fromName(String candidate) {
+    if (candidate == null) {
+      throw new IllegalArgumentException("Logical kind must not be null");
+    }
+
+    String normalized = normalize(candidate);
+
+    // First try exact enum match (INT32, FLOAT64, ...)
+    try {
+      return LogicalKind.valueOf(normalized);
+    } catch (IllegalArgumentException ignore) {
+      // fall through
+    }
+
+    LogicalKind alias = ALIASES.get(normalized);
+    if (alias != null) {
+      return alias;
+    }
+
+    throw new IllegalArgumentException("Unknown logical kind: " + candidate);
+  }
+
+  private static String normalize(String s) {
+    String out = s.trim().toUpperCase(Locale.ROOT);
+    if (out.isEmpty()) {
+      throw new IllegalArgumentException("Logical kind must not be blank");
+    }
+    // Collapse internal whitespace so inputs like "double   precision" normalize sensibly
+    return out.replaceAll("\\s+", " ");
+  }
 }


### PR DESCRIPTION
# Propagate engine hints into system graph nodes and improve LogicalType parsing

This PR improves engine-specific hint handling across the system catalog and type layer.

## Engine hints
- Engine-specific hints are now propagated into all system graph nodes 
- SystemNodeRegistry passes the normalized engine version when building nodes so hint keys are stable and consistent.
- Duplicate engine hints no longer fail catalog construction; the last rule wins and a warning is logged to make overrides visible.

## Type normalization
- Hardened logical type parsing and normalization to be format- and SQL-agnostic:
- Case-insensitive type resolution
- Support for NUMERIC(p,s) alongside DECIMAL(p,s)

Fixes https://github.com/eng-floe/floecat/issues/125 