### PR TITLE
Add connector SPI and hook reconciler for constraints

### DIFF
--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
@@ -20,6 +20,7 @@ import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
 import ai.floedb.floecat.catalog.rpc.FileContent;
 import ai.floedb.floecat.catalog.rpc.Ndv;
 import ai.floedb.floecat.catalog.rpc.PartitionSpecInfo;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.TableStats;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.execution.rpc.ScanFile;
@@ -67,6 +68,33 @@ public interface FloecatConnector extends Closeable {
       Set<String> includeColumns,
       boolean includeStatistics) {
     return enumerateSnapshotsWithStats(namespaceFq, tableName, destinationTableId, includeColumns);
+  }
+
+  /**
+   * Returns per-snapshot constraints for a table snapshot, if available.
+   *
+   * <p>Default: no constraints emitted.
+   */
+  default Optional<SnapshotConstraints> snapshotConstraints(
+      String namespaceFq, String tableName, ResourceId destinationTableId, long snapshotId) {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns per-snapshot constraints for the provided snapshot bundle, if available.
+   *
+   * <p>Default: delegates to {@link #snapshotConstraints(String, String, ResourceId, long)}.
+   */
+  default Optional<SnapshotConstraints> snapshotConstraints(
+      String namespaceFq,
+      String tableName,
+      ResourceId destinationTableId,
+      SnapshotBundle snapshotBundle) {
+    if (snapshotBundle == null || snapshotBundle.snapshotId() < 0) {
+      return Optional.empty();
+    }
+    return snapshotConstraints(
+        namespaceFq, tableName, destinationTableId, snapshotBundle.snapshotId());
   }
 
   record SnapshotEnumerationOptions(

--- a/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcilerBackend.java
+++ b/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcilerBackend.java
@@ -19,6 +19,7 @@ import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
 import ai.floedb.floecat.catalog.rpc.ColumnStats;
 import ai.floedb.floecat.catalog.rpc.FileColumnStats;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.TableStats;
 import ai.floedb.floecat.catalog.rpc.ViewSpec;
 import ai.floedb.floecat.common.rpc.NameRef;
@@ -60,6 +61,9 @@ public interface ReconcilerBackend {
   void putColumnStats(ReconcileContext ctx, List<ColumnStats> stats);
 
   void putFileColumnStats(ReconcileContext ctx, List<FileColumnStats> stats);
+
+  default void putSnapshotConstraints(
+      ReconcileContext ctx, ResourceId tableId, long snapshotId, SnapshotConstraints constraints) {}
 
   String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId);
 

--- a/core/types/src/main/java/ai/floedb/floecat/types/Hashing.java
+++ b/core/types/src/main/java/ai/floedb/floecat/types/Hashing.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package ai.floedb.floecat.service.repo.util;
+package ai.floedb.floecat.types;
 
 import java.security.MessageDigest;
 
-public final class ResourceHash {
-  private ResourceHash() {}
+/** Shared hashing helpers for cross-module stable digest generation. */
+public final class Hashing {
+  private Hashing() {}
 
   public static String sha256Hex(byte[] bytes) {
     try {

--- a/docs/reconciler.md
+++ b/docs/reconciler.md
@@ -46,6 +46,15 @@ Internally, the scheduler exposes `pollEvery` via `@Scheduled` (default every se
   `ConnectorState` update or raises conflicts.
 - **Statistics ingestion** – Table stats plus column/file stats are streamed one request per item via
   `PutColumnStats` / `PutFileColumnStats`, keeping a single idempotency key per table/snapshot.
+- **Snapshot constraints ingestion** – Reconciler ingests snapshot constraints through
+  `PutTableConstraints` after snapshot/stats handling.
+  - Behavior is intentionally strict (not best-effort): constraint extraction/write failures fail
+    the current table reconcile, including when table stats were already captured.
+  - Constraints writes are repeatable/upsert-like: reconciler may rewrite the same
+    table+snapshot constraints on repeated runs (no separate "constraints already captured"
+    tracking is introduced here).
+  - Idempotency keys are derived from `SnapshotConstraints.toByteArray()` (byte-level,
+    order-sensitive payload hashing), not semantic normalization.
 - **Mode-aware behavior** – In `STATS_ONLY`, destination-table misses are treated as skip/no-op
   rather than job-fatal errors.
 - **Error handling** – Exceptions inside the per-table loop are caught, logged, and recorded in the

--- a/reconciler/pom.xml
+++ b/reconciler/pom.xml
@@ -34,6 +34,11 @@
     </dependency>
     <dependency>
       <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-types</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
       <artifactId>floecat-reconciler-spi</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -34,12 +34,15 @@ import ai.floedb.floecat.catalog.rpc.NamespaceServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.NamespaceSpec;
 import ai.floedb.floecat.catalog.rpc.PutColumnStatsRequest;
 import ai.floedb.floecat.catalog.rpc.PutFileColumnStatsRequest;
+import ai.floedb.floecat.catalog.rpc.PutTableConstraintsRequest;
 import ai.floedb.floecat.catalog.rpc.PutTableStatsRequest;
 import ai.floedb.floecat.catalog.rpc.ResolveNamespaceRequest;
 import ai.floedb.floecat.catalog.rpc.ResolveTableRequest;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.SnapshotServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.SnapshotSpec;
+import ai.floedb.floecat.catalog.rpc.TableConstraintsServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.catalog.rpc.TableServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.TableSpec;
@@ -66,6 +69,7 @@ import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend.TableSpecDescriptor;
 import ai.floedb.floecat.reconciler.spi.SnapshotHelpers;
+import ai.floedb.floecat.types.Hashing;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import io.grpc.Metadata;
@@ -132,6 +136,9 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
 
   @GrpcClient("floecat")
   ViewServiceGrpc.ViewServiceBlockingStub view;
+
+  @GrpcClient("floecat")
+  TableConstraintsServiceGrpc.TableConstraintsServiceBlockingStub constraintsStub;
 
   @Override
   public ResourceId ensureNamespace(ReconcileContext ctx, ResourceId catalogId, NameRef namespace) {
@@ -388,6 +395,54 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
         .atMost(statsTimeout);
   }
 
+  @Override
+  public void putSnapshotConstraints(
+      ReconcileContext ctx,
+      ResourceId tableId,
+      long snapshotId,
+      SnapshotConstraints snapshotConstraints) {
+    if (snapshotConstraints == null || snapshotId < 0) {
+      return;
+    }
+    constraintsStub(ctx)
+        .putTableConstraints(
+            buildPutTableConstraintsRequest(tableId, snapshotId, snapshotConstraints));
+  }
+
+  static PutTableConstraintsRequest buildPutTableConstraintsRequest(
+      ResourceId tableId, long snapshotId, SnapshotConstraints snapshotConstraints) {
+    String idempotencyKey =
+        snapshotConstraintsIdempotencyKey(tableId, snapshotId, snapshotConstraints);
+    return PutTableConstraintsRequest.newBuilder()
+        .setTableId(tableId)
+        .setSnapshotId(snapshotId)
+        .setConstraints(snapshotConstraints)
+        .setIdempotency(IdempotencyKey.newBuilder().setKey(idempotencyKey).build())
+        .build();
+  }
+
+  private static String snapshotConstraintsIdempotencyKey(
+      ResourceId tableId, long snapshotId, SnapshotConstraints constraints) {
+    String accountId = tableId == null ? "" : tableId.getAccountId();
+    String tableValue = tableId == null ? "" : tableId.getId();
+    int kindValue = tableId == null ? 0 : tableId.getKindValue();
+    // Idempotency is based on protobuf bytes for the emitted payload. This assumes reconciler
+    // input ordering is deterministic; semantically equivalent but differently ordered payloads
+    // will intentionally hash differently.
+    byte[] payload = constraints == null ? new byte[0] : constraints.toByteArray();
+    String digest = Hashing.sha256Hex(payload);
+    return "reconciler.constraints/"
+        + accountId
+        + "/"
+        + kindValue
+        + "/"
+        + tableValue
+        + "/"
+        + snapshotId
+        + "/"
+        + digest;
+  }
+
   private List<PutColumnStatsRequest> groupColumnRequests(List<ColumnStats> stats) {
     Map<StatsGroupKey, List<ColumnStats>> grouped = new LinkedHashMap<>();
     for (ColumnStats column : stats) {
@@ -520,6 +575,11 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
     return withHeaders(view, ctx);
   }
 
+  private TableConstraintsServiceGrpc.TableConstraintsServiceBlockingStub constraintsStub(
+      ReconcileContext ctx) {
+    return withHeaders(constraintsStub, ctx);
+  }
+
   private <T extends AbstractStub<T>> T withHeaders(T stub, ReconcileContext ctx) {
     return stub.withInterceptors(
         MetadataUtils.newAttachHeadersInterceptor(metadataForContext(ctx)));
@@ -543,7 +603,7 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
     return AUTHORIZATION;
   }
 
-  private String withBearerPrefix(String token) {
+  static String withBearerPrefix(String token) {
     if (token.regionMatches(true, 0, "bearer ", 0, 7)) {
       return token;
     }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -21,6 +21,7 @@ import static ai.floedb.floecat.reconciler.util.NameParts.split;
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
 import ai.floedb.floecat.catalog.rpc.ColumnStats;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.catalog.rpc.ViewSpec;
 import ai.floedb.floecat.common.rpc.NameRef;
@@ -78,6 +79,8 @@ import org.jboss.logging.Logger;
 public class ReconcilerService {
   private static final Logger LOG = Logger.getLogger(ReconcilerService.class);
   private static final int SCHEMA_CACHE_MAX_ENTRIES = 64;
+  private static final BooleanSupplier NO_CANCEL = () -> false;
+  private static final ProgressListener NO_PROGRESS = (s, c, e, sp, stp, m) -> {};
 
   public enum CaptureMode {
     METADATA_ONLY,
@@ -114,15 +117,8 @@ public class ReconcilerService {
       ResourceId connectorId,
       boolean fullRescan,
       ReconcileScope scopeIn) {
-    return reconcile(
-        principal,
-        connectorId,
-        fullRescan,
-        scopeIn,
-        CaptureMode.METADATA_AND_STATS,
-        null,
-        () -> false,
-        (s, c, e, sp, stp, m) -> {});
+    return reconcileWithDefaults(
+        principal, connectorId, fullRescan, scopeIn, CaptureMode.METADATA_AND_STATS, null);
   }
 
   public Result reconcile(
@@ -131,18 +127,21 @@ public class ReconcilerService {
       boolean fullRescan,
       ReconcileScope scopeIn,
       CaptureMode captureMode) {
-    return reconcile(
-        principal,
-        connectorId,
-        fullRescan,
-        scopeIn,
-        captureMode,
-        null,
-        () -> false,
-        (s, c, e, sp, stp, m) -> {});
+    return reconcileWithDefaults(principal, connectorId, fullRescan, scopeIn, captureMode, null);
   }
 
   public Result reconcile(
+      PrincipalContext principal,
+      ResourceId connectorId,
+      boolean fullRescan,
+      ReconcileScope scopeIn,
+      CaptureMode captureMode,
+      String bearerToken) {
+    return reconcileWithDefaults(
+        principal, connectorId, fullRescan, scopeIn, captureMode, bearerToken);
+  }
+
+  private Result reconcileWithDefaults(
       PrincipalContext principal,
       ResourceId connectorId,
       boolean fullRescan,
@@ -156,8 +155,8 @@ public class ReconcilerService {
         scopeIn,
         captureMode,
         bearerToken,
-        () -> false,
-        (s, c, e, sp, stp, m) -> {});
+        NO_CANCEL,
+        NO_PROGRESS);
   }
 
   public Result reconcile(
@@ -179,8 +178,8 @@ public class ReconcilerService {
     String corr = ctx.correlationId();
 
     final ArrayList<String> errSummaries = new ArrayList<>();
-    final BooleanSupplier cancelCheck = cancelRequested == null ? () -> false : cancelRequested;
-    final ProgressListener progressOut = progress == null ? (s, c, e, sp, stp, m) -> {} : progress;
+    final BooleanSupplier cancelCheck = cancelRequested == null ? NO_CANCEL : cancelRequested;
+    final ProgressListener progressOut = progress == null ? NO_PROGRESS : progress;
 
     final Connector stored;
     try {
@@ -905,7 +904,10 @@ public class ReconcilerService {
         continue;
       }
 
-      if (!fullRescan && backend.statsAlreadyCaptured(ctx, tableId, snapshotId)) {
+      boolean statsCaptured = !fullRescan && backend.statsAlreadyCaptured(ctx, tableId, snapshotId);
+      if (statsCaptured) {
+        maybeIngestSnapshotConstraints(
+            ctx, tableId, connector, sourceNs, sourceTable, snapshotBundle, snapshotId);
         continue;
       }
 
@@ -977,8 +979,30 @@ public class ReconcilerService {
         backend.putFileColumnStats(ctx, fileStatsOut);
         statsProcessed += fileStatsOut.size();
       }
+
+      maybeIngestSnapshotConstraints(
+          ctx, tableId, connector, sourceNs, sourceTable, snapshotBundle, snapshotId);
     }
     return new IngestCounts(snapshotsProcessed, statsProcessed);
+  }
+
+  private void maybeIngestSnapshotConstraints(
+      ReconcileContext ctx,
+      ResourceId tableId,
+      FloecatConnector connector,
+      String sourceNs,
+      String sourceTable,
+      FloecatConnector.SnapshotBundle snapshotBundle,
+      long snapshotId) {
+    if (snapshotId < 0) {
+      return;
+    }
+    Optional<SnapshotConstraints> constraints =
+        connector.snapshotConstraints(sourceNs, sourceTable, tableId, snapshotBundle);
+    if (constraints.isEmpty()) {
+      return;
+    }
+    backend.putSnapshotConstraints(ctx, tableId, snapshotId, constraints.get());
   }
 
   private static TableFormat toTableFormat(ConnectorFormat format) {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FloecatConnectorCompatibilityTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FloecatConnectorCompatibilityTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.connector.spi.ConnectorFormat;
+import ai.floedb.floecat.connector.spi.FloecatConnector;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class FloecatConnectorCompatibilityTest {
+
+  @Test
+  void defaultSnapshotConstraintsMethodsAreBackwardCompatible() {
+    FloecatConnector connector = new LegacyConnector();
+    ResourceId tableId = ResourceId.newBuilder().setAccountId("acct").setId("tbl").build();
+
+    assertTrue(connector.snapshotConstraints("ns", "tbl", tableId, 10L).isEmpty());
+
+    FloecatConnector.SnapshotBundle bundle =
+        new FloecatConnector.SnapshotBundle(
+            10L,
+            0L,
+            0L,
+            null,
+            List.of(),
+            List.of(),
+            null,
+            null,
+            0L,
+            null,
+            java.util.Map.of(),
+            0,
+            java.util.Map.of());
+    Optional<?> fromBundle = connector.snapshotConstraints("ns", "tbl", tableId, bundle);
+    assertTrue(fromBundle.isEmpty());
+  }
+
+  private static final class LegacyConnector implements FloecatConnector {
+
+    @Override
+    public String id() {
+      return "legacy";
+    }
+
+    @Override
+    public ConnectorFormat format() {
+      return ConnectorFormat.CF_DELTA;
+    }
+
+    @Override
+    public List<String> listNamespaces() {
+      return List.of();
+    }
+
+    @Override
+    public List<String> listTables(String namespaceFq) {
+      return List.of();
+    }
+
+    @Override
+    public TableDescriptor describe(String namespaceFq, String tableName) {
+      return new TableDescriptor(
+          namespaceFq, tableName, "", "{}", List.of(), null, java.util.Map.of());
+    }
+
+    @Override
+    public List<SnapshotBundle> enumerateSnapshotsWithStats(
+        String namespaceFq,
+        String tableName,
+        ResourceId destinationTableId,
+        Set<String> includeColumns) {
+      return List.of();
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendTest.java
@@ -17,33 +17,111 @@ package ai.floedb.floecat.reconciler.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Method;
-import java.time.Duration;
-import java.util.Optional;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.catalog.rpc.PutTableConstraintsRequest;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import org.junit.jupiter.api.Test;
 
 class GrpcReconcilerBackendTest {
   @Test
-  void withBearerPrefixLeavesExistingBearer() throws Exception {
-    var backend =
-        new GrpcReconcilerBackend(
-            Optional.<String>empty(), Optional.<String>empty(), Optional.<Duration>empty());
-    Method method = GrpcReconcilerBackend.class.getDeclaredMethod("withBearerPrefix", String.class);
-    method.setAccessible(true);
-
-    String token = (String) method.invoke(backend, "Bearer abc123");
+  void withBearerPrefixLeavesExistingBearer() {
+    String token = GrpcReconcilerBackend.withBearerPrefix("Bearer abc123");
     assertThat(token).isEqualTo("Bearer abc123");
   }
 
   @Test
-  void withBearerPrefixAddsPrefixWhenMissing() throws Exception {
-    var backend =
-        new GrpcReconcilerBackend(
-            Optional.<String>empty(), Optional.<String>empty(), Optional.<Duration>empty());
-    Method method = GrpcReconcilerBackend.class.getDeclaredMethod("withBearerPrefix", String.class);
-    method.setAccessible(true);
-
-    String token = (String) method.invoke(backend, "abc123");
+  void withBearerPrefixAddsPrefixWhenMissing() {
+    String token = GrpcReconcilerBackend.withBearerPrefix("abc123");
     assertThat(token).isEqualTo("Bearer abc123");
+  }
+
+  @Test
+  void snapshotConstraintsIdempotencyKeyIsStableForSamePayload() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("users")
+            .build();
+    SnapshotConstraints constraints =
+        SnapshotConstraints.newBuilder()
+            .addConstraints(
+                ConstraintDefinition.newBuilder()
+                    .setName("pk_users")
+                    .setType(ConstraintType.CT_PRIMARY_KEY)
+                    .build())
+            .build();
+
+    PutTableConstraintsRequest request1 =
+        GrpcReconcilerBackend.buildPutTableConstraintsRequest(tableId, 42L, constraints);
+    PutTableConstraintsRequest request2 =
+        GrpcReconcilerBackend.buildPutTableConstraintsRequest(tableId, 42L, constraints);
+
+    assertThat(request1.getIdempotency().getKey()).isEqualTo(request2.getIdempotency().getKey());
+  }
+
+  @Test
+  void snapshotConstraintsIdempotencyKeyChangesWhenPayloadChanges() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("users")
+            .build();
+    SnapshotConstraints first =
+        SnapshotConstraints.newBuilder()
+            .addConstraints(
+                ConstraintDefinition.newBuilder()
+                    .setName("pk_users")
+                    .setType(ConstraintType.CT_PRIMARY_KEY)
+                    .build())
+            .build();
+    SnapshotConstraints second =
+        SnapshotConstraints.newBuilder()
+            .addConstraints(
+                ConstraintDefinition.newBuilder()
+                    .setName("pk_users_alt")
+                    .setType(ConstraintType.CT_PRIMARY_KEY)
+                    .build())
+            .build();
+
+    PutTableConstraintsRequest request1 =
+        GrpcReconcilerBackend.buildPutTableConstraintsRequest(tableId, 42L, first);
+    PutTableConstraintsRequest request2 =
+        GrpcReconcilerBackend.buildPutTableConstraintsRequest(tableId, 42L, second);
+
+    assertThat(request1.getIdempotency().getKey()).isNotEqualTo(request2.getIdempotency().getKey());
+  }
+
+  @Test
+  void buildPutTableConstraintsRequestPopulatesAllFieldsAndStableIdempotencyKey() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("users")
+            .build();
+    SnapshotConstraints snapshotConstraints =
+        SnapshotConstraints.newBuilder()
+            .addConstraints(
+                ConstraintDefinition.newBuilder()
+                    .setName("pk_users")
+                    .setType(ConstraintType.CT_PRIMARY_KEY)
+                    .build())
+            .build();
+
+    PutTableConstraintsRequest request =
+        GrpcReconcilerBackend.buildPutTableConstraintsRequest(tableId, 42L, snapshotConstraints);
+    PutTableConstraintsRequest request2 =
+        GrpcReconcilerBackend.buildPutTableConstraintsRequest(tableId, 42L, snapshotConstraints);
+
+    assertThat(request.getTableId()).isEqualTo(tableId);
+    assertThat(request.getSnapshotId()).isEqualTo(42L);
+    assertThat(request.getConstraints()).isEqualTo(snapshotConstraints);
+    assertThat(request.getIdempotency().getKey()).isNotBlank();
+    assertThat(request2.getIdempotency().getKey()).isEqualTo(request.getIdempotency().getKey());
   }
 }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -19,8 +19,11 @@ package ai.floedb.floecat.reconciler.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ai.floedb.floecat.catalog.rpc.ColumnStats;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
 import ai.floedb.floecat.catalog.rpc.FileColumnStats;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.TableStats;
 import ai.floedb.floecat.catalog.rpc.ViewSpec;
 import ai.floedb.floecat.common.rpc.NameRef;
@@ -97,6 +100,753 @@ class ReconcilerServiceTest {
     assertThat(result.errors).isEqualTo(1);
     assertThat(result.error).isInstanceOf(IllegalStateException.class);
     assertThat(result.error.getMessage()).contains("Connector not ACTIVE");
+  }
+
+  @Test
+  void reconcileWritesSnapshotConstraintsViaStatsPathWhenProvidedByConnector() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("table-1")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    class CapturingBackend extends DefaultBackend {
+      Set<Long> capturedTargetSnapshotIds = Set.of();
+      Set<Long> capturedKnownSnapshotIds = Set.of();
+      long putConstraintsSnapshotId = -1L;
+      SnapshotConstraints putConstraints = null;
+
+      @Override
+      public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+        return activeConnector();
+      }
+
+      @Override
+      public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+        return "dest_cat";
+      }
+
+      @Override
+      public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+        return "dest_ns";
+      }
+
+      @Override
+      public ResourceId ensureTable(
+          ReconcileContext ctx,
+          ResourceId namespaceId,
+          NameRef table,
+          TableSpecDescriptor descriptor) {
+        return tableId;
+      }
+
+      @Override
+      public ResourceId ensureNamespace(
+          ReconcileContext ctx, ResourceId catalogId, NameRef namespace) {
+        return ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("dest-ns")
+            .build();
+      }
+
+      @Override
+      public Optional<Snapshot> fetchSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return Optional.empty();
+      }
+
+      @Override
+      public void ingestSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, Snapshot snapshot) {}
+
+      @Override
+      public Set<Long> existingSnapshotIds(ReconcileContext ctx, ResourceId ignoredTableId) {
+        return Set.of(42L);
+      }
+
+      @Override
+      public boolean statsAlreadyCaptured(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return true;
+      }
+
+      @Override
+      public void putSnapshotConstraints(
+          ReconcileContext ctx,
+          ResourceId ignoredTableId,
+          long snapshotId,
+          SnapshotConstraints constraints) {
+        this.putConstraintsSnapshotId = snapshotId;
+        this.putConstraints = constraints;
+      }
+
+      @Override
+      public void updateConnectorDestination(
+          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
+    }
+
+    class ConstraintsConnector extends FakeConnector {
+      ConstraintsConnector() {
+        super(List.of());
+      }
+
+      @Override
+      public List<String> listTables(String namespaceFq) {
+        return List.of("tbl");
+      }
+
+      @Override
+      public TableDescriptor describe(String namespaceFq, String tableName) {
+        return new TableDescriptor(
+            namespaceFq,
+            tableName,
+            "s3://bucket/path",
+            "{\"type\":\"struct\",\"fields\":[]}",
+            List.of(),
+            ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
+            Map.of());
+      }
+
+      @Override
+      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          Set<String> includeColumns,
+          SnapshotEnumerationOptions options) {
+        return List.of(
+            new SnapshotBundle(
+                42L,
+                0L,
+                Instant.now().toEpochMilli(),
+                null,
+                List.of(),
+                List.of(),
+                null,
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                Map.of()));
+      }
+
+      @Override
+      public Optional<SnapshotConstraints> snapshotConstraints(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          SnapshotBundle snapshotBundle) {
+        return Optional.of(
+            SnapshotConstraints.newBuilder()
+                .addConstraints(
+                    ConstraintDefinition.newBuilder()
+                        .setName("pk_tbl")
+                        .setType(ConstraintType.CT_PRIMARY_KEY)
+                        .build())
+                .build());
+      }
+    }
+
+    CapturingBackend backend = new CapturingBackend();
+    service.backend = backend;
+    service.connectorOpener =
+        cfg ->
+            new ConstraintsConnector() {
+              @Override
+              public List<SnapshotBundle> enumerateSnapshotsWithStats(
+                  String namespaceFq,
+                  String tableName,
+                  ResourceId destinationTableId,
+                  Set<String> includeColumns,
+                  SnapshotEnumerationOptions options) {
+                backend.capturedTargetSnapshotIds = options.targetSnapshotIds();
+                backend.capturedKnownSnapshotIds = options.knownSnapshotIds();
+                return super.enumerateSnapshotsWithStats(
+                    namespaceFq, tableName, destinationTableId, includeColumns, options);
+              }
+            };
+
+    ReconcileScope scope =
+        ReconcileScope.of(List.of(List.of("dest_ns")), "tbl", List.of(), List.of(42L));
+    var result = service.reconcile(principal, connectorId, false, scope);
+
+    assertThat(result.ok()).isTrue();
+    assertThat(backend.capturedTargetSnapshotIds).containsExactly(42L);
+    assertThat(backend.capturedKnownSnapshotIds).containsExactly(42L);
+    assertThat(backend.putConstraintsSnapshotId).isEqualTo(42L);
+    assertThat(backend.putConstraints).isNotNull();
+    assertThat(backend.putConstraints.getConstraintsCount()).isEqualTo(1);
+    assertThat(backend.putConstraints.getConstraints(0).getName()).isEqualTo("pk_tbl");
+  }
+
+  @Test
+  void reconcileFailsWhenConnectorSnapshotConstraintsThrows() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("table-connector-throw")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    class Backend extends DefaultBackend {
+      int putConstraintsCalls = 0;
+
+      @Override
+      public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+        return activeConnector();
+      }
+
+      @Override
+      public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+        return "dest_cat";
+      }
+
+      @Override
+      public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+        return "dest_ns";
+      }
+
+      @Override
+      public ResourceId ensureTable(
+          ReconcileContext ctx,
+          ResourceId namespaceId,
+          NameRef table,
+          TableSpecDescriptor descriptor) {
+        return tableId;
+      }
+
+      @Override
+      public Optional<Snapshot> fetchSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return Optional.empty();
+      }
+
+      @Override
+      public void ingestSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, Snapshot snapshot) {}
+
+      @Override
+      public boolean statsAlreadyCaptured(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return false;
+      }
+
+      @Override
+      public void putSnapshotConstraints(
+          ReconcileContext ctx,
+          ResourceId ignoredTableId,
+          long snapshotId,
+          SnapshotConstraints constraints) {
+        putConstraintsCalls++;
+      }
+
+      @Override
+      public void updateConnectorDestination(
+          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
+    }
+
+    class ThrowingConnector extends FakeConnector {
+      ThrowingConnector() {
+        super(List.of());
+      }
+
+      @Override
+      public List<String> listTables(String namespaceFq) {
+        return List.of("tbl");
+      }
+
+      @Override
+      public TableDescriptor describe(String namespaceFq, String tableName) {
+        return new TableDescriptor(
+            namespaceFq,
+            tableName,
+            "s3://bucket/path",
+            "{\"type\":\"struct\",\"fields\":[]}",
+            List.of(),
+            ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
+            Map.of());
+      }
+
+      @Override
+      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          Set<String> includeColumns,
+          SnapshotEnumerationOptions options) {
+        return List.of(
+            new SnapshotBundle(
+                101L,
+                0L,
+                Instant.now().toEpochMilli(),
+                null,
+                List.of(),
+                List.of(),
+                null,
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                Map.of()));
+      }
+
+      @Override
+      public Optional<SnapshotConstraints> snapshotConstraints(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          SnapshotBundle snapshotBundle) {
+        throw new RuntimeException("connector-constraints-fail");
+      }
+    }
+
+    Backend backend = new Backend();
+    service.backend = backend;
+    service.connectorOpener = cfg -> new ThrowingConnector();
+
+    var result = service.reconcile(principal, connectorId, false, null);
+
+    assertThat(result.ok()).isFalse();
+    assertThat(result.errors).isEqualTo(1);
+    assertThat(result.error).isNotNull();
+    assertThat(result.error.getMessage()).contains("connector-constraints-fail");
+    assertThat(backend.putConstraintsCalls).isZero();
+  }
+
+  @Test
+  void reconcileFailsWhenBackendPutSnapshotConstraintsThrows() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("table-backend-throw")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    class Backend extends DefaultBackend {
+      @Override
+      public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+        return activeConnector();
+      }
+
+      @Override
+      public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+        return "dest_cat";
+      }
+
+      @Override
+      public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+        return "dest_ns";
+      }
+
+      @Override
+      public ResourceId ensureTable(
+          ReconcileContext ctx,
+          ResourceId namespaceId,
+          NameRef table,
+          TableSpecDescriptor descriptor) {
+        return tableId;
+      }
+
+      @Override
+      public Optional<Snapshot> fetchSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return Optional.empty();
+      }
+
+      @Override
+      public void ingestSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, Snapshot snapshot) {}
+
+      @Override
+      public boolean statsAlreadyCaptured(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return false;
+      }
+
+      @Override
+      public void putSnapshotConstraints(
+          ReconcileContext ctx,
+          ResourceId ignoredTableId,
+          long snapshotId,
+          SnapshotConstraints constraints) {
+        throw new RuntimeException("backend-constraints-fail");
+      }
+
+      @Override
+      public void updateConnectorDestination(
+          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
+    }
+
+    class ConstraintsConnector extends FakeConnector {
+      ConstraintsConnector() {
+        super(List.of());
+      }
+
+      @Override
+      public List<String> listTables(String namespaceFq) {
+        return List.of("tbl");
+      }
+
+      @Override
+      public TableDescriptor describe(String namespaceFq, String tableName) {
+        return new TableDescriptor(
+            namespaceFq,
+            tableName,
+            "s3://bucket/path",
+            "{\"type\":\"struct\",\"fields\":[]}",
+            List.of(),
+            ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
+            Map.of());
+      }
+
+      @Override
+      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          Set<String> includeColumns,
+          SnapshotEnumerationOptions options) {
+        return List.of(
+            new SnapshotBundle(
+                102L,
+                0L,
+                Instant.now().toEpochMilli(),
+                null,
+                List.of(),
+                List.of(),
+                null,
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                Map.of()));
+      }
+
+      @Override
+      public Optional<SnapshotConstraints> snapshotConstraints(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          SnapshotBundle snapshotBundle) {
+        return Optional.of(
+            SnapshotConstraints.newBuilder()
+                .addConstraints(
+                    ConstraintDefinition.newBuilder()
+                        .setName("pk_backend")
+                        .setType(ConstraintType.CT_PRIMARY_KEY)
+                        .build())
+                .build());
+      }
+    }
+
+    service.backend = new Backend();
+    service.connectorOpener = cfg -> new ConstraintsConnector();
+
+    var result = service.reconcile(principal, connectorId, false, null);
+
+    assertThat(result.ok()).isFalse();
+    assertThat(result.errors).isEqualTo(1);
+    assertThat(result.error).isNotNull();
+    assertThat(result.error.getMessage()).contains("backend-constraints-fail");
+  }
+
+  @Test
+  void reconcileSucceedsWhenConnectorReturnsEmptySnapshotConstraints() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("table-no-constraints")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    class Backend extends DefaultBackend {
+      int putConstraintsCalls = 0;
+
+      @Override
+      public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+        return activeConnector();
+      }
+
+      @Override
+      public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+        return "dest_cat";
+      }
+
+      @Override
+      public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+        return "dest_ns";
+      }
+
+      @Override
+      public ResourceId ensureTable(
+          ReconcileContext ctx,
+          ResourceId namespaceId,
+          NameRef table,
+          TableSpecDescriptor descriptor) {
+        return tableId;
+      }
+
+      @Override
+      public Optional<Snapshot> fetchSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return Optional.empty();
+      }
+
+      @Override
+      public void ingestSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, Snapshot snapshot) {}
+
+      @Override
+      public boolean statsAlreadyCaptured(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return false;
+      }
+
+      @Override
+      public void putSnapshotConstraints(
+          ReconcileContext ctx,
+          ResourceId ignoredTableId,
+          long snapshotId,
+          SnapshotConstraints constraints) {
+        putConstraintsCalls++;
+      }
+
+      @Override
+      public void updateConnectorDestination(
+          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
+    }
+
+    class EmptyConstraintsConnector extends FakeConnector {
+      EmptyConstraintsConnector() {
+        super(List.of());
+      }
+
+      @Override
+      public List<String> listTables(String namespaceFq) {
+        return List.of("tbl");
+      }
+
+      @Override
+      public TableDescriptor describe(String namespaceFq, String tableName) {
+        return new TableDescriptor(
+            namespaceFq,
+            tableName,
+            "s3://bucket/path",
+            "{\"type\":\"struct\",\"fields\":[]}",
+            List.of(),
+            ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
+            Map.of());
+      }
+
+      @Override
+      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          Set<String> includeColumns,
+          SnapshotEnumerationOptions options) {
+        return List.of(
+            new SnapshotBundle(
+                103L,
+                0L,
+                Instant.now().toEpochMilli(),
+                null,
+                List.of(),
+                List.of(),
+                null,
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                Map.of()));
+      }
+
+      @Override
+      public Optional<SnapshotConstraints> snapshotConstraints(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          SnapshotBundle snapshotBundle) {
+        return Optional.empty();
+      }
+    }
+
+    Backend backend = new Backend();
+    service.backend = backend;
+    service.connectorOpener = cfg -> new EmptyConstraintsConnector();
+
+    var result = service.reconcile(principal, connectorId, false, null);
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.errors).isZero();
+    assertThat(backend.putConstraintsCalls).isZero();
+  }
+
+  @Test
+  void reconcileFailsWhenStatsAlreadyCapturedAndConstraintWriteFails() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("table-stats-captured-constraints-fail")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    class Backend extends DefaultBackend {
+      int putTableStatsCalls = 0;
+      int putColumnStatsCalls = 0;
+      int putFileColumnStatsCalls = 0;
+
+      @Override
+      public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+        return activeConnector();
+      }
+
+      @Override
+      public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+        return "dest_cat";
+      }
+
+      @Override
+      public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+        return "dest_ns";
+      }
+
+      @Override
+      public ResourceId ensureTable(
+          ReconcileContext ctx,
+          ResourceId namespaceId,
+          NameRef table,
+          TableSpecDescriptor descriptor) {
+        return tableId;
+      }
+
+      @Override
+      public Optional<Snapshot> fetchSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return Optional.empty();
+      }
+
+      @Override
+      public void ingestSnapshot(
+          ReconcileContext ctx, ResourceId ignoredTableId, Snapshot snapshot) {}
+
+      @Override
+      public boolean statsAlreadyCaptured(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return true;
+      }
+
+      @Override
+      public void putTableStats(ReconcileContext ctx, ResourceId ignoredTableId, TableStats stats) {
+        putTableStatsCalls++;
+      }
+
+      @Override
+      public void putColumnStats(ReconcileContext ctx, List<ColumnStats> stats) {
+        putColumnStatsCalls++;
+      }
+
+      @Override
+      public void putFileColumnStats(ReconcileContext ctx, List<FileColumnStats> stats) {
+        putFileColumnStatsCalls++;
+      }
+
+      @Override
+      public void putSnapshotConstraints(
+          ReconcileContext ctx,
+          ResourceId ignoredTableId,
+          long snapshotId,
+          SnapshotConstraints constraints) {
+        throw new RuntimeException("stats-captured-constraints-fail");
+      }
+
+      @Override
+      public void updateConnectorDestination(
+          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
+    }
+
+    class ConstraintsConnector extends FakeConnector {
+      ConstraintsConnector() {
+        super(List.of());
+      }
+
+      @Override
+      public List<String> listTables(String namespaceFq) {
+        return List.of("tbl");
+      }
+
+      @Override
+      public TableDescriptor describe(String namespaceFq, String tableName) {
+        return new TableDescriptor(
+            namespaceFq,
+            tableName,
+            "s3://bucket/path",
+            "{\"type\":\"struct\",\"fields\":[]}",
+            List.of(),
+            ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
+            Map.of());
+      }
+
+      @Override
+      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          Set<String> includeColumns,
+          SnapshotEnumerationOptions options) {
+        return List.of(
+            new SnapshotBundle(
+                104L,
+                0L,
+                Instant.now().toEpochMilli(),
+                TableStats.newBuilder().setSnapshotId(104L).build(),
+                List.of(),
+                List.of(),
+                null,
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                Map.of()));
+      }
+
+      @Override
+      public Optional<SnapshotConstraints> snapshotConstraints(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          SnapshotBundle snapshotBundle) {
+        return Optional.of(
+            SnapshotConstraints.newBuilder()
+                .addConstraints(
+                    ConstraintDefinition.newBuilder()
+                        .setName("pk_stats_captured")
+                        .setType(ConstraintType.CT_PRIMARY_KEY)
+                        .build())
+                .build());
+      }
+    }
+
+    Backend backend = new Backend();
+    service.backend = backend;
+    service.connectorOpener = cfg -> new ConstraintsConnector();
+
+    var result = service.reconcile(principal, connectorId, false, null);
+
+    assertThat(result.ok()).isFalse();
+    assertThat(result.errors).isEqualTo(1);
+    assertThat(result.error).isNotNull();
+    assertThat(result.error.getMessage()).contains("stats-captured-constraints-fail");
+    assertThat(backend.putTableStatsCalls).isZero();
+    assertThat(backend.putColumnStatsCalls).isZero();
+    assertThat(backend.putFileColumnStatsCalls).isZero();
   }
 
   private static final class ThrowingBackend extends DefaultBackend {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -27,9 +27,9 @@ import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.model.TableStatsKey;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
-import ai.floedb.floecat.service.repo.util.ResourceHash;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
+import ai.floedb.floecat.types.Hashing;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -408,7 +408,7 @@ public class StatsRepository {
     do {
       List<ColumnStats> page = columnStatsRepo.listByPrefix(colPrefix, 200, token, next);
       for (ColumnStats cs : page) {
-        String sha = ResourceHash.sha256Hex(cs.toByteArray());
+        String sha = Hashing.sha256Hex(cs.toByteArray());
         ColumnStatsKey key =
             new ColumnStatsKey(
                 cs.getTableId().getAccountId(),
@@ -430,7 +430,7 @@ public class StatsRepository {
     do {
       List<FileColumnStats> page = fileStatsRepo.listByPrefix(filePrefix, 200, token, next);
       for (FileColumnStats fs : page) {
-        String sha = ResourceHash.sha256Hex(fs.toByteArray());
+        String sha = Hashing.sha256Hex(fs.toByteArray());
         FileColumnStatsKey key =
             new FileColumnStatsKey(
                 fs.getTableId().getAccountId(),

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Schemas.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Schemas.java
@@ -29,10 +29,10 @@ import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.service.repo.util.ColumnStatsNormalizer;
 import ai.floedb.floecat.service.repo.util.ConstraintNormalizer;
-import ai.floedb.floecat.service.repo.util.ResourceHash;
 import ai.floedb.floecat.service.repo.util.TableStatsNormalizer;
 import ai.floedb.floecat.transaction.rpc.Transaction;
 import ai.floedb.floecat.transaction.rpc.TransactionIntent;
+import ai.floedb.floecat.types.Hashing;
 import com.google.protobuf.util.Timestamps;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,7 +47,7 @@ public final class Schemas {
               key -> Keys.accountBlobUri(key.accountId(), key.sha256()),
               v -> Map.of("byName", Keys.accountPointerByName(v.getDisplayName())),
               v -> {
-                var sha = ResourceHash.sha256Hex(v.toByteArray());
+                var sha = Hashing.sha256Hex(v.toByteArray());
                 return new AccountKey(v.getResourceId().getId(), sha);
               })
           .withCasBlobs();
@@ -63,7 +63,7 @@ public final class Schemas {
                       Keys.catalogPointerByName(
                           v.getResourceId().getAccountId(), v.getDisplayName())),
               v -> {
-                var sha = ResourceHash.sha256Hex(v.toByteArray());
+                var sha = Hashing.sha256Hex(v.toByteArray());
                 return new CatalogKey(
                     v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
               })
@@ -83,7 +83,7 @@ public final class Schemas {
                         v.getResourceId().getAccountId(), v.getCatalogId().getId(), fullPath));
               },
               v -> {
-                var sha = ResourceHash.sha256Hex(v.toByteArray());
+                var sha = Hashing.sha256Hex(v.toByteArray());
                 return new NamespaceKey(
                     v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
               })
@@ -103,7 +103,7 @@ public final class Schemas {
                           v.getNamespaceId().getId(),
                           v.getDisplayName())),
               v -> {
-                var sha = ResourceHash.sha256Hex(v.toByteArray());
+                var sha = Hashing.sha256Hex(v.toByteArray());
                 return new TableKey(
                     v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
               })
@@ -128,7 +128,7 @@ public final class Schemas {
                               v.getTableId().getAccountId(), v.getTableId().getId(),
                               v.getSnapshotId(), Timestamps.toMillis(v.getUpstreamCreatedAt()))),
               v -> {
-                var sha = ResourceHash.sha256Hex(v.toByteArray());
+                var sha = Hashing.sha256Hex(v.toByteArray());
                 return new SnapshotKey(
                     v.getTableId().getAccountId(), v.getTableId().getId(), v.getSnapshotId(), sha);
               })
@@ -144,7 +144,7 @@ public final class Schemas {
               (TableStats v) -> Map.of(),
               (TableStats v) -> {
                 var norm = TableStatsNormalizer.normalize(v);
-                var sha = ResourceHash.sha256Hex(norm.toByteArray());
+                var sha = Hashing.sha256Hex(norm.toByteArray());
                 return new TableStatsKey(
                     v.getTableId().getAccountId(), v.getTableId().getId(), v.getSnapshotId(), sha);
               })
@@ -162,7 +162,7 @@ public final class Schemas {
               (ColumnStats v) -> Map.of(),
               (ColumnStats v) -> {
                 var norm = ColumnStatsNormalizer.normalize(v);
-                var sha = ResourceHash.sha256Hex(norm.toByteArray());
+                var sha = Hashing.sha256Hex(norm.toByteArray());
                 return new ColumnStatsKey(
                     v.getTableId().getAccountId(),
                     v.getTableId().getId(),
@@ -184,7 +184,7 @@ public final class Schemas {
               v -> Map.of(),
               v -> {
                 var bytes = v.toByteArray();
-                var sha = ResourceHash.sha256Hex(bytes);
+                var sha = Hashing.sha256Hex(bytes);
                 return new FileColumnStatsKey(
                     v.getTableId().getAccountId(),
                     v.getTableId().getId(),
@@ -213,7 +213,7 @@ public final class Schemas {
                               v.getSnapshotId())),
                   (SnapshotConstraints v) -> {
                     var norm = ConstraintNormalizer.normalize(v);
-                    var sha = ResourceHash.sha256Hex(norm.toByteArray());
+                    var sha = Hashing.sha256Hex(norm.toByteArray());
                     return new SnapshotConstraintsKey(
                         v.getTableId().getAccountId(),
                         v.getTableId().getId(),
@@ -236,7 +236,7 @@ public final class Schemas {
                           v.getNamespaceId().getId(),
                           v.getDisplayName())),
               v -> {
-                var sha = ResourceHash.sha256Hex(v.toByteArray());
+                var sha = Hashing.sha256Hex(v.toByteArray());
                 return new ViewKey(
                     v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
               })
@@ -253,7 +253,7 @@ public final class Schemas {
                       Keys.connectorPointerByName(
                           v.getResourceId().getAccountId(), v.getDisplayName())),
               v -> {
-                var sha = ResourceHash.sha256Hex(v.toByteArray());
+                var sha = Hashing.sha256Hex(v.toByteArray());
                 return new ConnectorKey(
                     v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
               })
@@ -266,7 +266,7 @@ public final class Schemas {
               key -> Keys.transactionBlobUri(key.accountId(), key.txId(), key.sha256()),
               v -> Map.of(),
               v -> {
-                var sha = ResourceHash.sha256Hex(v.toByteArray());
+                var sha = Hashing.sha256Hex(v.toByteArray());
                 return new TransactionKey(v.getAccountId(), v.getTxId(), sha);
               })
           .withCasBlobs();
@@ -282,7 +282,7 @@ public final class Schemas {
                       Keys.transactionIntentPointerByTx(
                           v.getAccountId(), v.getTxId(), v.getTargetPointerKey())),
               v -> {
-                var sha = ResourceHash.sha256Hex(v.toByteArray());
+                var sha = Hashing.sha256Hex(v.toByteArray());
                 return new TransactionIntentKey(
                     v.getAccountId(), v.getTxId(), v.getTargetPointerKey(), sha);
               })

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/ColumnStatsNormalizer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/ColumnStatsNormalizer.java
@@ -20,6 +20,7 @@ import ai.floedb.floecat.catalog.rpc.ColumnStats;
 import ai.floedb.floecat.catalog.rpc.Ndv;
 import ai.floedb.floecat.catalog.rpc.NdvApprox;
 import ai.floedb.floecat.catalog.rpc.NdvSketch;
+import ai.floedb.floecat.types.Hashing;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -74,9 +75,7 @@ public final class ColumnStatsNormalizer {
                 .thenComparingInt(s -> s.getData().isEmpty() ? -1 : s.getData().size())
                 .thenComparing(
                     s ->
-                        s.getData().isEmpty()
-                            ? null
-                            : ResourceHash.sha256Hex(s.getData().toByteArray()),
+                        s.getData().isEmpty() ? null : Hashing.sha256Hex(s.getData().toByteArray()),
                     Comparator.nullsFirst(Comparator.naturalOrder()));
         sketches.sort(sketchCmp);
         ndv.clearSketches();

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
@@ -30,7 +30,6 @@ import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository.PreconditionFailedException;
-import ai.floedb.floecat.service.repo.util.ResourceHash;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.storage.spi.BlobStore;
@@ -50,6 +49,7 @@ import ai.floedb.floecat.transaction.rpc.TransactionIntent;
 import ai.floedb.floecat.transaction.rpc.TransactionState;
 import ai.floedb.floecat.transaction.rpc.Transactions;
 import ai.floedb.floecat.transaction.rpc.TxChange;
+import ai.floedb.floecat.types.Hashing;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import io.quarkus.grpc.GrpcService;
@@ -672,14 +672,14 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         if (!tablePayload.getResourceId().getAccountId().equals(accountId)) {
           throw new IllegalArgumentException("table payload account mismatch for target");
         }
-        String sha = ResourceHash.sha256Hex(tablePayload.toByteArray());
+        String sha = Hashing.sha256Hex(tablePayload.toByteArray());
         blobUri = Keys.tableBlobUri(accountId, tableId.getId(), sha);
         inlineBytes = tablePayload.toByteArray();
         inlineContentType = "application/x-protobuf";
       }
       case PAYLOAD -> {
         byte[] payload = change.getPayload().toByteArray();
-        String sha = ResourceHash.sha256Hex(payload);
+        String sha = Hashing.sha256Hex(payload);
         blobUri = Keys.transactionObjectBlobUri(accountId, txId, sha);
         inlineBytes = payload;
         inlineContentType = "application/octet-stream";
@@ -727,12 +727,12 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         if (!tablePayload.getResourceId().getAccountId().equals(accountId)) {
           throw new IllegalArgumentException("table payload account mismatch for target");
         }
-        String sha = ResourceHash.sha256Hex(tablePayload.toByteArray());
+        String sha = Hashing.sha256Hex(tablePayload.toByteArray());
         blobUri = Keys.tableBlobUri(accountId, tableId.getId(), sha);
       }
       case PAYLOAD -> {
         byte[] payload = change.getPayload().toByteArray();
-        String sha = ResourceHash.sha256Hex(payload);
+        String sha = Hashing.sha256Hex(payload);
         blobUri = Keys.transactionObjectBlobUri(accountId, txId, sha);
       }
       case CHANGEPAYLOAD_NOT_SET -> {

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionGcTest.java
@@ -21,12 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.service.gc.TransactionGc;
 import ai.floedb.floecat.service.repo.model.Keys;
-import ai.floedb.floecat.service.repo.util.ResourceHash;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.transaction.rpc.Transaction;
 import ai.floedb.floecat.transaction.rpc.TransactionIntent;
 import ai.floedb.floecat.transaction.rpc.TransactionState;
+import ai.floedb.floecat.types.Hashing;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import java.lang.reflect.Field;
@@ -51,7 +51,7 @@ class TransactionGcTest {
             .setCreatedAt(now())
             .setUpdatedAt(now())
             .build();
-    var txSha = ResourceHash.sha256Hex(tx.toByteArray());
+    var txSha = Hashing.sha256Hex(tx.toByteArray());
     var txBlob = Keys.transactionBlobUri(accountId, txId, txSha);
     blobs.put(txBlob, tx.toByteArray(), "application/x-protobuf");
     String txPtr = Keys.transactionPointerById(accountId, txId);
@@ -67,7 +67,7 @@ class TransactionGcTest {
             .setExpectedVersion(1L)
             .setCreatedAt(now())
             .build();
-    var intentSha = ResourceHash.sha256Hex(intent.toByteArray());
+    var intentSha = Hashing.sha256Hex(intent.toByteArray());
     var intentBlob = Keys.transactionIntentBlobUri(accountId, txId, intentSha);
     blobs.put(intentBlob, intent.toByteArray(), "application/x-protobuf");
 
@@ -279,7 +279,7 @@ class TransactionGcTest {
             .setUpdatedAt(now())
             .setExpiresAt(expiresAt)
             .build();
-    var txSha = ResourceHash.sha256Hex(tx.toByteArray());
+    var txSha = Hashing.sha256Hex(tx.toByteArray());
     var txBlob = Keys.transactionBlobUri(accountId, txId, txSha);
     blobs.put(txBlob, tx.toByteArray(), "application/x-protobuf");
     String txPtr = Keys.transactionPointerById(accountId, txId);
@@ -315,7 +315,7 @@ class TransactionGcTest {
             .setExpectedVersion(1L)
             .setCreatedAt(now())
             .build();
-    var intentSha = ResourceHash.sha256Hex(intent.toByteArray());
+    var intentSha = Hashing.sha256Hex(intent.toByteArray());
     var intentBlob = Keys.transactionIntentBlobUri(accountId, txId, intentSha);
     blobs.put(intentBlob, intent.toByteArray(), "application/x-protobuf");
     return intentBlob;


### PR DESCRIPTION
## Summary

Add snapshot constraint ingestion to the reconciler, including connector SPI, backend support, and idempotent writes.

Constraints (PK, FK, UNIQUE, CHECK, NOT NULL) are now extracted per snapshot from connectors and written via `PutTableConstraints`. This is integrated into the existing reconcile flow alongside stats ingestion.

Close: https://github.com/eng-floe/floecat/issues/218 

### Key Changes

- **Connector SPI (additive)**
  - Add `snapshotConstraints(...)` with default no-op implementation

- **Reconciler**
  - Extract and ingest constraints per snapshot
  - Execute both in normal stats path and `statsAlreadyCaptured` fast path
  - Fail reconcile on constraint extraction or write errors (not best-effort)

- **Backend**
  - Add `putSnapshotConstraints(...)` (default no-op)
  - Implement gRPC call via `TableConstraintsService`

- **Idempotency**
  - Requests include idempotency key based on `(table, snapshot, sha256(payload bytes))`

- **Refactor**
  - Move hashing utility to shared `core/types` module

### Behavior

- Constraints are written per `(table_id, snapshot_id)`
- Writes are repeatable (reconciler may resend same payload)
- Empty constraints → no-op
- Failures in connector or backend **fail reconcile**
- Idempotency is **byte-based and order-sensitive** (no semantic normalization)

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

### New tests
- Connector SPI compatibility
- Idempotency key stability and change detection
- Reconciler success + failure paths:
  - connector failure
  - backend failure
  - empty constraints
  - stats-already-captured path
  - 
## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
