### PR TITLE
Add system objects constraints

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/def/SystemTableDef.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/def/SystemTableDef.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.systemcatalog.def;
 
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.query.rpc.FlightEndpointRef;
@@ -35,7 +36,8 @@ public record SystemTableDef(
     String storagePath,
     String storageEndpointKey,
     List<EngineSpecificRule> engineSpecific,
-    FlightEndpointRef flightEndpoint)
+    FlightEndpointRef flightEndpoint,
+    List<ConstraintDefinition> constraints)
     implements SystemObjectDef {
 
   public SystemTableDef {
@@ -47,6 +49,7 @@ public record SystemTableDef(
     storagePath = storagePath == null ? "" : storagePath;
     storageEndpointKey = storageEndpointKey == null ? "" : storageEndpointKey;
     engineSpecific = List.copyOf(engineSpecific == null ? List.of() : engineSpecific);
+    constraints = List.copyOf(constraints == null ? List.of() : constraints);
     Set<String> columnNames = new HashSet<>();
     for (SystemColumnDef column : columns) {
       if (!columnNames.add(column.name())) {
@@ -67,6 +70,29 @@ public record SystemTableDef(
                 + " TABLE_BACKEND_KIND_STORAGE");
       }
     }
+  }
+
+  public SystemTableDef(
+      NameRef name,
+      String displayName,
+      List<SystemColumnDef> columns,
+      TableBackendKind backendKind,
+      String scannerId,
+      String storagePath,
+      String storageEndpointKey,
+      List<EngineSpecificRule> engineSpecific,
+      FlightEndpointRef flightEndpoint) {
+    this(
+        name,
+        displayName,
+        columns,
+        backendKind,
+        scannerId,
+        storagePath,
+        storageEndpointKey,
+        engineSpecific,
+        flightEndpoint,
+        List.of());
   }
 
   @Override

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/graph/SystemNodeRegistry.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/graph/SystemNodeRegistry.java
@@ -598,7 +598,8 @@ public class SystemNodeRegistry {
         def.storagePath(),
         def.storageEndpointKey(),
         matched,
-        def.flightEndpoint());
+        def.flightEndpoint(),
+        def.constraints());
   }
 
   private SystemViewDef withViewRules(SystemViewDef def, String engineKind, String engineVersion) {

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/registry/SystemCatalogProtoMapper.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/registry/SystemCatalogProtoMapper.java
@@ -45,6 +45,7 @@ import ai.floedb.floecat.systemcatalog.def.SystemTypeDef;
 import ai.floedb.floecat.systemcatalog.def.SystemViewDef;
 import ai.floedb.floecat.systemcatalog.engine.EngineSpecificRule;
 import com.google.protobuf.ByteString;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -329,6 +330,7 @@ public final class SystemCatalogProtoMapper {
       default -> {}
     }
     def.columns().forEach(col -> builder.addColumns(toProtoColumn(col)));
+    def.constraints().forEach(builder::addConstraints);
     def.engineSpecific().forEach(es -> builder.addEngineSpecific(toProtoRule(es)));
     return builder.build();
   }
