### PR TITLE
QueryService: support query replay via client query_id and upfront input pinning

### DIFF
--- a/core/proto/src/main/proto/floecat/query/lifecycle.proto
+++ b/core/proto/src/main/proto/floecat/query/lifecycle.proto
@@ -142,6 +142,12 @@ message BeginQueryRequest {
   
   // default catalog for this query
   ai.floedb.floecat.common.ResourceId default_catalog_id = 3;
+
+  // Optional client-supplied identifier for deterministic replay; duplicates are rejected.
+  optional string query_id = 4;
+
+  // Optional inputs to resolve/pin (tables/views and snapshots) when creating the context.
+  repeated ai.floedb.floecat.common.QueryInput inputs = 5;
 }
 
 /**

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -95,8 +95,13 @@ engine release.
 3. Connectors written against the SPI return `ScanFile` and stats payloads that exactly match the
   protos defined here; the reconciler pipes them back via the catalog/statistics services.
 4. Planners call `QueryService.BeginQuery` to create query leases, optionally extend them via
-  `RenewQuery`, call `FetchScanBundle` per table when they need manifests, and close leases out via
-  `EndQuery` once execution is complete.
+   `RenewQuery`, call `FetchScanBundle` per table when they need manifests, and close leases out via
+   `EndQuery` once execution is complete.
+
+   * BeginQuery now allows clients to provide an optional `query_id` (duplicates are rejected) and
+     a list of `common.QueryInput` records so the lifecycle service can pin snapshots and expansions
+     at creation time for deterministic replay. Schema resolution and planning still occur in the
+     downstream services.
 
 _State diagram for the query lease protocol:_
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -169,7 +169,9 @@ Extension points:
 - **Security** – Replace `Authorizer` or interceptors with CDI alternatives.
 - **Connectors** – Register new SPI implementations and expose them via `ConnectorRepository`.
 - **QueryService** – Extend query metadata by enriching `QueryContext` creation or injecting
-  additional connector metadata via the `FetchScanBundle` RPC / `ScanBundleService`.
+  additional connector metadata via the `FetchScanBundle` RPC / `ScanBundleService`. `BeginQuery`
+  optionally accepts a client-specified `query_id` plus `common.QueryInput` records so lifecycle can
+  pre-pin snapshots/expansions for deterministic replay.
 
 ## Examples & Scenarios
 - **Create Catalog** – `CatalogServiceImpl.createCatalog` canonicalises `display_name`, allocates a

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
@@ -73,6 +73,16 @@ public final class GrpcErrors {
     return build(io.grpc.Status.ABORTED, ErrorCode.MC_CONFLICT, corrId, params, suffix(key), t);
   }
 
+  public static StatusRuntimeException alreadyExists(
+      String corrId,
+      GeneratedErrorMessages.MessageKey key,
+      Map<String, String> params,
+      Throwable t) {
+    validateErrorCode("alreadyExists", key, ErrorCode.MC_CONFLICT);
+    return build(
+        io.grpc.Status.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, corrId, params, suffix(key), t);
+  }
+
   public static StatusRuntimeException preconditionFailed(
       String corrId,
       GeneratedErrorMessages.MessageKey key,

--- a/service/src/main/java/ai/floedb/floecat/service/query/QueryContextStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/QueryContextStore.java
@@ -34,6 +34,13 @@ public interface QueryContextStore extends AutoCloseable {
   /** Insert a new context only if one does not already exist. */
   void put(QueryContext ctx);
 
