### PR TITLE
Support bootstrap of connectors

### DIFF
--- a/docs/fixed-roles.md
+++ b/docs/fixed-roles.md
@@ -12,7 +12,7 @@ Source of truth: `service/src/main/java/ai/floedb/floecat/service/security/RoleP
 | `administrator` | Full tenant-scoped administration of metadata and connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `system-objects.read` |
 | `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `system-objects.read` |
 | `platform-admin` (or configured value of `floecat.auth.platform-admin.role`) | Platform-level account management role from IdP. | `account.read`, `account.write` |
-| `init-account` | Bootstrap role used to initialize account/catalog/namespace state. | `account.write`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `connector.manage` |
+| `init-account` | Bootstrap role used to initialize account + initial resources. | `account.write`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `connector.create` |
 | `system-objects` | Minimal role for SystemObjects/GetSystemObjects access. | `system-objects.read` |
 
 ## Behavior Notes

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -238,7 +238,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                   var accountId = pc.getAccountId();
                   var corr = pc.getCorrelationId();
 
-                  authz.require(pc, "connector.manage");
+                  authz.require(pc, List.of("connector.manage", "connector.create"));
 
                   var tsNow = nowTs();
                   var spec = request.getSpec();

--- a/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
@@ -52,7 +52,7 @@ public final class RolePermissions {
           "catalog.write",
           "namespace.read",
           "namespace.write",
-          "connector.manage");
+          "connector.create");
 
   private RolePermissions() {}
 

--- a/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
@@ -46,7 +46,7 @@ class RolePermissionsTest {
           "catalog.write",
           "namespace.read",
           "namespace.write",
-          "connector.manage");
+          "connector.create");
   private static final List<String> PLATFORM_PERMS = List.of("account.read", "account.write");
 
   @Test


### PR DESCRIPTION
## Summary

Floe needs to bootstrap optional connectors at account creation, so needs connector.manage permission for init-account role.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [x] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

We should revisit permissions for connectors, as "connector.manage" is too broad.  There should be probably only a "connector.write", which is all that is required to create a connector during account initialization.