@@ -352,7 +354,8 @@ public final class SystemCatalogProtoMapper {
         proto.getEngineSpecificList().stream()
             .map(es -> fromProtoRule(es, defaultEngineKind))
             .toList(),
-        flightEndpoint);
+        flightEndpoint,
+        List.copyOf(proto.getConstraintsList()));
   }
 
   private static SystemView toProtoView(SystemViewDef def) {

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/validation/SystemCatalogValidator.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/validation/SystemCatalogValidator.java
@@ -14,10 +14,14 @@
 
 package ai.floedb.floecat.systemcatalog.validation;
 
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.systemcatalog.def.SystemAggregateDef;
 import ai.floedb.floecat.systemcatalog.def.SystemCastDef;
 import ai.floedb.floecat.systemcatalog.def.SystemCollationDef;
+import ai.floedb.floecat.systemcatalog.def.SystemColumnDef;
 import ai.floedb.floecat.systemcatalog.def.SystemFunctionDef;
 import ai.floedb.floecat.systemcatalog.def.SystemNamespaceDef;
 import ai.floedb.floecat.systemcatalog.def.SystemObjectDef;
@@ -28,10 +32,14 @@ import ai.floedb.floecat.systemcatalog.def.SystemViewDef;
 import ai.floedb.floecat.systemcatalog.engine.EngineSpecificRule;
 import ai.floedb.floecat.systemcatalog.engine.VersionIntervals;
 import ai.floedb.floecat.systemcatalog.registry.SystemCatalogData;
+import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
 import ai.floedb.floecat.systemcatalog.util.SignatureUtil;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
@@ -140,6 +148,26 @@ public final class SystemCatalogValidator {
     interface Column {
       String SCHEMA_REQUIRED = "floe.column.schema.required";
       String ORDINAL_DUPLICATE = "floe.column.ordinal_duplicate";
+    }
+
+    interface Constraint {
+      String TYPE_REQUIRED = "table.constraint.type.required";
+      String NAME_DUPLICATE = "table.constraint.name.duplicate";
+      String COLUMNS_REQUIRED = "table.constraint.columns.required";
+      String FK_REFERENCED_TABLE_REQUIRED = "table.constraint.fk.referenced_table.required";
+      String FK_REFERENCED_TABLE_UNKNOWN = "table.constraint.fk.referenced_table.unknown";
+      String REFERENCED_COLUMNS_REQUIRED = "table.constraint.referenced_columns.required";
+      String FK_COLUMN_ARITY_MISMATCH = "table.constraint.fk.arity.mismatch";
+      String FK_REFERENCED_NOT_ALLOWED = "table.constraint.fk_only.field.not_allowed";
+      String CHECK_EXPRESSION_REQUIRED = "table.constraint.check.expression.required";
+      String CHECK_EXPRESSION_NOT_ALLOWED = "table.constraint.check_only.expression.not_allowed";
+      String NOT_NULL_SINGLE_COLUMN = "table.constraint.not_null.single_column";
+      String NOT_NULL_NULLABLE_COLUMN = "table.constraint.not_null.column_is_nullable";
+      String COLUMN_REF_TARGET_REQUIRED = "table.constraint.column_ref.target.required";
+      String COLUMN_REF_UNKNOWN = "table.constraint.column_ref.unknown";
+      String COLUMN_REF_ID_NAME_MISMATCH = "table.constraint.column_ref.id_name.mismatch";
+      String COLUMN_REF_ORDINAL_INVALID = "table.constraint.column_ref.ordinal.invalid";
+      String COLUMN_REF_ORDINAL_DUPLICATE = "table.constraint.column_ref.ordinal.duplicate";
     }
   }
 
@@ -747,6 +775,15 @@ public final class SystemCatalogValidator {
       return;
     }
 
+    Map<String, TableColumnIndex> tableColumnsByCanonical = new LinkedHashMap<>();
+    for (SystemTableDef table : tables) {
+      if (table == null || table.name() == null || isBlank(table.name().getName())) {
+        continue;
+      }
+      tableColumnsByCanonical.put(
+          NameRefUtil.canonical(table.name()), indexColumns(table.columns()));
+    }
+
     Set<NameRef> seen = new HashSet<>();
     for (SystemTableDef tbl : tables) {
       if (tbl == null) {
@@ -766,7 +803,287 @@ public final class SystemCatalogValidator {
       requireQualifiedObjectName("table", name, issues, Codes.Relation.TABLE_QUALIFIED_REQUIRED);
       requireNamespaceExists(
           "table", name, namespaceNames, issues, Codes.Relation.TABLE_NAMESPACE_UNKNOWN);
+      validateTableConstraints(tbl, ctx, tableColumnsByCanonical, issues);
     }
+  }
+
+  private static void validateTableConstraints(
+      SystemTableDef table,
+      String tableCtx,
+      Map<String, TableColumnIndex> tableColumnsByCanonical,
+      List<ValidationIssue> issues) {
+    List<ConstraintDefinition> constraints = table.constraints();
+    if (constraints == null || constraints.isEmpty()) {
+      return;
+    }
+    Map<String, SystemColumnDef> columnsByName = new HashMap<>();
+    Map<Long, SystemColumnDef> columnsById = new HashMap<>();
+    for (SystemColumnDef column : table.columns()) {
+      columnsByName.put(column.name(), column);
+      if (column.hasId() && column.id() > 0) {
+        columnsById.put(column.id(), column);
+      }
+    }
+    TableColumnIndex localTableIndex =
+        new TableColumnIndex(Map.copyOf(columnsByName), Map.copyOf(columnsById));
+    Set<String> constraintNames = new HashSet<>();
+    for (int i = 0; i < constraints.size(); i++) {
+      ConstraintDefinition constraint = constraints.get(i);
+      if (constraint == null) {
+        continue;
+      }
+      String constraintCtx = tableCtx + ".constraints[" + i + "]";
+      if (constraint.getType() == ConstraintType.CT_UNSPECIFIED) {
+        err(issues, Codes.Constraint.TYPE_REQUIRED, constraintCtx, null);
+      }
+
+      String constraintName = nullToEmpty(constraint.getName()).trim();
+      if (!constraintName.isEmpty() && !constraintNames.add(constraintName)) {
+        err(issues, Codes.Constraint.NAME_DUPLICATE, constraintCtx, null, constraintName);
+      }
+
+      if (requiresLocalColumns(constraint.getType()) && constraint.getColumnsCount() == 0) {
+        err(issues, Codes.Constraint.COLUMNS_REQUIRED, constraintCtx, null);
+      }
+      if (constraint.getType() == ConstraintType.CT_NOT_NULL && constraint.getColumnsCount() != 1) {
+        err(
+            issues,
+            Codes.Constraint.NOT_NULL_SINGLE_COLUMN,
+            constraintCtx,
+            null,
+            Integer.toString(constraint.getColumnsCount()));
+      } else if (constraint.getType() == ConstraintType.CT_NOT_NULL
+          && constraint.getColumnsCount() == 1) {
+        ConstraintColumnRef notNullColumn = constraint.getColumns(0);
+        SystemColumnDef target = resolveLocalColumn(columnsByName, columnsById, notNullColumn);
+        if (target != null && target.nullable()) {
+          err(
+              issues,
+              Codes.Constraint.NOT_NULL_NULLABLE_COLUMN,
+              constraintCtx,
+              null,
+              target.name());
+        }
+      }
+      if (constraint.getType() == ConstraintType.CT_FOREIGN_KEY) {
+        if (!constraint.hasReferencedTableId() && isBlank(constraint.getReferencedTableName())) {
+          err(issues, Codes.Constraint.FK_REFERENCED_TABLE_REQUIRED, constraintCtx, null);
+        }
+        if (constraint.getReferencedColumnsCount() == 0) {
+          err(issues, Codes.Constraint.REFERENCED_COLUMNS_REQUIRED, constraintCtx, null);
+        }
+        if (constraint.getColumnsCount() != constraint.getReferencedColumnsCount()) {
+          err(
+              issues,
+              Codes.Constraint.FK_COLUMN_ARITY_MISMATCH,
+              constraintCtx,
+              null,
+              Integer.toString(constraint.getColumnsCount()),
+              Integer.toString(constraint.getReferencedColumnsCount()));
+        }
+      } else if (constraint.hasReferencedTableId()
+          || !isBlank(constraint.getReferencedTableName())
+          || constraint.getReferencedColumnsCount() > 0) {
+        err(issues, Codes.Constraint.FK_REFERENCED_NOT_ALLOWED, constraintCtx, null);
+      }
+
+      if (constraint.getType() == ConstraintType.CT_CHECK) {
+        if (isBlank(constraint.getCheckExpression())) {
+          err(issues, Codes.Constraint.CHECK_EXPRESSION_REQUIRED, constraintCtx, null);
+        }
+      } else if (!isBlank(constraint.getCheckExpression())) {
+        err(issues, Codes.Constraint.CHECK_EXPRESSION_NOT_ALLOWED, constraintCtx, null);
+      }
+
+      validateConstraintColumnRefs(
+          constraintCtx + ".columns",
+          constraint.getColumnsList(),
+          columnsByName,
+          columnsById,
+          issues);
+      Map<String, SystemColumnDef> referencedColumnsByName = Map.of();
+      Map<Long, SystemColumnDef> referencedColumnsById = Map.of();
+      if (constraint.getType() == ConstraintType.CT_FOREIGN_KEY) {
+        TableColumnIndex referencedIndex =
+            resolveReferencedTableColumns(
+                table, constraint, tableColumnsByCanonical, localTableIndex);
+        if (referencedIndex != null) {
+          referencedColumnsByName = referencedIndex.byName();
+          referencedColumnsById = referencedIndex.byId();
+        } else if (!constraint.hasReferencedTableId()
+            && !isBlank(constraint.getReferencedTableName())) {
+          err(
+              issues,
+              Codes.Constraint.FK_REFERENCED_TABLE_UNKNOWN,
+              constraintCtx,
+              null,
+              constraint.getReferencedTableName());
+        }
+      }
+      validateConstraintColumnRefs(
+          constraintCtx + ".referenced_columns",
+          constraint.getReferencedColumnsList(),
+          referencedColumnsByName,
+          referencedColumnsById,
+          issues);
+    }
+  }
+
+  private static TableColumnIndex resolveReferencedTableColumns(
+      SystemTableDef localTable,
+      ConstraintDefinition constraint,
+      Map<String, TableColumnIndex> tableColumnsByCanonical,
+      TableColumnIndex localTableIndex) {
+    // Referenced-column target lookup is currently name-based only: referenced_table_id satisfies
+    // FK presence requirements but is not used to resolve a table schema in validator checks.
+    // This is acceptable for current builtin definitions (name-authored), but should be revisited
+    // if ID-first authoring becomes primary.
+    if (localTable == null
+        || localTable.name() == null
+        || constraint == null
+        || isBlank(constraint.getReferencedTableName())) {
+      return null;
+    }
+    String referencedRaw = constraint.getReferencedTableName().trim().toLowerCase();
+
+    if (referencedRaw.contains(".")) {
+      return tableColumnsByCanonical.get(referencedRaw);
+    }
+
+    String localNamespace = namespacePrefix(localTable.name());
+    if (!localNamespace.isEmpty()) {
+      TableColumnIndex inNamespace =
+          tableColumnsByCanonical.get(localNamespace + "." + referencedRaw);
+      if (inNamespace != null) {
+        return inNamespace;
+      }
+    }
+
+    if (referencedRaw.equalsIgnoreCase(nullToEmpty(localTable.name().getName()))) {
+      return localTableIndex;
+    }
+
+    return null;
+  }
+
+  private static TableColumnIndex indexColumns(List<SystemColumnDef> columns) {
+    Map<String, SystemColumnDef> byName = new LinkedHashMap<>();
+    Map<Long, SystemColumnDef> byId = new LinkedHashMap<>();
+    if (columns == null) {
+      return new TableColumnIndex(Map.of(), Map.of());
+    }
+    for (SystemColumnDef column : columns) {
+      if (column == null) {
+        continue;
+      }
+      byName.put(column.name(), column);
+      if (column.hasId() && column.id() > 0) {
+        byId.put(column.id(), column);
+      }
+    }
+    return new TableColumnIndex(Map.copyOf(byName), Map.copyOf(byId));
+  }
+
+  private static String namespacePrefix(NameRef tableName) {
+    if (tableName == null || tableName.getPathCount() == 0) {
+      return "";
+    }
+    return String.join(".", tableName.getPathList()).toLowerCase();
+  }
+
+  private static boolean requiresLocalColumns(ConstraintType type) {
+    return type == ConstraintType.CT_PRIMARY_KEY
+        || type == ConstraintType.CT_UNIQUE
+        || type == ConstraintType.CT_FOREIGN_KEY
+        || type == ConstraintType.CT_NOT_NULL;
+  }
+
+  private static void validateConstraintColumnRefs(
+      String refsCtx,
+      List<ConstraintColumnRef> refs,
+      Map<String, SystemColumnDef> columnsByName,
+      Map<Long, SystemColumnDef> columnsById,
+      List<ValidationIssue> issues) {
+    if (refs == null || refs.isEmpty()) {
+      return;
+    }
+    Set<Integer> ordinals = new HashSet<>();
+    for (int i = 0; i < refs.size(); i++) {
+      ConstraintColumnRef ref = refs.get(i);
+      if (ref == null) {
+        continue;
+      }
+      String refCtx = refsCtx + "[" + i + "]";
+      if (ref.getOrdinal() <= 0) {
+        err(
+            issues,
+            Codes.Constraint.COLUMN_REF_ORDINAL_INVALID,
+            refCtx,
+            null,
+            Integer.toString(ref.getOrdinal()));
+      } else if (!ordinals.add(ref.getOrdinal())) {
+        err(
+            issues,
+            Codes.Constraint.COLUMN_REF_ORDINAL_DUPLICATE,
+            refCtx,
+            null,
+            Integer.toString(ref.getOrdinal()));
+      }
+
+      boolean hasId = ref.getColumnId() > 0;
+      boolean hasName = !isBlank(ref.getColumnName());
+      if (!hasId && !hasName) {
+        err(issues, Codes.Constraint.COLUMN_REF_TARGET_REQUIRED, refCtx, null);
+        continue;
+      }
+      if ((columnsByName == null || columnsByName.isEmpty())
+          && (columnsById == null || columnsById.isEmpty())) {
+        continue;
+      }
+      SystemColumnDef byId =
+          hasId && columnsById != null ? columnsById.get(ref.getColumnId()) : null;
+      SystemColumnDef byName =
+          hasName && columnsByName != null ? columnsByName.get(ref.getColumnName()) : null;
+
+      if (hasId && hasName) {
+        if (byId != null && byName != null && byId.equals(byName)) {
+          continue;
+        }
+        err(
+            issues,
+            Codes.Constraint.COLUMN_REF_ID_NAME_MISMATCH,
+            refCtx,
+            null,
+            Long.toString(ref.getColumnId()),
+            ref.getColumnName());
+        continue;
+      }
+      if (byId != null || byName != null) {
+        continue;
+      }
+      err(
+          issues,
+          Codes.Constraint.COLUMN_REF_UNKNOWN,
+          refCtx,
+          null,
+          hasId ? Long.toString(ref.getColumnId()) : ref.getColumnName());
+    }
+  }
+
+  private static SystemColumnDef resolveLocalColumn(
+      Map<String, SystemColumnDef> columnsByName,
+      Map<Long, SystemColumnDef> columnsById,
+      ConstraintColumnRef ref) {
+    if (ref == null) {
+      return null;
+    }
+    if (ref.getColumnId() > 0 && columnsById.containsKey(ref.getColumnId())) {
+      return columnsById.get(ref.getColumnId());
+    }
+    if (!isBlank(ref.getColumnName()) && columnsByName.containsKey(ref.getColumnName())) {
+      return columnsByName.get(ref.getColumnName());
+    }
+    return null;
   }
 
   private static void validateViews(
@@ -1006,4 +1323,7 @@ public final class SystemCatalogValidator {
   private static String nullToEmpty(String s) {
     return s == null ? "" : s;
   }
+
+  private record TableColumnIndex(
+      Map<String, SystemColumnDef> byName, Map<Long, SystemColumnDef> byId) {}
 }

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/registry/SystemCatalogProtoMapperTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/registry/SystemCatalogProtoMapperTest.java
@@ -18,8 +18,12 @@ package ai.floedb.floecat.systemcatalog.registry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.query.rpc.SystemObjectsRegistry;
+import ai.floedb.floecat.query.rpc.TableBackendKind;
 import ai.floedb.floecat.systemcatalog.def.*;
 import ai.floedb.floecat.systemcatalog.engine.EngineSpecificRule;
 import java.util.Arrays;
@@ -188,6 +192,54 @@ final class SystemCatalogProtoMapperTest {
     SystemCatalogData output = SystemCatalogProtoMapper.fromProto(proto);
 
     assertThat(output.functions().get(0).engineSpecific()).isEmpty();
+  }
+
+  @Test
+  void roundTrip_preservesSystemTableConstraints() {
+    ConstraintDefinition constraint =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_tables")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .addColumns(
+                ConstraintColumnRef.newBuilder()
+                    .setColumnName("table_name")
+                    .setColumnId(1L)
+                    .setOrdinal(1)
+                    .build())
+            .build();
+    SystemCatalogData input =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(
+                new SystemTableDef(
+                    NameRef.newBuilder().addPath("information_schema").setName("tables").build(),
+                    "tables",
+                    List.of(
+                        new SystemColumnDef(
+                            "table_name", name("VARCHAR"), false, 1, 1L, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(constraint))),
+            List.of(),
+            List.of());
+
+    SystemObjectsRegistry proto = SystemCatalogProtoMapper.toProto(input);
+    SystemCatalogData output = SystemCatalogProtoMapper.fromProto(proto, "floedb");
+
+    assertThat(output.tables()).hasSize(1);
+    assertThat(output.tables().get(0).constraints()).hasSize(1);
+    assertThat(output.tables().get(0).constraints().get(0).toByteString())
+        .isEqualTo(constraint.toByteString());
   }
 
   @Test

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/validation/SystemCatalogValidatorTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/validation/SystemCatalogValidatorTest.java
@@ -18,7 +18,11 @@ package ai.floedb.floecat.systemcatalog.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
 import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.query.rpc.TableBackendKind;
 import ai.floedb.floecat.systemcatalog.def.*;
 import ai.floedb.floecat.systemcatalog.engine.EngineSpecificRule;
 import ai.floedb.floecat.systemcatalog.registry.SystemCatalogData;
@@ -581,6 +585,580 @@ final class SystemCatalogValidatorTest {
     ValidationIssue issue = findFirst(issues, "engine_specific.payload_type.required");
     assertThat(issue).isNotNull();
     assertThat(issue.ctx()).isEqualTo("function:f.engineSpecific[0]");
+  }
+
+  @Test
+  void validate_tableConstraintUnknownColumnRef() {
+    ConstraintDefinition badConstraint =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_tables")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .addColumns(
+                ConstraintColumnRef.newBuilder().setColumnName("missing_col").setOrdinal(1).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(
+                        new SystemColumnDef(
+                            "table_name", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(badConstraint))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.column_ref.unknown");
+  }
+
+  @Test
+  void validate_tableConstraintRejectsDuplicateConstraintName() {
+    ConstraintDefinition c1 =
+        ConstraintDefinition.newBuilder()
+            .setName("dup_name")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .addColumns(
+                ConstraintColumnRef.newBuilder().setColumnName("table_name").setOrdinal(1).build())
+            .build();
+    ConstraintDefinition c2 =
+        ConstraintDefinition.newBuilder()
+            .setName("dup_name")
+            .setType(ConstraintType.CT_UNIQUE)
+            .addColumns(
+                ConstraintColumnRef.newBuilder().setColumnName("table_name").setOrdinal(1).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(
+                        new SystemColumnDef(
+                            "table_name", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(c1, c2))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.name.duplicate");
+  }
+
+  @Test
+  void validate_notNullConstraintMustHaveExactlyOneColumn() {
+    ConstraintDefinition notNullWithTwoColumns =
+        ConstraintDefinition.newBuilder()
+            .setName("bad_nn")
+            .setType(ConstraintType.CT_NOT_NULL)
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c2").setOrdinal(2).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(
+                        new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of()),
+                        new SystemColumnDef("c2", name("VARCHAR"), false, 2, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(notNullWithTwoColumns))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.not_null.single_column");
+  }
+
+  @Test
+  void validate_fkConstraintRequiresReferencedTable() {
+    ConstraintDefinition fkMissingReferencedTable =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_tables")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .addReferencedColumns(
+                ConstraintColumnRef.newBuilder().setColumnName("x1").setOrdinal(1).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(fkMissingReferencedTable))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.fk.referenced_table.required");
+  }
+
+  @Test
+  void validate_nonFkCannotSetReferencedFields() {
+    ConstraintDefinition pkWithReferencedFields =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_bad")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .setReferencedTableName("other")
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(pkWithReferencedFields))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.fk_only.field.not_allowed");
+  }
+
+  @Test
+  void validate_checkRequiresExpressionAndOnlyCheckCanUseExpression() {
+    ConstraintDefinition checkWithoutExpression =
+        ConstraintDefinition.newBuilder()
+            .setName("check_bad")
+            .setType(ConstraintType.CT_CHECK)
+            .build();
+    ConstraintDefinition pkWithCheckExpression =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_bad_expr")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .setCheckExpression("c1 > 0")
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(checkWithoutExpression, pkWithCheckExpression))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues))
+        .contains(
+            "table.constraint.check.expression.required",
+            "table.constraint.check_only.expression.not_allowed");
+  }
+
+  @Test
+  void validate_validCompositePrimaryKeyPasses() {
+    ConstraintDefinition compositePk =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_composite")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c2").setOrdinal(2).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(
+                        new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of()),
+                        new SystemColumnDef("c2", name("VARCHAR"), false, 2, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(compositePk))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  void validate_validCompositeForeignKeyPasses() {
+    ConstraintDefinition compositeFk =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_composite")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .setReferencedTableName("information_schema.other_table")
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c2").setOrdinal(2).build())
+            .addReferencedColumns(
+                ConstraintColumnRef.newBuilder().setColumnName("r1").setOrdinal(1).build())
+            .addReferencedColumns(
+                ConstraintColumnRef.newBuilder().setColumnName("r2").setOrdinal(2).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(
+                        new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of()),
+                        new SystemColumnDef("c2", name("VARCHAR"), false, 2, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(compositeFk)),
+                new SystemTableDef(
+                    name("information_schema", "other_table"),
+                    "other_table",
+                    List.of(
+                        new SystemColumnDef("r1", name("VARCHAR"), false, 1, null, List.of()),
+                        new SystemColumnDef("r2", name("VARCHAR"), false, 2, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "other_tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of())),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  void validate_selfReferencingForeignKeyChecksReferencedColumnExistence() {
+    ConstraintDefinition selfFkWithUnknownReferencedColumn =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_self")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .setReferencedTableName("tables")
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .addReferencedColumns(
+                ConstraintColumnRef.newBuilder().setColumnName("missing_ref").setOrdinal(1).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(selfFkWithUnknownReferencedColumn))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.column_ref.unknown");
+  }
+
+  @Test
+  void validate_foreignKeyReferencedColumnsCheckedAgainstReferencedTableWhenKnown() {
+    ConstraintDefinition fkWithUnknownReferencedColumn =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_known_ref")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .setReferencedTableName("information_schema.ref_table")
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .addReferencedColumns(
+                ConstraintColumnRef.newBuilder().setColumnName("missing_ref").setOrdinal(1).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(fkWithUnknownReferencedColumn)),
+                new SystemTableDef(
+                    name("information_schema", "ref_table"),
+                    "ref_table",
+                    List.of(
+                        new SystemColumnDef("ref_id", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "ref_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of())),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.column_ref.unknown");
+  }
+
+  @Test
+  void validate_foreignKeyReferencedColumnIdNameMismatchIsRejected() {
+    ConstraintDefinition fkWithMismatchedReferencedRef =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_ref_mismatch")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .setReferencedTableName("information_schema.ref_table")
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .addReferencedColumns(
+                ConstraintColumnRef.newBuilder()
+                    .setColumnId(1L)
+                    .setColumnName("ref_two")
+                    .setOrdinal(1)
+                    .build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(fkWithMismatchedReferencedRef)),
+                new SystemTableDef(
+                    name("information_schema", "ref_table"),
+                    "ref_table",
+                    List.of(
+                        new SystemColumnDef("ref_one", name("VARCHAR"), false, 1, 1L, List.of()),
+                        new SystemColumnDef("ref_two", name("VARCHAR"), false, 2, 2L, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "ref_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of())),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.column_ref.id_name.mismatch");
+  }
+
+  @Test
+  void validate_foreignKeyReferencedTableNameMustResolveWhenNoReferencedTableId() {
+    ConstraintDefinition fkUnknownTable =
+        ConstraintDefinition.newBuilder()
+            .setName("fk_unknown_table")
+            .setType(ConstraintType.CT_FOREIGN_KEY)
+            .setReferencedTableName("information_schema.missing_table")
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .addReferencedColumns(
+                ConstraintColumnRef.newBuilder().setColumnName("id").setOrdinal(1).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(new SystemColumnDef("c1", name("VARCHAR"), false, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(fkUnknownTable))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.fk.referenced_table.unknown");
+  }
+
+  @Test
+  void validate_notNullConstraintOnNullableColumnIsRejected() {
+    ConstraintDefinition explicitNotNull =
+        ConstraintDefinition.newBuilder()
+            .setName("nn_bad")
+            .setType(ConstraintType.CT_NOT_NULL)
+            .addColumns(ConstraintColumnRef.newBuilder().setColumnName("c1").setOrdinal(1).build())
+            .build();
+
+    SystemCatalogData catalog =
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(namespace("information_schema")),
+            List.of(
+                new SystemTableDef(
+                    name("information_schema", "tables"),
+                    "tables",
+                    List.of(new SystemColumnDef("c1", name("VARCHAR"), true, 1, null, List.of())),
+                    TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+                    "tables_scanner",
+                    "",
+                    "",
+                    List.of(),
+                    null,
+                    List.of(explicitNotNull))),
+            List.of(),
+            List.of());
+
+    List<ValidationIssue> issues = SystemCatalogValidator.validate(catalog);
+    assertThat(codes(issues)).contains("table.constraint.not_null.column_is_nullable");
   }
 
   // ---------------------------------------------------------------------------

--- a/core/proto/src/main/proto/floecat/query/system_objects_registry.proto
+++ b/core/proto/src/main/proto/floecat/query/system_objects_registry.proto
@@ -18,6 +18,7 @@ package ai.floedb.floecat.query;
 import "floecat/query/engine_specific.proto";
 import "floecat/query/sql_objects.proto";
 import "floecat/common/common.proto";
+import "floecat/catalog/constraints.proto";
 
 option java_multiple_files = true;
 option java_package = "ai.floedb.floecat.query.rpc";
@@ -103,6 +104,9 @@ message SystemTable {
     /** Engine backend metadata. */
     EngineTableDetails engine = 7;
   }
+
+  /** Immutable constraints declared for this system table. */
+  repeated ai.floedb.floecat.catalog.ConstraintDefinition constraints = 8;
 
   /** Engine-specific metadata scoped to this table. */
   repeated EngineSpecific engine_specific = 99;

--- a/docs/system-objects.md
+++ b/docs/system-objects.md
@@ -79,6 +79,50 @@ The core pieces:
 - **`SystemObjectScannerProvider`** – SPI for providers of definitions and scanners. `definitions()` lists every `SystemObjectDef` (no filtering). `supportsEngine`/`supports(NameRef, engineKind)` gate when a definition applies. `provide(scannerId, engineKind, engineVersion)` lets the runtime look up the scanner for a node’s `scannerId`. The SPI now exposes version-aware helpers (`definitions(engineKind, engineVersion)` and `supports(NameRef, engineKind, engineVersion)`) so providers can evolve schemas per engine version. During catalog assembly `SystemNodeRegistry.mergeCatalogData` seeds the map with the `floecat_internal` base from `FloecatInternalProvider`, overlays the plugin catalog, and finally applies provider definitions so every overlay can override earlier entries.
 - **`ServiceLoaderSystemCatalogProvider`** – Discovers `EngineSystemCatalogExtension`s (which already extend `SystemObjectScannerProvider`), loads the catalog for each normalized engine kind, fingerprints it, and hands it to `SystemDefinitionRegistry`. It exposes `internalProvider()` for the shared `floecat_internal` layer and `providers()` for the extension-only overlays; provider merges happen later in `SystemNodeRegistry`.
 - **`SystemNodeRegistry` + `SystemGraph`** – The registry filters the snapshot for the requested engine/version, materialises `GraphNode`s (functions, types, aggregates) and `SystemTableNode`s (with their `scannerId`s), and caches the result, seeding each merge with the shared `information_schema` definitions provided by `FloecatInternalProvider`. Overlays are only applied when `EngineContext.enginePluginOverlaysEnabled()` returns true. Unknown or missing headers fall back to the base view while still exposing `information_schema`. `SystemGraph` builds `GraphSnapshot`s from those nodes and keeps them in an LRU `LinkedHashMap` keyed by `(engineKind, engineVersion)`. Each snapshot stores namespace buckets, table relations, and a `nodesById` map for constant-time resolution.
+- **System constraint catalog** – Planner/system constraint lookups are backed by an immutable cache keyed by `(engineKind, engineVersion, systemRelationId)` and built from the pbtxt-backed builtin table definitions loaded by `FloecatInternalProvider`/`SystemNodeRegistry` (not from `information_schema` scans). Constraints are explicit metadata (`SystemTable.constraints`) and are validated during builtin catalog load. The runtime currently de-duplicates only `CT_NOT_NULL` between explicit and nullable-derived implicit entries (and keeps other constraint kinds as declared), so semantic de-duplication of PK/UNIQUE/FK/CHECK is intentionally out of scope here.
+  - Validator note: FK referenced-column target validation is currently name-based. `referenced_table_id` satisfies FK presence requirements, but column-target lookup for validation uses `referenced_table_name`.
+  - pbtxt authoring example (common constraint types):
+```pbtxt
+system_tables {
+  name { path: "information_schema" name: "orders" }
+  display_name: "orders"
+  backend_kind: TABLE_BACKEND_KIND_FLOECAT
+  floecat { scanner_id: "orders_scanner" }
+  columns { name: "id" type { name: "BIGINT" } nullable: false ordinal: 1 id: 1 }
+  columns { name: "customer_id" type { name: "BIGINT" } nullable: false ordinal: 2 id: 2 }
+  columns { name: "order_no" type { name: "VARCHAR" } nullable: false ordinal: 3 id: 3 }
+  columns { name: "total_amount" type { name: "DECIMAL" } nullable: false ordinal: 4 id: 4 }
+
+  constraints {
+    name: "pk_orders"
+    type: CT_PRIMARY_KEY
+    columns { column_id: 1 column_name: "id" ordinal: 1 }
+  }
+  constraints {
+    name: "uq_orders_order_no"
+    type: CT_UNIQUE
+    columns { column_id: 3 column_name: "order_no" ordinal: 1 }
+  }
+  constraints {
+    name: "ck_orders_total_non_negative"
+    type: CT_CHECK
+    check_expression: "total_amount >= 0"
+    columns { column_id: 4 column_name: "total_amount" ordinal: 1 }
+  }
+  constraints {
+    name: "fk_orders_customers"
+    type: CT_FOREIGN_KEY
+    columns { column_id: 2 column_name: "customer_id" ordinal: 1 }
+    referenced_table_name: "information_schema.customers"
+    referenced_columns { column_id: 1 column_name: "id" ordinal: 1 }
+  }
+  constraints {
+    name: "nn_orders_total_amount"
+    type: CT_NOT_NULL
+    columns { column_id: 4 column_name: "total_amount" ordinal: 1 }
+  }
+}
+```
 - **Namespace resolution** – Objects are mapped to namespaces by canonical name, trimming everything after the final dot. That means `t` resolves to namespace `t` rather than a default schema, so every system function/table/view must be defined with a fully qualified name (e.g., `foo.bar`). If you need to expose unqualified identifiers you must provide a dedicated namespace node whose canonical path matches the identifier you intend to publish; otherwise the node will be skipped during merging because `findNamespaceId` can’t map it to an existing namespace.
 - **`CatalogOverlay` / `MetaGraph`** – The overlay implements `SystemObjectGraphView` and exposes an immutable view over `MetadataGraph` plus the `_system` snapshot from `SystemGraph`. `SystemObjectScanContext` receives this view and uses it for every lookup, so scanners consistently benefit from the metadata graph’s caches.
 - **Registry-level engine hints** – `SystemObjectsRegistry` now carries a `repeated EngineSpecific engine_specific` section that plugins can use to ship shared dictionaries (pg_opfamily/opclass/amop-like payloads) or other planner-only metadata once per `(engine_kind, engine_version)`. These payloads are filtered by `EngineSpecificRule` and travel alongside the node-level definitions, so the planner and scanners can deserialize them without adding new system tables (see `SystemObjectsRegistry.engine_specific` in `core/proto/src/main/proto/floecat/query/system_objects_registry.proto`).

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/ConstraintProviderFactory.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/ConstraintProviderFactory.java
@@ -44,11 +44,19 @@ public final class ConstraintProviderFactory {
   private final ConstraintProvider systemProvider;
 
   @Inject
-  public ConstraintProviderFactory(ConstraintRepository repository, CatalogOverlay overlay) {
-    this(repository, overlay, ConstraintProvider.NONE);
+  public ConstraintProviderFactory(
+      ConstraintRepository repository,
+      CatalogOverlay overlay,
+      SystemConstraintProvider systemProvider) {
+    this(repository, overlay, (ConstraintProvider) systemProvider);
   }
 
-  ConstraintProviderFactory(
+  static ConstraintProviderFactory forTesting(
+      ConstraintRepository repository, CatalogOverlay overlay, ConstraintProvider systemProvider) {
+    return new ConstraintProviderFactory(repository, overlay, systemProvider);
+  }
+
+  private ConstraintProviderFactory(
       ConstraintRepository repository, CatalogOverlay overlay, ConstraintProvider systemProvider) {
     this.repository = repository;
     this.overlay = overlay;

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/SystemConstraintCatalog.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/SystemConstraintCatalog.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintEnforcement;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.scanner.spi.ConstraintProvider;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.systemcatalog.def.SystemColumnDef;
+import ai.floedb.floecat.systemcatalog.def.SystemTableDef;
+import ai.floedb.floecat.systemcatalog.graph.SystemCatalogTranslator;
+import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
+import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Immutable, engine/version-scoped cache of system relation constraints.
+ *
+ * <p>System constraints come from builtin system table definitions (pbtxt-backed), not from
+ * information_schema scans, and are not snapshot-scoped.
+ */
+@ApplicationScoped
+final class SystemConstraintCatalog {
+
+  private final SystemNodeRegistry systemNodeRegistry;
+  private final ConcurrentMap<VersionKey, Map<ResourceId, ConstraintProvider.ConstraintSetView>>
+      byVersion = new ConcurrentHashMap<>();
+
+  @Inject
+  SystemConstraintCatalog(SystemNodeRegistry systemNodeRegistry) {
+    this.systemNodeRegistry = systemNodeRegistry;
+  }
+
+  Optional<ConstraintProvider.ConstraintSetView> constraints(
+      EngineContext engineContext, ResourceId relationId) {
+    ResourceId normalized = SystemCatalogTranslator.normalizeSystemId(relationId);
+    if (normalized == null) {
+      normalized = relationId;
+    }
+    return Optional.ofNullable(catalogFor(engineContext).get(normalized));
+  }
+
+  private Map<ResourceId, ConstraintProvider.ConstraintSetView> catalogFor(EngineContext ctx) {
+    EngineContext effective = ctx == null ? EngineContext.empty() : ctx;
+    VersionKey key = new VersionKey(effective.effectiveEngineKind(), effective.normalizedVersion());
+    return byVersion.computeIfAbsent(key, ignored -> buildCatalog(effective));
+  }
+
+  private Map<ResourceId, ConstraintProvider.ConstraintSetView> buildCatalog(EngineContext ctx) {
+    var nodes = systemNodeRegistry.nodesFor(ctx);
+    Map<ResourceId, ConstraintProvider.ConstraintSetView> out = new LinkedHashMap<>();
+    for (var tableDef : nodes.toCatalogData().tables()) {
+      ResourceId tableId = nodes.tableNames().get(NameRefUtil.canonical(tableDef.name()));
+      if (tableId == null) {
+        continue;
+      }
+      List<ConstraintDefinition> constraints = effectiveConstraints(tableDef);
+      if (constraints.isEmpty()) {
+        continue;
+      }
+      out.put(
+          tableId,
+          new SystemConstraintSetView(
+              tableId,
+              constraints,
+              Map.of(
+                  "source", "system_catalog",
+                  "engine_kind", ctx.effectiveEngineKind(),
+                  "engine_version", ctx.normalizedVersion())));
+    }
+    return Map.copyOf(out);
+  }
+
+  private static List<ConstraintDefinition> effectiveConstraints(SystemTableDef tableDef) {
+    List<ConstraintDefinition> explicit = tableDef.constraints();
+    if ((explicit == null || explicit.isEmpty()) && tableDef.columns().isEmpty()) {
+      return List.of();
+    }
+
+    List<ConstraintDefinition> out = new java.util.ArrayList<>();
+    LinkedHashSet<String> emittedNotNullKeys = new LinkedHashSet<>();
+
+    for (ConstraintDefinition constraint : explicit) {
+      if (constraint.getType() != ConstraintType.CT_NOT_NULL) {
+        out.add(constraint);
+        continue;
+      }
+      String key = notNullKey(constraint);
+      if (key == null) {
+        out.add(constraint);
+        continue;
+      }
+      if (emittedNotNullKeys.add(key)) {
+        out.add(constraint);
+      }
+    }
+
+    for (SystemColumnDef column : tableDef.columns()) {
+      if (column.nullable()) {
+        continue;
+      }
+      String key = notNullKey(column);
+      if (!emittedNotNullKeys.contains(key)) {
+        out.add(implicitNotNull(column));
+        emittedNotNullKeys.add(key);
+      }
+    }
+
+    return List.copyOf(out);
+  }
+
+  private static ConstraintDefinition implicitNotNull(SystemColumnDef column) {
+    ConstraintColumnRef.Builder ref =
+        ConstraintColumnRef.newBuilder().setColumnName(column.name()).setOrdinal(1);
+    String constraintName = "nn_" + column.name();
+    if (column.hasId() && column.id() > 0) {
+      ref.setColumnId(column.id());
+      constraintName = "nn_" + column.id();
+    }
+    return ConstraintDefinition.newBuilder()
+        .setName(constraintName)
+        .setType(ConstraintType.CT_NOT_NULL)
+        .setEnforcement(ConstraintEnforcement.CE_ENFORCED)
+        .addColumns(ref.build())
+        .build();
+  }
+
+  private static String notNullKey(ConstraintDefinition constraint) {
+    if (constraint.getColumnsCount() != 1) {
+      return null;
+    }
+    ConstraintColumnRef ref = constraint.getColumns(0);
+    if (ref.getColumnId() > 0) {
+      return "id:" + ref.getColumnId();
+    }
+    if (!ref.getColumnName().isBlank()) {
+      return "name:" + ref.getColumnName();
+    }
+    return null;
+  }
+
+  private static String notNullKey(SystemColumnDef column) {
+    if (column.hasId() && column.id() > 0) {
+      return "id:" + column.id();
+    }
+    return "name:" + column.name();
+  }
+
+  private record VersionKey(String engineKind, String engineVersion) {}
+
+  private record SystemConstraintSetView(
+      ResourceId relationId, List<ConstraintDefinition> constraints, Map<String, String> properties)
+      implements ConstraintProvider.ConstraintSetView {}
+}

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/SystemConstraintProvider.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/SystemConstraintProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.scanner.spi.ConstraintProvider;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.context.EngineContextProvider;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/** Constraint provider backed by immutable system catalog metadata. */
+@ApplicationScoped
+final class SystemConstraintProvider implements ConstraintProvider {
+
+  private final SystemConstraintCatalog catalog;
+  private final EngineContextProvider engineContextProvider;
+
+  @Inject
+  SystemConstraintProvider(
+      SystemConstraintCatalog catalog, EngineContextProvider engineContextProvider) {
+    this.catalog = catalog;
+    this.engineContextProvider = engineContextProvider;
+  }
+
+  @Override
+  public Optional<ConstraintSetView> constraints(ResourceId relationId, OptionalLong snapshotId) {
+    EngineContext context =
+        engineContextProvider.isPresent()
+            ? engineContextProvider.engineContext()
+            : EngineContext.empty();
+    return catalog.constraints(context, relationId);
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/ConstraintProviderFactoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/ConstraintProviderFactoryTest.java
@@ -61,7 +61,8 @@ class ConstraintProviderFactoryTest {
     CatalogOverlay overlay = mock(CatalogOverlay.class);
     when(overlay.resolve(USER_TABLE)).thenReturn(Optional.empty());
 
-    ConstraintProviderFactory factory = new ConstraintProviderFactory(repository, overlay);
+    ConstraintProviderFactory factory =
+        ConstraintProviderFactory.forTesting(repository, overlay, ConstraintProvider.NONE);
     long snapshotId = 101L;
     repository.putSnapshotConstraints(
         USER_TABLE, snapshotId, constraints(USER_TABLE, snapshotId, "pk_users"));
@@ -79,7 +80,8 @@ class ConstraintProviderFactoryTest {
     CountingConstraintRepository repository = new CountingConstraintRepository();
     CatalogOverlay overlay = mock(CatalogOverlay.class);
     when(overlay.resolve(USER_TABLE)).thenReturn(Optional.empty());
-    ConstraintProviderFactory factory = new ConstraintProviderFactory(repository, overlay);
+    ConstraintProviderFactory factory =
+        ConstraintProviderFactory.forTesting(repository, overlay, ConstraintProvider.NONE);
     ConstraintProvider provider = factory.provider();
 
     assertTrue(provider.constraints(USER_TABLE, OptionalLong.empty()).isEmpty());
@@ -120,7 +122,7 @@ class ConstraintProviderFactoryTest {
         };
 
     ConstraintProviderFactory factory =
-        new ConstraintProviderFactory(repository, overlay, systemProvider);
+        ConstraintProviderFactory.forTesting(repository, overlay, systemProvider);
     ConstraintProvider provider = factory.provider();
 
     var system = provider.constraints(SYSTEM_TABLE, OptionalLong.of(snapshotId)).orElseThrow();

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/SystemConstraintCatalogTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/SystemConstraintCatalogTest.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
+import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
+import ai.floedb.floecat.catalog.rpc.ConstraintEnforcement;
+import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.query.rpc.TableBackendKind;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.systemcatalog.def.SystemColumnDef;
+import ai.floedb.floecat.systemcatalog.def.SystemTableDef;
+import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
+import ai.floedb.floecat.systemcatalog.registry.SystemCatalogData;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SystemConstraintCatalogTest {
+
+  @Test
+  void lookupBySystemRelationIdUsesPbtxtDeclaredConstraints() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId tableId = tableId();
+    when(registry.nodesFor(any(EngineContext.class))).thenReturn(builtinNodes(tableId));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    var view = catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).orElseThrow();
+
+    assertEquals(tableId, view.relationId());
+    assertEquals(1, view.constraints().size());
+    assertEquals(ConstraintType.CT_NOT_NULL, view.constraints().get(0).getType());
+    assertEquals("tables_table_name_nn", view.constraints().get(0).getName());
+    assertEquals("floedb", view.properties().get("engine_kind"));
+  }
+
+  @Test
+  void lookupSynthesizesNotNullFromNonNullableColumnsWhenNotExplicitlyDeclared() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId tableId = tableId();
+    when(registry.nodesFor(any(EngineContext.class)))
+        .thenReturn(builtinNodesWithoutExplicitConstraint(tableId));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    var view = catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).orElseThrow();
+
+    assertEquals(1, view.constraints().size());
+    assertEquals(ConstraintType.CT_NOT_NULL, view.constraints().get(0).getType());
+    assertEquals("nn_10", view.constraints().get(0).getName());
+    assertEquals(ConstraintEnforcement.CE_ENFORCED, view.constraints().get(0).getEnforcement());
+  }
+
+  @Test
+  void lookupDedupesExplicitAndImplicitNotNullForSameColumn() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId tableId = tableId();
+    when(registry.nodesFor(any(EngineContext.class))).thenReturn(builtinNodes(tableId));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    var view = catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).orElseThrow();
+
+    assertEquals(1, view.constraints().size());
+    assertEquals("tables_table_name_nn", view.constraints().get(0).getName());
+  }
+
+  @Test
+  void lookupDedupesExplicitAndImplicitNotNullWhenExplicitKeyedByColumnId() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId tableId = tableId();
+    when(registry.nodesFor(any(EngineContext.class)))
+        .thenReturn(
+            builtinNodesWithColumnsAndConstraints(
+                tableId,
+                List.of(
+                    new SystemColumnDef(
+                        "c1",
+                        NameRef.newBuilder().setName("VARCHAR").build(),
+                        false,
+                        1,
+                        10L,
+                        List.of())),
+                List.of(
+                    ConstraintDefinition.newBuilder()
+                        .setName("nn_c1_explicit_id")
+                        .setType(ConstraintType.CT_NOT_NULL)
+                        .addColumns(
+                            ConstraintColumnRef.newBuilder().setColumnId(10L).setOrdinal(1).build())
+                        .build())));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    var view = catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).orElseThrow();
+
+    assertEquals(1, view.constraints().size());
+    assertEquals("nn_c1_explicit_id", view.constraints().get(0).getName());
+  }
+
+  @Test
+  void lookupDedupesExplicitAndImplicitNotNullWhenExplicitKeyedByColumnName() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId tableId = tableId();
+    when(registry.nodesFor(any(EngineContext.class)))
+        .thenReturn(
+            builtinNodesWithColumnsAndConstraints(
+                tableId,
+                List.of(
+                    new SystemColumnDef(
+                        "c1",
+                        NameRef.newBuilder().setName("VARCHAR").build(),
+                        false,
+                        1,
+                        null,
+                        List.of())),
+                List.of(
+                    ConstraintDefinition.newBuilder()
+                        .setName("nn_c1_explicit_name")
+                        .setType(ConstraintType.CT_NOT_NULL)
+                        .addColumns(
+                            ConstraintColumnRef.newBuilder()
+                                .setColumnName("c1")
+                                .setOrdinal(1)
+                                .build())
+                        .build())));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    var view = catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).orElseThrow();
+
+    assertEquals(1, view.constraints().size());
+    assertEquals("nn_c1_explicit_name", view.constraints().get(0).getName());
+  }
+
+  @Test
+  void lookupMalformedExplicitNotNullStillSynthesizesImplicitNotNull() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId tableId = tableId();
+    when(registry.nodesFor(any(EngineContext.class)))
+        .thenReturn(
+            builtinNodesWithColumnsAndConstraints(
+                tableId,
+                List.of(
+                    new SystemColumnDef(
+                        "c1",
+                        NameRef.newBuilder().setName("VARCHAR").build(),
+                        false,
+                        1,
+                        10L,
+                        List.of())),
+                List.of(
+                    ConstraintDefinition.newBuilder()
+                        .setName("nn_malformed")
+                        .setType(ConstraintType.CT_NOT_NULL)
+                        .addColumns(ConstraintColumnRef.newBuilder().setOrdinal(1).build())
+                        .build())));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    var view = catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).orElseThrow();
+
+    assertEquals(2, view.constraints().size());
+    assertEquals("nn_malformed", view.constraints().get(0).getName());
+    assertEquals("nn_10", view.constraints().get(1).getName());
+  }
+
+  @Test
+  void lookupSynthesizesImplicitNotNullForEachNonNullableColumn() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId tableId = tableId();
+    when(registry.nodesFor(any(EngineContext.class)))
+        .thenReturn(
+            builtinNodesWithColumnsAndConstraints(
+                tableId,
+                List.of(
+                    new SystemColumnDef(
+                        "c1",
+                        NameRef.newBuilder().setName("VARCHAR").build(),
+                        false,
+                        1,
+                        1L,
+                        List.of()),
+                    new SystemColumnDef(
+                        "c2",
+                        NameRef.newBuilder().setName("VARCHAR").build(),
+                        false,
+                        2,
+                        2L,
+                        List.of()),
+                    new SystemColumnDef(
+                        "c3",
+                        NameRef.newBuilder().setName("VARCHAR").build(),
+                        true,
+                        3,
+                        3L,
+                        List.of())),
+                List.of()));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    var view = catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).orElseThrow();
+
+    assertEquals(2, view.constraints().size());
+    assertEquals("nn_1", view.constraints().get(0).getName());
+    assertEquals("nn_2", view.constraints().get(1).getName());
+  }
+
+  @Test
+  void lookupPreservesExplicitOrderAndAppendsMissingImplicitNotNulls() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId tableId = tableId();
+    when(registry.nodesFor(any(EngineContext.class))).thenReturn(builtinNodesWithOrder(tableId));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    var view = catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).orElseThrow();
+
+    assertEquals(4, view.constraints().size());
+    assertEquals("pk_tables", view.constraints().get(0).getName());
+    assertEquals("nn_c2_explicit", view.constraints().get(1).getName());
+    assertEquals("ck_tables", view.constraints().get(2).getName());
+    assertEquals("nn_1", view.constraints().get(3).getName());
+  }
+
+  @Test
+  void lookupNormalizesSystemMarkerIdsAcrossAccounts() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId systemId = tableId();
+    when(registry.nodesFor(any(EngineContext.class))).thenReturn(builtinNodes(systemId));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    ResourceId userAccountAlias = systemId.toBuilder().setAccountId("acct").build();
+
+    var view =
+        catalog.constraints(EngineContext.of("floedb", "1.0"), userAccountAlias).orElseThrow();
+    assertEquals(systemId, view.relationId());
+  }
+
+  @Test
+  void catalogIsCachedPerEngineVersionKey() {
+    SystemNodeRegistry registry = mock(SystemNodeRegistry.class);
+    ResourceId tableId = tableId();
+    when(registry.nodesFor(any(EngineContext.class))).thenReturn(builtinNodes(tableId));
+
+    SystemConstraintCatalog catalog = new SystemConstraintCatalog(registry);
+    assertTrue(catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).isPresent());
+    assertTrue(catalog.constraints(EngineContext.of("floedb", "1.0"), tableId).isPresent());
+
+    verify(registry, times(1)).nodesFor(any(EngineContext.class));
+  }
+
+  private static SystemNodeRegistry.BuiltinNodes builtinNodes(ResourceId tableId) {
+    ConstraintDefinition tableNameNotNull =
+        ConstraintDefinition.newBuilder()
+            .setName("tables_table_name_nn")
+            .setType(ConstraintType.CT_NOT_NULL)
+            .addColumns(
+                ConstraintColumnRef.newBuilder()
+                    .setColumnName("table_name")
+                    .setColumnId(10L)
+                    .setOrdinal(1)
+                    .build())
+            .build();
+    SystemTableDef tableDef =
+        new SystemTableDef(
+            NameRef.newBuilder().addPath("information_schema").setName("tables").build(),
+            "tables",
+            List.of(
+                new SystemColumnDef(
+                    "table_name",
+                    NameRef.newBuilder().setName("VARCHAR").build(),
+                    false,
+                    1,
+                    10L,
+                    List.of()),
+                new SystemColumnDef(
+                    "table_catalog",
+                    NameRef.newBuilder().setName("VARCHAR").build(),
+                    true,
+                    2,
+                    11L,
+                    List.of())),
+            TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+            "tables_scanner",
+            "",
+            "",
+            List.of(),
+            null,
+            List.of(tableNameNotNull));
+    return new SystemNodeRegistry.BuiltinNodes(
+        "floedb",
+        "1.0",
+        "fingerprint",
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        Map.of(),
+        Map.of(),
+        Map.of("information_schema.tables", tableId),
+        Map.of(),
+        Map.of(),
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(tableDef),
+            List.of(),
+            List.of()));
+  }
+
+  private static ResourceId tableId() {
+    return SystemNodeRegistry.resourceId(
+        "floedb",
+        ResourceKind.RK_TABLE,
+        NameRef.newBuilder()
+            .setCatalog("floedb")
+            .addPath("information_schema")
+            .setName("tables")
+            .build());
+  }
+
+  private static SystemNodeRegistry.BuiltinNodes builtinNodesWithoutExplicitConstraint(
+      ResourceId tableId) {
+    ResourceId namespaceId =
+        SystemNodeRegistry.resourceId(
+            "floedb",
+            ResourceKind.RK_NAMESPACE,
+            NameRef.newBuilder().setCatalog("floedb").setName("information_schema").build());
+    SystemTableDef tableDef =
+        new SystemTableDef(
+            NameRef.newBuilder().addPath("information_schema").setName("tables").build(),
+            "tables",
+            List.of(
+                new SystemColumnDef(
+                    "table_name",
+                    NameRef.newBuilder().setName("VARCHAR").build(),
+                    false,
+                    1,
+                    10L,
+                    List.of())),
+            TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+            "tables_scanner",
+            "",
+            "",
+            List.of(),
+            null,
+            List.of());
+    return new SystemNodeRegistry.BuiltinNodes(
+        "floedb",
+        "1.0",
+        "fingerprint",
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        Map.of(),
+        Map.of(),
+        Map.of("information_schema.tables", tableId),
+        Map.of(),
+        Map.of("information_schema", namespaceId),
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(tableDef),
+            List.of(),
+            List.of()));
+  }
+
+  private static SystemNodeRegistry.BuiltinNodes builtinNodesWithOrder(ResourceId tableId) {
+    ResourceId namespaceId =
+        SystemNodeRegistry.resourceId(
+            "floedb",
+            ResourceKind.RK_NAMESPACE,
+            NameRef.newBuilder().setCatalog("floedb").setName("information_schema").build());
+    ConstraintDefinition pk =
+        ConstraintDefinition.newBuilder()
+            .setName("pk_tables")
+            .setType(ConstraintType.CT_PRIMARY_KEY)
+            .addColumns(
+                ConstraintColumnRef.newBuilder()
+                    .setColumnName("c1")
+                    .setColumnId(1L)
+                    .setOrdinal(1)
+                    .build())
+            .build();
+    ConstraintDefinition explicitNotNullC2 =
+        ConstraintDefinition.newBuilder()
+            .setName("nn_c2_explicit")
+            .setType(ConstraintType.CT_NOT_NULL)
+            .addColumns(
+                ConstraintColumnRef.newBuilder()
+                    .setColumnName("c2")
+                    .setColumnId(2L)
+                    .setOrdinal(1)
+                    .build())
+            .build();
+    ConstraintDefinition check =
+        ConstraintDefinition.newBuilder()
+            .setName("ck_tables")
+            .setType(ConstraintType.CT_CHECK)
+            .setCheckExpression("c1 > 0")
+            .build();
+    SystemTableDef tableDef =
+        new SystemTableDef(
+            NameRef.newBuilder().addPath("information_schema").setName("tables").build(),
+            "tables",
+            List.of(
+                new SystemColumnDef(
+                    "c1", NameRef.newBuilder().setName("VARCHAR").build(), false, 1, 1L, List.of()),
+                new SystemColumnDef(
+                    "c2",
+                    NameRef.newBuilder().setName("VARCHAR").build(),
+                    false,
+                    2,
+                    2L,
+                    List.of())),
+            TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+            "tables_scanner",
+            "",
+            "",
+            List.of(),
+            null,
+            List.of(pk, explicitNotNullC2, check));
+    return new SystemNodeRegistry.BuiltinNodes(
+        "floedb",
+        "1.0",
+        "fingerprint",
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        Map.of(),
+        Map.of(),
+        Map.of("information_schema.tables", tableId),
+        Map.of(),
+        Map.of("information_schema", namespaceId),
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(tableDef),
+            List.of(),
+            List.of()));
+  }
+
+  private static SystemNodeRegistry.BuiltinNodes builtinNodesWithColumnsAndConstraints(
+      ResourceId tableId, List<SystemColumnDef> columns, List<ConstraintDefinition> constraints) {
+    ResourceId namespaceId =
+        SystemNodeRegistry.resourceId(
+            "floedb",
+            ResourceKind.RK_NAMESPACE,
+            NameRef.newBuilder().setCatalog("floedb").setName("information_schema").build());
+    SystemTableDef tableDef =
+        new SystemTableDef(
+            NameRef.newBuilder().addPath("information_schema").setName("tables").build(),
+            "tables",
+            columns,
+            TableBackendKind.TABLE_BACKEND_KIND_FLOECAT,
+            "tables_scanner",
+            "",
+            "",
+            List.of(),
+            null,
+            constraints);
+    return new SystemNodeRegistry.BuiltinNodes(
+        "floedb",
+        "1.0",
+        "fingerprint",
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        Map.of(),
+        Map.of(),
+        Map.of("information_schema.tables", tableId),
+        Map.of(),
+        Map.of("information_schema", namespaceId),
+        new SystemCatalogData(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(tableDef),
+            List.of(),
+            List.of()));
+  }
+}