+  /**
+   * Insert a new context only if one does not already exist.
+   *
+   * @return true if the context was inserted, false if the id already exists
+   */
+  boolean putIfAbsent(QueryContext ctx);
+
   /** Extend TTL of an existing active context. */
   Optional<QueryContext> extendLease(String queryId, long requestedExpiresAtMs);
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContext.java
@@ -337,7 +337,7 @@ public final class QueryContext {
    * default.
    */
   public java.util.Optional<Timestamp> parseAsOfDefault(String correlationId) {
-    if (asOfDefault == null) {
+    if (asOfDefault == null || asOfDefault.length == 0) {
       return java.util.Optional.empty();
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContextStoreImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContextStoreImpl.java
@@ -85,8 +85,15 @@ public class QueryContextStoreImpl implements QueryContextStore {
 
   @Override
   public void put(QueryContext ctx) {
-    // Insert only if absent
-    cache.asMap().compute(ctx.getQueryId(), (k, existing) -> existing != null ? existing : ctx);
+    putIfAbsent(ctx);
+  }
+
+  @Override
+  public boolean putIfAbsent(QueryContext ctx) {
+    return cache
+            .asMap()
+            .compute(ctx.getQueryId(), (k, existing) -> existing != null ? existing : ctx)
+        == ctx;
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.impl;
+
+import ai.floedb.floecat.common.rpc.QueryInput;
+import ai.floedb.floecat.query.rpc.ExpansionMap;
+import ai.floedb.floecat.query.rpc.SnapshotSet;
+import ai.floedb.floecat.query.rpc.TableObligations;
+import ai.floedb.floecat.service.query.resolver.ObligationsResolver;
+import ai.floedb.floecat.service.query.resolver.QueryInputResolver;
+import ai.floedb.floecat.service.query.resolver.ViewExpansionResolver;
+import com.google.protobuf.Timestamp;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@ApplicationScoped
+public class QueryInputMetadataAssembler {
+
+  @Inject QueryInputResolver inputResolver;
+  @Inject ViewExpansionResolver expansions;
+  @Inject ObligationsResolver obligations;
+
+  /**
+   * Combines the existing resolvers to build the lifecycle metadata that BeginQuery should store
+   * when inputs are supplied up front.
+   */
+  public QueryInputMetadata assemble(
+      String correlationId, List<QueryInput> inputs, Optional<Timestamp> asOfDefault) {
+    if (inputs.isEmpty()) {
+      return QueryInputMetadata.empty();
+    }
+
+    var resolution = inputResolver.resolveInputs(correlationId, inputs, asOfDefault);
+    SnapshotSet snapshotSet = resolution.snapshotSet();
+    ExpansionMap expansionMap =
+        expansions.computeExpansion(correlationId, List.copyOf(resolution.resolved()));
+    var obligationsResult =
+        obligations.resolveObligations(correlationId, snapshotSet.getPinsList());
+
+    return new QueryInputMetadata(
+        snapshotSet, expansionMap, obligationsResult.bytes(), obligationsResult.obligations());
+  }
+
+  /**
+   * Encapsulates the blobs stored inside {@link QueryContext} for resolved inputs.
+   *
+   * <p>Empty metadata uses the default instances so BeginQuery can still create contexts when no
+   * inputs are supplied.
+   */
+  public record QueryInputMetadata(
+      SnapshotSet snapshotSet,
+      ExpansionMap expansionMap,
+      byte[] obligationsBytes,
+      List<TableObligations> obligations) {
+
+    public static QueryInputMetadata empty() {
+      return new QueryInputMetadata(
+          SnapshotSet.getDefaultInstance(),
+          ExpansionMap.getDefaultInstance(),
+          new byte[0],
+          Collections.emptyList());
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
@@ -24,6 +24,7 @@ import ai.floedb.floecat.connector.common.resolver.LogicalSchemaMapper;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.DescribeInputsRequest;
 import ai.floedb.floecat.query.rpc.DescribeInputsResponse;
+import ai.floedb.floecat.query.rpc.ExpansionMap;
 import ai.floedb.floecat.query.rpc.QuerySchemaService;
 import ai.floedb.floecat.query.rpc.SchemaDescriptor;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
@@ -104,10 +105,12 @@ public class QuerySchemaServiceImpl extends BaseServiceImpl implements QuerySche
                   }
 
                   // Compute expansions + obligations and store updated context
-                  byte[] expansionBytes =
-                      expansions.computeExpansion(correlationId(), request.getInputsList());
+                  ExpansionMap expansionMap =
+                      expansions.computeExpansion(correlationId(), List.copyOf(rr.resolved()));
+                  byte[] expansionBytes = expansionMap.toByteArray();
 
-                  byte[] obligationsBytes = obligations.resolveObligations(correlationId(), pins);
+                  var obligationsResult = obligations.resolveObligations(correlationId(), pins);
+                  byte[] obligationsBytes = obligationsResult.bytes();
 
                   var updated =
                       ctx.toBuilder()

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/ObligationsResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/ObligationsResolver.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.query.resolver;
 
 import ai.floedb.floecat.query.rpc.SnapshotPin;
+import ai.floedb.floecat.query.rpc.TableObligations;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 
@@ -27,8 +28,14 @@ import java.util.List;
 @ApplicationScoped
 public class ObligationsResolver {
 
-  public byte[] resolveObligations(String correlationId, List<SnapshotPin> pins) {
+  /**
+   * Result includes both the decoded obligations and the exact bytes stored on the {@link
+   * QueryContext}.
+   */
+  public record Result(List<TableObligations> obligations, byte[] bytes) {}
+
+  public Result resolveObligations(String correlationId, List<SnapshotPin> pins) {
     // TODO: load obligations from governance service
-    return new byte[0];
+    return new Result(List.of(), new byte[0]);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/ViewExpansionResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/ViewExpansionResolver.java
@@ -16,7 +16,8 @@
 
 package ai.floedb.floecat.service.query.resolver;
 
-import ai.floedb.floecat.common.rpc.QueryInput;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.query.rpc.ExpansionMap;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 
@@ -30,8 +31,8 @@ import java.util.List;
 @ApplicationScoped
 public class ViewExpansionResolver {
 
-  public byte[] computeExpansion(String correlationId, List<QueryInput> inputs) {
+  public ExpansionMap computeExpansion(String correlationId, List<ResourceId> resolvedInputs) {
     // TODO: full view expansion logic for internal planner
-    return new byte[0];
+    return ExpansionMap.getDefaultInstance();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -337,6 +337,15 @@ public final class UserObjectBundleTestSupport {
     }
 
     @Override
+    public boolean putIfAbsent(QueryContext ctx) {
+      if (contexts.containsKey(ctx.getQueryId())) {
+        return false;
+      }
+      contexts.put(ctx.getQueryId(), ctx);
+      return true;
+    }
+
+    @Override
     public Optional<QueryContext> extendLease(String queryId, long requestedExpiresAtMs) {
       return Optional.empty();
     }


### PR DESCRIPTION
## QueryService: support query replay via client query_id and upfront input pinning

This PR extends `QueryService.BeginQuery` to support **deterministic query replay** by allowing clients to:
- Provide an optional **client-supplied `query_id`** (duplicates are rejected)
- Optionally supply **`common.QueryInput` records** so lifecycle metadata can be pinned at creation time

When inputs are provided, the lifecycle service now resolves tables/views, pins snapshots, computes view expansions, and resolves governance obligations up front.

### API changes
- `BeginQueryRequest`
  - `optional string query_id`
  - `repeated common.QueryInput inputs`

Both fields are optional; existing clients are unaffected.

### Behavior
- Client-supplied `query_id` must be unique (`ALREADY_EXISTS` on duplicates)
- Server-generated IDs behave as before
- Pinned snapshots, expansions, and obligations are stored on the query context and returned in `QueryDescriptor`
