### PR TITLE
Make telemetry docgen skippable and stabilize doc output resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
   <description>Floecat, Root</description>
 
   <properties>
+    <telemetry.docgen.skip>false</telemetry.docgen.skip>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.quarkus>3.29.4</version.quarkus>
     <maven.compiler.source>25</maven.compiler.source>

--- a/telemetry-hub/tool-docgen/pom.xml
+++ b/telemetry-hub/tool-docgen/pom.xml
@@ -67,6 +67,7 @@
               <goal>java</goal>
             </goals>
             <configuration>
+              <skip>${telemetry.docgen.skip}</skip>
               <mainClass>ai.floedb.floecat.telemetry.docgen.MetricCatalogDocgen</mainClass>
             </configuration>
           </execution>

--- a/telemetry-hub/tool-docgen/src/main/java/ai/floedb/floecat/telemetry/docgen/MetricCatalogDocgen.java
+++ b/telemetry-hub/tool-docgen/src/main/java/ai/floedb/floecat/telemetry/docgen/MetricCatalogDocgen.java
@@ -54,15 +54,11 @@ public final class MetricCatalogDocgen {
     if (override != null && !override.isBlank()) {
       return Path.of(override);
     }
-    Path candidate = Path.of("docs", "telemetry");
-    if (Files.exists(candidate)) {
-      return candidate;
+    String cwd = System.getProperty("user.dir");
+    if (cwd != null && !cwd.isBlank()) {
+      return Path.of(cwd, "docs", "telemetry");
     }
-    Path fallback = Path.of("..", "..", "docs", "telemetry");
-    if (Files.exists(fallback)) {
-      return fallback;
-    }
-    return candidate;
+    return Path.of("docs", "telemetry");
   }
 
   public static void main(String[] args) throws IOException {

--- a/telemetry-hub/tool-docgen/src/test/java/ai/floedb/floecat/telemetry/docgen/MetricCatalogDocgenTest.java
+++ b/telemetry-hub/tool-docgen/src/test/java/ai/floedb/floecat/telemetry/docgen/MetricCatalogDocgenTest.java
@@ -24,12 +24,18 @@ import java.nio.file.Path;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class MetricCatalogDocgenTest {
   @Test
-  void generatedDocsMatchOnDisk() throws IOException {
+  void generatedDocsMatchOnDisk(@TempDir Path tempRepo) throws IOException {
+    System.setProperty(
+        "telemetry.doc.dir", tempRepo.resolve("docs").resolve("telemetry").toString());
+
     Path markdown = MetricCatalogDocgen.docDir().resolve("contract.md");
     Path json = MetricCatalogDocgen.docDir().resolve("contract.json");
+
+    MetricCatalogDocgen.main(new String[0]);
 
     TelemetryRegistry registry = Telemetry.newRegistryWithCore();
     Map<String, MetricDef> catalog = Telemetry.metricCatalog(registry);


### PR DESCRIPTION
## Make telemetry docgen skippable and stabilize doc output resolution  

This makes telemetry doc generation configurable and improves test isolation.

###  **Add Maven skip flag**  
  Introduces `telemetry.docgen.skip` (default: `false`) and wires it to the `exec-maven-plugin`, allowing docgen to be skipped with: ``` mvn -Dtelemetry.docgen.skip=true ```

### **Simplify doc directory resolution**  
`MetricCatalogDocgen` now resolves the output directory in this order:
1. `telemetry.doc.dir` system property (if set)
2. `${user.dir}/docs/telemetry`
3. `docs/telemetry` (fallback)

Fixes: https://github.com/eng-floe/core/issues/556
