### PR TITLE
Stats: unify trigger outcomes and metadata-first reconcile stats flow

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
@@ -96,30 +96,14 @@ abstract class DeltaConnector implements FloecatConnector {
   }
 
   @Override
-  public List<SnapshotBundle> enumerateSnapshotsWithStats(
+  public List<SnapshotBundle> enumerateSnapshots(
       String namespaceFq,
       String tableName,
       ResourceId destinationTableId,
-      Set<String> includeColumns) {
-    return enumerateSnapshotsWithStats(
-        namespaceFq,
-        tableName,
-        destinationTableId,
-        includeColumns,
-        FloecatConnector.SnapshotEnumerationOptions.full(true));
-  }
-
-  @Override
-  public List<SnapshotBundle> enumerateSnapshotsWithStats(
-      String namespaceFq,
-      String tableName,
-      ResourceId destinationTableId,
-      Set<String> includeColumns,
       FloecatConnector.SnapshotEnumerationOptions options) {
 
     final String tableRoot = storageLocation(namespaceFq, tableName);
     final Table table = loadTable(tableRoot);
-    boolean includeStatistics = options == null || options.includeStatistics();
     boolean fullRescan = options == null || options.fullRescan();
     Set<Long> knownSnapshotIds = options == null ? Set.of() : options.knownSnapshotIds();
     final Snapshot latestSnapshot = table.getLatestSnapshot(engine);
@@ -141,11 +125,28 @@ abstract class DeltaConnector implements FloecatConnector {
       if (snapshot == null) {
         continue;
       }
-      bundles.add(
-          buildSnapshotBundle(
-              tableRoot, destinationTableId, includeColumns, includeStatistics, version, snapshot));
+      bundles.add(buildSnapshotBundle(tableRoot, version, snapshot));
     }
     return List.copyOf(bundles);
+  }
+
+  @Override
+  public List<TargetStatsRecord> captureSnapshotTargetStats(
+      String namespaceFq,
+      String tableName,
+      ResourceId destinationTableId,
+      long snapshotId,
+      Set<String> includeColumns) {
+    if (snapshotId < 0) {
+      return List.of();
+    }
+    final String tableRoot = storageLocation(namespaceFq, tableName);
+    final Table table = loadTable(tableRoot);
+    Snapshot snapshot = table.getSnapshotAsOfVersion(engine, snapshotId);
+    if (snapshot == null) {
+      return List.of();
+    }
+    return buildTargetStats(tableRoot, destinationTableId, includeColumns, snapshotId, snapshot);
   }
 
   @Override
@@ -343,21 +344,26 @@ abstract class DeltaConnector implements FloecatConnector {
     return List.copyOf(out);
   }
 
-  private SnapshotBundle buildSnapshotBundle(
-      String tableRoot,
-      ResourceId destinationTableId,
-      Set<String> includeColumns,
-      boolean includeStatistics,
-      long version,
-      Snapshot snapshot) {
+  private SnapshotBundle buildSnapshotBundle(String tableRoot, long version, Snapshot snapshot) {
     final long createdMs = snapshot.getTimestamp(engine);
     final long parent = Math.max(0L, version - 1L);
 
     final StructType kernelSchema = snapshot.getSchema();
-    final Map<String, LogicalType> nameToType = DeltaTypeMapper.deltaTypeMap(kernelSchema);
     final String schemaJson = kernelSchema.toJson();
     final PartitionSpecInfo partitionSpec = toPartitionSpecInfo(snapshot);
+    return new SnapshotBundle(
+        version, parent, createdMs, schemaJson, partitionSpec, 0L, null, Map.of(), 0, Map.of());
+  }
 
+  private List<TargetStatsRecord> buildTargetStats(
+      String tableRoot,
+      ResourceId destinationTableId,
+      Set<String> includeColumns,
+      long version,
+      Snapshot snapshot) {
+    final StructType kernelSchema = snapshot.getSchema();
+    final Map<String, LogicalType> nameToType = DeltaTypeMapper.deltaTypeMap(kernelSchema);
+    final String schemaJson = kernelSchema.toJson();
     final Set<String> includeNames =
         (includeColumns == null || includeColumns.isEmpty())
             ? new LinkedHashSet<>(nameToType.keySet())
@@ -366,97 +372,80 @@ abstract class DeltaConnector implements FloecatConnector {
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
-    List<TargetStatsRecord> targetStats = List.of();
+    EngineOut engineOut = runEngine(tableRoot, version, includeNames, nameToType);
+    if (engineOut.hasInlineDeletionVectors()) {
+      throw new UnsupportedOperationException(
+          "Delta table uses inline deletion vectors; not supported for snapshot " + version);
+    }
+    var result = engineOut.result();
+    var logicalTypes = engineOut.logicalTypes();
 
-    if (includeStatistics) {
-      EngineOut engineOut = runEngine(tableRoot, version, includeNames, nameToType);
-      if (engineOut.hasInlineDeletionVectors()) {
-        throw new UnsupportedOperationException(
-            "Delta table uses inline deletion vectors; not supported for snapshot " + version);
-      }
-      var result = engineOut.result();
-      var logicalTypes = engineOut.logicalTypes();
+    var tStats =
+        ConnectorStatsViewBuilder.toTableValueStats(
+            version, snapshot.getTimestamp(engine), TableFormat.TF_DELTA, result);
 
-      var tStats =
-          ConnectorStatsViewBuilder.toTableValueStats(
-              version, createdMs, TableFormat.TF_DELTA, result);
+    var positions =
+        LogicalSchemaMapper.buildColumnOrdinals(
+            ColumnIdAlgorithm.CID_PATH_ORDINAL, TableFormat.TF_DELTA, schemaJson);
 
-      var positions =
-          LogicalSchemaMapper.buildColumnOrdinals(
-              ColumnIdAlgorithm.CID_PATH_ORDINAL, TableFormat.TF_DELTA, schemaJson);
+    var cStats =
+        ConnectorStatsViewBuilder.toColumnStatsView(
+            result.columns(),
+            name -> name,
+            name -> name,
+            name -> positions.getOrDefault(name, 0),
+            name -> 0,
+            name -> {
+              var lt = logicalTypes.get(name);
+              return (lt != null) ? lt : nameToType.get(name);
+            },
+            result.totalRowCount());
 
-      var cStats =
-          ConnectorStatsViewBuilder.toColumnStatsView(
-              result.columns(),
-              name -> name,
-              name -> name,
-              name -> positions.getOrDefault(name, 0),
-              name -> 0,
-              name -> {
-                var lt = logicalTypes.get(name);
-                return (lt != null) ? lt : nameToType.get(name);
-              },
-              result.totalRowCount());
+    var mutableFiles =
+        new ArrayList<FloecatConnector.FileColumnStatsView>(
+            ConnectorStatsViewBuilder.toFileColumnStatsView(
+                result.files(),
+                name -> name,
+                name -> name,
+                name -> positions.getOrDefault(name, 0),
+                name -> 0,
+                name -> {
+                  var lt = logicalTypes.get(name);
+                  return (lt != null) ? lt : nameToType.get(name);
+                }));
 
-      var mutableFiles =
-          new ArrayList<FloecatConnector.FileColumnStatsView>(
-              ConnectorStatsViewBuilder.toFileColumnStatsView(
-                  result.files(),
-                  name -> name,
-                  name -> name,
-                  name -> positions.getOrDefault(name, 0),
-                  name -> 0,
-                  name -> {
-                    var lt = logicalTypes.get(name);
-                    return (lt != null) ? lt : nameToType.get(name);
-                  }));
-
-      for (DeletionVectorDescriptor dv : engineOut.deletionVectors()) {
-        String dvPath =
-            (dv.isOnDisk() && dv.getPathOrInlineDv() != null) ? dv.getPathOrInlineDv() : "";
-        long rowCount = dv.getCardinality();
-        long sizeBytes = dv.getSizeInBytes();
-        mutableFiles.add(
-            new FloecatConnector.FileColumnStatsView(
-                dvPath,
-                "",
-                rowCount,
-                sizeBytes,
-                FileContent.FC_POSITION_DELETES,
-                "",
-                0,
-                List.of(),
-                null,
-                List.of()));
-      }
-
-      List<TargetStatsRecord> materialized = new ArrayList<>();
-      materialized.add(
-          StatsProtoEmitter.tableStatsToTargetRecord(destinationTableId, version, tStats));
-      materialized.addAll(
-          StatsProtoEmitter.toTargetColumnStatsFromViews(
-              destinationTableId, version, ColumnIdAlgorithm.CID_PATH_ORDINAL, cStats));
-      materialized.addAll(
-          StatsProtoEmitter.toTargetFileStatsFromViews(
-              destinationTableId,
-              version,
-              ColumnIdAlgorithm.CID_PATH_ORDINAL,
-              List.copyOf(mutableFiles)));
-      targetStats = List.copyOf(materialized);
+    for (DeletionVectorDescriptor dv : engineOut.deletionVectors()) {
+      String dvPath =
+          (dv.isOnDisk() && dv.getPathOrInlineDv() != null) ? dv.getPathOrInlineDv() : "";
+      long rowCount = dv.getCardinality();
+      long sizeBytes = dv.getSizeInBytes();
+      mutableFiles.add(
+          new FloecatConnector.FileColumnStatsView(
+              dvPath,
+              "",
+              rowCount,
+              sizeBytes,
+              FileContent.FC_POSITION_DELETES,
+              "",
+              0,
+              List.of(),
+              null,
+              List.of()));
     }
 
-    return new SnapshotBundle(
-        version,
-        parent,
-        createdMs,
-        targetStats,
-        schemaJson,
-        partitionSpec,
-        0L,
-        null,
-        Map.of(),
-        0,
-        Map.of());
+    List<TargetStatsRecord> materialized = new ArrayList<>();
+    materialized.add(
+        StatsProtoEmitter.tableStatsToTargetRecord(destinationTableId, version, tStats));
+    materialized.addAll(
+        StatsProtoEmitter.toTargetColumnStatsFromViews(
+            destinationTableId, version, ColumnIdAlgorithm.CID_PATH_ORDINAL, cStats));
+    materialized.addAll(
+        StatsProtoEmitter.toTargetFileStatsFromViews(
+            destinationTableId,
+            version,
+            ColumnIdAlgorithm.CID_PATH_ORDINAL,
+            List.copyOf(mutableFiles)));
+    return List.copyOf(materialized);
   }
 
   protected Snapshot resolveSnapshot(Table table, long snapshotId, long asOfTime) {

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 class DeltaConnectorTest {
 
   @Test
-  void enumerateSnapshotsWithStatsReturnsAvailableVersionsForFullRescan() {
+  void enumerateSnapshotsHonorsExplicitTargetVersions() {
     Snapshot latest = snapshot(7L, 7000L);
     Snapshot v3 = snapshot(3L, 3000L);
     Snapshot v5 = snapshot(5L, 5000L);
@@ -53,12 +53,11 @@ class DeltaConnectorTest {
     TestDeltaConnector connector = new TestDeltaConnector(table);
 
     List<FloecatConnector.SnapshotBundle> bundles =
-        connector.enumerateSnapshotsWithStats(
+        connector.enumerateSnapshots(
             "ns",
             "tbl",
             ResourceId.getDefaultInstance(),
-            Set.of(),
-            new FloecatConnector.SnapshotEnumerationOptions(false, true, Set.of()));
+            new FloecatConnector.SnapshotEnumerationOptions(true, Set.of(), Set.of(3L, 5L)));
 
     List<Long> snapshotIds =
         bundles.stream()
@@ -69,7 +68,7 @@ class DeltaConnectorTest {
   }
 
   @Test
-  void enumerateSnapshotsWithStatsReturnsAllUnknownVersionsForIncrementalRuns() {
+  void enumerateSnapshotsReturnsAllUnknownVersionsForIncrementalRuns() {
     Snapshot latest = snapshot(5L, 5000L);
     Table table =
         new StubTable(
@@ -85,12 +84,11 @@ class DeltaConnectorTest {
     TestDeltaConnector connector = new TestDeltaConnector(table);
 
     List<FloecatConnector.SnapshotBundle> bundles =
-        connector.enumerateSnapshotsWithStats(
+        connector.enumerateSnapshots(
             "ns",
             "tbl",
             ResourceId.getDefaultInstance(),
-            Set.of(),
-            new FloecatConnector.SnapshotEnumerationOptions(false, false, Set.of(1L, 4L)));
+            new FloecatConnector.SnapshotEnumerationOptions(false, Set.of(1L, 4L), Set.of()));
 
     List<Long> snapshotIds =
         bundles.stream()
@@ -163,6 +161,20 @@ class DeltaConnectorTest {
             .toList();
     assertEquals(1, checks.size(), "duplicate key should produce exactly one CHECK constraint");
     assertEquals("amount >= 1", checks.get(0).getCheckExpression(), "snapshot expression wins");
+  }
+
+  @Test
+  void captureSnapshotTargetStatsReturnsEmptyForUnknownSnapshot() {
+    Snapshot latest = snapshot(7L, 7000L);
+    Table table = new StubTable(latest, Map.of(7L, latest));
+
+    TestDeltaConnector connector = new TestDeltaConnector(table);
+
+    List<ai.floedb.floecat.catalog.rpc.TargetStatsRecord> stats =
+        connector.captureSnapshotTargetStats(
+            "ns", "tbl", ResourceId.getDefaultInstance(), 999L, Set.of());
+
+    assertTrue(stats.isEmpty(), "unknown snapshot should return empty stats");
   }
 
   private static Snapshot snapshot(long version, long timestampMs) {

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/FloecatConnectorDefaultChainTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/FloecatConnectorDefaultChainTest.java
@@ -65,10 +65,20 @@ class FloecatConnectorDefaultChainTest {
     }
 
     @Override
-    public List<SnapshotBundle> enumerateSnapshotsWithStats(
+    public List<SnapshotBundle> enumerateSnapshots(
         String namespaceFq,
         String tableName,
         ResourceId destinationTableId,
+        SnapshotEnumerationOptions options) {
+      return List.of();
+    }
+
+    @Override
+    public List<ai.floedb.floecat.catalog.rpc.TargetStatsRecord> captureSnapshotTargetStats(
+        String namespaceFq,
+        String tableName,
+        ResourceId destinationTableId,
+        long snapshotId,
         Set<String> includeColumns) {
       return List.of();
     }

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
@@ -150,65 +150,27 @@ public abstract class IcebergConnector implements FloecatConnector {
   }
 
   @Override
-  public List<SnapshotBundle> enumerateSnapshotsWithStats(
+  public List<SnapshotBundle> enumerateSnapshots(
       String namespaceFq,
       String tableName,
       ResourceId destinationTableId,
-      Set<String> includeColumns) {
-    return enumerateSnapshotsWithStats(
-        namespaceFq, tableName, destinationTableId, includeColumns, true);
-  }
-
-  @Override
-  public List<SnapshotBundle> enumerateSnapshotsWithStats(
-      String namespaceFq,
-      String tableName,
-      ResourceId destinationTableId,
-      Set<String> includeColumns,
-      boolean includeStatistics) {
-    return enumerateSnapshotsWithStats(
-        namespaceFq,
-        tableName,
-        destinationTableId,
-        includeColumns,
-        FloecatConnector.SnapshotEnumerationOptions.full(includeStatistics));
-  }
-
-  @Override
-  public List<SnapshotBundle> enumerateSnapshotsWithStats(
-      String namespaceFq,
-      String tableName,
-      ResourceId destinationTableId,
-      Set<String> includeColumns,
       FloecatConnector.SnapshotEnumerationOptions options) {
     Table table = loadTable(namespaceFq, tableName);
-    boolean includeStatistics = options == null || options.includeStatistics();
     boolean fullRescan = options == null || options.fullRescan();
     Set<Long> knownSnapshotIds = options == null ? Set.of() : options.knownSnapshotIds();
-    List<Snapshot> snapshots = snapshotsToEnumerate(table, fullRescan, knownSnapshotIds);
-    if (shouldRetryEmptyIncrementalEnumeration(
-        table, includeStatistics, fullRescan, knownSnapshotIds, snapshots)) {
+    Set<Long> targetSnapshotIds = options == null ? Set.of() : options.targetSnapshotIds();
+    List<Snapshot> snapshots =
+        snapshotsToEnumerate(table, fullRescan, knownSnapshotIds, targetSnapshotIds);
+    if (shouldRetryEmptyIncrementalEnumeration(table, fullRescan, knownSnapshotIds, snapshots)) {
       throw new ConnectorNotReadyException(
           "Current snapshot for " + namespaceFq + "." + tableName + " is not fully observable yet");
     }
     IcebergMetadata icebergMetadata = buildIcebergMetadata(namespaceFq, tableName, table);
 
-    final Set<Integer> includeIds;
-    if (!includeStatistics) {
-      includeIds = Set.of();
-    } else if (includeColumns == null || includeColumns.isEmpty()) {
-      includeIds =
-          table.schema().columns().stream()
-              .map(Types.NestedField::fieldId)
-              .collect(Collectors.toCollection(LinkedHashSet::new));
-    } else {
-      includeIds = resolveFieldIdsNested(table.schema(), includeColumns);
-    }
-
     List<SnapshotBundle> out = new ArrayList<>();
     for (Snapshot snapshot : snapshots) {
       long snapshotId = snapshot.snapshotId();
-      long parentId = snapshot.parentId() != null ? snapshot.parentId().longValue() : 0;
+      long parentId = snapshot.parentId() != null ? snapshot.parentId().longValue() : -1L;
       long createdMs = snapshot.timestampMillis();
 
       Integer snapshotSchemaId = snapshot != null ? snapshot.schemaId() : null;
@@ -218,136 +180,6 @@ public abstract class IcebergConnector implements FloecatConnector {
               : table.schema().schemaId();
       Schema schema = Optional.ofNullable(table.schemas().get(schemaId)).orElse(table.schema());
       String schemaJson = SchemaParser.toJson(schema);
-
-      List<TargetStatsRecord> targetStats = List.of();
-      if (includeStatistics) {
-        EngineOut engineOutput = runEngine(table, snapshotId, includeIds);
-
-        var columnNames = engineOutput.columnNames();
-        var logicalTypes = engineOutput.logicalTypes();
-
-        var tStats =
-            ConnectorStatsViewBuilder.toTableValueStats(
-                snapshotId, createdMs, TableFormat.TF_ICEBERG, engineOutput.result());
-        // Build per-field metadata so ColumnRef can carry field_id + physical_path (+ optional
-        // ordinal); single traversal for efficiency
-        var fieldMaps = fieldIdMaps(schema);
-        Map<Integer, String> idToPath = fieldMaps.getKey();
-        Map<Integer, Integer> idToOrdinal = fieldMaps.getValue();
-
-        // Extract snapshot's total-records as primary source for NDV rowsTotal
-        long snapshotRowCount = 0;
-        Map<String, String> summary = snapshot.summary() == null ? Map.of() : snapshot.summary();
-        String totalRecordsStr = summary.get("total-records");
-        if (totalRecordsStr != null && !totalRecordsStr.isBlank()) {
-          try {
-            snapshotRowCount = Long.parseLong(totalRecordsStr);
-          } catch (NumberFormatException ignore) {
-            // keep snapshotRowCount as 0
-          }
-        }
-
-        // Fallback to engineOutput.result().totalRowCount() if snapshot summary doesn't have it
-        if (snapshotRowCount <= 0) {
-          snapshotRowCount = engineOutput.result().totalRowCount();
-        }
-
-        var cStats =
-            ConnectorStatsViewBuilder.toColumnStatsView(
-                engineOutput.result().columns(),
-                id -> {
-                  String name = columnNames.get(id);
-                  if (name != null && !name.isBlank()) {
-                    return name;
-                  }
-                  var f = schema.findField(id);
-                  return f == null ? "" : f.name();
-                },
-                id -> idToPath.getOrDefault(id, ""),
-                id -> idToOrdinal.getOrDefault(id, 0),
-                id -> id,
-                id -> {
-                  LogicalType lt = logicalTypes.get(id);
-                  if (lt != null) {
-                    return lt;
-                  }
-                  var f = schema.findField(id);
-                  return f == null ? null : IcebergTypeMapper.toLogical(f.type());
-                },
-                snapshotRowCount);
-
-        // Consolidate file stats conversion using ProtoStatsBuilder for format-agnostic handling
-        var baseFiles =
-            ConnectorStatsViewBuilder.toFileColumnStatsView(
-                engineOutput.result().files(),
-                id -> {
-                  String name = columnNames.get(id);
-                  if (name != null && !name.isBlank()) {
-                    return name;
-                  }
-                  var f = schema.findField(id);
-                  return f == null ? "" : f.name();
-                },
-                id -> idToPath.getOrDefault(id, ""),
-                id -> idToOrdinal.getOrDefault(id, 0),
-                id -> id,
-                id -> {
-                  LogicalType lt = logicalTypes.get(id);
-                  if (lt != null) {
-                    return lt;
-                  }
-                  var f = schema.findField(id);
-                  return f == null ? null : IcebergTypeMapper.toLogical(f.type());
-                });
-
-        List<FloecatConnector.FileColumnStatsView> deleteStats = new ArrayList<>();
-        TableScan scan = table.newScan().useSnapshot(snapshotId);
-        try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-          for (FileScanTask task : tasks) {
-            for (var df : task.deletes()) {
-              List<Integer> eqIds =
-                  df.content() == org.apache.iceberg.FileContent.EQUALITY_DELETES
-                      ? df.equalityFieldIds()
-                      : List.of();
-
-              FileContent fc =
-                  df.content() == org.apache.iceberg.FileContent.EQUALITY_DELETES
-                      ? FileContent.FC_EQUALITY_DELETES
-                      : FileContent.FC_POSITION_DELETES;
-
-              deleteStats.add(
-                  new FloecatConnector.FileColumnStatsView(
-                      df.location(),
-                      "", // format often unknown for deletes; leave blank
-                      df.recordCount(),
-                      df.fileSizeInBytes(),
-                      fc,
-                      "", // partition json not needed for deletes
-                      0,
-                      eqIds,
-                      df.fileSequenceNumber(),
-                      List.of() // no per-column stats for deletes
-                      ));
-            }
-          }
-        } catch (Exception e) {
-          throw new RuntimeException(
-              "Failed to enumerate delete files for snapshot " + snapshotId, e);
-        }
-
-        List<FileColumnStatsView> allFiles = new ArrayList<>(baseFiles);
-        allFiles.addAll(deleteStats);
-        List<TargetStatsRecord> materialized = new ArrayList<>();
-        materialized.add(
-            StatsProtoEmitter.tableStatsToTargetRecord(destinationTableId, snapshotId, tStats));
-        materialized.addAll(
-            StatsProtoEmitter.toTargetColumnStatsFromViews(
-                destinationTableId, snapshotId, ColumnIdAlgorithm.CID_FIELD_ID, cStats));
-        materialized.addAll(
-            StatsProtoEmitter.toTargetFileStatsFromViews(
-                destinationTableId, snapshotId, ColumnIdAlgorithm.CID_FIELD_ID, allFiles));
-        targetStats = List.copyOf(materialized);
-      }
 
       Map<String, String> summary = snapshot.summary() == null ? Map.of() : snapshot.summary();
       Map<String, String> summaryWithOperation =
@@ -367,7 +199,6 @@ public abstract class IcebergConnector implements FloecatConnector {
               snapshotId,
               parentId,
               createdMs,
-              targetStats,
               schemaJson,
               toPartitionSpecInfo(table, snapshot),
               sequenceNumber,
@@ -377,6 +208,167 @@ public abstract class IcebergConnector implements FloecatConnector {
               metadataAttachments));
     }
     return out;
+  }
+
+  @Override
+  public List<TargetStatsRecord> captureSnapshotTargetStats(
+      String namespaceFq,
+      String tableName,
+      ResourceId destinationTableId,
+      long snapshotId,
+      Set<String> includeColumns) {
+    if (snapshotId < 0) {
+      return List.of();
+    }
+    Table table = loadTable(namespaceFq, tableName);
+    Snapshot snapshot = table.snapshot(snapshotId);
+    if (snapshot == null) {
+      return List.of();
+    }
+    return buildTargetStats(table, destinationTableId, snapshot, includeColumns);
+  }
+
+  private List<TargetStatsRecord> buildTargetStats(
+      Table table, ResourceId destinationTableId, Snapshot snapshot, Set<String> includeColumns) {
+    long snapshotId = snapshot.snapshotId();
+    long createdMs = snapshot.timestampMillis();
+    Integer snapshotSchemaId = snapshot.schemaId();
+    int schemaId =
+        snapshotSchemaId != null && snapshotSchemaId > 0
+            ? snapshotSchemaId
+            : table.schema().schemaId();
+    Schema schema = Optional.ofNullable(table.schemas().get(schemaId)).orElse(table.schema());
+
+    final Set<Integer> includeIds;
+    if (includeColumns == null || includeColumns.isEmpty()) {
+      includeIds =
+          table.schema().columns().stream()
+              .map(Types.NestedField::fieldId)
+              .collect(Collectors.toCollection(LinkedHashSet::new));
+    } else {
+      includeIds = resolveFieldIdsNested(table.schema(), includeColumns);
+    }
+
+    EngineOut engineOutput = runEngine(table, snapshotId, includeIds);
+    var columnNames = engineOutput.columnNames();
+    var logicalTypes = engineOutput.logicalTypes();
+    var tStats =
+        ConnectorStatsViewBuilder.toTableValueStats(
+            snapshotId, createdMs, TableFormat.TF_ICEBERG, engineOutput.result());
+
+    // Build per-field metadata so ColumnRef can carry field_id + physical_path (+ optional
+    // ordinal); single traversal for efficiency.
+    var fieldMaps = fieldIdMaps(schema);
+    Map<Integer, String> idToPath = fieldMaps.getKey();
+    Map<Integer, Integer> idToOrdinal = fieldMaps.getValue();
+
+    long snapshotRowCount = 0;
+    Map<String, String> summary = snapshot.summary() == null ? Map.of() : snapshot.summary();
+    String totalRecordsStr = summary.get("total-records");
+    if (totalRecordsStr != null && !totalRecordsStr.isBlank()) {
+      try {
+        snapshotRowCount = Long.parseLong(totalRecordsStr);
+      } catch (NumberFormatException ignore) {
+        // keep snapshotRowCount as 0
+      }
+    }
+    if (snapshotRowCount <= 0) {
+      snapshotRowCount = engineOutput.result().totalRowCount();
+    }
+
+    var cStats =
+        ConnectorStatsViewBuilder.toColumnStatsView(
+            engineOutput.result().columns(),
+            id -> {
+              String name = columnNames.get(id);
+              if (name != null && !name.isBlank()) {
+                return name;
+              }
+              var f = schema.findField(id);
+              return f == null ? "" : f.name();
+            },
+            id -> idToPath.getOrDefault(id, ""),
+            id -> idToOrdinal.getOrDefault(id, 0),
+            id -> id,
+            id -> {
+              LogicalType lt = logicalTypes.get(id);
+              if (lt != null) {
+                return lt;
+              }
+              var f = schema.findField(id);
+              return f == null ? null : IcebergTypeMapper.toLogical(f.type());
+            },
+            snapshotRowCount);
+
+    var baseFiles =
+        ConnectorStatsViewBuilder.toFileColumnStatsView(
+            engineOutput.result().files(),
+            id -> {
+              String name = columnNames.get(id);
+              if (name != null && !name.isBlank()) {
+                return name;
+              }
+              var f = schema.findField(id);
+              return f == null ? "" : f.name();
+            },
+            id -> idToPath.getOrDefault(id, ""),
+            id -> idToOrdinal.getOrDefault(id, 0),
+            id -> id,
+            id -> {
+              LogicalType lt = logicalTypes.get(id);
+              if (lt != null) {
+                return lt;
+              }
+              var f = schema.findField(id);
+              return f == null ? null : IcebergTypeMapper.toLogical(f.type());
+            });
+
+    List<FloecatConnector.FileColumnStatsView> deleteStats = new ArrayList<>();
+    TableScan scan = table.newScan().useSnapshot(snapshotId);
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      for (FileScanTask task : tasks) {
+        for (var df : task.deletes()) {
+          List<Integer> eqIds =
+              df.content() == org.apache.iceberg.FileContent.EQUALITY_DELETES
+                  ? df.equalityFieldIds()
+                  : List.of();
+
+          FileContent fc =
+              df.content() == org.apache.iceberg.FileContent.EQUALITY_DELETES
+                  ? FileContent.FC_EQUALITY_DELETES
+                  : FileContent.FC_POSITION_DELETES;
+
+          deleteStats.add(
+              new FloecatConnector.FileColumnStatsView(
+                  df.location(),
+                  "", // format often unknown for deletes; leave blank
+                  df.recordCount(),
+                  df.fileSizeInBytes(),
+                  fc,
+                  "", // partition json not needed for deletes
+                  0,
+                  eqIds,
+                  df.fileSequenceNumber(),
+                  List.of() // no per-column stats for deletes
+                  ));
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to enumerate delete files for snapshot " + snapshotId, e);
+    }
+
+    List<FileColumnStatsView> allFiles = new ArrayList<>(baseFiles);
+    allFiles.addAll(deleteStats);
+    List<TargetStatsRecord> materialized = new ArrayList<>();
+    materialized.add(
+        StatsProtoEmitter.tableStatsToTargetRecord(destinationTableId, snapshotId, tStats));
+    materialized.addAll(
+        StatsProtoEmitter.toTargetColumnStatsFromViews(
+            destinationTableId, snapshotId, ColumnIdAlgorithm.CID_FIELD_ID, cStats));
+    materialized.addAll(
+        StatsProtoEmitter.toTargetFileStatsFromViews(
+            destinationTableId, snapshotId, ColumnIdAlgorithm.CID_FIELD_ID, allFiles));
+    return List.copyOf(materialized);
   }
 
   @Override
@@ -469,10 +461,18 @@ public abstract class IcebergConnector implements FloecatConnector {
   }
 
   private List<Snapshot> snapshotsToEnumerate(
-      Table table, boolean fullRescan, Set<Long> knownSnapshotIds) {
+      Table table, boolean fullRescan, Set<Long> knownSnapshotIds, Set<Long> targetSnapshotIds) {
     if (fullRescan || knownSnapshotIds == null || knownSnapshotIds.isEmpty()) {
       List<Snapshot> snapshots = new ArrayList<>();
       for (Snapshot snapshot : table.snapshots()) {
+        if (snapshot == null) {
+          continue;
+        }
+        if (targetSnapshotIds != null
+            && !targetSnapshotIds.isEmpty()
+            && !targetSnapshotIds.contains(snapshot.snapshotId())) {
+          continue;
+        }
         snapshots.add(snapshot);
       }
       return snapshots;
@@ -486,6 +486,11 @@ public abstract class IcebergConnector implements FloecatConnector {
       if (!fullRescan && knownSnapshotIds.contains(snapshotId)) {
         continue;
       }
+      if (targetSnapshotIds != null
+          && !targetSnapshotIds.isEmpty()
+          && !targetSnapshotIds.contains(snapshotId)) {
+        continue;
+      }
       incremental.add(snapshot);
     }
     incremental.sort(
@@ -496,12 +501,8 @@ public abstract class IcebergConnector implements FloecatConnector {
   }
 
   private static boolean shouldRetryEmptyIncrementalEnumeration(
-      Table table,
-      boolean includeStatistics,
-      boolean fullRescan,
-      Set<Long> knownSnapshotIds,
-      List<Snapshot> snapshots) {
-    if (!includeStatistics || fullRescan) {
+      Table table, boolean fullRescan, Set<Long> knownSnapshotIds, List<Snapshot> snapshots) {
+    if (fullRescan) {
       return false;
     }
     if (knownSnapshotIds != null && !knownSnapshotIds.isEmpty()) {

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorIncrementalEnumerationTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorIncrementalEnumerationTest.java
@@ -63,12 +63,12 @@ class IcebergConnectorIncrementalEnumerationTest {
 
     Method method =
         IcebergConnector.class.getDeclaredMethod(
-            "snapshotsToEnumerate", Table.class, boolean.class, Set.class);
+            "snapshotsToEnumerate", Table.class, boolean.class, Set.class, Set.class);
     method.setAccessible(true);
 
     @SuppressWarnings("unchecked")
     List<Snapshot> snapshots =
-        (List<Snapshot>) method.invoke(connector, table, false, Set.of(100L, 200L));
+        (List<Snapshot>) method.invoke(connector, table, false, Set.of(100L, 200L), Set.of());
 
     assertEquals(List.of(300L, 250L), snapshots.stream().map(Snapshot::snapshotId).toList());
   }
@@ -100,17 +100,18 @@ class IcebergConnectorIncrementalEnumerationTest {
 
     Method method =
         IcebergConnector.class.getDeclaredMethod(
-            "snapshotsToEnumerate", Table.class, boolean.class, Set.class);
+            "snapshotsToEnumerate", Table.class, boolean.class, Set.class, Set.class);
     method.setAccessible(true);
 
     @SuppressWarnings("unchecked")
-    List<Snapshot> snapshots = (List<Snapshot>) method.invoke(connector, table, true, Set.of());
+    List<Snapshot> snapshots =
+        (List<Snapshot>) method.invoke(connector, table, true, Set.of(), Set.of());
 
     assertEquals(List.of(300L, 200L, 100L), snapshots.stream().map(Snapshot::snapshotId).toList());
   }
 
   @Test
-  void enumerateSnapshotsWithStatsFailsWhenCurrentSnapshotExistsButIncrementalEnumerationIsEmpty() {
+  void enumerateSnapshotsFailsWhenCurrentSnapshotExistsButIncrementalEnumerationIsEmpty() {
     Snapshot current = snapshot(300L, 3L, 3000L, 200L);
     Table table = table(List.of(), current);
 
@@ -135,12 +136,11 @@ class IcebergConnectorIncrementalEnumerationTest {
     assertThrows(
         ConnectorNotReadyException.class,
         () ->
-            connector.enumerateSnapshotsWithStats(
+            connector.enumerateSnapshots(
                 "iceberg",
                 "duckdb_mutation_smoke",
                 ResourceId.getDefaultInstance(),
-                Set.of(),
-                FloecatConnector.SnapshotEnumerationOptions.incremental(true, Set.of())));
+                FloecatConnector.SnapshotEnumerationOptions.incremental(Set.of())));
   }
 
   private static Snapshot snapshot(

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorIssuesTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorIssuesTest.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.gateway.iceberg.rest.common.TestS3Fixtures;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -50,10 +51,10 @@ class IcebergConnectorIssuesTest {
     try (FloecatConnector connector =
         IcebergConnectorFactory.create(
             metadataLocation, props, "none", new HashMap<>(), new HashMap<>())) {
-      var snapshots =
+      List<FloecatConnector.SnapshotBundle> snapshots =
           assertDoesNotThrow(
               () ->
-                  connector.enumerateSnapshotsWithStats(
+                  connector.enumerateSnapshots(
                       "tpcds_sfone",
                       "catalog_returns",
                       ResourceId.newBuilder()
@@ -61,15 +62,30 @@ class IcebergConnectorIssuesTest {
                           .setId("test-table")
                           .setKind(ResourceKind.RK_TABLE)
                           .build(),
-                      Set.of()));
+                      FloecatConnector.SnapshotEnumerationOptions.full(true)));
 
       assertNotNull(snapshots);
       assertFalse(snapshots.isEmpty(), "expected snapshots from tpcds_sfone fixture");
+
+      long snapshotId = snapshots.get(0).snapshotId();
+      var targetStats =
+          assertDoesNotThrow(
+              () ->
+                  connector.captureSnapshotTargetStats(
+                      "tpcds_sfone",
+                      "catalog_returns",
+                      ResourceId.newBuilder()
+                          .setAccountId("test-account")
+                          .setId("test-table")
+                          .setKind(ResourceKind.RK_TABLE)
+                          .build(),
+                      snapshotId,
+                      Set.of()));
       assertTrue(
-          snapshots.get(0).targetStats().stream().anyMatch(r -> r.hasTable()),
+          targetStats.stream().anyMatch(r -> r.hasTable()),
           "expected table stats to still be produced");
       assertTrue(
-          snapshots.get(0).targetStats().stream()
+          targetStats.stream()
               .filter(r -> r.hasFile())
               .anyMatch(r -> !r.getFile().getColumnsList().isEmpty()),
           "expected file-level stats to still be produced");

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
@@ -44,31 +44,36 @@ public interface FloecatConnector extends Closeable {
 
   TableDescriptor describe(String namespaceFq, String tableName);
 
-  List<SnapshotBundle> enumerateSnapshotsWithStats(
+  List<SnapshotBundle> enumerateSnapshots(
       String namespaceFq,
       String tableName,
       ResourceId destinationTableId,
+      SnapshotEnumerationOptions options);
+
+  default List<SnapshotBundle> enumerateSnapshots(
+      String namespaceFq, String tableName, ResourceId destinationTableId, boolean fullRescan) {
+    return enumerateSnapshots(
+        namespaceFq, tableName, destinationTableId, SnapshotEnumerationOptions.full(fullRescan));
+  }
+
+  /**
+   * Captures target stats for one snapshot and optional selector scope.
+   *
+   * <p>Selector semantics are best-effort and connector-native:
+   *
+   * <ul>
+   *   <li>`#<id>` selectors target stable destination column ids when available.
+   *   <li>name/path selectors are interpreted as connector-specific display or physical paths.
+   *   <li>unknown selectors are ignored; connectors may return a strict subset of requested
+   *       targets.
+   * </ul>
+   */
+  List<TargetStatsRecord> captureSnapshotTargetStats(
+      String namespaceFq,
+      String tableName,
+      ResourceId destinationTableId,
+      long snapshotId,
       Set<String> includeColumns);
-
-  default List<SnapshotBundle> enumerateSnapshotsWithStats(
-      String namespaceFq,
-      String tableName,
-      ResourceId destinationTableId,
-      Set<String> includeColumns,
-      SnapshotEnumerationOptions options) {
-    boolean includeStatistics = options == null || options.includeStatistics();
-    return enumerateSnapshotsWithStats(
-        namespaceFq, tableName, destinationTableId, includeColumns, includeStatistics);
-  }
-
-  default List<SnapshotBundle> enumerateSnapshotsWithStats(
-      String namespaceFq,
-      String tableName,
-      ResourceId destinationTableId,
-      Set<String> includeColumns,
-      boolean includeStatistics) {
-    return enumerateSnapshotsWithStats(namespaceFq, tableName, destinationTableId, includeColumns);
-  }
 
   /**
    * Returns per-snapshot constraints for a table snapshot, if available.
@@ -98,19 +103,27 @@ public interface FloecatConnector extends Closeable {
   }
 
   record SnapshotEnumerationOptions(
-      boolean includeStatistics, boolean fullRescan, Set<Long> knownSnapshotIds) {
+      boolean fullRescan, Set<Long> knownSnapshotIds, Set<Long> targetSnapshotIds) {
     public SnapshotEnumerationOptions {
       knownSnapshotIds =
           knownSnapshotIds == null ? Set.of() : Set.copyOf(new LinkedHashSet<>(knownSnapshotIds));
     }
 
-    public static SnapshotEnumerationOptions full(boolean includeStatistics) {
-      return new SnapshotEnumerationOptions(includeStatistics, true, Set.of());
+    public static SnapshotEnumerationOptions full(boolean fullRescan) {
+      return new SnapshotEnumerationOptions(fullRescan, Set.of(), Set.of());
+    }
+
+    public static SnapshotEnumerationOptions full(boolean fullRescan, Set<Long> targetSnapshotIds) {
+      return new SnapshotEnumerationOptions(fullRescan, Set.of(), targetSnapshotIds);
+    }
+
+    public static SnapshotEnumerationOptions incremental(Set<Long> knownSnapshotIds) {
+      return new SnapshotEnumerationOptions(false, knownSnapshotIds, Set.of());
     }
 
     public static SnapshotEnumerationOptions incremental(
-        boolean includeStatistics, Set<Long> knownSnapshotIds) {
-      return new SnapshotEnumerationOptions(includeStatistics, false, knownSnapshotIds);
+        Set<Long> knownSnapshotIds, Set<Long> targetSnapshotIds) {
+      return new SnapshotEnumerationOptions(false, knownSnapshotIds, targetSnapshotIds);
     }
   }
 
@@ -168,7 +181,6 @@ public interface FloecatConnector extends Closeable {
       long snapshotId,
       long parentId,
       long upstreamCreatedAtMs,
-      List<TargetStatsRecord> targetStats,
       String schemaJson,
       PartitionSpecInfo partitionSpec,
       long sequenceNumber,

--- a/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsCapabilities.java
+++ b/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsCapabilities.java
@@ -41,8 +41,7 @@ public record StatsCapabilities(
     Set<StatsTargetType> targetTypes,
     Map<StatsTargetType, Set<StatsKind>> statisticKindsByTarget,
     Set<StatsExecutionMode> executionModes,
-    Set<StatsSamplingSupport> samplingSupport,
-    boolean snapshotAware) {
+    Set<StatsSamplingSupport> samplingSupport) {
 
   public StatsCapabilities {
     connectors = normalizeConnectors(connectors);
@@ -69,9 +68,6 @@ public record StatsCapabilities(
   public boolean supports(StatsCaptureRequest request) {
     Objects.requireNonNull(request, "request");
     StatsTargetType targetType = StatsTargetType.from(request.target());
-    if (request.snapshotId() > 0L && !snapshotAware) {
-      return false;
-    }
     if (!targetTypes.isEmpty() && !targetTypes.contains(targetType)) {
       return false;
     }
@@ -130,7 +126,6 @@ public record StatsCapabilities(
    *   <li>{@code statisticKinds}: empty set (all statistic kinds)
    *   <li>{@code executionModes}: {@code [SYNC]}
    *   <li>{@code samplingSupport}: {@code [NONE]}
-   *   <li>{@code snapshotAware}: {@code true}
    * </ul>
    */
   public static final class Builder {
@@ -140,7 +135,6 @@ public record StatsCapabilities(
     private Set<StatsExecutionMode> executionModes = Set.of(StatsExecutionMode.SYNC);
     // Default to NONE unless explicitly declared otherwise.
     private Set<StatsSamplingSupport> samplingSupport = Set.of(StatsSamplingSupport.NONE);
-    private boolean snapshotAware = true;
 
     private Builder() {}
 
@@ -175,20 +169,9 @@ public record StatsCapabilities(
       return this;
     }
 
-    /** Declares whether snapshot-scoped requests are supported by this engine. */
-    public Builder snapshotAware(boolean snapshotAware) {
-      this.snapshotAware = snapshotAware;
-      return this;
-    }
-
     public StatsCapabilities build() {
       return new StatsCapabilities(
-          connectors,
-          targetTypes,
-          statisticKindsByTarget,
-          executionModes,
-          samplingSupport,
-          snapshotAware);
+          connectors, targetTypes, statisticKindsByTarget, executionModes, samplingSupport);
     }
   }
 

--- a/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsCaptureControlPlane.java
+++ b/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsCaptureControlPlane.java
@@ -16,8 +16,6 @@
 
 package ai.floedb.floecat.stats.spi;
 
-import java.util.Optional;
-
 /**
  * Control-plane entrypoint for explicit stats capture requests.
  *
@@ -26,6 +24,17 @@ import java.util.Optional;
  */
 public interface StatsCaptureControlPlane {
 
-  /** Executes one capture attempt for the provided request. */
-  Optional<StatsCaptureResult> capture(StatsCaptureRequest request);
+  /**
+   * Executes one capture trigger attempt for the provided request.
+   *
+   * <p>Implementations should return:
+   *
+   * <ul>
+   *   <li>{@code CAPTURED} when a capture payload was produced
+   *   <li>{@code QUEUED} when work was accepted for deferred execution
+   *   <li>{@code UNCAPTURABLE} when request/engine capabilities do not match
+   *   <li>{@code DEGRADED} for runtime/transient failures
+   * </ul>
+   */
+  StatsTriggerResult trigger(StatsCaptureRequest request);
 }

--- a/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsCaptureRequest.java
+++ b/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsCaptureRequest.java
@@ -26,8 +26,8 @@ import java.util.Set;
 /**
  * Canonical request envelope used by stats engine routing.
  *
- * <p>{@code snapshotId} accepts non-negative values. A value of {@code 0} is reserved for
- * unresolved/current-snapshot flows and may be resolved upstream before execution.
+ * <p>{@code snapshotId} accepts non-negative values. A value of {@code 0} is a valid concrete
+ * snapshot identifier for connectors that use zero-based snapshot/version numbering.
  *
  * <p>{@code columnSelectors} allows scoped capture requests to declare the set of relevant columns
  * in one request (for example destination column IDs or source column names).

--- a/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsTriggerOutcome.java
+++ b/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsTriggerOutcome.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.stats.spi;
+
+/** High-level outcome of a stats trigger attempt. */
+public enum StatsTriggerOutcome {
+  /** Capture completed and returned a record payload. */
+  CAPTURED,
+  /** Work was accepted and queued for background execution. */
+  QUEUED,
+  /** Request cannot be satisfied for current capabilities/configuration. */
+  UNCAPTURABLE,
+  /** Request could not be completed because of a transient/runtime failure. */
+  DEGRADED
+}

--- a/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsTriggerResult.java
+++ b/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsTriggerResult.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.stats.spi;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Result payload for a stats trigger attempt.
+ *
+ * <p>When {@link #outcome()} is {@link StatsTriggerOutcome#CAPTURED}, {@link #captureResult()}
+ * contains the engine record payload. For other outcomes, {@code captureResult} is empty and {@link
+ * #detail()} carries an operator-facing reason.
+ */
+public record StatsTriggerResult(
+    StatsTriggerOutcome outcome, Optional<StatsCaptureResult> captureResult, String detail) {
+
+  public StatsTriggerResult {
+    outcome = Objects.requireNonNull(outcome, "outcome");
+    captureResult = Objects.requireNonNull(captureResult, "captureResult");
+    detail = detail == null ? "" : detail;
+  }
+
+  /** Build a successful captured result with payload. */
+  public static StatsTriggerResult captured(StatsCaptureResult captureResult) {
+    return new StatsTriggerResult(
+        StatsTriggerOutcome.CAPTURED,
+        Optional.of(Objects.requireNonNull(captureResult, "captureResult")),
+        "captured");
+  }
+
+  /** Build a queued outcome for deferred/background execution. */
+  public static StatsTriggerResult queued(String detail) {
+    return new StatsTriggerResult(StatsTriggerOutcome.QUEUED, Optional.empty(), detail);
+  }
+
+  /** Build a capability/configuration miss outcome. */
+  public static StatsTriggerResult uncapturable(String detail) {
+    return new StatsTriggerResult(StatsTriggerOutcome.UNCAPTURABLE, Optional.empty(), detail);
+  }
+
+  /** Build a degraded outcome for runtime/transient failures. */
+  public static StatsTriggerResult degraded(String detail) {
+    return new StatsTriggerResult(StatsTriggerOutcome.DEGRADED, Optional.empty(), detail);
+  }
+
+  /** Optional capture payload; present only when outcome is {@code CAPTURED}. */
+  public Optional<StatsCaptureResult> captureResult() {
+    return captureResult;
+  }
+}

--- a/core/stats/src/test/java/ai/floedb/floecat/stats/spi/StatsCapabilitiesTest.java
+++ b/core/stats/src/test/java/ai/floedb/floecat/stats/spi/StatsCapabilitiesTest.java
@@ -37,7 +37,6 @@ class StatsCapabilitiesTest {
             .statisticKindsByTarget(Map.of(StatsTargetType.TABLE, Set.of(StatsKind.ROW_COUNT)))
             .executionModes(Set.of(StatsExecutionMode.SYNC))
             .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-            .snapshotAware(true)
             .build();
 
     assertThat(caps.connectors()).containsExactlyInAnyOrder("iceberg", "delta");
@@ -52,7 +51,6 @@ class StatsCapabilitiesTest {
             .statisticKindsByTarget(Map.of(StatsTargetType.TABLE, Set.of()))
             .executionModes(Set.of(StatsExecutionMode.SYNC))
             .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-            .snapshotAware(true)
             .build();
 
     StatsCaptureRequest request =
@@ -81,7 +79,6 @@ class StatsCapabilitiesTest {
                     StatsTargetType.COLUMN, Set.of(StatsKind.NDV)))
             .executionModes(Set.of(StatsExecutionMode.SYNC))
             .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-            .snapshotAware(true)
             .build();
 
     StatsCaptureRequest tableNdvRequest =
@@ -108,7 +105,6 @@ class StatsCapabilitiesTest {
                         Map.of(StatsTargetType.TABLE, Set.of(StatsKind.ROW_COUNT)))
                     .executionModes(Set.of(StatsExecutionMode.SYNC))
                     .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-                    .snapshotAware(true)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("must declare supported kinds");

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,8 +57,8 @@ The following modules compose the system (see linked docs for deep dives):
    repository APIs, and records incremental NDV, histograms, and scan manifests. Reconcile execution
    is mode-split:
    - `METADATA_ONLY` for table/snapshot state
-   - `STATS_ONLY` for stats enrichment only
-   - `METADATA_AND_STATS` for combined capture
+   - `STATS_ONLY` for stats enrichment only (via stats control-plane / engine registry)
+   - `METADATA_AND_STATS` for metadata ingest plus queued `STATS_ONLY` follow-up capture
 3. The **Service** exposes CRUD RPCs for catalogs/namespaces/tables/views, plus query-lifecycle and
    statistics APIs. Requests traverse interceptors that inject `PrincipalContext`, correlation IDs,
    and optional query leases before hitting service implementations.

--- a/docs/connectors-delta.md
+++ b/docs/connectors-delta.md
@@ -40,12 +40,14 @@ Databricks SQL execution, and custom file readers for S3.
   filters to `data_source_format == DELTA`.
 - `describe(namespace, table)` – Fetches table metadata from Unity Catalog, reads the Delta schema via
   Delta Kernel, and returns a `TableDescriptor` containing location, partition keys, and properties.
-- `enumerateSnapshotsWithStats(...)` – Iterates Delta snapshots, optionally samples Parquet files to
-  produce NDV stats (`SamplingNdvProvider`, `ParquetNdvProvider`), and emits `SnapshotBundle`s with
-  per-file stats (row count/size plus per-column metrics when available). In incremental mode, the
+- `enumerateSnapshots(...)` – Iterates Delta snapshots and emits `SnapshotBundle`s for snapshot
+  lineage/metadata. In incremental mode, the
   connector enumerates all Delta versions that Floecat has not already ingested. When
   `SnapshotEnumerationOptions.targetSnapshotIds` is supplied, enumeration is limited to that
   explicit version set even when `fullRescan=true`.
+- `captureSnapshotTargetStats(...)` – Captures table/column/file stats for one snapshot and optional
+  selector scope, optionally sampling Parquet files for NDV (`SamplingNdvProvider`,
+  `ParquetNdvProvider`).
 
 ## Important Internal Details
 
@@ -88,8 +90,10 @@ ConnectorFactory.create(cfg)
       → Configure Unity Catalog HTTP and optional SQL client when needed
   → listNamespaces/listTables via Unity Catalog REST
   → describe via REST + Delta Kernel schema inspection
-  → enumerateSnapshotsWithStats
-      → Delta Kernel Snapshot → Parquet stats engine → SnapshotBundle (table/column/file stats)
+  → enumerateSnapshots
+      → Delta Kernel snapshot lineage
+  → captureSnapshotTargetStats
+      → Delta Kernel Snapshot → Parquet stats engine → TargetStatsRecord (table/column/file stats)
   → plan
       → DeltaPlanner traverses _delta_log → ScanBundle entries for data/delete files
 ```

--- a/docs/connectors-iceberg.md
+++ b/docs/connectors-iceberg.md
@@ -32,13 +32,13 @@ specializing discovery and catalog wiring.
 - `listTables(namespace)` – Uses REST or Glue discovery depending on the selected source.
 - `describe(namespace, table)` – Loads the table, serialises the Iceberg schema to JSON via
   `SchemaParser.toJson`, captures partition keys, and returns table properties.
-- `enumerateSnapshotsWithStats(...)` – Iterates Iceberg snapshots, loads table/column stats using
-  the configured `StatsEngine` and NDV providers, and emits `SnapshotBundle`s including upstream
-  timestamps, parent IDs, stats payloads, per-file stats (row count/size plus per-column metrics),
-  sequence numbers, manifest lists, and summary maps.
+- `enumerateSnapshots(...)` – Iterates Iceberg snapshots and emits `SnapshotBundle`s with upstream
+  timestamps, parent IDs, sequence numbers, manifest lists, and summary maps.
   When invoked with incremental `SnapshotEnumerationOptions`, the connector walks back from the
   current snapshot through the parent chain and stops once it reaches a snapshot already known to
   Floecat, returning only the newly discovered lineage.
+- `captureSnapshotTargetStats(...)` – Captures table/column/file stats for one snapshot (optionally
+  selector-scoped), using the configured `StatsEngine` and NDV providers.
 
 ## Important Internal Details
 - **Authentication** – The connector supports multiple schemes: `aws-sigv4` (default), OAuth2 token,
@@ -75,9 +75,10 @@ ConnectorFactory.create(cfg)
       → Choose REST/Glue/filesystem connector based on options
       → Initialize RESTCatalog (and Glue filter when needed)
   → listNamespaces/listTables/describe
-  → enumerateSnapshotsWithStats
-      → For each snapshot load Table, StatsEngine pulls Parquet stats (table/column + per-file),
-        NDV provider merges sketches
+  → enumerateSnapshots
+      → For each snapshot load Table metadata lineage
+  → captureSnapshotTargetStats
+      → StatsEngine pulls Parquet stats (table/column + per-file), NDV provider merges sketches
       → plan
       → Build TableScan, collect FileScanTask -> ScanBundle
 ```
@@ -146,8 +147,9 @@ To extend behavior:
     --props external.table-name=trino_test
   ```
 - **Reconciliation** – `ReconcilerService` iterates Iceberg tables, uses `describe` to create or
-  update Floecat Table records (storing schema JSON + upstream ref), then calls
-  `enumerateSnapshotsWithStats` to ingest snapshots and `plan` when acquiring scan bundles.
+  update Floecat Table records (storing schema JSON + upstream ref), ingests snapshot lineage via
+  `enumerateSnapshots`, then routes stats capture through the stats control plane (native engine
+  uses `captureSnapshotTargetStats`).
 
 ## Cross-References
 - SPI contract: [`docs/connectors-spi.md`](connectors-spi.md)

--- a/docs/connectors-spi.md
+++ b/docs/connectors-spi.md
@@ -2,8 +2,8 @@
 
 ## Overview
 `core/connectors/spi/` defines the contract that every upstream metadata connector must implement. The
-SPI abstracts discovery of namespaces/tables, enumeration of snapshots with statistics (table,
-column, and file-level), enumeration of physical files for a snapshot, and authentication adapters. It
+SPI abstracts discovery of namespaces/tables, snapshot enumeration, targeted snapshot-stat capture
+(table/column/file), enumeration of physical files for a snapshot, and authentication adapters. It
 also packages shared tooling for column statistics, file statistics, and NDV estimation.
 
 Connectors implement `FloecatConnector` and typically wrap an upstream catalog API (Iceberg REST,
@@ -17,12 +17,11 @@ Unity Catalog, etc.), translating its schemas, snapshots, and metrics into Floec
   - `listTables(namespaceFq)`.
   - `describe(namespaceFq, tableName)` → `TableDescriptor` with location, schema JSON, partition
     keys, and properties.
-  - `enumerateSnapshotsWithStats(...)` → `SnapshotBundle`s containing per-snapshot table/column/file stats.
-    Connectors may also receive `SnapshotEnumerationOptions`, which carries:
-    - `includeStatistics`
-    - `fullRescan`
-    - `knownSnapshotIds`
-    This lets connectors short-circuit incremental runs instead of always scanning full upstream history.
+  - `enumerateSnapshots(...)` → `SnapshotBundle`s containing per-snapshot metadata.
+    Connectors receive `SnapshotEnumerationOptions` with `fullRescan`, `knownSnapshotIds`, and
+    optional `targetSnapshotIds` for scoped enumeration.
+  - `captureSnapshotTargetStats(...)` → targeted stats capture for one snapshot and optional selector
+    hints (`#<column_id>` and/or connector-native names/paths).
 - **`ConnectorFactory`** – Instantiates connectors given a `ConnectorConfig` (URI, options,
   authentication). The service uses it to validate specs and the reconciler uses it during runs.
 - **`ConnectorConfigMapper`** – Bidirectional conversion between RPC `Connector` protobufs and the
@@ -99,7 +98,8 @@ interface FloecatConnector extends Closeable {
   List<String> listNamespaces();
   List<String> listTables(String namespaceFq);
   TableDescriptor describe(String namespaceFq, String tableName);
-  List<SnapshotBundle> enumerateSnapshotsWithStats(...);
+  List<SnapshotBundle> enumerateSnapshots(...);
+  List<TargetStatsRecord> captureSnapshotTargetStats(...);
 }
 ```
 For incremental reconcile, the runtime now passes the set of already-ingested destination snapshot ids
@@ -108,7 +108,7 @@ only newly discovered snapshots. The reconciler still applies a destination-side
 `TableDescriptor`, `SnapshotBundle`, and `ScanBundle` are immutable records; connectors populate them
 with canonical metadata that the reconciler ingests. `SnapshotBundle.fileStats` is optional but
 should be populated when Parquet footers or upstream metadata can provide per-file row counts, sizes,
-and per-column stats. Snapshot bundles also carry manifest-list URIs, sequence numbers, and summary
+and per-column stats for planner scan paths. Snapshot bundles also carry manifest-list URIs, sequence numbers, and summary
 maps so downstream APIs can mirror Iceberg’s REST contract.
 
 `ConnectorConfig` encodes:
@@ -142,7 +142,8 @@ ConnectorFactory.create(ConnectorConfig)
   → FloecatConnector (opens upstream clients, auth providers)
       → listNamespaces/listTables → service repo ensures namespace/table existence
       → describe → Table specs persisted with upstream references
-      → enumerateSnapshotsWithStats → StatsRepository writes Table/Column/File stats per snapshot
+      → enumerateSnapshots (metadata only)
+      → captureSnapshotTargetStats (stats capture per snapshot/selector scope)
   ← close() cleans up HTTP/S3/DB connections
 ```
 `ConnectorFactory.create` is invoked both in `ConnectorsImpl.validate` (short-lived) and in the
@@ -161,8 +162,9 @@ reconciler (long-running); connectors must tolerate repeated instantiation and r
   from RPC input, invokes `ConnectorFactory.create`, calls `listNamespaces()` to ensure the upstream
   responds, then closes the connector.
 - **Reconciliation run** – `ReconcilerService` constructs a connector inside a try-with-resources
-  block, iterates `listTables`, calls `enumerateSnapshotsWithStats`, and writes the returned
-  `SnapshotBundle`s (table stats + column stats) through the service’s gRPC API.
+  block, iterates `listTables`, calls `enumerateSnapshots` for metadata/snapshot ingestion, and
+  routes stats capture through the stats control plane (which uses
+  `captureSnapshotTargetStats` in native engines).
 - **Query lifecycle** – `QueryService.FetchScanBundle` fetch file lists pinned to the requested snapshot
 directly from table and file statistics stored in the catalog (via TableStatisticsService).
 

--- a/docs/reconciler.md
+++ b/docs/reconciler.md
@@ -26,7 +26,8 @@ creates jobs in the reconciler’s store.
   6. Supports explicit capture modes:
      - `METADATA_ONLY`: advances/creates table + snapshot state without writing stats.
      - `STATS_ONLY`: writes stats only.
-     - `METADATA_AND_STATS`: ingests both metadata and stats in one pass.
+     - `METADATA_AND_STATS`: ingests metadata/snapshots/constraints, then enqueues scoped
+       `STATS_ONLY` follow-up jobs for discovered snapshots.
 - **`GrpcClients`** – Provides blocking stubs for all service RPCs (Catalog, Namespace, Table,
   Snapshot, Statistics, Directory, Connectors).
 - **`NameParts`** – Utility for parsing namespace/table names.
@@ -44,8 +45,9 @@ Internally, the scheduler exposes `pollEvery` via `@Scheduled` (default every se
 - **Destination binding** – When reconciling, the service ensures the connector’s declared
   destination catalog/namespace/table IDs align with actual resources. Any mismatch triggers a
   `ConnectorState` update or raises conflicts.
-- **Statistics ingestion** – Target stats (including file targets) are streamed one request per
-  item via `PutTargetStats`, keeping a single idempotency key per table/snapshot.
+- **Statistics ingestion** – Stats persistence is centralized behind the stats control-plane
+  (`StatsCaptureControlPlane` / orchestrator). `STATS_ONLY` runs route capture through registry
+  engines; `METADATA_AND_STATS` schedules those captures asynchronously via follow-up jobs.
 - **Snapshot constraints ingestion** – Reconciler ingests snapshot constraints through
   `PutTableConstraints` after snapshot/stats handling.
   - Behavior is intentionally strict (not best-effort): constraint extraction/write failures fail
@@ -89,8 +91,10 @@ Connector StartCapture → ReconcileJobStore.enqueue
           → Connectors.GetConnector → ConnectorConfig
           → Ensure destination catalog/namespace/table
           → ConnectorFactory.create + try-with-resources
-              → listTables / describe / enumerateSnapshotsWithStats
-              → ingest snapshots/stats via service RPCs
+              → listTables / describe / enumerateSnapshots
+              → ingest metadata/snapshots/constraints
+              → (for METADATA_AND_STATS) enqueue STATS_ONLY follow-up by snapshot
+              → (for STATS_ONLY) capture via stats control-plane/engine registry
           → Update connector destination IDs if missing
       → markSucceeded or markFailed
 ```

--- a/docs/service.md
+++ b/docs/service.md
@@ -140,8 +140,8 @@ populates demo data when `floecat.seed.enabled=true`.
 For connector-backed fixture tables, seeding now runs a combined reconcile pass per fixture scope
 using `METADATA_AND_STATS`.
 
-This ensures query scan bundles and Delta-compat manifest materialization have required file stats
-available immediately after startup.
+This ingests metadata/snapshots first and enqueues scoped `STATS_ONLY` follow-up capture for stats.
+Query scan bundles remain available immediately; stats availability follows queued capture completion.
 
 ### Statistics streaming semantics
 `TableStatisticsServiceImpl` enforces a single `table_id` + `snapshot_id` per streamed call to

--- a/docs/statistics-engine-spi.md
+++ b/docs/statistics-engine-spi.md
@@ -61,7 +61,7 @@ Service wiring:
 - `StatsEngineRegistry` handles capability/priority engine selection for compute capture.
 - `StatsCaptureControlPlane` is the explicit capture entrypoint for control-plane callers
   (for example reconciler `STATS_ONLY` routing); current service implementation delegates to
-  `StatsOrchestrator.capture(request)`.
+  `StatsOrchestrator.trigger(request)`.
 - Public read/list RPCs remain `StatsStore` authoritative reads.
 
 Authoritative model:
@@ -134,10 +134,10 @@ Current enqueue policy:
 
 The registry is selection-only and does not merge multi-engine outputs.
 
-`StatsCaptureControlPlane.capture(request)`:
+`StatsCaptureControlPlane.trigger(request)`:
 
 1. serves as the explicit capture control-plane entrypoint (non-query callers)
-2. in service runtime, delegates to `StatsOrchestrator.capture(request)`
+2. in service runtime, delegates to `StatsOrchestrator.trigger(request)`
 3. executes one registry-routed capture attempt (no store-read short-circuit, no enqueue fallback)
 
 Result model:

--- a/docs/statistics-engine-spi.md
+++ b/docs/statistics-engine-spi.md
@@ -92,7 +92,6 @@ Each `StatsCaptureEngine` advertises:
 - supported statistic kinds per target (`statisticKindsByTarget`)
 - supported execution modes (`SYNC`, `ASYNC`)
 - sampling support (`NONE`, `RANDOM_ROW_GROUP`, `METADATA_GUIDED`)
-- snapshot awareness
 
 Kind routing note:
 
@@ -102,11 +101,6 @@ Kind routing note:
 
 `StatsEngineRegistry` uses these capabilities plus `priority()` to select candidate engines in
 order.
-
-Snapshot-awareness rule:
-
-- for concrete snapshot requests (`snapshot_id > 0`), only `snapshotAware=true` engines are eligible
-- for unresolved/current sentinel requests (`snapshot_id = 0`), both engine types may be eligible
 
 ## Routing behavior
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -372,7 +372,7 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
         if (tableStatsResponse == null || tableStatsResponse.getRecordsList().isEmpty()) {
           return false;
         }
-        var tableRecord = tableStatsResponse.getRecords(0).getStats();
+        var tableRecord = tableStatsResponse.getRecords(0);
         if (!tableRecord.hasTable()) {
           return false;
         }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -362,6 +362,35 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
       return hasAnyCapturedStats(ctx, tableId, snapshotId);
     }
     try {
+      if (targetKind == StatsTargetKind.STK_TABLE) {
+        var tableStatsResponse =
+            statistics(ctx)
+                .listTargetStats(
+                    buildStatsAlreadyCapturedRequest(tableId, snapshotId).toBuilder()
+                        .addTargetKinds(StatsTargetKind.STK_TABLE)
+                        .build());
+        if (tableStatsResponse == null || tableStatsResponse.getRecordsList().isEmpty()) {
+          return false;
+        }
+        var tableRecord = tableStatsResponse.getRecords(0).getStats();
+        if (!tableRecord.hasTable()) {
+          return false;
+        }
+        if (tableRecord.getTable().getDataFileCount() <= 0) {
+          return true;
+        }
+        var fileStatsResponse =
+            statistics(ctx)
+                .listTargetStats(
+                    ListTargetStatsRequest.newBuilder()
+                        .setTableId(tableId)
+                        .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(snapshotId).build())
+                        .setPage(PageRequest.newBuilder().setPageSize(1).build())
+                        .addTargetKinds(StatsTargetKind.STK_FILE)
+                        .build());
+        return fileStatsResponse != null && !fileStatsResponse.getRecordsList().isEmpty();
+      }
+
       var response =
           statistics(ctx)
               .listTargetStats(

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -54,6 +54,7 @@ import ai.floedb.floecat.stats.spi.StatsCaptureControlPlane;
 import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
 import ai.floedb.floecat.stats.spi.StatsCaptureResult;
 import ai.floedb.floecat.stats.spi.StatsExecutionMode;
+import ai.floedb.floecat.stats.spi.StatsTriggerResult;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
@@ -385,15 +386,14 @@ public class ReconcilerService {
             continue;
           }
           var upstreamBundles =
-              connector.enumerateSnapshotsWithStats(
+              connector.enumerateSnapshots(
                   sourceNsFq,
                   srcTable,
                   destTableId,
-                  includeSelectors,
                   fullRescan
-                      ? FloecatConnector.SnapshotEnumerationOptions.full(includeStats)
+                      ? FloecatConnector.SnapshotEnumerationOptions.full(true, targetSnapshotIds)
                       : FloecatConnector.SnapshotEnumerationOptions.incremental(
-                          includeStats, enumerationKnownSnapshotIds));
+                          enumerationKnownSnapshotIds, targetSnapshotIds));
           var bundles =
               filterBundlesForMode(
                   upstreamBundles, fullRescan, includeStats, knownSnapshotIds, progressOut);
@@ -843,6 +843,7 @@ public class ReconcilerService {
     }
     return filtered;
   }
+
   static Set<Long> knownSnapshotIdsForEnumeration(
       boolean fullRescan,
       boolean includeStats,
@@ -1078,13 +1079,14 @@ public class ReconcilerService {
       return new LinkedHashSet<>(targetSnapshotIds);
     }
     List<FloecatConnector.SnapshotBundle> discovered =
-        connector.enumerateSnapshotsWithStats(
+        connector.enumerateSnapshots(
             sourceNs,
             sourceTable,
             tableId,
-            includeSelectors == null ? Set.of() : includeSelectors,
-            new FloecatConnector.SnapshotEnumerationOptions(
-                false, fullRescan, enumerationKnownSnapshotIds));
+            fullRescan
+                ? FloecatConnector.SnapshotEnumerationOptions.full(true, targetSnapshotIds)
+                : FloecatConnector.SnapshotEnumerationOptions.incremental(
+                    enumerationKnownSnapshotIds, targetSnapshotIds));
     Set<Long> snapshotIds = new LinkedHashSet<>();
     if (discovered == null) {
       return snapshotIds;
@@ -1103,7 +1105,8 @@ public class ReconcilerService {
       return Optional.empty();
     }
     try {
-      return statsCaptureControlPlane.get().capture(request);
+      StatsTriggerResult result = statsCaptureControlPlane.get().trigger(request);
+      return result.captureResult();
     } catch (RuntimeException e) {
       LOG.warnf(
           e,

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -188,6 +188,7 @@ public class ReconcilerService {
     String corr = ctx.correlationId();
 
     final ArrayList<String> errSummaries = new ArrayList<>();
+    final ArrayList<String> degradedSummaries = new ArrayList<>();
     final BooleanSupplier cancelCheck = cancelRequested == null ? NO_CANCEL : cancelRequested;
     final ProgressListener progressOut = progress == null ? NO_PROGRESS : progress;
 
@@ -416,6 +417,7 @@ public class ReconcilerService {
                   captureMode);
           snapshotsProcessed += upstreamBundles.ingestCounts().snapshotsProcessed;
           statsProcessed += upstreamBundles.ingestCounts().statsProcessed;
+          upstreamBundles.degradedReason().ifPresent(degradedSummaries::add);
           if (upstreamBundles.tableChanged()) {
             changed++;
           }
@@ -538,7 +540,14 @@ public class ReconcilerService {
       }
 
       if (errors == 0) {
-        return new Result(scanned, changed, 0, snapshotsProcessed, statsProcessed, null);
+        return new Result(
+            scanned,
+            changed,
+            0,
+            snapshotsProcessed,
+            statsProcessed,
+            null,
+            List.copyOf(degradedSummaries));
       } else {
         var summary = new StringBuilder();
         summary.append("Partial failure (errors=").append(errors).append("):");
@@ -551,7 +560,8 @@ public class ReconcilerService {
             errors,
             snapshotsProcessed,
             statsProcessed,
-            new RuntimeException(summary.toString()));
+            new RuntimeException(summary.toString()),
+            List.copyOf(degradedSummaries));
       }
 
     } catch (Exception e) {
@@ -1103,25 +1113,32 @@ public class ReconcilerService {
     }
   }
 
-  private void enqueueStatsOnlyCapture(
+  private Optional<String> enqueueStatsOnlyCapture(
       ResourceId connectorId,
       String namespaceFq,
       String tableDisplayName,
       Set<String> includeSelectors,
       Set<Long> snapshotIds) {
     if (reconcileJobStore == null || reconcileJobStore.isUnsatisfied()) {
+      String reason =
+          "stats_followup_unavailable connector="
+              + (connectorId != null ? connectorId.getId() : "")
+              + " table="
+              + (namespaceFq == null ? "" : namespaceFq)
+              + "."
+              + (tableDisplayName == null ? "" : tableDisplayName);
       LOG.warnf(
           "Skipping follow-up STATS_ONLY enqueue: reconcile job store unavailable for connector=%s table=%s.%s",
           connectorId != null ? connectorId.getId() : "",
           namespaceFq == null ? "" : namespaceFq,
           tableDisplayName == null ? "" : tableDisplayName);
-      return;
+      return Optional.of(reason);
     }
     if (connectorId == null
         || connectorId.getAccountId().isBlank()
         || connectorId.getId().isBlank()) {
       LOG.warn("Skipping follow-up STATS_ONLY enqueue: connector identity is incomplete");
-      return;
+      return Optional.of("stats_followup_unavailable connector_identity_incomplete");
     }
     if (namespaceFq == null
         || namespaceFq.isBlank()
@@ -1130,7 +1147,8 @@ public class ReconcilerService {
       LOG.warnf(
           "Skipping follow-up STATS_ONLY enqueue: scope identity missing for connector=%s",
           connectorId.getId());
-      return;
+      return Optional.of(
+          "stats_followup_unavailable scope_identity_missing connector=" + connectorId.getId());
     }
     List<List<String>> namespacePaths = List.of(namespacePath(namespaceFq));
     List<String> columns =
@@ -1148,6 +1166,7 @@ public class ReconcilerService {
     LOG.infof(
         "Enqueued follow-up STATS_ONLY capture job=%s connector=%s table=%s.%s snapshots=%s",
         jobId, connectorId.getId(), namespaceFq, tableDisplayName, snapshotIds);
+    return Optional.empty();
   }
 
   private Set<Long> snapshotIdsFromBundles(List<FloecatConnector.SnapshotBundle> bundles) {
@@ -1216,15 +1235,17 @@ public class ReconcilerService {
             errors,
             snapshotsProcessedBase,
             statsProcessedBase);
+    Optional<String> degradedReason = Optional.empty();
     if (captureMode == CaptureMode.METADATA_AND_STATS) {
-      enqueueStatsOnlyCapture(
-          connectorId,
-          scopeNamespaceFq,
-          destTableDisplay,
-          includeSelectors,
-          snapshotIdsFromBundles(bundles));
+      degradedReason =
+          enqueueStatsOnlyCapture(
+              connectorId,
+              scopeNamespaceFq,
+              destTableDisplay,
+              includeSelectors,
+              snapshotIdsFromBundles(bundles));
     }
-    return new MetadataPassOutcome(ingestCounts, tableChanged(bundles));
+    return new MetadataPassOutcome(ingestCounts, tableChanged(bundles), degradedReason);
   }
 
   private List<String> namespacePath(String namespaceFq) {
@@ -1450,6 +1471,7 @@ public class ReconcilerService {
     // target records for a single successful capture attempt.
     public final long scanned, changed, errors, snapshotsProcessed, statsProcessed;
     public final Exception error;
+    public final List<String> degradedReasons;
 
     public Result(
         long scanned,
@@ -1458,12 +1480,27 @@ public class ReconcilerService {
         long snapshotsProcessed,
         long statsProcessed,
         Exception error) {
+      this(scanned, changed, errors, snapshotsProcessed, statsProcessed, error, List.of());
+    }
+
+    public Result(
+        long scanned,
+        long changed,
+        long errors,
+        long snapshotsProcessed,
+        long statsProcessed,
+        Exception error,
+        List<String> degradedReasons) {
       this.scanned = scanned;
       this.changed = changed;
       this.errors = errors;
       this.snapshotsProcessed = snapshotsProcessed;
       this.statsProcessed = statsProcessed;
       this.error = error;
+      this.degradedReasons =
+          degradedReasons == null || degradedReasons.isEmpty()
+              ? List.of()
+              : List.copyOf(degradedReasons);
     }
 
     public boolean ok() {
@@ -1474,8 +1511,15 @@ public class ReconcilerService {
       return error instanceof ReconcileCancelledException;
     }
 
+    public boolean degraded() {
+      return !degradedReasons.isEmpty();
+    }
+
     public String message() {
-      return ok() ? "OK" : rootCauseMessage(error);
+      if (!ok()) {
+        return rootCauseMessage(error);
+      }
+      return degraded() ? "DEGRADED: " + String.join("; ", degradedReasons) : "OK";
     }
   }
 
@@ -1507,5 +1551,6 @@ public class ReconcilerService {
     }
   }
 
-  private record MetadataPassOutcome(IngestCounts ingestCounts, boolean tableChanged) {}
+  private record MetadataPassOutcome(
+      IngestCounts ingestCounts, boolean tableChanged, Optional<String> degradedReason) {}
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -1295,8 +1295,7 @@ public class ReconcilerService {
       return false;
     }
     if (includeSelectors != null && !includeSelectors.isEmpty()) {
-      return backend.statsAlreadyCapturedForTargetKind(
-          ctx, tableId, snapshotId, StatsTargetKind.STK_COLUMN);
+      return backend.statsCapturedForColumnSelectors(ctx, tableId, snapshotId, includeSelectors);
     }
     return backend.statsAlreadyCapturedForTargetKind(
             ctx, tableId, snapshotId, StatsTargetKind.STK_COLUMN)

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -810,6 +810,39 @@ public class ReconcilerService {
     return filtered;
   }
 
+  private List<FloecatConnector.SnapshotBundle> filterBundlesForSnapshotScope(
+      List<FloecatConnector.SnapshotBundle> bundles,
+      Set<Long> targetSnapshotIds,
+      ProgressListener progress) {
+    if (bundles == null
+        || bundles.isEmpty()
+        || targetSnapshotIds == null
+        || targetSnapshotIds.isEmpty()) {
+      return bundles == null ? List.of() : bundles;
+    }
+    List<FloecatConnector.SnapshotBundle> filtered = new ArrayList<>(bundles.size());
+    int skipped = 0;
+    for (FloecatConnector.SnapshotBundle bundle : bundles) {
+      if (bundle == null) {
+        continue;
+      }
+      if (!targetSnapshotIds.contains(bundle.snapshotId())) {
+        skipped++;
+        continue;
+      }
+      filtered.add(bundle);
+    }
+    if (skipped > 0) {
+      progress.onProgress(
+          0,
+          0,
+          0,
+          0,
+          0,
+          "Reconcile skipped " + skipped + " snapshots outside explicit snapshot scope");
+    }
+    return filtered;
+  }
   static Set<Long> knownSnapshotIdsForEnumeration(
       boolean fullRescan,
       boolean includeStats,

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -348,11 +348,14 @@ public class ReconcilerService {
           Set<Long> targetSnapshotIds = Set.of();
           Set<Long> knownSnapshotIds =
               fullRescan ? Set.of() : backend.existingSnapshotIds(ctx, destTableId);
-          Predicate<Long> statsCompleteForSnapshot =
-              snapshotCompletenessChecker(ctx, destTableId, includeSelectors);
           Set<Long> enumerationKnownSnapshotIds =
               knownSnapshotIdsForEnumeration(
-                  fullRescan, includeStats, knownSnapshotIds, statsCompleteForSnapshot);
+                  fullRescan,
+                  includeStats,
+                  knownSnapshotIds,
+                  snapshotId ->
+                      isStatsCaptureCompleteForScope(
+                          ctx, destTableId, snapshotId, includeSelectors));
           if (captureMode == CaptureMode.STATS_ONLY) {
             IngestCounts ingestCounts =
                 captureStatsOnlyViaControlPlane(
@@ -365,7 +368,6 @@ public class ReconcilerService {
                     knownSnapshotIds,
                     enumerationKnownSnapshotIds,
                     targetSnapshotIds,
-                    statsCompleteForSnapshot,
                     includeSelectors,
                     cancelCheck,
                     progressOut,
@@ -387,50 +389,35 @@ public class ReconcilerService {
             continue;
           }
           var upstreamBundles =
-              connector.enumerateSnapshots(
-                  sourceNsFq,
-                  srcTable,
-                  destTableId,
-                  fullRescan
-                      ? FloecatConnector.SnapshotEnumerationOptions.full(true, targetSnapshotIds)
-                      : FloecatConnector.SnapshotEnumerationOptions.incremental(
-                          enumerationKnownSnapshotIds, targetSnapshotIds));
-          var bundles =
-              filterBundlesForMode(
-                  upstreamBundles, fullRescan, includeStats, knownSnapshotIds, progressOut);
-          IngestCounts ingestCounts =
-              ingestAllSnapshotsAndStatsFiltered(
+              processMetadataPass(
                   ctx,
+                  connectorId,
                   destTableId,
                   connector,
                   resolved.kind(),
-                  bundles,
-                  includeCoreMetadata,
-                  includeStats,
-                  fullRescan,
-                  statsCompleteForSnapshot,
-                  includeSelectors,
-                  cancelCheck,
-                  progressOut,
                   sourceNsFq,
                   srcTable,
+                  scopeNamespaceFq,
+                  destTableDisplay,
+                  fullRescan,
+                  includeCoreMetadata,
+                  includeStats,
+                  includeSelectors,
+                  knownSnapshotIds,
+                  enumerationKnownSnapshotIds,
+                  targetSnapshotIds,
+                  cancelCheck,
+                  progressOut,
                   scanned,
                   changed,
                   errors,
                   snapshotsProcessed,
-                  statsProcessed);
-          snapshotsProcessed += ingestCounts.snapshotsProcessed;
-          statsProcessed += ingestCounts.statsProcessed;
-          if (tableChanged(bundles)) {
+                  statsProcessed,
+                  captureMode);
+          snapshotsProcessed += upstreamBundles.ingestCounts().snapshotsProcessed;
+          statsProcessed += upstreamBundles.ingestCounts().statsProcessed;
+          if (upstreamBundles.tableChanged()) {
             changed++;
-          }
-          if (captureMode == CaptureMode.METADATA_AND_STATS) {
-            enqueueStatsOnlyCapture(
-                connectorId,
-                scopeNamespaceFq,
-                destTableDisplay,
-                includeSelectors,
-                snapshotIdsFromBundles(bundles));
           }
           progressOut.onProgress(
               scanned,
@@ -664,7 +651,7 @@ public class ReconcilerService {
     NameRef tableRef =
         NameRef.newBuilder()
             .setCatalog(catalogName)
-            .addAllPath(List.of(namespaceFq.split("\\.")))
+            .addAllPath(namespacePath(namespaceFq))
             .setName(tableDisplay)
             .build();
     Optional<ResourceId> tableId = backend.lookupTable(ctx, NameRefNormalizer.normalize(tableRef));
@@ -927,7 +914,6 @@ public class ReconcilerService {
       boolean includeCoreMetadata,
       boolean includeStats,
       boolean fullRescan,
-      Predicate<Long> statsCompleteForSnapshot,
       Set<String> includeSelectors,
       BooleanSupplier cancelRequested,
       ProgressListener progress,
@@ -973,9 +959,7 @@ public class ReconcilerService {
       }
 
       boolean statsCaptured =
-          !fullRescan
-              && statsCompleteForSnapshot != null
-              && statsCompleteForSnapshot.test(snapshotId);
+          !fullRescan && isStatsCaptureCompleteForScope(ctx, tableId, snapshotId, includeSelectors);
       if (statsCaptured) {
         continue;
       }
@@ -1008,7 +992,6 @@ public class ReconcilerService {
       Set<Long> knownSnapshotIds,
       Set<Long> enumerationKnownSnapshotIds,
       Set<Long> targetSnapshotIds,
-      Predicate<Long> statsCompleteForSnapshot,
       Set<String> includeSelectors,
       BooleanSupplier cancelRequested,
       ProgressListener progress,
@@ -1026,8 +1009,7 @@ public class ReconcilerService {
             tableId,
             fullRescan,
             enumerationKnownSnapshotIds,
-            targetSnapshotIds,
-            includeSelectors);
+            targetSnapshotIds);
     if (snapshotIds.isEmpty()) {
       return new IngestCounts(0L, 0L);
     }
@@ -1049,8 +1031,7 @@ public class ReconcilerService {
       if (!fullRescan
           && knownSnapshotIds != null
           && knownSnapshotIds.contains(snapshotId)
-          && statsCompleteForSnapshot != null
-          && statsCompleteForSnapshot.test(snapshotId)) {
+          && isStatsCaptureCompleteForScope(ctx, tableId, snapshotId, includeSelectors)) {
         continue;
       }
 
@@ -1079,8 +1060,7 @@ public class ReconcilerService {
       ResourceId tableId,
       boolean fullRescan,
       Set<Long> enumerationKnownSnapshotIds,
-      Set<Long> targetSnapshotIds,
-      Set<String> includeSelectors) {
+      Set<Long> targetSnapshotIds) {
     if (targetSnapshotIds != null && !targetSnapshotIds.isEmpty()) {
       return new LinkedHashSet<>(targetSnapshotIds);
     }
@@ -1152,7 +1132,7 @@ public class ReconcilerService {
           connectorId.getId());
       return;
     }
-    List<List<String>> namespacePaths = List.of(List.of(namespaceFq.split("\\.")));
+    List<List<String>> namespacePaths = List.of(namespacePath(namespaceFq));
     List<String> columns =
         includeSelectors == null ? List.of() : includeSelectors.stream().sorted().toList();
     ReconcileScope scope = ReconcileScope.of(namespacePaths, tableDisplayName, columns);
@@ -1178,6 +1158,84 @@ public class ReconcilerService {
         .filter(bundle -> bundle != null && bundle.snapshotId() >= 0)
         .map(FloecatConnector.SnapshotBundle::snapshotId)
         .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private MetadataPassOutcome processMetadataPass(
+      ReconcileContext ctx,
+      ResourceId connectorId,
+      ResourceId tableId,
+      FloecatConnector connector,
+      ConnectorConfig.Kind connectorKind,
+      String sourceNs,
+      String sourceTable,
+      String scopeNamespaceFq,
+      String destTableDisplay,
+      boolean fullRescan,
+      boolean includeCoreMetadata,
+      boolean includeStats,
+      Set<String> includeSelectors,
+      Set<Long> knownSnapshotIds,
+      Set<Long> enumerationKnownSnapshotIds,
+      Set<Long> targetSnapshotIds,
+      BooleanSupplier cancelRequested,
+      ProgressListener progress,
+      long scanned,
+      long changed,
+      long errors,
+      long snapshotsProcessedBase,
+      long statsProcessedBase,
+      CaptureMode captureMode) {
+    List<FloecatConnector.SnapshotBundle> upstreamBundles =
+        connector.enumerateSnapshots(
+            sourceNs,
+            sourceTable,
+            tableId,
+            fullRescan
+                ? FloecatConnector.SnapshotEnumerationOptions.full(true, targetSnapshotIds)
+                : FloecatConnector.SnapshotEnumerationOptions.incremental(
+                    enumerationKnownSnapshotIds, targetSnapshotIds));
+    List<FloecatConnector.SnapshotBundle> bundles =
+        filterBundlesForMode(upstreamBundles, fullRescan, includeStats, knownSnapshotIds, progress);
+    IngestCounts ingestCounts =
+        ingestAllSnapshotsAndStatsFiltered(
+            ctx,
+            tableId,
+            connector,
+            connectorKind,
+            bundles,
+            includeCoreMetadata,
+            includeStats,
+            fullRescan,
+            includeSelectors,
+            cancelRequested,
+            progress,
+            sourceNs,
+            sourceTable,
+            scanned,
+            changed,
+            errors,
+            snapshotsProcessedBase,
+            statsProcessedBase);
+    if (captureMode == CaptureMode.METADATA_AND_STATS) {
+      enqueueStatsOnlyCapture(
+          connectorId,
+          scopeNamespaceFq,
+          destTableDisplay,
+          includeSelectors,
+          snapshotIdsFromBundles(bundles));
+    }
+    return new MetadataPassOutcome(ingestCounts, tableChanged(bundles));
+  }
+
+  private List<String> namespacePath(String namespaceFq) {
+    var parts = split(namespaceFq);
+    if (parts.parents.isEmpty()) {
+      return List.of(parts.leaf);
+    }
+    List<String> path = new ArrayList<>(parts.parents.size() + 1);
+    path.addAll(parts.parents);
+    path.add(parts.leaf);
+    return path;
   }
 
   private static String connectorTypeFor(ConnectorConfig.Kind kind) {
@@ -1216,7 +1274,8 @@ public class ReconcilerService {
       return false;
     }
     if (includeSelectors != null && !includeSelectors.isEmpty()) {
-      return backend.statsCapturedForColumnSelectors(ctx, tableId, snapshotId, includeSelectors);
+      return backend.statsAlreadyCapturedForTargetKind(
+          ctx, tableId, snapshotId, StatsTargetKind.STK_COLUMN);
     }
     return backend.statsAlreadyCapturedForTargetKind(
             ctx, tableId, snapshotId, StatsTargetKind.STK_COLUMN)
@@ -1224,18 +1283,6 @@ public class ReconcilerService {
             ctx, tableId, snapshotId, StatsTargetKind.STK_FILE)
         || backend.statsAlreadyCapturedForTargetKind(
             ctx, tableId, snapshotId, StatsTargetKind.STK_EXPRESSION);
-  }
-
-  /**
-   * Builds a memoized snapshot completeness checker so repeated lookups in one table reconcile pass
-   * do not issue duplicate backend calls for the same snapshot.
-   */
-  private Predicate<Long> snapshotCompletenessChecker(
-      ReconcileContext ctx, ResourceId tableId, Set<String> includeSelectors) {
-    Map<Long, Boolean> completenessBySnapshot = new LinkedHashMap<>();
-    return snapshotId ->
-        completenessBySnapshot.computeIfAbsent(
-            snapshotId, id -> isStatsCaptureCompleteForScope(ctx, tableId, id, includeSelectors));
   }
 
   private static TableFormat toTableFormat(ConnectorFormat format) {
@@ -1459,4 +1506,6 @@ public class ReconcilerService {
       this.statsProcessed = statsProcessed;
     }
   }
+
+  private record MetadataPassOutcome(IngestCounts ingestCounts, boolean tableChanged) {}
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -42,6 +42,7 @@ import ai.floedb.floecat.connector.spi.CredentialResolver;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.query.rpc.SchemaDescriptor;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.spi.NameRefNormalizer;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
@@ -80,6 +81,7 @@ import java.util.function.LongConsumer;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -109,6 +111,7 @@ public class ReconcilerService {
   @Inject LogicalSchemaMapper schemaMapper;
   @Inject CredentialResolver credentialResolver;
   @Inject Instance<StatsCaptureControlPlane> statsCaptureControlPlane;
+  @Inject Instance<ReconcileJobStore> reconcileJobStore;
 
   /** Opens a connector from a resolved configuration. */
   @FunctionalInterface
@@ -341,9 +344,7 @@ public class ReconcilerService {
           boolean includeCoreMetadata =
               captureMode == CaptureMode.METADATA_ONLY
                   || captureMode == CaptureMode.METADATA_AND_STATS;
-          boolean includeStats =
-              captureMode == CaptureMode.STATS_ONLY
-                  || captureMode == CaptureMode.METADATA_AND_STATS;
+          boolean includeStats = captureMode == CaptureMode.STATS_ONLY;
           Set<Long> targetSnapshotIds = Set.of();
           Set<Long> knownSnapshotIds =
               fullRescan ? Set.of() : backend.existingSnapshotIds(ctx, destTableId);
@@ -422,6 +423,14 @@ public class ReconcilerService {
           statsProcessed += ingestCounts.statsProcessed;
           if (tableChanged(bundles)) {
             changed++;
+          }
+          if (captureMode == CaptureMode.METADATA_AND_STATS) {
+            enqueueStatsOnlyCapture(
+                connectorId,
+                scopeNamespaceFq,
+                destTableDisplay,
+                includeSelectors,
+                snapshotIdsFromBundles(bundles));
           }
           progressOut.onProgress(
               scanned,
@@ -955,6 +964,8 @@ public class ReconcilerService {
 
       if (includeCoreMetadata) {
         ensureSnapshot(ctx, tableId, snapshotBundle);
+        maybeIngestSnapshotConstraints(
+            ctx, tableId, connector, sourceNs, sourceTable, snapshotBundle, snapshotId);
       }
 
       if (!includeStats) {
@@ -966,8 +977,6 @@ public class ReconcilerService {
               && statsCompleteForSnapshot != null
               && statsCompleteForSnapshot.test(snapshotId);
       if (statsCaptured) {
-        maybeIngestSnapshotConstraints(
-            ctx, tableId, connector, sourceNs, sourceTable, snapshotBundle, snapshotId);
         continue;
       }
 
@@ -985,9 +994,6 @@ public class ReconcilerService {
         // target records.
         statsProcessed++;
       }
-
-      maybeIngestSnapshotConstraints(
-          ctx, tableId, connector, sourceNs, sourceTable, snapshotBundle, snapshotId);
     }
     return new IngestCounts(snapshotsProcessed, statsProcessed);
   }
@@ -1115,6 +1121,63 @@ public class ReconcilerService {
           request.snapshotId());
       return Optional.empty();
     }
+  }
+
+  private void enqueueStatsOnlyCapture(
+      ResourceId connectorId,
+      String namespaceFq,
+      String tableDisplayName,
+      Set<String> includeSelectors,
+      Set<Long> snapshotIds) {
+    if (reconcileJobStore == null || reconcileJobStore.isUnsatisfied()) {
+      LOG.warnf(
+          "Skipping follow-up STATS_ONLY enqueue: reconcile job store unavailable for connector=%s table=%s.%s",
+          connectorId != null ? connectorId.getId() : "",
+          namespaceFq == null ? "" : namespaceFq,
+          tableDisplayName == null ? "" : tableDisplayName);
+      return;
+    }
+    if (connectorId == null
+        || connectorId.getAccountId().isBlank()
+        || connectorId.getId().isBlank()) {
+      LOG.warn("Skipping follow-up STATS_ONLY enqueue: connector identity is incomplete");
+      return;
+    }
+    if (namespaceFq == null
+        || namespaceFq.isBlank()
+        || tableDisplayName == null
+        || tableDisplayName.isBlank()) {
+      LOG.warnf(
+          "Skipping follow-up STATS_ONLY enqueue: scope identity missing for connector=%s",
+          connectorId.getId());
+      return;
+    }
+    List<List<String>> namespacePaths = List.of(List.of(namespaceFq.split("\\.")));
+    List<String> columns =
+        includeSelectors == null ? List.of() : includeSelectors.stream().sorted().toList();
+    ReconcileScope scope = ReconcileScope.of(namespacePaths, tableDisplayName, columns);
+    String jobId =
+        reconcileJobStore
+            .get()
+            .enqueue(
+                connectorId.getAccountId(),
+                connectorId.getId(),
+                false,
+                CaptureMode.STATS_ONLY,
+                scope);
+    LOG.infof(
+        "Enqueued follow-up STATS_ONLY capture job=%s connector=%s table=%s.%s snapshots=%s",
+        jobId, connectorId.getId(), namespaceFq, tableDisplayName, snapshotIds);
+  }
+
+  private Set<Long> snapshotIdsFromBundles(List<FloecatConnector.SnapshotBundle> bundles) {
+    if (bundles == null || bundles.isEmpty()) {
+      return Set.of();
+    }
+    return bundles.stream()
+        .filter(bundle -> bundle != null && bundle.snapshotId() >= 0)
+        .map(FloecatConnector.SnapshotBundle::snapshotId)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   private static String connectorTypeFor(ConnectorConfig.Kind kind) {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
+import ai.floedb.floecat.catalog.rpc.ViewSpec;
+import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.common.resolver.LogicalSchemaMapper;
+import ai.floedb.floecat.connector.rpc.AuthCredentials;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorKind;
+import ai.floedb.floecat.connector.rpc.ConnectorState;
+import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceSelector;
+import ai.floedb.floecat.connector.spi.ConnectorFormat;
+import ai.floedb.floecat.connector.spi.CredentialResolver;
+import ai.floedb.floecat.connector.spi.FloecatConnector;
+import ai.floedb.floecat.query.rpc.SnapshotPin;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.spi.ReconcileContext;
+import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
+import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
+import ai.floedb.floecat.stats.spi.StatsCaptureControlPlane;
+import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
+import ai.floedb.floecat.stats.spi.StatsCaptureResult;
+import ai.floedb.floecat.stats.spi.StatsTriggerResult;
+import jakarta.enterprise.inject.Instance;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+
+abstract class AbstractReconcilerServiceTestBase {
+  protected ReconcilerService service;
+  protected PrincipalContext principal;
+  protected ResourceId connectorId;
+
+  @BeforeEach
+  void setUp() {
+    service = new ReconcilerService();
+    service.schemaMapper = new LogicalSchemaMapper();
+    service.credentialResolver = new InMemoryCredentialResolver();
+    principal =
+        PrincipalContext.newBuilder().setAccountId("acct").setCorrelationId("corr-id").build();
+    connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("connector-1")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+
+    ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
+    Mockito.when(
+            jobStore.enqueue(
+                Mockito.anyString(),
+                Mockito.anyString(),
+                Mockito.anyBoolean(),
+                Mockito.any(),
+                Mockito.any()))
+        .thenReturn("job-default");
+    @SuppressWarnings("unchecked")
+    Instance<ReconcileJobStore> jobStoreInstance = Mockito.mock(Instance.class);
+    Mockito.when(jobStoreInstance.isUnsatisfied()).thenReturn(false);
+    Mockito.when(jobStoreInstance.get()).thenReturn(jobStore);
+    service.reconcileJobStore = jobStoreInstance;
+  }
+
+  protected Connector activeConnector() {
+    ResourceId destCatalogId = ResourceId.newBuilder().setAccountId("acct").setId("cat-1").build();
+    ResourceId destNamespaceId = ResourceId.newBuilder().setAccountId("acct").setId("ns-1").build();
+    return Connector.newBuilder()
+        .setResourceId(connectorId)
+        .setState(ConnectorState.CS_ACTIVE)
+        .setKind(ConnectorKind.CK_DELTA)
+        .setSource(
+            SourceSelector.newBuilder()
+                .setNamespace(
+                    NamespacePath.newBuilder().addSegments("src_cat").addSegments("src_ns")))
+        .setDestination(
+            DestinationTarget.newBuilder()
+                .setCatalogId(destCatalogId)
+                .setNamespaceId(destNamespaceId))
+        .build();
+  }
+
+  protected static StatsCaptureControlPlane capturedControlPlane(AtomicInteger captureCalls) {
+    return capturedControlPlane(captureCalls, null);
+  }
+
+  protected static StatsCaptureControlPlane capturedControlPlane(
+      AtomicInteger captureCalls, AtomicReference<StatsCaptureRequest> capturedRequest) {
+    return request -> {
+      if (capturedRequest != null) {
+        capturedRequest.set(request);
+      }
+      captureCalls.incrementAndGet();
+      return capturedResult(request);
+    };
+  }
+
+  private static StatsTriggerResult capturedResult(StatsCaptureRequest request) {
+    return StatsTriggerResult.captured(
+        StatsCaptureResult.forRecord(
+            "test-engine",
+            TargetStatsRecord.newBuilder()
+                .setTableId(request.tableId())
+                .setSnapshotId(request.snapshotId())
+                .setTarget(StatsTargetIdentity.tableTarget())
+                .setTable(
+                    ai.floedb.floecat.catalog.rpc.TableValueStats.newBuilder()
+                        .setRowCount(1L)
+                        .build())
+                .build(),
+            Map.of()));
+  }
+
+  protected static final class ThrowingBackend extends DefaultBackend {
+    private final RuntimeException failure;
+
+    protected ThrowingBackend(RuntimeException failure) {
+      this.failure = failure;
+    }
+
+    @Override
+    public Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId) {
+      throw failure;
+    }
+  }
+
+  protected static final class ReturningBackend extends DefaultBackend {
+    private final Connector connector;
+
+    protected ReturningBackend(Connector connector) {
+      this.connector = connector;
+    }
+
+    @Override
+    public Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId) {
+      return connector;
+    }
+  }
+
+  protected abstract static class DefaultBackend implements ReconcilerBackend {
+    @Override
+    public ResourceId ensureNamespace(
+        ReconcileContext ctx, ResourceId catalogId, NameRef namespace) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ResourceId ensureTable(
+        ReconcileContext ctx,
+        ResourceId namespaceId,
+        NameRef table,
+        TableSpecDescriptor descriptor) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ResourceId> lookupTable(ReconcileContext ctx, NameRef table) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> lookupTableDisplayName(ReconcileContext ctx, ResourceId tableId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SnapshotPin snapshotPinFor(
+        ReconcileContext ctx,
+        ResourceId tableId,
+        ai.floedb.floecat.common.rpc.SnapshotRef ref,
+        Optional<com.google.protobuf.Timestamp> asOf) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Snapshot> fetchSnapshot(
+        ReconcileContext ctx, ResourceId tableId, long snapshotId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Long> existingSnapshotIds(ReconcileContext ctx, ResourceId tableId) {
+      return Set.of();
+    }
+
+    @Override
+    public void ingestSnapshot(ReconcileContext ctx, ResourceId tableId, Snapshot snapshot) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean statsAlreadyCaptured(ReconcileContext ctx, ResourceId tableId, long snapshotId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void putTargetStats(ReconcileContext ctx, List<TargetStatsRecord> stats) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateConnectorDestination(
+        ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  protected static final class InMemoryCredentialResolver implements CredentialResolver {
+    private final Map<String, AuthCredentials> store = new HashMap<>();
+
+    @Override
+    public Optional<AuthCredentials> resolve(String accountId, String credentialId) {
+      return Optional.ofNullable(store.get(key(accountId, credentialId)));
+    }
+
+    @Override
+    public void store(String accountId, String credentialId, AuthCredentials credentials) {
+      store.put(key(accountId, credentialId), credentials);
+    }
+
+    @Override
+    public void delete(String accountId, String credentialId) {
+      store.remove(key(accountId, credentialId));
+    }
+
+    private String key(String accountId, String credentialId) {
+      return accountId + ":" + credentialId;
+    }
+  }
+
+  protected static class ViewCapturingBackend extends DefaultBackend {
+    private final Connector connector;
+    final List<ViewSpec> capturedViews = new ArrayList<>();
+    final List<String> capturedIdempotencyKeys = new ArrayList<>();
+
+    protected ViewCapturingBackend(Connector connector) {
+      this.connector = connector;
+    }
+
+    @Override
+    public Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId) {
+      return connector;
+    }
+
+    @Override
+    public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+      return "dest_cat";
+    }
+
+    @Override
+    public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+      return "dest_ns";
+    }
+
+    @Override
+    public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+      capturedViews.add(spec);
+      capturedIdempotencyKeys.add(idempotencyKey);
+      return ResourceId.newBuilder().setId("view-1").build();
+    }
+
+    @Override
+    public void updateConnectorDestination(
+        ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {
+      // no-op
+    }
+  }
+
+  protected static class FakeConnector implements FloecatConnector {
+    private final List<FloecatConnector.ViewDescriptor> viewDescriptors;
+
+    protected FakeConnector(List<FloecatConnector.ViewDescriptor> viewDescriptors) {
+      this.viewDescriptors = viewDescriptors;
+    }
+
+    @Override
+    public String id() {
+      return "fake";
+    }
+
+    @Override
+    public ConnectorFormat format() {
+      return ConnectorFormat.CF_DELTA;
+    }
+
+    @Override
+    public List<String> listNamespaces() {
+      return List.of();
+    }
+
+    @Override
+    public List<String> listTables(String namespaceFq) {
+      return List.of();
+    }
+
+    @Override
+    public TableDescriptor describe(String namespaceFq, String tableName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<SnapshotBundle> enumerateSnapshots(
+        String namespaceFq,
+        String tableName,
+        ResourceId destinationTableId,
+        SnapshotEnumerationOptions options) {
+      return List.of();
+    }
+
+    @Override
+    public List<TargetStatsRecord> captureSnapshotTargetStats(
+        String namespaceFq,
+        String tableName,
+        ResourceId destinationTableId,
+        long snapshotId,
+        Set<String> includeColumns) {
+      return List.of();
+    }
+
+    @Override
+    public List<FloecatConnector.ViewDescriptor> listViewDescriptors(String namespaceFq) {
+      return viewDescriptors;
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
@@ -207,6 +207,12 @@ abstract class AbstractReconcilerServiceTestBase {
     }
 
     @Override
+    public boolean statsCapturedForColumnSelectors(
+        ReconcileContext ctx, ResourceId tableId, long snapshotId, Set<String> selectors) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void putTargetStats(ReconcileContext ctx, List<TargetStatsRecord> stats) {
       throw new UnsupportedOperationException();
     }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
@@ -35,7 +35,6 @@ import ai.floedb.floecat.connector.spi.ConnectorFormat;
 import ai.floedb.floecat.connector.spi.CredentialResolver;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
-import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
@@ -43,7 +42,6 @@ import ai.floedb.floecat.stats.spi.StatsCaptureControlPlane;
 import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
 import ai.floedb.floecat.stats.spi.StatsCaptureResult;
 import ai.floedb.floecat.stats.spi.StatsTriggerResult;
-import jakarta.enterprise.inject.Instance;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -53,7 +51,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.Mockito;
 
 abstract class AbstractReconcilerServiceTestBase {
   protected ReconcilerService service;
@@ -73,21 +70,6 @@ abstract class AbstractReconcilerServiceTestBase {
             .setId("connector-1")
             .setKind(ResourceKind.RK_CONNECTOR)
             .build();
-
-    ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
-    Mockito.when(
-            jobStore.enqueue(
-                Mockito.anyString(),
-                Mockito.anyString(),
-                Mockito.anyBoolean(),
-                Mockito.any(),
-                Mockito.any()))
-        .thenReturn("job-default");
-    @SuppressWarnings("unchecked")
-    Instance<ReconcileJobStore> jobStoreInstance = Mockito.mock(Instance.class);
-    Mockito.when(jobStoreInstance.isUnsatisfied()).thenReturn(false);
-    Mockito.when(jobStoreInstance.get()).thenReturn(jobStore);
-    service.reconcileJobStore = jobStoreInstance;
   }
 
   protected Connector activeConnector() {
@@ -186,7 +168,6 @@ abstract class AbstractReconcilerServiceTestBase {
       throw new UnsupportedOperationException();
     }
 
-    @Override
     public Optional<String> lookupTableDisplayName(ReconcileContext ctx, ResourceId tableId) {
       throw new UnsupportedOperationException();
     }
@@ -217,7 +198,11 @@ abstract class AbstractReconcilerServiceTestBase {
     }
 
     @Override
-    public boolean statsAlreadyCaptured(ReconcileContext ctx, ResourceId tableId, long snapshotId) {
+    public boolean statsAlreadyCapturedForTargetKind(
+        ReconcileContext ctx,
+        ResourceId tableId,
+        long snapshotId,
+        ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
       throw new UnsupportedOperationException();
     }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FloecatConnectorCompatibilityTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FloecatConnectorCompatibilityTest.java
@@ -37,7 +37,7 @@ class FloecatConnectorCompatibilityTest {
 
     FloecatConnector.SnapshotBundle bundle =
         new FloecatConnector.SnapshotBundle(
-            10L, 0L, 0L, List.of(), "", null, 0L, null, java.util.Map.of(), 0, java.util.Map.of());
+            10L, 0L, 0L, "", null, 0L, null, java.util.Map.of(), 0, java.util.Map.of());
     Optional<?> fromBundle = connector.snapshotConstraints("ns", "tbl", tableId, bundle);
     assertTrue(fromBundle.isEmpty());
   }
@@ -71,10 +71,20 @@ class FloecatConnectorCompatibilityTest {
     }
 
     @Override
-    public List<SnapshotBundle> enumerateSnapshotsWithStats(
+    public List<SnapshotBundle> enumerateSnapshots(
         String namespaceFq,
         String tableName,
         ResourceId destinationTableId,
+        SnapshotEnumerationOptions options) {
+      return List.of();
+    }
+
+    @Override
+    public List<ai.floedb.floecat.catalog.rpc.TargetStatsRecord> captureSnapshotTargetStats(
+        String namespaceFq,
+        String tableName,
+        ResourceId destinationTableId,
+        long snapshotId,
         Set<String> includeColumns) {
       return List.of();
     }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.connector.rpc.SourceSelector;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.spi.ReconcileContext;
+import com.google.protobuf.ByteString;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBase {
+
+  @Test
+  void buildSnapshotRetainsExistingDataWhenBundleOmitsFields() {
+    ResourceId tableId = ResourceId.newBuilder().setAccountId("acct").setId("tbl").build();
+    Snapshot existing =
+        Snapshot.newBuilder()
+            .setTableId(tableId)
+            .setSnapshotId(123L)
+            .setSchemaJson("existing-schema")
+            .setManifestList("existing-manifest")
+            .putSummary("existing-key", "existing-val")
+            .putFormatMetadata("meta-key", ByteString.copyFromUtf8("old"))
+            .build();
+
+    var bundle =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+            existing.getSnapshotId(),
+            existing.getParentSnapshotId(),
+            Instant.now().toEpochMilli(),
+            "",
+            null,
+            0L,
+            null,
+            Map.of("new-key", "new-val"),
+            0,
+            Map.of(
+                "meta-key", ByteString.copyFromUtf8("new"),
+                "extra", ByteString.copyFromUtf8("value")));
+
+    ReconcileContext ctx =
+        new ReconcileContext("ctx", principal, "svc-test", Instant.now(), Optional.<String>empty());
+    Snapshot result = service.buildSnapshot(ctx, tableId, bundle, existing).orElseThrow();
+
+    assertThat(result.getManifestList()).isEqualTo(existing.getManifestList());
+    assertThat(result.getSchemaJson()).isEqualTo(existing.getSchemaJson());
+    assertThat(result.getSummaryMap()).containsEntry("existing-key", "existing-val");
+    assertThat(result.getSummaryMap()).containsEntry("new-key", "new-val");
+    assertThat(result.getFormatMetadataMap())
+        .containsEntry("meta-key", ByteString.copyFromUtf8("new"));
+    assertThat(result.getFormatMetadataMap())
+        .containsEntry("extra", ByteString.copyFromUtf8("value"));
+  }
+
+  @Test
+  void effectiveSelectorsPreferScopeColumnsOverConnectorSourceColumns() {
+    ReconcileScope scope = ReconcileScope.of(List.of(List.of("ns")), "tbl", List.of("barf", "#2"));
+    SourceSelector source = SourceSelector.newBuilder().addColumns("i").addColumns("#1").build();
+
+    Set<String> selectors = ReconcilerService.effectiveSelectors(scope, source);
+
+    assertThat(selectors).containsExactlyInAnyOrder("barf", "#2");
+  }
+
+  @Test
+  void effectiveSelectorsFallbackToConnectorSourceColumnsWhenScopeHasNoColumns() {
+    ReconcileScope scope = ReconcileScope.of(List.of(List.of("ns")), "tbl", List.of());
+    SourceSelector source = SourceSelector.newBuilder().addColumns("i").addColumns("#1").build();
+
+    Set<String> selectors = ReconcilerService.effectiveSelectors(scope, source);
+
+    assertThat(selectors).containsExactlyInAnyOrder("i", "#1");
+  }
+
+  @Test
+  void filterBundlesForModeSkipsAlreadyIngestedSnapshotsForIncremental() {
+    List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> bundles =
+        List.of(
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                10L, 0L, 1L, "", null, 0L, null, Map.of(), 0, Map.of()),
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                11L, 10L, 2L, "", null, 0L, null, Map.of(), 0, Map.of()),
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                12L, 11L, 3L, "", null, 0L, null, Map.of(), 0, Map.of()));
+
+    List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
+        service.filterBundlesForMode(
+            bundles, false, false, Set.of(10L, 12L), Set.of(), (s, c, e, sp, stp, m) -> {});
+
+    assertThat(filtered)
+        .extracting(ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle::snapshotId)
+        .containsExactly(11L);
+  }
+
+  @Test
+  void filterBundlesForModeKeepsAllSnapshotsForFullRescan() {
+    List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> bundles =
+        List.of(
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                10L, 0L, 1L, "", null, 0L, null, Map.of(), 0, Map.of()),
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                11L, 10L, 2L, "", null, 0L, null, Map.of(), 0, Map.of()));
+
+    List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
+        service.filterBundlesForMode(
+            bundles, true, false, Set.of(10L, 12L), Set.of(), (s, c, e, sp, stp, m) -> {});
+
+    assertThat(filtered)
+        .extracting(ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle::snapshotId)
+        .containsExactly(10L, 11L);
+  }
+
+  @Test
+  void filterBundlesForModeSkipsIncrementalPruningWhenSkipExistingSnapshotsEnabled() {
+    List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> bundles =
+        List.of(
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                10L, 0L, 1L, "", null, 0L, null, Map.of(), 0, Map.of()),
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                11L, 10L, 2L, "", null, 0L, null, Map.of(), 0, Map.of()));
+
+    List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
+        service.filterBundlesForMode(
+            bundles, false, true, Set.of(10L), Set.of(), (s, c, e, sp, stp, m) -> {});
+
+    assertThat(filtered)
+        .extracting(ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle::snapshotId)
+        .containsExactly(10L, 11L);
+  }
+
+  @Test
+  void filterBundlesForModeAppliesIncrementalPruningWithinExplicitSnapshotScope() {
+    List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> bundles =
+        List.of(
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                10L, 0L, 1L, "", null, 0L, null, Map.of(), 0, Map.of()),
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                11L, 10L, 2L, "", null, 0L, null, Map.of(), 0, Map.of()),
+            new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                12L, 11L, 3L, "", null, 0L, null, Map.of(), 0, Map.of()));
+
+    List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
+        service.filterBundlesForMode(
+            bundles, false, false, Set.of(11L), Set.of(11L, 12L), (s, c, e, sp, stp, m) -> {});
+
+    assertThat(filtered)
+        .extracting(ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle::snapshotId)
+        .containsExactly(12L);
+  }
+
+  @Test
+  void knownSnapshotIdsForEnumerationPrunesAllIncrementalRuns() {
+    Set<Long> metadataOnly =
+        ReconcilerService.knownSnapshotIdsForEnumeration(false, Set.of(10L, 11L));
+    Set<Long> metadataAndStats =
+        ReconcilerService.knownSnapshotIdsForEnumeration(false, Set.of(10L, 11L));
+    Set<Long> statsOnly = ReconcilerService.knownSnapshotIdsForEnumeration(false, Set.of(10L, 11L));
+    Set<Long> fullRescan = ReconcilerService.knownSnapshotIdsForEnumeration(true, Set.of(10L, 11L));
+
+    assertThat(metadataOnly).containsExactlyInAnyOrder(10L, 11L);
+    assertThat(metadataAndStats).containsExactlyInAnyOrder(10L, 11L);
+    assertThat(statsOnly).containsExactlyInAnyOrder(10L, 11L);
+    assertThat(fullRescan).isEmpty();
+  }
+
+  @Test
+  void tableChangedIsFalseWhenNoBundlesRemain() {
+    assertThat(ReconcilerService.tableChanged(List.of())).isFalse();
+  }
+
+  @Test
+  void tableChangedIsTrueWhenBundlesRemain() {
+    assertThat(
+            ReconcilerService.tableChanged(
+                List.of(
+                    new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
+                        11L, 10L, 2L, "", null, 0L, null, Map.of(), 0, Map.of()))))
+        .isTrue();
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
@@ -172,17 +172,23 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
   }
 
   @Test
-  void knownSnapshotIdsForEnumerationPrunesAllIncrementalRuns() {
+  void knownSnapshotIdsForEnumerationIsStatsAwareForStatsModes() {
     Set<Long> metadataOnly =
-        ReconcilerService.knownSnapshotIdsForEnumeration(false, Set.of(10L, 11L));
+        ReconcilerService.knownSnapshotIdsForEnumeration(
+            false, false, Set.of(10L, 11L), snapshotId -> false);
     Set<Long> metadataAndStats =
-        ReconcilerService.knownSnapshotIdsForEnumeration(false, Set.of(10L, 11L));
-    Set<Long> statsOnly = ReconcilerService.knownSnapshotIdsForEnumeration(false, Set.of(10L, 11L));
-    Set<Long> fullRescan = ReconcilerService.knownSnapshotIdsForEnumeration(true, Set.of(10L, 11L));
+        ReconcilerService.knownSnapshotIdsForEnumeration(
+            false, true, Set.of(10L, 11L), snapshotId -> snapshotId == 10L);
+    Set<Long> statsOnly =
+        ReconcilerService.knownSnapshotIdsForEnumeration(
+            false, true, Set.of(10L, 11L), snapshotId -> false);
+    Set<Long> fullRescan =
+        ReconcilerService.knownSnapshotIdsForEnumeration(
+            true, true, Set.of(10L, 11L), snapshotId -> true);
 
     assertThat(metadataOnly).containsExactlyInAnyOrder(10L, 11L);
-    assertThat(metadataAndStats).containsExactlyInAnyOrder(10L, 11L);
-    assertThat(statsOnly).containsExactlyInAnyOrder(10L, 11L);
+    assertThat(metadataAndStats).containsExactly(10L);
+    assertThat(statsOnly).isEmpty();
     assertThat(fullRescan).isEmpty();
   }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
@@ -108,7 +108,7 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
 
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
         service.filterBundlesForMode(
-            bundles, false, false, Set.of(10L, 12L), Set.of(), (s, c, e, sp, stp, m) -> {});
+            bundles, false, false, Set.of(10L, 12L), (s, c, e, sp, stp, m) -> {});
 
     assertThat(filtered)
         .extracting(ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle::snapshotId)
@@ -126,7 +126,7 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
 
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
         service.filterBundlesForMode(
-            bundles, true, false, Set.of(10L, 12L), Set.of(), (s, c, e, sp, stp, m) -> {});
+            bundles, true, false, Set.of(10L, 12L), (s, c, e, sp, stp, m) -> {});
 
     assertThat(filtered)
         .extracting(ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle::snapshotId)
@@ -144,7 +144,7 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
 
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
         service.filterBundlesForMode(
-            bundles, false, true, Set.of(10L), Set.of(), (s, c, e, sp, stp, m) -> {});
+            bundles, false, true, Set.of(10L), (s, c, e, sp, stp, m) -> {});
 
     assertThat(filtered)
         .extracting(ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle::snapshotId)
@@ -164,11 +164,11 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
 
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
         service.filterBundlesForMode(
-            bundles, false, false, Set.of(11L), Set.of(11L, 12L), (s, c, e, sp, stp, m) -> {});
+            bundles, false, false, Set.of(11L), (s, c, e, sp, stp, m) -> {});
 
     assertThat(filtered)
         .extracting(ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle::snapshotId)
-        .containsExactly(12L);
+        .containsExactly(10L, 12L);
   }
 
   @Test

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalsTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalsTest.java
@@ -147,7 +147,7 @@ class ReconcilerServiceInternalsTest {
   private static FloecatConnector.SnapshotBundle bundle(
       long snapshotId, long parentId, long createdAtMs) {
     return new FloecatConnector.SnapshotBundle(
-        snapshotId, parentId, createdAtMs, List.of(), "", null, 0L, null, Map.of(), 0, Map.of());
+        snapshotId, parentId, createdAtMs, "", null, 0L, null, Map.of(), 0, Map.of());
   }
 
   private static ReconcilerService.ProgressListener noopProgress() {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -229,11 +229,11 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
             };
 
     ReconcileScope scope = ReconcileScope.of(List.of(List.of("dest_ns")), "tbl", List.of());
-    var result = service.reconcile(principal, connectorId, false, scope);
+    var result = service.reconcile(principal, connectorId, true, scope);
 
     assertThat(result.ok()).isTrue();
     assertThat(backend.capturedTargetSnapshotIds).isEmpty();
-    assertThat(backend.capturedKnownSnapshotIds).containsExactly(42L);
+    assertThat(backend.capturedKnownSnapshotIds).isEmpty();
     assertThat(backend.putConstraintsSnapshotId).isEqualTo(42L);
     assertThat(backend.putConstraints).isNotNull();
     assertThat(backend.putConstraints.getConstraintsCount()).isEqualTo(1);

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -232,6 +232,9 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
     var result = service.reconcile(principal, connectorId, true, scope);
 
     assertThat(result.ok()).isTrue();
+    assertThat(result.degraded()).isTrue();
+    assertThat(result.degradedReasons)
+        .anyMatch(reason -> reason.contains("stats_followup_unavailable"));
     assertThat(backend.capturedTargetSnapshotIds).isEmpty();
     assertThat(backend.capturedKnownSnapshotIds).isEmpty();
     assertThat(backend.putConstraintsSnapshotId).isEqualTo(42L);

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -22,62 +22,32 @@ import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
 import ai.floedb.floecat.catalog.rpc.ConstraintType;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
-import ai.floedb.floecat.catalog.rpc.StatsTargetKind;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
-import ai.floedb.floecat.catalog.rpc.ViewSpec;
 import ai.floedb.floecat.common.rpc.NameRef;
-import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
-import ai.floedb.floecat.common.rpc.SnapshotRef;
-import ai.floedb.floecat.connector.common.resolver.LogicalSchemaMapper;
-import ai.floedb.floecat.connector.rpc.AuthCredentials;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorKind;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
 import ai.floedb.floecat.connector.rpc.NamespacePath;
 import ai.floedb.floecat.connector.rpc.SourceSelector;
-import ai.floedb.floecat.connector.spi.ConnectorFormat;
-import ai.floedb.floecat.connector.spi.ConnectorNotReadyException;
-import ai.floedb.floecat.connector.spi.CredentialResolver;
-import ai.floedb.floecat.connector.spi.FloecatConnector;
-import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
-import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
-import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Timestamp;
+import ai.floedb.floecat.stats.spi.StatsCaptureControlPlane;
+import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
+import jakarta.enterprise.inject.Instance;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-class ReconcilerServiceTest {
-  private ReconcilerService service;
-  private PrincipalContext principal;
-  private ResourceId connectorId;
-
-  @BeforeEach
-  void setUp() {
-    service = new ReconcilerService();
-    service.schemaMapper = new LogicalSchemaMapper();
-    service.credentialResolver = new InMemoryCredentialResolver();
-    principal =
-        PrincipalContext.newBuilder().setAccountId("acct").setCorrelationId("corr-id").build();
-    connectorId =
-        ResourceId.newBuilder()
-            .setAccountId("acct")
-            .setId("connector-1")
-            .setKind(ResourceKind.RK_CONNECTOR)
-            .build();
-  }
+class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
 
   @Test
   void reconcileReturnsResultWhenConnectorLookupFails() {
@@ -85,8 +55,6 @@ class ReconcilerServiceTest {
     var result = service.reconcile(principal, connectorId, true, null);
     assertThat(result.errors).isEqualTo(1);
     assertThat(result.error).isInstanceOf(ReconcileFailureException.class);
-    assertThat(((ReconcileFailureException) result.error).failureKind())
-        .isEqualTo(ReconcileExecutor.ExecutionResult.FailureKind.CONNECTOR_MISSING);
     assertThat(result.error.getMessage()).contains("getConnector failed:");
   }
 
@@ -114,6 +82,7 @@ class ReconcilerServiceTest {
             .build();
 
     class CapturingBackend extends DefaultBackend {
+      Set<Long> capturedTargetSnapshotIds = Set.of();
       Set<Long> capturedKnownSnapshotIds = Set.of();
       long putConstraintsSnapshotId = -1L;
       SnapshotConstraints putConstraints = null;
@@ -172,7 +141,7 @@ class ReconcilerServiceTest {
           ReconcileContext ctx,
           ResourceId ignoredTableId,
           long snapshotId,
-          StatsTargetKind targetKind) {
+          ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return true;
       }
 
@@ -214,25 +183,14 @@ class ReconcilerServiceTest {
       }
 
       @Override
-      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+      public List<SnapshotBundle> enumerateSnapshots(
           String namespaceFq,
           String tableName,
           ResourceId destinationTableId,
-          Set<String> includeColumns,
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                42L,
-                0L,
-                Instant.now().toEpochMilli(),
-                List.of(),
-                "",
-                null,
-                0L,
-                null,
-                Map.of(),
-                0,
-                Map.of()));
+                42L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, Map.of()));
       }
 
       @Override
@@ -258,15 +216,15 @@ class ReconcilerServiceTest {
         cfg ->
             new ConstraintsConnector() {
               @Override
-              public List<SnapshotBundle> enumerateSnapshotsWithStats(
+              public List<SnapshotBundle> enumerateSnapshots(
                   String namespaceFq,
                   String tableName,
                   ResourceId destinationTableId,
-                  Set<String> includeColumns,
                   SnapshotEnumerationOptions options) {
+                backend.capturedTargetSnapshotIds = options.targetSnapshotIds();
                 backend.capturedKnownSnapshotIds = options.knownSnapshotIds();
-                return super.enumerateSnapshotsWithStats(
-                    namespaceFq, tableName, destinationTableId, includeColumns, options);
+                return super.enumerateSnapshots(
+                    namespaceFq, tableName, destinationTableId, options);
               }
             };
 
@@ -274,6 +232,7 @@ class ReconcilerServiceTest {
     var result = service.reconcile(principal, connectorId, false, scope);
 
     assertThat(result.ok()).isTrue();
+    assertThat(backend.capturedTargetSnapshotIds).isEmpty();
     assertThat(backend.capturedKnownSnapshotIds).containsExactly(42L);
     assertThat(backend.putConstraintsSnapshotId).isEqualTo(42L);
     assertThat(backend.putConstraints).isNotNull();
@@ -332,8 +291,13 @@ class ReconcilerServiceTest {
           ReconcileContext ctx,
           ResourceId ignoredTableId,
           long snapshotId,
-          StatsTargetKind targetKind) {
+          ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return false;
+      }
+
+      @Override
+      public Optional<String> lookupTableDisplayName(ReconcileContext ctx, ResourceId tableId) {
+        return Optional.of("tbl");
       }
 
       @Override
@@ -373,25 +337,14 @@ class ReconcilerServiceTest {
       }
 
       @Override
-      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+      public List<SnapshotBundle> enumerateSnapshots(
           String namespaceFq,
           String tableName,
           ResourceId destinationTableId,
-          Set<String> includeColumns,
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                101L,
-                0L,
-                Instant.now().toEpochMilli(),
-                List.of(),
-                "",
-                null,
-                0L,
-                null,
-                Map.of(),
-                0,
-                Map.of()));
+                101L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, Map.of()));
       }
 
       @Override
@@ -429,7 +382,10 @@ class ReconcilerServiceTest {
     class Backend extends DefaultBackend {
       @Override
       public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
-        return activeConnector();
+        Connector base = activeConnector();
+        return base.toBuilder()
+            .setDestination(base.getDestination().toBuilder().setTableId(tableId))
+            .build();
       }
 
       @Override
@@ -466,7 +422,7 @@ class ReconcilerServiceTest {
           ReconcileContext ctx,
           ResourceId ignoredTableId,
           long snapshotId,
-          StatsTargetKind targetKind) {
+          ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return false;
       }
 
@@ -507,25 +463,14 @@ class ReconcilerServiceTest {
       }
 
       @Override
-      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+      public List<SnapshotBundle> enumerateSnapshots(
           String namespaceFq,
           String tableName,
           ResourceId destinationTableId,
-          Set<String> includeColumns,
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                102L,
-                0L,
-                Instant.now().toEpochMilli(),
-                List.of(),
-                "",
-                null,
-                0L,
-                null,
-                Map.of(),
-                0,
-                Map.of()));
+                102L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, Map.of()));
       }
 
       @Override
@@ -607,7 +552,7 @@ class ReconcilerServiceTest {
           ReconcileContext ctx,
           ResourceId ignoredTableId,
           long snapshotId,
-          StatsTargetKind targetKind) {
+          ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return false;
       }
 
@@ -648,25 +593,14 @@ class ReconcilerServiceTest {
       }
 
       @Override
-      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+      public List<SnapshotBundle> enumerateSnapshots(
           String namespaceFq,
           String tableName,
           ResourceId destinationTableId,
-          Set<String> includeColumns,
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                103L,
-                0L,
-                Instant.now().toEpochMilli(),
-                List.of(),
-                "",
-                null,
-                0L,
-                null,
-                Map.of(),
-                0,
-                Map.of()));
+                103L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, Map.of()));
       }
 
       @Override
@@ -741,7 +675,7 @@ class ReconcilerServiceTest {
           ReconcileContext ctx,
           ResourceId ignoredTableId,
           long snapshotId,
-          StatsTargetKind targetKind) {
+          ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return true;
       }
 
@@ -787,25 +721,14 @@ class ReconcilerServiceTest {
       }
 
       @Override
-      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+      public List<SnapshotBundle> enumerateSnapshots(
           String namespaceFq,
           String tableName,
           ResourceId destinationTableId,
-          Set<String> includeColumns,
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                104L,
-                0L,
-                Instant.now().toEpochMilli(),
-                List.of(),
-                "",
-                null,
-                0L,
-                null,
-                Map.of(),
-                0,
-                Map.of()));
+                104L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, Map.of()));
       }
 
       @Override
@@ -839,7 +762,162 @@ class ReconcilerServiceTest {
   }
 
   @Test
-  void reconcileStatsOnlyFailsWhenDestinationTableIsNotVisibleYet() {
+  void statsOnlyRoutesThroughCaptureEnginesForAllDiscoveredSnapshots() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("table-stats-only-engine")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    class Backend extends DefaultBackend {
+      int putTargetStatsCalls = 0;
+
+      @Override
+      public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+        ResourceId destCatalogId =
+            ResourceId.newBuilder().setAccountId("acct").setId("cat-1").build();
+        ResourceId destNamespaceId =
+            ResourceId.newBuilder().setAccountId("acct").setId("ns-1").build();
+        return Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setState(ConnectorState.CS_ACTIVE)
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setSource(
+                SourceSelector.newBuilder()
+                    .setNamespace(
+                        NamespacePath.newBuilder().addSegments("src_cat").addSegments("src_ns")))
+            .setDestination(
+                DestinationTarget.newBuilder()
+                    .setCatalogId(destCatalogId)
+                    .setNamespaceId(destNamespaceId)
+                    .setTableId(tableId))
+            .build();
+      }
+
+      @Override
+      public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+        return "dest_cat";
+      }
+
+      @Override
+      public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+        return "dest_ns";
+      }
+
+      @Override
+      public Set<Long> existingSnapshotIds(ReconcileContext ctx, ResourceId ignoredTableId) {
+        return Set.of();
+      }
+
+      @Override
+      public boolean statsAlreadyCapturedForTargetKind(
+          ReconcileContext ctx,
+          ResourceId ignoredTableId,
+          long snapshotId,
+          ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
+        return false;
+      }
+
+      @Override
+      public Optional<String> lookupTableDisplayName(ReconcileContext ctx, ResourceId tableId) {
+        return Optional.of("tbl");
+      }
+
+      @Override
+      public void putTargetStats(ReconcileContext ctx, List<TargetStatsRecord> stats) {
+        putTargetStatsCalls++;
+      }
+
+      @Override
+      public void updateConnectorDestination(
+          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
+    }
+
+    class SnapshotOnlyConnector extends FakeConnector {
+      SnapshotOnlyConnector() {
+        super(List.of());
+      }
+
+      @Override
+      public List<String> listTables(String namespaceFq) {
+        return List.of("tbl");
+      }
+
+      @Override
+      public TableDescriptor describe(String namespaceFq, String tableName) {
+        return new TableDescriptor(
+            namespaceFq,
+            tableName,
+            "s3://bucket/path",
+            "{\"type\":\"struct\",\"fields\":[]}",
+            List.of(),
+            ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
+            Map.of());
+      }
+
+      @Override
+      public List<SnapshotBundle> enumerateSnapshots(
+          String namespaceFq,
+          String tableName,
+          ResourceId destinationTableId,
+          SnapshotEnumerationOptions options) {
+        return List.of(
+            new SnapshotBundle(
+                201L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, Map.of()),
+            new SnapshotBundle(
+                202L,
+                201L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                Map.of()));
+      }
+    }
+
+    AtomicInteger captureCalls = new AtomicInteger();
+    AtomicReference<StatsCaptureRequest> capturedRequest = new AtomicReference<>();
+    StatsCaptureControlPlane controlPlane = capturedControlPlane(captureCalls, capturedRequest);
+
+    @SuppressWarnings("unchecked")
+    Instance<StatsCaptureControlPlane> instance = Mockito.mock(Instance.class);
+    Mockito.when(instance.isUnsatisfied()).thenReturn(false);
+    Mockito.when(instance.get()).thenReturn(controlPlane);
+
+    Backend backend = new Backend();
+    service.backend = backend;
+    service.statsCaptureControlPlane = instance;
+    service.connectorOpener = cfg -> new SnapshotOnlyConnector();
+
+    var result =
+        service.reconcile(
+            principal,
+            connectorId,
+            false,
+            ReconcileScope.of(List.of(List.of("dest_ns")), "tbl", List.of("c7", "#9")),
+            ReconcilerService.CaptureMode.STATS_ONLY);
+
+    assertThat(result.ok()).isTrue();
+    assertThat(captureCalls.get()).isEqualTo(2);
+    assertThat(result.statsProcessed).isEqualTo(2L);
+    assertThat(capturedRequest.get()).isNotNull();
+    assertThat(capturedRequest.get().columnSelectors()).containsExactlyInAnyOrder("c7", "#9");
+    assertThat(backend.putTargetStatsCalls).isZero();
+  }
+
+  @Test
+  void statsOnlyConnectorAssistedPathFailsWhenNoSnapshotsAreCapturable() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("table-stats-only-engine")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
     class Backend extends DefaultBackend {
       @Override
       public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
@@ -858,106 +936,19 @@ class ReconcilerServiceTest {
             .setDestination(
                 DestinationTarget.newBuilder()
                     .setCatalogId(destCatalogId)
-                    .setNamespaceId(destNamespaceId))
+                    .setNamespaceId(destNamespaceId)
+                    .setTableId(tableId))
             .build();
       }
 
       @Override
       public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
-        return "examples";
+        return "dest_cat";
       }
 
       @Override
       public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
-        return "iceberg";
-      }
-
-      @Override
-      public Optional<ResourceId> lookupTable(ReconcileContext ctx, NameRef table) {
-        return Optional.empty();
-      }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
-    }
-
-    class StatsOnlyConnector extends FakeConnector {
-      StatsOnlyConnector() {
-        super(List.of());
-      }
-
-      @Override
-      public ConnectorFormat format() {
-        return ConnectorFormat.CF_ICEBERG;
-      }
-
-      @Override
-      public List<String> listTables(String namespaceFq) {
-        return List.of("duckdb_mutation_smoke");
-      }
-
-      @Override
-      public TableDescriptor describe(String namespaceFq, String tableName) {
-        return new TableDescriptor(
-            "iceberg",
-            "duckdb_mutation_smoke",
-            "s3://floecat/iceberg/duckdb_mutation_smoke",
-            "{\"type\":\"struct\",\"fields\":[]}",
-            List.of(),
-            ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_FIELD_ID,
-            Map.of());
-      }
-    }
-
-    service.backend = new Backend();
-    service.connectorOpener = cfg -> new StatsOnlyConnector();
-
-    var result =
-        service.reconcile(
-            principal, connectorId, false, null, ReconcilerService.CaptureMode.STATS_ONLY);
-
-    assertThat(result.ok()).isFalse();
-    assertThat(result.errors).isEqualTo(1);
-    assertThat(result.snapshotsProcessed).isZero();
-    assertThat(result.statsProcessed).isZero();
-    assertThat(result.error).isNotNull();
-    assertThat(result.error.getMessage())
-        .contains("Destination table examples.iceberg.duckdb_mutation_smoke is not visible yet");
-  }
-
-  @Test
-  void reconcileIcebergRestStatsCaptureRetriesWhenCurrentSnapshotEnumeratesEmpty() {
-    ResourceId tableId =
-        ResourceId.newBuilder()
-            .setAccountId("acct")
-            .setId("table-1")
-            .setKind(ResourceKind.RK_TABLE)
-            .build();
-
-    class Backend extends DefaultBackend {
-      @Override
-      public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
-        return activeIcebergConnector(tableId);
-      }
-
-      @Override
-      public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
-        return "examples";
-      }
-
-      @Override
-      public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
-        return "iceberg";
-      }
-
-      @Override
-      public ResourceId ensureTable(
-          ReconcileContext ctx,
-          ResourceId namespaceId,
-          NameRef table,
-          TableSpecDescriptor descriptor) {
-        return tableId;
+        return "dest_ns";
       }
 
       @Override
@@ -966,594 +957,83 @@ class ReconcilerServiceTest {
       }
 
       @Override
+      public boolean statsAlreadyCapturedForTargetKind(
+          ReconcileContext ctx,
+          ResourceId ignoredTableId,
+          long snapshotId,
+          ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
+        return false;
+      }
+
+      @Override
       public void updateConnectorDestination(
           ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
-    class EmptyIcebergRestConnector extends FakeConnector {
-      EmptyIcebergRestConnector() {
+    class SnapshotOnlyConnector extends FakeConnector {
+      SnapshotOnlyConnector() {
         super(List.of());
       }
 
       @Override
-      public ConnectorFormat format() {
-        return ConnectorFormat.CF_ICEBERG;
-      }
-
-      @Override
       public List<String> listTables(String namespaceFq) {
-        return List.of("duckdb_mutation_smoke");
+        return List.of("tbl");
       }
 
       @Override
       public TableDescriptor describe(String namespaceFq, String tableName) {
         return new TableDescriptor(
-            "iceberg",
-            "duckdb_mutation_smoke",
-            "s3://floecat/iceberg/duckdb_mutation_smoke",
+            namespaceFq,
+            tableName,
+            "s3://bucket/path",
             "{\"type\":\"struct\",\"fields\":[]}",
             List.of(),
-            ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_FIELD_ID,
+            ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
             Map.of());
       }
 
       @Override
-      public List<SnapshotBundle> enumerateSnapshotsWithStats(
+      public List<SnapshotBundle> enumerateSnapshots(
           String namespaceFq,
           String tableName,
           ResourceId destinationTableId,
-          Set<String> includeColumns,
           SnapshotEnumerationOptions options) {
-        throw new ConnectorNotReadyException(
-            "Current snapshot for iceberg.duckdb_mutation_smoke is not fully observable yet");
+        return List.of(
+            new SnapshotBundle(
+                201L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, Map.of()),
+            new SnapshotBundle(
+                202L,
+                201L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                Map.of()));
       }
     }
 
+    @SuppressWarnings("unchecked")
+    Instance<StatsCaptureControlPlane> instance = Mockito.mock(Instance.class);
+    Mockito.when(instance.isUnsatisfied()).thenReturn(true);
+
     service.backend = new Backend();
-    service.connectorOpener = cfg -> new EmptyIcebergRestConnector();
+    service.statsCaptureControlPlane = instance;
+    service.connectorOpener = cfg -> new SnapshotOnlyConnector();
 
     var result =
         service.reconcile(
-            principal, connectorId, false, null, ReconcilerService.CaptureMode.METADATA_AND_STATS);
+            principal,
+            connectorId,
+            false,
+            ReconcileScope.of(List.of(List.of("dest_ns")), "tbl", List.of("c7", "#9")),
+            ReconcilerService.CaptureMode.STATS_ONLY);
 
-    assertThat(result.ok()).isFalse();
-    assertThat(result.errors).isEqualTo(1);
-    assertThat(result.snapshotsProcessed).isZero();
+    assertThat(result.ok()).isTrue();
+    assertThat(result.snapshotsProcessed).isEqualTo(2L);
     assertThat(result.statsProcessed).isZero();
-    assertThat(result.error).isNotNull();
-    assertThat(result.error.getMessage())
-        .contains("Current snapshot for iceberg.duckdb_mutation_smoke is not fully observable yet");
-  }
-
-  private static final class ThrowingBackend extends DefaultBackend {
-    private final RuntimeException failure;
-
-    private ThrowingBackend(RuntimeException failure) {
-      this.failure = failure;
-    }
-
-    @Override
-    public Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId) {
-      throw failure;
-    }
-  }
-
-  private static final class ReturningBackend extends DefaultBackend {
-    private final Connector connector;
-
-    private ReturningBackend(Connector connector) {
-      this.connector = connector;
-    }
-
-    @Override
-    public Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId) {
-      return connector;
-    }
-  }
-
-  private abstract static class DefaultBackend implements ReconcilerBackend {
-    @Override
-    public ResourceId ensureNamespace(
-        ReconcileContext ctx, ResourceId catalogId, NameRef namespace) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ResourceId ensureTable(
-        ReconcileContext ctx,
-        ResourceId namespaceId,
-        NameRef table,
-        TableSpecDescriptor descriptor) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<ResourceId> lookupTable(ReconcileContext ctx, NameRef table) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SnapshotPin snapshotPinFor(
-        ReconcileContext ctx, ResourceId tableId, SnapshotRef ref, Optional<Timestamp> asOf) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<Snapshot> fetchSnapshot(
-        ReconcileContext ctx, ResourceId tableId, long snapshotId) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Set<Long> existingSnapshotIds(ReconcileContext ctx, ResourceId tableId) {
-      return Set.of();
-    }
-
-    @Override
-    public void ingestSnapshot(ReconcileContext ctx, ResourceId tableId, Snapshot snapshot) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean statsAlreadyCapturedForTargetKind(
-        ReconcileContext ctx, ResourceId tableId, long snapshotId, StatsTargetKind targetKind) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean statsCapturedForColumnSelectors(
-        ReconcileContext ctx, ResourceId tableId, long snapshotId, Set<String> selectors) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void putTargetStats(ReconcileContext ctx, List<TargetStatsRecord> stats) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void updateConnectorDestination(
-        ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
-      throw new UnsupportedOperationException();
-    }
-  }
-
-  private static final class InMemoryCredentialResolver implements CredentialResolver {
-    private final Map<String, AuthCredentials> store = new HashMap<>();
-
-    @Override
-    public Optional<AuthCredentials> resolve(String accountId, String credentialId) {
-      return Optional.ofNullable(store.get(key(accountId, credentialId)));
-    }
-
-    @Override
-    public void store(String accountId, String credentialId, AuthCredentials credentials) {
-      store.put(key(accountId, credentialId), credentials);
-    }
-
-    @Override
-    public void delete(String accountId, String credentialId) {
-      store.remove(key(accountId, credentialId));
-    }
-
-    private String key(String accountId, String credentialId) {
-      return accountId + ":" + credentialId;
-    }
-  }
-
-  @Test
-  void buildSnapshotRetainsExistingDataWhenBundleOmitsFields() {
-    ResourceId tableId = ResourceId.newBuilder().setAccountId("acct").setId("tbl").build();
-    Snapshot existing =
-        Snapshot.newBuilder()
-            .setTableId(tableId)
-            .setSnapshotId(123L)
-            .setSchemaJson("existing-schema")
-            .setManifestList("existing-manifest")
-            .putSummary("existing-key", "existing-val")
-            .putFormatMetadata("meta-key", ByteString.copyFromUtf8("old"))
-            .build();
-
-    FloecatConnector.SnapshotBundle bundle =
-        new FloecatConnector.SnapshotBundle(
-            existing.getSnapshotId(),
-            existing.getParentSnapshotId(),
-            Instant.now().toEpochMilli(),
-            List.of(),
-            "",
-            null,
-            0L,
-            null,
-            Map.of("new-key", "new-val"),
-            0,
-            Map.of(
-                "meta-key", ByteString.copyFromUtf8("new"),
-                "extra", ByteString.copyFromUtf8("value")));
-
-    ReconcileContext ctx =
-        new ReconcileContext("ctx", principal, "svc-test", Instant.now(), Optional.<String>empty());
-    Snapshot result = service.buildSnapshot(ctx, tableId, bundle, existing).orElseThrow();
-
-    assertThat(result.getManifestList()).isEqualTo(existing.getManifestList());
-    assertThat(result.getSchemaJson()).isEqualTo(existing.getSchemaJson());
-    assertThat(result.getSummaryMap()).containsEntry("existing-key", "existing-val");
-    assertThat(result.getSummaryMap()).containsEntry("new-key", "new-val");
-    assertThat(result.getFormatMetadataMap())
-        .containsEntry("meta-key", ByteString.copyFromUtf8("new"));
-    assertThat(result.getFormatMetadataMap())
-        .containsEntry("extra", ByteString.copyFromUtf8("value"));
-  }
-
-  // -------------------------------------------------------------------------
-  // View pass tests
-  // -------------------------------------------------------------------------
-
-  @Test
-  void viewPassSyncsViewsViaEnsureView() {
-    FloecatConnector.ViewDescriptor viewDesc =
-        new FloecatConnector.ViewDescriptor(
-            "src_cat.src_ns",
-            "revenue_view",
-            "SELECT amount FROM sales",
-            "spark",
-            List.of("src_ns"), // schema-only; connector strips catalog prefix (fix 3)
-            "{\"type\":\"struct\",\"fields\":"
-                + "[{\"name\":\"amount\",\"type\":\"double\",\"nullable\":true}]}");
-
-    var capturingBackend = new ViewCapturingBackend(activeConnector());
-    service.backend = capturingBackend;
-    service.connectorOpener = cfg -> new FakeConnector(List.of(viewDesc));
-
-    var result = service.reconcile(principal, connectorId, true, null);
-
-    assertThat(result.ok()).isTrue();
-    assertThat(result.scanned).isEqualTo(1);
-    assertThat(result.changed).isEqualTo(1);
-    assertThat(capturingBackend.capturedViews).hasSize(1);
-    ViewSpec spec = capturingBackend.capturedViews.get(0);
-    assertThat(spec.getDisplayName()).isEqualTo("revenue_view");
-    assertThat(spec.getSql()).isEqualTo("SELECT amount FROM sales");
-    assertThat(spec.getDialect()).isEqualTo("spark");
-    assertThat(spec.getOutputColumnsCount()).isEqualTo(1);
-    assertThat(spec.getOutputColumns(0).getName()).isEqualTo("amount");
-    assertThat(spec.getOutputColumns(0).getLogicalType()).isEqualTo("DOUBLE");
-    assertThat(spec.getCreationSearchPathList()).containsExactly("src_ns");
-    assertThat(capturingBackend.capturedIdempotencyKeys).containsExactly("dest_ns.revenue_view");
-  }
-
-  @Test
-  void viewPassCountsErrorWhenListViewDescriptorsThrows() {
-    var capturingBackend = new ViewCapturingBackend(activeConnector());
-    service.backend = capturingBackend;
-    service.connectorOpener =
-        cfg ->
-            new FakeConnector(List.of()) {
-              @Override
-              public List<FloecatConnector.ViewDescriptor> listViewDescriptors(String ns) {
-                throw new RuntimeException("UC unavailable");
-              }
-            };
-
-    var result = service.reconcile(principal, connectorId, true, null);
-
-    assertThat(result.errors).isGreaterThanOrEqualTo(1);
-    assertThat(capturingBackend.capturedViews).isEmpty();
-    assertThat(result.error).isNotNull();
-    assertThat(result.error.getMessage()).contains("listViewDescriptors");
-  }
-
-  @Test
-  void viewPassSkipsViewWithBlankSql() {
-    FloecatConnector.ViewDescriptor noSql =
-        new FloecatConnector.ViewDescriptor(
-            "src_cat.src_ns", "empty_view", "", "spark", List.of(), "");
-
-    var capturingBackend = new ViewCapturingBackend(activeConnector());
-    service.backend = capturingBackend;
-    service.connectorOpener = cfg -> new FakeConnector(List.of(noSql));
-
-    var result = service.reconcile(principal, connectorId, true, null);
-
-    assertThat(result.ok()).isTrue();
-    // Blank SQL views are filtered before scanned++ — they should not count as scanned.
-    assertThat(result.scanned).isEqualTo(0);
-    assertThat(result.changed).isEqualTo(0);
-    assertThat(capturingBackend.capturedViews).isEmpty();
-  }
-
-  @Test
-  void viewPassSkipsViewWithNoOutputColumns() {
-    // schemaJson present but resolves to 0 leaf columns (empty struct)
-    FloecatConnector.ViewDescriptor noSchema =
-        new FloecatConnector.ViewDescriptor(
-            "src_cat.src_ns",
-            "no_cols_view",
-            "SELECT 1",
-            "spark",
-            List.of(),
-            "{\"type\":\"struct\",\"fields\":[]}");
-
-    var capturingBackend = new ViewCapturingBackend(activeConnector());
-    service.backend = capturingBackend;
-    service.connectorOpener = cfg -> new FakeConnector(List.of(noSchema));
-
-    var result = service.reconcile(principal, connectorId, true, null);
-
-    assertThat(result.ok()).isTrue();
-    // Empty-column views are filtered before scanned++ — they should not count as scanned.
-    assertThat(result.scanned).isEqualTo(0);
-    assertThat(result.changed).isEqualTo(0);
-    assertThat(capturingBackend.capturedViews).isEmpty();
-  }
-
-  @Test
-  void viewPassCountsErrorWhenEnsureViewThrows() {
-    FloecatConnector.ViewDescriptor view1 =
-        new FloecatConnector.ViewDescriptor(
-            "src_cat.src_ns",
-            "bad_view",
-            "SELECT a FROM t",
-            "spark",
-            List.of("src_cat", "src_ns"),
-            "{\"type\":\"struct\",\"fields\":"
-                + "[{\"name\":\"a\",\"type\":\"int\",\"nullable\":true}]}");
-    FloecatConnector.ViewDescriptor view2 =
-        new FloecatConnector.ViewDescriptor(
-            "src_cat.src_ns",
-            "good_view",
-            "SELECT b FROM t",
-            "spark",
-            List.of("src_cat", "src_ns"),
-            "{\"type\":\"struct\",\"fields\":"
-                + "[{\"name\":\"b\",\"type\":\"double\",\"nullable\":true}]}");
-
-    // ensureView throws for the first view, succeeds for the second.
-    var capturingBackend =
-        new ViewCapturingBackend(activeConnector()) {
-          @Override
-          public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
-            if ("dest_ns.bad_view".equals(idempotencyKey)) {
-              throw new RuntimeException("backend error for " + spec.getDisplayName());
-            }
-            return super.ensureView(ctx, spec, idempotencyKey);
-          }
-        };
-    service.backend = capturingBackend;
-    service.connectorOpener = cfg -> new FakeConnector(List.of(view1, view2));
-
-    var result = service.reconcile(principal, connectorId, true, null);
-
-    // One error from the failing view; one change from the succeeding view.
-    assertThat(result.errors).isEqualTo(1);
-    assertThat(result.changed).isEqualTo(1);
-    assertThat(result.error).isNotNull();
-    assertThat(result.error.getMessage()).contains("bad_view");
-    // The good view must still have been synced despite the earlier failure.
-    assertThat(capturingBackend.capturedViews).hasSize(1);
-    assertThat(capturingBackend.capturedViews.get(0).getDisplayName()).isEqualTo("good_view");
-  }
-
-  @Test
-  void viewPassDoesNotCountAlreadyExistingView() {
-    FloecatConnector.ViewDescriptor viewDesc =
-        new FloecatConnector.ViewDescriptor(
-            "src_cat.src_ns",
-            "existing_view",
-            "SELECT x FROM t",
-            "spark",
-            List.of("src_cat", "src_ns"),
-            "{\"type\":\"struct\",\"fields\":"
-                + "[{\"name\":\"x\",\"type\":\"int\",\"nullable\":false}]}");
-
-    // ensureView returns getDefaultInstance() — signals ALREADY_EXISTS.
-    var capturingBackend =
-        new ViewCapturingBackend(activeConnector()) {
-          @Override
-          public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
-            capturedViews.add(spec);
-            capturedIdempotencyKeys.add(idempotencyKey);
-            return ResourceId.getDefaultInstance(); // empty id → already exists
-          }
-        };
-    service.backend = capturingBackend;
-    service.connectorOpener = cfg -> new FakeConnector(List.of(viewDesc));
-
-    var result = service.reconcile(principal, connectorId, true, null);
-
-    assertThat(result.ok()).isTrue();
-    assertThat(result.scanned).isEqualTo(1);
-    // View already existed → should NOT be counted as a change.
-    assertThat(result.changed).isEqualTo(0);
-    assertThat(capturingBackend.capturedViews).hasSize(1);
-  }
-
-  @Test
-  void viewsOnlyNamespaceWithTableFilterSyncsViews() {
-    // Verifies fix for issue 1: the "No tables matched scope" guard must not prevent the view pass
-    // from running. A table-filtered reconcile on a views-only namespace should record the miss as
-    // an error AND still sync all views.
-    FloecatConnector.ViewDescriptor viewDesc =
-        new FloecatConnector.ViewDescriptor(
-            "src_cat.src_ns",
-            "revenue_view",
-            "SELECT amount FROM sales",
-            "spark",
-            List.of("src_ns"),
-            "{\"type\":\"struct\",\"fields\":"
-                + "[{\"name\":\"amount\",\"type\":\"double\",\"nullable\":true}]}");
-
-    var capturingBackend = new ViewCapturingBackend(activeConnector());
-    service.backend = capturingBackend;
-    // FakeConnector has no tables (views-only namespace).
-    service.connectorOpener = cfg -> new FakeConnector(List.of(viewDesc));
-
-    // Scope carries a table filter even though the namespace has no tables.
-    ReconcileScope scope = ReconcileScope.of(List.of(List.of("dest_ns")), "some_table", List.of());
-
-    var result = service.reconcile(principal, connectorId, true, scope);
-
-    // Table filter didn't match → one error recorded …
-    assertThat(result.errors).isEqualTo(1);
-    assertThat(result.error).isNotNull();
-    assertThat(result.error.getMessage()).contains("No tables matched scope");
-    // … but the view pass still ran and synced the view.
-    assertThat(capturingBackend.capturedViews).hasSize(1);
-    assertThat(capturingBackend.capturedViews.get(0).getDisplayName()).isEqualTo("revenue_view");
-  }
-
-  /** A minimal {@link Connector} proto configured as CS_ACTIVE with source + destination. */
-  private Connector activeConnector() {
-    ResourceId destCatalogId = ResourceId.newBuilder().setAccountId("acct").setId("cat-1").build();
-    ResourceId destNamespaceId = ResourceId.newBuilder().setAccountId("acct").setId("ns-1").build();
-    return Connector.newBuilder()
-        .setResourceId(connectorId)
-        .setState(ConnectorState.CS_ACTIVE)
-        .setKind(ConnectorKind.CK_DELTA)
-        .setSource(
-            SourceSelector.newBuilder()
-                .setNamespace(
-                    NamespacePath.newBuilder().addSegments("src_cat").addSegments("src_ns")))
-        .setDestination(
-            DestinationTarget.newBuilder()
-                .setCatalogId(destCatalogId)
-                .setNamespaceId(destNamespaceId))
-        .build();
-  }
-
-  private Connector activeIcebergConnector(ResourceId tableId) {
-    ResourceId destCatalogId = ResourceId.newBuilder().setAccountId("acct").setId("cat-1").build();
-    ResourceId destNamespaceId = ResourceId.newBuilder().setAccountId("acct").setId("ns-1").build();
-    return Connector.newBuilder()
-        .setResourceId(connectorId)
-        .setState(ConnectorState.CS_ACTIVE)
-        .setKind(ConnectorKind.CK_ICEBERG)
-        .setUri("http://iceberg-rest:9200")
-        .putProperties("iceberg.source", "rest")
-        .setSource(
-            SourceSelector.newBuilder()
-                .setNamespace(
-                    NamespacePath.newBuilder().addSegments("src_cat").addSegments("src_ns")))
-        .setDestination(
-            DestinationTarget.newBuilder()
-                .setCatalogId(destCatalogId)
-                .setNamespaceId(destNamespaceId)
-                .setTableId(tableId))
-        .build();
-  }
-
-  /**
-   * Backend that tracks {@link #ensureView} calls and provides enough plumbing for the view pass to
-   * run end-to-end (no table snapshots needed since FakeConnector returns empty tables list).
-   */
-  private static class ViewCapturingBackend extends DefaultBackend {
-    private final Connector connector;
-    final List<ViewSpec> capturedViews = new ArrayList<>();
-    final List<String> capturedIdempotencyKeys = new ArrayList<>();
-
-    ViewCapturingBackend(Connector connector) {
-      this.connector = connector;
-    }
-
-    @Override
-    public Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId) {
-      return connector;
-    }
-
-    @Override
-    public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
-      return "dest_cat";
-    }
-
-    @Override
-    public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
-      return "dest_ns";
-    }
-
-    @Override
-    public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
-      capturedViews.add(spec);
-      capturedIdempotencyKeys.add(idempotencyKey);
-      return ResourceId.newBuilder().setId("view-1").build();
-    }
-
-    @Override
-    public void updateConnectorDestination(
-        ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {
-      // no-op — destination already has namespaceId set
-    }
-  }
-
-  /**
-   * A no-op {@link FloecatConnector} that returns empty tables and a configurable list of view
-   * descriptors. Connectors are auto-closed; {@link #close()} is a no-op.
-   */
-  private static class FakeConnector implements FloecatConnector {
-    private final List<FloecatConnector.ViewDescriptor> viewDescriptors;
-
-    FakeConnector(List<FloecatConnector.ViewDescriptor> viewDescriptors) {
-      this.viewDescriptors = viewDescriptors;
-    }
-
-    @Override
-    public String id() {
-      return "fake";
-    }
-
-    @Override
-    public ConnectorFormat format() {
-      return ConnectorFormat.CF_DELTA;
-    }
-
-    @Override
-    public List<String> listNamespaces() {
-      return List.of();
-    }
-
-    @Override
-    public List<String> listTables(String namespaceFq) {
-      return List.of();
-    }
-
-    @Override
-    public TableDescriptor describe(String namespaceFq, String tableName) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<SnapshotBundle> enumerateSnapshotsWithStats(
-        String namespaceFq,
-        String tableName,
-        ResourceId destinationTableId,
-        Set<String> includeColumns) {
-      return List.of();
-    }
-
-    @Override
-    public List<FloecatConnector.ViewDescriptor> listViewDescriptors(String namespaceFq) {
-      return viewDescriptors;
-    }
-
-    @Override
-    public void close() {}
+    assertThat(result.errors).isZero();
   }
 }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceViewPassTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceViewPassTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.catalog.rpc.ViewSpec;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.spi.ReconcileContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ReconcilerServiceViewPassTest extends AbstractReconcilerServiceTestBase {
+
+  @Test
+  void viewPassSyncsViewsViaEnsureView() {
+    var viewDesc =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
+            "src_cat.src_ns",
+            "revenue_view",
+            "SELECT amount FROM sales",
+            "spark",
+            List.of("src_ns"),
+            "{\"type\":\"struct\",\"fields\":[{\"name\":\"amount\",\"type\":\"double\",\"nullable\":true}]}");
+
+    var capturingBackend = new ViewCapturingBackend(activeConnector());
+    service.backend = capturingBackend;
+    service.connectorOpener = cfg -> new FakeConnector(List.of(viewDesc));
+
+    var result = service.reconcile(principal, connectorId, true, null);
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.scanned).isEqualTo(1);
+    assertThat(result.changed).isEqualTo(1);
+    assertThat(capturingBackend.capturedViews).hasSize(1);
+    ViewSpec spec = capturingBackend.capturedViews.get(0);
+    assertThat(spec.getDisplayName()).isEqualTo("revenue_view");
+    assertThat(spec.getSql()).isEqualTo("SELECT amount FROM sales");
+    assertThat(spec.getDialect()).isEqualTo("spark");
+    assertThat(spec.getOutputColumnsCount()).isEqualTo(1);
+    assertThat(spec.getOutputColumns(0).getName()).isEqualTo("amount");
+    assertThat(spec.getOutputColumns(0).getLogicalType()).isEqualTo("DOUBLE");
+    assertThat(spec.getCreationSearchPathList()).containsExactly("src_ns");
+    assertThat(capturingBackend.capturedIdempotencyKeys).containsExactly("dest_ns.revenue_view");
+  }
+
+  @Test
+  void viewPassCountsErrorWhenListViewDescriptorsThrows() {
+    var capturingBackend = new ViewCapturingBackend(activeConnector());
+    service.backend = capturingBackend;
+    service.connectorOpener =
+        cfg ->
+            new FakeConnector(List.of()) {
+              @Override
+              public List<ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor>
+                  listViewDescriptors(String ns) {
+                throw new RuntimeException("UC unavailable");
+              }
+            };
+
+    var result = service.reconcile(principal, connectorId, true, null);
+
+    assertThat(result.errors).isGreaterThanOrEqualTo(1);
+    assertThat(capturingBackend.capturedViews).isEmpty();
+    assertThat(result.error).isNotNull();
+    assertThat(result.error.getMessage()).contains("listViewDescriptors");
+  }
+
+  @Test
+  void viewPassSkipsViewWithBlankSql() {
+    var noSql =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
+            "src_cat.src_ns", "empty_view", "", "spark", List.of("src_cat", "src_ns"), "");
+
+    var capturingBackend = new ViewCapturingBackend(activeConnector());
+    service.backend = capturingBackend;
+    service.connectorOpener = cfg -> new FakeConnector(List.of(noSql));
+
+    var result = service.reconcile(principal, connectorId, true, null);
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.scanned).isEqualTo(0);
+    assertThat(result.changed).isEqualTo(0);
+    assertThat(capturingBackend.capturedViews).isEmpty();
+  }
+
+  @Test
+  void viewPassSkipsViewWithNoOutputColumns() {
+    var noSchema =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
+            "src_cat.src_ns",
+            "no_cols_view",
+            "SELECT 1",
+            "spark",
+            List.of(),
+            "{\"type\":\"struct\",\"fields\":[]}");
+
+    var capturingBackend = new ViewCapturingBackend(activeConnector());
+    service.backend = capturingBackend;
+    service.connectorOpener = cfg -> new FakeConnector(List.of(noSchema));
+
+    var result = service.reconcile(principal, connectorId, true, null);
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.scanned).isEqualTo(0);
+    assertThat(result.changed).isEqualTo(0);
+    assertThat(capturingBackend.capturedViews).isEmpty();
+  }
+
+  @Test
+  void viewPassCountsErrorWhenEnsureViewThrows() {
+    var view1 =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
+            "src_cat.src_ns",
+            "bad_view",
+            "SELECT a FROM t",
+            "spark",
+            List.of("src_cat", "src_ns"),
+            "{\"type\":\"struct\",\"fields\":[{\"name\":\"a\",\"type\":\"int\",\"nullable\":true}]}");
+    var view2 =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
+            "src_cat.src_ns",
+            "good_view",
+            "SELECT b FROM t",
+            "spark",
+            List.of("src_cat", "src_ns"),
+            "{\"type\":\"struct\",\"fields\":[{\"name\":\"b\",\"type\":\"double\",\"nullable\":true}]}");
+
+    var capturingBackend =
+        new ViewCapturingBackend(activeConnector()) {
+          @Override
+          public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+            if ("dest_ns.bad_view".equals(idempotencyKey)) {
+              throw new RuntimeException("backend error for " + spec.getDisplayName());
+            }
+            return super.ensureView(ctx, spec, idempotencyKey);
+          }
+        };
+    service.backend = capturingBackend;
+    service.connectorOpener = cfg -> new FakeConnector(List.of(view1, view2));
+
+    var result = service.reconcile(principal, connectorId, true, null);
+
+    assertThat(result.errors).isEqualTo(1);
+    assertThat(result.changed).isEqualTo(1);
+    assertThat(result.error).isNotNull();
+    assertThat(result.error.getMessage()).contains("bad_view");
+    assertThat(capturingBackend.capturedViews).hasSize(1);
+    assertThat(capturingBackend.capturedViews.get(0).getDisplayName()).isEqualTo("good_view");
+  }
+
+  @Test
+  void viewPassDoesNotCountAlreadyExistingView() {
+    var viewDesc =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
+            "src_cat.src_ns",
+            "existing_view",
+            "SELECT x FROM t",
+            "spark",
+            List.of("src_cat", "src_ns"),
+            "{\"type\":\"struct\",\"fields\":[{\"name\":\"x\",\"type\":\"int\",\"nullable\":false}]}");
+
+    var capturingBackend =
+        new ViewCapturingBackend(activeConnector()) {
+          @Override
+          public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+            capturedViews.add(spec);
+            capturedIdempotencyKeys.add(idempotencyKey);
+            return ResourceId.getDefaultInstance();
+          }
+        };
+    service.backend = capturingBackend;
+    service.connectorOpener = cfg -> new FakeConnector(List.of(viewDesc));
+
+    var result = service.reconcile(principal, connectorId, true, null);
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.scanned).isEqualTo(1);
+    assertThat(result.changed).isEqualTo(0);
+    assertThat(capturingBackend.capturedViews).hasSize(1);
+  }
+
+  @Test
+  void viewsOnlyNamespaceWithTableFilterSyncsViews() {
+    var viewDesc =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
+            "src_cat.src_ns",
+            "revenue_view",
+            "SELECT amount FROM sales",
+            "spark",
+            List.of("src_ns"),
+            "{\"type\":\"struct\",\"fields\":[{\"name\":\"amount\",\"type\":\"double\",\"nullable\":true}]}");
+
+    var capturingBackend = new ViewCapturingBackend(activeConnector());
+    service.backend = capturingBackend;
+    service.connectorOpener = cfg -> new FakeConnector(List.of(viewDesc));
+
+    ReconcileScope scope = ReconcileScope.of(List.of(List.of("dest_ns")), "some_table", List.of());
+    var result = service.reconcile(principal, connectorId, true, scope);
+
+    assertThat(result.errors).isEqualTo(1);
+    assertThat(result.error).isNotNull();
+    assertThat(result.error.getMessage()).contains("No tables matched scope");
+    assertThat(capturingBackend.capturedViews).hasSize(1);
+    assertThat(capturingBackend.capturedViews.get(0).getDisplayName()).isEqualTo("revenue_view");
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/ReconcileScopeTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/ReconcileScopeTest.java
@@ -16,7 +16,8 @@
 
 package ai.floedb.floecat.reconciler.jobs;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -24,9 +25,19 @@ import org.junit.jupiter.api.Test;
 class ReconcileScopeTest {
 
   @Test
-  void emptyScopeIsReturnedWhenAllFiltersAreBlank() {
-    ReconcileScope scope = ReconcileScope.of(List.of(), "", List.of());
+  void namespaceMatchingAcceptsSegmentedAndFqSingleSegmentPaths() {
+    ReconcileScope segmented = ReconcileScope.of(List.of(List.of("dest", "ns")), null, List.of());
+    ReconcileScope fqSingle = ReconcileScope.of(List.of(List.of("dest.ns")), null, List.of());
 
-    assertEquals(ReconcileScope.empty(), scope);
+    assertTrue(segmented.matchesNamespace("dest.ns"));
+    assertTrue(fqSingle.matchesNamespace("dest.ns"));
+  }
+
+  @Test
+  void tableAcceptanceRequiresMatchingTableWhenTableFilterPresent() {
+    ReconcileScope scope = ReconcileScope.of(List.of(List.of("dest", "ns")), "tbl", List.of());
+
+    assertTrue(scope.acceptsTable("dest.ns", "tbl"));
+    assertFalse(scope.acceptsTable("dest.ns", "other"));
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
@@ -351,14 +351,29 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
   @Override
   public boolean statsAlreadyCapturedForTargetKind(
       ReconcileContext ctx, ResourceId tableId, long snapshotId, StatsTargetKind targetKind) {
+    if (targetKind == null || targetKind == StatsTargetKind.STK_UNSPECIFIED) {
+      return statsStore.countTargetStats(tableId, snapshotId, Optional.empty()) > 0;
+    }
+    if (targetKind == StatsTargetKind.STK_TABLE) {
+      var tableRecord =
+          statsStore
+              .getTargetStats(tableId, snapshotId, StatsTargetIdentity.tableTarget())
+              .orElse(null);
+      if (tableRecord == null || !tableRecord.hasTable()) {
+        return false;
+      }
+      if (tableRecord.getTable().getDataFileCount() <= 0) {
+        return true;
+      }
+      return statsStore.countTargetStats(tableId, snapshotId, Optional.of(StatsTargetType.FILE))
+          > 0;
+    }
     Optional<StatsTargetType> targetType =
         switch (targetKind) {
-          case STK_UNSPECIFIED -> Optional.empty();
-          case STK_TABLE -> Optional.of(StatsTargetType.TABLE);
           case STK_COLUMN -> Optional.of(StatsTargetType.COLUMN);
           case STK_EXPRESSION -> Optional.of(StatsTargetType.EXPRESSION);
           case STK_FILE -> Optional.of(StatsTargetType.FILE);
-          case UNRECOGNIZED -> Optional.empty();
+          case STK_TABLE, STK_UNSPECIFIED, UNRECOGNIZED -> Optional.empty();
         };
     return statsStore.countTargetStats(tableId, snapshotId, targetType) > 0;
   }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
@@ -51,6 +51,7 @@ import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
+import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsTargetType;
 import com.google.protobuf.Timestamp;

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsCaptureControlPlaneAdapter.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsCaptureControlPlaneAdapter.java
@@ -18,10 +18,9 @@ package ai.floedb.floecat.service.statistics;
 
 import ai.floedb.floecat.stats.spi.StatsCaptureControlPlane;
 import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
-import ai.floedb.floecat.stats.spi.StatsCaptureResult;
+import ai.floedb.floecat.stats.spi.StatsTriggerResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.util.Optional;
 
 /**
  * Service-layer adapter exposing {@link StatsOrchestrator} through reconciler's control-plane SPI.
@@ -37,7 +36,7 @@ public class StatsCaptureControlPlaneAdapter implements StatsCaptureControlPlane
   }
 
   @Override
-  public Optional<StatsCaptureResult> capture(StatsCaptureRequest request) {
-    return orchestrator.capture(request);
+  public StatsTriggerResult trigger(StatsCaptureRequest request) {
+    return orchestrator.trigger(request);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
@@ -28,6 +28,8 @@ import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
 import ai.floedb.floecat.stats.spi.StatsCaptureResult;
 import ai.floedb.floecat.stats.spi.StatsExecutionMode;
 import ai.floedb.floecat.stats.spi.StatsStore;
+import ai.floedb.floecat.stats.spi.StatsTriggerOutcome;
+import ai.floedb.floecat.stats.spi.StatsTriggerResult;
 import ai.floedb.floecat.stats.spi.StatsUnsupportedTargetException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -42,7 +44,7 @@ import org.jboss.logging.Logger;
  *
  * <ul>
  *   <li>query-time resolution policy via {@link #resolve(StatsCaptureRequest)}
- *   <li>explicit capture execution via {@link #capture(StatsCaptureRequest)}
+ *   <li>explicit capture execution via {@link #trigger(StatsCaptureRequest)}
  * </ul>
  *
  * <p>Resolution is store-first, then optional synchronous capture, then async enqueue fallback when
@@ -77,30 +79,35 @@ public class StatsOrchestrator {
    * for misses that have at least one registry-capable ASYNC engine candidate.
    */
   public Optional<TargetStatsRecord> resolve(StatsCaptureRequest request) {
-    // Fast path: authoritative persisted read.
-    Optional<TargetStatsRecord> stored =
-        statsStore.getTargetStats(request.tableId(), request.snapshotId(), request.target());
+    Optional<TargetStatsRecord> stored = readStore(request);
     if (stored.isPresent()) {
       return stored;
     }
 
-    // PR6 behavior: for SYNC requests, attempt one inline capture pass before queue fallback.
-    // PR10 insertion point: after enqueue below, wait up to latency budget and re-read store.
-    boolean enqueueEligible = true;
     if (request.executionMode() == StatsExecutionMode.SYNC) {
+      // PR6 behavior: for SYNC requests, attempt one inline capture pass before queue fallback.
+      // PR10 insertion point: after enqueue, wait up to latency budget and re-read store.
       CaptureAttempt attempt = captureAttempt(request);
       if (attempt.result().isPresent()) {
         return attempt.result().map(StatsCaptureResult::record);
       }
-      enqueueEligible = attempt.supported();
+      maybeEnqueue(request, attempt.supported());
+      return Optional.empty();
     }
-
-    // Miss fallback: schedule table-scoped async stats-only capture for the requested snapshot
-    // when the registry advertises ASYNC support for the requested target.
-    if (enqueueEligible) {
-      tryEnqueueAsyncCapture(request);
-    }
+    maybeEnqueue(request, true);
     return Optional.empty();
+  }
+
+  private Optional<TargetStatsRecord> readStore(StatsCaptureRequest request) {
+    // Fast path: authoritative persisted read.
+    return statsStore.getTargetStats(request.tableId(), request.snapshotId(), request.target());
+  }
+
+  private void maybeEnqueue(StatsCaptureRequest request, boolean enqueueEligible) {
+    if (!enqueueEligible) {
+      return;
+    }
+    tryEnqueueAsyncCapture(request);
   }
 
   private void tryEnqueueAsyncCapture(StatsCaptureRequest request) {
@@ -108,7 +115,8 @@ public class StatsOrchestrator {
     if (request.snapshotId() < 0L) {
       return;
     }
-    if (!isAsyncCapturableByRegistry(request)) {
+    StatsCaptureRequest asyncRequest = toAsyncRequest(request);
+    if (!hasAsyncCandidates(asyncRequest)) {
       return;
     }
     try {
@@ -143,26 +151,44 @@ public class StatsOrchestrator {
     }
   }
 
-  private boolean isAsyncCapturableByRegistry(StatsCaptureRequest request) {
-    StatsCaptureRequest asyncRequest =
-        request.executionMode() == StatsExecutionMode.ASYNC
-            ? request
-            : StatsCaptureRequest.builder(request.tableId(), request.snapshotId(), request.target())
-                .columnSelectors(request.columnSelectors())
-                .requestedKinds(request.requestedKinds())
-                .executionMode(StatsExecutionMode.ASYNC)
-                .connectorType(request.connectorType())
-                .correlationId(request.correlationId())
-                .samplingRequested(request.samplingRequested())
-                .latencyBudget(request.latencyBudget())
-                .build();
+  private StatsCaptureRequest toAsyncRequest(StatsCaptureRequest request) {
+    if (request.executionMode() == StatsExecutionMode.ASYNC) {
+      return request;
+    }
+    return StatsCaptureRequest.builder(request.tableId(), request.snapshotId(), request.target())
+        .columnSelectors(request.columnSelectors())
+        .requestedKinds(request.requestedKinds())
+        .executionMode(StatsExecutionMode.ASYNC)
+        .connectorType(request.connectorType())
+        .correlationId(request.correlationId())
+        .samplingRequested(request.samplingRequested())
+        .latencyBudget(request.latencyBudget())
+        .build();
+  }
+
+  private boolean hasAsyncCandidates(StatsCaptureRequest asyncRequest) {
     List<StatsCaptureEngine> candidates = statsEngineRegistry.candidates(asyncRequest);
     return candidates != null && !candidates.isEmpty();
   }
 
-  /** Executes one capture attempt via the shared registry-backed control plane. */
-  public Optional<StatsCaptureResult> capture(StatsCaptureRequest request) {
-    return captureAttempt(request).result();
+  /**
+   * Executes one explicit trigger attempt through the registry.
+   *
+   * <p>This path does not perform store-read short-circuiting and does not enqueue fallback work.
+   * It is intended for control-plane callers that explicitly request capture now.
+   */
+  public StatsTriggerResult trigger(StatsCaptureRequest request) {
+    CaptureAttempt attempt = captureAttempt(request);
+    StatsTriggerResult result;
+    if (attempt.result().isPresent()) {
+      result = StatsTriggerResult.captured(attempt.result().get());
+    } else if (!attempt.supported()) {
+      result = StatsTriggerResult.uncapturable("target unsupported");
+    } else {
+      result = StatsTriggerResult.uncapturable("no capture result");
+    }
+    logTriggerOutcome(request, result);
+    return result;
   }
 
   private CaptureAttempt captureAttempt(StatsCaptureRequest request) {
@@ -177,4 +203,16 @@ public class StatsOrchestrator {
   }
 
   private record CaptureAttempt(Optional<StatsCaptureResult> result, boolean supported) {}
+
+  private void logTriggerOutcome(StatsCaptureRequest request, StatsTriggerResult result) {
+    if (result.outcome() == StatsTriggerOutcome.CAPTURED) {
+      LOG.debugf(
+          "stats_trigger outcome=%s table=%s snapshot=%d reason=%s",
+          result.outcome(), request.tableId(), request.snapshotId(), result.detail());
+      return;
+    }
+    LOG.warnf(
+        "stats_trigger outcome=%s table=%s snapshot=%d reason=%s",
+        result.outcome(), request.tableId(), request.snapshotId(), result.detail());
+  }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/engine/impl/AbstractNativeStatsCaptureEngine.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/engine/impl/AbstractNativeStatsCaptureEngine.java
@@ -44,6 +44,7 @@ import ai.floedb.floecat.stats.spi.StatsExecutionMode;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import com.google.protobuf.util.Timestamps;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -120,34 +121,36 @@ abstract class AbstractNativeStatsCaptureEngine implements StatsCaptureEngine {
               upstream.getConnectorId());
 
       try (FloecatConnector floecatConnector = connectorOpener.open(resolved)) {
-        // Connector SPI expects namespace as fully-qualified string.
-        List<FloecatConnector.SnapshotBundle> bundles =
-            floecatConnector.enumerateSnapshotsWithStats(
-                String.join(".", upstream.getNamespacePathList()),
+        String namespaceFq = String.join(".", upstream.getNamespacePathList());
+        List<TargetStatsRecord> capturedRecords =
+            floecatConnector.captureSnapshotTargetStats(
+                namespaceFq,
                 upstream.getTableDisplayName(),
                 request.tableId(),
-                request.columnSelectors(),
-                new FloecatConnector.SnapshotEnumerationOptions(true, false, Set.of()));
-        Optional<FloecatConnector.SnapshotBundle> bundle =
-            bundles.stream().filter(b -> b.snapshotId() == request.snapshotId()).findFirst();
-        if (bundle.isEmpty()) {
+                request.snapshotId(),
+                request.columnSelectors());
+        if (capturedRecords == null || capturedRecords.isEmpty()) {
           return Optional.empty();
         }
-        Optional<TargetStatsRecord> record =
-            findMatchingRecord(bundle.get().targetStats(), request);
+        Optional<TargetStatsRecord> record = findMatchingRecord(capturedRecords, request);
         if (record.isEmpty()) {
           return Optional.empty();
         }
         TargetStatsRecord canonicalRecord = withCanonicalMetadata(record.get(), request);
         if (request.target().hasTable()) {
-          // Table-target capture persists the full bundle so later column/file lookups hit store
-          // without additional capture. Replace the table entry with the matched canonical record.
-          for (TargetStatsRecord bundleRecord : bundle.get().targetStats()) {
+          // Table-target capture persists the full snapshot capture so later column/file lookups
+          // hit store without additional capture. Replace the table entry with the matched
+          // canonical record.
+          Set<String> seenTargets = new LinkedHashSet<>();
+          for (TargetStatsRecord bundleRecord : capturedRecords) {
             TargetStatsRecord toPersist =
                 bundleRecord.hasTable()
                     ? canonicalRecord
                     : withCanonicalMetadata(bundleRecord, request);
-            persistRecord(toPersist);
+            String storageId = StatsTargetIdentity.storageId(toPersist.getTarget());
+            if (seenTargets.add(storageId)) {
+              persistRecord(toPersist);
+            }
           }
         } else {
           persistRecord(canonicalRecord);

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/engine/impl/DeltaNativeStatsCaptureEngine.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/engine/impl/DeltaNativeStatsCaptureEngine.java
@@ -56,7 +56,6 @@ public class DeltaNativeStatsCaptureEngine extends AbstractNativeStatsCaptureEng
                   Set.of(StatsKind.ROW_COUNT, StatsKind.NULL_COUNT, StatsKind.MIN_MAX)))
           .executionModes(Set.of(StatsExecutionMode.SYNC, StatsExecutionMode.ASYNC))
           .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-          .snapshotAware(true)
           .build();
 
   @Inject

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/engine/impl/IcebergNativeStatsCaptureEngine.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/engine/impl/IcebergNativeStatsCaptureEngine.java
@@ -56,7 +56,6 @@ public class IcebergNativeStatsCaptureEngine extends AbstractNativeStatsCaptureE
                   Set.of(StatsKind.ROW_COUNT, StatsKind.NULL_COUNT, StatsKind.MIN_MAX)))
           .executionModes(Set.of(StatsExecutionMode.SYNC, StatsExecutionMode.ASYNC))
           .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-          .snapshotAware(true)
           .build();
 
   @Inject

--- a/service/src/test/java/ai/floedb/floecat/connector/dummy/DummyConnector.java
+++ b/service/src/test/java/ai/floedb/floecat/connector/dummy/DummyConnector.java
@@ -133,12 +133,27 @@ public final class DummyConnector implements FloecatConnector {
   }
 
   @Override
-  public List<SnapshotBundle> enumerateSnapshotsWithStats(
-      String namespace, String table, ResourceId destinationTableId, Set<String> includeColumns) {
-
+  public List<SnapshotBundle> enumerateSnapshots(
+      String namespace,
+      String table,
+      ResourceId destinationTableId,
+      SnapshotEnumerationOptions options) {
     long snapshotId = 42L;
     long createdAt = 1_700_000_000_000L;
+    String schemaJson = describe(namespace, table).schemaJson();
+    return List.of(
+        new SnapshotBundle(
+            snapshotId, 0L, createdAt, schemaJson, null, 0L, null, Map.of(), 0, Map.of()));
+  }
 
+  @Override
+  public List<TargetStatsRecord> captureSnapshotTargetStats(
+      String namespace,
+      String table,
+      ResourceId destinationTableId,
+      long snapshotId,
+      Set<String> includeColumns) {
+    long createdAt = 1_700_000_000_000L;
     var tStats =
         TableValueStats.newBuilder()
             .setRowCount(100)
@@ -251,8 +266,6 @@ public final class DummyConnector implements FloecatConnector {
 
     List<FileColumnStatsView> fileStats = List.of(f1, f2, f3);
 
-    String schemaJson = describe(namespace, table).schemaJson();
-
     List<TargetStatsRecord> materialized = new ArrayList<>();
     materialized.add(
         StatsProtoEmitter.tableStatsToTargetRecord(destinationTableId, snapshotId, tStats));
@@ -262,20 +275,7 @@ public final class DummyConnector implements FloecatConnector {
     materialized.addAll(
         StatsProtoEmitter.toTargetFileStatsFromViews(
             destinationTableId, snapshotId, ColumnIdAlgorithm.CID_FIELD_ID, fileStats));
-
-    return List.of(
-        new SnapshotBundle(
-            snapshotId,
-            0L,
-            createdAt,
-            List.copyOf(materialized),
-            schemaJson,
-            null,
-            0L,
-            null,
-            Map.of(),
-            0,
-            Map.of()));
+    return List.copyOf(materialized);
   }
 
   @Override

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
@@ -335,6 +335,74 @@ public class ConnectorIT {
   }
 
   @Test
+  void metadataAndStatsReturnsBeforeFollowUpStatsAreVisible() throws Exception {
+    TestS3Fixtures.seedFixturesOnce();
+
+    var accountId = seedAccountId;
+    TestSupport.createCatalog(catalogService, "cat-iceberg-deferred-contract", "");
+
+    var dest =
+        DestinationTarget.newBuilder()
+            .setCatalogDisplayName("cat-iceberg-deferred-contract")
+            .setNamespace(NamespacePath.newBuilder().addSegments("iceberg").build())
+            .setTableDisplayName("trino_test")
+            .build();
+
+    var props = new HashMap<String, String>();
+    props.putAll(
+        TestS3Fixtures.fileIoProperties(
+            TestS3Fixtures.bucketPath().getParent().toAbsolutePath().toString()));
+    props.put("external.namespace", "fixtures.simple");
+    props.put("external.table-name", "trino_test");
+    props.put("stats.ndv.enabled", "false");
+    props.put("iceberg.source", "filesystem");
+    String metadataLocation =
+        TestS3Fixtures.bucketUri(
+            "metadata/00002-503f4508-3824-4cb6-bdf1-4bd6bf5a0ade.metadata.json");
+
+    var conn =
+        TestSupport.createConnector(
+            connectors,
+            ConnectorSpec.newBuilder()
+                .setDisplayName("fixture-iceberg-deferred-contract")
+                .setKind(ConnectorKind.CK_ICEBERG)
+                .setUri(metadataLocation)
+                .setSource(source(List.of("fixtures", "simple")))
+                .setDestination(dest)
+                .setAuth(AuthConfig.newBuilder().setScheme("none").build())
+                .putAllProperties(props)
+                .build());
+
+    var metadataJob = runReconcile(conn.getResourceId(), true);
+    assertNotNull(metadataJob);
+    assertEquals("JS_SUCCEEDED", metadataJob.state, () -> "job failed: " + metadataJob.message);
+    assertEquals(
+        0L,
+        metadataJob.statsProcessed,
+        "metadata+stats reconcile enqueues follow-up stats jobs; it does not inline stats");
+
+    var catId =
+        catalogs
+            .getByName(accountId.getId(), "cat-iceberg-deferred-contract")
+            .orElseThrow()
+            .getResourceId();
+    var ns =
+        namespaces.getByPath(accountId.getId(), catId.getId(), List.of("iceberg")).orElseThrow();
+    var table =
+        tables
+            .getByName(accountId.getId(), catId.getId(), ns.getResourceId().getId(), "trino_test")
+            .orElseThrow();
+
+    var immediate = listCurrentFileStats(table.getResourceId(), 200);
+    assertTrue(
+        immediate.isEmpty(),
+        "metadata+stats should complete before follow-up STATS_ONLY capture makes stats visible");
+
+    var eventual = awaitCurrentFileStats(table.getResourceId(), 200, Duration.ofSeconds(30));
+    assertFalse(eventual.isEmpty(), "expected follow-up STATS_ONLY job to materialize file stats");
+  }
+
+  @Test
   void icebergFixtureIncrementalReconcileSkipsAlreadyIngestedSnapshots() throws Exception {
     TestS3Fixtures.seedFixturesOnce();
 

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
@@ -255,7 +255,7 @@ public class ConnectorIT {
             .get(0)
             .getResourceId();
 
-    var fileStats = listCurrentFileStats(tbl, 100);
+    var fileStats = awaitCurrentFileStats(tbl, 100, Duration.ofSeconds(30));
 
     assertEquals(3, fileStats.size(), "expected 3 files");
 
@@ -326,7 +326,7 @@ public class ConnectorIT {
             .getByName(accountId.getId(), catId.getId(), ns.getResourceId().getId(), "trino_test")
             .orElseThrow();
 
-    var fileStats = listCurrentFileStats(table.getResourceId(), 200);
+    var fileStats = awaitCurrentFileStats(table.getResourceId(), 200, Duration.ofSeconds(30));
 
     assertTrue(fileStats.size() > 0, "expected file stats for iceberg fixture");
     boolean hasSeq =
@@ -378,7 +378,10 @@ public class ConnectorIT {
     assertEquals("JS_SUCCEEDED", fullJob.state, () -> "job failed: " + fullJob.message);
     assertTrue(fullJob.fullRescan);
     assertTrue(fullJob.snapshotsProcessed > 0, "expected full reconcile to process snapshots");
-    assertTrue(fullJob.statsProcessed > 0, "expected full reconcile to process stats");
+    assertEquals(
+        0L,
+        fullJob.statsProcessed,
+        "metadata+stats reconcile enqueues follow-up stats jobs; it does not inline stats");
 
     var catId =
         catalogs
@@ -481,14 +484,16 @@ public class ConnectorIT {
     assertFalse(incrementalJob.fullRescan);
     assertEquals(
         1L, incrementalJob.snapshotsProcessed, "incremental should ingest one new snapshot");
-    assertTrue(
-        incrementalJob.statsProcessed > 0, "incremental should capture stats for the new snapshot");
+    assertEquals(
+        0L,
+        incrementalJob.statsProcessed,
+        "metadata+stats reconcile enqueues follow-up stats jobs; it does not inline stats");
     assertEquals(
         2,
         snaps.count(table.getResourceId()),
         "expected second snapshot after incremental reconcile");
 
-    var fileResp = listCurrentFileStats(table.getResourceId(), 200);
+    var fileResp = awaitCurrentFileStats(table.getResourceId(), 200, Duration.ofSeconds(30));
     assertTrue(
         fileResp.size() > 0, "expected current snapshot file stats after incremental reconcile");
   }
@@ -569,15 +574,16 @@ public class ConnectorIT {
     assertFalse(incrementalJob.fullRescan);
     assertEquals(
         1L, incrementalJob.snapshotsProcessed, "incremental should ingest one delete snapshot");
-    assertTrue(
-        incrementalJob.statsProcessed > 0,
-        "incremental should capture stats for the delete snapshot");
+    assertEquals(
+        0L,
+        incrementalJob.statsProcessed,
+        "metadata+stats reconcile enqueues follow-up stats jobs; it does not inline stats");
     assertEquals(
         3,
         snaps.count(table.getResourceId()),
         "expected third snapshot after incremental reconcile");
 
-    var fileResp = listCurrentFileStats(table.getResourceId(), 200);
+    var fileResp = awaitCurrentFileStats(table.getResourceId(), 200, Duration.ofSeconds(30));
     assertTrue(
         fileResp.stream().anyMatch(f -> f.getFileContent() == FileContent.FC_POSITION_DELETES),
         "expected current snapshot to expose a position delete file");
@@ -630,7 +636,10 @@ public class ConnectorIT {
         job.tablesChanged > 0, "expected complex fixture reconcile to persist table updates");
     assertTrue(
         job.snapshotsProcessed > 0, "expected complex fixture reconcile to process snapshots");
-    assertTrue(job.statsProcessed > 0, "expected complex fixture reconcile to generate stats");
+    assertEquals(
+        0L,
+        job.statsProcessed,
+        "metadata+stats reconcile enqueues follow-up stats jobs; it does not inline stats");
 
     var catId =
         catalogs.getByName(accountId.getId(), "cat-iceberg-complex").orElseThrow().getResourceId();
@@ -643,7 +652,7 @@ public class ConnectorIT {
             .getByName(accountId.getId(), catId.getId(), ns.getResourceId().getId(), "trino_types")
             .orElseThrow();
 
-    var fileResp = listCurrentFileStats(table.getResourceId(), 200);
+    var fileResp = awaitCurrentFileStats(table.getResourceId(), 200, Duration.ofSeconds(30));
 
     assertFalse(fileResp.isEmpty(), "expected file stats for complex iceberg fixture");
 
@@ -953,19 +962,17 @@ public class ConnectorIT {
       assertTrue(td.schemaJson().contains("\"items\""));
       assertTrue(td.schemaJson().contains("\"attrs\""));
 
-      var onlyIds =
-          conn.enumerateSnapshotsWithStats(
-              "db",
-              "events",
-              ResourceId.newBuilder()
-                  .setAccountId("t")
-                  .setId("tbl")
-                  .setKind(ResourceKind.RK_TABLE)
-                  .build(),
-              Set.of("#1", "#4", "#9"));
+      ResourceId tableId =
+          ResourceId.newBuilder()
+              .setAccountId("t")
+              .setId("tbl")
+              .setKind(ResourceKind.RK_TABLE)
+              .build();
 
       var cs1 =
-          onlyIds.get(0).targetStats().stream()
+          conn
+              .captureSnapshotTargetStats("db", "events", tableId, 1L, Set.of("#1", "#4", "#9"))
+              .stream()
               .filter(
                   r ->
                       r.hasTarget()
@@ -985,19 +992,11 @@ public class ConnectorIT {
       assertEquals(Set.of(1L, 4L, 9L), ids1);
       assertEquals(Set.of("id", "user.id", "items.element.qty"), names1);
 
-      var onlyNames =
-          conn.enumerateSnapshotsWithStats(
-              "db",
-              "events",
-              ResourceId.newBuilder()
-                  .setAccountId("t")
-                  .setId("tbl")
-                  .setKind(ResourceKind.RK_TABLE)
-                  .build(),
-              Set.of("user.name", "attrs.value"));
-
       var cs2 =
-          onlyNames.get(0).targetStats().stream()
+          conn
+              .captureSnapshotTargetStats(
+                  "db", "events", tableId, 1L, Set.of("user.name", "attrs.value"))
+              .stream()
               .filter(
                   r ->
                       r.hasTarget()
@@ -1017,19 +1016,11 @@ public class ConnectorIT {
       assertEquals(Set.of(5L, 12L), ids2);
       assertEquals(Set.of("user.name", "attrs.value"), names2);
 
-      var mixed =
-          conn.enumerateSnapshotsWithStats(
-              "db",
-              "events",
-              ResourceId.newBuilder()
-                  .setAccountId("t")
-                  .setId("tbl")
-                  .setKind(ResourceKind.RK_TABLE)
-                  .build(),
-              Set.of("#2", "items.element.sku"));
-
       var cs3 =
-          mixed.get(0).targetStats().stream()
+          conn
+              .captureSnapshotTargetStats(
+                  "db", "events", tableId, 1L, Set.of("#2", "items.element.sku"))
+              .stream()
               .filter(
                   r ->
                       r.hasTarget()
@@ -1049,19 +1040,10 @@ public class ConnectorIT {
       assertEquals(Set.of(2L, 8L), ids3);
       assertEquals(Set.of("ts", "items.element.sku"), names3);
 
-      var allCols =
-          conn.enumerateSnapshotsWithStats(
-              "db",
-              "events",
-              ResourceId.newBuilder()
-                  .setAccountId("t")
-                  .setId("tbl")
-                  .setKind(ResourceKind.RK_TABLE)
-                  .build(),
-              Collections.emptySet());
-
       long allColsCount =
-          allCols.get(0).targetStats().stream()
+          conn
+              .captureSnapshotTargetStats("db", "events", tableId, 1L, Collections.emptySet())
+              .stream()
               .filter(
                   r ->
                       r.hasTarget()

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackendTest.java
@@ -302,6 +302,21 @@ class DirectReconcilerBackendTest {
   }
 
   @Test
+  void statsAlreadyCapturedRequiresFileStatsWhenTableReportsDataFiles() {
+    TableValueStats tableStats = TableValueStats.newBuilder().setDataFileCount(2L).build();
+    backend.putTargetStats(
+        ctx, List.of(TargetStatsRecords.tableRecord(tableId, SNAPSHOT_ID, tableStats, null)));
+
+    assertThat(backend.statsAlreadyCaptured(ctx, tableId, SNAPSHOT_ID)).isFalse();
+
+    FileTargetStats fileStats = FileTargetStats.newBuilder().setFilePath("/data/file-1").build();
+    backend.putTargetStats(
+        ctx, List.of(TargetStatsRecords.fileRecord(tableId, SNAPSHOT_ID, fileStats)));
+
+    assertThat(backend.statsAlreadyCaptured(ctx, tableId, SNAPSHOT_ID)).isTrue();
+  }
+
+  @Test
   void ensureTableDoesNotMutateExistingCoreState() {
     NameRef tableRef = referenceNameRef();
     Table before = tableRepo.getById(tableId).orElseThrow();

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackendTest.java
@@ -307,13 +307,19 @@ class DirectReconcilerBackendTest {
     backend.putTargetStats(
         ctx, List.of(TargetStatsRecords.tableRecord(tableId, SNAPSHOT_ID, tableStats, null)));
 
-    assertThat(backend.statsAlreadyCaptured(ctx, tableId, SNAPSHOT_ID)).isFalse();
+    assertThat(
+            backend.statsAlreadyCapturedForTargetKind(
+                ctx, tableId, SNAPSHOT_ID, StatsTargetKind.STK_TABLE))
+        .isFalse();
 
     FileTargetStats fileStats = FileTargetStats.newBuilder().setFilePath("/data/file-1").build();
     backend.putTargetStats(
         ctx, List.of(TargetStatsRecords.fileRecord(tableId, SNAPSHOT_ID, fileStats)));
 
-    assertThat(backend.statsAlreadyCaptured(ctx, tableId, SNAPSHOT_ID)).isTrue();
+    assertThat(
+            backend.statsAlreadyCapturedForTargetKind(
+                ctx, tableId, SNAPSHOT_ID, StatsTargetKind.STK_TABLE))
+        .isTrue();
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsCaptureControlPlaneAdapterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsCaptureControlPlaneAdapterTest.java
@@ -28,8 +28,9 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
 import ai.floedb.floecat.stats.spi.StatsCaptureResult;
 import ai.floedb.floecat.stats.spi.StatsExecutionMode;
+import ai.floedb.floecat.stats.spi.StatsTriggerOutcome;
+import ai.floedb.floecat.stats.spi.StatsTriggerResult;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -39,15 +40,7 @@ class StatsCaptureControlPlaneAdapterTest {
   void delegatesCaptureToOrchestrator() {
     StatsOrchestrator orchestrator = Mockito.mock(StatsOrchestrator.class);
     StatsCaptureControlPlaneAdapter adapter = new StatsCaptureControlPlaneAdapter(orchestrator);
-    StatsCaptureRequest request =
-        StatsCaptureRequest.builder(
-                ResourceId.newBuilder().setAccountId("acct").setId("tbl-1").build(),
-                42L,
-                StatsTarget.newBuilder().setTable(TableStatsTarget.getDefaultInstance()).build())
-            .executionMode(StatsExecutionMode.ASYNC)
-            .connectorType("iceberg")
-            .correlationId("corr-1")
-            .build();
+    StatsCaptureRequest request = request();
     StatsCaptureResult expected =
         StatsCaptureResult.forRecord(
             "test",
@@ -58,11 +51,69 @@ class StatsCaptureControlPlaneAdapterTest {
                 .setTable(TableValueStats.newBuilder().setRowCount(1L).build())
                 .build(),
             Map.of());
-    when(orchestrator.capture(request)).thenReturn(Optional.of(expected));
+    when(orchestrator.trigger(request)).thenReturn(StatsTriggerResult.captured(expected));
 
-    Optional<StatsCaptureResult> out = adapter.capture(request);
+    StatsTriggerResult out = adapter.trigger(request);
 
-    assertThat(out).contains(expected);
-    verify(orchestrator).capture(request);
+    assertThat(out.outcome()).isEqualTo(StatsTriggerOutcome.CAPTURED);
+    assertThat(out.captureResult()).contains(expected);
+    verify(orchestrator).trigger(request);
+  }
+
+  @Test
+  void delegatesQueuedOutcome() {
+    StatsOrchestrator orchestrator = Mockito.mock(StatsOrchestrator.class);
+    StatsCaptureControlPlaneAdapter adapter = new StatsCaptureControlPlaneAdapter(orchestrator);
+    StatsCaptureRequest request = request();
+    when(orchestrator.trigger(request)).thenReturn(StatsTriggerResult.queued("queued for worker"));
+
+    StatsTriggerResult out = adapter.trigger(request);
+
+    assertThat(out.outcome()).isEqualTo(StatsTriggerOutcome.QUEUED);
+    assertThat(out.captureResult()).isEmpty();
+    assertThat(out.detail()).isEqualTo("queued for worker");
+    verify(orchestrator).trigger(request);
+  }
+
+  @Test
+  void delegatesUncapturableOutcome() {
+    StatsOrchestrator orchestrator = Mockito.mock(StatsOrchestrator.class);
+    StatsCaptureControlPlaneAdapter adapter = new StatsCaptureControlPlaneAdapter(orchestrator);
+    StatsCaptureRequest request = request();
+    when(orchestrator.trigger(request))
+        .thenReturn(StatsTriggerResult.uncapturable("engine unsupported"));
+
+    StatsTriggerResult out = adapter.trigger(request);
+
+    assertThat(out.outcome()).isEqualTo(StatsTriggerOutcome.UNCAPTURABLE);
+    assertThat(out.captureResult()).isEmpty();
+    assertThat(out.detail()).isEqualTo("engine unsupported");
+    verify(orchestrator).trigger(request);
+  }
+
+  @Test
+  void delegatesDegradedOutcome() {
+    StatsOrchestrator orchestrator = Mockito.mock(StatsOrchestrator.class);
+    StatsCaptureControlPlaneAdapter adapter = new StatsCaptureControlPlaneAdapter(orchestrator);
+    StatsCaptureRequest request = request();
+    when(orchestrator.trigger(request)).thenReturn(StatsTriggerResult.degraded("runtime failure"));
+
+    StatsTriggerResult out = adapter.trigger(request);
+
+    assertThat(out.outcome()).isEqualTo(StatsTriggerOutcome.DEGRADED);
+    assertThat(out.captureResult()).isEmpty();
+    assertThat(out.detail()).isEqualTo("runtime failure");
+    verify(orchestrator).trigger(request);
+  }
+
+  private static StatsCaptureRequest request() {
+    return StatsCaptureRequest.builder(
+            ResourceId.newBuilder().setAccountId("acct").setId("tbl-1").build(),
+            42L,
+            StatsTarget.newBuilder().setTable(TableStatsTarget.getDefaultInstance()).build())
+        .executionMode(StatsExecutionMode.ASYNC)
+        .connectorType("iceberg")
+        .correlationId("corr-1")
+        .build();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/engine/StatsEngineRegistryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/engine/StatsEngineRegistryTest.java
@@ -88,7 +88,6 @@ class StatsEngineRegistryTest {
                     .statisticKindsByTarget(Map.of(StatsTargetType.COLUMN, Set.of(StatsKind.NDV)))
                     .executionModes(Set.of(StatsExecutionMode.SYNC))
                     .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-                    .snapshotAware(true)
                     .build())
             .fixed(Optional.empty())
             .build();
@@ -118,7 +117,6 @@ class StatsEngineRegistryTest {
                         Map.of(StatsTargetType.COLUMN, Set.of(StatsKind.ROW_COUNT)))
                     .executionModes(Set.of(StatsExecutionMode.SYNC))
                     .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-                    .snapshotAware(true)
                     .build())
             .fixed(Optional.empty())
             .build();
@@ -152,7 +150,6 @@ class StatsEngineRegistryTest {
                         Map.of(StatsTargetType.COLUMN, Set.of(StatsKind.ROW_COUNT)))
                     .executionModes(Set.of(StatsExecutionMode.SYNC))
                     .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-                    .snapshotAware(true)
                     .build())
             .fixed(Optional.empty())
             .build();
@@ -166,7 +163,6 @@ class StatsEngineRegistryTest {
                         Map.of(StatsTargetType.FILE, Set.of(StatsKind.ROW_COUNT)))
                     .executionModes(Set.of(StatsExecutionMode.SYNC))
                     .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-                    .snapshotAware(true)
                     .build())
             .fixed(Optional.empty())
             .build();
@@ -175,71 +171,6 @@ class StatsEngineRegistryTest {
     assertThat(registry.candidates(request))
         .extracting(StatsCaptureEngine::id)
         .containsExactly("supported");
-  }
-
-  @Test
-  void candidatesExcludeNonSnapshotAwareEngineForConcreteSnapshot() {
-    StatsCaptureRequest request = sampleRequest(); // concrete snapshot id: 100
-    StatsCaptureEngine notSnapshotAware =
-        TestStatsCaptureEngine.builder("not-snapshot-aware")
-            .priority(1)
-            .capabilities(
-                StatsCapabilities.builder()
-                    .targetTypes(Set.of(StatsTargetType.TABLE))
-                    .statisticKindsByTarget(
-                        Map.of(StatsTargetType.TABLE, Set.of(StatsKind.ROW_COUNT)))
-                    .executionModes(Set.of(StatsExecutionMode.SYNC))
-                    .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-                    .snapshotAware(false)
-                    .build())
-            .fixed(Optional.empty())
-            .build();
-    StatsCaptureEngine snapshotAware =
-        TestStatsCaptureEngine.builder("snapshot-aware")
-            .priority(2)
-            .capabilities(tableOnlyCaps())
-            .fixed(Optional.empty())
-            .build();
-
-    StatsEngineRegistry registry =
-        new StatsEngineRegistry(List.of(notSnapshotAware, snapshotAware));
-
-    assertThat(registry.candidates(request))
-        .extracting(StatsCaptureEngine::id)
-        .containsExactly("snapshot-aware");
-  }
-
-  @Test
-  void candidatesAllowNonSnapshotAwareEngineForUnresolvedSnapshotSentinel() {
-    StatsCaptureRequest request =
-        StatsCaptureRequest.builder(
-                ResourceId.newBuilder().setAccountId("a").setId("t").build(),
-                0L,
-                StatsTarget.newBuilder().setTable(TableStatsTarget.getDefaultInstance()).build())
-            .requestedKinds(Set.of(StatsKind.ROW_COUNT))
-            .executionMode(StatsExecutionMode.SYNC)
-            .correlationId("test-corr-zero")
-            .build();
-    StatsCaptureEngine notSnapshotAware =
-        TestStatsCaptureEngine.builder("not-snapshot-aware")
-            .priority(1)
-            .capabilities(
-                StatsCapabilities.builder()
-                    .targetTypes(Set.of(StatsTargetType.TABLE))
-                    .statisticKindsByTarget(
-                        Map.of(StatsTargetType.TABLE, Set.of(StatsKind.ROW_COUNT)))
-                    .executionModes(Set.of(StatsExecutionMode.SYNC))
-                    .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-                    .snapshotAware(false)
-                    .build())
-            .fixed(Optional.empty())
-            .build();
-
-    StatsEngineRegistry registry = new StatsEngineRegistry(List.of(notSnapshotAware));
-
-    assertThat(registry.candidates(request))
-        .extracting(StatsCaptureEngine::id)
-        .containsExactly("not-snapshot-aware");
   }
 
   private static StatsCaptureRequest sampleRequest() {
@@ -259,7 +190,6 @@ class StatsEngineRegistryTest {
         .statisticKindsByTarget(Map.of(StatsTargetType.TABLE, Set.of(StatsKind.ROW_COUNT)))
         .executionModes(Set.of(StatsExecutionMode.SYNC))
         .samplingSupport(Set.of(StatsSamplingSupport.NONE))
-        .snapshotAware(true)
         .build();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/engine/impl/DeltaNativeStatsCaptureEngineTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/engine/impl/DeltaNativeStatsCaptureEngineTest.java
@@ -18,6 +18,8 @@ package ai.floedb.floecat.service.statistics.engine.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -108,21 +110,8 @@ class DeltaNativeStatsCaptureEngineTest {
             .setTarget(columnTarget)
             .setScalar(ScalarStats.newBuilder().setDisplayName("c9").setLogicalType("BIGINT"))
             .build();
-    when(floecatConnector.enumerateSnapshotsWithStats(any(), any(), any(), any(), any()))
-        .thenReturn(
-            List.of(
-                new FloecatConnector.SnapshotBundle(
-                    0L,
-                    0L,
-                    0L,
-                    List.of(tableRecord, columnRecord),
-                    "",
-                    null,
-                    0L,
-                    "",
-                    java.util.Map.of(),
-                    0,
-                    java.util.Map.of())));
+    when(floecatConnector.captureSnapshotTargetStats(any(), any(), any(), anyLong(), any()))
+        .thenReturn(List.of(tableRecord, columnRecord));
 
     StatsCaptureRequest request =
         StatsCaptureRequest.builder(tableId, 0L, tableTarget)
@@ -197,21 +186,8 @@ class DeltaNativeStatsCaptureEngineTest {
             .setTarget(requested)
             .setScalar(ScalarStats.newBuilder().setDisplayName("c9").setLogicalType("BIGINT"))
             .build();
-    when(floecatConnector.enumerateSnapshotsWithStats(any(), any(), any(), any(), any()))
-        .thenReturn(
-            List.of(
-                new FloecatConnector.SnapshotBundle(
-                    77L,
-                    0L,
-                    0L,
-                    List.of(columnRecord),
-                    "",
-                    null,
-                    0L,
-                    "",
-                    java.util.Map.of(),
-                    0,
-                    java.util.Map.of())));
+    when(floecatConnector.captureSnapshotTargetStats(any(), any(), any(), anyLong(), any()))
+        .thenReturn(List.of(columnRecord));
 
     StatsCaptureRequest request =
         StatsCaptureRequest.builder(tableId, 77L, requested)
@@ -240,12 +216,12 @@ class DeltaNativeStatsCaptureEngineTest {
         .containsEntry("method", "connector_native")
         .containsEntry("engine_id", DeltaNativeStatsCaptureEngine.ENGINE_ID);
     verify(floecatConnector)
-        .enumerateSnapshotsWithStats(
+        .captureSnapshotTargetStats(
             any(),
             any(),
             any(),
-            org.mockito.ArgumentMatchers.argThat(selectors -> selectors.contains("c9")),
-            any());
+            anyLong(),
+            org.mockito.ArgumentMatchers.argThat(selectors -> selectors.contains("c9")));
     verify(statsStore)
         .putTargetStats(
             org.mockito.ArgumentMatchers.argThat(
@@ -338,21 +314,8 @@ class DeltaNativeStatsCaptureEngineTest {
             .setTarget(fileTarget)
             .setFile(fileStats)
             .build();
-    when(floecatConnector.enumerateSnapshotsWithStats(any(), any(), any(), any(), any()))
-        .thenReturn(
-            List.of(
-                new FloecatConnector.SnapshotBundle(
-                    77L,
-                    0L,
-                    0L,
-                    List.of(fileRecord),
-                    "",
-                    null,
-                    0L,
-                    "",
-                    java.util.Map.of(),
-                    0,
-                    java.util.Map.of())));
+    when(floecatConnector.captureSnapshotTargetStats(any(), any(), any(), anyLong(), any()))
+        .thenReturn(List.of(fileRecord));
 
     StatsCaptureRequest request =
         StatsCaptureRequest.builder(tableId, 77L, fileTarget)
@@ -370,5 +333,60 @@ class DeltaNativeStatsCaptureEngineTest {
         .putTargetStats(
             org.mockito.ArgumentMatchers.argThat(
                 r -> r.hasFile() && "/delta/file-1.parquet".equals(r.getFile().getFilePath())));
+  }
+
+  @Test
+  void returnsEmptyWhenSnapshotNotFoundInConnectorCapture() {
+    TableRepository tableRepository = Mockito.mock(TableRepository.class);
+    ConnectorRepository connectorRepository = Mockito.mock(ConnectorRepository.class);
+    CredentialResolver credentialResolver = Mockito.mock(CredentialResolver.class);
+    StatsStore statsStore = Mockito.mock(StatsStore.class);
+    FloecatConnector floecatConnector = Mockito.mock(FloecatConnector.class);
+
+    DeltaNativeStatsCaptureEngine engine =
+        new DeltaNativeStatsCaptureEngine(
+            tableRepository, connectorRepository, credentialResolver, statsStore);
+    engine.connectorOpener = config -> floecatConnector;
+
+    ResourceId tableId = ResourceId.newBuilder().setAccountId("acct").setId("table-1").build();
+    ResourceId connectorId = ResourceId.newBuilder().setAccountId("acct").setId("conn-2").build();
+    when(tableRepository.getById(tableId))
+        .thenReturn(
+            Optional.of(
+                Table.newBuilder()
+                    .setResourceId(tableId)
+                    .setDisplayName("events")
+                    .setUpstream(
+                        ai.floedb.floecat.catalog.rpc.UpstreamRef.newBuilder()
+                            .setConnectorId(connectorId)
+                            .addNamespacePath("db")
+                            .setTableDisplayName("events")
+                            .build())
+                    .build()));
+    when(connectorRepository.getById(connectorId))
+        .thenReturn(
+            Optional.of(
+                Connector.newBuilder()
+                    .setResourceId(connectorId)
+                    .setDisplayName("delta-main")
+                    .setKind(ConnectorKind.CK_DELTA)
+                    .setUri("s3://delta")
+                    .build()));
+    when(floecatConnector.captureSnapshotTargetStats(any(), any(), any(), anyLong(), any()))
+        .thenReturn(List.of());
+
+    StatsCaptureRequest request =
+        StatsCaptureRequest.builder(
+                tableId,
+                999999L,
+                StatsTarget.newBuilder().setTable(TableStatsTarget.getDefaultInstance()).build())
+            .executionMode(StatsExecutionMode.SYNC)
+            .connectorType("delta")
+            .correlationId("corr")
+            .build();
+
+    assertThat(engine.capture(request)).isEmpty();
+    verify(floecatConnector).captureSnapshotTargetStats(any(), any(), any(), anyLong(), any());
+    verify(statsStore, never()).putTargetStats(any());
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/engine/impl/IcebergNativeStatsCaptureEngineTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/engine/impl/IcebergNativeStatsCaptureEngineTest.java
@@ -18,7 +18,9 @@ package ai.floedb.floecat.service.statistics.engine.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -111,21 +113,8 @@ class IcebergNativeStatsCaptureEngineTest {
             .setScalar(ScalarStats.newBuilder().setDisplayName("c7").setLogicalType("BIGINT"))
             .build();
 
-    when(floecatConnector.enumerateSnapshotsWithStats(any(), any(), any(), any(), any()))
-        .thenReturn(
-            List.of(
-                new FloecatConnector.SnapshotBundle(
-                    101L,
-                    0L,
-                    0L,
-                    List.of(tableRecord, columnRecord),
-                    "",
-                    null,
-                    0L,
-                    "",
-                    java.util.Map.of(),
-                    0,
-                    java.util.Map.of())));
+    when(floecatConnector.captureSnapshotTargetStats(any(), any(), any(), anyLong(), any()))
+        .thenReturn(List.of(tableRecord, columnRecord));
 
     StatsCaptureRequest request =
         StatsCaptureRequest.builder(tableId, 101L, tableTarget)
@@ -154,8 +143,8 @@ class IcebergNativeStatsCaptureEngineTest {
         .containsEntry("method", "connector_native")
         .containsEntry("engine_id", IcebergNativeStatsCaptureEngine.ENGINE_ID);
     verify(floecatConnector)
-        .enumerateSnapshotsWithStats(
-            any(), any(), any(), argThat(selectors -> selectors.contains("c7")), any());
+        .captureSnapshotTargetStats(
+            any(), any(), any(), anyLong(), argThat(selectors -> selectors.contains("c7")));
     verify(statsStore, times(1))
         .putTargetStats(argThat(r -> r.hasTable() && r.getSnapshotId() == 101L));
     verify(statsStore, times(1))
@@ -227,21 +216,8 @@ class IcebergNativeStatsCaptureEngineTest {
             .setFile(fileStats)
             .build();
 
-    when(floecatConnector.enumerateSnapshotsWithStats(any(), any(), any(), any(), any()))
-        .thenReturn(
-            List.of(
-                new FloecatConnector.SnapshotBundle(
-                    101L,
-                    0L,
-                    0L,
-                    List.of(fileRecord),
-                    "",
-                    null,
-                    0L,
-                    "",
-                    java.util.Map.of(),
-                    0,
-                    java.util.Map.of())));
+    when(floecatConnector.captureSnapshotTargetStats(any(), any(), any(), anyLong(), any()))
+        .thenReturn(List.of(fileRecord));
 
     StatsCaptureRequest request =
         StatsCaptureRequest.builder(tableId, 101L, fileTarget)
@@ -258,5 +234,60 @@ class IcebergNativeStatsCaptureEngineTest {
     verify(statsStore, times(1))
         .putTargetStats(
             argThat(r -> r.hasFile() && "/data/file-1.parquet".equals(r.getFile().getFilePath())));
+  }
+
+  @Test
+  void returnsEmptyWhenSnapshotNotFoundInConnectorCapture() {
+    TableRepository tableRepository = Mockito.mock(TableRepository.class);
+    ConnectorRepository connectorRepository = Mockito.mock(ConnectorRepository.class);
+    CredentialResolver credentialResolver = Mockito.mock(CredentialResolver.class);
+    StatsStore statsStore = Mockito.mock(StatsStore.class);
+    FloecatConnector floecatConnector = Mockito.mock(FloecatConnector.class);
+
+    IcebergNativeStatsCaptureEngine engine =
+        new IcebergNativeStatsCaptureEngine(
+            tableRepository, connectorRepository, credentialResolver, statsStore);
+    engine.connectorOpener = config -> floecatConnector;
+
+    ResourceId tableId = ResourceId.newBuilder().setAccountId("acct").setId("table-1").build();
+    ResourceId connectorId = ResourceId.newBuilder().setAccountId("acct").setId("conn-1").build();
+    when(tableRepository.getById(tableId))
+        .thenReturn(
+            Optional.of(
+                Table.newBuilder()
+                    .setResourceId(tableId)
+                    .setDisplayName("events")
+                    .setUpstream(
+                        ai.floedb.floecat.catalog.rpc.UpstreamRef.newBuilder()
+                            .setConnectorId(connectorId)
+                            .addNamespacePath("db")
+                            .setTableDisplayName("events")
+                            .build())
+                    .build()));
+    when(connectorRepository.getById(connectorId))
+        .thenReturn(
+            Optional.of(
+                Connector.newBuilder()
+                    .setResourceId(connectorId)
+                    .setDisplayName("iceberg-main")
+                    .setKind(ConnectorKind.CK_ICEBERG)
+                    .setUri("s3://warehouse")
+                    .build()));
+    when(floecatConnector.captureSnapshotTargetStats(any(), any(), any(), anyLong(), any()))
+        .thenReturn(List.of());
+
+    StatsCaptureRequest request =
+        StatsCaptureRequest.builder(
+                tableId,
+                999999L,
+                StatsTarget.newBuilder().setTable(TableStatsTarget.getDefaultInstance()).build())
+            .executionMode(StatsExecutionMode.SYNC)
+            .connectorType("iceberg")
+            .correlationId("corr")
+            .build();
+
+    assertThat(engine.capture(request)).isEmpty();
+    verify(floecatConnector).captureSnapshotTargetStats(any(), any(), any(), anyLong(), any());
+    verify(statsStore, never()).putTargetStats(any());
   }
 }


### PR DESCRIPTION
## Summary

This PR finalizes the reconciler/stats orchestration cleanup so stats capture paths are explicit, observable, and easier to maintain.

## Key Changes

- Unified stats trigger semantics with explicit outcomes:
  - `CAPTURED`
  - `QUEUED`
  - `UNCAPTURABLE`
  - `DEGRADED`
 
- Standardized structured trigger logging across service + reconciler:
  - `outcome`, `table`, `snapshot`, `reason`
 
- Kept `METADATA_AND_STATS` metadata-first:
  - metadata/snapshots are ingested in reconcile pass
  - stats follow-up is queued as `STATS_ONLY`

- Aligned snapshot semantics:
  - `snapshotId >= 0` is valid (including `0` for Delta)

- Normalized namespace/scope handling and connector type mapping

- Refactored reconciler tests to reduce duplication and improve readability:
  - extracted shared test base
  - split internal logic/view pass tests from the main reconciler test class

- Added/updated contract tests around control-plane trigger outcomes


## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [] No breaking changes
- [x] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

