### PR TITLE
Add TableInfo to fetchScanBundle RPC

### DIFF
--- a/core/proto/src/main/proto/floecat/query/user_scan.proto
+++ b/core/proto/src/main/proto/floecat/query/user_scan.proto
@@ -22,6 +22,7 @@ option java_outer_classname = "QueryScanProto";
 
 import "floecat/common/common.proto";       // ResourceId
 import "floecat/common/predicate.proto";    // Predicate
+import "floecat/catalog/partition.proto";   // PartitionSpecInfo
 import "floecat/execution/scan.proto";      // ScanBundle
 
 /**
@@ -51,8 +52,17 @@ message FetchScanBundleRequest {
   repeated ai.floedb.floecat.common.Predicate predicates = 4;
 }
 
+message TableInfo {
+  ai.floedb.floecat.common.ResourceId table_id = 1;
+  string schema_json = 2;
+  ai.floedb.floecat.catalog.PartitionSpecInfo partition_specs = 3;
+  map<string,string> properties = 4;
+  string metadata_location = 5;
+}
+
 message FetchScanBundleResponse {
   ai.floedb.floecat.execution.ScanBundle bundle = 1;
+  TableInfo table_info = 2;
 }
 
 service QueryScanService {


### PR DESCRIPTION
# Add TableInfo to fetchScanBundle RPC

This PR extends FetchScanBundle to return a snapshot-consistent TableInfo alongside the scan bundle.

The EE needs full table metadata (schema, partition spec, properties, Iceberg metadata location) to initialize scan workers, but currently only has the table_id. 

## Key Changes:
- Adds TableInfo to FetchScanBundleResponse
- Builds metadata from table + snapshot
- Refactors scan bundle construction to use repositories rather than doing internal gRPC 
- Adds integration coverage for returned table metadata

This should allow the EE to directly populate scan InitRequest with no extra catalog calls.

Fixes: https://github.com/eng-floe/core/issues/404 