### PR DESCRIPTION
## Summary

Add first-class constraint metadata support for system objects, so builtin system tables can declare immutable constraints in their catalog definitions and expose them through the planner/runtime constraint lookup path.

This change is only about system-object constraints. 

## Key changes

### Adds constraints to system table definitions

SystemTableDef now carries: `List<ConstraintDefinition> constraints`

This lets pbtxt-backed builtin system tables declare constraints directly as part of their definition, alongside columns, scanner metadata, and engine-specific overlays.

The field is normalized to an immutable empty list by default, and an overload is kept so existing call sites that do not pass constraints remain source-compatible.

---

### Persists system-table constraints through the system catalog proto layer

SystemObjectsRegistry.SystemTable now includes:
```proto
repeated ai.floedb.floecat.catalog.ConstraintDefinition constraints = 8;
```

SystemCatalogProtoMapper is updated so system-table constraints round-trip cleanly between:
- in-memory system definitions
- registry protobufs
- reconstructed SystemCatalogData

This makes constraints a real part of the serialized builtin system catalog rather than an in-memory side channel.

---

### Propagates constraints through engine/version filtering

SystemNodeRegistry now preserves constraints when applying engine-specific rule filtering and rebuilding SystemTableDef instances.

That means constraints remain attached to the effective system-table definition after overlay/rule resolution.

---

### Validates system-table constraints at builtin catalog load time

SystemCatalogValidator is extended to validate system-table constraints, including:
- constraint type must be present
 - constraint names must be unique per table
- PK / UNIQUE / FK / NOT NULL must have local columns
- NOT NULL must reference exactly one column
- NOT NULL cannot target a nullable column
- CHECK must have a check expression
- non-CHECK constraints cannot carry a check expression
- FK must have a referenced table reference
- FK must have referenced columns
- FK local/referenced column arity must match
 -non-FK constraints cannot populate FK-only fields
- column refs must have either id or name
- column ref ordinals must be positive and unique
- column refs must resolve to known columns when validation has a target table
- id+name refs must agree when both are present
- FK referenced-table names are resolved against known builtin tables for referenced-column validation

This ensures invalid builtin constraint metadata is rejected early and deterministically.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

