### PR TITLE
Replace FetchScanBundle with fully streaming scan API 

### DIFF
--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/QueryCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/QueryCliSupport.java
@@ -27,23 +27,29 @@ import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.execution.rpc.ScanFile;
 import ai.floedb.floecat.query.rpc.BeginQueryRequest;
 import ai.floedb.floecat.query.rpc.BeginQueryResponse;
+import ai.floedb.floecat.query.rpc.DataFile;
+import ai.floedb.floecat.query.rpc.DataFileBatch;
+import ai.floedb.floecat.query.rpc.DeleteFileBatch;
 import ai.floedb.floecat.query.rpc.DescribeInputsRequest;
 import ai.floedb.floecat.query.rpc.DescribeInputsResponse;
 import ai.floedb.floecat.query.rpc.EndQueryRequest;
 import ai.floedb.floecat.query.rpc.EndQueryResponse;
 import ai.floedb.floecat.query.rpc.ExpansionMap;
-import ai.floedb.floecat.query.rpc.FetchScanBundleRequest;
 import ai.floedb.floecat.query.rpc.GetQueryRequest;
 import ai.floedb.floecat.query.rpc.GetQueryResponse;
+import ai.floedb.floecat.query.rpc.InitScanRequest;
+import ai.floedb.floecat.query.rpc.InitScanResponse;
 import ai.floedb.floecat.query.rpc.QueryDescriptor;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
 import ai.floedb.floecat.query.rpc.RenewQueryRequest;
 import ai.floedb.floecat.query.rpc.RenewQueryResponse;
+import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.query.rpc.SchemaDescriptor;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
+import ai.floedb.floecat.query.rpc.TableInfo;
 import ai.floedb.floecat.query.rpc.TableObligations;
 import com.google.protobuf.Timestamp;
 import java.io.PrintStream;
@@ -387,19 +393,40 @@ final class QueryCliSupport {
       return;
     }
 
-    var resp =
-        queryScan.fetchScanBundle(
-            FetchScanBundleRequest.newBuilder().setQueryId(queryId).setTableId(tableId).build());
+    InitScanResponse initResp =
+        queryScan.initScan(
+            InitScanRequest.newBuilder().setQueryId(queryId).setTableId(tableId).build());
+    ScanHandle handle = initResp.getHandle();
 
-    if (!resp.hasBundle()) {
-      out.println("query fetch-scan: no bundle returned");
-      return;
+    List<ScanFile> deleteFiles = new ArrayList<>();
+    var deleteStream = queryScan.streamDeleteFiles(handle);
+    while (deleteStream.hasNext()) {
+      DeleteFileBatch batch = deleteStream.next();
+      batch.getItemsList().forEach(deleteFile -> deleteFiles.add(deleteFile.getFile()));
+    }
+
+    List<DataFile> dataFiles = new ArrayList<>();
+    var dataStream = queryScan.streamDataFiles(handle);
+    while (dataStream.hasNext()) {
+      DataFileBatch batch = dataStream.next();
+      dataFiles.addAll(batch.getItemsList());
+    }
+
+    try {
+      queryScan.closeScan(handle);
+    } catch (Exception ignored) {
+      // best-effort cleanup
     }
 
     out.println("query id: " + queryId);
     out.println("table id: " + CliUtils.rid(tableId));
-    printQueryFiles("data_files", resp.getBundle().getDataFilesList(), out);
-    printQueryFiles("delete_files", resp.getBundle().getDeleteFilesList(), out);
+    if (initResp.hasTableInfo()) {
+      TableInfo tableInfo = initResp.getTableInfo();
+      out.println("schema: " + tableInfo.getSchemaJson());
+      out.println("metadata-location: " + tableInfo.getMetadataLocation());
+    }
+    printQueryFiles("data_files", dataFiles.stream().map(DataFile::getFile).toList(), out);
+    printQueryFiles("delete_files", deleteFiles, out);
   }
 
   // --- input option parsing ---

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/QueryCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/QueryCliSupportTest.java
@@ -25,23 +25,27 @@ import ai.floedb.floecat.catalog.rpc.LookupCatalogResponse;
 import ai.floedb.floecat.catalog.rpc.ResolveCatalogRequest;
 import ai.floedb.floecat.catalog.rpc.ResolveCatalogResponse;
 import ai.floedb.floecat.common.rpc.ResourceId;
-import ai.floedb.floecat.execution.rpc.ScanBundle;
 import ai.floedb.floecat.query.rpc.BeginQueryRequest;
 import ai.floedb.floecat.query.rpc.BeginQueryResponse;
+import ai.floedb.floecat.query.rpc.DataFileBatch;
+import ai.floedb.floecat.query.rpc.DeleteFileBatch;
 import ai.floedb.floecat.query.rpc.DescribeInputsRequest;
 import ai.floedb.floecat.query.rpc.DescribeInputsResponse;
 import ai.floedb.floecat.query.rpc.EndQueryRequest;
 import ai.floedb.floecat.query.rpc.EndQueryResponse;
-import ai.floedb.floecat.query.rpc.FetchScanBundleRequest;
-import ai.floedb.floecat.query.rpc.FetchScanBundleResponse;
 import ai.floedb.floecat.query.rpc.GetQueryRequest;
 import ai.floedb.floecat.query.rpc.GetQueryResponse;
+import ai.floedb.floecat.query.rpc.InitScanRequest;
+import ai.floedb.floecat.query.rpc.InitScanResponse;
 import ai.floedb.floecat.query.rpc.QueryDescriptor;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
 import ai.floedb.floecat.query.rpc.RenewQueryRequest;
 import ai.floedb.floecat.query.rpc.RenewQueryResponse;
+import ai.floedb.floecat.query.rpc.ScanHandle;
+import ai.floedb.floecat.query.rpc.TableInfo;
+import com.google.protobuf.Empty;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
 import io.grpc.inprocess.InProcessChannelBuilder;
@@ -282,8 +286,8 @@ class QueryCliSupportTest {
           () -> CATALOG_NAME,
           () -> ACCOUNT_ID);
 
-      assertEquals(1, h.queryScanService.fetchScanBundleCalls.get());
-      assertEquals(QUERY_ID, h.queryScanService.lastFetchScanRequest.getQueryId());
+      assertEquals(1, h.queryScanService.initScanCalls.get());
+      assertEquals(QUERY_ID, h.queryScanService.lastInitScanRequest.getQueryId());
       assertTrue(buf.toString().contains("query id: " + QUERY_ID));
     }
   }
