### PR TITLE
Fixup Arrow -> logicalType mapping

### DIFF
--- a/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowSchemaUtil.java
+++ b/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowSchemaUtil.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.arrow;
 
 import ai.floedb.floecat.query.rpc.SchemaColumn;
+import ai.floedb.floecat.types.LogicalKind;
 import ai.floedb.floecat.types.LogicalType;
 import ai.floedb.floecat.types.LogicalTypeFormat;
 import java.util.ArrayList;
@@ -95,6 +96,80 @@ public final class ArrowSchemaUtil {
       throw new IllegalArgumentException("Logical type must not be blank");
     }
     return normalized;
+  }
+
+  public static String logicalType(Field field) {
+    Objects.requireNonNull(field, "field");
+    FieldType fieldType = field.getFieldType();
+    if (fieldType == null) {
+      throw new IllegalArgumentException("FieldType must not be null for " + field.getName());
+    }
+    return logicalType(fieldType.getType());
+  }
+
+  public static String logicalType(ArrowType arrowType) {
+    Objects.requireNonNull(arrowType, "arrowType");
+    LogicalType logical = logicalTypeFromArrowType(arrowType);
+    return LogicalTypeFormat.format(logical);
+  }
+
+  private static LogicalType logicalTypeFromArrowType(ArrowType arrowType) {
+    if (arrowType instanceof ArrowType.Bool) {
+      return LogicalType.of(LogicalKind.BOOLEAN);
+    }
+    if (arrowType instanceof ArrowType.Int) {
+      return LogicalType.of(LogicalKind.INT);
+    }
+    if (arrowType instanceof ArrowType.FloatingPoint) {
+      ArrowType.FloatingPoint fp = (ArrowType.FloatingPoint) arrowType;
+      FloatingPointPrecision precision = fp.getPrecision();
+      return LogicalType.of(
+          precision == FloatingPointPrecision.SINGLE ? LogicalKind.FLOAT : LogicalKind.DOUBLE);
+    }
+    if (arrowType instanceof ArrowType.Decimal) {
+      ArrowType.Decimal decimal = (ArrowType.Decimal) arrowType;
+      return LogicalType.decimal(decimal.getPrecision(), decimal.getScale());
+    }
+    if (arrowType instanceof ArrowType.Utf8) {
+      return LogicalType.of(LogicalKind.STRING);
+    }
+    if (arrowType instanceof ArrowType.Binary) {
+      return LogicalType.of(LogicalKind.BINARY);
+    }
+    if (arrowType instanceof ArrowType.FixedSizeBinary fixed) {
+      if (fixed.getByteWidth() == 16) {
+        return LogicalType.of(LogicalKind.UUID);
+      }
+      return LogicalType.of(LogicalKind.BINARY);
+    }
+    if (arrowType instanceof ArrowType.Date) {
+      return LogicalType.of(LogicalKind.DATE);
+    }
+    if (arrowType instanceof ArrowType.Time) {
+      ArrowType.Time time = (ArrowType.Time) arrowType;
+      return LogicalType.temporal(LogicalKind.TIME, temporalPrecision(time.getUnit()));
+    }
+    if (arrowType instanceof ArrowType.Timestamp) {
+      ArrowType.Timestamp timestamp = (ArrowType.Timestamp) arrowType;
+      LogicalKind kind =
+          (timestamp.getTimezone() == null || timestamp.getTimezone().isBlank())
+              ? LogicalKind.TIMESTAMP
+              : LogicalKind.TIMESTAMPTZ;
+      return LogicalType.temporal(kind, temporalPrecision(timestamp.getUnit()));
+    }
+    throw new IllegalArgumentException("Unsupported Arrow type: " + arrowType);
+  }
+
+  private static int temporalPrecision(TimeUnit unit) {
+    if (unit == null) {
+      return 0;
+    }
+    return switch (unit) {
+      case SECOND -> 0;
+      case MILLISECOND -> 3;
+      case MICROSECOND -> 6;
+      case NANOSECOND -> 9;
+    };
   }
 
   /** Normalize the user-requested projection list so it can be compared case-insensitively. */

--- a/core/arrow/src/test/java/ai/floedb/floecat/arrow/ArrowSchemaUtilTest.java
+++ b/core/arrow/src/test/java/ai/floedb/floecat/arrow/ArrowSchemaUtilTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
@@ -161,5 +162,29 @@ class ArrowSchemaUtilTest {
     assertThatThrownBy(() -> ArrowSchemaUtil.toArrowSchema(List.of(column)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("must not be blank");
+  }
+
+  @Test
+  void derivesLogicalTypeFromArrowUtf8Field() {
+    Field field = Field.nullable("text", new ArrowType.Utf8());
+    assertThat(ArrowSchemaUtil.logicalType(field)).isEqualTo("STRING");
+  }
+
+  @Test
+  void derivesLogicalTypeFromArrowDecimalField() {
+    Field field = Field.nullable("dec", new ArrowType.Decimal(12, 3, 128));
+    assertThat(ArrowSchemaUtil.logicalType(field)).isEqualTo("DECIMAL(12,3)");
+  }
+
+  @Test
+  void derivesLogicalTypeFromArrowTimestampWithTz() {
+    Field field = Field.nullable("ts", new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"));
+    assertThat(ArrowSchemaUtil.logicalType(field)).isEqualTo("TIMESTAMPTZ(6)");
+  }
+
+  @Test
+  void derivesLogicalTypeFromArrowTimeWithoutTz() {
+    Field field = Field.nullable("t", new ArrowType.Time(TimeUnit.MICROSECOND, 64));
+    assertThat(ArrowSchemaUtil.logicalType(field)).isEqualTo("TIME(6)");
   }
 }


### PR DESCRIPTION
## Summary

Fix the conversion in between Arrow and Floecat LogicalType so that Schema descriptors in Floecat get correct and parsable types rather than their Arrow counterparts

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Include any follow-ups, risks, or reviewer guidance.
