### PR TITLE
Add connector implementation for constraints ingestion

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
@@ -17,8 +17,13 @@
 package ai.floedb.floecat.connector.delta.uc.impl;
 
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintEnforcement;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
 import ai.floedb.floecat.catalog.rpc.FileContent;
 import ai.floedb.floecat.catalog.rpc.PartitionSpecInfo;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.catalog.rpc.TableStats;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -28,6 +33,7 @@ import ai.floedb.floecat.connector.common.StatsEngine;
 import ai.floedb.floecat.connector.common.ndv.NdvProvider;
 import ai.floedb.floecat.connector.common.ndv.ParquetNdvProvider;
 import ai.floedb.floecat.connector.common.ndv.SamplingNdvProvider;
+import ai.floedb.floecat.connector.common.resolver.ColumnIdComputer;
 import ai.floedb.floecat.connector.common.resolver.LogicalSchemaMapper;
 import ai.floedb.floecat.connector.spi.ConnectorFormat;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
@@ -36,13 +42,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.Table;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -51,6 +60,7 @@ import org.apache.parquet.io.InputFile;
 abstract class DeltaConnector implements FloecatConnector {
 
   protected static final ObjectMapper M = new ObjectMapper();
+  private static final String DELTA_CHECK_CONSTRAINT_PREFIX = "delta.constraints.";
 
   private final String connectorId;
   protected final Engine engine;
@@ -142,7 +152,67 @@ abstract class DeltaConnector implements FloecatConnector {
   @Override
   public void close() {}
 
+  @Override
+  public Optional<SnapshotConstraints> snapshotConstraints(
+      String namespaceFq, String tableName, ResourceId destinationTableId, long snapshotId) {
+    if (snapshotId < 0) {
+      return Optional.empty();
+    }
+    final String tableRoot = storageLocation(namespaceFq, tableName);
+    final Table table = loadTable(tableRoot);
+    Snapshot snapshot = table.getSnapshotAsOfVersion(engine, snapshotId);
+    if (snapshot == null) {
+      return Optional.empty();
+    }
+    Map<String, String> tableProperties =
+        mergeConstraintProperties(
+            fallbackTablePropertiesForConstraints(namespaceFq, tableName),
+            snapshotTableProperties(snapshot));
+    List<ConstraintDefinition> constraints =
+        mapDeltaConstraints(snapshot.getSchema(), tableProperties);
+    if (constraints.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        SnapshotConstraints.newBuilder()
+            .setTableId(destinationTableId)
+            .setSnapshotId(snapshotId)
+            .addAllConstraints(constraints)
+            .build());
+  }
+
   protected abstract String storageLocation(String namespaceFq, String tableName);
+
+  /**
+   * Snapshot-scoped properties used for constraint extraction.
+   *
+   * <p>Default behavior reads Delta snapshot metadata when available.
+   */
+  protected Map<String, String> snapshotTableProperties(Snapshot snapshot) {
+    return extractTableProperties(snapshot);
+  }
+
+  /**
+   * Best-effort catalog-level fallback when snapshot metadata does not expose properties.
+   *
+   * <p>Returned values are merged with {@link #snapshotTableProperties(Snapshot)}. Snapshot
+   * properties win on key collisions.
+   */
+  protected Map<String, String> fallbackTablePropertiesForConstraints(
+      String namespaceFq, String tableName) {
+    return Map.of();
+  }
+
+  private static Map<String, String> mergeConstraintProperties(
+      Map<String, String> fallbackProperties, Map<String, String> snapshotProperties) {
+    if (fallbackProperties.isEmpty() && snapshotProperties.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, String> merged = new LinkedHashMap<>(fallbackProperties);
+    // Snapshot metadata is preferred when both sources expose the same property key.
+    merged.putAll(snapshotProperties);
+    return Map.copyOf(merged);
+  }
 
   protected Table loadTable(String tableRoot) {
     return Table.forPath(engine, tableRoot);
@@ -262,6 +332,31 @@ abstract class DeltaConnector implements FloecatConnector {
       versions.add(version);
     }
     return List.copyOf(versions);
+  }
+
+  static List<ConstraintDefinition> mapDeltaConstraints(StructType schema) {
+    return mapDeltaConstraints(schema, Map.of());
+  }
+
+  static List<ConstraintDefinition> mapDeltaConstraints(
+      StructType schema, Map<String, String> tableProperties) {
+    if (schema == null) {
+      return List.of();
+    }
+    // Compute path → ordinal map so NOT NULL constraints carry stable CID_PATH_ORDINAL column IDs,
+    // consistent with how column stats are keyed for Delta tables.
+    Map<String, Integer> ordinals = Map.of();
+    try {
+      ordinals =
+          LogicalSchemaMapper.buildColumnOrdinals(
+              ColumnIdAlgorithm.CID_PATH_ORDINAL, TableFormat.TF_DELTA, schema.toJson());
+    } catch (Exception ignored) {
+      // Fall back to columnId=0 if schema JSON conversion fails.
+    }
+    List<ConstraintDefinition> out = new ArrayList<>();
+    collectDeltaNotNullConstraints(schema.fields(), "", out, ordinals);
+    out.addAll(mapDeltaCheckConstraints(tableProperties));
+    return List.copyOf(out);
   }
 
   private SnapshotBundle buildSnapshotBundle(
@@ -403,5 +498,81 @@ abstract class DeltaConnector implements FloecatConnector {
               .build());
     }
     return builder.build();
+  }
+
+  private static void collectDeltaNotNullConstraints(
+      List<StructField> fields,
+      String prefix,
+      List<ConstraintDefinition> out,
+      Map<String, Integer> ordinals) {
+    for (StructField field : fields) {
+      String path = prefix.isEmpty() ? field.getName() : prefix + "." + field.getName();
+      boolean fieldIsNonNull = !field.isNullable();
+      boolean isStruct = field.getDataType() instanceof StructType;
+      if (fieldIsNonNull && !isStruct) {
+        int ordinal = ordinals.getOrDefault(path, 0);
+        long columnId =
+            (ordinal > 0)
+                ? ColumnIdComputer.compute(
+                    ColumnIdAlgorithm.CID_PATH_ORDINAL, path, null, ordinal, 0)
+                : 0L;
+        // Name encodes columnId when available (stable for column renames iff path+ordinal
+        // unchanged — same invariant as the column_id itself), or path for nested struct leaves
+        // where no stable ID is computable without catalog support.
+        String constraintName = (columnId != 0L) ? "nn_" + columnId : "nn_" + path;
+        out.add(
+            ConstraintDefinition.newBuilder()
+                .setName(constraintName)
+                .setType(ConstraintType.CT_NOT_NULL)
+                .setEnforcement(ConstraintEnforcement.CE_ENFORCED)
+                .addColumns(
+                    ConstraintColumnRef.newBuilder()
+                        .setColumnId(columnId)
+                        .setColumnName(path)
+                        .setOrdinal(1)
+                        .build())
+                .build());
+      }
+      if (isStruct && fieldIsNonNull) {
+        // Only descend into a struct when the struct itself is non-nullable; a non-nullable child
+        // inside a nullable parent struct is conditionally present, not flat-relational NOT NULL.
+        collectDeltaNotNullConstraints(
+            ((StructType) field.getDataType()).fields(), path, out, ordinals);
+      }
+    }
+  }
+
+  private static List<ConstraintDefinition> mapDeltaCheckConstraints(
+      Map<String, String> tableProperties) {
+    if (tableProperties == null || tableProperties.isEmpty()) {
+      return List.of();
+    }
+    List<ConstraintDefinition> checks = new ArrayList<>();
+    tableProperties.entrySet().stream()
+        .filter(e -> e.getKey() != null && e.getKey().startsWith(DELTA_CHECK_CONSTRAINT_PREFIX))
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            e -> {
+              String name = e.getKey().substring(DELTA_CHECK_CONSTRAINT_PREFIX.length()).trim();
+              String expression = e.getValue() == null ? "" : e.getValue().trim();
+              if (name.isEmpty() || expression.isEmpty()) {
+                return;
+              }
+              checks.add(
+                  ConstraintDefinition.newBuilder()
+                      .setName(name)
+                      .setType(ConstraintType.CT_CHECK)
+                      .setCheckExpression(expression)
+                      .setEnforcement(ConstraintEnforcement.CE_ENFORCED)
+                      .build());
+            });
+    return List.copyOf(checks);
+  }
+
+  private static Map<String, String> extractTableProperties(Snapshot snapshot) {
+    if (snapshot instanceof SnapshotImpl snapshotImpl && snapshotImpl.getMetadata() != null) {
+      return snapshotImpl.getMetadata().getConfiguration();
+    }
+    return Map.of();
   }
 }

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaGlueConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaGlueConnector.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.connector.delta.uc.impl;
 
 import io.delta.kernel.engine.Engine;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import org.apache.parquet.io.InputFile;
 
