### PR TITLE
Remove internal gRPC dependency from SnapshotHelper and UserGraph

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -16,7 +16,6 @@
 
 package ai.floedb.floecat.service.metagraph.overlay.user;
 
-import ai.floedb.floecat.catalog.rpc.SnapshotServiceGrpc.SnapshotServiceBlockingStub;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
@@ -42,7 +41,6 @@ import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.telemetry.Observability;
 import com.google.protobuf.Timestamp;
-import io.quarkus.grpc.GrpcClient;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Duration;
@@ -100,7 +98,6 @@ public final class UserGraph {
       SnapshotRepository snapshotRepo,
       TableRepository tableRepo,
       ViewRepository viewRepo,
-      @GrpcClient("floecat") SnapshotServiceBlockingStub snapshotStub,
       Observability observability,
       PrincipalProvider principal,
       @ConfigProperty(name = "floecat.metadata.graph.cache-max-size", defaultValue = "50000")
@@ -111,7 +108,7 @@ public final class UserGraph {
     this.nodes = new NodeLoader(catalogRepo, nsRepo, tableRepo, viewRepo);
     this.names = new NameResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
     this.fq = new FullyQualifiedResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
-    this.snapshots = new SnapshotHelper(snapshotRepo, snapshotStub);
+    this.snapshots = new SnapshotHelper(snapshotRepo);
     this.hints = engineHints;
     this.principal = principal;
   }
@@ -131,7 +128,7 @@ public final class UserGraph {
     this.fq = new FullyQualifiedResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
 
     // Snapshot helper without gRPC client
-    this.snapshots = new SnapshotHelper(snapshotRepo, null);
+    this.snapshots = new SnapshotHelper(snapshotRepo);
 
     this.principal =
         new PrincipalProvider() {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
@@ -18,9 +18,7 @@ package ai.floedb.floecat.service.metagraph.snapshot;
 
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
-import ai.floedb.floecat.catalog.rpc.GetSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
-import ai.floedb.floecat.catalog.rpc.SnapshotServiceGrpc.SnapshotServiceBlockingStub;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.common.rpc.SpecialSnapshot;
@@ -30,6 +28,7 @@ import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph.SchemaResolution;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import com.google.protobuf.Timestamp;
+import jakarta.enterprise.context.ApplicationScoped;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
@@ -39,28 +38,13 @@ import java.util.Optional;
  * resolution - AS OF timestamp fallback - Default "CURRENT" snapshot semantics - Schema resolution
  * based on effective snapshot
  */
+@ApplicationScoped
 public class SnapshotHelper {
 
-  public interface SnapshotClient {
-    ai.floedb.floecat.catalog.rpc.GetSnapshotResponse getSnapshot(
-        ai.floedb.floecat.catalog.rpc.GetSnapshotRequest request);
-  }
-
-  private SnapshotClient client;
   private final SnapshotRepository snapshots;
 
-  public SnapshotHelper(SnapshotRepository snapshots, SnapshotServiceBlockingStub stub) {
+  public SnapshotHelper(SnapshotRepository snapshots) {
     this.snapshots = snapshots;
-    this.client =
-        (stub != null)
-            ? stub::getSnapshot
-            : req -> {
-              throw new IllegalStateException("Snapshot client missing");
-            };
-  }
-
-  public void setSnapshotClient(SnapshotClient c) {
-    this.client = c;
   }
 
   // ----------------------------------------------------------------------
@@ -82,14 +66,8 @@ public class SnapshotHelper {
       return pin(tableId, 0, asOfDefault.get());
     }
 
-    var resp =
-        client.getSnapshot(
-            GetSnapshotRequest.newBuilder()
-                .setTableId(tableId)
-                .setSnapshot(SnapshotRef.newBuilder().setSpecial(SpecialSnapshot.SS_CURRENT))
-                .build());
-
-    return pin(tableId, resp.getSnapshot().getSnapshotId(), null);
+    Snapshot current = currentSnapshot(cid, tableId);
+    return pin(tableId, current.getSnapshotId(), null);
   }
 
   // ----------------------------------------------------------------------
@@ -160,10 +138,7 @@ public class SnapshotHelper {
               cid, SNAPSHOT_SPECIAL_UNSUPPORTED, Map.of("requested", ref.getSpecial().name()));
         }
 
-        yield snapshots
-            .getCurrentSnapshot(tableId)
-            .orElseThrow(
-                () -> GrpcErrors.notFound(cid, SNAPSHOT, Map.of("table_id", tableId.getId())));
+        yield currentSnapshot(cid, tableId);
       }
 
       case WHICH_NOT_SET ->
@@ -181,5 +156,11 @@ public class SnapshotHelper {
     if (id > 0) b.setSnapshotId(id);
     if (ts != null) b.setAsOf(ts);
     return b.build();
+  }
+
+  private Snapshot currentSnapshot(String cid, ResourceId tableId) {
+    return snapshots
+        .getCurrentSnapshot(tableId)
+        .orElseThrow(() -> GrpcErrors.notFound(cid, SNAPSHOT, Map.of("table_id", tableId.getId())));
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
@@ -19,12 +19,10 @@ package ai.floedb.floecat.service.metagraph.snapshot;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import ai.floedb.floecat.catalog.rpc.GetSnapshotResponse;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
-import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.service.testsupport.SnapshotTestSupport;
 import ai.floedb.floecat.service.testsupport.TestNodes;
@@ -38,14 +36,11 @@ class SnapshotHelperTest {
 
   private SnapshotHelper helper;
   private SnapshotTestSupport.FakeSnapshotRepository repository;
-  private SnapshotTestSupport.FakeSnapshotClient snapshotClient;
 
   @BeforeEach
   void setUp() {
     repository = new SnapshotTestSupport.FakeSnapshotRepository();
-    helper = new SnapshotHelper(repository, null);
-    snapshotClient = new SnapshotTestSupport.FakeSnapshotClient();
-    helper.setSnapshotClient(snapshotClient);
+    helper = new SnapshotHelper(repository);
   }
 
   @Test
@@ -80,19 +75,18 @@ class SnapshotHelperTest {
   }
 
   @Test
-  void pinFallsBackToSnapshotService() {
+  void pinUsesRepositoryCurrentSnapshotWhenNoRefProvided() {
+    ResourceId tableId = tableId("tbl");
     Snapshot snapshot =
         Snapshot.newBuilder()
             .setSnapshotId(99L)
             .setUpstreamCreatedAt(ts("2024-03-01T00:00:00Z"))
             .build();
-    snapshotClient.nextResponse = GetSnapshotResponse.newBuilder().setSnapshot(snapshot).build();
+    repository.put(tableId, snapshot);
 
-    SnapshotPin pin = helper.snapshotPinFor("corr", tableId("tbl"), null, Optional.empty());
+    SnapshotPin pin = helper.snapshotPinFor("corr", tableId, null, Optional.empty());
 
     assertThat(pin.getSnapshotId()).isEqualTo(99L);
-    assertThat(snapshotClient.lastRequest.getSnapshot().getSpecial())
-        .isEqualTo(SpecialSnapshot.SS_CURRENT);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/SnapshotTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/SnapshotTestSupport.java
@@ -16,11 +16,8 @@
 
 package ai.floedb.floecat.service.testsupport;
 
-import ai.floedb.floecat.catalog.rpc.GetSnapshotRequest;
-import ai.floedb.floecat.catalog.rpc.GetSnapshotResponse;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.common.rpc.ResourceId;
-import ai.floedb.floecat.service.metagraph.snapshot.SnapshotHelper;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
@@ -72,21 +69,6 @@ public final class SnapshotTestSupport {
     private long createdMillis(Snapshot snapshot) {
       Timestamp ts = snapshot.getUpstreamCreatedAt();
       return ts.getSeconds() * 1000L + ts.getNanos() / 1_000_000L;
-    }
-  }
-
-  public static final class FakeSnapshotClient implements SnapshotHelper.SnapshotClient {
-
-    public GetSnapshotResponse nextResponse;
-    public GetSnapshotRequest lastRequest;
-
-    @Override
-    public GetSnapshotResponse getSnapshot(GetSnapshotRequest request) {
-      lastRequest = request;
-      if (nextResponse == null) {
-        throw new IllegalStateException("no snapshot response configured");
-      }
-      return nextResponse;
     }
   }
 }


### PR DESCRIPTION
### Remove internal gRPC dependency from SnapshotHelper and UserGraph 

This eliminates the loopback SnapshotService gRPC call used by the metadata graph for resolving the current snapshot.

With this change:
- SnapshotHelper no longer depends on gRPC or a SnapshotClient.
- Current snapshot resolution is performed directly via SnapshotRepository#getCurrentSnapshot.
- UserGraph no longer injects or wires a SnapshotServiceBlockingStub.