### PR TITLE
fix: set client.region in the iceberg connector properties

### DIFF
--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactory.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactory.java
@@ -122,6 +122,7 @@ final class IcebergConnectorFactory {
     if (cleanOpts != null && !cleanOpts.isEmpty()) {
       props.putAll(cleanOpts);
     }
+    normalizeAwsRegionProperties(props);
     return props;
   }
 
@@ -142,6 +143,7 @@ final class IcebergConnectorFactory {
 
         props.putIfAbsent("io-impl", "org.apache.iceberg.aws.s3.S3FileIO");
         props.putIfAbsent("s3.region", signingRegion);
+        props.putIfAbsent("client.region", signingRegion);
 
         AwsProfileSupport.applyProfileProperties(props, authProps);
       }
@@ -156,6 +158,24 @@ final class IcebergConnectorFactory {
 
       default -> throw new IllegalArgumentException("Unsupported auth scheme: " + authScheme);
     }
+  }
+
+  private static void normalizeAwsRegionProperties(Map<String, String> props) {
+    if (props == null || props.isEmpty()) {
+      return;
+    }
+    String region = props.get("client.region");
+    if (region == null || region.isBlank()) {
+      region = props.get("s3.region");
+    }
+    if (region == null || region.isBlank()) {
+      region = props.get("aws.region");
+    }
+    if (region == null || region.isBlank()) {
+      return;
+    }
+    props.putIfAbsent("client.region", region);
+    props.putIfAbsent("s3.region", region);
   }
 
   static IcebergSource selectSource(Map<String, String> options) {

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactoryTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactoryTest.java
@@ -58,4 +58,43 @@ class IcebergConnectorFactoryTest {
                     IcebergConnectorFactory.IcebergSource.REST, "s3://bucket/metadata.json"));
     assertTrue(ex.getMessage().contains("iceberg.source=filesystem"));
   }
+
+  @Test
+  void buildRestPropsMirrorsS3RegionIntoClientRegion() throws Exception {
+    var method =
+        IcebergConnectorFactory.class.getDeclaredMethod("buildRestProps", String.class, Map.class);
+    method.setAccessible(true);
+
+    @SuppressWarnings("unchecked")
+    Map<String, String> props =
+        (Map<String, String>)
+            method.invoke(
+                null,
+                "https://glue.us-east-2.amazonaws.com/iceberg/",
+                Map.of("iceberg.source", "glue", "s3.region", "us-east-2"));
+
+    assertEquals("us-east-2", props.get("s3.region"));
+    assertEquals("us-east-2", props.get("client.region"));
+  }
+
+  @Test
+  void buildRestPropsPreservesExplicitClientRegion() throws Exception {
+    var method =
+        IcebergConnectorFactory.class.getDeclaredMethod("buildRestProps", String.class, Map.class);
+    method.setAccessible(true);
+
+    @SuppressWarnings("unchecked")
+    Map<String, String> props =
+        (Map<String, String>)
+            method.invoke(
+                null,
+                "https://glue.us-east-2.amazonaws.com/iceberg/",
+                Map.of(
+                    "iceberg.source", "glue",
+                    "s3.region", "us-east-2",
+                    "client.region", "us-west-2"));
+
+    assertEquals("us-east-2", props.get("s3.region"));
+    assertEquals("us-west-2", props.get("client.region"));
+  }
 }


### PR DESCRIPTION
## Summary

Add missing configuration of client.region to the Iceberg connector to allow the connector to read tables in other regions beyond us-east-1. Although we set s3.region in the connector, this isn't enough to allow the connector to address buckets in other regions.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