@@ -56,6 +57,16 @@ final class DeltaGlueConnector extends DeltaConnector {
   @Override
   protected String storageLocation(String namespaceFq, String tableName) {
     return glueCatalog.storageLocation(namespaceFq, tableName);
+  }
+
+  @Override
+  protected Map<String, String> fallbackTablePropertiesForConstraints(
+      String namespaceFq, String tableName) {
+    try {
+      return glueCatalog.tableParameters(namespaceFq, tableName);
+    } catch (RuntimeException ignored) {
+      return Map.of();
+    }
   }
 
   @Override

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/GlueDeltaCatalog.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/GlueDeltaCatalog.java
@@ -94,6 +94,16 @@ final class GlueDeltaCatalog implements AutoCloseable {
     return location;
   }
 
+  Map<String, String> tableParameters(String namespace, String tableName) {
+    var response =
+        glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
+    var table = response.table();
+    if (table == null || table.parameters() == null) {
+      return Map.of();
+    }
+    return table.parameters();
+  }
+
   @Override
   public void close() {
     try {

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnector.java
@@ -158,6 +158,22 @@ public final class UnityDeltaConnector extends DeltaConnector {
   }
 
   @Override
+  protected Map<String, String> fallbackTablePropertiesForConstraints(
+      String namespaceFq, String tableName) {
+    try {
+      String full = namespaceFq + "." + tableName;
+      var response = ucHttp.get("/api/2.1/unity-catalog/tables/" + UcBaseSupport.url(full));
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        return Map.of();
+      }
+      JsonNode meta = M.readTree(response.body());
+      return extractConstraintProperties(meta);
+    } catch (Exception ignored) {
+      return Map.of();
+    }
+  }
+
+  @Override
   public List<String> listViews(String namespaceFq) {
     try {
       var tables = listTablesNode(namespaceFq);
@@ -314,6 +330,51 @@ public final class UnityDeltaConnector extends DeltaConnector {
   private static void putIfPresent(Map<String, String> props, JsonNode n, String field) {
     if (!n.path(field).isMissingNode()) {
       props.put(field, n.path(field).asText());
+    }
+  }
+
+  static Map<String, String> extractConstraintProperties(JsonNode tableMeta) {
+    if (tableMeta == null || tableMeta.isMissingNode()) {
+      return Map.of();
+    }
+    Map<String, String> out = new LinkedHashMap<>();
+    // UC exposes table properties in two shapes depending on the API version and table type:
+    // either a JSON object {"key": "value", ...} or a JSON array [{"key": ..., "value": ...}].
+    // Each parser handles one shape and no-ops on the other, so both are applied to each field.
+    collectStringMap(out, tableMeta.path("properties"));
+    collectStringMap(out, tableMeta.path("table_properties"));
+    collectKeyValueArray(out, tableMeta.path("properties"));
+    collectKeyValueArray(out, tableMeta.path("table_properties"));
+    return Map.copyOf(out);
+  }
+
+  private static void collectStringMap(Map<String, String> out, JsonNode node) {
+    if (node == null || !node.isObject()) {
+      return;
+    }
+    node.fields()
+        .forEachRemaining(
+            entry -> {
+              JsonNode value = entry.getValue();
+              if (value != null && value.isTextual() && !value.asText().isBlank()) {
+                out.put(entry.getKey(), value.asText());
+              }
+            });
+  }
+
+  private static void collectKeyValueArray(Map<String, String> out, JsonNode node) {
+    if (node == null || !node.isArray()) {
+      return;
+    }
+    for (JsonNode item : node) {
+      if (!item.isObject()) {
+        continue;
+      }
+      String key = item.path("key").asText(item.path("name").asText(""));
+      String value = item.path("value").asText("");
+      if (!key.isBlank() && !value.isBlank()) {
+        out.put(key, value);
+      }
     }
   }
 }

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
@@ -17,7 +17,10 @@
 package ai.floedb.floecat.connector.delta.uc.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
 import io.delta.kernel.Operation;
@@ -34,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
@@ -102,6 +106,66 @@ class DeltaConnectorTest {
     assertEquals(List.of(0L, 2000L, 3000L, 5000L), timestamps);
   }
 
+  @Test
+  void snapshotConstraintsUsesFallbackTablePropertiesWhenSnapshotPropertiesUnavailable() {
+    Snapshot latest = snapshot(7L, 7000L);
+    Table table = new StubTable(latest, Map.of(7L, latest));
+
+    TestDeltaConnector connector = new TestDeltaConnector(table);
+    connector.setFallbackTableProperties(Map.of("delta.constraints.ck_id_positive", "id > 0"));
+
+    Optional<SnapshotConstraints> constraints =
+        connector.snapshotConstraints("ns", "tbl", ResourceId.getDefaultInstance(), 7L);
+
+    assertTrue(constraints.isPresent());
+    assertEquals(1, constraints.get().getConstraintsCount());
+    assertEquals(ConstraintType.CT_CHECK, constraints.get().getConstraints(0).getType());
+    assertEquals("ck_id_positive", constraints.get().getConstraints(0).getName());
+  }
+
+  @Test
+  void snapshotConstraintsPrefersSnapshotPropertiesOverFallbackProperties() {
+    Snapshot latest = snapshot(8L, 8000L);
+    Table table = new StubTable(latest, Map.of(8L, latest));
+
+    TestDeltaConnector connector = new TestDeltaConnector(table);
+    connector.setSnapshotTableProperties(Map.of("delta.constraints.ck_snapshot", "id > 0"));
+    connector.setFallbackTableProperties(Map.of("delta.constraints.ck_fallback", "id < 100"));
+
+    Optional<SnapshotConstraints> constraints =
+        connector.snapshotConstraints("ns", "tbl", ResourceId.getDefaultInstance(), 8L);
+
+    assertTrue(constraints.isPresent());
+    assertEquals(2, constraints.get().getConstraintsCount());
+    assertEquals(
+        List.of("ck_fallback", "ck_snapshot"),
+        constraints.get().getConstraintsList().stream().map(c -> c.getName()).toList());
+    assertTrue(
+        connector.fallbackCalled.get(), "fallback source should be merged with snapshot metadata");
+  }
+
+  @Test
+  void snapshotConstraintsSnapshotExpressionWinsOnKeyCollision() {
+    // Same constraint name in both fallback and snapshot — snapshot expression must win.
+    Snapshot latest = snapshot(9L, 9000L);
+    Table table = new StubTable(latest, Map.of(9L, latest));
+
+    TestDeltaConnector connector = new TestDeltaConnector(table);
+    connector.setFallbackTableProperties(Map.of("delta.constraints.ck_amount", "amount > 0"));
+    connector.setSnapshotTableProperties(Map.of("delta.constraints.ck_amount", "amount >= 1"));
+
+    Optional<SnapshotConstraints> constraints =
+        connector.snapshotConstraints("ns", "tbl", ResourceId.getDefaultInstance(), 9L);
+
+    assertTrue(constraints.isPresent());
+    List<ai.floedb.floecat.catalog.rpc.ConstraintDefinition> checks =
+        constraints.get().getConstraintsList().stream()
+            .filter(c -> c.getType() == ai.floedb.floecat.catalog.rpc.ConstraintType.CT_CHECK)
+            .toList();
+    assertEquals(1, checks.size(), "duplicate key should produce exactly one CHECK constraint");
+    assertEquals("amount >= 1", checks.get(0).getCheckExpression(), "snapshot expression wins");
+  }
+
   private static Snapshot snapshot(long version, long timestampMs) {
     return new Snapshot() {
       @Override
@@ -138,6 +202,9 @@ class DeltaConnectorTest {
 
   private static final class TestDeltaConnector extends DeltaConnector {
     private final Table table;
+    private Map<String, String> snapshotTableProperties = Map.of();
+    private Map<String, String> fallbackTableProperties = Map.of();
+    private final AtomicBoolean fallbackCalled = new AtomicBoolean(false);
 
     TestDeltaConnector(Table table) {
       super("delta-test", null, path -> null, false, 0.0d, 0L);
@@ -155,6 +222,18 @@ class DeltaConnectorTest {
     }
 
     @Override
+    protected Map<String, String> snapshotTableProperties(Snapshot snapshot) {
+      return snapshotTableProperties;
+    }
+
+    @Override
+    protected Map<String, String> fallbackTablePropertiesForConstraints(
+        String namespaceFq, String tableName) {
+      fallbackCalled.set(true);
+      return fallbackTableProperties;
+    }
+
+    @Override
     public List<String> listTables(String namespaceFq) {
       return List.of();
     }
@@ -167,6 +246,14 @@ class DeltaConnectorTest {
     @Override
     public TableDescriptor describe(String namespaceFq, String tableName) {
       throw new UnsupportedOperationException();
+    }
+
+    void setSnapshotTableProperties(Map<String, String> snapshotTableProperties) {
+      this.snapshotTableProperties = snapshotTableProperties;
+    }
+
+    void setFallbackTableProperties(Map<String, String> fallbackTableProperties) {
+      this.fallbackTableProperties = fallbackTableProperties;
     }
   }
 

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConstraintMappingTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConstraintMappingTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.delta.uc.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintEnforcement;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DeltaConstraintMappingTest {
+
+  @Test
+  void mapDeltaConstraintsEmitsNotNullForNonNullableLeafColumns() {
+    StructType schema =
+        new StructType()
+            .add("id", LongType.LONG, false)
+            .add("name", StringType.STRING, true)
+            .add(
+                "address",
+                new StructType()
+                    .add("zip", StringType.STRING, false)
+                    .add("line2", StringType.STRING, true),
+                false);
+
+    List<ConstraintDefinition> constraints = DeltaConnector.mapDeltaConstraints(schema);
+
+    assertThat(constraints).allMatch(c -> c.getType() == ConstraintType.CT_NOT_NULL);
+    assertThat(constraints).allMatch(c -> c.getEnforcement() == ConstraintEnforcement.CE_ENFORCED);
+    assertThat(constraints).hasSize(2);
+    assertThat(constraints)
+        .extracting(c -> c.getColumns(0).getColumnName())
+        .containsExactlyInAnyOrder("id", "address.zip");
+    // Top-level non-nullable columns (e.g. "id") get a stable CID_PATH_ORDINAL column ID;
+    // nested columns inside a struct (e.g. "address.zip") get column_id=0 because Delta does
+    // not produce per-field statistics for nested struct leaves, so there is no stats entry to
+    // correlate with.
+    ConstraintDefinition idConstraint =
+        constraints.stream()
+            .filter(c -> c.getColumns(0).getColumnName().equals("id"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(idConstraint.getColumns(0).getColumnId())
+        .as("top-level non-nullable column should have a stable CID_PATH_ORDINAL column_id")
+        .isNotZero();
+  }
+
+  @Test
+  void mapDeltaConstraintsDoesNotEmitNotNullForNonNullableChildInsideNullableParentStruct() {
+    // address is nullable; zip inside address is non-nullable.
+    // nn_address.zip must NOT be emitted because address can be absent entirely.
+    StructType schema =
+        new StructType()
+            .add("id", LongType.LONG, false)
+            .add(
+                "address",
+                new StructType()
+                    .add("zip", StringType.STRING, false)
+                    .add("line2", StringType.STRING, true),
+                true); // address is nullable
+
+    List<ConstraintDefinition> constraints = DeltaConnector.mapDeltaConstraints(schema);
+
+    assertThat(constraints).allMatch(c -> c.getType() == ConstraintType.CT_NOT_NULL);
+    assertThat(constraints).hasSize(1);
+    assertThat(constraints.get(0).getColumns(0).getColumnName()).isEqualTo("id");
+    // address.zip must not appear
+    assertThat(constraints)
+        .extracting(c -> c.getColumns(0).getColumnName())
+        .doesNotContain("address.zip");
+  }
+
+  @Test
+  void mapDeltaConstraintsEmitsCheckConstraintsFromDeltaProperties() {
+    StructType schema = new StructType().add("amount", LongType.LONG, false);
+
+    List<ConstraintDefinition> constraints =
+        DeltaConnector.mapDeltaConstraints(
+            schema,
+            Map.of(
+                "delta.constraints.positive_amount", "amount > 0",
+                "delta.constraints.valid_amount", "amount < 1000",
+                "delta.appendOnly", "true"));
+
+    List<ConstraintDefinition> checks =
+        constraints.stream().filter(c -> c.getType() == ConstraintType.CT_CHECK).toList();
+    assertThat(checks).hasSize(2);
+    assertThat(checks)
+        .extracting(ConstraintDefinition::getName)
+        .containsExactly("positive_amount", "valid_amount");
+    assertThat(checks)
+        .extracting(ConstraintDefinition::getCheckExpression)
+        .containsExactly("amount > 0", "amount < 1000");
+    assertThat(checks).allMatch(c -> c.getEnforcement() == ConstraintEnforcement.CE_ENFORCED);
+  }
+
+  @Test
+  void mapDeltaCheckConstraintsIgnoresBlankConstraintName() {
+    // "delta.constraints. " has a whitespace-only name after the prefix — should be skipped.
+    StructType schema = new StructType().add("id", LongType.LONG, false);
+
+    List<ConstraintDefinition> constraints =
+        DeltaConnector.mapDeltaConstraints(
+            schema,
+            Map.of(
+                "delta.constraints. ", "id > 0",
+                "delta.constraints.ck_id", "id > 0"));
+
+    List<ConstraintDefinition> checks =
+        constraints.stream().filter(c -> c.getType() == ConstraintType.CT_CHECK).toList();
+    assertThat(checks).hasSize(1);
+    assertThat(checks.get(0).getName()).isEqualTo("ck_id");
+  }
+
+  @Test
+  void mapDeltaCheckConstraintsIgnoresBlankExpression() {
+    // "delta.constraints.ck_foo" with empty/whitespace expression — should be skipped.
+    StructType schema = new StructType().add("id", LongType.LONG, false);
+
+    List<ConstraintDefinition> constraints =
+        DeltaConnector.mapDeltaConstraints(
+            schema,
+            Map.of(
+                "delta.constraints.ck_blank", "   ",
+                "delta.constraints.ck_id", "id > 0"));
+
+    List<ConstraintDefinition> checks =
+        constraints.stream().filter(c -> c.getType() == ConstraintType.CT_CHECK).toList();
+    assertThat(checks).hasSize(1);
+    assertThat(checks.get(0).getName()).isEqualTo("ck_id");
+  }
+}

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnectorTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnectorTest.java
@@ -441,4 +441,61 @@ class UnityDeltaConnectorTest {
         .cause()
         .hasMessageContaining("UC list returned HTTP 403");
   }
+
+  @Test
+  void extractConstraintPropertiesReadsMapStyleProperties() throws Exception {
+    var node =
+        DeltaConnector.M.readTree(
+            """
+            {
+              "name":"t",
+              "properties":{
+                "delta.constraints.ck_positive":"amount > 0",
+                "delta.appendOnly":"true"
+              }
+            }
+            """);
+
+    Map<String, String> props = UnityDeltaConnector.extractConstraintProperties(node);
+
+    assertThat(props)
+        .containsEntry("delta.constraints.ck_positive", "amount > 0")
+        .containsEntry("delta.appendOnly", "true");
+  }
+
+  @Test
+  void extractConstraintPropertiesReadsTablePropertiesObjectStyle() throws Exception {
+    var node =
+        DeltaConnector.M.readTree(
+            """
+            {
+              "name":"t",
+              "table_properties":{
+                "delta.constraints.ck_nonzero":"amount <> 0"
+              }
+            }
+            """);
+
+    Map<String, String> props = UnityDeltaConnector.extractConstraintProperties(node);
+
+    assertThat(props).containsEntry("delta.constraints.ck_nonzero", "amount <> 0");
+  }
+
+  @Test
+  void extractConstraintPropertiesReadsArrayStyleProperties() throws Exception {
+    var node =
+        DeltaConnector.M.readTree(
+            """
+            {
+              "name":"t",
+              "table_properties":[
+                {"key":"delta.constraints.ck_valid","value":"amount < 1000"}
+              ]
+            }
+            """);
+
+    Map<String, String> props = UnityDeltaConnector.extractConstraintProperties(node);
+
+    assertThat(props).containsEntry("delta.constraints.ck_valid", "amount < 1000");
+  }
 }

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
@@ -17,8 +17,13 @@
 package ai.floedb.floecat.connector.iceberg.impl;
 
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintEnforcement;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
 import ai.floedb.floecat.catalog.rpc.FileContent;
 import ai.floedb.floecat.catalog.rpc.PartitionSpecInfo;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.catalog.rpc.TableStats;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -365,6 +370,109 @@ public abstract class IcebergConnector implements FloecatConnector {
               metadataAttachments));
     }
     return out;
+  }
+
+  @Override
+  public Optional<SnapshotConstraints> snapshotConstraints(
+      String namespaceFq, String tableName, ResourceId destinationTableId, long snapshotId) {
+    Table table = loadTable(namespaceFq, tableName);
+    Snapshot snapshot = table.snapshot(snapshotId);
+    if (snapshot == null) {
+      return Optional.empty();
+    }
+
+    int schemaId = snapshot.schemaId() == null ? table.schema().schemaId() : snapshot.schemaId();
+    Schema schema = Optional.ofNullable(table.schemas().get(schemaId)).orElse(table.schema());
+    List<ConstraintDefinition> constraints =
+        mergeConstraints(
+            mapIcebergConstraints(schema),
+            sourceSpecificConstraints(namespaceFq, tableName, table, snapshot));
+    if (constraints.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        SnapshotConstraints.newBuilder()
+            .setTableId(destinationTableId)
+            .setSnapshotId(snapshotId)
+            .addAllConstraints(constraints)
+            .build());
+  }
+
+  /**
+   * Source-specific constraint extraction hook (for example, catalog metadata side channels).
+   *
+   * <p>Default implementation contributes no additional constraints.
+   */
+  protected List<ConstraintDefinition> sourceSpecificConstraints(
+      String namespaceFq, String tableName, Table table, Snapshot snapshot) {
+    return List.of();
+  }
+
+  static List<ConstraintDefinition> mapIcebergConstraints(Schema schema) {
+    if (schema == null) {
+      return List.of();
+    }
+    List<ConstraintDefinition> out = new ArrayList<>();
+    var fieldMaps = fieldIdMaps(schema);
+    Map<Integer, String> idToPath = fieldMaps.getKey();
+
+    Set<Integer> identifierFieldIds = schema.identifierFieldIds();
+    if (!identifierFieldIds.isEmpty()) {
+      List<Integer> sortedIds =
+          identifierFieldIds.stream()
+              .sorted(
+                  Comparator.comparing(
+                          (Integer id) -> idToPath.getOrDefault(id, ""),
+                          Comparator.nullsFirst(Comparator.naturalOrder()))
+                      .thenComparingInt(Integer::intValue))
+              .toList();
+      ConstraintDefinition.Builder pk =
+          ConstraintDefinition.newBuilder()
+              .setName("pk_identifier_fields")
+              .setType(ConstraintType.CT_PRIMARY_KEY)
+              .setEnforcement(ConstraintEnforcement.CE_NOT_ENFORCED);
+      int ordinal = 1;
+      for (Integer id : sortedIds) {
+        Types.NestedField field = schema.findField(id);
+        if (field == null) {
+          continue;
+        }
+        pk.addColumns(
+            ConstraintColumnRef.newBuilder()
+                .setColumnId(id)
+                .setColumnName(idToPath.getOrDefault(id, field.name()))
+                .setOrdinal(ordinal++)
+                .build());
+      }
+      if (pk.getColumnsCount() > 0) {
+        out.add(pk.build());
+      }
+    }
+
+    collectNotNullConstraints(schema.columns(), "", out);
+    return List.copyOf(out);
+  }
+
+  static List<ConstraintDefinition> mergeConstraints(
+      List<ConstraintDefinition> primary, List<ConstraintDefinition> secondary) {
+    if ((primary == null || primary.isEmpty()) && (secondary == null || secondary.isEmpty())) {
+      return List.of();
+    }
+    // Deduplication uses full proto payload (toByteString()), not semantic identity.
+    // Constraints with different names, ordinals, or enforcement for the same logical key
+    // will both be retained. Acceptable while sourceSpecificConstraints() is unused;
+    // revisit if that hook gains implementations that may duplicate schema-derived constraints.
+    // TODO: switch to semantic dedup (type + column signature) once sourceSpecificConstraints()
+    // has implementations that may produce logically equivalent constraints under different names.
+    Map<ByteString, ConstraintDefinition> deduped = new LinkedHashMap<>();
+    for (ConstraintDefinition constraint : primary) {
+      deduped.put(constraint.toByteString(), constraint);
+    }
+    for (ConstraintDefinition constraint : secondary) {
+      deduped.putIfAbsent(constraint.toByteString(), constraint);
+    }
+    return List.copyOf(deduped.values());
   }
 
   private List<Snapshot> snapshotsToEnumerate(
@@ -1042,6 +1150,36 @@ public abstract class IcebergConnector implements FloecatConnector {
       // Use canonical {} notation for map values (matching IcebergSchemaMapper output)
       collectNestedWithOrdinal(key, name + ".key", 1, idToPath, idToOrdinal);
       collectNestedWithOrdinal(val, name + ".value", 2, idToPath, idToOrdinal);
+    }
+  }
+
+  private static void collectNotNullConstraints(
+      List<Types.NestedField> fields, String prefix, List<ConstraintDefinition> out) {
+    for (Types.NestedField field : fields) {
+      String path = prefix.isEmpty() ? field.name() : prefix + "." + field.name();
+      if (field.isRequired() && !field.type().isStructType()) {
+        // For non-primitive types (LIST, MAP) this means the container itself is non-null;
+        // element/value nullability is a separate concern not captured here.
+        // Name uses the stable Iceberg field ID so a column rename does not change the constraint
+        // identity; the human-readable path is preserved in columns[0].column_name.
+        out.add(
+            ConstraintDefinition.newBuilder()
+                .setName("nn_" + field.fieldId())
+                .setType(ConstraintType.CT_NOT_NULL)
+                .setEnforcement(ConstraintEnforcement.CE_ENFORCED)
+                .addColumns(
+                    ConstraintColumnRef.newBuilder()
+                        .setColumnId(field.fieldId())
+                        .setColumnName(path)
+                        .setOrdinal(1)
+                        .build())
+                .build());
+      }
+      if (field.type().isStructType() && field.isRequired()) {
+        // Only descend into a struct when the struct itself is required; a required child
+        // inside an optional parent struct is conditionally present, not flat-relational NOT NULL.
+        collectNotNullConstraints(field.type().asStructType().fields(), path, out);
+      }
     }
   }
 }

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConstraintMappingTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConstraintMappingTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.iceberg.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintEnforcement;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class IcebergConstraintMappingTest {
+
+  @Test
+  void mapIcebergConstraintsEmitsIdentifierPkAndNotNullConstraints() {
+    Schema schema =
+        new Schema(
+            List.of(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "name", Types.StringType.get()),
+                Types.NestedField.required(
+                    3,
+                    "address",
+                    Types.StructType.of(
+                        Types.NestedField.required(4, "zip", Types.StringType.get()),
+                        Types.NestedField.optional(5, "line2", Types.StringType.get())))),
+            Set.of(1));
+
+    List<ConstraintDefinition> constraints = IcebergConnector.mapIcebergConstraints(schema);
+
+    ConstraintDefinition pk =
+        constraints.stream()
+            .filter(c -> c.getType() == ConstraintType.CT_PRIMARY_KEY)
+            .findFirst()
+            .orElseThrow();
+    assertThat(pk.getEnforcement()).isEqualTo(ConstraintEnforcement.CE_NOT_ENFORCED);
+    assertThat(pk.getColumnsList()).hasSize(1);
+    assertThat(pk.getColumns(0).getColumnId()).isEqualTo(1L);
+    assertThat(pk.getColumns(0).getColumnName()).isEqualTo("id");
+
+    List<ConstraintDefinition> notNull =
+        constraints.stream().filter(c -> c.getType() == ConstraintType.CT_NOT_NULL).toList();
+    assertThat(notNull).hasSize(2);
+    assertThat(notNull)
+        .extracting(c -> c.getColumns(0).getColumnName())
+        .containsExactlyInAnyOrder("id", "address.zip");
+    assertThat(notNull).allMatch(c -> c.getEnforcement() == ConstraintEnforcement.CE_ENFORCED);
+  }
+
+  @Test
+  void mapIcebergConstraintsDoesNotEmitNotNullForRequiredChildInsideOptionalParentStruct() {
+    // address is optional; zip inside address is required.
+    // nn_address.zip must NOT be emitted because address can be absent entirely.
+    Schema schema =
+        new Schema(
+            List.of(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(
+                    2,
+                    "address",
+                    Types.StructType.of(
+                        Types.NestedField.required(3, "zip", Types.StringType.get()),
+                        Types.NestedField.optional(4, "line2", Types.StringType.get())))));
+
+    List<ConstraintDefinition> constraints = IcebergConnector.mapIcebergConstraints(schema);
+
+    List<ConstraintDefinition> notNull =
+        constraints.stream().filter(c -> c.getType() == ConstraintType.CT_NOT_NULL).toList();
+    assertThat(notNull).hasSize(1);
+    assertThat(notNull.get(0).getColumns(0).getColumnName()).isEqualTo("id");
+    // address.zip must not appear — its presence depends on address being non-null
+    assertThat(notNull)
+        .extracting(c -> c.getColumns(0).getColumnName())
+        .doesNotContain("address.zip");
+  }
+
+  @Test
+  void mapIcebergConstraintsEmitsNotNullForRequiredListField() {
+    // A required list field (non-nullable list) should emit NOT NULL just like Delta does.
+    Schema schema =
+        new Schema(
+            List.of(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.required(
+                    2, "tags", Types.ListType.ofOptional(3, Types.StringType.get())),
+                Types.NestedField.optional(
+                    4, "scores", Types.ListType.ofOptional(5, Types.DoubleType.get()))));
+
+    List<ConstraintDefinition> constraints = IcebergConnector.mapIcebergConstraints(schema);
+
+    List<ConstraintDefinition> notNull =
+        constraints.stream().filter(c -> c.getType() == ConstraintType.CT_NOT_NULL).toList();
+    assertThat(notNull)
+        .extracting(c -> c.getColumns(0).getColumnName())
+        .containsExactlyInAnyOrder("id", "tags");
+    // optional list 'scores' must not appear
+    assertThat(notNull).extracting(c -> c.getColumns(0).getColumnName()).doesNotContain("scores");
+  }
+
+  @Test
+  void mapIcebergConstraintsPkColumnsAreSortedByPathThenFieldId() {
+    // Identifier fields {3, 1, 2}: paths "c", "a", "b" → expected sorted order: a(1), b(2), c(3)
+    Schema schema =
+        new Schema(
+            List.of(
+                Types.NestedField.required(1, "a", Types.LongType.get()),
+                Types.NestedField.required(2, "b", Types.LongType.get()),
+                Types.NestedField.required(3, "c", Types.LongType.get())),
+            Set.of(3, 1, 2));
+
+    List<ConstraintDefinition> constraints = IcebergConnector.mapIcebergConstraints(schema);
+
+    ConstraintDefinition pk =
+        constraints.stream()
+            .filter(c -> c.getType() == ConstraintType.CT_PRIMARY_KEY)
+            .findFirst()
+            .orElseThrow();
+    assertThat(pk.getColumnsList()).hasSize(3);
+    assertThat(pk.getColumns(0).getColumnName()).isEqualTo("a");
+    assertThat(pk.getColumns(1).getColumnName()).isEqualTo("b");
+    assertThat(pk.getColumns(2).getColumnName()).isEqualTo("c");
+    assertThat(pk.getColumns(0).getOrdinal()).isEqualTo(1);
+    assertThat(pk.getColumns(1).getOrdinal()).isEqualTo(2);
+    assertThat(pk.getColumns(2).getOrdinal()).isEqualTo(3);
+  }
+
+  // Note: we cannot test the schema.findField(id) null-guard via Iceberg's public Schema
+  // constructor because it validates that all identifierFieldIds exist at construction time.
+  // The guard remains as a defensive measure against data-corruption scenarios where
+  // schema and identifier metadata are out of sync in storage.
+
+  @Test
+  void mergeConstraintsDedupesByPayloadAndPreservesPrimaryOrder() {
+    ConstraintDefinition primary =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_identifier_fields")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .setEnforcement(ConstraintEnforcement.CE_NOT_ENFORCED)
+            .build();
+    ConstraintDefinition secondaryOnly =
+        ConstraintDefinition.newBuilder()
+            .setName("nn_id")
+            .setType(ConstraintType.CT_NOT_NULL)
+            .setEnforcement(ConstraintEnforcement.CE_ENFORCED)
+            .build();
+
+    List<ConstraintDefinition> merged =
+        IcebergConnector.mergeConstraints(List.of(primary), List.of(primary, secondaryOnly));
+
+    assertThat(merged).containsExactly(primary, secondaryOnly);
+  }
+
+  @Test
+  void mergeConstraintsPrimaryWinsOnExactPayloadCollision() {
+    // Same logical constraint in both sources: primary-sourced instance is kept
+    ConstraintDefinition constraint =
+        ConstraintDefinition.newBuilder()
+            .setName("nn_id")
+            .setType(ConstraintType.CT_NOT_NULL)
+            .setEnforcement(ConstraintEnforcement.CE_ENFORCED)
+            .build();
+
+    List<ConstraintDefinition> merged =
+        IcebergConnector.mergeConstraints(List.of(constraint), List.of(constraint));
+
+    assertThat(merged).hasSize(1);
+    assertThat(merged.get(0)).isEqualTo(constraint);
+  }
+
+  @Test
+  void mergeConstraintsIncludesSecondaryOnlyEntryWhenPrimaryIsNonEmpty() {
+    ConstraintDefinition fromPrimary =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_identifier_fields")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .setEnforcement(ConstraintEnforcement.CE_NOT_ENFORCED)
+            .build();
+    ConstraintDefinition fromSecondary =
+        ConstraintDefinition.newBuilder()
+            .setName("nn_id")
+            .setType(ConstraintType.CT_NOT_NULL)
+            .setEnforcement(ConstraintEnforcement.CE_ENFORCED)
+            .build();
+
+    List<ConstraintDefinition> merged =
+        IcebergConnector.mergeConstraints(List.of(fromPrimary), List.of(fromSecondary));
+
+    assertThat(merged).containsExactlyInAnyOrder(fromPrimary, fromSecondary);
+  }
+}

--- a/docs/connectors-delta.md
+++ b/docs/connectors-delta.md
@@ -61,6 +61,22 @@ Databricks SQL execution, and custom file readers for S3.
   `stats.ndv.max_files`. Samples combine streaming NDV with Parquet footers for accuracy.
 - **Type mapping** – `DeltaTypeMapper` ensures nested Delta/Parquet types are faithfully represented
   when computing stats, aligning with `types/` definitions.
+- **Constraint mapping** – Snapshot constraints currently emit metadata that is reliably exposed by
+  Delta snapshots/table metadata:
+  - `CT_NOT_NULL` from non-nullable schema fields (including nested struct leaves).
+  - `CT_CHECK` from table properties using `delta.constraints.<name>=<sql_expression>`.
+  - `CT_PRIMARY_KEY`, `CT_FOREIGN_KEY`, and `CT_UNIQUE` are not emitted from core Delta metadata
+    because no portable source is defined for them.
+  - Source-specific extraction path:
+    - **Unity Catalog**: merge of snapshot metadata + UC table properties from
+      `/api/2.1/unity-catalog/tables/{full_name}`. Snapshot metadata wins on key collisions.
+    - **Glue**: merge of snapshot metadata + Glue table parameters. Snapshot metadata wins on key
+      collisions.
+    - **Filesystem**: snapshot metadata only (no catalog-level fallback source).
+  - Connector matrix (current behavior):
+    - **Unity**: `CT_NOT_NULL`, `CT_CHECK` (`delta.constraints.*`) from merged snapshot + UC metadata.
+    - **Glue**: `CT_NOT_NULL`, `CT_CHECK` (`delta.constraints.*`) from merged snapshot + Glue metadata.
+    - **Filesystem**: `CT_NOT_NULL`, `CT_CHECK` (`delta.constraints.*`) from snapshot metadata only.
 
 ## Data Flow & Lifecycle
 

--- a/docs/connectors-iceberg.md
+++ b/docs/connectors-iceberg.md
@@ -51,6 +51,20 @@ specializing discovery and catalog wiring.
 - **Metadata capture** – `IcebergConnector` embeds the serialized `IcebergMetadata` protobuf in the
   `SnapshotBundle.metadata` map so the reconciler can persist schemas/specs/refs/logs without
   leaking Iceberg-specific types into the core SPI.
+- **Constraint mapping** – Snapshot constraints currently emit only metadata that is reliably
+  exposed by core Iceberg tables:
+  - `CT_PRIMARY_KEY` from Iceberg `identifier-field-ids` (advisory, emitted as not-enforced).
+  - `CT_NOT_NULL` from required primitive schema fields (including nested struct leaves).
+  - `CT_FOREIGN_KEY`, `CT_UNIQUE`, and `CT_CHECK` are not emitted from core Iceberg metadata
+    because no portable source is defined for them.
+  - Source-specific extraction path:
+    - **REST**: snapshot/schema-derived constraints + source-specific additions (currently none).
+    - **Glue**: snapshot/schema-derived constraints + source-specific additions (currently none).
+    - **Filesystem**: snapshot/schema-derived constraints + source-specific additions (currently none).
+  - Connector matrix (current behavior):
+    - **REST**: `CT_PRIMARY_KEY`, `CT_NOT_NULL`.
+    - **Glue**: `CT_PRIMARY_KEY`, `CT_NOT_NULL`.
+    - **Filesystem**: `CT_PRIMARY_KEY`, `CT_NOT_NULL`.
 
 ## Data Flow & Lifecycle
 ```


### PR DESCRIPTION
## Summary

Add snapshot-level constraint extraction for Delta and Iceberg connectors, and document the current cross-format mapping contract.

This PR teaches connectors to emit `SnapshotConstraints` from metadata that is reliably available in each source format:

- **Delta**
  - `CT_NOT_NULL` from non-nullable schema fields
  - `CT_CHECK` from `delta.constraints.<name>=<sql_expression>` table properties
  - snapshot metadata merged with catalog fallback properties where available
    - Unity Catalog
    - Glue
- **Iceberg**
  - `CT_PRIMARY_KEY` from `identifier-field-ids` (advisory / not enforced)
  - `CT_NOT_NULL` from required fields

It also adds tests and docs clarifying exactly what is and is not portable today.

---

### What changed

#### Delta connector
- Added `snapshotConstraints(...)` implementation
- Extracts:
  - `NOT NULL` for non-nullable leaf fields
  - `CHECK` from `delta.constraints.*`
- Merges constraint properties from:
  - snapshot metadata
  - Unity Catalog table metadata fallback
  - Glue table parameters fallback
- Snapshot metadata wins on key collisions
- Uses stable `CID_PATH_ORDINAL`-based IDs when computable for top-level fields
- Falls back to `column_id = 0` when stable IDs cannot be derived

#### Unity / Glue Delta metadata support
- Added best-effort fallback property extraction:
  - `UnityDeltaConnector.extractConstraintProperties(...)`
  - `GlueDeltaCatalog.tableParameters(...)`

#### Iceberg connector
- Added `snapshotConstraints(...)` implementation
- Extracts:
  - `PRIMARY KEY` from Iceberg identifier fields
  - `NOT NULL` from required fields
- Adds `sourceSpecificConstraints(...)` hook for future catalog-specific extensions
- Merges schema-derived and source-specific constraints

#### Documentation
- Added connector docs describing current constraint mapping behavior for:
  - Delta
  - Iceberg

---

### Semantics / mapping rules

#### Delta
Current portable mapping:
- `CT_NOT_NULL` from non-nullable schema fields
- `CT_CHECK` from `delta.constraints.*`

Not emitted from core Delta metadata:
- `CT_PRIMARY_KEY`
- `CT_FOREIGN_KEY`
- `CT_UNIQUE`

Important details:
- nested non-nullable children inside a **nullable parent struct** do **not** become flat relational `NOT NULL`
- snapshot properties override fallback catalog properties for the same key

#### Iceberg
Current portable mapping:
- `CT_PRIMARY_KEY` from `identifier-field-ids`
- `CT_NOT_NULL` from required fields

Not emitted from core Iceberg metadata:
- `CT_FOREIGN_KEY`
- `CT_UNIQUE`
- `CT_CHECK`

Important details:
- Iceberg identifier fields are emitted as **advisory** (`CE_NOT_ENFORCED`)
- required children inside an **optional parent struct** do **not** become flat relational `NOT NULL`
- required list/map/container fields emit container-level `NOT NULL`

---

### Notes / limitations

- Delta CHECK constraints currently preserve the raw SQL expression, and do not yet extract referenced columns
- Iceberg constraint dedup currently uses full proto payload equality, not semantic identity
- This PR intentionally maps only constraints that are reliably portable from source metadata; it does not invent unsupported PK/FK/UNIQUE semantics

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

Added coverage for:
- Delta:
  - fallback property usage
  - snapshot-vs-fallback precedence
  - duplicate key collision behavior
  - NOT NULL extraction
  - nullable-parent / required-child struct semantics
  - blank constraint names / expressions
  - Unity Catalog property parsing for both object and array shapes
- Iceberg:
  - identifier-field PK extraction
  - NOT NULL extraction
  - optional-parent / required-child struct semantics
  - required list field handling
  - deterministic PK column ordering
  - merge/dedup behavior


## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

