### PR TITLE
Fix missing metadata-location for connector-driven Iceberg commits

### DIFF
--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/metadata/MaterializeMetadataService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/metadata/MaterializeMetadataService.java
@@ -247,7 +247,14 @@ public class MaterializeMetadataService {
 
   private String resolveVersionedLocation(
       FileIO fileIO, String metadataLocation, TableMetadataView metadata) {
-    String directory = metadataLocation != null ? directoryOf(metadataLocation) : null;
+    String directory = null;
+    if (metadataLocation != null) {
+      if (metadataLocation.endsWith("/")) {
+        directory = metadataLocation;
+      } else {
+        directory = directoryOf(metadataLocation);
+      }
+    }
     if (directory == null) {
       directory = metadataDirectory(metadata);
     }

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/metadata/SnapshotUpdateService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/metadata/SnapshotUpdateService.java
@@ -1057,6 +1057,19 @@ public class SnapshotUpdateService {
     }
     IcebergMetadata.Builder builder = currentMetadata.toBuilder();
     String metadataLocation = metadataLocationFrom(table);
+    if (metadataLocation == null || metadataLocation.isBlank()) {
+      /*
+       * Fall back to a location already carried in the snapshot metadata, so we
+       * preserve whatever file path was discovered even if the table property
+       * has not yet been populated. The “true” first commit with nothing yet is
+       * handled by the derivation/materialization path in
+       * TableCommitSideEffectService.
+       */
+      String incoming = currentMetadata.getMetadataLocation();
+      if (incoming != null && !incoming.isBlank()) {
+        metadataLocation = incoming;
+      }
+    }
     if (metadataLocation != null && !metadataLocation.isBlank()) {
       builder.setMetadataLocation(metadataLocation);
     }

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitSideEffectService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitSideEffectService.java
@@ -35,6 +35,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import org.jboss.logging.Logger;
@@ -56,6 +57,12 @@ public class TableCommitSideEffectService {
     if (metadata == null) {
       return MaterializeMetadataResult.failure(
           IcebergErrorResponses.validation("metadata is required for materialization"));
+    }
+    // When no metadata-location is available (e.g. first gRPC connector-driven
+    // commit), derive one from the table's location so that materialization can
+    // seed the property and break the chicken-and-egg cycle.
+    if (!hasText(metadataLocation) && !hasText(metadata.metadataLocation())) {
+      metadataLocation = deriveMetadataLocation(tableRecord, metadata);
     }
     boolean requestedLocation = hasText(metadataLocation) || hasText(metadata.metadataLocation());
     try {
@@ -304,6 +311,33 @@ public class TableCommitSideEffectService {
       return null;
     }
     return connectorId;
+  }
+
+  /**
+   * Derive an initial metadata-location directory hint from the table's location (upstream URI or
+   * {@code location} property). This is used to seed the first metadata materialization for tables
+   * that were registered without a metadata-location (e.g. gRPC connector-driven imports).
+   */
+  private String deriveMetadataLocation(Table tableRecord, TableMetadataView metadata) {
+    String location = tableLocation(tableRecord);
+    if (location == null && metadata != null) {
+      location = metadata.location();
+    }
+    if (location == null || location.isBlank()) {
+      return null;
+    }
+    String base = stripTrailingSlash(location);
+    if (base.toLowerCase(Locale.ROOT).endsWith("/metadata")) {
+      return base + "/";
+    }
+    return base + "/metadata/";
+  }
+
+  private String stripTrailingSlash(String value) {
+    if (value == null || value.length() <= 1) {
+      return value;
+    }
+    return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
   }
 
   private String tableLocation(Table tableRecord) {

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/metadata/SnapshotMetadataServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/metadata/SnapshotMetadataServiceTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.gateway.iceberg.rest.services.metadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.any;
@@ -24,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.rpc.CreateSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.CreateSnapshotResponse;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -31,7 +33,9 @@ import ai.floedb.floecat.gateway.iceberg.rest.api.error.IcebergErrorResponse;
 import ai.floedb.floecat.gateway.iceberg.rest.common.TrinoFixtureTestSupport;
 import ai.floedb.floecat.gateway.iceberg.rest.services.catalog.TableGatewaySupport;
 import ai.floedb.floecat.gateway.iceberg.rest.services.client.SnapshotClient;
+import ai.floedb.floecat.gateway.iceberg.rpc.IcebergMetadata;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
 import jakarta.ws.rs.core.Response;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -39,6 +43,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class SnapshotMetadataServiceTest {
   private SnapshotMetadataService service;
@@ -130,6 +135,55 @@ class SnapshotMetadataServiceTest {
             "commit-key");
 
     assertNull(response);
+  }
+
+  @Test
+  void addSnapshotPreservesIncomingMetadataLocationWhenTablePropertyMissing() throws Exception {
+    // Simulate a gRPC connector-driven table with NO metadata-location property
+    Table table = Table.newBuilder().setSchemaJson(FIXTURE.table().getSchemaJson()).build();
+    // The IcebergMetadata carried by the current snapshot DOES have a metadata-location
+    // (e.g. from a prior import). The table property is blank—this is the bug scenario.
+    IcebergMetadata metadataWithLocation =
+        FIXTURE.metadata().toBuilder()
+            .setMetadataLocation("s3://warehouse/tables/orders/metadata/00000-abc.metadata.json")
+            .build();
+    when(tableSupport.loadCurrentMetadata(table)).thenReturn(metadataWithLocation);
+
+    ArgumentCaptor<CreateSnapshotRequest> captor =
+        ArgumentCaptor.forClass(CreateSnapshotRequest.class);
+    when(service.snapshotClient.createSnapshot(captor.capture()))
+        .thenReturn(CreateSnapshotResponse.newBuilder().build());
+
+    Map<String, Object> snapshot = new LinkedHashMap<>();
+    snapshot.put("snapshot-id", 42L);
+    snapshot.put("schema-id", 0);
+    snapshot.put("sequence-number", 1L);
+    snapshot.put("timestamp-ms", 123L);
+    Map<String, Object> update = new LinkedHashMap<>();
+    update.put("action", "add-snapshot");
+    update.put("snapshot", snapshot);
+
+    Response response =
+        service.applySnapshotUpdates(
+            tableSupport,
+            ResourceId.newBuilder().setId("cat:db:orders").build(),
+            List.of("db"),
+            "orders",
+            () -> table,
+            List.of(update),
+            "commit-key");
+
+    assertNull(response);
+    // Verify the snapshot's format metadata carries the metadata-location from the
+    // incoming IcebergMetadata, even though the table property was blank.
+    CreateSnapshotRequest request = captor.getValue();
+    ByteString icebergBytes = request.getSpec().getFormatMetadataOrDefault("iceberg", null);
+    assertFalse(icebergBytes == null || icebergBytes.isEmpty(), "iceberg metadata must be present");
+    IcebergMetadata written = IcebergMetadata.parseFrom(icebergBytes);
+    assertEquals(
+        "s3://warehouse/tables/orders/metadata/00000-abc.metadata.json",
+        written.getMetadataLocation(),
+        "metadata-location must be preserved from incoming metadata when table property is blank");
   }
 
   private Supplier<Table> neverInvokedTableSupplier() {

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitSideEffectServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitSideEffectServiceTest.java
@@ -118,11 +118,14 @@ class TableCommitSideEffectServiceTest {
         metadata("s3://warehouse/tables/orders/metadata/00000-abc.metadata.json");
     Map<String, String> props = new LinkedHashMap<>(base.properties());
     props.remove("metadata-location");
+    props.remove("location");
+    // No metadata-location, no table location, no upstream URI — truly no location
+    // available so materialization cannot derive a target and should skip cleanly.
     TableMetadataView noLocation =
         new TableMetadataView(
             base.formatVersion(),
             base.tableUuid(),
-            base.location(),
+            null,
             null,
             base.lastUpdatedMs(),
             props,
@@ -297,6 +300,139 @@ class TableCommitSideEffectServiceTest {
     assertNull(result.error());
     assertSame(response, result.response());
     verify(materializeMetadataService, never()).materialize(any(), any(), any(), any());
+  }
+
+  @Test
+  void materializeMetadataDerivesLocationFromTableWhenMissing() throws Exception {
+    // Simulate a gRPC connector-driven table: has a location property but NO
+    // metadata-location. Both the explicit param and metadata.metadataLocation()
+    // are null — this is the bug scenario where materialization silently skips.
+    TableMetadataView base =
+        metadata("s3://warehouse/tables/orders/metadata/00000-abc.metadata.json");
+    Map<String, String> props = new LinkedHashMap<>(base.properties());
+    props.remove("metadata-location");
+    props.put("location", "s3://warehouse/tables/orders");
+    TableMetadataView noMetadataLocation =
+        new TableMetadataView(
+            base.formatVersion(),
+            base.tableUuid(),
+            "s3://warehouse/tables/orders",
+            null,
+            base.lastUpdatedMs(),
+            props,
+            base.lastColumnId(),
+            base.currentSchemaId(),
+            base.defaultSpecId(),
+            base.lastPartitionId(),
+            base.defaultSortOrderId(),
+            base.currentSnapshotId(),
+            base.lastSequenceNumber(),
+            base.schemas(),
+            base.partitionSpecs(),
+            base.sortOrders(),
+            base.refs(),
+            base.snapshotLog(),
+            base.metadataLog(),
+            base.statistics(),
+            base.partitionStatistics(),
+            base.snapshots());
+    ResourceId tableId = ResourceId.newBuilder().setId("cat:db:orders").build();
+    Table table =
+        Table.newBuilder()
+            .setResourceId(tableId)
+            .putProperties("location", "s3://warehouse/tables/orders")
+            .build();
+    // The derived metadata-location directory should be passed to materialize
+    TableMetadataView materialized =
+        noMetadataLocation.withMetadataLocation(
+            "s3://warehouse/tables/orders/metadata/00001-new.metadata.json");
+    when(materializeMetadataService.materialize(
+            eq("cat.db"),
+            eq("orders"),
+            eq(noMetadataLocation),
+            eq("s3://warehouse/tables/orders/metadata/")))
+        .thenReturn(
+            new MaterializeResult(
+                "s3://warehouse/tables/orders/metadata/00001-new.metadata.json", materialized));
+
+    MaterializeMetadataResult result =
+        service.materializeMetadata("cat.db", tableId, "orders", table, noMetadataLocation, null);
+
+    assertNull(result.error());
+    assertEquals(
+        "s3://warehouse/tables/orders/metadata/00001-new.metadata.json",
+        result.metadataLocation(),
+        "metadata-location must be derived from table location for first commit");
+
+    // Verify that updateTableMetadataProperties was called to persist it
+    ArgumentCaptor<UpdateTableRequest> captor = ArgumentCaptor.forClass(UpdateTableRequest.class);
+    verify(tableLifecycleService).updateTable(captor.capture());
+    assertEquals(
+        "s3://warehouse/tables/orders/metadata/00001-new.metadata.json",
+        captor.getValue().getSpec().getPropertiesOrThrow("metadata-location"));
+  }
+
+  @Test
+  void materializeMetadataDerivesLocationFromUpstreamUri() throws Exception {
+    // Same scenario but the location comes from the table's upstream URI
+    TableMetadataView base =
+        metadata("s3://warehouse/tables/orders/metadata/00000-abc.metadata.json");
+    Map<String, String> props = new LinkedHashMap<>(base.properties());
+    props.remove("metadata-location");
+    TableMetadataView noMetadataLocation =
+        new TableMetadataView(
+            base.formatVersion(),
+            base.tableUuid(),
+            null,
+            null,
+            base.lastUpdatedMs(),
+            props,
+            base.lastColumnId(),
+            base.currentSchemaId(),
+            base.defaultSpecId(),
+            base.lastPartitionId(),
+            base.defaultSortOrderId(),
+            base.currentSnapshotId(),
+            base.lastSequenceNumber(),
+            base.schemas(),
+            base.partitionSpecs(),
+            base.sortOrders(),
+            base.refs(),
+            base.snapshotLog(),
+            base.metadataLog(),
+            base.statistics(),
+            base.partitionStatistics(),
+            base.snapshots());
+    ResourceId tableId = ResourceId.newBuilder().setId("cat:db:orders").build();
+    Table table =
+        Table.newBuilder()
+            .setResourceId(tableId)
+            .setUpstream(
+                UpstreamRef.newBuilder()
+                    .setFormat(TableFormat.TF_ICEBERG)
+                    .setUri("s3://warehouse/tables/orders")
+                    .build())
+            .build();
+    TableMetadataView materialized =
+        noMetadataLocation.withMetadataLocation(
+            "s3://warehouse/tables/orders/metadata/00001-new.metadata.json");
+    when(materializeMetadataService.materialize(
+            eq("cat.db"),
+            eq("orders"),
+            eq(noMetadataLocation),
+            eq("s3://warehouse/tables/orders/metadata/")))
+        .thenReturn(
+            new MaterializeResult(
+                "s3://warehouse/tables/orders/metadata/00001-new.metadata.json", materialized));
+
+    MaterializeMetadataResult result =
+        service.materializeMetadata("cat.db", tableId, "orders", table, noMetadataLocation, null);
+
+    assertNull(result.error());
+    assertEquals(
+        "s3://warehouse/tables/orders/metadata/00001-new.metadata.json",
+        result.metadataLocation(),
+        "metadata-location must be derived from upstream URI for first commit");
   }
 
   private TableMetadataView metadata(String metadataLocation) {


### PR DESCRIPTION
# Fix missing metadata-location for connector-driven Iceberg commits

## Problem

Iceberg tables created/committed via the gRPC connector path could end up without a populated metadata-location property. Because metadata materialization requires a non-blank location (or override), it was skipped, and the property was never written - causing subsequent commits to continue serializing blank metadata locations.

The CLI path did not have this issue because it seeds metadata-location up front.

## Fix

This PR breaks the cycle by:
- Seeding materialization on first commit:
When no metadata-location exists, we derive a /metadata/ directory hint from the table location (or upstream URI) so materialization runs and persists the resolved metadata JSON file path.

- Preserving existing metadata-location:
Snapshot serialization now keeps any metadataLocation already present in the snapshot metadata, even if the table property is blank.

- Clarifying override semantics:
MaterializeMetadataService now treats overrides ending with / as directory hints and non-slash values as file paths.

## Result
- First connector-driven commit correctly materializes metadata.
- metadata-location is persisted as a full metadata JSON file path.
- Subsequent commits behave as expected.
- No change to the external metadata-location contract.

Fixes: https://github.com/eng-floe/floecat/issues/158 