### PR TITLE
Fix: issue 151 - change conflict errors to already exists

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -174,7 +174,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                   if (idempotencyKey == null) {
                     var existingOpt = accountRepo.getByName(normName);
                     if (existingOpt.isPresent()) {
-                      throw GrpcErrors.conflict(
+                      throw GrpcErrors.alreadyExists(
                           corr, ACCOUNT_ALREADY_EXISTS, Map.of("display_name", normName));
                     }
 
@@ -207,7 +207,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                                               existingOpt.get(), existingOpt.get().getResourceId());
                                         }
                                       }
-                                      throw GrpcErrors.conflict(
+                                      throw GrpcErrors.alreadyExists(
                                           corr,
                                           ACCOUNT_ALREADY_EXISTS,
                                           Map.of("display_name", normName));
@@ -336,7 +336,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                               "actual", Long.toString(nowMeta.getPointerVersion())));
                     }
                   } catch (BaseResourceRepository.NameConflictException nce) {
-                    throw GrpcErrors.conflict(
+                    throw GrpcErrors.alreadyExists(
                         corr,
                         ACCOUNT_ALREADY_EXISTS,
                         Map.of("display_name", desired.getDisplayName()));

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImpl.java
@@ -181,7 +181,7 @@ public class CatalogServiceImpl extends BaseServiceImpl implements CatalogServic
                   if (idempotencyKey == null) {
                     var existing = catalogRepo.getByName(accountId, normName);
                     if (existing.isPresent()) {
-                      throw GrpcErrors.conflict(
+                      throw GrpcErrors.alreadyExists(
                           corr, CATALOG_ALREADY_EXISTS, Map.of("display_name", normName));
                     }
 
@@ -217,7 +217,7 @@ public class CatalogServiceImpl extends BaseServiceImpl implements CatalogServic
                                               existingOpt.get(), existingOpt.get().getResourceId());
                                         }
                                       }
-                                      throw GrpcErrors.conflict(
+                                      throw GrpcErrors.alreadyExists(
                                           corr,
                                           CATALOG_ALREADY_EXISTS,
                                           Map.of("display_name", normName));
@@ -310,7 +310,7 @@ public class CatalogServiceImpl extends BaseServiceImpl implements CatalogServic
                               "actual", Long.toString(nowMeta.getPointerVersion())));
                     }
                   } catch (BaseResourceRepository.NameConflictException nce) {
-                    throw GrpcErrors.conflict(
+                    throw GrpcErrors.alreadyExists(
                         corr,
                         CATALOG_ALREADY_EXISTS,
                         Map.of("display_name", desired.getDisplayName()));

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
@@ -659,7 +659,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                       systemNamespacePathMatch(spec.getCatalogId(), fullPath, sysNamespaces);
                   if (sysMatch == SystemPathMatch.EXACT) {
                     // Exact collision with an existing SYSTEM namespace.
-                    throw GrpcErrors.conflict(
+                    throw GrpcErrors.alreadyExists(
                         correlationId,
                         GeneratedErrorMessages.MessageKey.NAMESPACE_ALREADY_EXISTS,
                         Map.of(
@@ -683,7 +683,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                     var existing =
                         namespaceRepo.getByPath(accountId, spec.getCatalogId().getId(), fullPath);
                     if (existing.isPresent()) {
-                      throw GrpcErrors.conflict(
+                      throw GrpcErrors.alreadyExists(
                           correlationId,
                           GeneratedErrorMessages.MessageKey.NAMESPACE_ALREADY_EXISTS,
                           Map.of("catalog", catalogName, "path", String.join(".", fullPath)));
@@ -753,7 +753,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                                               existing, existing.getResourceId());
                                         }
                                       }
-                                      throw GrpcErrors.conflict(
+                                      throw GrpcErrors.alreadyExists(
                                           correlationId,
                                           GeneratedErrorMessages.MessageKey
                                               .NAMESPACE_ALREADY_EXISTS,
@@ -914,7 +914,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                               "actual", Long.toString(nowMeta.getPointerVersion())));
                     }
                   } catch (BaseResourceRepository.NameConflictException nce) {
-                    throw GrpcErrors.conflict(
+                    throw GrpcErrors.alreadyExists(
                         corr,
                         GeneratedErrorMessages.MessageKey.NAMESPACE_ALREADY_EXISTS,
                         conflictInfo);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
@@ -529,7 +529,7 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
                               "actual", Long.toString(nowMeta.getPointerVersion())));
                     }
                   } catch (BaseResourceRepository.NameConflictException nce) {
-                    throw GrpcErrors.conflict(corr, SNAPSHOT_ALREADY_EXISTS, conflictInfo);
+                    throw GrpcErrors.alreadyExists(corr, SNAPSHOT_ALREADY_EXISTS, conflictInfo);
                   } catch (BaseResourceRepository.PreconditionFailedException pfe) {
                     var nowMeta = snapshotRepo.metaForSafe(tableId, snapshotId);
                     throw GrpcErrors.preconditionFailed(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
@@ -458,7 +458,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                             spec.getNamespaceId().getId(),
                             normName);
                     if (existing.isPresent()) {
-                      throw GrpcErrors.conflict(
+                      throw GrpcErrors.alreadyExists(
                           corr,
                           TABLE_ALREADY_EXISTS,
                           Map.of(
@@ -469,7 +469,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                     try {
                       tableRepo.create(table);
                     } catch (BaseResourceRepository.NameConflictException nce) {
-                      throw GrpcErrors.conflict(
+                      throw GrpcErrors.alreadyExists(
                           corr,
                           TABLE_ALREADY_EXISTS,
                           Map.of(
@@ -513,7 +513,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                                               existingOpt.get(), existingOpt.get().getResourceId());
                                         }
                                       }
-                                      throw GrpcErrors.conflict(
+                                      throw GrpcErrors.alreadyExists(
                                           corr,
                                           TABLE_ALREADY_EXISTS,
                                           Map.of(
@@ -628,7 +628,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                               "actual", Long.toString(nowMeta.getPointerVersion())));
                     }
                   } catch (BaseResourceRepository.NameConflictException nce) {
-                    throw GrpcErrors.conflict(corr, TABLE_ALREADY_EXISTS, conflictInfo);
+                    throw GrpcErrors.alreadyExists(corr, TABLE_ALREADY_EXISTS, conflictInfo);
                   } catch (BaseResourceRepository.PreconditionFailedException pfe) {
                     var nowMeta = tableRepo.metaForSafe(tableId);
                     throw GrpcErrors.preconditionFailed(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
@@ -310,7 +310,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                             spec.getNamespaceId().getId(),
                             normName);
                     if (existing.isPresent()) {
-                      throw GrpcErrors.conflict(
+                      throw GrpcErrors.alreadyExists(
                           corr,
                           VIEW_ALREADY_EXISTS,
                           Map.of(
@@ -352,7 +352,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                                               existingOpt.get(), existingOpt.get().getResourceId());
                                         }
                                       }
-                                      throw GrpcErrors.conflict(
+                                      throw GrpcErrors.alreadyExists(
                                           corr,
                                           VIEW_ALREADY_EXISTS,
                                           Map.of(
@@ -459,7 +459,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                               "actual", Long.toString(nowMeta.getPointerVersion())));
                     }
                   } catch (BaseResourceRepository.NameConflictException nce) {
-                    throw GrpcErrors.conflict(corr, VIEW_ALREADY_EXISTS, conflictInfo);
+                    throw GrpcErrors.alreadyExists(corr, VIEW_ALREADY_EXISTS, conflictInfo);
                   } catch (BaseResourceRepository.PreconditionFailedException pfe) {
                     var nowMeta = viewRepo.metaForSafe(viewId);
                     throw GrpcErrors.preconditionFailed(

--- a/service/src/main/java/ai/floedb/floecat/service/common/MutationOps.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/MutationOps.java
@@ -173,8 +173,8 @@ public final class MutationOps {
                 "actual", Long.toString(nowMeta.getPointerVersion())));
       }
     } catch (BaseResourceRepository.NameConflictException nce) {
-      throw GrpcErrors.conflict(
-          correlationId, GeneratedErrorMessages.bySuffix(entity + ".already_exists"), conflictKVs);
+      throw GrpcErrors.alreadyExists(
+          correlationId, GeneratedErrorMessages.bySuffix(entity + ".already.exists"), conflictKVs);
     } catch (BaseResourceRepository.PreconditionFailedException pfe) {
       final var nowMeta = nowMetaSupplier.get();
       throw GrpcErrors.preconditionFailed(

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -379,7 +379,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                   if (idempotencyKey == null) {
                     var existing = connectorRepo.getByName(accountId, display);
                     if (existing.isPresent()) {
-                      throw GrpcErrors.conflict(
+                      throw GrpcErrors.alreadyExists(
                           corr,
                           GeneratedErrorMessages.MessageKey.CONNECTOR_ALREADY_EXISTS,
                           Map.of("display_name", display));
@@ -396,7 +396,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                       if (storedCredentials) {
                         credentialResolver.delete(accountId, secretId);
                       }
-                      throw GrpcErrors.conflict(
+                      throw GrpcErrors.alreadyExists(
                           corr,
                           GeneratedErrorMessages.MessageKey.CONNECTOR_ALREADY_EXISTS,
                           Map.of("display_name", display));
@@ -455,7 +455,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                                               existingOpt.get(), existingOpt.get().getResourceId());
                                         }
                                       }
-                                      throw GrpcErrors.conflict(
+                                      throw GrpcErrors.alreadyExists(
                                           corr,
                                           GeneratedErrorMessages.MessageKey
                                               .CONNECTOR_ALREADY_EXISTS,
@@ -581,7 +581,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                     if (incomingHasCredentials) {
                       restoreCredentials(accountId, secretId, priorCredentials);
                     }
-                    throw GrpcErrors.conflict(
+                    throw GrpcErrors.alreadyExists(
                         corr,
                         GeneratedErrorMessages.MessageKey.CONNECTOR_ALREADY_EXISTS,
                         Map.of("display_name", desired.getDisplayName()));

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
@@ -215,6 +215,11 @@ public final class GrpcErrors {
     return conflict(corrId, key, params, null);
   }
 
+  public static StatusRuntimeException alreadyExists(
+      String corrId, GeneratedErrorMessages.MessageKey key, Map<String, String> params) {
+    return alreadyExists(corrId, key, params, null);
+  }
+
   public static StatusRuntimeException preconditionFailed(
       String corrId, GeneratedErrorMessages.MessageKey key, Map<String, String> params) {
     return preconditionFailed(corrId, key, params, null);

--- a/service/src/test/java/ai/floedb/floecat/service/it/AccountMutationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/AccountMutationIT.java
@@ -97,7 +97,8 @@ class AccountMutationIT {
             StatusRuntimeException.class,
             () ->
                 tenancy.createAccount(CreateAccountRequest.newBuilder().setSpec(newSpec).build()));
-    TestSupport.assertGrpcAndMc(ex, Status.Code.ABORTED, ErrorCode.MC_CONFLICT, "already exists");
+    TestSupport.assertGrpcAndMc(
+        ex, Status.Code.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, "already exists");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/it/CatalogMutationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/CatalogMutationIT.java
@@ -94,7 +94,8 @@ class CatalogMutationIT {
                                 .setDescription("d1")
                                 .build())
                         .build()));
-    TestSupport.assertGrpcAndMc(ex, Status.Code.ABORTED, ErrorCode.MC_CONFLICT, "already exists");
+    TestSupport.assertGrpcAndMc(
+        ex, Status.Code.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, "already exists");
   }
 
   @Test
@@ -226,7 +227,8 @@ class CatalogMutationIT {
         assertThrows(
             StatusRuntimeException.class,
             () -> TestSupport.createCatalog(catalog, catalogPrefix + "cat1", "cat1 catalog"));
-    TestSupport.assertGrpcAndMc(ex, Status.Code.ABORTED, ErrorCode.MC_CONFLICT, "already exists");
+    TestSupport.assertGrpcAndMc(
+        ex, Status.Code.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, "already exists");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
@@ -943,7 +943,7 @@ public class ConnectorIT {
                         .build()));
 
     TestSupport.assertGrpcAndMc(
-        ex, Status.Code.ABORTED, ErrorCode.MC_CONFLICT, "Connector \"u-a1\" already exists");
+        ex, Status.Code.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, "Connector \"u-a1\" already exists");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/it/NamespaceMutationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/NamespaceMutationIT.java
@@ -84,7 +84,8 @@ class NamespaceMutationIT {
             () ->
                 TestSupport.createNamespace(
                     namespace, cat.getResourceId(), "2025", List.of("staging"), "2025 namespace"));
-    TestSupport.assertGrpcAndMc(ex, Status.Code.ABORTED, ErrorCode.MC_CONFLICT, "already exists");
+    TestSupport.assertGrpcAndMc(
+        ex, Status.Code.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, "already exists");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/it/NamespacePagingIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/NamespacePagingIT.java
@@ -207,7 +207,8 @@ class NamespacesPagingIT {
     StatusRuntimeException ex =
         assertThrows(StatusRuntimeException.class, () -> namespaces.createNamespace(req));
 
-    TestSupport.assertGrpcAndMc(ex, Status.Code.ABORTED, ErrorCode.MC_CONFLICT, "already exists");
+    TestSupport.assertGrpcAndMc(
+        ex, Status.Code.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, "already exists");
   }
 
   private List<Namespace> collectAllNamespacesAtRootChildrenOnly(int pageSize) {

--- a/service/src/test/java/ai/floedb/floecat/service/it/ResourceMutationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ResourceMutationIT.java
@@ -72,7 +72,7 @@ class ResourceMutationIT {
             StatusRuntimeException.class,
             () -> TestSupport.createCatalog(catalog, "cat1", "cat1 catalog"));
     TestSupport.assertGrpcAndMc(
-        exCat, Status.Code.ABORTED, ErrorCode.MC_CONFLICT, "already exists");
+        exCat, Status.Code.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, "already exists");
 
     var ns =
         TestSupport.createNamespace(
@@ -83,7 +83,8 @@ class ResourceMutationIT {
             () ->
                 TestSupport.createNamespace(
                     namespace, cat.getResourceId(), "2025", List.of("staging"), "2025 namespace"));
-    TestSupport.assertGrpcAndMc(exNs, Status.Code.ABORTED, ErrorCode.MC_CONFLICT, "already exists");
+    TestSupport.assertGrpcAndMc(
+        exNs, Status.Code.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, "already exists");
 
     TestSupport.createTable(
         table, cat.getResourceId(), ns.getResourceId(), "events", "s3://events", "{}", "none");
@@ -101,7 +102,7 @@ class ResourceMutationIT {
                     "{}",
                     "A description"));
     TestSupport.assertGrpcAndMc(
-        exTable, Status.Code.ABORTED, ErrorCode.MC_CONFLICT, "already exists");
+        exTable, Status.Code.ALREADY_EXISTS, ErrorCode.MC_CONFLICT, "already exists");
   }
 
   @Test


### PR DESCRIPTION
Conflict / abort errors are confined to true conflicts such as idempotency errors.