### PR TITLE
Fix Flight test allocator teardown race

### DIFF
--- a/flight/src/test/java/ai/floedb/floecat/flight/SystemTableFlightProducerBaseTest.java
+++ b/flight/src/test/java/ai/floedb/floecat/flight/SystemTableFlightProducerBaseTest.java
@@ -116,10 +116,14 @@ class SystemTableFlightProducerBaseTest {
   }
 
   @AfterEach
-  void tearDown() {
+  void tearDown() throws InterruptedException {
+    executor.executor().shutdown();
+    if (!executor.executor().awaitTermination(5, TimeUnit.SECONDS)) {
+      executor.executor().shutdownNow();
+      executor.executor().awaitTermination(5, TimeUnit.SECONDS);
+    }
     allocator.close();
     allocatorHolder.clear();
-    executor.executor().shutdownNow();
   }
 
   @Test


### PR DESCRIPTION
```
Error:  Tests run: 7, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.217 s <<< FAILURE! -- in ai.floedb.floecat.flight.SystemTableFlightProducerBaseTest
Error:  ai.floedb.floecat.flight.SystemTableFlightProducerBaseTest.getStreamNameOnlyTicketSucceedsWithoutIdResolution -- Time elapsed: 0.149 s <<< ERROR!
java.lang.IllegalStateException: 
Memory was leaked by query. Memory leaked: (16384)
Outstanding child allocators : 
  Allocator(flight-stream) 0/16384/16384/9223372036854775807 (res/actual/peak/limit)
Allocator(ROOT) 0/16384/16384/9223372036854775807 (res/actual/peak/limit)

	at org.apache.arrow.memory.BaseAllocator.close(BaseAllocator.java:504)
	at org.apache.arrow.memory.RootAllocator.close(RootAllocator.java:27)
	at ai.floedb.floecat.flight.SystemTableFlightProducerBaseTest.tearDown(SystemTableFlightProducerBaseTest.java:120)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
```


Likely a race closing allocator before the executor