### PR TITLE
Planner Constraint Streaming + Request-Scoped Pruning

### DIFF
--- a/core/proto/src/main/proto/floecat/query/planner_stats_bundle.proto
+++ b/core/proto/src/main/proto/floecat/query/planner_stats_bundle.proto
@@ -42,6 +42,21 @@ service PlannerStatsService {
    *   planner_stats.column_stats.error – an unexpected repository failure occurred while reading stats.
    */
   rpc GetColumnStats(FetchColumnStatsRequest) returns (stream ColumnStatsBundleChunk);
+
+  /**
+   * GetTableConstraints returns table-scoped constraints for planner-selected relations.
+   *
+   * GetTableConstraints provides a dedicated constraints stream for planner clients that fetch
+   * constraints separately. GetColumnStats(include_constraints=true) remains available for clients
+   * that prefer combined retrieval in one roundtrip.
+   *
+   * Visibility semantics are request-scoped at relation level: results may be pruned/redacted
+   * by requested tables (for example, foreign keys to non-requested tables are hidden).
+   *
+   * Unlike GetColumnStats(include_constraints=true), this request does not carry column
+   * projection context, so column-level pruning/masking cannot be made projection-aware here.
+   */
+  rpc GetTableConstraints(FetchTableConstraintsRequest) returns (stream TableConstraintsBundleChunk);
 }
 
 /** Request stats for a set of columns across one or more relations. */
@@ -60,6 +75,19 @@ message FetchColumnStatsRequest {
    * Defaults to false to preserve existing stats-only behavior for older clients.
    */
   bool include_constraints = 3;
+}
+
+/** Request table-scoped constraints for one or more relations. */
+message FetchTableConstraintsRequest {
+  /** Query ID obtained from BeginQuery (and used for snapshot pins). */
+  string query_id = 1;
+
+  /**
+   * Table IDs the planner needs constraints for. Duplicates are deduped server-side.
+   *
+   * This request is relation-scoped and does not include requested column IDs.
+   */
+  repeated ai.floedb.floecat.common.ResourceId table_ids = 2;
 }
 
 /** Columns requested for one table. */
@@ -85,7 +113,20 @@ message ColumnStatsBundleChunk {
   }
 }
 
+/** Streamed chunk for table constraints bundles. */
+message TableConstraintsBundleChunk {
+  string query_id = 1;
+  uint64 seq = 2;
+
+  oneof payload {
+    TableConstraintsBundleHeader header = 10;
+    TableConstraintsBatch batch = 20;
+    TableConstraintsBundleEnd end = 90;
+  }
+}
+
 message ColumnStatsBundleHeader {}
+message TableConstraintsBundleHeader {}
 
 message ColumnStatsBundleEnd {
   uint64 requested_tables = 1;
@@ -93,6 +134,13 @@ message ColumnStatsBundleEnd {
   uint64 returned_columns = 3;
   uint64 not_found_columns = 4;
   uint64 error_columns = 5;
+}
+
+message TableConstraintsBundleEnd {
+  uint64 requested_tables = 1;
+  uint64 returned_tables = 2;
+  uint64 not_found_tables = 3;
+  uint64 error_tables = 4;
 }
 
 message StatsWarning {
@@ -114,6 +162,13 @@ message ColumnStatsBatch {
    * Emitted only when requested via FetchColumnStatsRequest.include_constraints.
    */
   repeated TableConstraintsResult constraints = 3;
+}
+
+/** Batch of table constraints results. */
+message TableConstraintsBatch {
+  repeated TableConstraintsResult constraints = 1;
+  // Reserved for future constraint warning signals (none are currently emitted).
+  repeated StatsWarning warnings = 2;
 }
 
 enum BundleResultStatus {

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -45,6 +45,7 @@ packages and are consumed by the Quarkus service, connectors, CLI, and reconcile
 | `AccountService` | Account CRUD. |
 | `Connectors` | Connector CRUD, `ValidateConnector`, `StartCapture`, `GetReconcileJob`. |
 | `QueryService` | `BeginQuery`, `RenewQuery`, `EndQuery`, `GetQuery`, `FetchScanBundle`. |
+| `PlannerStatsService` | `GetColumnStats`, `GetTableConstraints` | Split planner-facing streams for column stats and table constraints; `GetColumnStats(include_constraints=true)` remains as a combined single-roundtrip convenience mode. |
 | `UserObjectsService` | `GetUserObjects` | Streams catalog metadata chunks (header → relations → end) as the service resolves each relation so planners can start binding earlier. |
 | &nbsp;&nbsp;&nbsp;— Consumption pattern | | Clients read `UserObjectsBundleChunk` in three phases: 1) header chunk (cheap metadata), 2) zero or more `resolutions` chunk batches where each `RelationResolution` carries `input_index` + FOUND/NOT_FOUND/ERROR, and 3) a single end chunk with summary counts. Use `input_index` to map back to planner `TableReferenceCandidate`s and bind as soon as a `FOUND` arrives. For each `RelationInfo`, inspect `columns[*].status`: `COLUMN_STATUS_OK` exposes `columns[*].column`, while `COLUMN_STATUS_FAILED` exposes `columns[*].failure` with typed `ColumnFailureCode` plus details. Extension-defined failures must use `COLUMN_FAILURE_CODE_ENGINE_EXTENSION` and set `extension_code_value`; clients branch on `extension_code_value` inside the engine domain (for FloeDB, see `FloeDecorationFailureCode` in `extensions/floedb/src/main/proto/engine_floe.proto`). |
 | `SystemObjectsService` | `GetSystemObjects` | Returns the builtin catalog filtered by the `x-engine-kind` / `x-engine-version` headers supplied with the request. |
@@ -84,6 +85,17 @@ engine release.
   (lenient ordering), while `PutTableConstraints` is strict and requires a materialized snapshot
   row before write. Rationale: stats keeps existing capture ordering compatibility, while
   constraints are modeled as snapshot-attached relational facts.
