### PR TITLE
Make typmod default be -1 in FloeDB specific protos

### DIFF
--- a/extensions/floedb/src/main/proto/engine_floe.proto
+++ b/extensions/floedb/src/main/proto/engine_floe.proto
@@ -70,7 +70,7 @@ message FloeColumnSpecific {
   optional uint32 atttypid = 2;
 
   /** Type modifier (atttypmod). */
-  optional int32 atttypmod = 3;
+  optional int32 atttypmod = 3 [default = -1];
 
   /** Attribute number (attnum). */
   optional int32 attnum = 4;


### PR DESCRIPTION
## Summary

Make typmod default be -1 in FloeDB specific protos. Default default value for unset proto is 0, which is wrong for typmod.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Include any follow-ups, risks, or reviewer guidance.
