### PR TITLE
fix: Preserve snapshot parent ID presence semantics

### DIFF
--- a/core/proto/src/main/proto/floecat/catalog/snapshot.proto
+++ b/core/proto/src/main/proto/floecat/catalog/snapshot.proto
@@ -30,7 +30,7 @@ message Snapshot {
   int64 snapshot_id = 2;
   google.protobuf.Timestamp upstream_created_at = 3;
   google.protobuf.Timestamp ingested_at = 4;
-  int64 parent_snapshot_id = 5;
+  optional int64 parent_snapshot_id = 5;
   string schema_json = 6;
   PartitionSpecInfo partition_spec = 7;
   int64 sequence_number = 8;
@@ -62,7 +62,7 @@ message SnapshotSpec {
   int64 snapshot_id = 2;
   google.protobuf.Timestamp upstream_created_at = 3;
   google.protobuf.Timestamp ingested_at = 4;
-  int64 parent_snapshot_id = 5;
+  optional int64 parent_snapshot_id = 5;
   optional string schema_json = 6;
   PartitionSpecInfo partition_spec = 7;
   optional int64 sequence_number = 8;

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/common/SnapshotMapper.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/common/SnapshotMapper.java
@@ -130,7 +130,7 @@ final class SnapshotMapper {
     for (Snapshot snapshot : snapshots) {
       Map<String, Object> entry = new LinkedHashMap<>();
       entry.put("snapshot-id", snapshot.getSnapshotId());
-      if (snapshot.getParentSnapshotId() > 0) {
+      if (snapshot.hasParentSnapshotId()) {
         entry.put("parent-snapshot-id", snapshot.getParentSnapshotId());
       }
       long sequenceNumber = snapshot.getSequenceNumber();

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitService.java
@@ -835,7 +835,7 @@ public class TransactionCommitService {
       builder.setUpstreamCreatedAt(Timestamps.fromMillis(upstreamCreated));
     }
     Long parentId = TableMappingUtil.asLong(snapshotMap.get("parent-snapshot-id"));
-    if (parentId != null && parentId > 0) {
+    if (parentId != null) {
       builder.setParentSnapshotId(parentId);
     }
     Long sequenceNumber = TableMappingUtil.asLong(snapshotMap.get("sequence-number"));

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/common/SnapshotMapperTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/common/SnapshotMapperTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.gateway.iceberg.rest.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.catalog.rpc.Snapshot;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SnapshotMapperTest {
+
+  @Test
+  void snapshotsOmitUnsetParentSnapshotIdButPreserveExplicitZero() {
+    Snapshot withoutParent = Snapshot.newBuilder().setSnapshotId(10L).build();
+    Snapshot explicitZeroParent =
+        Snapshot.newBuilder().setSnapshotId(11L).setParentSnapshotId(0L).build();
+
+    List<java.util.Map<String, Object>> mapped =
+        SnapshotMapper.snapshots(List.of(withoutParent, explicitZeroParent));
+
+    assertFalse(mapped.get(0).containsKey("parent-snapshot-id"));
+    assertTrue(mapped.get(1).containsKey("parent-snapshot-id"));
+    assertEquals(0L, mapped.get(1).get("parent-snapshot-id"));
+  }
+}

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/resources/AbstractRestResourceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/resources/AbstractRestResourceTest.java
@@ -479,7 +479,7 @@ public abstract class AbstractRestResourceTest {
     if (snapshot == null) {
       return null;
     }
-    Long parentId = snapshot.getParentSnapshotId() == 0 ? null : snapshot.getParentSnapshotId();
+    Long parentId = snapshot.hasParentSnapshotId() ? snapshot.getParentSnapshotId() : null;
     Long sequence = snapshot.getSequenceNumber() == 0 ? null : snapshot.getSequenceNumber();
     Long timestampMs =
         snapshot.hasUpstreamCreatedAt()

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitServiceTest.java
@@ -2797,6 +2797,22 @@ class TransactionCommitServiceTest {
     return requestWithAddSnapshotAndSchemaId(snapshotId, 1);
   }
 
+  private TransactionCommitRequest requestWithAddSnapshotAndParentId(
+      long snapshotId, long parentId) {
+    Map<String, Object> snapshot = new LinkedHashMap<>();
+    snapshot.put("snapshot-id", snapshotId);
+    snapshot.put("parent-snapshot-id", parentId);
+    snapshot.put("schema-id", 1);
+    snapshot.put("schema-json", "{\"type\":\"struct\",\"fields\":[]}");
+    Map<String, Object> addUpdate = new LinkedHashMap<>();
+    addUpdate.put("action", "add-snapshot");
+    addUpdate.put("snapshot", snapshot);
+    return new TransactionCommitRequest(
+        List.of(
+            new TransactionCommitRequest.TableChange(
+                new TableIdentifierDto(List.of("db"), "orders"), List.of(), List.of(addUpdate))));
+  }
+
   private TransactionCommitRequest requestWithAddSnapshotAndSchemaId(
       long snapshotId, int schemaId) {
     Map<String, Object> snapshot = new LinkedHashMap<>();
@@ -2810,6 +2826,52 @@ class TransactionCommitServiceTest {
         List.of(
             new TransactionCommitRequest.TableChange(
                 new TableIdentifierDto(List.of("db"), "orders"), List.of(), List.of(addUpdate))));
+  }
+
+  @Test
+  void addSnapshotPreservesExplicitZeroParentSnapshotId() throws Exception {
+    when(grpcClient.beginTransaction(any()))
+        .thenReturn(
+            BeginTransactionResponse.newBuilder()
+                .setTransaction(Transaction.newBuilder().setTxId("tx-1"))
+                .build());
+    when(grpcClient.getTransaction(any()))
+        .thenReturn(
+            GetTransactionResponse.newBuilder()
+                .setTransaction(
+                    Transaction.newBuilder().setTxId("tx-1").setState(TransactionState.TS_OPEN))
+                .build());
+    when(grpcClient.prepareTransaction(any()))
+        .thenReturn(
+            PrepareTransactionResponse.newBuilder()
+                .setTransaction(
+                    Transaction.newBuilder().setTxId("tx-1").setState(TransactionState.TS_PREPARED))
+                .build());
+    when(grpcClient.commitTransaction(any()))
+        .thenReturn(
+            CommitTransactionResponse.newBuilder()
+                .setTransaction(
+                    Transaction.newBuilder().setTxId("tx-1").setState(TransactionState.TS_APPLIED))
+                .build());
+
+    Response response =
+        service.commit("pref", "idem", requestWithAddSnapshotAndParentId(123L, 0L), tableSupport);
+
+    assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+
+    verify(grpcClient)
+        .prepareTransaction(
+            argThat(
+                prepare -> {
+                  var changes = prepare.getChangesList();
+                  for (var change : changes) {
+                    Snapshot snapshot = parseSnapshot(change.getPayload());
+                    if (snapshot != null && snapshot.getSnapshotId() == 123L) {
+                      return snapshot.hasParentSnapshotId() && snapshot.getParentSnapshotId() == 0L;
+                    }
+                  }
+                  return false;
+                }));
   }
 
   private TransactionCommitRequest requestWithSetMetadataLocationAndAddSnapshot(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
@@ -269,8 +269,10 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
                           .setTableId(tableId)
                           .setSnapshotId(spec.getSnapshotId())
                           .setIngestedAt(tsNow)
-                          .setUpstreamCreatedAt(spec.getUpstreamCreatedAt())
-                          .setParentSnapshotId(spec.getParentSnapshotId());
+                          .setUpstreamCreatedAt(spec.getUpstreamCreatedAt());
+                  if (spec.hasParentSnapshotId()) {
+                    snapBuilder.setParentSnapshotId(spec.getParentSnapshotId());
+                  }
                   if (spec.hasSchemaJson() && !spec.getSchemaJson().isBlank()) {
                     snapBuilder.setSchemaJson(spec.getSchemaJson());
                   } else {
@@ -589,7 +591,12 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
           }
           builder.setUpstreamCreatedAt(spec.getUpstreamCreatedAt());
         }
-        case "parent_snapshot_id" -> builder.setParentSnapshotId(spec.getParentSnapshotId());
+        case "parent_snapshot_id" -> {
+          builder.clearParentSnapshotId();
+          if (spec.hasParentSnapshotId()) {
+            builder.setParentSnapshotId(spec.getParentSnapshotId());
+          }
+        }
         case "schema_json" -> {
           if (!spec.hasSchemaJson()) {
             throw GrpcErrors.invalidArgument(corr, SNAPSHOT_SCHEMA_JSON_REQUIRED, Map.of());
@@ -664,7 +671,9 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
     canonicalResourceId(c, "table_id", spec.getTableId());
     c.scalar("snapshot_id", spec.getSnapshotId());
     canonicalTimestamp(c, "upstream_created_at", spec.getUpstreamCreatedAt());
-    c.scalar("parent_snapshot_id", spec.getParentSnapshotId());
+    if (spec.hasParentSnapshotId()) {
+      c.scalar("parent_snapshot_id", spec.getParentSnapshotId());
+    }
     if (spec.hasSchemaJson()) {
       c.scalar("schema_json", spec.getSchemaJson());
     }

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImplTest.java
@@ -140,4 +140,55 @@ class SnapshotServiceImplTest {
 
     assertEquals("{\"type\":\"struct\"}", cap.getValue().getSchemaJson());
   }
+
+  @Test
+  void createSnapshot_preservesExplicitZeroParentSnapshotId() {
+    var svc = new SnapshotServiceImpl();
+
+    svc.snapshotRepo = mock(SnapshotRepository.class);
+    svc.tableRepo = mock(TableRepository.class);
+    svc.statsRepo = mock(StatsRepository.class);
+    svc.principal = mock(PrincipalProvider.class);
+    svc.authz = mock(Authorizer.class);
+    svc.idempotencyStore = mock(IdempotencyRepository.class);
+    svc.overlay = mock(CatalogOverlay.class);
+
+    var tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("t1")
+            .build();
+
+    when(svc.overlay.resolve(eq(tableId))).thenReturn(Optional.of(mock(UserTableNode.class)));
+    when(svc.tableRepo.getById(eq(tableId)))
+        .thenReturn(Optional.of(Table.newBuilder().setResourceId(tableId).build()));
+
+    var pc = mock(PrincipalContext.class);
+    when(svc.principal.get()).thenReturn(pc);
+    when(pc.getCorrelationId()).thenReturn("corr");
+    when(pc.getAccountId()).thenReturn("acct");
+    doNothing().when(svc.authz).require(any(), anyString());
+
+    when(svc.snapshotRepo.getById(eq(tableId), anyLong())).thenReturn(Optional.empty());
+    doNothing().when(svc.snapshotRepo).create(any(Snapshot.class));
+    when(svc.snapshotRepo.metaForSafe(eq(tableId), anyLong()))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(1).build());
+
+    var spec =
+        SnapshotSpec.newBuilder()
+            .setTableId(tableId)
+            .setSnapshotId(123L)
+            .setParentSnapshotId(0L)
+            .build();
+
+    svc.createSnapshot(CreateSnapshotRequest.newBuilder().setSpec(spec).build())
+        .await()
+        .indefinitely();
+
+    ArgumentCaptor<Snapshot> cap = ArgumentCaptor.forClass(Snapshot.class);
+    verify(svc.snapshotRepo).create(cap.capture());
+    assertTrue(cap.getValue().hasParentSnapshotId());
+    assertEquals(0L, cap.getValue().getParentSnapshotId());
+  }
 }


### PR DESCRIPTION
## Summary

make `parent_snapshot_id` presence explicit in proto and preserve explicit zero values through service storage and REST mapping.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [X] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)