### PR TITLE
Stabilize ConcurrencyOCCIdempotencyIT

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/IdempotencyRepositoryImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/IdempotencyRepositoryImpl.java
@@ -58,6 +58,10 @@ public final class IdempotencyRepositoryImpl implements IdempotencyRepository {
 
     try {
       var bytes = blobs.get(p.get().getBlobUri());
+      if (bytes == null) {
+        throw new StorageAbortRetryableException(
+            "idempotency blob not yet visible: " + p.get().getBlobUri());
+      }
       return Optional.of(IdempotencyRecord.parseFrom(bytes));
     } catch (StorageNotFoundException nf) {
       throw new StorageAbortRetryableException(

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConcurrencyOCCIdemotencyTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConcurrencyOCCIdemotencyTest.java
@@ -344,12 +344,14 @@ class ConcurrencyOCCIdempotencyIT {
       case UPDATE_SCHEMA ->
           c == Status.Code.FAILED_PRECONDITION
               || c == Status.Code.NOT_FOUND
-              || c == Status.Code.ABORTED;
+              || c == Status.Code.ABORTED
+              || c == Status.Code.ALREADY_EXISTS;
 
       case RENAME, MOVE ->
           c == Status.Code.FAILED_PRECONDITION
               || c == Status.Code.ABORTED
-              || c == Status.Code.NOT_FOUND;
+              || c == Status.Code.NOT_FOUND
+              || c == Status.Code.ALREADY_EXISTS;
 
       case DELETE_SEED -> c == Status.Code.FAILED_PRECONDITION || c == Status.Code.NOT_FOUND;
     };


### PR DESCRIPTION
ConcurrencyOCCIdempotencyIT became flaky after conflict semantics were updated to return ALREADY_EXISTS for name collisions. The test still treated those responses as unexpected for some concurrent operations, causing intermittent assertion failures.

At the same time, the same stress test could rarely hit an INTERNAL error when reading idempotency records.

Fix is to update the integration tests to accept ALREADY_EXISTS and in In dempotencyRepositoryImpl.get(), treat bytes == null as retryable.