### PR TITLE
fix: delta snapshot version "0" handling

### DIFF
--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -271,7 +271,7 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
   @Override
   public Optional<Snapshot> fetchSnapshot(
       ReconcileContext ctx, ResourceId tableId, long snapshotId) {
-    if (snapshotId <= 0) {
+    if (snapshotId < 0) {
       return Optional.empty();
     }
     try {
@@ -293,7 +293,7 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
 
   @Override
   public void ingestSnapshot(ReconcileContext ctx, ResourceId tableId, Snapshot snapshot) {
-    if (snapshot == null || snapshot.getSnapshotId() <= 0) {
+    if (snapshot == null || snapshot.getSnapshotId() < 0) {
       return;
     }
     var spec = buildSnapshotSpec(snapshot);
@@ -543,7 +543,7 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
 
   private SnapshotPin pin(ResourceId tableId, long snapshotId, Timestamp asOf) {
     SnapshotPin.Builder builder = SnapshotPin.newBuilder().setTableId(tableId);
-    if (snapshotId > 0) {
+    if (snapshotId >= 0 && asOf == null) {
       builder.setSnapshotId(snapshotId);
     }
     if (asOf != null) {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -355,7 +355,7 @@ public class ReconcilerService {
 
   private void ensureSnapshot(
       ReconcileContext ctx, ResourceId tableId, FloecatConnector.SnapshotBundle snapshotBundle) {
-    if (snapshotBundle == null || snapshotBundle.snapshotId() <= 0) {
+    if (snapshotBundle == null || snapshotBundle.snapshotId() < 0) {
       return;
     }
     Snapshot existing =

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
@@ -153,7 +153,7 @@ public class SnapshotHelper {
 
   private SnapshotPin pin(ResourceId tableId, long id, Timestamp ts) {
     SnapshotPin.Builder b = SnapshotPin.newBuilder().setTableId(tableId);
-    if (id > 0) b.setSnapshotId(id);
+    if (id >= 0 && ts == null) b.setSnapshotId(id);
     if (ts != null) b.setAsOf(ts);
     return b.build();
   }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -238,7 +238,7 @@ public class QueryInputResolver {
     if (pin == null) {
       return -1;
     }
-    if (pin.hasSnapshotId() && pin.getSnapshotId() > 0) {
+    if (pin.hasSnapshotId() && pin.getSnapshotId() >= 0) {
       return 3;
     }
     if (pin.hasAsOf()) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
@@ -302,8 +302,8 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
       return;
     }
     long snapshotId = snapshot.getSnapshotId();
-    if (snapshotId <= 0) {
-      throw new IllegalArgumentException("snapshotId must be positive");
+    if (snapshotId < 0) {
+      throw new IllegalArgumentException("snapshotId must be non-negative");
     }
     Optional<Snapshot> existing = snapshotRepo.getById(tableId, snapshotId);
     if (existing.isPresent()) {

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
@@ -446,6 +446,19 @@ public class ConnectorIT {
 
       assertEquals(1, outTables.size(), "expected exactly one table in destination namespace");
       assertEquals("call_center", outTables.get(0).getDisplayName());
+
+      var outTableId = outTables.get(0).getResourceId();
+      assertTrue(snaps.getById(outTableId, 0L).isPresent(), "expected Delta snapshot_id=0");
+
+      var fileStats =
+          statsService.listFileColumnStats(
+              ListFileColumnStatsRequest.newBuilder()
+                  .setTableId(outTableId)
+                  .setSnapshot(SnapshotRef.newBuilder().setSpecial(SpecialSnapshot.SS_CURRENT))
+                  .setPage(PageRequest.newBuilder().setPageSize(10))
+                  .build());
+      assertFalse(
+          fileStats.getFileColumnsList().isEmpty(), "expected file stats at current snapshot");
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
@@ -53,6 +53,20 @@ class SnapshotHelperTest {
             Optional.empty());
 
     assertThat(pin.getSnapshotId()).isEqualTo(5);
+    assertThat(pin.hasSnapshotId()).isTrue();
+  }
+
+  @Test
+  void pinUsesExplicitSnapshotIdZero() {
+    SnapshotPin pin =
+        helper.snapshotPinFor(
+            "corr",
+            tableId("tbl"),
+            SnapshotRef.newBuilder().setSnapshotId(0).build(),
+            Optional.empty());
+
+    assertThat(pin.getSnapshotId()).isEqualTo(0);
+    assertThat(pin.hasSnapshotId()).isTrue();
   }
 
   @Test
@@ -63,7 +77,7 @@ class SnapshotHelperTest {
             "corr", tableId("tbl"), SnapshotRef.newBuilder().setAsOf(ts).build(), Optional.empty());
 
     assertThat(pin.getAsOf()).isEqualTo(ts);
-    assertThat(pin.getSnapshotId()).isZero();
+    assertThat(pin.hasSnapshotId()).isFalse();
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackendTest.java
@@ -261,6 +261,21 @@ class DirectReconcilerBackendTest {
   }
 
   @Test
+  void ingestSnapshotAcceptsZeroSnapshotId() {
+    Snapshot snapshot =
+        Snapshot.newBuilder()
+            .setTableId(tableId)
+            .setSnapshotId(0L)
+            .setSchemaJson("{}")
+            .setUpstreamCreatedAt(Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()))
+            .build();
+
+    backend.ingestSnapshot(ctx, tableId, snapshot);
+
+    assertThat(snapshotRepo.getById(tableId, 0L)).isPresent();
+  }
+
+  @Test
   void lookupTableMatchesNormalizedNameRef() {
     ResourceId tableId = createReferenceTable();
     assertThat(backend.lookupTable(ctx, referenceNameRef())).contains(tableId);


### PR DESCRIPTION
## Summary

Floecat does not support importing a delta table with a perfectly valid snapshot version of zero. This prevents the snapshots being properly imported from the delta table seeding table.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