+- **Planner split vs combined retrieval** – `PlannerStatsService.GetTableConstraints` provides a
+  dedicated constraints-only stream, while `GetColumnStats(include_constraints=true)` remains
+  available as a combined convenience mode. Split mode is relation-scoped (table visibility pruning
+  only) because `FetchTableConstraintsRequest` does not carry column projection context; combined
+  mode can apply relation+column request-shape-aware pruning. For constraints lookups,
+  `provider_missing` means no bundle exists, while `provider_empty` means a bundle exists and is
+  explicitly empty. For planner client simplicity, both are currently surfaced as
+  `BUNDLE_RESULT_STATUS_NOT_FOUND` (same as `pruned_empty`), with
+  `failure.details.reason` preserving the distinction.
+  For CHECK masking to work correctly, connector constraint payloads should populate
+  `ConstraintDefinition.columns` with referenced local column IDs.
 - **Idempotency/Preconditions** – Mutating RPCs accept `IdempotencyKey` or `Precondition` (expected
   CAS version/ETag). Repository logic mirrors these fields, so clients should obey the same values
   when retrying.

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/ConstraintPruner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/ConstraintPruner.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import java.util.List;
+
+/**
+ * Prunes/redacts emitted constraints for a relation according to caller visibility policy.
+ *
+ * <p>Package-private by design: this is internal service plumbing, not a public extension point.
+ */
+interface ConstraintPruner {
+  List<ConstraintDefinition> prune(ResourceId tableId, List<ConstraintDefinition> constraints);
+
+  ConstraintPruner NONE = (tableId, constraints) -> constraints;
+}

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/ConstraintPrunerFactory.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/ConstraintPrunerFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Temporary composition point for future visibility-aware pruning policies.
+ *
+ * <p>Today this is a thin constructor wrapper for request-scoped pruners, but it intentionally
+ * centralizes selection so ACL-aware policy variants can be introduced without rewiring planner
+ * bundle assembly call sites.
+ */
+@ApplicationScoped
+class ConstraintPrunerFactory {
+
+  ConstraintPruner forRequest(
+      Set<String> requestedRelationKeys, Map<String, Set<Long>> requestedColumnsByRelationKey) {
+    return new RequestScopeConstraintPruner(requestedRelationKeys, requestedColumnsByRelationKey);
+  }
+
+  ConstraintPruner forConstraintsOnlyRequest(Set<String> requestedRelationKeys) {
+    return RequestScopeConstraintPruner.forRequestedTablesOnly(requestedRelationKeys);
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleService.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.query.catalog;
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
 import ai.floedb.floecat.catalog.rpc.ColumnStats;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.query.rpc.BundleFailure;
 import ai.floedb.floecat.query.rpc.BundleResultStatus;
@@ -29,8 +30,15 @@ import ai.floedb.floecat.query.rpc.ColumnStatsBundleHeader;
 import ai.floedb.floecat.query.rpc.ColumnStatsInfo;
 import ai.floedb.floecat.query.rpc.ColumnStatsResult;
 import ai.floedb.floecat.query.rpc.FetchColumnStatsRequest;
+import ai.floedb.floecat.query.rpc.FetchTableConstraintsRequest;
 import ai.floedb.floecat.query.rpc.StatsWarning;
 import ai.floedb.floecat.query.rpc.TableColumnStatsRequest;
+import ai.floedb.floecat.query.rpc.TableConstraintsBatch;
+import ai.floedb.floecat.query.rpc.TableConstraintsBundleChunk;
+import ai.floedb.floecat.query.rpc.TableConstraintsBundleEnd;
+import ai.floedb.floecat.query.rpc.TableConstraintsBundleHeader;
+import ai.floedb.floecat.query.rpc.TableConstraintsResult;
+import ai.floedb.floecat.scanner.spi.ConstraintProvider;
 import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.impl.QueryContext;
@@ -41,12 +49,17 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.OptionalLong;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
@@ -58,9 +71,15 @@ public class PlannerStatsBundleService {
   private static final String PIN_MISSING_CODE = "planner_stats.pin.missing";
   private static final String COLUMN_MISSING_CODE = "planner_stats.column_stats.missing";
   private static final String COLUMN_ERROR_CODE = "planner_stats.column_stats.error";
+  private static final String CONSTRAINT_MISSING_CODE = "planner_stats.constraints.missing";
+  private static final String CONSTRAINT_ERROR_CODE = "planner_stats.constraints.error";
   private static final String SCAN_CAPPED_CODE = "planner_stats.column_stats.scan_capped";
 
   private final StatsProviderFactory statsFactory;
+  private final Supplier<ConstraintProvider> constraintProviderSupplier;
+  private final BiFunction<Set<String>, Map<String, Set<Long>>, ConstraintPruner>
+      constraintPrunerFactory;
+  private final Function<Set<String>, ConstraintPruner> constraintsOnlyPrunerFactory;
   private final StatsRepository repository;
   private final int maxTables;
   private final int maxColumns;
@@ -72,6 +91,8 @@ public class PlannerStatsBundleService {
   @Inject
   public PlannerStatsBundleService(
       StatsProviderFactory statsFactory,
+      ConstraintProviderFactory constraintFactory,
+      ConstraintPrunerFactory constraintPrunerFactory,
       StatsRepository repository,
       @ConfigProperty(name = "floecat.planner.stats.max-tables", defaultValue = "50") int maxTables,
       @ConfigProperty(name = "floecat.planner.stats.max-columns", defaultValue = "1024")
@@ -80,13 +101,27 @@ public class PlannerStatsBundleService {
           int maxResultsPerChunk) {
     this(
         statsFactory,
+        constraintFactory::provider,
+        constraintPrunerFactory::forRequest,
+        constraintPrunerFactory::forConstraintsOnlyRequest,
         repository,
         new PlannerStatsLimits(maxTables, maxColumns, maxResultsPerChunk));
   }
 
   PlannerStatsBundleService(
-      StatsProviderFactory statsFactory, StatsRepository repository, PlannerStatsLimits limits) {
+      StatsProviderFactory statsFactory,
+      Supplier<ConstraintProvider> constraintProviderSupplier,
+      BiFunction<Set<String>, Map<String, Set<Long>>, ConstraintPruner> constraintPrunerFactory,
+      Function<Set<String>, ConstraintPruner> constraintsOnlyPrunerFactory,
+      StatsRepository repository,
+      PlannerStatsLimits limits) {
     this.statsFactory = Objects.requireNonNull(statsFactory, "statsFactory");
+    this.constraintProviderSupplier =
+        Objects.requireNonNull(constraintProviderSupplier, "constraintProviderSupplier");
+    this.constraintPrunerFactory =
+        Objects.requireNonNull(constraintPrunerFactory, "constraintPrunerFactory");
+    this.constraintsOnlyPrunerFactory =
+        Objects.requireNonNull(constraintsOnlyPrunerFactory, "constraintsOnlyPrunerFactory");
     this.repository = Objects.requireNonNull(repository, "repository");
     this.maxTables = Math.max(1, limits.maxTables);
     this.maxColumns = Math.max(1, limits.maxColumns);
@@ -99,8 +134,27 @@ public class PlannerStatsBundleService {
       int maxTables,
       int maxColumns,
       int maxResultsPerChunk) {
+    return forTesting(
+        statsFactory,
+        ConstraintProvider.NONE,
+        repository,
+        maxTables,
+        maxColumns,
+        maxResultsPerChunk);
+  }
+
+  public static PlannerStatsBundleService forTesting(
+      StatsProviderFactory statsFactory,
+      ConstraintProvider constraintProvider,
+      StatsRepository repository,
+      int maxTables,
+      int maxColumns,
+      int maxResultsPerChunk) {
     return new PlannerStatsBundleService(
         statsFactory,
+        () -> constraintProvider == null ? ConstraintProvider.NONE : constraintProvider,
+        RequestScopeConstraintPruner::new,
+        RequestScopeConstraintPruner::forRequestedTablesOnly,
         repository,
         new PlannerStatsLimits(maxTables, maxColumns, maxResultsPerChunk));
   }
@@ -111,6 +165,11 @@ public class PlannerStatsBundleService {
         request == null ? FetchColumnStatsRequest.getDefaultInstance() : request;
     NormalizedRequest normalized = normalizeRequest(correlationId, safeRequest);
     List<TableRequest> tableRequests = normalized.tables();
+    ConstraintProvider constraintProvider =
+        safeRequest.getIncludeConstraints()
+            ? constraintProviderSupplier.get()
+            : ConstraintProvider.NONE;
+    SnapshotPinLookup pinLookup = statsFactory.pinLookupForQuery(ctx, correlationId);
     return Multi.createFrom()
         .<ColumnStatsBundleChunk>deferred(
             () ->
@@ -121,11 +180,42 @@ public class PlannerStatsBundleService {
                                 ctx.getQueryId(),
                                 correlationId,
                                 tableRequests,
-                                statsFactory.forQuery(ctx, correlationId),
+                                pinLookup,
+                                constraintProvider,
+                                safeRequest.getIncludeConstraints(),
+                                constraintPrunerFactory,
                                 repository,
                                 maxResultsPerChunk,
                                 tableRequests.size(),
                                 normalized.requestedColumns())));
+  }
+
+  public Multi<TableConstraintsBundleChunk> streamConstraints(
+      String correlationId, QueryContext ctx, FetchTableConstraintsRequest request) {
+    FetchTableConstraintsRequest safeRequest =
+        request == null ? FetchTableConstraintsRequest.getDefaultInstance() : request;
+    List<ResourceId> tableIds = normalizeConstraintsRequest(correlationId, safeRequest);
+    Set<String> requestedRelationKeys = new LinkedHashSet<>();
+    for (ResourceId tableId : tableIds) {
+      requestedRelationKeys.add(RequestScopeConstraintPruner.relationKey(tableId));
+    }
+    ConstraintPruner constraintPruner =
+        constraintsOnlyPrunerFactory.apply(Set.copyOf(requestedRelationKeys));
+    ConstraintProvider constraintProvider = constraintProviderSupplier.get();
+    SnapshotPinLookup pinLookup = statsFactory.pinLookupForQuery(ctx, correlationId);
+    return Multi.createFrom()
+        .<TableConstraintsBundleChunk>deferred(
+            () ->
+                Multi.createFrom()
+                    .iterable(
+                        () ->
+                            new TableConstraintsIterator(
+                                ctx.getQueryId(),
+                                tableIds,
+                                pinLookup,
+                                constraintProvider,
+                                constraintPruner,
+                                maxResultsPerChunk)));
   }
 
   private NormalizedRequest normalizeRequest(
@@ -181,6 +271,33 @@ public class PlannerStatsBundleService {
     return new NormalizedRequest(List.copyOf(normalized), totalColumns);
   }
 
+  private List<ResourceId> normalizeConstraintsRequest(
+      String correlationId, FetchTableConstraintsRequest request) {
+    if (request.getTableIdsCount() == 0) {
+      throw GrpcErrors.invalidArgument(
+          correlationId, PLANNER_STATS_REQUEST_TABLES_MISSING, Map.of());
+    }
+    if (request.getTableIdsCount() > maxTables) {
+      throw GrpcErrors.invalidArgument(
+          correlationId,
+          PLANNER_STATS_REQUEST_TABLES_LIMIT,
+          Map.of("max_tables", Integer.toString(maxTables)));
+    }
+
+    Map<String, ResourceId> deduped = new LinkedHashMap<>(request.getTableIdsCount());
+    for (int tableIndex = 0; tableIndex < request.getTableIdsCount(); tableIndex++) {
+      ResourceId tableId = request.getTableIds(tableIndex);
+      if (tableId.getId().isBlank()) {
+        throw GrpcErrors.invalidArgument(
+            correlationId,
+            PLANNER_STATS_REQUEST_TABLE_ID_MISSING,
+            Map.of("table_index", Integer.toString(tableIndex)));
+      }
+      deduped.putIfAbsent(RequestScopeConstraintPruner.relationKey(tableId), tableId);
+    }
+    return List.copyOf(deduped.values());
+  }
+
   private static List<Long> dedupeColumnIds(
       String correlationId, String tableId, List<Long> columnIds) {
     LinkedHashSet<Long> seen = new LinkedHashSet<>(columnIds.size());
@@ -196,96 +313,145 @@ public class PlannerStatsBundleService {
     return new ArrayList<>(seen);
   }
 
-  private static final class PlannerStatsIterator implements Iterator<ColumnStatsBundleChunk> {
+  // ---------------------------------------------------------------------------
+  // Shared iterator base
+  // ---------------------------------------------------------------------------
 
-    private final String queryId;
+  private abstract static class BundleIterator<C> implements Iterator<C> {
+
+    protected final String queryId;
+    protected long seq = 1;
+    private boolean headerEmitted = false;
+    private boolean endEmitted = false;
+
+    protected BundleIterator(String queryId) {
+      this.queryId = queryId;
+    }
+
+    @Override
+    public final boolean hasNext() {
+      return !endEmitted;
+    }
+
+    @Override
+    public final C next() {
+      if (!headerEmitted) {
+        headerEmitted = true;
+        return header();
+      }
+      if (hasMoreWork()) {
+        return batch();
+      }
+      if (!endEmitted) {
+        endEmitted = true;
+        return end();
+      }
+      throw new NoSuchElementException();
+    }
+
+    protected abstract C header();
+
+    protected abstract C batch();
+
+    protected abstract C end();
+
+    protected abstract boolean hasMoreWork();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Column stats iterator
+  // ---------------------------------------------------------------------------
+
+  private static final class PlannerStatsIterator extends BundleIterator<ColumnStatsBundleChunk> {
+
     private final String correlationId;
     private final List<TableWork> tableWorks;
-    private final StatsProvider statsProvider;
+    private final SnapshotPinLookup pinLookup;
+    private final ConstraintProvider constraintProvider;
+    private final boolean includeConstraints;
+    private final ConstraintPruner constraintPruner;
     private final StatsRepository repository;
     private final int maxResultsPerChunk;
     private final long requestedTables;
     private final long requestedColumns;
 
     private int nextTableIndex = 0;
-    private long seq = 1;
     private long returnedColumns = 0;
     private long notFoundColumns = 0;
     private long errorColumns = 0;
-    private boolean headerEmitted = false;
-    private boolean endEmitted = false;
     private final List<StatsWarning> pendingWarnings = new ArrayList<>();
 
     private PlannerStatsIterator(
         String queryId,
         String correlationId,
         List<TableRequest> tables,
-        StatsProvider statsProvider,
+        SnapshotPinLookup pinLookup,
+        ConstraintProvider constraintProvider,
+        boolean includeConstraints,
+        BiFunction<Set<String>, Map<String, Set<Long>>, ConstraintPruner> constraintPrunerFactory,
         StatsRepository repository,
         int maxResultsPerChunk,
         long requestedTables,
         long requestedColumns) {
-      this.queryId = queryId;
+      super(queryId);
       this.correlationId = correlationId;
-      this.statsProvider = statsProvider;
+      this.pinLookup = pinLookup;
+      this.constraintProvider = constraintProvider;
+      this.includeConstraints = includeConstraints;
       this.repository = repository;
       this.maxResultsPerChunk = maxResultsPerChunk;
       this.requestedTables = requestedTables;
       this.requestedColumns = requestedColumns;
+      Set<String> requestedRelationKeys = new LinkedHashSet<>();
+      Map<String, Set<Long>> requestedColumnsByRelationKey = new LinkedHashMap<>();
       this.tableWorks = new ArrayList<>(tables.size());
       for (TableRequest table : tables) {
+        String key = RequestScopeConstraintPruner.relationKey(table.tableId());
+        requestedRelationKeys.add(key);
+        requestedColumnsByRelationKey.put(key, new LinkedHashSet<>(table.columnIds()));
         this.tableWorks.add(new TableWork(table.tableId(), table.columnIds()));
       }
+      this.constraintPruner =
+          constraintPrunerFactory.apply(
+              Set.copyOf(requestedRelationKeys),
+              requestedColumnsByRelationKey.entrySet().stream()
+                  .collect(
+                      java.util.stream.Collectors.toUnmodifiableMap(
+                          Map.Entry::getKey, e -> Set.copyOf(e.getValue()))));
     }
 
     @Override
-    public boolean hasNext() {
-      return !endEmitted;
-    }
-
-    @Override
-    public ColumnStatsBundleChunk next() {
-      if (!headerEmitted) {
-        headerEmitted = true;
-        return headerChunk();
-      }
-
-      if (hasMoreWork()) {
-        return batchChunk();
-      }
-
-      if (!endEmitted) {
-        endEmitted = true;
-        return endChunk();
-      }
-
-      throw new NoSuchElementException();
-    }
-
-    private boolean hasMoreWork() {
+    protected boolean hasMoreWork() {
       return nextTableIndex < tableWorks.size();
     }
 
-    private ColumnStatsBundleChunk headerChunk() {
-      ColumnStatsBundleHeader header = ColumnStatsBundleHeader.newBuilder().build();
+    @Override
+    protected ColumnStatsBundleChunk header() {
       return ColumnStatsBundleChunk.newBuilder()
           .setQueryId(queryId)
           .setSeq(seq++)
-          .setHeader(header)
+          .setHeader(ColumnStatsBundleHeader.newBuilder().build())
           .build();
     }
 
-    private ColumnStatsBundleChunk batchChunk() {
+    @Override
+    protected ColumnStatsBundleChunk batch() {
       List<ColumnStatsResult> out = new ArrayList<>(Math.min(maxResultsPerChunk, 16));
+      List<TableConstraintsResult> constraintsOut = new ArrayList<>();
       while (out.size() < maxResultsPerChunk && hasMoreWork()) {
         TableWork work = tableWorks.get(nextTableIndex);
         ColumnStatsResult result = processNextColumn(work);
         out.add(result);
+        if (includeConstraints && !work.constraintsEmitted()) {
+          constraintsOut.add(processConstraints(work));
+          work.markConstraintsEmitted();
+        }
         if (!work.hasMoreColumns()) {
           nextTableIndex++;
         }
       }
-      ColumnStatsBatch.Builder batchBuilder = ColumnStatsBatch.newBuilder().addAllColumns(out);
+      ColumnStatsBatch.Builder batchBuilder =
+          ColumnStatsBatch.newBuilder().addAllColumns(out).addAllConstraints(constraintsOut);
       if (!pendingWarnings.isEmpty()) {
         batchBuilder.addAllWarnings(pendingWarnings);
         pendingWarnings.clear();
@@ -295,6 +461,23 @@ public class PlannerStatsBundleService {
           .setQueryId(queryId)
           .setSeq(seq++)
           .setBatch(batch)
+          .build();
+    }
+
+    @Override
+    protected ColumnStatsBundleChunk end() {
+      ColumnStatsBundleEnd end =
+          ColumnStatsBundleEnd.newBuilder()
+              .setRequestedTables(requestedTables)
+              .setRequestedColumns(requestedColumns)
+              .setReturnedColumns(returnedColumns)
+              .setNotFoundColumns(notFoundColumns)
+              .setErrorColumns(errorColumns)
+              .build();
+      return ColumnStatsBundleChunk.newBuilder()
+          .setQueryId(queryId)
+          .setSeq(seq++)
+          .setEnd(end)
           .build();
     }
 
@@ -325,11 +508,17 @@ public class PlannerStatsBundleService {
       return result;
     }
 
+    private TableConstraintsResult processConstraints(TableWork work) {
+      return resolveConstraintResult(
+              work.tableId, resolveSnapshot(work), constraintProvider, constraintPruner)
+          .result();
+    }
+
     private OptionalLong resolveSnapshot(TableWork work) {
       if (work.pinResolved) {
         return work.pinnedSnapshot;
       }
-      work.pinnedSnapshot = statsProvider.pinnedSnapshotId(work.tableId);
+      work.pinnedSnapshot = pinLookup.pinnedSnapshotId(work.tableId);
       work.pinResolved = true;
       return work.pinnedSnapshot;
     }
@@ -393,24 +582,19 @@ public class PlannerStatsBundleService {
       view.maxValue().ifPresent(info::setMax);
       view.ndv().ifPresent(info::setNdv);
 
-      ColumnStatsResult.Builder builder =
-          ColumnStatsResult.newBuilder()
-              .setTableId(tableId)
-              .setColumnId(columnId)
-              .setColumnName(view.columnName())
-              .setStatus(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND)
-              .setStats(info.build());
-      return builder.build();
+      return ColumnStatsResult.newBuilder()
+          .setTableId(tableId)
+          .setColumnId(columnId)
+          .setColumnName(view.columnName())
+          .setStatus(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND)
+          .setStats(info.build())
+          .build();
     }
 
     private ColumnStatsResult buildErrorResult(
         ResourceId tableId, long columnId, long snapshotId, RuntimeException e) {
       BundleFailure failure =
-          BundleFailure.newBuilder()
-              .setCode(COLUMN_ERROR_CODE)
-              .setMessage("column stats lookup failed")
-              .putDetails("table_id", tableId.getId())
-              .putDetails("account_id", tableId.getAccountId())
+          failureBase(tableId, COLUMN_ERROR_CODE, "column stats lookup failed")
               .putDetails("column_id", Long.toString(columnId))
               .putDetails("snapshot_id", Long.toString(snapshotId))
               .putDetails("exception", e.getClass().getSimpleName())
@@ -426,35 +610,20 @@ public class PlannerStatsBundleService {
 
     private ColumnStatsResult notFoundResult(
         ResourceId tableId, long columnId, String code, String message, OptionalLong snapshotId) {
-      BundleFailure failure =
-          BundleFailure.newBuilder()
-              .setCode(code)
-              .setMessage(message)
-              .putDetails("table_id", tableId.getId())
-              .putDetails("account_id", tableId.getAccountId())
-              .putDetails("column_id", Long.toString(columnId))
-              .build();
-      if (snapshotId.isPresent()) {
-        failure =
-            failure.toBuilder()
-                .putDetails("snapshot_id", Long.toString(snapshotId.getAsLong()))
-                .build();
-      }
+      BundleFailure.Builder failure =
+          failureBase(tableId, code, message).putDetails("column_id", Long.toString(columnId));
+      snapshotId.ifPresent(id -> failure.putDetails("snapshot_id", Long.toString(id)));
       return ColumnStatsResult.newBuilder()
           .setTableId(tableId)
           .setColumnId(columnId)
           .setStatus(BundleResultStatus.BUNDLE_RESULT_STATUS_NOT_FOUND)
-          .setFailure(failure)
+          .setFailure(failure.build())
           .build();
     }
 
     private ColumnStatsResult pinMissingResult(ResourceId tableId, long columnId) {
       BundleFailure failure =
-          BundleFailure.newBuilder()
-              .setCode(PIN_MISSING_CODE)
-              .setMessage("snapshot pin missing")
-              .putDetails("table_id", tableId.getId())
-              .putDetails("account_id", tableId.getAccountId())
+          failureBase(tableId, PIN_MISSING_CODE, "snapshot pin missing")
               .putDetails("column_id", Long.toString(columnId))
               .build();
       return ColumnStatsResult.newBuilder()
@@ -464,23 +633,246 @@ public class PlannerStatsBundleService {
           .setFailure(failure)
           .build();
     }
+  }
 
-    private ColumnStatsBundleChunk endChunk() {
-      ColumnStatsBundleEnd end =
-          ColumnStatsBundleEnd.newBuilder()
-              .setRequestedTables(requestedTables)
-              .setRequestedColumns(requestedColumns)
-              .setReturnedColumns(returnedColumns)
-              .setNotFoundColumns(notFoundColumns)
-              .setErrorColumns(errorColumns)
+  // ---------------------------------------------------------------------------
+  // Constraints-only iterator
+  // ---------------------------------------------------------------------------
+
+  private static final class TableConstraintsIterator
+      extends BundleIterator<TableConstraintsBundleChunk> {
+
+    private final List<ResourceId> tableIds;
+    private final SnapshotPinLookup pinLookup;
+    private final ConstraintProvider constraintProvider;
+    private final ConstraintPruner constraintPruner;
+    private final int maxResultsPerChunk;
+
+    private int nextTableIndex = 0;
+    private long returnedTables = 0;
+    private long notFoundTables = 0;
+    private long errorTables = 0;
+
+    private TableConstraintsIterator(
+        String queryId,
+        List<ResourceId> tableIds,
+        SnapshotPinLookup pinLookup,
+        ConstraintProvider constraintProvider,
+        ConstraintPruner constraintPruner,
+        int maxResultsPerChunk) {
+      super(queryId);
+      this.tableIds = tableIds;
+      this.pinLookup = pinLookup;
+      this.constraintProvider = constraintProvider;
+      this.constraintPruner = constraintPruner;
+      this.maxResultsPerChunk = maxResultsPerChunk;
+    }
+
+    @Override
+    protected boolean hasMoreWork() {
+      return nextTableIndex < tableIds.size();
+    }
+
+    @Override
+    protected TableConstraintsBundleChunk header() {
+      return TableConstraintsBundleChunk.newBuilder()
+          .setQueryId(queryId)
+          .setSeq(seq++)
+          .setHeader(TableConstraintsBundleHeader.newBuilder().build())
+          .build();
+    }
+
+    @Override
+    protected TableConstraintsBundleChunk batch() {
+      List<TableConstraintsResult> out = new ArrayList<>(Math.min(maxResultsPerChunk, 16));
+      while (out.size() < maxResultsPerChunk && nextTableIndex < tableIds.size()) {
+        out.add(processTable(tableIds.get(nextTableIndex++)));
+      }
+      TableConstraintsBatch batch =
+          TableConstraintsBatch.newBuilder().addAllConstraints(out).build();
+      return TableConstraintsBundleChunk.newBuilder()
+          .setQueryId(queryId)
+          .setSeq(seq++)
+          .setBatch(batch)
+          .build();
+    }
+
+    @Override
+    protected TableConstraintsBundleChunk end() {
+      TableConstraintsBundleEnd end =
+          TableConstraintsBundleEnd.newBuilder()
+              .setRequestedTables(tableIds.size())
+              .setReturnedTables(returnedTables)
+              .setNotFoundTables(notFoundTables)
+              .setErrorTables(errorTables)
               .build();
-      return ColumnStatsBundleChunk.newBuilder()
+      return TableConstraintsBundleChunk.newBuilder()
           .setQueryId(queryId)
           .setSeq(seq++)
           .setEnd(end)
           .build();
     }
+
+    private TableConstraintsResult processTable(ResourceId tableId) {
+      ConstraintResolution result =
+          resolveConstraintResult(
+              tableId, pinLookup.pinnedSnapshotId(tableId), constraintProvider, constraintPruner);
+      switch (result.status()) {
+        case FOUND -> returnedTables++;
+        case NOT_FOUND -> notFoundTables++;
+        case ERROR -> errorTables++;
+      }
+      return result.result();
+    }
   }
+
+  // ---------------------------------------------------------------------------
+  // Constraint resolution (shared between both iterators)
+  // ---------------------------------------------------------------------------
+
+  private enum ConstraintResolutionStatus {
+    FOUND,
+    NOT_FOUND,
+    ERROR
+  }
+
+  private record ConstraintResolution(
+      TableConstraintsResult result, ConstraintResolutionStatus status) {}
+
+  private static ConstraintResolution resolveConstraintResult(
+      ResourceId tableId,
+      OptionalLong snapshotId,
+      ConstraintProvider constraintProvider,
+      ConstraintPruner constraintPruner) {
+    if (snapshotId.isEmpty()) {
+      LOG.debugf("constraint pin missing for %s", tableId.getId());
+      return new ConstraintResolution(
+          constraintPinMissingResult(tableId), ConstraintResolutionStatus.ERROR);
+    }
+
+    try {
+      OptionalLong pinnedSnapshotId = OptionalLong.of(snapshotId.getAsLong());
+      // Deliberate client-contract choice: constraints "absence" states are intentionally
+      // collapsed to NOT_FOUND for planner simplicity, while callers can distinguish the cause via
+      // failure.details["reason"]. This is not a statement that these storage states are
+      // equivalent:
+      // - provider_missing: no provider view
+      // - provider_empty: provider view with zero constraints
+      // - pruned_empty: provider view exists but request-scope pruning hid all constraints
+      // TODO: Revisit status mapping if planner clients need to distinguish provider_empty as
+      // FOUND with zero constraints while keeping provider_missing as NOT_FOUND.
+      var maybeView = constraintProvider.constraints(tableId, pinnedSnapshotId);
+      if (maybeView.isEmpty()) {
+        LOG.tracef(
+            "no constraints stored for %s snapshot %d", tableId.getId(), snapshotId.getAsLong());
+        return new ConstraintResolution(
+            constraintNotFoundResult(tableId, pinnedSnapshotId, "provider_missing"),
+            ConstraintResolutionStatus.NOT_FOUND);
+      }
+
+      List<ConstraintDefinition> visible = maybeView.get().constraints();
+      if (visible.isEmpty()) {
+        LOG.debugf(
+            "constraint provider returned empty bundle for %s snapshot %d",
+            tableId.getId(), snapshotId.getAsLong());
+        return new ConstraintResolution(
+            constraintNotFoundResult(tableId, pinnedSnapshotId, "provider_empty"),
+            ConstraintResolutionStatus.NOT_FOUND);
+      }
+      visible = constraintPruner.prune(tableId, visible);
+
+      // Semantics choice: provider FOUND + prune-to-empty is surfaced as NOT_FOUND to callers.
+      // This keeps client handling simple: no visible constraints for the request scope.
+      if (visible.isEmpty()) {
+        LOG.tracef(
+            "all constraints pruned for %s snapshot %d", tableId.getId(), snapshotId.getAsLong());
+        return new ConstraintResolution(
+            constraintNotFoundResult(tableId, pinnedSnapshotId, "pruned_empty"),
+            ConstraintResolutionStatus.NOT_FOUND);
+      }
+
+      LOG.tracef(
+          "constraints resolved for %s snapshot %d: %d constraints",
+          tableId.getId(), snapshotId.getAsLong(), visible.size());
+      if (LOG.isTraceEnabled()) {
+        for (ConstraintDefinition c : visible) {
+          LOG.tracef(
+              "  constraint: type=%s name=%s columns=%d enforcement=%s",
+              c.getType(), c.getName(), c.getColumnsCount(), c.getEnforcement());
+        }
+      }
+      return new ConstraintResolution(
+          TableConstraintsResult.newBuilder()
+              .setTableId(tableId)
+              .setStatus(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND)
+              .addAllConstraints(visible)
+              .build(),
+          ConstraintResolutionStatus.FOUND);
+    } catch (RuntimeException e) {
+      LOG.debugf(
+          e,
+          "constraint lookup failed for %s snapshot %d",
+          tableId.getId(),
+          snapshotId.getAsLong());
+      return new ConstraintResolution(
+          constraintErrorResult(tableId, OptionalLong.of(snapshotId.getAsLong()), e),
+          ConstraintResolutionStatus.ERROR);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Failure builders
+  // ---------------------------------------------------------------------------
+
+  private static BundleFailure.Builder failureBase(
+      ResourceId tableId, String code, String message) {
+    return BundleFailure.newBuilder()
+        .setCode(code)
+        .setMessage(message)
+        .putDetails("table_id", tableId.getId())
+        .putDetails("account_id", tableId.getAccountId());
+  }
+
+  private static TableConstraintsResult constraintPinMissingResult(ResourceId tableId) {
+    BundleFailure failure = failureBase(tableId, PIN_MISSING_CODE, "snapshot pin missing").build();
+    return TableConstraintsResult.newBuilder()
+        .setTableId(tableId)
+        .setStatus(BundleResultStatus.BUNDLE_RESULT_STATUS_ERROR)
+        .setFailure(failure)
+        .build();
+  }
+
+  private static TableConstraintsResult constraintNotFoundResult(
+      ResourceId tableId, OptionalLong snapshotId, String reason) {
+    BundleFailure.Builder failure =
+        failureBase(tableId, CONSTRAINT_MISSING_CODE, "constraints missing")
+            .putDetails("reason", reason);
+    snapshotId.ifPresent(id -> failure.putDetails("snapshot_id", Long.toString(id)));
+    return TableConstraintsResult.newBuilder()
+        .setTableId(tableId)
+        .setStatus(BundleResultStatus.BUNDLE_RESULT_STATUS_NOT_FOUND)
+        .setFailure(failure.build())
+        .build();
+  }
+
+  private static TableConstraintsResult constraintErrorResult(
+      ResourceId tableId, OptionalLong snapshotId, RuntimeException exception) {
+    BundleFailure.Builder failure =
+        failureBase(tableId, CONSTRAINT_ERROR_CODE, "constraints lookup failed");
+    snapshotId.ifPresent(id -> failure.putDetails("snapshot_id", Long.toString(id)));
+    failure
+        .putDetails("exception", exception.getClass().getSimpleName())
+        .putDetails("message", exception.getMessage() == null ? "" : exception.getMessage());
+    return TableConstraintsResult.newBuilder()
+        .setTableId(tableId)
+        .setStatus(BundleResultStatus.BUNDLE_RESULT_STATUS_ERROR)
+        .setFailure(failure.build())
+        .build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Supporting types
+  // ---------------------------------------------------------------------------
 
   private static final class TableWork {
     private final ResourceId tableId;
@@ -490,6 +882,7 @@ public class PlannerStatsBundleService {
     private Map<Long, ColumnStats> statsByColumn;
     private RuntimeException statsError;
     private int columnIndex = 0;
+    private boolean constraintsEmitted = false;
 
     private TableWork(ResourceId tableId, List<Long> columnIds) {
       this.tableId = tableId;
@@ -510,6 +903,14 @@ public class PlannerStatsBundleService {
 
     private int columnIndex() {
       return columnIndex;
+    }
+
+    private boolean constraintsEmitted() {
+      return constraintsEmitted;
+    }
+
+    private void markConstraintsEmitted() {
+      this.constraintsEmitted = true;
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/RequestScopeConstraintPruner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/RequestScopeConstraintPruner.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Interim conservative pruning policy based on request-scoped relation/column projection.
+ *
+ * <p>This is intentionally a scaffold for future visibility-aware pruning.
+ *
+ * <p>Current policy preserves PK/UNIQUE and single-column nullability constraints for requested
+ * relations, treating requested column IDs as stats projection hints rather than strict visibility
+ * boundaries. FK/CHECK are pruned or masked using request-scoped visibility.
+ *
+ * <p>CHECK masking assumes CHECK constraints populate {@code ConstraintDefinition.columns} with
+ * referenced local columns. If connectors omit those column refs, this pruner cannot detect hidden
+ * column usage and will not mask the check expression.
+ */
+final class RequestScopeConstraintPruner implements ConstraintPruner {
+
+  private final Set<String> requestedRelationKeys;
+  private final Map<String, Set<Long>> requestedColumnsByRelationKey;
+  private final Set<String> allColumnsVisibleRelationKeys;
+
+  RequestScopeConstraintPruner(
+      Set<String> requestedRelationKeys, Map<String, Set<Long>> requestedColumnsByRelationKey) {
+    this(requestedRelationKeys, requestedColumnsByRelationKey, Set.of());
+  }
+
+  private RequestScopeConstraintPruner(
+      Set<String> requestedRelationKeys,
+      Map<String, Set<Long>> requestedColumnsByRelationKey,
+      Set<String> allColumnsVisibleRelationKeys) {
+    this.requestedRelationKeys = requestedRelationKeys;
+    this.requestedColumnsByRelationKey = requestedColumnsByRelationKey;
+    this.allColumnsVisibleRelationKeys = allColumnsVisibleRelationKeys;
+  }
+
+  static RequestScopeConstraintPruner forRequestedTablesOnly(Set<String> requestedRelationKeys) {
+    return new RequestScopeConstraintPruner(requestedRelationKeys, Map.of(), requestedRelationKeys);
+  }
+
+  @Override
+  public List<ConstraintDefinition> prune(
+      ResourceId tableId, List<ConstraintDefinition> constraints) {
+    String localTableKey = relationKey(tableId);
+    Set<Long> requestedLocalColumns =
+        requestedColumnsByRelationKey.getOrDefault(localTableKey, Set.of());
+    boolean allLocalColumnsVisible = allColumnsVisibleRelationKeys.contains(localTableKey);
+    List<ConstraintDefinition> out = new ArrayList<>(constraints.size());
+    for (ConstraintDefinition constraint : constraints) {
+      // Preserve PK/UNIQUE and column nullability when the relation is requested.
+      // Requested column IDs are treated as stats projection hints for these constraints.
+      if (isRelationScopedConstraint(constraint.getType())) {
+        out.add(constraint);
+        continue;
+      }
+
+      // Conservative FK policy:
+      // 1) hide FK if referenced table is outside request scope,
+      // 2) filter local/referenced columns to requested sets,
+      // 3) drop FK if either side becomes empty after filtering.
+      if (constraint.getType() == ConstraintType.CT_FOREIGN_KEY
+          && constraint.hasReferencedTableId()
+          && !requestedRelationKeys.contains(relationKey(constraint.getReferencedTableId()))) {
+        continue;
+      }
+
+      List<ConstraintColumnRef> localColumns =
+          allLocalColumnsVisible
+              ? constraint.getColumnsList()
+              : filterRequestedColumns(constraint.getColumnsList(), requestedLocalColumns);
+      ConstraintDefinition.Builder builder = constraint.toBuilder().clearColumns();
+      builder.addAllColumns(localColumns);
+
+      if (constraint.getType() == ConstraintType.CT_FOREIGN_KEY) {
+        List<ConstraintColumnRef> referencedColumns = constraint.getReferencedColumnsList();
+        if (constraint.hasReferencedTableId()) {
+          String referencedTableKey = relationKey(constraint.getReferencedTableId());
+          if (!allColumnsVisibleRelationKeys.contains(referencedTableKey)) {
+            Set<Long> requestedReferenced =
+                requestedColumnsByRelationKey.getOrDefault(referencedTableKey, Set.of());
+            referencedColumns = filterRequestedColumns(referencedColumns, requestedReferenced);
+          }
+        }
+        builder.clearReferencedColumns().addAllReferencedColumns(referencedColumns);
+        if (localColumns.isEmpty() || referencedColumns.isEmpty()) {
+          continue;
+        }
+      } else if (constraint.getType() == ConstraintType.CT_CHECK) {
+        if (!allLocalColumnsVisible
+            && hasUnrequestedColumns(constraint.getColumnsList(), requestedLocalColumns)) {
+          builder.setCheckExpression("");
+        }
+      } else if (!constraint.getColumnsList().isEmpty() && localColumns.isEmpty()) {
+        continue;
+      }
+      out.add(builder.build());
+    }
+    return out;
+  }
+
+  static String relationKey(ResourceId tableId) {
+    return tableId.getAccountId() + "/" + tableId.getKindValue() + "/" + tableId.getId();
+  }
+
+  private static boolean isRelationScopedConstraint(ConstraintType type) {
+    return type == ConstraintType.CT_PRIMARY_KEY
+        || type == ConstraintType.CT_UNIQUE
+        || type == ConstraintType.CT_NOT_NULL;
+  }
+
+  private static boolean hasUnrequestedColumns(
+      List<ConstraintColumnRef> columns, Set<Long> requestedColumns) {
+    for (ConstraintColumnRef column : columns) {
+      if (column.getColumnId() > 0 && !requestedColumns.contains(column.getColumnId())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static List<ConstraintColumnRef> filterRequestedColumns(
+      List<ConstraintColumnRef> columns, Set<Long> requestedColumns) {
+    if (columns.isEmpty()) {
+      return List.of();
+    }
+    List<ConstraintColumnRef> filtered = new ArrayList<>(columns.size());
+    for (ConstraintColumnRef column : columns) {
+      if (column.getColumnId() <= 0 || requestedColumns.contains(column.getColumnId())) {
+        filtered.add(column);
+      }
+    }
+    return filtered;
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/SnapshotPinLookup.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/SnapshotPinLookup.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import java.util.OptionalLong;
+
+/** Query-scoped snapshot pin lookup used by planner bundle assembly. */
+interface SnapshotPinLookup {
+  OptionalLong pinnedSnapshotId(ResourceId tableId);
+}

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/SnapshotPinResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/SnapshotPinResolver.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.LongFunction;
 
-final class SnapshotPinResolver {
+final class SnapshotPinResolver implements SnapshotPinLookup {
 
   private final QueryContextStore queryStore;
   private final QueryContext initialCtx;
@@ -38,7 +38,8 @@ final class SnapshotPinResolver {
     this.correlationId = correlationId;
   }
 
-  OptionalLong pinnedSnapshotId(ResourceId tableId) {
+  @Override
+  public OptionalLong pinnedSnapshotId(ResourceId tableId) {
     Optional<SnapshotPin> pin = liveContext().findSnapshotPin(tableId, correlationId);
     return pin.isPresent() ? OptionalLong.of(pin.get().getSnapshotId()) : OptionalLong.empty();
   }

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
@@ -48,6 +48,10 @@ public final class StatsProviderFactory {
     return new CachedStatsProvider(repository, queryStore, ctx, correlationId);
   }
 
+  SnapshotPinLookup pinLookupForQuery(QueryContext ctx, String correlationId) {
+    return new SnapshotPinResolver(queryStore, ctx, correlationId);
+  }
+
   private static final class CachedStatsProvider implements StatsProvider {
 
     private final StatsRepository repository;

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImpl.java
@@ -20,7 +20,9 @@ import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.Messag
 
 import ai.floedb.floecat.query.rpc.ColumnStatsBundleChunk;
 import ai.floedb.floecat.query.rpc.FetchColumnStatsRequest;
+import ai.floedb.floecat.query.rpc.FetchTableConstraintsRequest;
 import ai.floedb.floecat.query.rpc.PlannerStatsService;
+import ai.floedb.floecat.query.rpc.TableConstraintsBundleChunk;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
@@ -69,20 +71,7 @@ public class PlannerStatsServiceImpl extends BaseServiceImpl implements PlannerS
 
                       String queryId =
                           mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-                      var ctxOpt = queryStore.get(queryId);
-                      if (ctxOpt.isEmpty()) {
-                        throw GrpcErrors.notFound(
-                            correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId));
-                      }
-
-                      QueryContext ctx = ctxOpt.get();
-                      if (!ctx.isActive()) {
-                        throw GrpcErrors.preconditionFailed(
-                            correlationId,
-                            QUERY_NOT_ACTIVE,
-                            Map.of("query_id", queryId, "state", ctx.getState().name()));
-                      }
-
+                      QueryContext ctx = requireActiveQuery(correlationId, queryId);
                       return bundles.stream(correlationId, ctx, request);
                     }))
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())
@@ -90,5 +79,48 @@ public class PlannerStatsServiceImpl extends BaseServiceImpl implements PlannerS
         .invoke(L::fail)
         .onCompletion()
         .invoke(L::ok);
+  }
+
+  @ActivateRequestContext
+  @Override
+  public Multi<TableConstraintsBundleChunk> getTableConstraints(
+      FetchTableConstraintsRequest request) {
+    var L = LogHelper.start(LOG, "GetTableConstraints");
+    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
+
+    return Multi.createFrom()
+        .<TableConstraintsBundleChunk>deferred(
+            () ->
+                grpcCtx.call(
+                    () -> {
+                      var principalContext = principal.get();
+                      var correlationId = principalContext.getCorrelationId();
+                      authz.require(principalContext, "catalog.read");
+
+                      String queryId =
+                          mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+                      QueryContext ctx = requireActiveQuery(correlationId, queryId);
+                      return bundles.streamConstraints(correlationId, ctx, request);
+                    }))
+        .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+        .onFailure()
+        .invoke(L::fail)
+        .onCompletion()
+        .invoke(L::ok);
+  }
+
+  private QueryContext requireActiveQuery(String correlationId, String queryId) {
+    var ctxOpt = queryStore.get(queryId);
+    if (ctxOpt.isEmpty()) {
+      throw GrpcErrors.notFound(correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId));
+    }
+    QueryContext ctx = ctxOpt.get();
+    if (!ctx.isActive()) {
+      throw GrpcErrors.preconditionFailed(
+          correlationId,
+          QUERY_NOT_ACTIVE,
+          Map.of("query_id", queryId, "state", ctx.getState().name()));
+    }
+    return ctx;
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceCombinedConstraintsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceCombinedConstraintsTest.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.query.rpc.BundleResultStatus;
+import ai.floedb.floecat.query.rpc.ColumnStatsBundleChunk;
+import ai.floedb.floecat.query.rpc.FetchColumnStatsRequest;
+import ai.floedb.floecat.query.rpc.TableConstraintsResult;
+import ai.floedb.floecat.scanner.spi.ConstraintProvider;
+import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
+import ai.floedb.floecat.service.query.impl.QueryContext;
+import ai.floedb.floecat.service.repo.impl.StatsRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+
+class PlannerStatsBundleServiceCombinedConstraintsTest
+    extends PlannerStatsBundleServiceTestSupport {
+
+  @Test
+  void includeConstraintsEmitsFoundOncePerTable() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx =
+        queryContextWithPins(
+            "query-constraints-found", List.of(pin(TABLE, 500L), pin(TABLE_TWO, 501L)));
+    store.seed(ctx);
+    repository.putColumnStats(TABLE, 500L, sampleStats(TABLE, 500L, 1L));
+    repository.putColumnStats(TABLE_TWO, 501L, sampleStats(TABLE_TWO, 501L, 2L));
+
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (snapshotId.isEmpty()) {
+              return Optional.empty();
+            }
+            long sid = snapshotId.getAsLong();
+            if (relationId.equals(TABLE) && sid == 500L) {
+              return Optional.of(
+                  newConstraintSet(
+                      TABLE,
+                      List.of(constraint("pk_users", ConstraintType.CT_PRIMARY_KEY, List.of(1L)))));
+            }
+            if (relationId.equals(TABLE_TWO) && sid == 501L) {
+              return Optional.of(
+                  newConstraintSet(
+                      TABLE_TWO,
+                      List.of(
+                          constraint("pk_orders", ConstraintType.CT_PRIMARY_KEY, List.of(2L)))));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 10,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 20);
+
+    FetchColumnStatsRequest request =
+        FetchColumnStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .setIncludeConstraints(true)
+            .addTables(tableRequest(TABLE, List.of(1L)))
+            .addTables(tableRequest(TABLE_TWO, List.of(2L)))
+            .build();
+    List<ColumnStatsBundleChunk> chunks =
+        service.stream("corr", ctx, request).collect().asList().await().indefinitely();
+
+    List<TableConstraintsResult> constraints = flattenConstraints(chunks);
+    assertEquals(2, constraints.size());
+    assertEquals(
+        2,
+        constraints.stream()
+            .filter(c -> c.getStatus() == BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND)
+            .count());
+    assertEquals(
+        1,
+        constraints.stream().filter(c -> c.getTableId().equals(TABLE)).count(),
+        "constraints should be emitted once per table");
+    assertEquals(
+        1,
+        constraints.stream().filter(c -> c.getTableId().equals(TABLE_TWO)).count(),
+        "constraints should be emitted once per table");
+  }
+
+  @Test
+  void includeConstraintsChunkedSingleTableEmitsConstraintsOnlyOnceAcrossBatches() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx = queryContextWithPin("query-constraints-chunked-once", 555L);
+    store.seed(ctx);
+    for (long columnId = 1; columnId <= 5; columnId++) {
+      repository.putColumnStats(TABLE, 555L, sampleStats(TABLE, 555L, columnId));
+    }
+
+    ConstraintDefinition pk =
+        constraint("pk_users_chunked", ConstraintType.CT_PRIMARY_KEY, List.of(1L));
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (relationId.equals(TABLE)
+                && snapshotId.isPresent()
+                && snapshotId.getAsLong() == 555L) {
+              return Optional.of(newConstraintSet(TABLE, List.of(pk)));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 2,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 20);
+
+    FetchColumnStatsRequest request =
+        FetchColumnStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .setIncludeConstraints(true)
+            .addTables(tableRequest(TABLE, List.of(1L, 2L, 3L, 4L, 5L)))
+            .build();
+    List<ColumnStatsBundleChunk> chunks =
+        service.stream("corr", ctx, request).collect().asList().await().indefinitely();
+
+    List<ColumnStatsBundleChunk> batches = new ArrayList<>();
+    for (ColumnStatsBundleChunk chunk : chunks) {
+      if (chunk.hasBatch()) {
+        batches.add(chunk);
+      }
+    }
+    assertEquals(3, batches.size(), "chunk size should force multiple batches");
+    assertEquals(1, batches.stream().filter(c -> c.getBatch().getConstraintsCount() == 1).count());
+    assertEquals(2, batches.stream().filter(c -> c.getBatch().getConstraintsCount() == 0).count());
+
+    List<TableConstraintsResult> constraints = flattenConstraints(chunks);
+    assertEquals(1, constraints.size());
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND, constraints.get(0).getStatus());
+    assertEquals("pk_users_chunked", constraints.get(0).getConstraints(0).getName());
+  }
+
+  @Test
+  void includeConstraintsPassesThroughWhenNoPruningNeeded() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx = queryContextWithPin("query-constraints-pass-through", 560L);
+    store.seed(ctx);
+    repository.putColumnStats(TABLE, 560L, sampleStats(TABLE, 560L, 1L));
+    repository.putColumnStats(TABLE, 560L, sampleStats(TABLE, 560L, 2L));
+
+    ConstraintDefinition expectedPk =
+        constraint("pk_users_passthrough", ConstraintType.CT_PRIMARY_KEY, List.of(1L));
+    ConstraintDefinition expectedUnique =
+        constraint("uq_users_passthrough", ConstraintType.CT_UNIQUE, List.of(2L));
+    List<ConstraintDefinition> expected = List.of(expectedPk, expectedUnique);
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (relationId.equals(TABLE)
+                && snapshotId.isPresent()
+                && snapshotId.getAsLong() == 560L) {
+              return Optional.of(newConstraintSet(TABLE, expected));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 5,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 10);
+
+    FetchColumnStatsRequest request =
+        FetchColumnStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .setIncludeConstraints(true)
+            .addTables(tableRequest(TABLE, List.of(1L, 2L)))
+            .build();
+    List<ColumnStatsBundleChunk> chunks =
+        service.stream("corr", ctx, request).collect().asList().await().indefinitely();
+
+    TableConstraintsResult result = flattenConstraints(chunks).get(0);
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND, result.getStatus());
+    assertEquals(expected.size(), result.getConstraintsCount());
+    for (int i = 0; i < expected.size(); i++) {
+      assertEquals(
+          expected.get(i).toByteString(),
+          result.getConstraints(i).toByteString(),
+          "constraint should pass through without pruning changes");
+    }
+  }
+
+  @Test
+  void includeConstraintsMissingPinYieldsErrorResult() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            ConstraintProvider.NONE,
+            /* chunkSize= */ 5,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 10);
+    QueryContext ctx = queryContextWithoutPin("query-constraints-no-pin");
+    store.seed(ctx);
+
+    FetchColumnStatsRequest request =
+        FetchColumnStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .setIncludeConstraints(true)
+            .addTables(tableRequest(TABLE, List.of(1L)))
+            .build();
+    List<ColumnStatsBundleChunk> chunks =
+        service.stream("corr", ctx, request).collect().asList().await().indefinitely();
+
+    TableConstraintsResult result = flattenConstraints(chunks).get(0);
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_ERROR, result.getStatus());
+    assertEquals("planner_stats.pin.missing", result.getFailure().getCode());
+  }
+
+  @Test
+  void includeConstraintsMissingSnapshotBundleYieldsNotFound() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx = queryContextWithPin("query-constraints-not-found", 600L);
+    store.seed(ctx);
+    repository.putColumnStats(TABLE, 600L, sampleStats(TABLE, 600L, 1L));
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            ConstraintProvider.NONE,
+            /* chunkSize= */ 5,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 10);
+
+    FetchColumnStatsRequest request =
+        FetchColumnStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .setIncludeConstraints(true)
+            .addTables(tableRequest(TABLE, List.of(1L)))
+            .build();
+    List<ColumnStatsBundleChunk> chunks =
+        service.stream("corr", ctx, request).collect().asList().await().indefinitely();
+
+    TableConstraintsResult result = flattenConstraints(chunks).get(0);
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_NOT_FOUND, result.getStatus());
+    assertEquals("planner_stats.constraints.missing", result.getFailure().getCode());
+    assertEquals("provider_missing", result.getFailure().getDetailsOrDefault("reason", ""));
+  }
+
+  @Test
+  void includeConstraintsPrunesForeignKeysAndCheckExpressions() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx = queryContextWithPin("query-constraints-prune", 700L);
+    store.seed(ctx);
+    repository.putColumnStats(TABLE, 700L, sampleStats(TABLE, 700L, 1L));
+
+    ConstraintDefinition hiddenCheck =
+        ConstraintDefinition.newBuilder()
+            .setName("check_hidden")
+            .setType(ConstraintType.CT_CHECK)
+            .setCheckExpression("secret_col > 0")
+            .addColumns(columnRef(99L, "secret_col", 1))
+            .build();
+    ConstraintDefinition hiddenFk =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_hidden_table")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .addColumns(columnRef(1L, "id", 1))
+            .setReferencedTableId(TABLE_TWO)
+            .addReferencedColumns(columnRef(2L, "order_id", 1))
+            .build();
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            return Optional.of(newConstraintSet(TABLE, List.of(hiddenCheck, hiddenFk)));
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 5,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 10);
+
+    FetchColumnStatsRequest request =
+        FetchColumnStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .setIncludeConstraints(true)
+            .addTables(tableRequest(TABLE, List.of(1L)))
+            .build();
+    List<ColumnStatsBundleChunk> chunks =
+        service.stream("corr", ctx, request).collect().asList().await().indefinitely();
+
+    TableConstraintsResult result = flattenConstraints(chunks).get(0);
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND, result.getStatus());
+    assertEquals(1, result.getConstraintsCount());
+    ConstraintDefinition check = result.getConstraints(0);
+    assertEquals("check_hidden", check.getName());
+    assertEquals("", check.getCheckExpression(), "check expression should be masked");
+  }
+
+  @Test
+  void includeConstraintsKeepsPkUniqueNotNullEvenWhenColumnsNotProjected() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx = queryContextWithPin("query-constraints-keep-relation-scoped", 705L);
+    store.seed(ctx);
+    repository.putColumnStats(TABLE, 705L, sampleStats(TABLE, 705L, 1L));
+
+    ConstraintDefinition pkHiddenProjection =
+        constraint("pk_not_projected", ConstraintType.CT_PRIMARY_KEY, List.of(2L));
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (relationId.equals(TABLE)
+                && snapshotId.isPresent()
+                && snapshotId.getAsLong() == 705L) {
+              return Optional.of(newConstraintSet(TABLE, List.of(pkHiddenProjection)));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 5,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 10);
+
+    FetchColumnStatsRequest request =
+        FetchColumnStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .setIncludeConstraints(true)
+            .addTables(tableRequest(TABLE, List.of(1L)))
+            .build();
+    List<ColumnStatsBundleChunk> chunks =
+        service.stream("corr", ctx, request).collect().asList().await().indefinitely();
+
+    TableConstraintsResult result = flattenConstraints(chunks).get(0);
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND, result.getStatus());
+    assertEquals(1, result.getConstraintsCount());
+    assertEquals("pk_not_projected", result.getConstraints(0).getName());
+    assertEquals(1, result.getConstraints(0).getColumnsCount());
+    assertEquals(2L, result.getConstraints(0).getColumns(0).getColumnId());
+  }
+
+  @Test
+  void includeConstraintsPrunedEmptyYieldsNotFoundWithReason() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx =
+        queryContextWithPins(
+            "query-constraints-pruned-empty", List.of(pin(TABLE, 710L), pin(TABLE_TWO, 711L)));
+    store.seed(ctx);
+    repository.putColumnStats(TABLE, 710L, sampleStats(TABLE, 710L, 1L));
+
+    ConstraintDefinition hiddenFk =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_hidden_only")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .addColumns(columnRef(1L, "id", 1))
+            .setReferencedTableId(TABLE_TWO)
+            .addReferencedColumns(columnRef(2L, "order_id", 1))
+            .build();
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (relationId.equals(TABLE)
+                && snapshotId.isPresent()
+                && snapshotId.getAsLong() == 710L) {
+              return Optional.of(newConstraintSet(TABLE, List.of(hiddenFk)));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 5,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 10);
+
+    FetchColumnStatsRequest request =
+        FetchColumnStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .setIncludeConstraints(true)
+            .addTables(tableRequest(TABLE, List.of(1L)))
+            .build();
+    List<ColumnStatsBundleChunk> chunks =
+        service.stream("corr", ctx, request).collect().asList().await().indefinitely();
+
+    TableConstraintsResult result = flattenConstraints(chunks).get(0);
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_NOT_FOUND, result.getStatus());
+    assertEquals("planner_stats.constraints.missing", result.getFailure().getCode());
+    assertEquals("pruned_empty", result.getFailure().getDetailsOrDefault("reason", ""));
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceSplitConstraintsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceSplitConstraintsTest.java
@@ -1,0 +1,496 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.query.rpc.BundleResultStatus;
+import ai.floedb.floecat.query.rpc.FetchTableConstraintsRequest;
+import ai.floedb.floecat.query.rpc.TableConstraintsBundleChunk;
+import ai.floedb.floecat.query.rpc.TableConstraintsBundleEnd;
+import ai.floedb.floecat.query.rpc.TableConstraintsResult;
+import ai.floedb.floecat.scanner.spi.ConstraintProvider;
+import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
+import ai.floedb.floecat.service.query.impl.QueryContext;
+import ai.floedb.floecat.service.repo.impl.StatsRepository;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+
+class PlannerStatsBundleServiceSplitConstraintsTest extends PlannerStatsBundleServiceTestSupport {
+
+  @Test
+  void streamConstraintsRejectsEmptyTableIds() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createService(
+            repository, store, /* chunkSize= */ 5, /* maxTables= */ 10, /* maxColumns= */ 10);
+    QueryContext ctx = queryContextWithPin("query-constraints-empty-ids", 495L);
+    store.seed(ctx);
+
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder().setQueryId(ctx.getQueryId()).build();
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .streamConstraints("corr", ctx, request)
+                    .collect()
+                    .asList()
+                    .await()
+                    .indefinitely());
+    assertEquals(Status.INVALID_ARGUMENT.getCode(), failure.getStatus().getCode());
+  }
+
+  @Test
+  void streamConstraintsRejectsTooManyTableIds() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createService(
+            repository, store, /* chunkSize= */ 5, /* maxTables= */ 1, /* maxColumns= */ 10);
+    QueryContext ctx = queryContextWithPin("query-constraints-too-many-ids", 496L);
+    store.seed(ctx);
+
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .addTableIds(TABLE_TWO)
+            .build();
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .streamConstraints("corr", ctx, request)
+                    .collect()
+                    .asList()
+                    .await()
+                    .indefinitely());
+    assertEquals(Status.INVALID_ARGUMENT.getCode(), failure.getStatus().getCode());
+  }
+
+  @Test
+  void streamConstraintsRejectsBlankTableId() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createService(
+            repository, store, /* chunkSize= */ 5, /* maxTables= */ 10, /* maxColumns= */ 10);
+    QueryContext ctx = queryContextWithPin("query-constraints-blank-id", 497L);
+    store.seed(ctx);
+
+    ResourceId blankId =
+        ResourceId.newBuilder()
+            .setAccountId(TABLE.getAccountId())
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("   ")
+            .build();
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(blankId)
+            .build();
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .streamConstraints("corr", ctx, request)
+                    .collect()
+                    .asList()
+                    .await()
+                    .indefinitely());
+    assertEquals(Status.INVALID_ARGUMENT.getCode(), failure.getStatus().getCode());
+  }
+
+  @Test
+  void streamConstraintsReturnsPerTableResults() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx =
+        queryContextWithPins(
+            "query-constraints-only", List.of(pin(TABLE, 800L), pin(TABLE_TWO, 801L)));
+    store.seed(ctx);
+
+    ConstraintDefinition pkUsers =
+        constraint("pk_users_only", ConstraintType.CT_PRIMARY_KEY, List.of(1L));
+    ConstraintDefinition pkOrders =
+        constraint("pk_orders_only", ConstraintType.CT_PRIMARY_KEY, List.of(2L));
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (snapshotId.isEmpty()) {
+              return Optional.empty();
+            }
+            if (relationId.equals(TABLE) && snapshotId.getAsLong() == 800L) {
+              return Optional.of(newConstraintSet(TABLE, List.of(pkUsers)));
+            }
+            if (relationId.equals(TABLE_TWO) && snapshotId.getAsLong() == 801L) {
+              return Optional.of(newConstraintSet(TABLE_TWO, List.of(pkOrders)));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 10,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 20);
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .addTableIds(TABLE_TWO)
+            .build();
+
+    List<TableConstraintsBundleChunk> chunks =
+        service.streamConstraints("corr", ctx, request).collect().asList().await().indefinitely();
+    List<TableConstraintsResult> results = flattenConstraintChunks(chunks);
+    assertEquals(2, results.size());
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND, results.get(0).getStatus());
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND, results.get(1).getStatus());
+
+    TableConstraintsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
+    assertEquals(2L, end.getRequestedTables());
+    assertEquals(2L, end.getReturnedTables());
+    assertEquals(0L, end.getNotFoundTables());
+    assertEquals(0L, end.getErrorTables());
+  }
+
+  @Test
+  void streamConstraintsDedupesDuplicateRequestedTableIds() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx = queryContextWithPin("query-constraints-only-dedupe", 830L);
+    store.seed(ctx);
+
+    ConstraintDefinition pkUsers =
+        constraint("pk_users_dedupe", ConstraintType.CT_PRIMARY_KEY, List.of(1L));
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (relationId.equals(TABLE)
+                && snapshotId.isPresent()
+                && snapshotId.getAsLong() == 830L) {
+              return Optional.of(newConstraintSet(TABLE, List.of(pkUsers)));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 10,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 20);
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .addTableIds(TABLE)
+            .build();
+
+    List<TableConstraintsBundleChunk> chunks =
+        service.streamConstraints("corr", ctx, request).collect().asList().await().indefinitely();
+    List<TableConstraintsResult> results = flattenConstraintChunks(chunks);
+    assertEquals(1, results.size(), "duplicate table_ids should be emitted once");
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND, results.get(0).getStatus());
+    assertEquals("pk_users_dedupe", results.get(0).getConstraints(0).getName());
+
+    TableConstraintsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
+    assertEquals(1L, end.getRequestedTables(), "deduped request count should be reflected in end");
+    assertEquals(1L, end.getReturnedTables());
+    assertEquals(0L, end.getNotFoundTables());
+    assertEquals(0L, end.getErrorTables());
+  }
+
+  @Test
+  void streamConstraintsChunkingRespectsMaxResultsPerChunk() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx =
+        queryContextWithPins(
+            "query-constraints-only-chunking", List.of(pin(TABLE, 840L), pin(TABLE_TWO, 841L)));
+    store.seed(ctx);
+
+    ConstraintDefinition pkUsers =
+        constraint("pk_users_chunk", ConstraintType.CT_PRIMARY_KEY, List.of(1L));
+    ConstraintDefinition pkOrders =
+        constraint("pk_orders_chunk", ConstraintType.CT_PRIMARY_KEY, List.of(2L));
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (snapshotId.isEmpty()) {
+              return Optional.empty();
+            }
+            if (relationId.equals(TABLE) && snapshotId.getAsLong() == 840L) {
+              return Optional.of(newConstraintSet(TABLE, List.of(pkUsers)));
+            }
+            if (relationId.equals(TABLE_TWO) && snapshotId.getAsLong() == 841L) {
+              return Optional.of(newConstraintSet(TABLE_TWO, List.of(pkOrders)));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 1,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 20);
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .addTableIds(TABLE_TWO)
+            .build();
+
+    List<TableConstraintsBundleChunk> chunks =
+        service.streamConstraints("corr", ctx, request).collect().asList().await().indefinitely();
+    List<TableConstraintsBundleChunk> batches = new ArrayList<>();
+    for (TableConstraintsBundleChunk chunk : chunks) {
+      if (chunk.hasBatch()) {
+        batches.add(chunk);
+      }
+    }
+    assertEquals(2, batches.size(), "chunkSize=1 should emit one table result per batch");
+    assertEquals(1, batches.get(0).getBatch().getConstraintsCount());
+    assertEquals(1, batches.get(1).getBatch().getConstraintsCount());
+
+    TableConstraintsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
+    assertEquals(2L, end.getRequestedTables());
+    assertEquals(2L, end.getReturnedTables());
+    assertEquals(0L, end.getNotFoundTables());
+    assertEquals(0L, end.getErrorTables());
+  }
+
+  @Test
+  void streamConstraintsKeepsPkUniqueNotNullWithoutColumnProjection() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx = queryContextWithPin("query-constraints-only-keep-relation-scoped", 850L);
+    store.seed(ctx);
+
+    ConstraintDefinition pkHiddenProjection =
+        constraint("pk_split_not_projected", ConstraintType.CT_PRIMARY_KEY, List.of(99L));
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (relationId.equals(TABLE)
+                && snapshotId.isPresent()
+                && snapshotId.getAsLong() == 850L) {
+              return Optional.of(newConstraintSet(TABLE, List.of(pkHiddenProjection)));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 10,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 20);
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .build();
+
+    List<TableConstraintsBundleChunk> chunks =
+        service.streamConstraints("corr", ctx, request).collect().asList().await().indefinitely();
+    List<TableConstraintsResult> results = flattenConstraintChunks(chunks);
+    assertEquals(1, results.size());
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND, results.get(0).getStatus());
+    assertEquals(1, results.get(0).getConstraintsCount());
+    assertEquals("pk_split_not_projected", results.get(0).getConstraints(0).getName());
+    assertEquals(1, results.get(0).getConstraints(0).getColumnsCount());
+    assertEquals(99L, results.get(0).getConstraints(0).getColumns(0).getColumnId());
+  }
+
+  @Test
+  void streamConstraintsProviderEmptyYieldsNotFoundWithReason() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx = queryContextWithPin("query-constraints-only-provider-empty", 860L);
+    store.seed(ctx);
+
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (relationId.equals(TABLE)
+                && snapshotId.isPresent()
+                && snapshotId.getAsLong() == 860L) {
+              return Optional.of(newConstraintSet(TABLE, List.of()));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 10,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 20);
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .build();
+
+    List<TableConstraintsBundleChunk> chunks =
+        service.streamConstraints("corr", ctx, request).collect().asList().await().indefinitely();
+    List<TableConstraintsResult> results = flattenConstraintChunks(chunks);
+    assertEquals(1, results.size());
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_NOT_FOUND, results.get(0).getStatus());
+    assertEquals("planner_stats.constraints.missing", results.get(0).getFailure().getCode());
+    assertEquals("provider_empty", results.get(0).getFailure().getDetailsOrDefault("reason", ""));
+  }
+
+  @Test
+  void streamConstraintsPrunesForeignKeysOutsideRequestedTables() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx =
+        queryContextWithPins(
+            "query-constraints-only-prune", List.of(pin(TABLE, 820L), pin(TABLE_TWO, 821L)));
+    store.seed(ctx);
+
+    ConstraintDefinition hiddenFk =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_hidden_in_split")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .addColumns(columnRef(1L, "id", 1))
+            .setReferencedTableId(TABLE_TWO)
+            .addReferencedColumns(columnRef(2L, "order_id", 1))
+            .build();
+    ConstraintProvider provider =
+        new ConstraintProvider() {
+          @Override
+          public Optional<ConstraintSetView> constraints(
+              ResourceId relationId, OptionalLong snapshotId) {
+            if (relationId.equals(TABLE)
+                && snapshotId.isPresent()
+                && snapshotId.getAsLong() == 820L) {
+              return Optional.of(newConstraintSet(TABLE, List.of(hiddenFk)));
+            }
+            return Optional.empty();
+          }
+        };
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            provider,
+            /* chunkSize= */ 10,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 20);
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .build();
+
+    List<TableConstraintsBundleChunk> chunks =
+        service.streamConstraints("corr", ctx, request).collect().asList().await().indefinitely();
+    List<TableConstraintsResult> results = flattenConstraintChunks(chunks);
+    assertEquals(1, results.size());
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_NOT_FOUND, results.get(0).getStatus());
+    assertEquals("pruned_empty", results.get(0).getFailure().getDetailsOrDefault("reason", ""));
+  }
+
+  @Test
+  void streamConstraintsMissingPinYieldsError() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    QueryContext ctx = queryContextWithoutPin("query-constraints-only-no-pin");
+    store.seed(ctx);
+
+    PlannerStatsBundleService service =
+        createService(
+            repository,
+            store,
+            ConstraintProvider.NONE,
+            /* chunkSize= */ 10,
+            /* maxTables= */ 10,
+            /* maxColumns= */ 20);
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .build();
+
+    List<TableConstraintsBundleChunk> chunks =
+        service.streamConstraints("corr", ctx, request).collect().asList().await().indefinitely();
+    List<TableConstraintsResult> results = flattenConstraintChunks(chunks);
+    assertEquals(1, results.size());
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_ERROR, results.get(0).getStatus());
+    assertEquals("planner_stats.pin.missing", results.get(0).getFailure().getCode());
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
@@ -23,9 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.catalog.rpc.ColumnStats;
 import ai.floedb.floecat.catalog.rpc.Ndv;
