### PR TITLE
Bump Quarkus version to 3.31.4

### DIFF
--- a/core/connectors/common/pom.xml
+++ b/core/connectors/common/pom.xml
@@ -160,7 +160,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>${version.junit.jupiter}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <telemetry.docgen.skip>false</telemetry.docgen.skip>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.quarkus>3.29.4</version.quarkus>
+    <version.quarkus>3.31.4</version.quarkus>
     <maven.compiler.source>25</maven.compiler.source>
     <maven.compiler.target>25</maven.compiler.target>
     <proto.compiler.release>25</proto.compiler.release>
@@ -58,7 +58,6 @@
     <version.javax.annotation>1.3.2</version.javax.annotation>
     <version.jboss.logmanager>3.1.2.Final</version.jboss.logmanager>
     <version.jline>3.30.6</version.jline>
-    <version.junit.jupiter>5.13.4</version.junit.jupiter>
     <version.maven>3.9.0</version.maven>
     <version.maven.plugin.tools>3.15.2</version.maven.plugin.tools>
     <version.mockito>5.20.0</version.mockito>
@@ -193,21 +192,6 @@
         <version>${version.slf4j.jboss.logmanager}</version>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${version.junit.jupiter}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${version.junit.jupiter}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${version.junit.jupiter}</version>
-      </dependency>
-      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.assertj}</version>
@@ -280,6 +264,7 @@
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-maven-plugin</artifactId>
           <version>${version.quarkus}</version>
+          <extensions>true</extensions>
         </plugin>
         <plugin>
           <groupId>io.smallrye</groupId>

--- a/reconciler/pom.xml
+++ b/reconciler/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <version>${version.quarkus}</version>
       <scope>test</scope>
     </dependency>
@@ -81,25 +81,21 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${version.mockito}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>${version.assertj}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>${version.junit.jupiter}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${version.junit.jupiter}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -96,7 +96,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -248,7 +248,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>${version.mockito}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -51,9 +51,7 @@ quarkus.log.category."ai.floedb.floecat.service.context.impl.InboundContextInter
 quarkus.log.category."ai.floedb.floecat.service.error.impl.RpcLoggingInterceptor".level=ERROR
 quarkus.banner.enabled=false
 # Expose prometheus test metrics
-quarkus.http.test-port=9101
 quarkus.management.enabled=true
-quarkus.management.test-port=9000
 quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true
 

--- a/storage/aws/pom.xml
+++ b/storage/aws/pom.xml
@@ -74,7 +74,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/storage/memory/pom.xml
+++ b/storage/memory/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/telemetry-hub/integration-profiling/pom.xml
+++ b/telemetry-hub/integration-profiling/pom.xml
@@ -106,7 +106,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Summary

Bump Quarkus version to 3.31.4. The latest 3.31 version has full support for Java 25.

## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Supposed to lead to faster build times with Java 25.
