### PR TITLE
Expose SYSTEM views via catalog overlay and enforce immutability in ViewService

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/graph/SystemNodeRegistry.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/graph/SystemNodeRegistry.java
@@ -340,6 +340,7 @@ public class SystemNodeRegistry {
               viewColumns,
               List.of(),
               List.of(),
+              GraphNodeOrigin.SYSTEM,
               Map.of(),
               Optional.empty(),
               viewHints);

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/spi/scanner/SystemObjectScanContextTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/spi/scanner/SystemObjectScanContextTest.java
@@ -204,6 +204,7 @@ class SystemObjectScanContextTest {
             List.of(), // outputColumns
             List.of(), // baseRelations
             List.of(), // creationSearchPath
+            GraphNodeOrigin.USER, // origin
             Map.of(), // properties
             Optional.empty(), // owner
             Map.of()); // engineHints

--- a/core/metagraph/src/main/java/ai/floedb/floecat/metagraph/model/ViewNode.java
+++ b/core/metagraph/src/main/java/ai/floedb/floecat/metagraph/model/ViewNode.java
@@ -41,6 +41,7 @@ public record ViewNode(
     List<SchemaColumn> outputColumns,
     List<ResourceId> baseRelations,
     List<String> creationSearchPath,
+    GraphNodeOrigin origin,
     Map<String, String> properties,
     Optional<String> owner,
     Map<EngineHintKey, EngineHint> engineHints)
@@ -62,6 +63,6 @@ public record ViewNode(
 
   @Override
   public GraphNodeOrigin origin() {
-    return GraphNodeOrigin.USER;
+    return origin;
   }
 }

--- a/extensions/floedb/src/test/java/ai/floedb/floecat/extensions/floedb/pgcatalog/PgClassScannerTest.java
+++ b/extensions/floedb/src/test/java/ai/floedb/floecat/extensions/floedb/pgcatalog/PgClassScannerTest.java
@@ -216,6 +216,7 @@ final class PgClassScannerTest {
         List.of(),
         List.of(),
         List.of(),
+        GraphNodeOrigin.SYSTEM,
         Map.of(),
         Optional.empty(),
         hints);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
@@ -326,7 +326,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                   // token.
                   String nextToken = repoNext;
 