@@ -470,16 +474,44 @@ class QueryCliSupportTest {
   private static final class CapturingQueryScanService
       extends QueryScanServiceGrpc.QueryScanServiceImplBase {
 
-    final AtomicInteger fetchScanBundleCalls = new AtomicInteger();
-    FetchScanBundleRequest lastFetchScanRequest;
+    final AtomicInteger initScanCalls = new AtomicInteger();
+    final AtomicInteger streamDeleteFilesCalls = new AtomicInteger();
+    final AtomicInteger streamDataFilesCalls = new AtomicInteger();
+    final AtomicInteger closeScanCalls = new AtomicInteger();
+    InitScanRequest lastInitScanRequest;
+    final ScanHandle handle = ScanHandle.newBuilder().setId("scan-handle").build();
 
     @Override
-    public void fetchScanBundle(
-        FetchScanBundleRequest request, StreamObserver<FetchScanBundleResponse> responseObserver) {
-      fetchScanBundleCalls.incrementAndGet();
-      lastFetchScanRequest = request;
+    public void initScan(
+        InitScanRequest request, StreamObserver<InitScanResponse> responseObserver) {
+      initScanCalls.incrementAndGet();
+      lastInitScanRequest = request;
       responseObserver.onNext(
-          FetchScanBundleResponse.newBuilder().setBundle(ScanBundle.getDefaultInstance()).build());
+          InitScanResponse.newBuilder()
+              .setHandle(handle)
+              .setTableInfo(TableInfo.getDefaultInstance())
+              .build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void streamDeleteFiles(
+        ScanHandle request, StreamObserver<DeleteFileBatch> responseObserver) {
+      streamDeleteFilesCalls.incrementAndGet();
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void streamDataFiles(
+        ScanHandle request, StreamObserver<DataFileBatch> responseObserver) {
+      streamDataFilesCalls.incrementAndGet();
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void closeScan(ScanHandle request, StreamObserver<Empty> responseObserver) {
+      closeScanCalls.incrementAndGet();
+      responseObserver.onNext(Empty.getDefaultInstance());
       responseObserver.onCompleted();
     }
   }

--- a/connectors/clients/trino/src/test/java/ai/floedb/floecat/client/trino/FloecatSplitManagerTest.java
+++ b/connectors/clients/trino/src/test/java/ai/floedb/floecat/client/trino/FloecatSplitManagerTest.java
@@ -26,21 +26,20 @@ import ai.floedb.floecat.common.rpc.Operator;
 import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
-import ai.floedb.floecat.execution.rpc.ScanBundle;
 import ai.floedb.floecat.execution.rpc.ScanFile;
+import ai.floedb.floecat.execution.rpc.ScanFileContent;
 import ai.floedb.floecat.query.rpc.*;
-
+import com.google.protobuf.Empty;
 import com.google.protobuf.Timestamp;
-
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
-
 import io.trino.plugin.iceberg.ColumnIdentity;
 import io.trino.plugin.iceberg.IcebergColumnHandle;
 import io.trino.plugin.iceberg.IcebergFileFormat;
+import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
@@ -48,24 +47,21 @@ import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.SchemaTableName;
-
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
-
 import io.trino.spi.security.ConnectorIdentity;
-import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.TimeZoneKey;
-
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
+import org.apache.iceberg.FileFormat;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -74,413 +70,516 @@ import org.junit.jupiter.api.Test;
 
 class FloecatSplitManagerTest {
 
-    private static Server server;
-    private static ManagedChannel channel;
+  private static Server server;
+  private static ManagedChannel channel;
 
-    private static LifecycleStub lifecycleStub;
-    private static SchemaStub schemaStub;
-    private static ScanStub scanStub;
-    private static DirectoryStub directoryStub;
+  private static LifecycleStub lifecycleStub;
+  private static SchemaStub schemaStub;
+  private static ScanStub scanStub;
+  private static DirectoryStub directoryStub;
 
-    private static QuerySchemaServiceGrpc.QuerySchemaServiceBlockingStub schema;
-    private static QueryScanServiceGrpc.QueryScanServiceBlockingStub scans;
-    private static QueryServiceGrpc.QueryServiceBlockingStub lifecycle;
-    private static DirectoryServiceGrpc.DirectoryServiceBlockingStub directory;
+  private static QuerySchemaServiceGrpc.QuerySchemaServiceBlockingStub schema;
+  private static QueryScanServiceGrpc.QueryScanServiceBlockingStub scans;
+  private static QueryServiceGrpc.QueryServiceBlockingStub lifecycle;
+  private static DirectoryServiceGrpc.DirectoryServiceBlockingStub directory;
 
-    @BeforeAll
-    static void startServer() throws Exception {
-        lifecycleStub = new LifecycleStub();
-        schemaStub = new SchemaStub();
-        scanStub = new ScanStub();
-        directoryStub = new DirectoryStub();
+  @BeforeAll
+  static void startServer() throws Exception {
+    lifecycleStub = new LifecycleStub();
+    schemaStub = new SchemaStub();
+    scanStub = new ScanStub();
+    directoryStub = new DirectoryStub();
 
-        String serverName = InProcessServerBuilder.generateName();
-        server =
-            InProcessServerBuilder.forName(serverName)
-                .addService(lifecycleStub)
-                .addService(schemaStub)
-                .addService(scanStub)
-                .addService(directoryStub)
-                .build()
-                .start();
+    String serverName = InProcessServerBuilder.generateName();
+    server =
+        InProcessServerBuilder.forName(serverName)
+            .addService(lifecycleStub)
+            .addService(schemaStub)
+            .addService(scanStub)
+            .addService(directoryStub)
+            .build()
+            .start();
 
-        channel = InProcessChannelBuilder.forName(serverName).build();
-        lifecycle = QueryServiceGrpc.newBlockingStub(channel);
-        scans = QueryScanServiceGrpc.newBlockingStub(channel);
-        schema = QuerySchemaServiceGrpc.newBlockingStub(channel);
-        directory = DirectoryServiceGrpc.newBlockingStub(channel);
-    }
+    channel = InProcessChannelBuilder.forName(serverName).build();
+    lifecycle = QueryServiceGrpc.newBlockingStub(channel);
+    scans = QueryScanServiceGrpc.newBlockingStub(channel);
+    schema = QuerySchemaServiceGrpc.newBlockingStub(channel);
+    directory = DirectoryServiceGrpc.newBlockingStub(channel);
+  }
 
-    @AfterAll
-    static void shutdown() {
-        if (channel != null) channel.shutdownNow();
-        if (server != null) server.shutdownNow();
-    }
+  @AfterAll
+  static void shutdown() {
+    if (channel != null) channel.shutdownNow();
+    if (server != null) server.shutdownNow();
+  }
 
-    @AfterEach
-    void resetStub() {
-        scanStub.dataFileFormat = "PARQUET";
-        scanStub.partitionDataJson = null;
-        lifecycleStub.lastBegin = null;
-        schemaStub.lastDescribe = null;
-        scanStub.lastFetch = null;
-    }
+  @AfterEach
+  void resetStub() {
+    scanStub.dataFileFormat = "PARQUET";
+    scanStub.partitionDataJson = null;
+    lifecycleStub.lastBegin = null;
+    schemaStub.lastDescribe = null;
+    scanStub.lastInit = null;
+  }
 
-    @Test
-    void includesSnapshotIdInBeginQuery() {
-        FloecatSplitManager splitManager =
-          new FloecatSplitManager(
-              lifecycle,
-              scans,
-              schema,
-              directory,
-              new CatalogName("test-catalog"),
-              new FloecatConfig());
+  @Test
+  void includesSnapshotIdInBeginQuery() {
+    FloecatSplitManager splitManager =
+        new FloecatSplitManager(
+            lifecycle,
+            scans,
+            schema,
+            directory,
+            new CatalogName("test-catalog"),
+            new FloecatConfig());
 
-        FloecatTableHandle handle =
-            new FloecatTableHandle(
-                new SchemaTableName("s", "t"),
-                "tbl",
-                "account",
-                ResourceKind.RK_TABLE.name(),
-                "s3://bucket/table",
-                "{}",
-                null,
-                "TF_ICEBERG",
-                "catalog",
-                TupleDomain.all(),
-                Set.of("col1"),
-                123L,
-                null);
+    FloecatTableHandle handle =
+        new FloecatTableHandle(
+            new SchemaTableName("s", "t"),
+            "tbl",
+            "account",
+            ResourceKind.RK_TABLE.name(),
+            "s3://bucket/table",
+            "{}",
+            null,
+            "TF_ICEBERG",
+            "catalog",
+            TupleDomain.all(),
+            Set.of("col1"),
+            123L,
+            null);
 
-        ConnectorSession session =
-            new SimpleSession(Map.of(
+    ConnectorSession session =
+        new SimpleSession(
+            Map.of(
                 FloecatSessionProperties.SNAPSHOT_ID, 123L,
                 FloecatSessionProperties.AS_OF_EPOCH_MILLIS, -1L));
 
-        try {
-            splitManager.getSplits(null, session, handle, DynamicFilter.EMPTY, Constraint.alwaysTrue());
-        } catch (Throwable t) {
-            assumeProcessAccessible(t);
-            throw t;
-        }
+    try {
+      splitManager.getSplits(null, session, handle, DynamicFilter.EMPTY, Constraint.alwaysTrue());
+    } catch (Throwable t) {
+      assumeProcessAccessible(t);
+      throw t;
+    }
 
-        QueryInput input = schemaStub.lastDescribe.getInputs(0);
-        assertTrue(input.hasSnapshot());
-        assertEquals(123L, input.getSnapshot().getSnapshotId());
+    QueryInput input = schemaStub.lastDescribe.getInputs(0);
+    assertTrue(input.hasSnapshot());
+    assertEquals(123L, input.getSnapshot().getSnapshotId());
 
-        ResourceId expectedCatalogId = ResourceId.newBuilder()
+    ResourceId expectedCatalogId =
+        ResourceId.newBuilder()
             .setId("catalog-id")
             .setAccountId("account")
             .setKind(ResourceKind.RK_CATALOG)
             .build();
-        assertEquals(expectedCatalogId, lifecycleStub.lastBegin.getDefaultCatalogId());
+    assertEquals(expectedCatalogId, lifecycleStub.lastBegin.getDefaultCatalogId());
+  }
+
+  @Test
+  void includesAsOfInBeginQuery() {
+    FloecatSplitManager splitManager =
+        new FloecatSplitManager(
+            lifecycle,
+            scans,
+            schema,
+            directory,
+            new CatalogName("test-catalog"),
+            new FloecatConfig());
+
+    long asOf = 1_700_000_000_000L;
+
+    FloecatTableHandle handle =
+        new FloecatTableHandle(
+            new SchemaTableName("s", "t"),
+            "tbl",
+            "account",
+            ResourceKind.RK_TABLE.name(),
+            "s3://bucket/table",
+            "{}",
+            null,
+            "TF_ICEBERG",
+            "catalog",
+            TupleDomain.all(),
+            Set.of("col1"),
+            null,
+            asOf);
+
+    ConnectorSession session =
+        new SimpleSession(
+            Map.of(
+                FloecatSessionProperties.SNAPSHOT_ID,
+                -1L,
+                FloecatSessionProperties.AS_OF_EPOCH_MILLIS,
+                asOf));
+
+    try {
+      splitManager.getSplits(null, session, handle, DynamicFilter.EMPTY, Constraint.alwaysTrue());
+    } catch (Throwable t) {
+      assumeProcessAccessible(t);
+      throw t;
     }
 
-    @Test
-    void includesAsOfInBeginQuery() {
-        FloecatSplitManager splitManager =
-            new FloecatSplitManager(
-                lifecycle,
-                scans,
-                schema,
-                directory,
-                new CatalogName("test-catalog"),
-                new FloecatConfig());
+    QueryInput input = schemaStub.lastDescribe.getInputs(0);
+    Timestamp ts = input.getSnapshot().getAsOf();
+    long millis = ts.getSeconds() * 1000L + ts.getNanos() / 1_000_000;
 
-        long asOf = 1_700_000_000_000L;
+    assertEquals(asOf, millis);
 
-        FloecatTableHandle handle =
-            new FloecatTableHandle(
-                new SchemaTableName("s", "t"),
-                "tbl",
-                "account",
-                ResourceKind.RK_TABLE.name(),
-                "s3://bucket/table",
-                "{}",
-                null,
-                "TF_ICEBERG",
-                "catalog",
-                TupleDomain.all(),
-                Set.of("col1"),
-                null,
-                asOf);
-
-        ConnectorSession session =
-            new SimpleSession(Map.of(
-                FloecatSessionProperties.SNAPSHOT_ID, -1L,
-                FloecatSessionProperties.AS_OF_EPOCH_MILLIS, asOf));
-
-        try {
-            splitManager.getSplits(null, session, handle, DynamicFilter.EMPTY, Constraint.alwaysTrue());
-        } catch (Throwable t) {
-            assumeProcessAccessible(t);
-            throw t;
-        }
-
-        QueryInput input = schemaStub.lastDescribe.getInputs(0);
-        Timestamp ts = input.getSnapshot().getAsOf();
-        long millis = ts.getSeconds() * 1000L + ts.getNanos() / 1_000_000;
-
-        assertEquals(asOf, millis);
-
-        ResourceId expectedCatalogId = ResourceId.newBuilder()
+    ResourceId expectedCatalogId =
+        ResourceId.newBuilder()
             .setId("catalog-id")
             .setAccountId("account")
             .setKind(ResourceKind.RK_CATALOG)
             .build();
-        assertEquals(expectedCatalogId, lifecycleStub.lastBegin.getDefaultCatalogId());
-    }
+    assertEquals(expectedCatalogId, lifecycleStub.lastBegin.getDefaultCatalogId());
+  }
 
-    @Test
-    void buildsPredicatesAndRequiredColumnsFromDomains() throws Exception {
-        FloecatSplitManager splitManager =
-            new FloecatSplitManager(
-                lifecycle,
-                scans,
-                schema,
-                directory,
-                new CatalogName("test-catalog"),
-                new FloecatConfig());
+  @Test
+  void buildsPredicatesAndRequiredColumnsFromDomains() throws Exception {
+    FloecatSplitManager splitManager =
+        new FloecatSplitManager(
+            lifecycle,
+            scans,
+            schema,
+            directory,
+            new CatalogName("test-catalog"),
+            new FloecatConfig());
 
-        IcebergColumnHandle idCol =
-            new IcebergColumnHandle(
-                ColumnIdentity.primitiveColumnIdentity(1, "id"),
-                BigintType.BIGINT,
-                List.of(),
-                BigintType.BIGINT,
-                false,
-                Optional.empty());
+    IcebergColumnHandle idCol =
+        new IcebergColumnHandle(
+            ColumnIdentity.primitiveColumnIdentity(1, "id"),
+            BigintType.BIGINT,
+            List.of(),
+            BigintType.BIGINT,
+            false,
+            Optional.empty());
 
-        IcebergColumnHandle bucketCol =
-            new IcebergColumnHandle(
-                ColumnIdentity.primitiveColumnIdentity(2, "bucket"),
-                BigintType.BIGINT,
-                List.of(),
-                BigintType.BIGINT,
-                false,
-                Optional.empty());
+    IcebergColumnHandle bucketCol =
+        new IcebergColumnHandle(
+            ColumnIdentity.primitiveColumnIdentity(2, "bucket"),
+            BigintType.BIGINT,
+            List.of(),
+            BigintType.BIGINT,
+            false,
+            Optional.empty());
 
-        TupleDomain<IcebergColumnHandle> enforced =
-            TupleDomain.withColumnDomains(Map.of(idCol, Domain.singleValue(BigintType.BIGINT, 7L)));
+    TupleDomain<IcebergColumnHandle> enforced =
+        TupleDomain.withColumnDomains(Map.of(idCol, Domain.singleValue(BigintType.BIGINT, 7L)));
 
-        FloecatTableHandle handle =
-            new FloecatTableHandle(
-                new SchemaTableName("s", "t"),
-                "tbl",
-                "account",
-                ResourceKind.RK_TABLE.name(),
-                "s3://bucket/table",
-                "{}",
-                null,
-                "TF_ICEBERG",
-                "catalog",
-                enforced,
-                Set.of("projected"),
-                123L,
-                null);
+    FloecatTableHandle handle =
+        new FloecatTableHandle(
+            new SchemaTableName("s", "t"),
+            "tbl",
+            "account",
+            ResourceKind.RK_TABLE.name(),
+            "s3://bucket/table",
+            "{}",
+            null,
+            "TF_ICEBERG",
+            "catalog",
+            enforced,
+            Set.of("projected"),
+            123L,
+            null);
 
-        Map<ColumnHandle, Domain> constraintDomains =
-            Map.of((ColumnHandle) bucketCol,
-                Domain.create(ValueSet.ofRanges(Range.greaterThan(BigintType.BIGINT, 4L)), false));
+    Map<ColumnHandle, Domain> constraintDomains =
+        Map.of(
+            (ColumnHandle) bucketCol,
+            Domain.create(ValueSet.ofRanges(Range.greaterThan(BigintType.BIGINT, 4L)), false));
 
-        Constraint constraint =
-            new Constraint(TupleDomain.withColumnDomains(constraintDomains));
+    Constraint constraint = new Constraint(TupleDomain.withColumnDomains(constraintDomains));
 
-        ConnectorSession session =
-            new SimpleSession(Map.of(
+    ConnectorSession session =
+        new SimpleSession(
+            Map.of(
                 FloecatSessionProperties.SNAPSHOT_ID, 123L,
                 FloecatSessionProperties.AS_OF_EPOCH_MILLIS, -1L));
 
-        ConnectorSplitSource splitSource;
+    ConnectorSplitSource splitSource;
 
-        try {
-            splitSource =
-                splitManager.getSplits(null, session, handle, DynamicFilter.EMPTY, constraint);
-        } catch (Throwable t) {
-            assumeProcessAccessible(t);
-            throw t;
-        }
+    try {
+      splitSource = splitManager.getSplits(null, session, handle, DynamicFilter.EMPTY, constraint);
+    } catch (Throwable t) {
+      assumeProcessAccessible(t);
+      throw t;
+    }
 
-        assertTrue(
-            scanStub.lastFetch.getRequiredColumnsList()
-                .containsAll(List.of("id", "bucket", "projected")));
+    assertTrue(
+        scanStub
+            .lastInit
+            .getRequiredColumnsList()
+            .containsAll(List.of("id", "bucket", "projected")));
 
-        assertEquals(4, scanStub.lastFetch.getPredicatesCount());
+    assertEquals(4, scanStub.lastInit.getPredicatesCount());
 
-        assertTrue(
-            scanStub.lastFetch.getPredicatesList().stream()
-                .anyMatch(p -> p.getColumn().equals("id")
-                    && p.getOp() == Operator.OP_EQ));
+    assertTrue(
+        scanStub.lastInit.getPredicatesList().stream()
+            .anyMatch(p -> p.getColumn().equals("id") && p.getOp() == Operator.OP_EQ));
 
-        assertTrue(
-            scanStub.lastFetch.getPredicatesList().stream()
-                .anyMatch(p -> p.getColumn().equals("bucket")
-                    && (p.getOp() == Operator.OP_GT || p.getOp() == Operator.OP_IS_NOT_NULL)));
+    assertTrue(
+        scanStub.lastInit.getPredicatesList().stream()
+            .anyMatch(
+                p ->
+                    p.getColumn().equals("bucket")
+                        && (p.getOp() == Operator.OP_GT || p.getOp() == Operator.OP_IS_NOT_NULL)));
 
-        List<ConnectorSplit> splits =
-            splitSource.getNextBatch(10).get().getSplits();
-        assertEquals(1, splits.size());
+    List<ConnectorSplit> splits = splitSource.getNextBatch(10).get().getSplits();
+    assertEquals(1, splits.size());
 
-        ResourceId expectedCatalogId = ResourceId.newBuilder()
+    ResourceId expectedCatalogId =
+        ResourceId.newBuilder()
             .setId("catalog-id")
             .setAccountId("account")
             .setKind(ResourceKind.RK_CATALOG)
             .build();
-        assertEquals(expectedCatalogId, lifecycleStub.lastBegin.getDefaultCatalogId());
-    }
+    assertEquals(expectedCatalogId, lifecycleStub.lastBegin.getDefaultCatalogId());
+  }
 
-    @Test
-    void defaultsFormatAndPartitionDataWhenMissing() throws Exception {
-        scanStub.dataFileFormat = "ORC";
-        scanStub.partitionDataJson = "";
+  @Test
+  void defaultsFormatAndPartitionDataWhenMissing() throws Exception {
+    scanStub.dataFileFormat = "ORC";
+    scanStub.partitionDataJson = "";
 
-        FloecatSplitManager splitManager =
-            new FloecatSplitManager(
-                lifecycle,
-                scans,
-                schema,
-                directory,
-                new CatalogName("test-catalog"),
-                new FloecatConfig());
+    FloecatSplitManager splitManager =
+        new FloecatSplitManager(
+            lifecycle,
+            scans,
+            schema,
+            directory,
+            new CatalogName("test-catalog"),
+            new FloecatConfig());
 
-        FloecatTableHandle handle =
-            new FloecatTableHandle(
-                new SchemaTableName("s", "t"),
-                "tbl",
-                "account",
-                ResourceKind.RK_TABLE.name(),
-                "s3://bucket/table",
-                "{}",
-                null,
-                "TF_ICEBERG",
-                "catalog",
-                TupleDomain.all(),
-                Set.of(),
-                null,
-                null);
+    FloecatTableHandle handle =
+        new FloecatTableHandle(
+            new SchemaTableName("s", "t"),
+            "tbl",
+            "account",
+            ResourceKind.RK_TABLE.name(),
+            "s3://bucket/table",
+            "{}",
+            null,
+            "TF_ICEBERG",
+            "catalog",
+            TupleDomain.all(),
+            Set.of(),
+            null,
+            null);
 
-        ConnectorSession session =
-            new SimpleSession(Map.of(
+    ConnectorSession session =
+        new SimpleSession(
+            Map.of(
                 FloecatSessionProperties.SNAPSHOT_ID, -1L,
                 FloecatSessionProperties.AS_OF_EPOCH_MILLIS, -1L));
 
-        ConnectorSplitSource splitSource;
+    ConnectorSplitSource splitSource;
 
-        try {
-            splitSource =
-                splitManager.getSplits(null, session, handle, DynamicFilter.EMPTY, Constraint.alwaysTrue());
-        } catch (Throwable t) {
-            assumeProcessAccessible(t);
-            throw t;
-        }
+    try {
+      splitSource =
+          splitManager.getSplits(
+              null, session, handle, DynamicFilter.EMPTY, Constraint.alwaysTrue());
+    } catch (Throwable t) {
+      assumeProcessAccessible(t);
+      throw t;
+    }
 
-        ConnectorSplit split =
-            splitSource.getNextBatch(10).get().getSplits().getFirst();
+    ConnectorSplit split = splitSource.getNextBatch(10).get().getSplits().getFirst();
 
-        io.trino.plugin.iceberg.IcebergSplit iceberg =
-            (io.trino.plugin.iceberg.IcebergSplit) split;
+    io.trino.plugin.iceberg.IcebergSplit iceberg = (io.trino.plugin.iceberg.IcebergSplit) split;
 
-        assertEquals("{\"partitionValues\":[]}", iceberg.getPartitionDataJson());
-        assertEquals(IcebergFileFormat.ORC, iceberg.getFileFormat());
+    assertEquals("{\"partitionValues\":[]}", iceberg.getPartitionDataJson());
+    assertEquals(IcebergFileFormat.ORC, iceberg.getFileFormat());
 
-        ResourceId expectedCatalogId = ResourceId.newBuilder()
+    ResourceId expectedCatalogId =
+        ResourceId.newBuilder()
             .setId("catalog-id")
             .setAccountId("account")
             .setKind(ResourceKind.RK_CATALOG)
             .build();
-        assertEquals(expectedCatalogId, lifecycleStub.lastBegin.getDefaultCatalogId());
+    assertEquals(expectedCatalogId, lifecycleStub.lastBegin.getDefaultCatalogId());
+  }
+
+  private static class SimpleSession implements ConnectorSession {
+    private final Map<String, Object> props;
+
+    SimpleSession(Map<String, Object> props) {
+      this.props = props;
     }
 
-    private static class SimpleSession implements ConnectorSession {
-        private final Map<String, Object> props;
-        SimpleSession(Map<String, Object> props) { this.props = props; }
-        @Override public String getQueryId() { return "query"; }
-        @Override public Optional<String> getSource() { return Optional.empty(); }
-        @Override public ConnectorIdentity getIdentity() { return ConnectorIdentity.ofUser("user"); }
-        @Override public TimeZoneKey getTimeZoneKey() { return TimeZoneKey.UTC_KEY; }
-        @Override public Locale getLocale() { return Locale.US; }
-        @Override public Optional<String> getTraceToken() { return Optional.empty(); }
-        @Override public Instant getStart() { return Instant.EPOCH; }
-        @SuppressWarnings("unchecked")
-        @Override public <T> T getProperty(String name, Class<T> type) { return (T) props.get(name); }
+    @Override
+    public String getQueryId() {
+      return "query";
     }
 
-    private static class DirectoryStub extends DirectoryServiceGrpc.DirectoryServiceImplBase {
-        public void resolveCatalog(
-            ResolveCatalogRequest request,
-            StreamObserver<ResolveCatalogResponse> responseObserver) {
-            ResourceId catalogId = ResourceId.newBuilder()
-                .setId("catalog-id")
-                .setAccountId("account")
-                .setKind(ResourceKind.RK_CATALOG)
-                .build();
-            responseObserver.onNext(ResolveCatalogResponse.newBuilder().setResourceId(catalogId).build());
-            responseObserver.onCompleted();
-        }
+    @Override
+    public Optional<String> getSource() {
+      return Optional.empty();
     }
 
-    private static class LifecycleStub extends QueryServiceGrpc.QueryServiceImplBase {
-        volatile BeginQueryRequest lastBegin;
-        @Override
-        public void beginQuery(
-            BeginQueryRequest request,
-            StreamObserver<BeginQueryResponse> responseObserver) {
-            this.lastBegin = request;
-            QueryDescriptor d = QueryDescriptor.newBuilder().setQueryId("q").build();
-            responseObserver.onNext(BeginQueryResponse.newBuilder().setQuery(d).build());
-            responseObserver.onCompleted();
-        }
+    @Override
+    public ConnectorIdentity getIdentity() {
+      return ConnectorIdentity.ofUser("user");
     }
 
-    private static class SchemaStub extends QuerySchemaServiceGrpc.QuerySchemaServiceImplBase {
-        volatile DescribeInputsRequest lastDescribe;
-        @Override
-        public void describeInputs(
-            DescribeInputsRequest request,
-            StreamObserver<DescribeInputsResponse> responseObserver) {
-            this.lastDescribe = request;
-            responseObserver.onNext(DescribeInputsResponse.newBuilder().build());
-            responseObserver.onCompleted();
-        }
+    @Override
+    public TimeZoneKey getTimeZoneKey() {
+      return TimeZoneKey.UTC_KEY;
     }
 
-    private static class ScanStub extends QueryScanServiceGrpc.QueryScanServiceImplBase {
-        volatile FetchScanBundleRequest lastFetch;
-        volatile String dataFileFormat = "PARQUET";
-        volatile String partitionDataJson;
-        @Override
-        public void fetchScanBundle(
-            FetchScanBundleRequest request,
-            StreamObserver<FetchScanBundleResponse> responseObserver) {
-            this.lastFetch = request;
-            ScanFile.Builder f =
-                ScanFile.newBuilder()
-                    .setFilePath("/tmp/file")
-                    .setFileFormat(dataFileFormat)
-                    .setFileSizeInBytes(10)
-                    .setRecordCount(1);
-            if (partitionDataJson != null)
-                f.setPartitionDataJson(partitionDataJson);
-            ScanBundle bundle =
-                ScanBundle.newBuilder().addDataFiles(f.build()).build();
-            responseObserver.onNext(
-                FetchScanBundleResponse.newBuilder()
-                    .setBundle(bundle)
-                    .build());
-            responseObserver.onCompleted();
-        }
+    @Override
+    public Locale getLocale() {
+      return Locale.US;
     }
 
-    private static void assumeProcessAccessible(Throwable t) {
-        Throwable c = t;
-        while (c != null) {
-            String msg = c.getMessage();
-            if (msg != null &&
-                msg.contains("io.smallrye.common.os.Process")) {
-                Assumptions.assumeTrue(false);
-            }
-            c = c.getCause();
-        }
+    @Override
+    public Optional<String> getTraceToken() {
+      return Optional.empty();
     }
+
+    @Override
+    public Instant getStart() {
+      return Instant.EPOCH;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getProperty(String name, Class<T> type) {
+      return (T) props.get(name);
+    }
+  }
+
+  private static class DirectoryStub extends DirectoryServiceGrpc.DirectoryServiceImplBase {
+    public void resolveCatalog(
+        ResolveCatalogRequest request, StreamObserver<ResolveCatalogResponse> responseObserver) {
+      ResourceId catalogId =
+          ResourceId.newBuilder()
+              .setId("catalog-id")
+              .setAccountId("account")
+              .setKind(ResourceKind.RK_CATALOG)
+              .build();
+      responseObserver.onNext(ResolveCatalogResponse.newBuilder().setResourceId(catalogId).build());
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Test
+  void resolveDeleteIdsUsesExplicitList() throws Exception {
+    Method resolveDeleteFiles =
+        FloecatSplitManager.class.getDeclaredMethod("resolveDeleteFiles", DeleteRef.class, Map.class);
+    resolveDeleteFiles.setAccessible(true);
+    io.trino.plugin.iceberg.delete.DeleteFile trinoDeleteFile =
+        new io.trino.plugin.iceberg.delete.DeleteFile(
+            org.apache.iceberg.FileContent.EQUALITY_DELETES,
+            "/tmp/delete",
+            org.apache.iceberg.FileFormat.PARQUET,
+            1,
+            2,
+            List.of(0),
+            Optional.empty(),
+            Optional.empty(),
+            0);
+    Map<Integer, io.trino.plugin.iceberg.delete.DeleteFile> deleteById =
+        Map.of(42, trinoDeleteFile);
+    DeleteRef deleteRef =
+        DeleteRef.newBuilder().setDeleteIds(DeleteIdList.newBuilder().addIds(42).build()).build();
+    @SuppressWarnings("unchecked")
+    List<io.trino.plugin.iceberg.delete.DeleteFile> resolved =
+        (List<io.trino.plugin.iceberg.delete.DeleteFile>)
+            resolveDeleteFiles.invoke(null, deleteRef, deleteById);
+    assertEquals(1, resolved.size());
+    assertEquals(trinoDeleteFile, resolved.get(0));
+  }
+
+  private static class LifecycleStub extends QueryServiceGrpc.QueryServiceImplBase {
+    volatile BeginQueryRequest lastBegin;
+
+    @Override
+    public void beginQuery(
+        BeginQueryRequest request, StreamObserver<BeginQueryResponse> responseObserver) {
+      this.lastBegin = request;
+      QueryDescriptor d = QueryDescriptor.newBuilder().setQueryId("q").build();
+      responseObserver.onNext(BeginQueryResponse.newBuilder().setQuery(d).build());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static class SchemaStub extends QuerySchemaServiceGrpc.QuerySchemaServiceImplBase {
+    volatile DescribeInputsRequest lastDescribe;
+
+    @Override
+    public void describeInputs(
+        DescribeInputsRequest request, StreamObserver<DescribeInputsResponse> responseObserver) {
+      this.lastDescribe = request;
+      responseObserver.onNext(DescribeInputsResponse.newBuilder().build());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static class ScanStub extends QueryScanServiceGrpc.QueryScanServiceImplBase {
+    volatile InitScanRequest lastInit;
+    volatile String dataFileFormat = "PARQUET";
+    volatile String partitionDataJson;
+    final ScanHandle handle = ScanHandle.newBuilder().setId("test-handle").build();
+
+    @Override
+    public void initScan(
+        InitScanRequest request, StreamObserver<InitScanResponse> responseObserver) {
+      this.lastInit = request;
+      responseObserver.onNext(
+          InitScanResponse.newBuilder()
+              .setHandle(handle)
+              .setTableInfo(TableInfo.newBuilder().setTableId(request.getTableId()).build())
+              .build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void streamDeleteFiles(
+        ScanHandle requestHandle, StreamObserver<DeleteFileBatch> responseObserver) {
+      DeleteFile deleteFile =
+          DeleteFile.newBuilder()
+              .setDeleteId(0)
+              .setFile(
+                  ScanFile.newBuilder().setFilePath("/tmp/delete").setFileFormat("PARQUET").build())
+              .build();
+      responseObserver.onNext(DeleteFileBatch.newBuilder().addItems(deleteFile).build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void streamDataFiles(
+        ScanHandle requestHandle, StreamObserver<DataFileBatch> responseObserver) {
+      ScanFile.Builder f =
+          ScanFile.newBuilder()
+              .setFilePath("/tmp/file")
+              .setFileFormat(dataFileFormat)
+              .setFileSizeInBytes(10)
+              .setRecordCount(1);
+      if (partitionDataJson != null) f.setPartitionDataJson(partitionDataJson);
+      ScanFile scanFile = f.build();
+      DataFile dataFile =
+          DataFile.newBuilder()
+              .setFile(scanFile)
+              .setDeletes(DeleteRef.newBuilder().setAllDeletes(true).build())
+              .build();
+      responseObserver.onNext(DataFileBatch.newBuilder().addItems(dataFile).build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void closeScan(ScanHandle requestHandle, StreamObserver<Empty> responseObserver) {
+      responseObserver.onNext(Empty.newBuilder().build());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static void assumeProcessAccessible(Throwable t) {
+    Throwable c = t;
+    while (c != null) {
+      String msg = c.getMessage();
+      if (msg != null && msg.contains("io.smallrye.common.os.Process")) {
+        Assumptions.assumeTrue(false);
+      }
+      c = c.getCause();
+    }
+  }
 }

--- a/core/proto/src/main/proto/floecat/query/user_scan.proto
+++ b/core/proto/src/main/proto/floecat/query/user_scan.proto
@@ -20,10 +20,11 @@ option java_multiple_files = true;
 option java_package = "ai.floedb.floecat.query.rpc";
 option java_outer_classname = "QueryScanProto";
 
-import "floecat/common/common.proto";       // ResourceId
-import "floecat/common/predicate.proto";    // Predicate
-import "floecat/catalog/partition.proto";   // PartitionSpecInfo
-import "floecat/execution/scan.proto";      // ScanBundle
+import "floecat/common/common.proto";
+import "floecat/common/predicate.proto";
+import "floecat/catalog/partition.proto";
+import "floecat/execution/scan.proto";
+import "google/protobuf/empty.proto";
 
 /**
  * QUERY FILE SCAN SERVICE
@@ -39,37 +40,116 @@ import "floecat/execution/scan.proto";      // ScanBundle
  *   - Predicate evaluation is conservative (may over-select files)
  *   - Never filters rows
  */
-message FetchScanBundleRequest {
-  string query_id = 1;
+service QueryScanService {
+  // Open a scan handle for the query/table pair, supplying required metadata before streams.
+  rpc InitScan(InitScanRequest) returns (InitScanResponse);
 
-  // The table whose bundle is being fetched.
-  ai.floedb.floecat.common.ResourceId table_id = 2;
+  // Stream delete files for the pinned snapshot. Delete batches must be fully consumed before
+  // invoking StreamDataFiles; the server rejects StreamDataFiles with FAILED_PRECONDITION otherwise.
+  rpc StreamDeleteFiles(ScanHandle) returns (stream DeleteFileBatch);
 
-  // Needed columns; all other column stats are dropped.
-  repeated string required_columns = 3;
+  // Stream data files and their delete references (all delete files if all_deletes=true).
+  rpc StreamDataFiles(ScanHandle) returns (stream DataFileBatch);
 
-  // Logical predicates used for file-level pruning.
-  repeated ai.floedb.floecat.common.Predicate predicates = 4;
-
-  // When true, return only table_info and omit scan bundle materialization.
-  bool metadata_only = 5;
+  // Close the scan handle and release server-side resources.
+  rpc CloseScan(ScanHandle) returns (google.protobuf.Empty);
 }
 
 message TableInfo {
+  // Table identity and metadata for the scan. Clients should use this schema/partition info
+  // when planning downstream execution.
   ai.floedb.floecat.common.ResourceId table_id = 1;
+
+  // Full schema JSON
   string schema_json = 2;
+
+  // Partition spec that matches the pinned snapshot.
   ai.floedb.floecat.catalog.PartitionSpecInfo partition_specs = 3;
+
+  // Table properties
   map<string,string> properties = 4;
+
+  // Optional Iceberg table metadata location for clients that pass FileIO directly.
   string metadata_location = 5;
   int64 snapshot_id = 6;
 }
 
-message FetchScanBundleResponse {
-  ai.floedb.floecat.execution.ScanBundle bundle = 1;
+message ScanHandle {
+  // Opaque scan identifier returned by InitScan and consumed by stream/close RPCs.
+  string id = 1;
+}
+
+message InitScanRequest {
+  // Query identifier. The query must exist and have pinned snapshots.
+  string query_id = 1;
+
+  // Table resource to scan.
+  ai.floedb.floecat.common.ResourceId table_id = 2;
+
+  // Optional list of columns clients need for pruning / column stats.
+  repeated string required_columns = 3;
+
+  // Optional predicates that should be applied during ScanPruningUtils pruning.
+  repeated ai.floedb.floecat.common.Predicate predicates = 4;
+
+  // Requested upper bound on batch item count (default 1k).
+  uint32 target_batch_items = 10;
+
+  // Requested rough batch size in bytes (approximate).
+  // This uses the file size on disk, not the serialized gRPC payload.
+  uint32 target_batch_bytes = 11;
+
+  // Whether to include column stats in emitted ScanFile metadata (default false).
+  bool include_column_stats = 20;
+
+  // Whether the client wants partition_data_json stripped from ScanFiles (default false → keep it).
+  bool exclude_partition_data_json = 21;
+}
+
+message InitScanResponse {
+  // Handle used for the subsequent delete/data streams.
+  ScanHandle handle = 1;
+
+  // Metadata for the Table (schema/partition info) that clients will read before streaming.
   TableInfo table_info = 2;
 }
 
-service QueryScanService {
-  rpc FetchScanBundle(FetchScanBundleRequest)
-      returns (FetchScanBundleResponse);
+message DeleteFile {
+  // Streaming sequence number per delete file so DataFile.delete_ids can reference it.
+  uint32 delete_id = 1;
+
+  // Catalog ScanFile metadata for the delete.
+  ai.floedb.floecat.execution.ScanFile file = 2;
+}
+
+message DeleteFileBatch {
+  // Delete files emitted in this batch.
+  repeated DeleteFile items = 1;
+}
+
+message DeleteRef {
+  oneof mode {
+    // Indicates all delete files provided by StreamDeleteFiles should be applied to this data file.
+    // When no delete files exist, all_deletes behaves like an empty set (no-op).
+    bool all_deletes = 1;
+
+    // Specific subset of indexed delete IDs that apply to this data file.
+    DeleteIdList delete_ids = 2;
+  }
+}
+
+message DeleteIdList {
+  repeated uint32 ids = 1;
+}
+
+message DataFile {
+  // Data file metadata.
+  ai.floedb.floecat.execution.ScanFile file = 1;
+
+  // Optional delete reference describing which deletes should be applied to this file.
+  DeleteRef deletes = 2;
+}
+
+message DataFileBatch {
+  repeated DataFile items = 1;
 }

--- a/docs/connectors-spi.md
+++ b/docs/connectors-spi.md
@@ -165,7 +165,7 @@ reconciler (long-running); connectors must tolerate repeated instantiation and r
   block, iterates `listTables`, calls `enumerateSnapshots` for metadata/snapshot ingestion, and
   routes stats capture through the stats control plane (which uses
   `captureSnapshotTargetStats` in native engines).
-- **Query lifecycle** – `QueryService.FetchScanBundle` fetch file lists pinned to the requested snapshot
+- **Query lifecycle** – `QueryScanService` streams file lists pinned to the requested snapshot
 directly from table and file statistics stored in the catalog (via TableStatisticsService).
 
 ## Cross-References

--- a/docs/iceberg-rest-gateway.md
+++ b/docs/iceberg-rest-gateway.md
@@ -138,7 +138,7 @@ short bounded confirmation poll before returning unknown-state errors. Poll beha
 
 ## Scan Planning & Task Consumption
 
-1. `TablePlanService` resolves the table ID, applies snapshot filters (start/end snapshot, stats fields, filter expressions), and issues `BeginQuery` + `FetchScanBundle` against Floecat’s `QueryService`.
+1. `TablePlanService` resolves the table ID, applies snapshot filters (start/end snapshot, stats fields, filter expressions), and issues `BeginQuery` plus `QueryScanService` streaming scan RPCs against Floecat.
 2. The resulting plan bundle is immediately completed (no async state today). `PlanTaskManager` registers the descriptor (plan-id, namespace, table, credentials, delete files) and chunks file scan tasks into deterministic task IDs (`{planId}-task-{n}`) based on configured chunk size.
 3. `/tables/{table}/plan` returns the plan descriptor, aggregated file scan tasks, delete files, storage credentials, and the list of `planTasks`.
 4. `/tables/{table}/tasks` accepts a `planTask` ID and consumes it exactly once, returning only the payload for that task. Invalid/consumed IDs return Iceberg-style 404 responses.

--- a/docs/metadata-graph.md
+++ b/docs/metadata-graph.md
@@ -196,8 +196,8 @@ shares the same `QueryContext` as the other query RPCs and relies on `CatalogOve
 `snapshotPinFor`, and view metadata stored in `ViewNode` to produce canonical names, pruned schemas,
 and view definitions without issuing a second RPC batch.
 Resolved tables/views also go through `QueryInputResolver` so their snapshot pins are merged into
-`QueryContext` before the response hits the planner—`FetchScanBundle` can therefore find the same
-pins later in the lifecycle. Builtins remain behind `GetSystemObjects`; the `information_schema`/`pg_catalog`
+`QueryContext` before the response hits the planner—`QueryScanService.InitScan` can therefore find
+the same pins later in the lifecycle. Builtins remain behind `GetSystemObjects`; the `information_schema`/`pg_catalog`
 relations are materialized in the engine-specific overlays for `_system` scans but do not appear in the RPC
 response to avoid exposing synthetic tables twice.
 Column decorations are surfaced per column via `RelationInfo.columns[*]` (`ColumnResult`), so a relation can

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -51,7 +51,9 @@ CLI, and reconciler.
 | `DirectoryService` | `Resolve*` & `Lookup*` RPCs | Translates between names and `ResourceId`s with pagination for batched lookups. |
 | `AccountService` | Account CRUD. |
 | `Connectors` | Connector CRUD, `ValidateConnector`, `StartCapture`, `GetReconcileJob`. |
-| `QueryService` | `BeginQuery`, `RenewQuery`, `EndQuery`, `GetQuery`, `FetchScanBundle`. |
+| `QueryService` | `BeginQuery`, `RenewQuery`, `EndQuery`, `GetQuery`. |
+| `QuerySchemaService` | `DescribeInputs`. |
+| `QueryScanService` | `InitScan`, `StreamDeleteFiles`, `StreamDataFiles`, `CloseScan`. |
 | `ReconcileControl` | `CaptureNow`, `StartCapture`, `GetReconcileJob`, `GetReconcileJobTree`, `ListReconcileJobs`, `GetFinalizedSnapshotStatus`, `CancelReconcileJob`, `GetReconcilerSettings`, `UpdateReconcilerSettings` | Client-facing reconcile control plane for synchronous execution, queued jobs, finalized snapshot status lookup, cancellation, and automatic reconcile defaults. `GetFinalizedSnapshotStatus` returns `FSS_PENDING` when no finalized snapshot record exists yet for the requested table/snapshot pair; `FSS_FINALIZED` includes `finalized_at` and `finalizer_job_id`. |
 | `ReconcileExecutorControl` | `LeaseReconcileJob`, `GetLeasedPlan*Input`, `SubmitLeasedPlan*Result`, `GetLeasedFileGroupExecution`, `SubmitLeasedFileGroupExecutionResult` | Executor-facing lease protocol for split reconcile workers. Carries typed planner and file-group payloads plus progress, cancellation, and completion RPCs. |
 | `PlannerStatsService` | `GetTargetStats`, `GetTableConstraints` | Split planner-facing streams for target stats and table constraints; `GetTargetStats(include_constraints=true)` remains as a combined single-roundtrip convenience mode. |
@@ -66,8 +68,8 @@ before hitting repository storage.
 `query/lifecycle.proto` captures everything the planner needs to hold a lease:
 - `QueryDescriptor` mirrors the live query context (IDs, expiry timestamps, snapshot pins, expansion
   maps, and table obligations). Per-table scan manifests are retrieved lazily via
-  `QueryService.FetchScanBundle`, which returns the `execution/scan.proto` records for a specific
-  table.
+  `QueryScanService`: clients call `InitScan`, fully consume `StreamDeleteFiles`, then consume
+  `StreamDataFiles` for a specific table before `CloseScan`.
 
 `execution/scan.proto` describes the scan inputs that executors consume:
 - `ScanFile` entries include the file path, size, record count, format, per-column stats, and whether
@@ -137,9 +139,10 @@ engine release.
 3. Connectors written against the SPI return `ScanFile`, stats, and file-group capture metadata
   that exactly match the protos defined here; the reconciler pipes them back via the
   catalog/statistics/index services.
-4. Planners call `QueryService.BeginQuery` to create query leases, optionally extend them via
-   `RenewQuery`, call `FetchScanBundle` per table when they need manifests, and close leases out via
-   `EndQuery` once execution is complete.
+4. Planners call `QueryService.BeginQuery` to create query leases, optionally resolve additional
+   inputs via `QuerySchemaService.DescribeInputs`, extend leases via `RenewQuery`, call
+   `QueryScanService` per table when they need manifests, and close leases out via `EndQuery` once
+   execution is complete.
 
    * BeginQuery allows clients to provide an optional `query_id` (duplicates are rejected) and
      a list of `common.QueryInput` records so the lifecycle service can pin snapshots and expansions

--- a/docs/service.md
+++ b/docs/service.md
@@ -85,8 +85,8 @@ helpers like `randomResourceId` (UUIDv4). Highlights:
   - capture only -> `CAPTURE_ONLY`
   - metadata plus capture -> `METADATA_AND_CAPTURE`
 - **QueryServiceImpl** – Administers query leases (`BeginQuery`, `RenewQuery`, `EndQuery`,
-  `GetQuery`) and exposes `FetchScanBundle` so planners can request connector scan metadata on
-  demand.
+  `GetQuery`) and exposes the scan streaming helpers (`InitScan`, `StreamDeleteFiles`,
+  `StreamDataFiles`, `CloseScan`) so planners can request connector metadata safely.
 - **SystemObjectsServiceImpl** – Loads immutable builtin catalogs from disk/classpath, caches them
   per engine version, and serves them via `GetSystemObjects`.
 
@@ -126,9 +126,15 @@ External session header authentication is documented in
 `QueryContextStore` is a Caffeine cache keyed by query ID. Each `QueryContext` tracks state,
 expiration, `PrincipalContext`, encoded `SnapshotSet`, and `ExpansionMap`.
 `QueryServiceImpl.beginQuery` resolves name or ID references via Directory/Snapshot/Table services,
-pins snapshots, and stores the lease. Planners request connector `ScanBundle`s later via
-`FetchScanBundle`, which streams data/delete files for a specific table. The lease data (snapshots,
-expansion map, obligations) is returned to the caller inside the `QueryDescriptor`.
+pins snapshots, and stores the lease. Planners request connector file lists with `InitScan` (which
+returns table metadata and a scan handle), then consume `StreamDeleteFiles` followed by
+`StreamDataFiles`, and finally call `CloseScan` when done. Ordering is strict: `StreamDeleteFiles`
+must be fully consumed before `StreamDataFiles` begins, otherwise the server rejects the data stream
+with `FAILED_PRECONDITION`. The server auto-releases the scan session as soon as both streams finish,
+so `CloseScan` is best-effort but still recommended to tidy server resources sooner. Each `DataFile`
+currently reports `DeleteRef.all_deletes=true`; finer-grain delete references will come later once the
+applicability logic is defined. The lease data (snapshots, expansion map, obligations) is returned to
+the caller inside the `QueryDescriptor`.
 
 ### Builtin Catalog Service
 `SystemObjectsLoader` reads immutable builtin catalogs (`<engine_kind>.pb[pbtxt]`) from the

--- a/docs/service.md
+++ b/docs/service.md
@@ -211,7 +211,7 @@ Extension points:
 - **Security** – Replace `Authorizer` or interceptors with CDI alternatives.
 - **Connectors** – Register new SPI implementations and expose them via `ConnectorRepository`.
 - **QueryService** – Extend query metadata by enriching `QueryContext` creation or injecting
-  additional connector metadata via the `FetchScanBundle` RPC / `ScanBundleService` on the query
+  additional connector metadata via the `QueryScanService` streaming RPCs / `ScanBundleService` on the query
   path. Reconcile planning/execution does not use `ScanBundleService`; it goes through
   `FloecatConnector` directly. `BeginQuery` optionally accepts a client-specified `query_id` plus
   `common.QueryInput` records so lifecycle can pre-pin snapshots/expansions for deterministic

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/client/GrpcServiceFacade.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/client/GrpcServiceFacade.java
@@ -78,16 +78,21 @@ import ai.floedb.floecat.connector.rpc.UpdateConnectorResponse;
 import ai.floedb.floecat.gateway.iceberg.grpc.GrpcWithHeaders;
 import ai.floedb.floecat.query.rpc.BeginQueryRequest;
 import ai.floedb.floecat.query.rpc.BeginQueryResponse;
+import ai.floedb.floecat.query.rpc.DataFile;
+import ai.floedb.floecat.query.rpc.DataFileBatch;
+import ai.floedb.floecat.query.rpc.DeleteFile;
+import ai.floedb.floecat.query.rpc.DeleteFileBatch;
 import ai.floedb.floecat.query.rpc.DescribeInputsRequest;
 import ai.floedb.floecat.query.rpc.DescribeInputsResponse;
 import ai.floedb.floecat.query.rpc.EndQueryRequest;
-import ai.floedb.floecat.query.rpc.FetchScanBundleRequest;
-import ai.floedb.floecat.query.rpc.FetchScanBundleResponse;
 import ai.floedb.floecat.query.rpc.GetQueryRequest;
 import ai.floedb.floecat.query.rpc.GetQueryResponse;
+import ai.floedb.floecat.query.rpc.InitScanRequest;
+import ai.floedb.floecat.query.rpc.InitScanResponse;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
+import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.reconciler.rpc.ReconcileControlGrpc;
 import ai.floedb.floecat.reconciler.rpc.StartCaptureRequest;
 import ai.floedb.floecat.reconciler.rpc.StartCaptureResponse;
@@ -111,6 +116,8 @@ import ai.floedb.floecat.transaction.rpc.ReserveTransactionTableIdResponse;
 import ai.floedb.floecat.transaction.rpc.TransactionsGrpc;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
 
 @ApplicationScoped
 public class GrpcServiceFacade {
@@ -229,9 +236,36 @@ public class GrpcServiceFacade {
     queryStub().endQuery(request);
   }
 
-  public FetchScanBundleResponse fetchScanBundle(FetchScanBundleRequest request) {
-    return queryScanStub().fetchScanBundle(request);
+  public ScanFileStreamResponse fetchScanFileStream(InitScanRequest request) {
+    QueryScanServiceGrpc.QueryScanServiceBlockingStub stub = queryScanStub();
+    InitScanResponse initResp = stub.initScan(request);
+    ScanHandle handle = initResp.getHandle();
+    try {
+      List<DeleteFile> deleteFiles = new ArrayList<>();
+      var deleteIter = stub.streamDeleteFiles(handle);
+      while (deleteIter.hasNext()) {
+        DeleteFileBatch batch = deleteIter.next();
+        deleteFiles.addAll(batch.getItemsList());
+      }
+
+      List<DataFile> dataFiles = new ArrayList<>();
+      var dataIter = stub.streamDataFiles(handle);
+      while (dataIter.hasNext()) {
+        DataFileBatch batch = dataIter.next();
+        dataFiles.addAll(batch.getItemsList());
+      }
+      return new ScanFileStreamResponse(initResp, dataFiles, deleteFiles);
+    } finally {
+      try {
+        stub.closeScan(handle);
+      } catch (Exception ignored) {
+        // best-effort cleanup
+      }
+    }
   }
+
+  public record ScanFileStreamResponse(
+      InitScanResponse initScan, List<DataFile> dataFiles, List<DeleteFile> deleteFiles) {}
 
   public DescribeInputsResponse describeInputs(DescribeInputsRequest request) {
     return querySchemaStub().describeInputs(request);

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/planning/TablePlanService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/planning/TablePlanService.java
@@ -33,11 +33,15 @@ import ai.floedb.floecat.gateway.iceberg.rest.api.dto.StorageCredentialDto;
 import ai.floedb.floecat.gateway.iceberg.rest.api.dto.TablePlanResponseDto;
 import ai.floedb.floecat.gateway.iceberg.rest.api.dto.TablePlanTasksResponseDto;
 import ai.floedb.floecat.gateway.iceberg.rest.services.client.GrpcServiceFacade;
+import ai.floedb.floecat.gateway.iceberg.rest.services.client.GrpcServiceFacade.ScanFileStreamResponse;
 import ai.floedb.floecat.query.rpc.BeginQueryRequest;
+import ai.floedb.floecat.query.rpc.DataFile;
+import ai.floedb.floecat.query.rpc.DeleteFile;
+import ai.floedb.floecat.query.rpc.DeleteRef;
 import ai.floedb.floecat.query.rpc.DescribeInputsRequest;
 import ai.floedb.floecat.query.rpc.EndQueryRequest;
-import ai.floedb.floecat.query.rpc.FetchScanBundleRequest;
 import ai.floedb.floecat.query.rpc.GetQueryRequest;
+import ai.floedb.floecat.query.rpc.InitScanRequest;
 import ai.floedb.floecat.query.rpc.QueryDescriptor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,6 +54,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @ApplicationScoped
 public class TablePlanService {
@@ -102,8 +109,10 @@ public class TablePlanService {
     var resp = grpcClient.getQuery(GetQueryRequest.newBuilder().setQueryId(planId).build());
     QueryDescriptor query = resp.getQuery();
 
-    ScanBundle bundle = fetchScanBundle(ctx, query.getQueryId());
-    TablePlanTasksResponseDto scanTasks = toScanTasksDto(bundle);
+    ScanBundleWithDataFiles bundleWithData = fetchScanFiles(ctx, query.getQueryId());
+    TablePlanTasksResponseDto scanTasks =
+        toScanTasksDto(
+            bundleWithData.bundle(), bundleWithData.dataFiles(), bundleWithData.deleteFiles());
     String resolvedPlanId =
         (query.getQueryId() == null || query.getQueryId().isBlank()) ? planId : query.getQueryId();
     List<String> planTasks =
@@ -124,32 +133,84 @@ public class TablePlanService {
     planContexts.remove(planId);
   }
 
-  private ScanBundle fetchScanBundle(PlanContext ctx, String queryId) {
-    FetchScanBundleRequest.Builder builder =
-        FetchScanBundleRequest.newBuilder().setQueryId(queryId).setTableId(ctx.tableId());
+  public TablePlanTasksResponseDto fetchTasks(String planId) {
+    PlanContext ctx = planContexts.get(planId);
+    if (ctx == null) {
+      throw new IllegalArgumentException("unknown plan id " + planId);
+    }
+    ScanBundleWithDataFiles bundleWithData = fetchScanFiles(ctx, planId);
+    planContexts.remove(planId);
+    return toScanTasksDto(
+        bundleWithData.bundle(), bundleWithData.dataFiles(), bundleWithData.deleteFiles());
+  }
+
+  private ScanBundleWithDataFiles fetchScanFiles(PlanContext ctx, String queryId) {
+    InitScanRequest.Builder builder =
+        InitScanRequest.newBuilder().setQueryId(queryId).setTableId(ctx.tableId());
     if (ctx.requiredColumns() != null && !ctx.requiredColumns().isEmpty()) {
       builder.addAllRequiredColumns(ctx.requiredColumns());
     }
     if (ctx.predicates() != null && !ctx.predicates().isEmpty()) {
       builder.addAllPredicates(ctx.predicates());
     }
-    return grpcClient.fetchScanBundle(builder.build()).getBundle();
+    ScanFileStreamResponse response = grpcClient.fetchScanFileStream(builder.build());
+    ScanBundle bundle =
+        ScanBundle.newBuilder()
+            .addAllDataFiles(response.dataFiles().stream().map(DataFile::getFile).toList())
+            .addAllDeleteFiles(response.deleteFiles().stream().map(DeleteFile::getFile).toList())
+            .build();
+    return new ScanBundleWithDataFiles(bundle, response.dataFiles(), response.deleteFiles());
   }
 
-  private TablePlanTasksResponseDto toScanTasksDto(ScanBundle bundle) {
-    List<ContentFileDto> deleteFiles = new ArrayList<>();
+  private TablePlanTasksResponseDto toScanTasksDto(
+      ScanBundle bundle, List<DataFile> dataFiles, List<DeleteFile> deleteFiles) {
+    List<ContentFileDto> deleteFileDtos = new ArrayList<>();
     List<FileScanTaskDto> tasks = new ArrayList<>();
     if (bundle != null) {
       for (ScanFile delete : bundle.getDeleteFilesList()) {
-        deleteFiles.add(toContentFile(delete));
+        deleteFileDtos.add(toContentFile(delete));
       }
-      for (ScanFile file : bundle.getDataFilesList()) {
-        List<Integer> deleteRefs =
-            file.getDeleteFileIndicesCount() > 0 ? file.getDeleteFileIndicesList() : List.of();
-        tasks.add(new FileScanTaskDto(toContentFile(file), deleteRefs, null));
+      List<Integer> allDeleteIndices = IntStream.range(0, deleteFiles.size()).boxed().toList();
+      Map<Integer, Integer> deleteIdToIndex =
+          IntStream.range(0, deleteFiles.size())
+              .boxed()
+              .collect(
+                  Collectors.toMap(idx -> deleteFiles.get(idx).getDeleteId(), Function.identity()));
+      for (var file : dataFiles) {
+        List<Integer> deleteRefs = dataFileDeleteRefs(file, allDeleteIndices, deleteIdToIndex);
+        tasks.add(new FileScanTaskDto(toContentFile(file.getFile()), deleteRefs, null));
       }
     }
-    return new TablePlanTasksResponseDto(List.of(), tasks, deleteFiles);
+    return new TablePlanTasksResponseDto(List.of(), tasks, deleteFileDtos);
+  }
+
+  private record ScanBundleWithDataFiles(
+      ScanBundle bundle, List<DataFile> dataFiles, List<DeleteFile> deleteFiles) {}
+
+  private List<Integer> dataFileDeleteRefs(
+      DataFile file, List<Integer> allDeleteIndices, Map<Integer, Integer> deleteIdToIndex) {
+    DeleteRef ref = file.getDeletes();
+    if (ref == null || ref.getModeCase() == DeleteRef.ModeCase.MODE_NOT_SET) {
+      return List.of();
+    }
+    if (ref.getModeCase() == DeleteRef.ModeCase.ALL_DELETES) {
+      return allDeleteIndices;
+    }
+    if (ref.getModeCase() == DeleteRef.ModeCase.DELETE_IDS) {
+      List<Integer> ids = new ArrayList<>();
+      for (int deleteId : ref.getDeleteIds().getIdsList()) {
+        Integer idx = deleteIdToIndex.get(deleteId);
+        if (idx == null) {
+          throw new IllegalStateException(
+              "DataFile referenced delete ID "
+                  + deleteId
+                  + " that was not emitted by StreamDeleteFiles");
+        }
+        ids.add(idx);
+      }
+      return ids;
+    }
+    return List.of();
   }
 
   private ContentFileDto toContentFile(ScanFile file) {

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/planning/TablePlanServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/planning/TablePlanServiceTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -34,20 +35,30 @@ import ai.floedb.floecat.gateway.iceberg.grpc.GrpcClients;
 import ai.floedb.floecat.gateway.iceberg.grpc.GrpcWithHeaders;
 import ai.floedb.floecat.gateway.iceberg.rest.api.dto.StorageCredentialDto;
 import ai.floedb.floecat.gateway.iceberg.rest.api.dto.TablePlanResponseDto;
+import ai.floedb.floecat.gateway.iceberg.rest.api.dto.TablePlanTasksResponseDto;
 import ai.floedb.floecat.gateway.iceberg.rest.services.client.GrpcServiceFacade;
 import ai.floedb.floecat.query.rpc.BeginQueryResponse;
+import ai.floedb.floecat.query.rpc.DataFile;
+import ai.floedb.floecat.query.rpc.DataFileBatch;
+import ai.floedb.floecat.query.rpc.DeleteFile;
+import ai.floedb.floecat.query.rpc.DeleteFileBatch;
+import ai.floedb.floecat.query.rpc.DeleteRef;
 import ai.floedb.floecat.query.rpc.DescribeInputsRequest;
 import ai.floedb.floecat.query.rpc.EndQueryRequest;
-import ai.floedb.floecat.query.rpc.FetchScanBundleRequest;
-import ai.floedb.floecat.query.rpc.FetchScanBundleResponse;
 import ai.floedb.floecat.query.rpc.GetQueryResponse;
+import ai.floedb.floecat.query.rpc.InitScanRequest;
+import ai.floedb.floecat.query.rpc.InitScanResponse;
 import ai.floedb.floecat.query.rpc.QueryDescriptor;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
+import ai.floedb.floecat.query.rpc.ScanHandle;
+import ai.floedb.floecat.query.rpc.TableInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.Empty;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -160,8 +171,7 @@ class TablePlanServiceTest {
             .build();
     ScanBundle bundle =
         ScanBundle.newBuilder().addDataFiles(data).addDeleteFiles(deleteFile).build();
-    when(scanStub.fetchScanBundle(any()))
-        .thenReturn(FetchScanBundleResponse.newBuilder().setBundle(bundle).build());
+    ScanHandle handle = mockScanForBundle(tableId, bundle);
 
     List<StorageCredentialDto> credentials =
         List.of(new StorageCredentialDto("s3", Map.of("role", "arn:aws:iam::123:role/Test")));
@@ -172,20 +182,21 @@ class TablePlanServiceTest {
     assertIterableEquals(List.of("plan-2"), response.planTasks());
     assertEquals(credentials, response.storageCredentials());
     assertEquals(1, response.fileScanTasks().size());
-    assertEquals(List.of(1, "A"), response.fileScanTasks().get(0).dataFile().partition());
-    assertEquals(List.of(0), response.fileScanTasks().get(0).deleteFileReferences());
+    assertEquals("s3://bucket/data.parquet", response.fileScanTasks().get(0).dataFile().filePath());
     assertEquals("s3://bucket/delete.parquet", response.deleteFiles().get(0).filePath());
 
-    ArgumentCaptor<FetchScanBundleRequest> fetch =
-        ArgumentCaptor.forClass(FetchScanBundleRequest.class);
-    verify(scanStub).fetchScanBundle(fetch.capture());
-    FetchScanBundleRequest sent = fetch.getValue();
+    ArgumentCaptor<InitScanRequest> fetch = ArgumentCaptor.forClass(InitScanRequest.class);
+    verify(scanStub).initScan(fetch.capture());
+    InitScanRequest sent = fetch.getValue();
     assertEquals(tableId, sent.getTableId());
     assertEquals(1, sent.getRequiredColumnsCount());
     assertEquals("id", sent.getRequiredColumns(0));
     assertEquals(2, sent.getPredicatesCount());
     assertEquals("customerid", sent.getPredicates(0).getColumn());
     assertEquals("DeletedFlag".toLowerCase(), sent.getPredicates(1).getColumn());
+    verify(scanStub).streamDeleteFiles(handle);
+    verify(scanStub).streamDataFiles(handle);
+    verify(scanStub).closeScan(handle);
   }
 
   @Test
@@ -219,15 +230,13 @@ class TablePlanServiceTest {
         null);
 
     ScanBundle bundle = ScanBundle.newBuilder().build();
-    when(scanStub.fetchScanBundle(any()))
-        .thenReturn(FetchScanBundleResponse.newBuilder().setBundle(bundle).build());
+    ScanHandle handle = mockScanForBundle(tableId, bundle);
 
     service.fetchPlan("plan-4", List.of());
 
-    ArgumentCaptor<FetchScanBundleRequest> fetch =
-        ArgumentCaptor.forClass(FetchScanBundleRequest.class);
-    verify(scanStub).fetchScanBundle(fetch.capture());
-    assertEquals(0, fetch.getValue().getPredicatesCount());
+    ArgumentCaptor<InitScanRequest> initFetch = ArgumentCaptor.forClass(InitScanRequest.class);
+    verify(scanStub).initScan(initFetch.capture());
+    assertEquals(0, initFetch.getValue().getPredicatesCount());
   }
 
   @Test
@@ -261,16 +270,42 @@ class TablePlanServiceTest {
         null);
 
     ScanBundle bundle = ScanBundle.newBuilder().build();
-    when(scanStub.fetchScanBundle(any()))
-        .thenReturn(FetchScanBundleResponse.newBuilder().setBundle(bundle).build());
+    ScanHandle handle = mockScanForBundle(tableId, bundle);
 
     service.fetchPlan("plan-5", List.of());
 
-    ArgumentCaptor<FetchScanBundleRequest> fetch =
-        ArgumentCaptor.forClass(FetchScanBundleRequest.class);
-    verify(scanStub).fetchScanBundle(fetch.capture());
-    assertEquals(1, fetch.getValue().getPredicatesCount());
-    assertEquals("OrderId", fetch.getValue().getPredicates(0).getColumn());
+    ArgumentCaptor<InitScanRequest> initFetch = ArgumentCaptor.forClass(InitScanRequest.class);
+    verify(scanStub).initScan(initFetch.capture());
+    assertEquals(1, initFetch.getValue().getPredicatesCount());
+    assertEquals("OrderId", initFetch.getValue().getPredicates(0).getColumn());
+  }
+
+  @Test
+  void fetchTasksReturnsBundleAndClearsContext() {
+    QueryDescriptor descriptor = QueryDescriptor.newBuilder().setQueryId("plan-3").build();
+    when(queryStub.beginQuery(any()))
+        .thenReturn(BeginQueryResponse.newBuilder().setQuery(descriptor).build());
+    ResourceId tableId = ResourceId.newBuilder().setId("cat:db:orders").build();
+    service.startPlan(
+        ResourceId.newBuilder().setId("cat").setKind(ResourceKind.RK_CATALOG).build(),
+        tableId,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        true,
+        false,
+        null);
+
+    ScanBundle bundle = ScanBundle.newBuilder().build();
+    mockScanForBundle(tableId, bundle);
+
+    TablePlanTasksResponseDto tasks = service.fetchTasks("plan-3");
+    assertTrue(tasks.fileScanTasks().isEmpty());
+
+    assertThrows(IllegalArgumentException.class, () -> service.fetchTasks("plan-3"));
   }
 
   @Test
@@ -325,5 +360,41 @@ class TablePlanServiceTest {
         false,
         null);
     verify(queryStub, times(1)).beginQuery(any());
+  }
+
+  private ScanHandle mockScanForBundle(ResourceId tableId, ScanBundle bundle) {
+    ScanHandle handle = ScanHandle.newBuilder().setId("handle").build();
+    InitScanResponse initResp =
+        InitScanResponse.newBuilder()
+            .setHandle(handle)
+            .setTableInfo(TableInfo.newBuilder().setTableId(tableId).build())
+            .build();
+    when(scanStub.initScan(any())).thenReturn(initResp);
+    AtomicInteger deleteId = new AtomicInteger(0);
+    List<DeleteFile> deleteFiles =
+        bundle.getDeleteFilesList().stream()
+            .map(
+                file ->
+                    DeleteFile.newBuilder()
+                        .setDeleteId(deleteId.getAndIncrement())
+                        .setFile(file)
+                        .build())
+            .toList();
+    when(scanStub.streamDeleteFiles(handle))
+        .thenReturn(
+            List.of(DeleteFileBatch.newBuilder().addAllItems(deleteFiles).build()).iterator());
+    List<DataFile> dataFiles =
+        bundle.getDataFilesList().stream()
+            .map(
+                file ->
+                    DataFile.newBuilder()
+                        .setFile(file)
+                        .setDeletes(DeleteRef.newBuilder().setAllDeletes(true))
+                        .build())
+            .toList();
+    when(scanStub.streamDataFiles(handle))
+        .thenReturn(List.of(DataFileBatch.newBuilder().addAllItems(dataFiles).build()).iterator());
+    when(scanStub.closeScan(handle)).thenReturn(Empty.newBuilder().build());
+    return handle;
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/common/ScanPruningUtils.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/ScanPruningUtils.java
@@ -174,6 +174,13 @@ public final class ScanPruningUtils {
     return true;
   }
 
+  public static boolean matchesPredicates(ScanFile file, List<Predicate> preds) {
+    if (preds == null || preds.isEmpty()) {
+      return true;
+    }
+    return matches(file, preds);
+  }
+
   /**
    * Determines whether a file may satisfy a predicate based on its column-level min/max statistics.
    * This is a conservative check: the method returns {@code true} unless the file is guaranteed to

--- a/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
@@ -18,35 +18,50 @@ package ai.floedb.floecat.service.execution.impl;
 
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
+import ai.floedb.floecat.catalog.rpc.FileColumnStats;
 import ai.floedb.floecat.catalog.rpc.FileContent;
 import ai.floedb.floecat.catalog.rpc.FileTargetStats;
 import ai.floedb.floecat.catalog.rpc.PartitionSpecInfo;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.Table;
+import ai.floedb.floecat.common.rpc.Predicate;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.common.resolver.DeltaSchemaNormalizer;
-import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.execution.rpc.ScanFile;
 import ai.floedb.floecat.execution.rpc.ScanFileContent;
-import ai.floedb.floecat.query.rpc.SnapshotPin;
+import ai.floedb.floecat.query.rpc.DataFile;
+import ai.floedb.floecat.query.rpc.DataFileBatch;
+import ai.floedb.floecat.query.rpc.DeleteFile;
+import ai.floedb.floecat.query.rpc.DeleteFileBatch;
+import ai.floedb.floecat.query.rpc.DeleteRef;
 import ai.floedb.floecat.query.rpc.TableInfo;
+import ai.floedb.floecat.service.common.ScanPruningUtils;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import ai.floedb.floecat.service.query.impl.ScanSession;
+import ai.floedb.floecat.service.query.impl.ScanSession.DeleteFileMetadata;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.storage.impl.ServerSideFileIoPropertiesResolver;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsTargetType;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.MultiEmitter;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.IntStream;
+import java.util.concurrent.CompletableFuture;
 
+/** Builds and streams ScanFile batches by pulling target stats directly from the stats store. */
 @ApplicationScoped
 public class ScanBundleService {
+
+  private static final int FILE_STATS_PAGE_SIZE = 1000;
 
   private final TableRepository tables;
   private final SnapshotRepository snapshots;
@@ -65,32 +80,14 @@ public class ScanBundleService {
     this.fileIoPropertiesResolver = fileIoPropertiesResolver;
   }
 
-  public ScanBundleWithInfo fetch(
-      String correlationId, ResourceId tableId, SnapshotPin snapshotPin) {
-    Table table = requireTable(correlationId, tableId);
-    Snapshot snapshot = requireSnapshot(correlationId, tableId, snapshotPin.getSnapshotId());
-    FloecatConnector.ScanBundle bundle = buildFromStats(table, snapshotPin.getSnapshotId());
-    TableInfo info = buildTableInfo(table, snapshot, snapshotPin.getSnapshotId());
-    return new ScanBundleWithInfo(bundle, info);
-  }
-
-  public TableInfo fetchTableInfo(
-      String correlationId, ResourceId tableId, SnapshotPin snapshotPin) {
-    Table table = requireTable(correlationId, tableId);
-    Snapshot snapshot = requireSnapshot(correlationId, tableId, snapshotPin.getSnapshotId());
-    return buildTableInfo(table, snapshot, snapshotPin.getSnapshotId());
-  }
-
-  private Table requireTable(String correlationId, ResourceId tableId) {
+  /** Loads table and snapshot metadata and builds the initial TableInfo for a scan handle. */
+  public InitData initScan(String correlationId, ResourceId tableId, long snapshotId) {
     Table table =
         tables
             .getById(tableId)
             .orElseThrow(
                 () -> GrpcErrors.notFound(correlationId, TABLE, Map.of("id", tableId.getId())));
-    return table;
-  }
 
-  private Snapshot requireSnapshot(String correlationId, ResourceId tableId, long snapshotId) {
     Snapshot snapshot =
         snapshots
             .getById(tableId, snapshotId)
@@ -104,69 +101,288 @@ public class ScanBundleService {
                             tableId.getId(),
                             "snapshot_id",
                             Long.toString(snapshotId))));
-    return snapshot;
+
+    TableInfo info = buildTableInfo(table, snapshot, snapshotId);
+    return new InitData(tableId, snapshotId, info);
   }
 
-  private FloecatConnector.ScanBundle buildFromStats(Table table, long snapshotId) {
-    var data = new ArrayList<ScanFile>();
-    var deletes = new ArrayList<ScanFile>();
+  /** Streams delete batches, caching metadata for potential retries before completion. */
+  public Multi<DeleteFileBatch> streamDeleteFiles(ScanSession session, String correlationId) {
+    CompletableFuture<List<List<DeleteFileMetadata>>> existing = session.deleteBatchesFuture();
+    if (existing != null) {
+      List<DeleteFileBatch> cached = batchesFromMetadata(existing.join());
+      if (!session.deletesComplete()) {
+        session.markDeletesComplete();
+      }
+      return Multi.createFrom().iterable(cached);
+    }
 
+    CompletableFuture<List<List<DeleteFileMetadata>>> completion = new CompletableFuture<>();
+    if (!session.initDeleteBatchesFuture(completion)) {
+      CompletableFuture<List<List<DeleteFileMetadata>>> active = session.deleteBatchesFuture();
+      List<DeleteFileBatch> cached = batchesFromMetadata(active.join());
+      if (!session.deletesComplete()) {
+        session.markDeletesComplete();
+      }
+      return Multi.createFrom().iterable(cached);
+    }
+
+    completion.whenComplete(
+        (ignored, failure) -> {
+          if (failure == null) {
+            session.markDeletesComplete();
+          }
+        });
+    return Multi.createFrom()
+        .emitter(
+            emitter -> {
+              List<List<DeleteFileMetadata>> batches = new ArrayList<>();
+              try {
+                emitDeleteBatches(session, emitter, batches);
+                completion.complete(List.copyOf(batches));
+                emitter.complete();
+              } catch (RuntimeException e) {
+                completion.completeExceptionally(e);
+                emitter.fail(e);
+              }
+            });
+  }
+
+  /** Streams data files after delete streaming has completed. */
+  public Multi<DataFileBatch> streamDataFiles(ScanSession session, String correlationId) {
+    if (!session.deletesComplete()) {
+      throw GrpcErrors.preconditionFailed(
+          correlationId, SCAN_DELETES_NOT_COMPLETE, Map.of("handle", session.handleId()));
+    }
+    return Multi.createFrom()
+        .emitter(
+            emitter -> {
+              try {
+                emitDataBatches(session, emitter);
+                emitter.complete();
+              } catch (RuntimeException e) {
+                emitter.fail(e);
+              }
+            });
+  }
+
+  /** Pulls delete file stats pages, emits delete batches, and records metadata for replay. */
+  private void emitDeleteBatches(
+      ScanSession session,
+      MultiEmitter<? super DeleteFileBatch> emitter,
+      List<List<DeleteFileMetadata>> stored) {
+    int batchItems = Math.max(1, session.targetBatchItems());
+    int batchBytes = Math.max(1, session.targetBatchBytes());
     String pageToken = "";
+    List<DeleteFile> batch = new ArrayList<>();
+    List<DeleteFileMetadata> metaBatch = new ArrayList<>();
+    long bytes = 0;
+
+    // Byte heuristic uses on-disk size rather than actual serialized payload; prefer
+    // targetBatchItems when include_column_stats means column metadata dominates the grpc frame.
     do {
       var page =
           statsStore.listTargetStats(
-              table.getResourceId(),
-              snapshotId,
+              session.tableId(),
+              session.snapshotId(),
               Optional.of(StatsTargetType.FILE),
-              1000,
+              FILE_STATS_PAGE_SIZE,
               pageToken);
-
       for (var record : page.records()) {
         if (!record.hasFile()) {
           continue;
         }
-        FileTargetStats fcs = record.getFile();
-        var builder =
-            ScanFile.newBuilder()
-                .setFilePath(fcs.getFilePath())
-                .setFileFormat(fcs.getFileFormat())
-                .setFileSizeInBytes(fcs.getSizeBytes())
-                .setRecordCount(fcs.getRowCount())
-                .setPartitionDataJson(fcs.getPartitionDataJson())
-                .setPartitionSpecId(fcs.getPartitionSpecId())
-                .addAllEqualityFieldIds(fcs.getEqualityFieldIdsList())
-                .setFileContent(mapContent(fcs.getFileContent()))
-                .addAllColumns(fcs.getColumnsList());
-        if (fcs.hasSequenceNumber()) {
-          builder.setSequenceNumber(fcs.getSequenceNumber());
+        FileTargetStats stats = record.getFile();
+        if (stats.getFileContent() == FileContent.FC_DATA) {
+          continue;
         }
-        var scanFile = builder.build();
-
-        if (fcs.getFileContent() == FileContent.FC_DATA) {
-          data.add(scanFile);
-        } else {
-          deletes.add(scanFile);
+        DeleteFile deleteFile = toDeleteFile(session, stats);
+        if (deleteFile == null) {
+          continue;
+        }
+        batch.add(deleteFile);
+        metaBatch.add(DeleteFileMetadata.fromDeleteFile(deleteFile));
+        bytes += Math.max(0L, stats.getSizeBytes());
+        if (batch.size() >= batchItems || bytes >= batchBytes) {
+          emitter.emit(buildDeleteBatch(batch));
+          stored.add(List.copyOf(metaBatch));
+          batch = new ArrayList<>();
+          metaBatch = new ArrayList<>();
+          bytes = 0;
         }
       }
-
       pageToken = page.nextPageToken();
     } while (!pageToken.isBlank());
 
-    List<ScanFile> linkedData =
-        deletes.isEmpty()
-            ? data
-            : data.stream()
-                .map(
-                    file ->
-                        file.toBuilder()
-                            .addAllDeleteFileIndices(
-                                IntStream.range(0, deletes.size()).boxed().toList())
-                            .build())
-                .toList();
-
-    return new FloecatConnector.ScanBundle(linkedData, deletes);
+    if (!batch.isEmpty()) {
+      emitter.emit(buildDeleteBatch(batch));
+      stored.add(List.copyOf(metaBatch));
+    }
   }
 
+  /** Streams data file batches after deletes are ready, honoring batching hints. */
+  private void emitDataBatches(ScanSession session, MultiEmitter<? super DataFileBatch> emitter) {
+    int batchItems = Math.max(1, session.targetBatchItems());
+    int batchBytes = Math.max(1, session.targetBatchBytes());
+    String pageToken = "";
+    List<DataFile> batch = new ArrayList<>();
+    long bytes = 0;
+
+    do {
+      var page =
+          statsStore.listTargetStats(
+              session.tableId(),
+              session.snapshotId(),
+              Optional.of(StatsTargetType.FILE),
+              FILE_STATS_PAGE_SIZE,
+              pageToken);
+      for (var record : page.records()) {
+        if (!record.hasFile()) {
+          continue;
+        }
+        FileTargetStats stats = record.getFile();
+        if (stats.getFileContent() != FileContent.FC_DATA) {
+          continue;
+        }
+        DataFile dataFile = toDataFile(session, stats);
+        if (dataFile == null) {
+          continue;
+        }
+        batch.add(dataFile);
+        bytes += Math.max(0L, stats.getSizeBytes());
+        if (batch.size() >= batchItems || bytes >= batchBytes) {
+          emitter.emit(buildDataBatch(batch));
+          batch = new ArrayList<>();
+          bytes = 0;
+        }
+      }
+      pageToken = page.nextPageToken();
+    } while (!pageToken.isBlank());
+
+    if (!batch.isEmpty()) {
+      emitter.emit(buildDataBatch(batch));
+    }
+  }
+
+  /** Convenience builder for delete batches. */
+  private DeleteFileBatch buildDeleteBatch(List<DeleteFile> batch) {
+    return DeleteFileBatch.newBuilder().addAllItems(batch).build();
+  }
+
+  /** Convenience builder for data batches. */
+  private DataFileBatch buildDataBatch(List<DataFile> batch) {
+    return DataFileBatch.newBuilder().addAllItems(batch).build();
+  }
+
+  /** Converts file stats into a DeleteFile, applying pruning filters. */
+  private DeleteFile toDeleteFile(ScanSession session, FileTargetStats stats) {
+    ScanFile scanFile = applySessionFilters(session, toScanFileBuilder(stats));
+    if (scanFile == null) {
+      return null;
+    }
+    int deleteId = session.nextDeleteId();
+    // Reserved for future delete-to-data mapping; currently data files emit all_deletes=true.
+    session.deleteIdByPath().put(scanFile.getFilePath(), deleteId);
+    session.recordDeleteId(deleteId);
+    return DeleteFile.newBuilder().setDeleteId(deleteId).setFile(scanFile).build();
+  }
+
+  /** Converts file stats into a DataFile, attaching the current delete reference state. */
+  private DataFile toDataFile(ScanSession session, FileTargetStats stats) {
+    ScanFile scanFile = applySessionFilters(session, toScanFileBuilder(stats));
+    if (scanFile == null) {
+      return null;
+    }
+    if (session.recordedDeleteIds().isEmpty()) {
+      return DataFile.newBuilder().setFile(scanFile).build();
+    }
+    // TODO(mrouvroy): switch to DeleteIdList when we know per-file applicability
+    // (equality/partition filters).
+    DeleteRef deletes = DeleteRef.newBuilder().setAllDeletes(true).build();
+    return DataFile.newBuilder().setFile(scanFile).setDeletes(deletes).build();
+  }
+
+  /** Reconstructs delete batches from cached metadata for retries. */
+  private List<DeleteFileBatch> batchesFromMetadata(List<List<DeleteFileMetadata>> metadata) {
+    return metadata.stream()
+        .map(
+            batch ->
+                DeleteFileBatch.newBuilder()
+                    .addAllItems(batch.stream().map(DeleteFileMetadata::toDeleteFile).toList())
+                    .build())
+        .toList();
+  }
+
+  /** Builds a scan file builder from FileTargetStats for further filtering. */
+  private ScanFile.Builder toScanFileBuilder(FileTargetStats stats) {
+    ScanFile.Builder builder =
+        ScanFile.newBuilder()
+            .setFilePath(stats.getFilePath())
+            .setFileFormat(stats.getFileFormat())
+            .setFileSizeInBytes(stats.getSizeBytes())
+            .setRecordCount(stats.getRowCount())
+            .setPartitionDataJson(stats.getPartitionDataJson())
+            .setPartitionSpecId(stats.getPartitionSpecId())
+            .addAllEqualityFieldIds(stats.getEqualityFieldIdsList())
+            .setFileContent(mapContent(stats.getFileContent()))
+            .addAllColumns(stats.getColumnsList());
+    if (stats.hasSequenceNumber()) {
+      builder.setSequenceNumber(stats.getSequenceNumber());
+    }
+    return builder;
+  }
+
+  /**
+   * Applies pruning, required-column filtering, and partition stripping before emitting a ScanFile.
+   */
+  private ScanFile applySessionFilters(ScanSession session, ScanFile.Builder builder) {
+    if (session.excludePartitionDataJson()) {
+      builder.clearPartitionDataJson();
+    }
+
+    if (builder.getColumnsCount() > 0
+        && (!session.requiredColumns().isEmpty() || !session.predicates().isEmpty())) {
+      HashSet<String> columnsToKeep = new HashSet<>();
+      for (String column : session.requiredColumns()) {
+        columnsToKeep.add(column.toLowerCase(Locale.ROOT));
+      }
+      for (Predicate predicate : session.predicates()) {
+        if (predicate.getColumn() != null && !predicate.getColumn().isBlank()) {
+          columnsToKeep.add(predicate.getColumn().toLowerCase(Locale.ROOT));
+        }
+      }
+
+      List<FileColumnStats> filteredColumns = new ArrayList<>();
+      for (FileColumnStats stats : builder.getColumnsList()) {
+        String columnName = displayName(stats);
+        if (columnName != null && columnsToKeep.contains(columnName.toLowerCase(Locale.ROOT))) {
+          filteredColumns.add(stats);
+        }
+      }
+      builder.clearColumns();
+      builder.addAllColumns(filteredColumns);
+    }
+
+    ScanFile file = builder.build();
+    if (!ScanPruningUtils.matchesPredicates(file, session.predicates())) {
+      return null;
+    }
+    if (!session.includeColumnStats()) {
+      // The pruning step already worked on the filtered stats, so we can drop them now.
+      return file.toBuilder().clearColumns().build();
+    }
+    return file;
+  }
+
+  private String displayName(FileColumnStats stats) {
+    if (!stats.hasScalar()) {
+      return null;
+    }
+    String displayName = stats.getScalar().getDisplayName();
+    return displayName == null || displayName.isBlank() ? null : displayName;
+  }
+
+  /** Builds the TableInfo payload from catalog and snapshot state. */
   private TableInfo buildTableInfo(Table table, Snapshot snapshot, long snapshotId) {
     TableInfo.Builder builder =
         TableInfo.newBuilder().setTableId(table.getResourceId()).setSnapshotId(snapshotId);
@@ -221,14 +437,14 @@ public class ScanBundleService {
     return builder.build();
   }
 
-  //  Direct mapping from catalog FileContent -> execution ScanFileContent
-  private ScanFileContent mapContent(FileContent fc) {
-    return switch (fc) {
+  /** Maps catalog FileContent into execution ScanFileContent. */
+  private ScanFileContent mapContent(FileContent content) {
+    return switch (content) {
       case FC_EQUALITY_DELETES -> ScanFileContent.SCAN_FILE_CONTENT_EQUALITY_DELETES;
       case FC_POSITION_DELETES -> ScanFileContent.SCAN_FILE_CONTENT_POSITION_DELETES;
       default -> ScanFileContent.SCAN_FILE_CONTENT_DATA;
     };
   }
 
-  public record ScanBundleWithInfo(FloecatConnector.ScanBundle bundle, TableInfo tableInfo) {}
+  public record InitData(ResourceId tableId, long snapshotId, TableInfo tableInfo) {}
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/QueryContextStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/QueryContextStore.java
@@ -16,7 +16,9 @@
 
 package ai.floedb.floecat.service.query;
 
+import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.service.query.impl.QueryContext;
+import ai.floedb.floecat.service.query.impl.ScanSession;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 
@@ -70,6 +72,16 @@ public interface QueryContextStore extends AutoCloseable {
    * resulting context version is bumped automatically.
    */
   Optional<QueryContext> update(String queryId, UnaryOperator<QueryContext> fn);
+
+  // ---------------------------------------------------------------------
+  //  Scan session helpers
+  // ---------------------------------------------------------------------
+
+  ScanHandle createScanSession(String correlationId, ScanSession session);
+
+  Optional<ScanSession> getScanSession(ScanHandle handle);
+
+  void removeScanSession(ScanHandle handle);
 
   @Override
   void close();

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContext.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -92,6 +93,7 @@ public final class QueryContext {
   private final State state;
   private final long version;
   private final ResourceId queryDefaultCatalogId;
+  private final Set<String> scanHandles;
 
   private static final Clock clock = Clock.systemUTC();
 
@@ -132,6 +134,7 @@ public final class QueryContext {
     this.queryDefaultCatalogId =
         Objects.requireNonNull(b.queryDefaultCatalogId, "queryDefaultCatalogId");
     this.queryStatus = new AtomicReference<>(Objects.requireNonNull(b.queryStatus, "queryStatus"));
+    this.scanHandles = b.scanHandles == null ? Set.of() : Set.copyOf(b.scanHandles);
   }
 
   /**
@@ -189,7 +192,8 @@ public final class QueryContext {
         .state(state)
         .version(version)
         .queryDefaultCatalogId(queryDefaultCatalogId)
-        .queryStatus(queryStatus.get());
+        .queryStatus(queryStatus.get())
+        .scanHandles(scanHandles);
   }
 
   public static final class Builder {
@@ -205,6 +209,7 @@ public final class QueryContext {
     private long version;
     private ResourceId queryDefaultCatalogId;
     private QueryStatus queryStatus = QueryStatus.SUBMITTED;
+    private Set<String> scanHandles = Set.of();
 
     private Builder() {}
 
@@ -266,6 +271,11 @@ public final class QueryContext {
 
     public Builder queryDefaultCatalogId(ResourceId v) {
       this.queryDefaultCatalogId = v;
+      return this;
+    }
+
+    public Builder scanHandles(Set<String> scanHandles) {
+      this.scanHandles = scanHandles == null ? Set.of() : Set.copyOf(scanHandles);
       return this;
     }
 
@@ -464,6 +474,10 @@ public final class QueryContext {
 
   public ResourceId getQueryDefaultCatalogId() {
     return queryDefaultCatalogId;
+  }
+
+  public Set<String> scanHandles() {
+    return scanHandles;
   }
 
   // ----------------------------------------------------------------------

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContextStoreImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContextStoreImpl.java
@@ -16,15 +16,25 @@
 
 package ai.floedb.floecat.service.query.impl;
 
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
+
+import ai.floedb.floecat.query.rpc.ScanHandle;
+import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.UnaryOperator;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -54,6 +64,8 @@ public class QueryContextStoreImpl implements QueryContextStore {
   private final Clock clock = Clock.systemUTC();
 
   private Cache<String, QueryContext> cache;
+  private Cache<String, ScanSession> scanSessionCache;
+  private final Map<String, String> handleToQuery = new ConcurrentHashMap<>();
 
   @PostConstruct
   void init() {
@@ -62,6 +74,24 @@ public class QueryContextStoreImpl implements QueryContextStore {
             .maximumSize(Math.max(1, maxSize))
             .expireAfterWrite(Duration.ofMinutes(Math.max(1, safetyExpiryMinutes)))
             .recordStats()
+            .removalListener(
+                (String key, QueryContext ctx, RemovalCause cause) -> {
+                  if (ctx != null) {
+                    cleanupScanHandles(ctx);
+                  }
+                })
+            .build();
+    scanSessionCache =
+        Caffeine.newBuilder()
+            .maximumSize(Math.max(1, maxSize))
+            .expireAfterWrite(Duration.ofMinutes(Math.max(1, safetyExpiryMinutes)))
+            .recordStats()
+            .removalListener(
+                (String handle, ScanSession session, RemovalCause cause) -> {
+                  if (handle != null) {
+                    handleToQuery.remove(handle);
+                  }
+                })
             .build();
   }
 
@@ -140,7 +170,11 @@ public class QueryContextStoreImpl implements QueryContextStore {
 
   @Override
   public boolean delete(String queryId) {
-    return cache.asMap().remove(queryId) != null;
+    QueryContext ctx = cache.asMap().remove(queryId);
+    if (ctx != null) {
+      cleanupScanHandles(ctx);
+    }
+    return ctx != null;
   }
 
   @Override
@@ -173,6 +207,87 @@ public class QueryContextStoreImpl implements QueryContextStore {
                   }
                   return updated.toBuilder().version(versionGen.incrementAndGet()).build();
                 }));
+  }
+
+  @Override
+  public ScanHandle createScanSession(String correlationId, ScanSession session) {
+    String id = UUID.randomUUID().toString();
+    ScanSession stored =
+        ScanSession.builder()
+            .handleId(id)
+            .queryId(session.queryId())
+            .tableId(session.tableId())
+            .snapshotId(session.snapshotId())
+            .tableInfo(session.tableInfo())
+            .requiredColumns(session.requiredColumns())
+            .predicates(session.predicates())
+            .includeColumnStats(session.includeColumnStats())
+            .excludePartitionDataJson(session.excludePartitionDataJson())
+            .targetBatchItems(session.targetBatchItems())
+            .targetBatchBytes(session.targetBatchBytes())
+            .build();
+    QueryContext updated =
+        update(
+                session.queryId(),
+                ctx -> ctx.toBuilder().scanHandles(addScanHandle(ctx.scanHandles(), id)).build())
+            .orElseThrow(
+                () ->
+                    GrpcErrors.notFound(
+                        correlationId, QUERY_NOT_FOUND, Map.of("query_id", session.queryId())));
+    handleToQuery.put(id, session.queryId());
+    scanSessionCache.put(id, stored);
+    return ScanHandle.newBuilder().setId(id).build();
+  }
+
+  @Override
+  public Optional<ScanSession> getScanSession(ScanHandle handle) {
+    if (handle == null) {
+      return Optional.empty();
+    }
+    String queryId = handleToQuery.get(handle.getId());
+    if (queryId == null) {
+      return Optional.empty();
+    }
+    QueryContext ctx = cache.getIfPresent(queryId);
+    if (ctx == null) {
+      handleToQuery.remove(handle.getId());
+      return Optional.empty();
+    }
+    return Optional.ofNullable(scanSessionCache.getIfPresent(handle.getId()));
+  }
+
+  @Override
+  public void removeScanSession(ScanHandle handle) {
+    if (handle == null) {
+      return;
+    }
+    String queryId = handleToQuery.remove(handle.getId());
+    if (queryId == null) {
+      return;
+    }
+    cache
+        .asMap()
+        .computeIfPresent(
+            queryId,
+            (k, ctx) -> {
+              Set<String> updated = new HashSet<>(ctx.scanHandles());
+              updated.remove(handle.getId());
+              return ctx.toBuilder().scanHandles(updated).build();
+            });
+    scanSessionCache.invalidate(handle.getId());
+  }
+
+  private Set<String> addScanHandle(Set<String> existing, String id) {
+    Set<String> updated = new HashSet<>(existing);
+    updated.add(id);
+    return Set.copyOf(updated);
+  }
+
+  private void cleanupScanHandles(QueryContext ctx) {
+    for (String handle : ctx.scanHandles()) {
+      handleToQuery.remove(handle);
+      scanSessionCache.invalidate(handle);
+    }
   }
 
   @PreDestroy

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
@@ -19,118 +19,210 @@ package ai.floedb.floecat.service.query.impl;
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
 import ai.floedb.floecat.common.rpc.ResourceId;
-import ai.floedb.floecat.execution.rpc.ScanBundle;
-import ai.floedb.floecat.query.rpc.FetchScanBundleRequest;
-import ai.floedb.floecat.query.rpc.FetchScanBundleResponse;
+import ai.floedb.floecat.query.rpc.DataFileBatch;
+import ai.floedb.floecat.query.rpc.DeleteFileBatch;
+import ai.floedb.floecat.query.rpc.InitScanRequest;
+import ai.floedb.floecat.query.rpc.InitScanResponse;
 import ai.floedb.floecat.query.rpc.QueryScanService;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
+import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
+import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
-import ai.floedb.floecat.service.common.ScanPruningUtils;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.execution.impl.ScanBundleService;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import com.google.protobuf.Empty;
 import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.inject.Inject;
 import java.util.Map;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
-/**
- * gRPC implementation of {@link QueryScanService}.
- *
- * <p>This service handles all scan-file–related operations:
- *
- * <ul>
- *   <li>retrieving raw scan bundles from connectors,
- *   <li>pruning by projection,
- *   <li>pruning by predicate (min/max statistics).
- * </ul>
- *
- * <p>Lifecycle operations (create/renew/end query) are handled in {@link QueryServiceImpl}.
- */
 @GrpcService
 public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanService {
 
+  private static final Logger LOG = Logger.getLogger(QueryScanServiceGrpc.class);
+
+  @ConfigProperty(name = "floecat.scan.default-batch-items", defaultValue = "1000")
+  int defaultBatchItems; // count of files per batch, overridden by request.target_batch_items
+
+  @ConfigProperty(name = "floecat.scan.default-batch-bytes", defaultValue = "1000000")
+  int defaultBatchBytes; // approximate bytes per batch, overridden by request.target_batch_bytes
+
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
-
   @Inject QueryContextStore queryStore;
   @Inject ScanBundleService scanBundles;
 
-  private static final Logger LOG = Logger.getLogger(QueryScanServiceGrpc.class);
-
-  /**
-   * FetchScanBundle
-   *
-   * <p>Retrieves raw scan bundles for a pinned table and applies both projection and predicate
-   * pruning. Query status is updated based on success or failure.
-   */
   @Override
-  public Uni<FetchScanBundleResponse> fetchScanBundle(FetchScanBundleRequest request) {
-    var L = LogHelper.start(LOG, "FetchScanBundle");
-
-    return mapFailures(
-            run(
-                () -> {
-                  var principalContext = principal.get();
-                  var correlationId = principalContext.getCorrelationId();
-
-                  authz.require(principalContext, "catalog.read");
-
-                  String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-
-                  if (!request.hasTableId()) {
-                    throw GrpcErrors.invalidArgument(
-                        correlationId, QUERY_TABLE_ID_REQUIRED, Map.of("query_id", queryId));
-                  }
-
-                  var ctxOpt = queryStore.get(queryId);
-                  if (ctxOpt.isEmpty()) {
-                    throw GrpcErrors.notFound(
-                        correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId));
-                  }
-                  var ctx = ctxOpt.get();
-
-                  ResourceId tableId = request.getTableId();
-                  var pin = ctx.requireSnapshotPin(tableId, correlationId);
-
-                  try {
-                    ScanBundle pruned;
-                    var tableInfo =
-                        request.getMetadataOnly()
-                            ? scanBundles.fetchTableInfo(correlationId, request.getTableId(), pin)
-                            : null;
-                    if (request.getMetadataOnly()) {
-                      pruned = ScanBundle.getDefaultInstance();
-                    } else {
-                      var raw = scanBundles.fetch(correlationId, request.getTableId(), pin);
-                      pruned =
-                          ScanPruningUtils.pruneBundle(
-                              raw.bundle(),
-                              request.getRequiredColumnsList(),
-                              request.getPredicatesList());
-                      tableInfo = raw.tableInfo();
-                    }
-
-                    ctx.markPlanningCompleted();
-
-                    return FetchScanBundleResponse.newBuilder()
-                        .setBundle(pruned)
-                        .setTableInfo(tableInfo)
-                        .build();
-
-                  } catch (RuntimeException e) {
-                    ctx.markPlanningFailed();
-                    throw e;
-                  }
-                }),
-            correlationId())
+  /**
+   * Handles the stream initialization RPC: validates the query/table, ensures the snapshot is
+   * pinned, and creates a server-side scan session that captures pruning hints + batch knobs.
+   */
+  public Uni<InitScanResponse> initScan(InitScanRequest request) {
+    var L = LogHelper.start(LOG, "InitScan");
+    return run(() -> {
+          String correlationId = principal.get().getCorrelationId();
+          authz.require(principal.get(), "catalog.read");
+          String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+          if (!request.hasTableId()) {
+            throw GrpcErrors.invalidArgument(
+                correlationId, QUERY_TABLE_ID_REQUIRED, Map.of("query_id", queryId));
+          }
+          var ctx =
+              queryStore
+                  .get(queryId)
+                  .orElseThrow(
+                      () ->
+                          GrpcErrors.notFound(
+                              correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId)));
+          ResourceId tableId = request.getTableId();
+          var pin = ctx.requireSnapshotPin(tableId, correlationId);
+          var initData = scanBundles.initScan(correlationId, tableId, pin.getSnapshotId());
+          var session =
+              ScanSession.builder()
+                  .queryId(queryId)
+                  .tableId(tableId)
+                  .snapshotId(initData.snapshotId())
+                  .tableInfo(initData.tableInfo())
+                  .includeColumnStats(request.getIncludeColumnStats())
+                  .excludePartitionDataJson(request.getExcludePartitionDataJson())
+                  .targetBatchItems(capped(request.getTargetBatchItems(), defaultBatchItems))
+                  .targetBatchBytes(capped(request.getTargetBatchBytes(), defaultBatchBytes))
+                  .requiredColumns(request.getRequiredColumnsList())
+                  .predicates(request.getPredicatesList())
+                  .build();
+          ScanHandle handle = queryStore.createScanSession(correlationId, session);
+          return InitScanResponse.newBuilder()
+              .setHandle(handle)
+              .setTableInfo(initData.tableInfo())
+              .build();
+        })
         .onFailure()
         .invoke(L::fail)
         .onItem()
-        .invoke(L::ok);
+        .invoke(item -> L.ok());
+  }
+
+  @Override
+  /**
+   * Streams delete files for a scan handle. The returned {@linkplain Multi} caches metadata so
+   * retries can replay the same batches, and the handle is automatically removed on
+   * termination/cancellation.
+   */
+  public Multi<DeleteFileBatch> streamDeleteFiles(ScanHandle handle) {
+    var L = LogHelper.start(LOG, "StreamDeleteFiles");
+    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
+    return Multi.createFrom()
+        .deferred(
+            () ->
+                grpcCtx.call(
+                    () -> {
+                      String correlationId = principal.get().getCorrelationId();
+                      ScanSession session = requireSession(handle, correlationId);
+                      return scanBundles
+                          .streamDeleteFiles(session, correlationId)
+                          .onFailure()
+                          .invoke(e -> markPlanningFailed(session, correlationId))
+                          .onFailure()
+                          .invoke(e -> queryStore.removeScanSession(handle))
+                          .onCompletion()
+                          .invoke(L::ok);
+                    }))
+        .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+        .onFailure()
+        .invoke(L::fail);
+  }
+
+  @Override
+  /**
+   * Streams data files after deletes are complete. Failing to observe deletes first results in
+   * FAILED_PRECONDITION; successful completion marks planning done and releases the session.
+   */
+  public Multi<DataFileBatch> streamDataFiles(ScanHandle handle) {
+    var L = LogHelper.start(LOG, "StreamDataFiles");
+    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
+    return Multi.createFrom()
+        .deferred(
+            () ->
+                grpcCtx.call(
+                    () -> {
+                      String correlationId = principal.get().getCorrelationId();
+                      ScanSession session = requireSession(handle, correlationId);
+                      return scanBundles
+                          .streamDataFiles(session, correlationId)
+                          .onFailure()
+                          .invoke(e -> markPlanningFailed(session, correlationId))
+                          .onFailure()
+                          .invoke(e -> queryStore.removeScanSession(handle))
+                          .onCompletion()
+                          .invoke(
+                              () -> {
+                                markPlanningCompleted(session, correlationId);
+                                L.ok();
+                              });
+                    }))
+        .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+        .onTermination()
+        .invoke(() -> queryStore.removeScanSession(handle))
+        .onFailure()
+        .invoke(L::fail);
+  }
+
+  @Override
+  /**
+   * Best-effort request to release server state for a handle. Close may be skipped if streams
+   * already finished, but it is provided so clients can proactively clean up resources.
+   */
+  public Uni<Empty> closeScan(ScanHandle handle) {
+    var L = LogHelper.start(LOG, "CloseScan");
+    return run(() -> {
+          String correlationId = principal.get().getCorrelationId();
+          queryStore
+              .getScanSession(handle)
+              .ifPresent(session -> markPlanningCompleted(session, correlationId));
+          queryStore.removeScanSession(handle);
+          return Empty.newBuilder().build();
+        })
+        .onFailure()
+        .invoke(L::fail)
+        .onItem()
+        .invoke(item -> L.ok());
+  }
+
+  private ScanSession requireSession(ScanHandle handle, String correlationId) {
+    return queryStore
+        .getScanSession(handle)
+        .orElseThrow(
+            () ->
+                GrpcErrors.notFound(correlationId, SCAN_HANDLE, Map.of("handle", handle.getId())));
+  }
+
+  private void markPlanningFailed(ScanSession session, String correlationId) {
+    queryStore.update(
+        session.queryId(),
+        ctx -> {
+          ctx.markPlanningFailed();
+          return ctx;
+        });
+  }
+
+  private void markPlanningCompleted(ScanSession session, String correlationId) {
+    queryStore.update(
+        session.queryId(),
+        ctx -> {
+          ctx.markPlanningCompleted();
+          return ctx;
+        });
+  }
+
+  private int capped(int value, int fallback) {
+    return value > 0 ? value : fallback;
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/ScanSession.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/ScanSession.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.impl;
+
+import ai.floedb.floecat.common.rpc.Predicate;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.execution.rpc.ScanFile;
+import ai.floedb.floecat.execution.rpc.ScanFileContent;
+import ai.floedb.floecat.query.rpc.DeleteFile;
+import ai.floedb.floecat.query.rpc.TableInfo;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Tracks state for an open scan handle: metadata, batching hints, and cached delete metadata. */
+public final class ScanSession {
+
+  private final String handleId;
+  private final String queryId;
+  private final ResourceId tableId;
+  private final long snapshotId;
+  private final TableInfo tableInfo;
+  private final boolean includeColumnStats;
+  private final boolean excludePartitionDataJson;
+  private final int targetBatchItems;
+  private final int targetBatchBytes;
+  private final List<String> requiredColumns;
+  private final List<Predicate> predicates;
+  private final AtomicInteger nextDeleteId;
+  private final List<Integer> deleteIdsByIndex;
+  private final Map<String, Integer> deleteIdByPath;
+  private final AtomicBoolean deletesComplete;
+  private final AtomicReference<CompletableFuture<List<List<DeleteFileMetadata>>>>
+      deleteBatchesFuture;
+
+  private ScanSession(Builder builder) {
+    this.handleId = builder.handleId;
+    this.queryId = builder.queryId;
+    this.tableId = builder.tableId;
+    this.snapshotId = builder.snapshotId;
+    this.tableInfo = builder.tableInfo;
+    this.includeColumnStats = builder.includeColumnStats;
+    this.excludePartitionDataJson = builder.excludePartitionDataJson;
+    this.targetBatchItems = builder.targetBatchItems;
+    this.targetBatchBytes = builder.targetBatchBytes;
+    this.requiredColumns = builder.requiredColumns;
+    this.predicates = builder.predicates;
+    this.nextDeleteId = new AtomicInteger(0);
+    this.deleteIdsByIndex = Collections.synchronizedList(new ArrayList<>());
+    this.deleteIdByPath = new ConcurrentHashMap<>();
+    this.deletesComplete = new AtomicBoolean(false);
+    this.deleteBatchesFuture = new AtomicReference<>();
+  }
+
+  public String handleId() {
+    return handleId;
+  }
+
+  public String queryId() {
+    return queryId;
+  }
+
+  public ResourceId tableId() {
+    return tableId;
+  }
+
+  public long snapshotId() {
+    return snapshotId;
+  }
+
+  public TableInfo tableInfo() {
+    return tableInfo;
+  }
+
+  public boolean includeColumnStats() {
+    return includeColumnStats;
+  }
+
+  public boolean excludePartitionDataJson() {
+    return excludePartitionDataJson;
+  }
+
+  public int targetBatchItems() {
+    return targetBatchItems;
+  }
+
+  public int targetBatchBytes() {
+    return targetBatchBytes;
+  }
+
+  public int nextDeleteId() {
+    return nextDeleteId.getAndIncrement();
+  }
+
+  public int recordDeleteId(int deleteId) {
+    synchronized (deleteIdsByIndex) {
+      deleteIdsByIndex.add(deleteId);
+      return deleteIdsByIndex.size() - 1;
+    }
+  }
+
+  public List<Integer> recordedDeleteIds() {
+    synchronized (deleteIdsByIndex) {
+      return new ArrayList<>(deleteIdsByIndex);
+    }
+  }
+
+  public Map<String, Integer> deleteIdByPath() {
+    return deleteIdByPath;
+  }
+
+  public boolean deletesComplete() {
+    return deletesComplete.get();
+  }
+
+  public void markDeletesComplete() {
+    deletesComplete.set(true);
+  }
+
+  public CompletableFuture<List<List<DeleteFileMetadata>>> deleteBatchesFuture() {
+    return deleteBatchesFuture.get();
+  }
+
+  public boolean initDeleteBatchesFuture(CompletableFuture<List<List<DeleteFileMetadata>>> future) {
+    return this.deleteBatchesFuture.compareAndSet(null, future);
+  }
+
+  public void cacheDeleteBatches(List<List<DeleteFileMetadata>> batches) {
+    CompletableFuture<List<List<DeleteFileMetadata>>> future = this.deleteBatchesFuture.get();
+    if (future != null && !future.isDone()) {
+      future.complete(List.copyOf(batches));
+    }
+  }
+
+  public static final class DeleteFileMetadata {
+    private final int deleteId;
+    private final String filePath;
+    private final String fileFormat;
+    private final long fileSizeInBytes;
+    private final long recordCount;
+    private final ScanFileContent fileContent;
+    private final String partitionDataJson;
+    private final int partitionSpecId;
+    private final List<Integer> equalityFieldIds;
+    private final OptionalLong sequenceNumber;
+
+    private DeleteFileMetadata(
+        int deleteId,
+        String filePath,
+        String fileFormat,
+        long fileSizeInBytes,
+        long recordCount,
+        ScanFileContent fileContent,
+        String partitionDataJson,
+        int partitionSpecId,
+        List<Integer> equalityFieldIds,
+        OptionalLong sequenceNumber) {
+      this.deleteId = deleteId;
+      this.filePath = filePath;
+      this.fileFormat = fileFormat;
+      this.fileSizeInBytes = fileSizeInBytes;
+      this.recordCount = recordCount;
+      this.fileContent = fileContent;
+      this.partitionDataJson = partitionDataJson;
+      this.partitionSpecId = partitionSpecId;
+      this.equalityFieldIds = equalityFieldIds;
+      this.sequenceNumber = sequenceNumber;
+    }
+
+    public static DeleteFileMetadata fromDeleteFile(DeleteFile file) {
+      ScanFile scanFile = file.getFile();
+      return new DeleteFileMetadata(
+          file.getDeleteId(),
+          scanFile.getFilePath(),
+          scanFile.getFileFormat(),
+          scanFile.getFileSizeInBytes(),
+          scanFile.getRecordCount(),
+          scanFile.getFileContent(),
+          scanFile.getPartitionDataJson(),
+          scanFile.getPartitionSpecId(),
+          List.copyOf(scanFile.getEqualityFieldIdsList()),
+          scanFile.hasSequenceNumber()
+              ? OptionalLong.of(scanFile.getSequenceNumber())
+              : OptionalLong.empty());
+    }
+
+    public DeleteFile toDeleteFile() {
+      ScanFile.Builder builder =
+          ScanFile.newBuilder()
+              .setFilePath(filePath)
+              .setFileFormat(fileFormat)
+              .setFileSizeInBytes(fileSizeInBytes)
+              .setRecordCount(recordCount)
+              .setFileContent(fileContent)
+              .setPartitionDataJson(partitionDataJson)
+              .setPartitionSpecId(partitionSpecId)
+              .addAllEqualityFieldIds(equalityFieldIds);
+      sequenceNumber.ifPresent(builder::setSequenceNumber);
+      return DeleteFile.newBuilder().setDeleteId(deleteId).setFile(builder.build()).build();
+    }
+  }
+
+  public List<String> requiredColumns() {
+    return requiredColumns;
+  }
+
+  public List<Predicate> predicates() {
+    return predicates;
+  }
+
+  /** Builds a ScanSession before handing the handle to the store. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String handleId;
+    private String queryId;
+    private ResourceId tableId;
+    private long snapshotId;
+    private TableInfo tableInfo;
+    private boolean includeColumnStats;
+    private boolean excludePartitionDataJson;
+    private int targetBatchItems;
+    private int targetBatchBytes;
+
+    private List<String> requiredColumns = List.of();
+    private List<Predicate> predicates = List.of();
+
+    private Builder() {}
+
+    public Builder handleId(String handleId) {
+      this.handleId = handleId;
+      return this;
+    }
+
+    public Builder queryId(String queryId) {
+      this.queryId = queryId;
+      return this;
+    }
+
+    public Builder tableId(ResourceId tableId) {
+      this.tableId = tableId;
+      return this;
+    }
+
+    public Builder snapshotId(long snapshotId) {
+      this.snapshotId = snapshotId;
+      return this;
+    }
+
+    public Builder tableInfo(TableInfo tableInfo) {
+      this.tableInfo = tableInfo;
+      return this;
+    }
+
+    public Builder includeColumnStats(boolean includeColumnStats) {
+      this.includeColumnStats = includeColumnStats;
+      return this;
+    }
+
+    public Builder excludePartitionDataJson(boolean excludePartitionDataJson) {
+      this.excludePartitionDataJson = excludePartitionDataJson;
+      return this;
+    }
+
+    public Builder targetBatchItems(int targetBatchItems) {
+      this.targetBatchItems = targetBatchItems;
+      return this;
+    }
+
+    public Builder targetBatchBytes(int targetBatchBytes) {
+      this.targetBatchBytes = targetBatchBytes;
+      return this;
+    }
+
+    public Builder requiredColumns(List<String> requiredColumns) {
+      this.requiredColumns = requiredColumns == null ? List.of() : List.copyOf(requiredColumns);
+      return this;
+    }
+
+    public Builder predicates(List<Predicate> predicates) {
+      this.predicates = predicates == null ? List.of() : List.copyOf(predicates);
+      return this;
+    }
+
+    public ScanSession build() {
+      return new ScanSession(this);
+    }
+  }
+}

--- a/service/src/main/resources/errors_en.properties
+++ b/service/src/main/resources/errors_en.properties
@@ -67,12 +67,14 @@ MC_NOT_FOUND.query.not.found=Query not found: {query_id}.
 MC_NOT_FOUND.query.table.not.pinned=Table "{table_id}" is not pinned for query "{query_id}".
 MC_NOT_FOUND.query.input.unresolved=Query input could not be resolved: {name}.
 MC_NOT_FOUND.systemcatalog.not.found=Builtin catalog not found for engine version: {engine_version}.
+MC_NOT_FOUND.scan.handle=Scan handle not found: {handle}.
 
 MC_PRECONDITION_FAILED.version.mismatch=Version mismatch (expected {expected}, got {actual}).
 MC_PRECONDITION_FAILED.catalog.children.changed=Catalog metadata changed while evaluating the request.
 MC_PRECONDITION_FAILED.namespace.children.changed=Namespace metadata changed while evaluating the request.
 MC_PRECONDITION_FAILED.query.not.active=The query is not in an active state.
 MC_PRECONDITION_FAILED.etag.mismatch=ETag mismatch (expected {expected}, got {actual}).
+MC_PRECONDITION_FAILED.scan.deletes.not.complete=Delete streaming must finish before data files can be emitted.
 
 MC_INTERNAL.query.expansion.parse.failed=Failed to parse the expansion.
 MC_INTERNAL.catalog.bundle.snapshot.parse.failed=Failed to parse the bundle snapshot.

--- a/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
@@ -28,23 +28,20 @@ import ai.floedb.floecat.connector.rpc.*;
 import ai.floedb.floecat.execution.rpc.ScanFile;
 import ai.floedb.floecat.query.rpc.*;
 import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
+import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.util.TestDataResetter;
 import ai.floedb.floecat.service.util.TestSupport;
 import com.google.protobuf.FieldMask;
-import io.grpc.Channel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.grpc.stub.StreamObserver;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -67,9 +64,6 @@ class QueryScanServiceIT {
   QueryScanServiceGrpc.QueryScanServiceBlockingStub scan;
 
   @GrpcClient("floecat")
-  Channel scanChannel;
-
-  @GrpcClient("floecat")
   CatalogServiceGrpc.CatalogServiceBlockingStub catalog;
 
   @GrpcClient("floecat")
@@ -89,6 +83,7 @@ class QueryScanServiceIT {
 
   @Inject TestDataResetter resetter;
   @Inject SeedRunner seeder;
+  @Inject QueryContextStore queryStore;
 
   String catalogPrefix = this.getClass().getSimpleName() + "_";
 
@@ -441,42 +436,22 @@ class QueryScanServiceIT {
   @Test
   void incompleteDeleteStreamPreventsData() throws Exception {
     ScanHandle handle = prepareScanHandle("delete-short");
-    scan.streamDeleteFiles(handle);
-    // intentionally keep delete stream unsettled (never drained)
+    var session = queryStore.getScanSession(handle).orElseThrow();
+    assertTrue(session.initDeleteBatchesFuture(new CompletableFuture<>()));
+
     StatusRuntimeException ex = assertStreamDataFilesFails(handle);
     assertEquals(Status.Code.FAILED_PRECONDITION, ex.getStatus().getCode());
     scan.closeScan(handle);
   }
 
-  private StatusRuntimeException assertStreamDataFilesFails(ScanHandle handle)
-      throws InterruptedException {
-    CountDownLatch done = new CountDownLatch(1);
-    AtomicBoolean receivedData = new AtomicBoolean();
-    AtomicReference<Throwable> terminalFailure = new AtomicReference<>();
-    QueryScanServiceGrpc.newStub(scanChannel)
-        .streamDataFiles(
-            handle,
-            new StreamObserver<>() {
-              @Override
-              public void onNext(DataFileBatch value) {
-                receivedData.set(true);
-              }
-
-              @Override
-              public void onError(Throwable t) {
-                terminalFailure.set(t);
-                done.countDown();
-              }
-
-              @Override
-              public void onCompleted() {
-                terminalFailure.set(new AssertionError("expected stream failure"));
-                done.countDown();
-              }
-            });
-
-    assertTrue(done.await(5, TimeUnit.SECONDS), "timed out waiting for StreamDataFiles failure");
-    assertFalse(receivedData.get(), "StreamDataFiles emitted data before delete stream completed");
-    return assertInstanceOf(StatusRuntimeException.class, terminalFailure.get());
+  private StatusRuntimeException assertStreamDataFilesFails(ScanHandle handle) {
+    Iterator<DataFileBatch> batches = scan.streamDataFiles(handle);
+    return assertThrows(
+        StatusRuntimeException.class,
+        () -> {
+          while (batches.hasNext()) {
+            batches.next();
+          }
+        });
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.connector.rpc.*;
+import ai.floedb.floecat.execution.rpc.ScanFile;
 import ai.floedb.floecat.query.rpc.*;
 import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
 import ai.floedb.floecat.service.util.TestDataResetter;
@@ -35,12 +36,14 @@ import io.grpc.StatusRuntimeException;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integration tests for QueryScanService (FetchScanBundle).
+ * Integration tests for QueryScanService streaming scans.
  *
  * <p>After API changes: - BeginQuery no longer takes inputs. - DescribeInputs establishes pinned
  * tables + snapshots.
@@ -86,9 +89,9 @@ class QueryScanServiceIT {
     seeder.seedData();
   }
 
-  /** Ensures FetchScanBundle returns empty bundle for a pinned table. */
+  /** Ensures streaming scans return empty file lists for a pinned table. */
   @Test
-  void fetchScanBundleReturnsBundleForPinnedTable() throws Exception {
+  void streamScanReturnsFilesForPinnedTable() throws Exception {
 
     var catName = catalogPrefix + "scan_cat";
     var cat = TestSupport.createCatalog(catalog, catName, "");
@@ -134,20 +137,16 @@ class QueryScanServiceIT {
                     .build())
             .build());
 
-    var resp =
-        scan.fetchScanBundle(
-            FetchScanBundleRequest.newBuilder()
-                .setQueryId(queryId)
-                .setTableId(tbl.getResourceId())
-                .build());
+    InitScanRequest initReq =
+        InitScanRequest.newBuilder().setQueryId(queryId).setTableId(tbl.getResourceId()).build();
+    var resp = collectScanFileStream(initReq);
 
-    assertTrue(resp.hasBundle());
-    assertEquals(0, resp.getBundle().getDataFilesCount());
-    assertEquals(0, resp.getBundle().getDeleteFilesCount());
+    assertEquals(0, resp.dataFiles().size());
+    assertEquals(0, resp.deleteFiles().size());
   }
 
   @Test
-  void fetchScanBundleReturnsTableInfo() throws Exception {
+  void streamScanReturnsTableInfo() throws Exception {
 
     var catName = catalogPrefix + "scan_info";
     var cat = TestSupport.createCatalog(catalog, catName, "");
@@ -207,15 +206,12 @@ class QueryScanServiceIT {
                     .build())
             .build());
 
-    var resp =
-        scan.fetchScanBundle(
-            FetchScanBundleRequest.newBuilder()
-                .setQueryId(queryId)
-                .setTableId(tbl.getResourceId())
-                .build());
+    InitScanRequest initReq =
+        InitScanRequest.newBuilder().setQueryId(queryId).setTableId(tbl.getResourceId()).build();
+    var resp = collectScanFileStream(initReq);
 
-    assertTrue(resp.hasTableInfo());
-    var info = resp.getTableInfo();
+    assertNotNull(resp.tableInfo());
+    var info = resp.tableInfo();
     assertEquals(tbl.getResourceId(), info.getTableId());
     assertEquals(tbl.getSchemaJson(), info.getSchemaJson());
     assertEquals(metadataLocation, info.getMetadataLocation());
@@ -223,9 +219,9 @@ class QueryScanServiceIT {
     assertEquals(snap.getSnapshotId(), info.getSnapshotId());
   }
 
-  /** Ensures FetchScanBundle rejects unpinned tables. */
+  /** Ensures streaming scans reject unpinned tables. */
   @Test
-  void fetchScanBundleRejectsUnpinnedTables() throws Exception {
+  void streamScanRejectsUnpinnedTables() throws Exception {
 
     var catName = catalogPrefix + "scan_nf";
     var cat = TestSupport.createCatalog(catalog, catName, "");
@@ -283,8 +279,8 @@ class QueryScanServiceIT {
         assertThrows(
             StatusRuntimeException.class,
             () ->
-                scan.fetchScanBundle(
-                    FetchScanBundleRequest.newBuilder()
+                collectScanFileStream(
+                    InitScanRequest.newBuilder()
                         .setQueryId(queryId)
                         .setTableId(tblB.getResourceId())
                         .build()));
@@ -342,5 +338,104 @@ class QueryScanServiceIT {
             .setSpec(spec)
             .setUpdateMask(mask)
             .build());
+  }
+
+  private record ScanFileStreamResponse(
+      TableInfo tableInfo, List<ScanFile> dataFiles, List<ScanFile> deleteFiles) {}
+
+  private ScanFileStreamResponse collectScanFileStream(InitScanRequest request) {
+    InitScanResponse initResp = scan.initScan(request);
+    ScanHandle handle = initResp.getHandle();
+    List<ScanFile> deleteFiles = new ArrayList<>();
+    var deleteIter = scan.streamDeleteFiles(handle);
+    while (deleteIter.hasNext()) {
+      DeleteFileBatch batch = deleteIter.next();
+      for (var delete : batch.getItemsList()) {
+        deleteFiles.add(delete.getFile());
+      }
+    }
+    List<ScanFile> dataFiles = new ArrayList<>();
+    var dataIter = scan.streamDataFiles(handle);
+    while (dataIter.hasNext()) {
+      DataFileBatch batch = dataIter.next();
+      for (var data : batch.getItemsList()) {
+        dataFiles.add(data.getFile());
+      }
+    }
+    scan.closeScan(handle);
+    return new ScanFileStreamResponse(initResp.getTableInfo(), dataFiles, deleteFiles);
+  }
+
+  private static final AtomicLong SNAPSHOT_SEQ = new AtomicLong(1000);
+
+  private ScanHandle prepareScanHandle(String tag) throws Exception {
+    var catName = catalogPrefix + "scan_precondition_" + tag;
+    var cat = TestSupport.createCatalog(catalog, catName, "");
+    var ns =
+        TestSupport.createNamespace(namespace, cat.getResourceId(), "scan", List.of("scan"), "");
+    var tbl =
+        TestSupport.createTable(
+            table,
+            cat.getResourceId(),
+            ns.getResourceId(),
+            "scan_table_" + tag,
+            "s3://bucket/scan_table_" + tag,
+            "{\"cols\":[{\"name\":\"id\",\"type\":\"int\"}]}",
+            "scan table");
+    var snap =
+        TestSupport.createSnapshot(
+            snapshot,
+            tbl.getResourceId(),
+            SNAPSHOT_SEQ.getAndIncrement(),
+            System.currentTimeMillis());
+    var connector = createDummyConnector(cat.getResourceId(), ns.getResourceId(), tag);
+    attachConnectorToTable(tbl.getResourceId(), connector);
+
+    var begin =
+        lifecycle.beginQuery(
+            BeginQueryRequest.newBuilder().setDefaultCatalogId(cat.getResourceId()).build());
+    var queryId = begin.getQuery().getQueryId();
+    schema.describeInputs(
+        DescribeInputsRequest.newBuilder()
+            .setQueryId(queryId)
+            .addInputs(
+                QueryInput.newBuilder()
+                    .setTableId(tbl.getResourceId())
+                    .setSnapshot(
+                        SnapshotRef.newBuilder().setSnapshotId(snap.getSnapshotId()).build())
+                    .build())
+            .build());
+    return scan.initScan(
+            InitScanRequest.newBuilder()
+                .setQueryId(queryId)
+                .setTableId(tbl.getResourceId())
+                .build())
+        .getHandle();
+  }
+
+  @Test
+  void streamDataBeforeDeletesFails() throws Exception {
+    ScanHandle handle = prepareScanHandle("precondition");
+    StatusRuntimeException ex =
+        assertThrows(StatusRuntimeException.class, () -> scan.streamDataFiles(handle).hasNext());
+    assertEquals(Status.Code.FAILED_PRECONDITION, ex.getStatus().getCode());
+    scan.closeScan(handle);
+  }
+
+  @Test
+  void closeScanIsIdempotent() throws Exception {
+    ScanHandle handle = prepareScanHandle("close twice");
+    scan.streamDeleteFiles(handle).forEachRemaining(batch -> {});
+    scan.closeScan(handle);
+    assertDoesNotThrow(() -> scan.closeScan(handle));
+  }
+
+  @Test
+  void incompleteDeleteStreamPreventsData() throws Exception {
+    ScanHandle handle = prepareScanHandle("delete-short");
+    scan.streamDeleteFiles(handle);
+    // intentionally keep delete stream unsettled (never drained)
+    assertThrows(StatusRuntimeException.class, () -> scan.streamDataFiles(handle).hasNext());
+    scan.closeScan(handle);
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
@@ -31,14 +31,20 @@ import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
 import ai.floedb.floecat.service.util.TestDataResetter;
 import ai.floedb.floecat.service.util.TestSupport;
 import com.google.protobuf.FieldMask;
+import io.grpc.Channel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +65,9 @@ class QueryScanServiceIT {
 
   @GrpcClient("floecat")
   QueryScanServiceGrpc.QueryScanServiceBlockingStub scan;
+
+  @GrpcClient("floecat")
+  Channel scanChannel;
 
   @GrpcClient("floecat")
   CatalogServiceGrpc.CatalogServiceBlockingStub catalog;
@@ -416,8 +425,7 @@ class QueryScanServiceIT {
   @Test
   void streamDataBeforeDeletesFails() throws Exception {
     ScanHandle handle = prepareScanHandle("precondition");
-    StatusRuntimeException ex =
-        assertThrows(StatusRuntimeException.class, () -> scan.streamDataFiles(handle).hasNext());
+    StatusRuntimeException ex = assertStreamDataFilesFails(handle);
     assertEquals(Status.Code.FAILED_PRECONDITION, ex.getStatus().getCode());
     scan.closeScan(handle);
   }
@@ -435,7 +443,40 @@ class QueryScanServiceIT {
     ScanHandle handle = prepareScanHandle("delete-short");
     scan.streamDeleteFiles(handle);
     // intentionally keep delete stream unsettled (never drained)
-    assertThrows(StatusRuntimeException.class, () -> scan.streamDataFiles(handle).hasNext());
+    StatusRuntimeException ex = assertStreamDataFilesFails(handle);
+    assertEquals(Status.Code.FAILED_PRECONDITION, ex.getStatus().getCode());
     scan.closeScan(handle);
+  }
+
+  private StatusRuntimeException assertStreamDataFilesFails(ScanHandle handle)
+      throws InterruptedException {
+    CountDownLatch done = new CountDownLatch(1);
+    AtomicBoolean receivedData = new AtomicBoolean();
+    AtomicReference<Throwable> terminalFailure = new AtomicReference<>();
+    QueryScanServiceGrpc.newStub(scanChannel)
+        .streamDataFiles(
+            handle,
+            new StreamObserver<>() {
+              @Override
+              public void onNext(DataFileBatch value) {
+                receivedData.set(true);
+              }
+
+              @Override
+              public void onError(Throwable t) {
+                terminalFailure.set(t);
+                done.countDown();
+              }
+
+              @Override
+              public void onCompleted() {
+                terminalFailure.set(new AssertionError("expected stream failure"));
+                done.countDown();
+              }
+            });
+
+    assertTrue(done.await(5, TimeUnit.SECONDS), "timed out waiting for StreamDataFiles failure");
+    assertFalse(receivedData.get(), "StreamDataFiles emitted data before delete stream completed");
+    return assertInstanceOf(StatusRuntimeException.class, terminalFailure.get());
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/it/UserObjectsServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/UserObjectsServiceIT.java
@@ -24,10 +24,13 @@ import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.rpc.*;
+import ai.floedb.floecat.execution.rpc.ScanFile;
 import ai.floedb.floecat.query.rpc.BeginQueryRequest;
-import ai.floedb.floecat.query.rpc.FetchScanBundleRequest;
-import ai.floedb.floecat.query.rpc.FetchScanBundleResponse;
+import ai.floedb.floecat.query.rpc.DataFileBatch;
+import ai.floedb.floecat.query.rpc.DeleteFileBatch;
 import ai.floedb.floecat.query.rpc.GetUserObjectsRequest;
+import ai.floedb.floecat.query.rpc.InitScanRequest;
+import ai.floedb.floecat.query.rpc.InitScanResponse;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
 import ai.floedb.floecat.query.rpc.RelationInfo;
@@ -35,7 +38,9 @@ import ai.floedb.floecat.query.rpc.RelationKind;
 import ai.floedb.floecat.query.rpc.RelationResolution;
 import ai.floedb.floecat.query.rpc.RelationResolutions;
 import ai.floedb.floecat.query.rpc.ResolutionStatus;
+import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
+import ai.floedb.floecat.query.rpc.TableInfo;
 import ai.floedb.floecat.query.rpc.TableReferenceCandidate;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
 import ai.floedb.floecat.query.rpc.UserObjectsServiceGrpc;
@@ -161,16 +166,10 @@ class UserObjectsServiceIT {
     assertEquals(1, end.getEnd().getFoundCount());
     assertEquals(0, end.getEnd().getNotFoundCount());
 
-    var response =
-        fetchScanBundle(
-                FetchScanBundleRequest.newBuilder()
-                    .setQueryId(queryId)
-                    .setTableId(tbl.getResourceId())
-                    .build())
-            .toCompletableFuture()
-            .join();
-    assertTrue(response.hasBundle());
-    assertEquals(0, response.getBundle().getDataFilesCount());
+    InitScanRequest initReq =
+        InitScanRequest.newBuilder().setQueryId(queryId).setTableId(tbl.getResourceId()).build();
+    var response = fetchScanFileStream(initReq).toCompletableFuture().join();
+    assertEquals(0, response.dataFiles().size());
   }
 
   @Test
@@ -361,33 +360,39 @@ class UserObjectsServiceIT {
     return future.orTimeout(5, TimeUnit.SECONDS);
   }
 
-  private CompletionStage<FetchScanBundleResponse> fetchScanBundle(FetchScanBundleRequest request) {
-    CompletableFuture<FetchScanBundleResponse> future = new CompletableFuture<>();
-    QueryScanServiceGrpc.QueryScanServiceStub async =
-        QueryScanServiceGrpc.newStub(channel).withDeadlineAfter(5, TimeUnit.SECONDS);
-    async.fetchScanBundle(
-        request,
-        new StreamObserver<>() {
-          @Override
-          public void onNext(FetchScanBundleResponse response) {
-            future.complete(response);
-          }
-
-          @Override
-          public void onError(Throwable t) {
-            future.completeExceptionally(t);
-          }
-
-          @Override
-          public void onCompleted() {
-            if (!future.isDone()) {
-              future.completeExceptionally(
-                  new IllegalStateException("fetchScanBundle completed without response"));
-            }
-          }
-        });
+  private CompletionStage<ScanFileStreamResponse> fetchScanFileStream(InitScanRequest request) {
+    CompletableFuture<ScanFileStreamResponse> future = new CompletableFuture<>();
+    QueryScanServiceGrpc.QueryScanServiceBlockingStub blocking =
+        QueryScanServiceGrpc.newBlockingStub(channel).withDeadlineAfter(5, TimeUnit.SECONDS);
+    try {
+      InitScanResponse initResp = blocking.initScan(request);
+      ScanHandle handle = initResp.getHandle();
+      List<ScanFile> dataFiles = new ArrayList<>();
+      List<ScanFile> deleteFiles = new ArrayList<>();
+      var deleteIter = blocking.streamDeleteFiles(handle);
+      while (deleteIter.hasNext()) {
+        DeleteFileBatch batch = deleteIter.next();
+        for (var delete : batch.getItemsList()) {
+          deleteFiles.add(delete.getFile());
+        }
+      }
+      var dataIter = blocking.streamDataFiles(handle);
+      while (dataIter.hasNext()) {
+        DataFileBatch batch = dataIter.next();
+        for (var data : batch.getItemsList()) {
+          dataFiles.add(data.getFile());
+        }
+      }
+      blocking.closeScan(handle);
+      future.complete(new ScanFileStreamResponse(initResp.getTableInfo(), dataFiles, deleteFiles));
+    } catch (Throwable t) {
+      future.completeExceptionally(t);
+    }
     return future.orTimeout(5, TimeUnit.SECONDS);
   }
+
+  private record ScanFileStreamResponse(
+      TableInfo tableInfo, List<ScanFile> dataFiles, List<ScanFile> deleteFiles) {}
 
   private Connector createDummyConnector(
       ResourceId catalogId, ResourceId namespaceId, String suffix) {

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -29,12 +29,14 @@ import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.RelationNode;
 import ai.floedb.floecat.metagraph.model.TypeNode;
+import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.impl.QueryContext;
+import ai.floedb.floecat.service.query.impl.ScanSession;
 import ai.floedb.floecat.service.query.resolver.QueryInputResolver;
 import com.google.protobuf.Timestamp;
 import java.time.Instant;
@@ -45,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Flow.Subscriber;
@@ -393,6 +396,7 @@ public final class UserObjectBundleTestSupport {
   public static final class TestQueryContextStore implements QueryContextStore {
     private final Map<String, QueryContext> contexts = new HashMap<>();
     private final List<QueryContext> updates = new ArrayList<>();
+    private final Map<String, ScanSession> scanSessions = new HashMap<>();
 
     public void seed(QueryContext ctx) {
       contexts.put(ctx.getQueryId(), ctx);
@@ -459,6 +463,28 @@ public final class UserObjectBundleTestSupport {
       contexts.put(queryId, updated);
       updates.add(updated);
       return Optional.of(updated);
+    }
+
+    @Override
+    public ScanHandle createScanSession(String correlationId, ScanSession session) {
+      String id = UUID.randomUUID().toString();
+      scanSessions.put(id, session);
+      return ScanHandle.newBuilder().setId(id).build();
+    }
+
+    @Override
+    public Optional<ScanSession> getScanSession(ScanHandle handle) {
+      if (handle == null) {
+        return Optional.empty();
+      }
+      return Optional.ofNullable(scanSessions.get(handle.getId()));
+    }
+
+    @Override
+    public void removeScanSession(ScanHandle handle) {
+      if (handle != null) {
+        scanSessions.remove(handle.getId());
+      }
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreLeaseOutcomeTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreLeaseOutcomeTest.java
@@ -142,7 +142,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   @Test
   void applyLeaseOutcomeReturnsTrueForAcceptedTransitions() {
     String succeededJobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob succeededLease = leaseNextEventually();
+    ReconcileJobStore.LeasedJob succeededLease = leaseJob(succeededJobId);
     assertTrue(
         store.applyLeaseOutcome(
             succeededJobId,
@@ -166,7 +166,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
             .state);
 
     String cancelledJobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob cancelledLease = leaseNextEventually();
+    ReconcileJobStore.LeasedJob cancelledLease = leaseJob(cancelledJobId);
     store.cancel(ACCOUNT_ID, cancelledJobId, "stop");
     assertTrue(
         store.applyLeaseOutcome(
@@ -194,7 +194,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   @Test
   void applyLeaseOutcomeCancellingSuccessResolvesImmediatelyToCancelled() {
     String jobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob lease = leaseNextEventually();
+    ReconcileJobStore.LeasedJob lease = leaseJob(jobId);
     store.cancel(ACCOUNT_ID, jobId, "stop");
 
     assertTrue(
@@ -233,7 +233,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   @Test
   void applyLeaseOutcomeCancellingFailureResolvesImmediatelyToCancelled() {
     String jobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob lease = leaseNextEventually();
+    ReconcileJobStore.LeasedJob lease = leaseJob(jobId);
     store.cancel(ACCOUNT_ID, jobId, "stop");
 
     assertTrue(
@@ -265,7 +265,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   @Test
   void applyLeaseOutcomeReturnsFalseForStaleLeaseEpoch() {
     String jobId = enqueueRoot();
-    leaseNextEventually();
+    leaseJob(jobId);
 
     assertFalse(
         store.applyLeaseOutcome(
@@ -312,7 +312,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   @Test
   void applyLeaseOutcomeReturnsFalseForTerminalJob() {
     String jobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob lease = leaseNextEventually();
+    ReconcileJobStore.LeasedJob lease = leaseJob(jobId);
     assertTrue(
         store.applyLeaseOutcome(
             jobId,
@@ -512,7 +512,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   void applyLeaseOutcomeReturnsTrueForExpiredLeaseWhenEpochStillMatches() {
     configureLeaseRenewGraceMs(0L);
     String jobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob lease = leaseNextEventually();
+    ReconcileJobStore.LeasedJob lease = leaseJob(jobId);
     expireLease(jobId);
 
     assertTrue(
@@ -563,11 +563,6 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
         ReconcileExecutionPolicy.defaults(),
         "",
         pinnedExecutorId);
-  }
-
-  private ReconcileJobStore.LeasedJob leaseNextEventually() {
-    return waitForValue(
-        () -> store.leaseNext().orElseThrow(), ignored -> true, "next reconcile job lease");
   }
 
   private <T> T waitForValue(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreLeaseOutcomeTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreLeaseOutcomeTest.java
@@ -48,6 +48,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import java.net.URI;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterAll;
@@ -141,7 +142,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   @Test
   void applyLeaseOutcomeReturnsTrueForAcceptedTransitions() {
     String succeededJobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob succeededLease = leaseJob(succeededJobId);
+    ReconcileJobStore.LeasedJob succeededLease = leaseNextEventually();
     assertTrue(
         store.applyLeaseOutcome(
             succeededJobId,
@@ -156,10 +157,16 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
             0L,
             0L,
             0L));
-    assertEquals("JS_SUCCEEDED", store.getLeaseView(succeededJobId).orElseThrow().state);
+    assertEquals(
+        "JS_SUCCEEDED",
+        waitForValue(
+                () -> store.getLeaseView(succeededJobId).orElseThrow(),
+                current -> "JS_SUCCEEDED".equals(current.state),
+                "succeeded lease outcome canonical view")
+            .state);
 
     String cancelledJobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob cancelledLease = leaseJob(cancelledJobId);
+    ReconcileJobStore.LeasedJob cancelledLease = leaseNextEventually();
     store.cancel(ACCOUNT_ID, cancelledJobId, "stop");
     assertTrue(
         store.applyLeaseOutcome(
@@ -175,13 +182,19 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
             0L,
             0L,
             0L));
-    assertEquals("JS_CANCELLED", store.getLeaseView(cancelledJobId).orElseThrow().state);
+    assertEquals(
+        "JS_CANCELLED",
+        waitForValue(
+                () -> store.getLeaseView(cancelledJobId).orElseThrow(),
+                current -> "JS_CANCELLED".equals(current.state),
+                "cancelled lease outcome canonical view")
+            .state);
   }
 
   @Test
   void applyLeaseOutcomeCancellingSuccessResolvesImmediatelyToCancelled() {
     String jobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob lease = leaseJob(jobId);
+    ReconcileJobStore.LeasedJob lease = leaseNextEventually();
     store.cancel(ACCOUNT_ID, jobId, "stop");
 
     assertTrue(
@@ -199,7 +212,11 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
             5L,
             7L));
 
-    ReconcileJobStore.ReconcileJob job = store.getLeaseView(jobId).orElseThrow();
+    ReconcileJobStore.ReconcileJob job =
+        waitForValue(
+            () -> store.getLeaseView(jobId).orElseThrow(),
+            current -> "JS_CANCELLED".equals(current.state) && current.finishedAtMs == 4_000L,
+            "cancelling success resolves to cancelled");
     assertEquals("JS_CANCELLED", job.state);
     assertEquals("stop", job.message);
     assertEquals(4_000L, job.finishedAtMs);
@@ -216,7 +233,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   @Test
   void applyLeaseOutcomeCancellingFailureResolvesImmediatelyToCancelled() {
     String jobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob lease = leaseJob(jobId);
+    ReconcileJobStore.LeasedJob lease = leaseNextEventually();
     store.cancel(ACCOUNT_ID, jobId, "stop");
 
     assertTrue(
@@ -234,7 +251,11 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
             0L,
             0L));
 
-    ReconcileJobStore.ReconcileJob job = store.getLeaseView(jobId).orElseThrow();
+    ReconcileJobStore.ReconcileJob job =
+        waitForValue(
+            () -> store.getLeaseView(jobId).orElseThrow(),
+            current -> "JS_CANCELLED".equals(current.state) && current.finishedAtMs == 5_000L,
+            "cancelling failure resolves to cancelled");
     assertEquals("JS_CANCELLED", job.state);
     assertEquals("stop", job.message);
     assertEquals(5_000L, job.finishedAtMs);
@@ -244,7 +265,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   @Test
   void applyLeaseOutcomeReturnsFalseForStaleLeaseEpoch() {
     String jobId = enqueueRoot();
-    leaseJob(jobId);
+    leaseNextEventually();
 
     assertFalse(
         store.applyLeaseOutcome(
@@ -261,7 +282,13 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
             0L,
             0L));
 
-    assertEquals("JS_RUNNING", store.getLeaseView(jobId).orElseThrow().state);
+    assertEquals(
+        "JS_RUNNING",
+        waitForValue(
+                () -> store.getLeaseView(jobId).orElseThrow(),
+                current -> "JS_RUNNING".equals(current.state),
+                "stale lease epoch leaves canonical state running")
+            .state);
   }
 
   @Test
@@ -285,7 +312,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   @Test
   void applyLeaseOutcomeReturnsFalseForTerminalJob() {
     String jobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob lease = leaseJob(jobId);
+    ReconcileJobStore.LeasedJob lease = leaseNextEventually();
     assertTrue(
         store.applyLeaseOutcome(
             jobId,
@@ -316,7 +343,13 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
             0L,
             0L));
 
-    assertEquals("JS_SUCCEEDED", store.getLeaseView(jobId).orElseThrow().state);
+    assertEquals(
+        "JS_SUCCEEDED",
+        waitForValue(
+                () -> store.getLeaseView(jobId).orElseThrow(),
+                current -> "JS_SUCCEEDED".equals(current.state),
+                "terminal lease outcome remains canonically succeeded")
+            .state);
   }
 
   @Test
@@ -354,7 +387,13 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
             0L,
             0L));
 
-    assertEquals("JS_SUCCEEDED", store.getLeaseView(jobId).orElseThrow().state);
+    assertEquals(
+        "JS_SUCCEEDED",
+        waitForValue(
+                () -> store.getLeaseView(jobId).orElseThrow(),
+                current -> "JS_SUCCEEDED".equals(current.state),
+                "expired lease outcome resolves to succeeded")
+            .state);
   }
 
   @Test
@@ -473,7 +512,7 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
   void applyLeaseOutcomeReturnsTrueForExpiredLeaseWhenEpochStillMatches() {
     configureLeaseRenewGraceMs(0L);
     String jobId = enqueueRoot();
-    ReconcileJobStore.LeasedJob lease = leaseJob(jobId);
+    ReconcileJobStore.LeasedJob lease = leaseNextEventually();
     expireLease(jobId);
 
     assertTrue(
@@ -524,6 +563,42 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
         ReconcileExecutionPolicy.defaults(),
         "",
         pinnedExecutorId);
+  }
+
+  private ReconcileJobStore.LeasedJob leaseNextEventually() {
+    return waitForValue(
+        () -> store.leaseNext().orElseThrow(), ignored -> true, "next reconcile job lease");
+  }
+
+  private <T> T waitForValue(
+      java.util.function.Supplier<T> supplier,
+      java.util.function.Predicate<T> done,
+      String description) {
+    T value = tryGetValue(supplier);
+    for (int attempt = 0; attempt < 100; attempt++) {
+      if (value != null && done.test(value)) {
+        return value;
+      }
+      try {
+        Thread.sleep(isDynamoMode() ? 25L : 0L);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("Interrupted while waiting for " + description, ie);
+      }
+      value = tryGetValue(supplier);
+    }
+    assertTrue(
+        value != null && done.test(value),
+        "Timed out waiting for " + description + "; last value=" + value);
+    return value;
+  }
+
+  private <T> T tryGetValue(java.util.function.Supplier<T> supplier) {
+    try {
+      return supplier.get();
+    } catch (IllegalStateException | NoSuchElementException e) {
+      return null;
+    }
   }
 
   private ReconcileJobStore.LeasedJob leaseJob(String jobId) {


### PR DESCRIPTION
# Replace FetchScanBundle with streaming scan API 

This PR replaces the legacy FetchScanBundle RPC with a streaming, handle-based scan API:
- InitScan
- StreamDeleteFiles
- StreamDataFiles
- CloseScan

The new API separates scan initialization, delete enumeration, and data file enumeration, while preserving correctness and supporting large tables without materializing full scan bundles in memory.

This change is fully wired end-to-end:
- gRPC API and protos
- service implementation and query lifecycle
- scan session management
- CLI, Trino connector, and Iceberg REST gateway
- unit + integration tests

---

## Motivation

FetchScanBundle forced the server to:
- compute all data + delete files eagerly
- return them in a single response
- couple data files to deletes via positional indices

This created scaling, memory, and extensibility limits, especially for:
- large tables
- many delete files
- future per-file delete applicability

The new API removes those constraints while keeping the initial implementation simple and correct.

---

## New scan model
### 1.	InitScan
- Validates query + pinned snapshot
- Applies pruning hints (required columns, predicates)
- Returns:
         - ScanHandle (opaque)
         - TableInfo (schema, partition spec, metadata location)
        
### 2.	StreamDeleteFiles
- Streams delete files in batches
- Assigns stable delete_ids
- Must be fully consumed before data streaming
- Server enforces ordering (FAILED_PRECONDITION otherwise)

### 3.	StreamDataFiles
- Streams data files in batches
- Each DataFile includes a DeleteRef
- Current implementation emits all_deletes=true

### 4.	CloseScan
- Best-effort cleanup
- Idempotent
- Sessions are also auto-released on stream completion or cancellation

---

## What this enables next (future work)

This API is designed to unlock incremental future improvements without breaking changes:
- Per-file delete applicability
        - Replace all_deletes=true with selective delete_ids
        - Use partition / equality / sequence metadata to compute applicability
- Delete index shrinking
        - Avoid propagating irrelevant deletes to unrelated data files
        - Reduce memory and planning overhead for large delete sets
- More efficient EE scanning
        - Early exit / partial planning for large tables
        - Adaptive batching based on downstream consumers
- Additional file metadata
        - Column stats, bloom filters, sketches
        - Optional, opt-in via InitScanRequest
- Alternative execution models
         - Parallel consumers of the same scan handle
         - Engine-specific optimizations 

Fixes : https://github.com/eng-floe/floecat/issues/63 