-import ai.floedb.floecat.common.rpc.PrincipalContext;
-import ai.floedb.floecat.common.rpc.ResourceId;
-import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.query.rpc.BundleResultStatus;
 import ai.floedb.floecat.query.rpc.ColumnStatsBatch;
 import ai.floedb.floecat.query.rpc.ColumnStatsBundleChunk;
@@ -33,37 +30,17 @@ import ai.floedb.floecat.query.rpc.ColumnStatsBundleEnd;
 import ai.floedb.floecat.query.rpc.ColumnStatsInfo;
 import ai.floedb.floecat.query.rpc.ColumnStatsResult;
 import ai.floedb.floecat.query.rpc.FetchColumnStatsRequest;
-import ai.floedb.floecat.query.rpc.SnapshotPin;
-import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.StatsWarning;
-import ai.floedb.floecat.query.rpc.TableColumnStatsRequest;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
 import ai.floedb.floecat.service.query.impl.QueryContext;
 import ai.floedb.floecat.service.repo.impl.StatsRepository;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
-import ai.floedb.floecat.storage.spi.BlobStore;
-import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
-class PlannerStatsBundleServiceTest {
-
-  private static final ResourceId CATALOG =
-      ResourceId.newBuilder()
-          .setAccountId("acct")
-          .setId("catalog")
-          .setKind(ResourceKind.RK_CATALOG)
-          .build();
-
-  private static final ResourceId TABLE =
-      ResourceId.newBuilder()
-          .setAccountId("acct")
-          .setId("users")
-          .setKind(ResourceKind.RK_TABLE)
-          .build();
+class PlannerStatsBundleServiceTest extends PlannerStatsBundleServiceTestSupport {
 
   @Test
   void emitsHeaderThenEnd() {
@@ -146,9 +123,7 @@ class PlannerStatsBundleServiceTest {
 
     List<ColumnStatsResult> results = flatten(chunks);
     assertEquals(1, results.size());
-    assertEquals(
-        results.get(0).getStatus(),
-        ai.floedb.floecat.query.rpc.BundleResultStatus.BUNDLE_RESULT_STATUS_ERROR);
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_ERROR, results.get(0).getStatus());
     assertEquals("planner_stats.pin.missing", results.get(0).getFailure().getCode());
 
     ColumnStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
@@ -178,18 +153,11 @@ class PlannerStatsBundleServiceTest {
     assertEquals(
         1,
         results.stream()
-            .filter(
-                r ->
-                    r.getStatus()
-                        .equals(
-                            ai.floedb.floecat.query.rpc.BundleResultStatus
-                                .BUNDLE_RESULT_STATUS_FOUND))
+            .filter(r -> r.getStatus().equals(BundleResultStatus.BUNDLE_RESULT_STATUS_FOUND))
             .count());
     ColumnStatsResult missing =
         results.stream().filter(r -> r.getColumnId() == 2).findFirst().orElseThrow();
-    assertEquals(
-        ai.floedb.floecat.query.rpc.BundleResultStatus.BUNDLE_RESULT_STATUS_NOT_FOUND,
-        missing.getStatus());
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_NOT_FOUND, missing.getStatus());
     assertEquals("planner_stats.column_stats.missing", missing.getFailure().getCode());
 
     ColumnStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
@@ -361,11 +329,10 @@ class PlannerStatsBundleServiceTest {
     PlannerStatsBundleService service =
         createService(
             repository, store, /* chunkSize= */ 5, /* maxTables= */ 10, /* maxColumns= */ 10);
-    ResourceId table = TABLE;
     long snapshotId = 400L;
     ColumnStats stats =
         ColumnStats.newBuilder()
-            .setTableId(table)
+            .setTableId(TABLE)
             .setSnapshotId(snapshotId)
             .setColumnId(42L)
             .setColumnName("optionable")
@@ -376,10 +343,10 @@ class PlannerStatsBundleServiceTest {
             .setMax("bar")
             .setNdv(Ndv.newBuilder().setExact(13L).build())
             .build();
-    repository.putColumnStats(table, snapshotId, stats);
+    repository.putColumnStats(TABLE, snapshotId, stats);
     QueryContext ctx = queryContextWithPin("query-optionals", snapshotId);
     store.seed(ctx);
-    FetchColumnStatsRequest request = requestFor(ctx.getQueryId(), table, List.of(42L));
+    FetchColumnStatsRequest request = requestFor(ctx.getQueryId(), TABLE, List.of(42L));
     List<ColumnStatsBundleChunk> chunks =
         service.stream("corr", ctx, request).collect().asList().await().indefinitely();
     ColumnStatsInfo info = flatten(chunks).get(0).getStats();
@@ -404,20 +371,19 @@ class PlannerStatsBundleServiceTest {
     PlannerStatsBundleService service =
         createService(
             repository, store, /* chunkSize= */ 5, /* maxTables= */ 10, /* maxColumns= */ 10);
-    ResourceId table = TABLE;
     long snapshotId = 410L;
     ColumnStats stats =
         ColumnStats.newBuilder()
-            .setTableId(table)
+            .setTableId(TABLE)
             .setSnapshotId(snapshotId)
             .setColumnId(43L)
             .setColumnName("bare")
             .setValueCount(12L)
             .build();
-    repository.putColumnStats(table, snapshotId, stats);
+    repository.putColumnStats(TABLE, snapshotId, stats);
     QueryContext ctx = queryContextWithPin("query-absent", snapshotId);
     store.seed(ctx);
-    FetchColumnStatsRequest request = requestFor(ctx.getQueryId(), table, List.of(43L));
+    FetchColumnStatsRequest request = requestFor(ctx.getQueryId(), TABLE, List.of(43L));
     List<ColumnStatsBundleChunk> chunks =
         service.stream("corr", ctx, request).collect().asList().await().indefinitely();
     ColumnStatsInfo info = flatten(chunks).get(0).getStats();
@@ -459,153 +425,5 @@ class PlannerStatsBundleServiceTest {
         io.grpc.StatusRuntimeException.class,
         () ->
             service.stream("corr", ctx, tooManyColumns).collect().asList().await().indefinitely());
-  }
-
-  private static PlannerStatsBundleService createService(
-      StatsRepository repository,
-      UserObjectBundleTestSupport.TestQueryContextStore store,
-      int chunkSize,
-      int maxTables,
-      int maxColumns) {
-    StatsProviderFactory factory = new StatsProviderFactory(repository, store);
-    return PlannerStatsBundleService.forTesting(
-        factory, repository, maxTables, maxColumns, chunkSize);
-  }
-
-  private static StatsRepository createRepository() {
-    return new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
-  }
-
-  private static ColumnStats sampleStats(ResourceId tableId, long snapshotId, long columnId) {
-    return ColumnStats.newBuilder()
-        .setTableId(tableId)
-        .setSnapshotId(snapshotId)
-        .setColumnId(columnId)
-        .setColumnName("col" + columnId)
-        .setValueCount(columnId * 10)
-        .setNullCount(columnId)
-        .build();
-  }
-
-  private static FetchColumnStatsRequest requestFor(
-      String queryId, ResourceId tableId, List<Long> columnIds) {
-    return FetchColumnStatsRequest.newBuilder()
-        .setQueryId(queryId)
-        .addTables(tableRequest(tableId, columnIds))
-        .build();
-  }
-
-  private static TableColumnStatsRequest tableRequest(ResourceId tableId, List<Long> columnIds) {
-    return TableColumnStatsRequest.newBuilder()
-        .setTableId(tableId)
-        .addAllColumnIds(columnIds)
-        .build();
-  }
-
-  private static QueryContext queryContextWithPin(String queryId, long snapshotId) {
-    SnapshotPin pin = SnapshotPin.newBuilder().setTableId(TABLE).setSnapshotId(snapshotId).build();
-    SnapshotSet set = SnapshotSet.newBuilder().addPins(pin).build();
-    PrincipalContext principal =
-        PrincipalContext.newBuilder()
-            .setAccountId(TABLE.getAccountId())
-            .setSubject("tester")
-            .build();
-    return QueryContext.builder()
-        .queryId(queryId)
-        .principal(principal)
-        .snapshotSet(set.toByteArray())
-        .createdAtMs(1)
-        .expiresAtMs(1_000)
-        .state(QueryContext.State.ACTIVE)
-        .version(1)
-        .queryDefaultCatalogId(CATALOG)
-        .build();
-  }
-
-  private static QueryContext queryContextWithoutPin(String queryId) {
-    PrincipalContext principal =
-        PrincipalContext.newBuilder()
-            .setAccountId(TABLE.getAccountId())
-            .setSubject("tester")
-            .build();
-    return QueryContext.builder()
-        .queryId(queryId)
-        .principal(principal)
-        .createdAtMs(1)
-        .expiresAtMs(1_000)
-        .state(QueryContext.State.ACTIVE)
-        .version(1)
-        .queryDefaultCatalogId(CATALOG)
-        .build();
-  }
-
-  private static List<ColumnStatsResult> flatten(List<ColumnStatsBundleChunk> chunks) {
-    List<ColumnStatsResult> results = new ArrayList<>();
-    for (ColumnStatsBundleChunk chunk : chunks) {
-      if (chunk.hasBatch()) {
-        results.addAll(chunk.getBatch().getColumnsList());
-      }
-    }
-    return results;
-  }
-
-  private static final class SmartScanOnlyStatsRepository extends StatsRepository {
-    private SmartScanOnlyStatsRepository(PointerStore pointerStore, BlobStore blobStore) {
-      super(
-          pointerStore,
-          blobStore,
-          /* smartThreshold= */ 2,
-          /* scanColumnsPerPage= */ 5,
-          /* maxScanPages= */ 5);
-    }
-
-    @Override
-    public List<ColumnStats> getColumnStatsBatch(
-        ResourceId tableId, long snapshotId, List<Long> columnIds) {
-      throw new AssertionError("smart scan path should not require per-column batches");
-    }
-  }
-
-  private static final class CappingStatsRepository extends StatsRepository {
-    private final AtomicInteger batchCalls = new AtomicInteger();
-
-    private CappingStatsRepository(PointerStore pointerStore, BlobStore blobStore) {
-      super(
-          pointerStore,
-          blobStore,
-          /* smartThreshold= */ 2,
-          /* scanColumnsPerPage= */ 1,
-          /* maxScanPages= */ 1);
-    }
-
-    @Override
-    public List<ColumnStats> getColumnStatsBatch(
-        ResourceId tableId, long snapshotId, List<Long> columnIds) {
-      batchCalls.incrementAndGet();
-      return super.getColumnStatsBatch(tableId, snapshotId, columnIds);
-    }
-
-    int batchCallCount() {
-      return batchCalls.get();
-    }
-  }
-
-  private static final class ThrowingStatsRepository extends StatsRepository {
-    private ThrowingStatsRepository(
-        InMemoryPointerStore pointerStore, InMemoryBlobStore blobStore) {
-      super(pointerStore, blobStore);
-    }
-
-    @Override
-    public List<ColumnStats> getColumnStatsBatch(
-        ResourceId tableId, long snapshotId, List<Long> columnIds) {
-      throw new RuntimeException("boom");
-    }
-
-    @Override
-    public ColumnStatsBatchResult getColumnStatsBatchSmart(
-        ResourceId tableId, long snapshotId, List<Long> columnIds) {
-      throw new RuntimeException("boom");
-    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTestSupport.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import ai.floedb.floecat.catalog.rpc.ColumnStats;
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.query.rpc.ColumnStatsBundleChunk;
+import ai.floedb.floecat.query.rpc.ColumnStatsResult;
+import ai.floedb.floecat.query.rpc.FetchColumnStatsRequest;
+import ai.floedb.floecat.query.rpc.SnapshotPin;
+import ai.floedb.floecat.query.rpc.SnapshotSet;
+import ai.floedb.floecat.query.rpc.TableColumnStatsRequest;
+import ai.floedb.floecat.query.rpc.TableConstraintsBundleChunk;
+import ai.floedb.floecat.query.rpc.TableConstraintsResult;
+import ai.floedb.floecat.scanner.spi.ConstraintProvider;
+import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
+import ai.floedb.floecat.service.query.impl.QueryContext;
+import ai.floedb.floecat.service.repo.impl.StatsRepository;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.BlobStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+abstract class PlannerStatsBundleServiceTestSupport {
+
+  protected static final ResourceId CATALOG =
+      ResourceId.newBuilder()
+          .setAccountId("acct")
+          .setId("catalog")
+          .setKind(ResourceKind.RK_CATALOG)
+          .build();
+
+  protected static final ResourceId TABLE =
+      ResourceId.newBuilder()
+          .setAccountId("acct")
+          .setId("users")
+          .setKind(ResourceKind.RK_TABLE)
+          .build();
+
+  protected static final ResourceId TABLE_TWO =
+      ResourceId.newBuilder()
+          .setAccountId("acct")
+          .setId("orders")
+          .setKind(ResourceKind.RK_TABLE)
+          .build();
+
+  protected static PlannerStatsBundleService createService(
+      StatsRepository repository,
+      UserObjectBundleTestSupport.TestQueryContextStore store,
+      int chunkSize,
+      int maxTables,
+      int maxColumns) {
+    return createService(
+        repository, store, ConstraintProvider.NONE, chunkSize, maxTables, maxColumns);
+  }
+
+  protected static PlannerStatsBundleService createService(
+      StatsRepository repository,
+      UserObjectBundleTestSupport.TestQueryContextStore store,
+      ConstraintProvider constraintProvider,
+      int chunkSize,
+      int maxTables,
+      int maxColumns) {
+    StatsProviderFactory factory = new StatsProviderFactory(repository, store);
+    return PlannerStatsBundleService.forTesting(
+        factory, constraintProvider, repository, maxTables, maxColumns, chunkSize);
+  }
+
+  protected static StatsRepository createRepository() {
+    return new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+  }
+
+  protected static ColumnStats sampleStats(ResourceId tableId, long snapshotId, long columnId) {
+    return ColumnStats.newBuilder()
+        .setTableId(tableId)
+        .setSnapshotId(snapshotId)
+        .setColumnId(columnId)
+        .setColumnName("col" + columnId)
+        .setValueCount(columnId * 10)
+        .setNullCount(columnId)
+        .build();
+  }
+
+  protected static FetchColumnStatsRequest requestFor(
+      String queryId, ResourceId tableId, List<Long> columnIds) {
+    return FetchColumnStatsRequest.newBuilder()
+        .setQueryId(queryId)
+        .addTables(tableRequest(tableId, columnIds))
+        .build();
+  }
+
+  protected static TableColumnStatsRequest tableRequest(ResourceId tableId, List<Long> columnIds) {
+    return TableColumnStatsRequest.newBuilder()
+        .setTableId(tableId)
+        .addAllColumnIds(columnIds)
+        .build();
+  }
+
+  protected static QueryContext queryContextWithPin(String queryId, long snapshotId) {
+    SnapshotPin pin = SnapshotPin.newBuilder().setTableId(TABLE).setSnapshotId(snapshotId).build();
+    SnapshotSet set = SnapshotSet.newBuilder().addPins(pin).build();
+    PrincipalContext principal =
+        PrincipalContext.newBuilder()
+            .setAccountId(TABLE.getAccountId())
+            .setSubject("tester")
+            .build();
+    return QueryContext.builder()
+        .queryId(queryId)
+        .principal(principal)
+        .snapshotSet(set.toByteArray())
+        .createdAtMs(1)
+        .expiresAtMs(1_000)
+        .state(QueryContext.State.ACTIVE)
+        .version(1)
+        .queryDefaultCatalogId(CATALOG)
+        .build();
+  }
+
+  protected static QueryContext queryContextWithoutPin(String queryId) {
+    PrincipalContext principal =
+        PrincipalContext.newBuilder()
+            .setAccountId(TABLE.getAccountId())
+            .setSubject("tester")
+            .build();
+    return QueryContext.builder()
+        .queryId(queryId)
+        .principal(principal)
+        .createdAtMs(1)
+        .expiresAtMs(1_000)
+        .state(QueryContext.State.ACTIVE)
+        .version(1)
+        .queryDefaultCatalogId(CATALOG)
+        .build();
+  }
+
+  protected static QueryContext queryContextWithPins(String queryId, List<SnapshotPin> pins) {
+    SnapshotSet set = SnapshotSet.newBuilder().addAllPins(pins).build();
+    PrincipalContext principal =
+        PrincipalContext.newBuilder()
+            .setAccountId(TABLE.getAccountId())
+            .setSubject("tester")
+            .build();
+    return QueryContext.builder()
+        .queryId(queryId)
+        .principal(principal)
+        .snapshotSet(set.toByteArray())
+        .createdAtMs(1)
+        .expiresAtMs(1_000)
+        .state(QueryContext.State.ACTIVE)
+        .version(1)
+        .queryDefaultCatalogId(CATALOG)
+        .build();
+  }
+
+  protected static SnapshotPin pin(ResourceId tableId, long snapshotId) {
+    return SnapshotPin.newBuilder().setTableId(tableId).setSnapshotId(snapshotId).build();
+  }
+
+  protected static List<ColumnStatsResult> flatten(List<ColumnStatsBundleChunk> chunks) {
+    List<ColumnStatsResult> results = new ArrayList<>();
+    for (ColumnStatsBundleChunk chunk : chunks) {
+      if (chunk.hasBatch()) {
+        results.addAll(chunk.getBatch().getColumnsList());
+      }
+    }
+    return results;
+  }
+
+  protected static List<TableConstraintsResult> flattenConstraints(
+      List<ColumnStatsBundleChunk> chunks) {
+    List<TableConstraintsResult> results = new ArrayList<>();
+    for (ColumnStatsBundleChunk chunk : chunks) {
+      if (chunk.hasBatch()) {
+        results.addAll(chunk.getBatch().getConstraintsList());
+      }
+    }
+    return results;
+  }
+
+  protected static List<TableConstraintsResult> flattenConstraintChunks(
+      List<TableConstraintsBundleChunk> chunks) {
+    List<TableConstraintsResult> results = new ArrayList<>();
+    for (TableConstraintsBundleChunk chunk : chunks) {
+      if (chunk.hasBatch()) {
+        results.addAll(chunk.getBatch().getConstraintsList());
+      }
+    }
+    return results;
+  }
+
+  protected static ConstraintDefinition constraint(
+      String name, ConstraintType type, List<Long> columnIds) {
+    ConstraintDefinition.Builder builder =
+        ConstraintDefinition.newBuilder().setName(name).setType(type);
+    int ordinal = 1;
+    for (Long columnId : columnIds) {
+      builder.addColumns(columnRef(columnId, "c" + columnId, ordinal++));
+    }
+    return builder.build();
+  }
+
+  protected static ConstraintColumnRef columnRef(long columnId, String name, int ordinal) {
+    return ConstraintColumnRef.newBuilder()
+        .setColumnId(columnId)
+        .setColumnName(name)
+        .setOrdinal(ordinal)
+        .build();
+  }
+
+  protected static ConstraintProvider.ConstraintSetView newConstraintSet(
+      ResourceId tableId, List<ConstraintDefinition> constraints) {
+    return new ConstraintProvider.ConstraintSetView() {
+      @Override
+      public ResourceId relationId() {
+        return tableId;
+      }
+
+      @Override
+      public List<ConstraintDefinition> constraints() {
+        return constraints;
+      }
+    };
+  }
+
+  protected static final class SmartScanOnlyStatsRepository extends StatsRepository {
+    protected SmartScanOnlyStatsRepository(PointerStore pointerStore, BlobStore blobStore) {
+      super(
+          pointerStore,
+          blobStore,
+          /* smartThreshold= */ 2,
+          /* scanColumnsPerPage= */ 5,
+          /* maxScanPages= */ 5);
+    }
+
+    @Override
+    public List<ColumnStats> getColumnStatsBatch(
+        ResourceId tableId, long snapshotId, List<Long> columnIds) {
+      throw new AssertionError("smart scan path should not require per-column batches");
+    }
+  }
+
+  protected static final class CappingStatsRepository extends StatsRepository {
+    private final AtomicInteger batchCalls = new AtomicInteger();
+
+    protected CappingStatsRepository(PointerStore pointerStore, BlobStore blobStore) {
+      super(
+          pointerStore,
+          blobStore,
+          /* smartThreshold= */ 2,
+          /* scanColumnsPerPage= */ 1,
+          /* maxScanPages= */ 1);
+    }
+
+    @Override
+    public List<ColumnStats> getColumnStatsBatch(
+        ResourceId tableId, long snapshotId, List<Long> columnIds) {
+      batchCalls.incrementAndGet();
+      return super.getColumnStatsBatch(tableId, snapshotId, columnIds);
+    }
+
+    int batchCallCount() {
+      return batchCalls.get();
+    }
+  }
+
+  protected static final class ThrowingStatsRepository extends StatsRepository {
+    protected ThrowingStatsRepository(
+        InMemoryPointerStore pointerStore, InMemoryBlobStore blobStore) {
+      super(pointerStore, blobStore);
+    }
+
+    @Override
+    public List<ColumnStats> getColumnStatsBatch(
+        ResourceId tableId, long snapshotId, List<Long> columnIds) {
+      throw new RuntimeException("boom");
+    }
+
+    @Override
+    public ColumnStatsBatchResult getColumnStatsBatchSmart(
+        ResourceId tableId, long snapshotId, List<Long> columnIds) {
+      throw new RuntimeException("boom");
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/RequestScopeConstraintPrunerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/RequestScopeConstraintPrunerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RequestScopeConstraintPrunerTest {
+
+  private static final ResourceId TABLE =
+      ResourceId.newBuilder()
+          .setAccountId("acct")
+          .setKind(ResourceKind.RK_TABLE)
+          .setId("users")
+          .build();
+
+  private static final ResourceId TABLE_TWO =
+      ResourceId.newBuilder()
+          .setAccountId("acct")
+          .setKind(ResourceKind.RK_TABLE)
+          .setId("orders")
+          .build();
+
+  @Test
+  void pkPreservedWhenColumnNotRequested() {
+    RequestScopeConstraintPruner pruner =
+        new RequestScopeConstraintPruner(
+            Set.of(RequestScopeConstraintPruner.relationKey(TABLE)),
+            Map.of(RequestScopeConstraintPruner.relationKey(TABLE), Set.of(1L)));
+
+    ConstraintDefinition pk =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_users")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .addColumns(column(99L, "hidden_pk_col", 1))
+            .build();
+
+    List<ConstraintDefinition> out = pruner.prune(TABLE, List.of(pk));
+    assertEquals(1, out.size());
+    assertEquals("pk_users", out.get(0).getName());
+    assertEquals(99L, out.get(0).getColumns(0).getColumnId());
+  }
+
+  @Test
+  void fkDroppedWhenReferencedTableNotRequested() {
+    RequestScopeConstraintPruner pruner =
+        new RequestScopeConstraintPruner(
+            Set.of(RequestScopeConstraintPruner.relationKey(TABLE)),
+            Map.of(RequestScopeConstraintPruner.relationKey(TABLE), Set.of(1L)));
+
+    ConstraintDefinition fk =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_users_orders")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .addColumns(column(1L, "user_id", 1))
+            .setReferencedTableId(TABLE_TWO)
+            .addReferencedColumns(column(2L, "order_id", 1))
+            .build();
+
+    List<ConstraintDefinition> out = pruner.prune(TABLE, List.of(fk));
+    assertTrue(out.isEmpty());
+  }
+
+  @Test
+  void checkExpressionBlankedWhenHiddenColumnExists() {
+    RequestScopeConstraintPruner pruner =
+        new RequestScopeConstraintPruner(
+            Set.of(RequestScopeConstraintPruner.relationKey(TABLE)),
+            Map.of(RequestScopeConstraintPruner.relationKey(TABLE), Set.of(1L)));
+
+    ConstraintDefinition check =
+        ConstraintDefinition.newBuilder()
+            .setName("check_users_secret")
+            .setType(ConstraintType.CT_CHECK)
+            .setCheckExpression("secret_col > 0")
+            .addColumns(column(99L, "secret_col", 1))
+            .build();
+
+    List<ConstraintDefinition> out = pruner.prune(TABLE, List.of(check));
+    assertEquals(1, out.size());
+    assertEquals("", out.get(0).getCheckExpression());
+  }
+
+  @Test
+  void constraintsOnlyModePreservesPkWithoutRequestedColumnMap() {
+    RequestScopeConstraintPruner pruner =
+        RequestScopeConstraintPruner.forRequestedTablesOnly(
+            Set.of(RequestScopeConstraintPruner.relationKey(TABLE)));
+
+    ConstraintDefinition pk =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_users_constraints_only")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .addColumns(column(99L, "hidden_pk_col", 1))
+            .build();
+
+    List<ConstraintDefinition> out = pruner.prune(TABLE, List.of(pk));
+    assertEquals(1, out.size());
+    assertEquals("pk_users_constraints_only", out.get(0).getName());
+    assertEquals(99L, out.get(0).getColumns(0).getColumnId());
+  }
+
+  @Test
+  void relationKeyIncludesKind() {
+    ResourceId tableKind =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("x")
+            .build();
+    ResourceId unspecifiedKind =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_UNSPECIFIED)
+            .setId("x")
+            .build();
+
+    String tableKey = RequestScopeConstraintPruner.relationKey(tableKind);
+    String unspecifiedKey = RequestScopeConstraintPruner.relationKey(unspecifiedKind);
+
+    assertNotEquals(tableKey, unspecifiedKey);
+    assertTrue(tableKey.contains("/" + ResourceKind.RK_TABLE_VALUE + "/"));
+  }
+
+  private static ConstraintColumnRef column(long id, String name, int ordinal) {
+    return ConstraintColumnRef.newBuilder()
+        .setColumnId(id)
+        .setColumnName(name)
+        .setOrdinal(ordinal)
+        .build();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImplTest.java
@@ -29,9 +29,12 @@ import ai.floedb.floecat.query.rpc.ColumnStatsBundleChunk;
 import ai.floedb.floecat.query.rpc.ColumnStatsBundleEnd;
 import ai.floedb.floecat.query.rpc.ColumnStatsResult;
 import ai.floedb.floecat.query.rpc.FetchColumnStatsRequest;
+import ai.floedb.floecat.query.rpc.FetchTableConstraintsRequest;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TableColumnStatsRequest;
+import ai.floedb.floecat.query.rpc.TableConstraintsBundleChunk;
+import ai.floedb.floecat.query.rpc.TableConstraintsResult;
 import ai.floedb.floecat.service.query.catalog.PlannerStatsBundleService;
 import ai.floedb.floecat.service.query.catalog.StatsProviderFactory;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
@@ -87,6 +90,65 @@ class PlannerStatsServiceImplTest {
   }
 
   @Test
+  void constraintsQueryNotFoundIsReported() {
+    StatsRepository repository = createRepository();
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    PlannerStatsBundleService bundles = createBundleService(repository, store);
+    PlannerStatsServiceImpl service = createServiceImpl(bundles, store);
+
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId("missing-query")
+            .addTableIds(TABLE)
+            .build();
+    PrincipalContext principal = principal("corr-missing-constraints", true);
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                withPrincipal(
+                    principal,
+                    () ->
+                        service
+                            .getTableConstraints(request)
+                            .collect()
+                            .asList()
+                            .await()
+                            .indefinitely()));
+    assertEquals(Status.NOT_FOUND.getCode(), failure.getStatus().getCode());
+  }
+
+  @Test
+  void getTableConstraintsRejectsBlankQueryId() {
+    StatsRepository repository = createRepository();
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    PlannerStatsBundleService bundles = createBundleService(repository, store);
+    PlannerStatsServiceImpl service = createServiceImpl(bundles, store);
+
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder().setQueryId("   ").addTableIds(TABLE).build();
+    PrincipalContext principal = principal("corr-blank-query-id-constraints", true);
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                withPrincipal(
+                    principal,
+                    () ->
+                        service
+                            .getTableConstraints(request)
+                            .collect()
+                            .asList()
+                            .await()
+                            .indefinitely()));
+    assertEquals(Status.INVALID_ARGUMENT.getCode(), failure.getStatus().getCode());
+  }
+
+  @Test
   void inactiveQueryIsRejected() {
     StatsRepository repository = createRepository();
     UserObjectBundleTestSupport.TestQueryContextStore store =
@@ -108,6 +170,41 @@ class PlannerStatsServiceImplTest {
                     principal,
                     () ->
                         service.getColumnStats(request).collect().asList().await().indefinitely()));
+    assertEquals(Status.FAILED_PRECONDITION.getCode(), failure.getStatus().getCode());
+  }
+
+  @Test
+  void constraintsInactiveQueryIsRejected() {
+    StatsRepository repository = createRepository();
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    PlannerStatsBundleService bundles = createBundleService(repository, store);
+    PlannerStatsServiceImpl service = createServiceImpl(bundles, store);
+
+    QueryContext ctx =
+        queryContextWithPin("query-inactive-constraints", 200L, QueryContext.State.ENDED_ABORT);
+    store.seed(ctx);
+
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .build();
+    PrincipalContext principal = principal("corr-inactive-constraints", true);
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                withPrincipal(
+                    principal,
+                    () ->
+                        service
+                            .getTableConstraints(request)
+                            .collect()
+                            .asList()
+                            .await()
+                            .indefinitely()));
     assertEquals(Status.FAILED_PRECONDITION.getCode(), failure.getStatus().getCode());
   }
 
@@ -137,6 +234,41 @@ class PlannerStatsServiceImplTest {
   }
 
   @Test
+  void constraintsMissingPermissionIsDenied() {
+    StatsRepository repository = createRepository();
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    PlannerStatsBundleService bundles = createBundleService(repository, store);
+    PlannerStatsServiceImpl service = createServiceImpl(bundles, store);
+
+    QueryContext ctx =
+        queryContextWithPin("query-auth-constraints", 201L, QueryContext.State.ACTIVE);
+    store.seed(ctx);
+
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .build();
+    PrincipalContext principal = principal("corr-auth-constraints", false);
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                withPrincipal(
+                    principal,
+                    () ->
+                        service
+                            .getTableConstraints(request)
+                            .collect()
+                            .asList()
+                            .await()
+                            .indefinitely()));
+    assertEquals(Status.PERMISSION_DENIED.getCode(), failure.getStatus().getCode());
+  }
+
+  @Test
   void happyPathStreamsStats() {
     StatsRepository repository = createRepository();
     UserObjectBundleTestSupport.TestQueryContextStore store =
@@ -162,6 +294,32 @@ class PlannerStatsServiceImplTest {
     ColumnStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
     assertEquals(1L, end.getReturnedColumns());
     assertEquals(0L, end.getNotFoundColumns());
+  }
+
+  @Test
+  void happyPathStreamsConstraints() {
+    StatsRepository repository = createRepository();
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    PlannerStatsBundleService bundles = createBundleService(repository, store);
+    PlannerStatsServiceImpl service = createServiceImpl(bundles, store);
+
+    QueryContext ctx = queryContextWithPin("query-constraints-ok", 203L, QueryContext.State.ACTIVE);
+    store.seed(ctx);
+
+    FetchTableConstraintsRequest request =
+        FetchTableConstraintsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTableIds(TABLE)
+            .build();
+    List<TableConstraintsBundleChunk> chunks =
+        withPrincipal(
+            principal("corr-constraints-ok", true),
+            () -> service.getTableConstraints(request).collect().asList().await().indefinitely());
+
+    List<TableConstraintsResult> results = flattenConstraints(chunks);
+    assertEquals(1, results.size());
+    assertEquals(BundleResultStatus.BUNDLE_RESULT_STATUS_NOT_FOUND, results.get(0).getStatus());
   }
 
   private static PlannerStatsServiceImpl createServiceImpl(
@@ -260,6 +418,17 @@ class PlannerStatsServiceImplTest {
     for (ColumnStatsBundleChunk chunk : chunks) {
       if (chunk.hasBatch()) {
         results.addAll(chunk.getBatch().getColumnsList());
+      }
+    }
+    return results;
+  }
+
+  private static List<TableConstraintsResult> flattenConstraints(
+      List<TableConstraintsBundleChunk> chunks) {
+    List<TableConstraintsResult> results = new ArrayList<>();
+    for (TableConstraintsBundleChunk chunk : chunks) {
+      if (chunk.hasBatch()) {
+        results.addAll(chunk.getBatch().getConstraintsList());
       }
     }
     return results;


### PR DESCRIPTION
# Planner Constraint Streaming + Request-Scoped Pruning

This PR adds planner-visible **constraint retrieval** alongside existing column statistics streaming.

Planners can now fetch relational constraints (PK / UNIQUE / NOT NULL / FK / CHECK) either:

1. **Combined with column stats** using `GetColumnStats(include_constraints=true)`
2. **Via a dedicated stream** using the new `GetTableConstraints` RPC

It also introduces **request-scoped constraint pruning**, ensuring planners only see constraints consistent with the requested planning scope.

Closes: https://github.com/eng-floe/floecat/issues/217

---

## Summary

This change introduces:

- Constraint streaming for planners
- A new RPC: `GetTableConstraints`
- Optional constraint emission in `GetColumnStats`
- A `ConstraintProvider` abstraction for retrieving constraint sets
- Request-scoped constraint pruning
- Tests for both combined and split retrieval paths

---

## API Changes

### Existing RPC

```proto
rpc GetColumnStats(FetchColumnStatsRequest)
```

Now supports:
```proto
bool include_constraints = true
```

When enabled, constraint results are streamed alongside column statistics.

---

### New RPC
```proto
rpc GetTableConstraints(FetchTableConstraintsRequest)
  returns (stream TableConstraintsBundleChunk)
```
This streams table constraints independently from column statistics.

---

## Constraint Pruning

Constraints are pruned according to the planner request scope.

### Always preserved (when the relation is requested)
- PRIMARY KEY
- UNIQUE
- NOT NULL

These remain visible even if their columns are not projected, since column projection is treated as a stats fetch hint, not a visibility boundary.

### Scope-sensitive

| Constraint |	Behavior |
|---|---|
| FOREIGN KEY | hidden if referenced table is not requested |
| CHECK | expression masked if it references hidden columns |

If pruning removes all constraints, the result is returned as:
`BUNDLE_RESULT_STATUS_NOT_FOUND`

with reason:

`pruned_empty`


---

### Constraint Absence Semantics

Constraint lookup may produce several absence states:

| Reason |	Meaning |
| --- | ---|
| provider_missing |	provider has no constraint view |
| provider_empty |	provider returned zero constraints |
| pruned_empty |	constraints existed but were hidden |

All are surfaced as NOT_FOUND, with the reason recorded in:
`failure.details.reason`

---

### Snapshot Semantics

Constraint retrieval is snapshot-consistent.

Constraints are resolved using the same snapshot pins used for column statistics.
If a snapshot pin is missing, the result returns:
`planner_stats.pin.missing`

---

## Implementation

Key components added:
- ConstraintProvider — abstraction for retrieving relation constraints
- ConstraintPruner — request-scoped pruning interface
- RequestScopeConstraintPruner — current pruning policy
- ConstraintPrunerFactory — request-scoped pruner creation

Constraints are emitted once per table during stats streaming to avoid duplication.

---

## Tests

Tests cover:
- combined stats + constraints streaming
- constraints-only streaming
- pruning behavior (FK removal, CHECK masking)
- preservation of PK / UNIQUE / NOT NULL
- chunking behavior
- failure handling (missing pins, provider absence)
- service-level RPC validation

---

## Backwards Compatibility

This change is fully additive.
- Existing GetColumnStats behavior is unchanged
- Constraint retrieval is opt-in
- The new RPC is optional for clients