-                  if (nextToken.isBlank() && out.size() == want) {
+                  if (nextToken.isBlank() && out.size() == want && sysCount > 0) {
                     // Continue in SYSTEM phase.
                     // lastEmittedRel may be blank if we haven't emitted any SYSTEM yet (bridge
                     // case):

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/loader/NodeLoader.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/loader/NodeLoader.java
@@ -188,6 +188,7 @@ public class NodeLoader {
         List.<SchemaColumn>of(),
         List.<ResourceId>of(),
         List.of(),
+        GraphNodeOrigin.USER,
         view.getPropertiesMap(),
         Optional.empty(),
         NO_ENGINE_HINTS);

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImplSystemViewTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImplSystemViewTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.catalog.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.rpc.DeleteViewRequest;
+import ai.floedb.floecat.catalog.rpc.GetViewRequest;
+import ai.floedb.floecat.catalog.rpc.UpdateViewRequest;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.metagraph.model.EngineHint;
+import ai.floedb.floecat.metagraph.model.EngineHintKey;
+import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
+import ai.floedb.floecat.metagraph.model.ViewNode;
+import ai.floedb.floecat.query.rpc.SchemaColumn;
+import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
+import ai.floedb.floecat.service.repo.impl.ViewRepository;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
+import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
+import com.google.protobuf.FieldMask;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ViewServiceImplSystemViewTest {
+
+  private ViewServiceImpl svc;
+
+  private ViewRepository viewRepo;
+  private PrincipalProvider principal;
+  private Authorizer authz;
+
+  private TestCatalogOverlay overlay;
+
+  @BeforeEach
+  void setup() {
+    svc = new ViewServiceImpl();
+
+    viewRepo = mock(ViewRepository.class);
+    principal = mock(PrincipalProvider.class);
+    authz = mock(Authorizer.class);
+    overlay = new TestCatalogOverlay();
+
+    svc.viewRepo = viewRepo;
+    svc.principal = principal;
+    svc.authz = authz;
+    svc.overlay = overlay;
+    svc.metadataGraph = mock(UserGraph.class);
+
+    var pc = mock(PrincipalContext.class);
+    when(principal.get()).thenReturn(pc);
+    when(pc.getCorrelationId()).thenReturn("corr");
+    when(pc.getAccountId()).thenReturn("acct");
+    doNothing().when(authz).require(any(), anyString());
+  }
+
+  @Test
+  void getView_systemView_usesOverlay_notRepo() {
+    ResourceId viewId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_VIEW)
+            .setId("sys_view_get")
+            .build();
+
+    var catalogId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_CATALOG)
+            .setId("sys_catalog")
+            .build();
+
+    var namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys_namespace")
+            .build();
+
+    var node =
+        new ViewNode(
+            viewId,
+            1L,
+            Instant.now(),
+            catalogId,
+            namespaceId,
+            "sys_view_get",
+            "select 1",
+            "sql",
+            List.<SchemaColumn>of(),
+            List.of(),
+            List.of(),
+            GraphNodeOrigin.SYSTEM,
+            Map.of(),
+            Optional.empty(),
+            Map.<EngineHintKey, EngineHint>of());
+
+    overlay.addNode(node);
+
+    var resp =
+        svc.getView(GetViewRequest.newBuilder().setViewId(viewId).build()).await().indefinitely();
+
+    assertEquals(viewId, resp.getView().getResourceId());
+    assertEquals("sys_view_get", resp.getView().getDisplayName());
+    verifyNoInteractions(viewRepo);
+  }
+
+  @Test
+  void updateView_systemView_permissionDenied() {
+    ResourceId viewId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_VIEW)
+            .setId("sys_view_update")
+            .build();
+
+    overlay.addNode(systemViewNode(viewId));
+
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                svc.updateView(
+                        UpdateViewRequest.newBuilder()
+                            .setViewId(viewId)
+                            .setUpdateMask(FieldMask.newBuilder().addPaths("sql").build())
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.PERMISSION_DENIED, ex.getStatus().getCode());
+    verifyNoInteractions(viewRepo);
+  }
+
+  @Test
+  void deleteView_systemView_permissionDenied() {
+    ResourceId viewId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_VIEW)
+            .setId("sys_view_delete")
+            .build();
+
+    overlay.addNode(systemViewNode(viewId));
+
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                svc.deleteView(DeleteViewRequest.newBuilder().setViewId(viewId).build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.PERMISSION_DENIED, ex.getStatus().getCode());
+    verifyNoInteractions(viewRepo);
+  }
+
+  private ViewNode systemViewNode(ResourceId id) {
+    var catalogId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_CATALOG)
+            .setId("sys_catalog")
+            .build();
+
+    var namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys_namespace")
+            .build();
+
+    return new ViewNode(
+        id,
+        1L,
+        Instant.now(),
+        catalogId,
+        namespaceId,
+        "sys_view_" + id.getId(),
+        "select 1",
+        "sql",
+        List.<SchemaColumn>of(),
+        List.of(),
+        List.of(),
+        GraphNodeOrigin.SYSTEM,
+        Map.of(),
+        Optional.empty(),
+        Map.<EngineHintKey, EngineHint>of());
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
@@ -643,6 +644,7 @@ public class QueryInputResolverTest {
         List.of(),
         baseRelations,
         List.of(),
+        GraphNodeOrigin.USER,
         Map.of(),
         Optional.empty(),
         Map.of());


### PR DESCRIPTION
# Expose SYSTEM views via catalog overlay and enforce immutability in ViewService

This change brings ViewServiceImpl in line with the Table service by making the catalog overlay the source of truth for SYSTEM views.

## Key changes

### Overlay-backed visibility
 - ListViews and GetView now resolve namespaces and views via the catalog overlay, exposing SYSTEM views alongside user views.
- SYSTEM views are materialized directly from overlay nodes and do not hit the repository.

### SYSTEM view immutability
- Update and delete operations now explicitly deny mutations on SYSTEM views.
- Best-effort delete semantics are preserved when callers do not provide meaningful preconditions.

Fixes https://github.com/eng-floe/floecat/issues/127