### PR TITLE
Split Reconciler Planning and Execution with Durable Queue Hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,7 @@ jobs:
           SMOKE_LOG="$DEBUG_DIR/docker-smoke.log"
           mkdir -p "$DEBUG_DIR"
           LOCALSTACK_ENDPOINT=http://localstack:4566 \
+          COMPOSE_SMOKE_DUCKDB_IMAGE=duckdb/duckdb:1.4.4 \
           COMPOSE_SMOKE_SAVE_LOG_DIR="$DEBUG_DIR/compose-logs" \
           FLOECAT_REST_LOG_REQUEST_BODY=true \
           FLOECAT_REST_LOG_COMMIT_TRAFFIC=true \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,8 @@ jobs:
           mkdir -p "$DEBUG_DIR"
           LOCALSTACK_ENDPOINT=http://localstack:4566 \
           COMPOSE_SMOKE_SAVE_LOG_DIR="$DEBUG_DIR/compose-logs" \
+          FLOECAT_REST_LOG_REQUEST_BODY=true \
+          FLOECAT_REST_LOG_COMMIT_TRAFFIC=true \
           make compose-smoke 2>&1 | tee "$SMOKE_LOG"
 
       - name: Upload Docker Smoke Artifacts

--- a/Makefile
+++ b/Makefile
@@ -762,11 +762,6 @@ guard-container-owner:
 	@test -n "$(CONTAINER_OWNER)" || (echo "CONTAINER_OWNER is required (example: CONTAINER_OWNER=eng-floe)"; exit 1)
 
 docker-service:
-	@if [ "$(DOCKER_SERVICE_STORAGE)" = "aws" ] && { [ -z "$(REAL_AWS_BUCKET)" ] || [ -z "$(REAL_AWS_TABLE)" ]; }; then \
-	  echo "ERROR: REAL_AWS_BUCKET and REAL_AWS_TABLE must be set when DOCKER_SERVICE_STORAGE=aws"; \
-	  echo "Example: make docker DOCKER_SERVICE_STORAGE=aws REAL_AWS_BUCKET=my-bucket REAL_AWS_TABLE=my-table"; \
-	  exit 1; \
-	fi
 	@echo "==> [DOCKER] service (jib -> docker daemon)"
 	$(MVN) -f ./pom.xml -pl service -am -DskipTests \
 	  -DskipUTs=true -DskipITs=true \
@@ -775,7 +770,6 @@ docker-service:
 	  -Dquarkus.jib.base-jvm-image=$(JIB_BASE_IMAGE) \
 	  $(if $(JIB_PLATFORMS),-Dquarkus.jib.platforms=$(JIB_PLATFORMS)) \
 	  -Dquarkus.container-image.image=floecat-service:local \
-	  $(DOCKER_SERVICE_STORAGE_PROPS) \
 	  package
 
 docker-iceberg-rest:
@@ -803,11 +797,6 @@ docker-cli:
 docker-publish: guard-container-owner docker-publish-service docker-publish-iceberg-rest docker-publish-cli
 
 docker-publish-service:
-	@if [ "$(DOCKER_SERVICE_STORAGE)" = "aws" ] && { [ -z "$(REAL_AWS_BUCKET)" ] || [ -z "$(REAL_AWS_TABLE)" ]; }; then \
-	  echo "ERROR: REAL_AWS_BUCKET and REAL_AWS_TABLE must be set when DOCKER_SERVICE_STORAGE=aws"; \
-	  echo "Example: make docker-publish DOCKER_SERVICE_STORAGE=aws REAL_AWS_BUCKET=my-bucket REAL_AWS_TABLE=my-table CONTAINER_OWNER=eng-floe"; \
-	  exit 1; \
-	fi
 	@echo "==> [DOCKER] publish service (jib -> registry)"
 	$(MVN) -f ./pom.xml -pl service -am -DskipTests \
 	  -DskipUTs=true -DskipITs=true \
@@ -818,7 +807,6 @@ docker-publish-service:
 	  $(if $(JIB_IMAGE_PLATFORMS),-Dquarkus.jib.platforms=$(JIB_IMAGE_PLATFORMS)) \
 	  -Dquarkus.container-image.image=$(CONTAINER_REGISTRY)/$(CONTAINER_OWNER)/floecat-service:$(CONTAINER_TAG) \
 	  $(if $(CONTAINER_EXTRA_TAGS),-Dquarkus.container-image.additional-tags=$(CONTAINER_EXTRA_TAGS)) \
-	  $(DOCKER_SERVICE_STORAGE_PROPS) \
 	  package
 
 docker-publish-iceberg-rest:

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -139,13 +139,17 @@ import ai.floedb.floecat.reconciler.rpc.CancelReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.CaptureMode;
 import ai.floedb.floecat.reconciler.rpc.CaptureNowRequest;
 import ai.floedb.floecat.reconciler.rpc.CaptureScope;
+import ai.floedb.floecat.reconciler.rpc.ExecutionClass;
+import ai.floedb.floecat.reconciler.rpc.ExecutionPolicy;
 import ai.floedb.floecat.reconciler.rpc.GetReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.GetReconcileJobResponse;
 import ai.floedb.floecat.reconciler.rpc.GetReconcilerSettingsRequest;
 import ai.floedb.floecat.reconciler.rpc.GetReconcilerSettingsResponse;
 import ai.floedb.floecat.reconciler.rpc.JobState;
 import ai.floedb.floecat.reconciler.rpc.ListReconcileJobsRequest;
+import ai.floedb.floecat.reconciler.rpc.ListReconcileJobsResponse;
 import ai.floedb.floecat.reconciler.rpc.ReconcileControlGrpc;
+import ai.floedb.floecat.reconciler.rpc.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.rpc.StartCaptureRequest;
 import ai.floedb.floecat.reconciler.rpc.UpdateReconcilerSettingsRequest;
 import ai.floedb.floecat.reconciler.rpc.UpdateReconcilerSettingsResponse;
@@ -662,8 +666,11 @@ public class Shell implements Runnable {
              [--mode metadata-only|metadata-and-stats|stats-only]
              [--dest-ns <a.b[.c]>] [--dest-table <name>] [--dest-cols c1,#id2,...]
              [--snapshot-ids id1,id2,...]
+             [--execution-class default|interactive|batch|heavy] [--lane <name>] [--exec-attr k=v ...]
          connector job <jobId>
-         connector jobs [--connector <display_name|id>] [--state <queued|running|cancelling|cancelled|succeeded|failed>[,...]] [--page-size <N>]
+         connector job <jobId> [--children] [--json] [--verbose]   # --children shows table jobs
+         connector jobs [--connector <display_name|id>] [--state <queued|running|cancelling|cancelled|succeeded|failed>[,...]] [--page-size <N>] [--children] [--json] [--verbose]
+             # default shows top-level jobs only; use --children for table jobs
          connector cancel <jobId> [--reason <text>]
          connector settings get
          connector settings update [--auto-enabled true|false] [--default-interval-sec <n>] [--default-mode incremental|full] [--finished-job-retention-sec <n>]
@@ -1728,6 +1735,31 @@ public class Shell implements Runnable {
     return (kind == null) ? all : all.stream().filter(c -> c.getKind() == kind).toList();
   }
 
+  private List<GetReconcileJobResponse> listReconcileJobs(
+      String connectorId, List<JobState> states, int pageSize) {
+    return collectPages(
+        pageSize,
+        page -> {
+          var req = ListReconcileJobsRequest.newBuilder().setPage(page);
+          if (connectorId != null && !connectorId.isBlank()) {
+            req.setConnectorId(connectorId);
+          }
+          for (JobState state : states) {
+            if (state != JobState.JS_UNSPECIFIED) {
+              req.addStates(state);
+            }
+          }
+          return reconcileControl.listReconcileJobs(req.build());
+        },
+        ListReconcileJobsResponse::getJobsList,
+        resp -> resp.hasPage() ? resp.getPage().getNextPageToken() : "");
+  }
+
+  private List<GetReconcileJobResponse> listReconcileJobsForConnector(
+      String connectorId, int pageSize) {
+    return listReconcileJobs(connectorId, List.of(), pageSize);
+  }
+
   private void cmdConnectorCrud(List<String> args) {
     if (args.isEmpty()) {
       out.println(
@@ -2087,7 +2119,9 @@ public class Shell implements Runnable {
               "usage: connector trigger <display_name|id> [--full]"
                   + " [--mode metadata-only|metadata-and-stats|stats-only]"
                   + " [--dest-ns <a.b[.c]>] [--dest-table <name>] [--dest-cols c1,#id2,...]"
-                  + " [--snapshot-ids id1,id2,...]");
+                  + " [--snapshot-ids id1,id2,...]"
+                  + " [--execution-class default|interactive|batch|heavy] [--lane <name>]"
+                  + " [--exec-attr k=v ...]");
           return;
         }
         boolean full = args.contains("--full");
@@ -2098,6 +2132,10 @@ public class Shell implements Runnable {
             csvList(Quotes.unquote(parseStringFlag(args, "--dest-cols", "")));
         List<Long> snapshotIds =
             parseSnapshotIds(Quotes.unquote(parseStringFlag(args, "--snapshot-ids", "")));
+        ExecutionClass executionClass =
+            parseExecutionClass(Quotes.unquote(parseStringFlag(args, "--execution-class", "")));
+        String lane = Quotes.unquote(parseStringFlag(args, "--lane", ""));
+        Map<String, String> executionAttrs = parseKeyValueList(args, "--exec-attr");
         ResourceId connectorId = resolveConnectorId(Quotes.unquote(args.get(1)));
         CaptureScope.Builder scope = CaptureScope.newBuilder().setConnectorId(connectorId);
         if (!destNs.isBlank()) {
@@ -2112,50 +2150,127 @@ public class Shell implements Runnable {
         if (!snapshotIds.isEmpty()) {
           scope.addAllDestinationSnapshotIds(snapshotIds);
         }
-        var resp =
-            reconcileControl.startCapture(
-                StartCaptureRequest.newBuilder()
-                    .setScope(scope.build())
-                    .setMode(mode)
-                    .setFullRescan(full)
-                    .build());
+        ExecutionPolicy.Builder executionPolicy = ExecutionPolicy.newBuilder();
+        if (executionClass != ExecutionClass.EC_UNSPECIFIED) {
+          executionPolicy.setExecutionClass(executionClass);
+        }
+        if (!lane.isBlank()) {
+          executionPolicy.setLane(lane);
+        }
+        if (!executionAttrs.isEmpty()) {
+          executionPolicy.putAllAttributes(executionAttrs);
+        }
+        StartCaptureRequest.Builder request =
+            StartCaptureRequest.newBuilder()
+                .setScope(scope.build())
+                .setMode(mode)
+                .setFullRescan(full);
+        if (executionPolicy.getExecutionClass() != ExecutionClass.EC_UNSPECIFIED
+            || !executionPolicy.getLane().isBlank()
+            || !executionPolicy.getAttributesMap().isEmpty()) {
+          request.setExecutionPolicy(executionPolicy.build());
+        }
+        var resp = reconcileControl.startCapture(request.build());
         out.println(resp.getJobId());
       }
       case "job" -> {
         if (args.size() < 2) {
-          out.println("usage: connector job <jobId>");
+          out.println("usage: connector job <jobId> [--children] [--json] [--verbose]");
           return;
         }
+        boolean showChildren = hasFlag(args, "--children");
+        boolean json = hasFlag(args, "--json");
+        boolean verbose = hasFlag(args, "--verbose");
         var resp =
             reconcileControl.getReconcileJob(
                 GetReconcileJobRequest.newBuilder().setJobId(Quotes.unquote(args.get(1))).build());
-        printReconcileJob(resp);
+        if (json) {
+          if (showChildren && isTopLevelReconcileJob(resp)) {
+            List<GetReconcileJobResponse> children =
+                listReconcileJobsForConnector(resp.getConnectorId(), DEFAULT_PAGE_SIZE).stream()
+                    .filter(job -> resp.getJobId().equals(job.getParentJobId()))
+                    .toList();
+            List<GetReconcileJobResponse> all = new ArrayList<>(1 + children.size());
+            all.add(resp);
+            all.addAll(children);
+            printJsonArray(all);
+          } else {
+            printJson(resp);
+          }
+          return;
+        }
+        printReconcileJob(resp, verbose);
+        if (showChildren && isTopLevelReconcileJob(resp)) {
+          List<GetReconcileJobResponse> children =
+              listReconcileJobsForConnector(resp.getConnectorId(), DEFAULT_PAGE_SIZE).stream()
+                  .filter(job -> resp.getJobId().equals(job.getParentJobId()))
+                  .toList();
+          for (GetReconcileJobResponse child : children) {
+            printReconcileJobSummary(child, verbose);
+          }
+        } else if (isTopLevelReconcileJob(resp)) {
+          out.println("tip: use --children to show table jobs");
+        }
       }
       case "jobs" -> {
         int pageSize = parseIntFlag(args, "--page-size", DEFAULT_PAGE_SIZE);
         String connectorRef = Quotes.unquote(parseStringFlag(args, "--connector", ""));
         String stateArg = Quotes.unquote(parseStringFlag(args, "--state", ""));
-        var req = ListReconcileJobsRequest.newBuilder();
-        req.setPage(PageRequest.newBuilder().setPageSize(pageSize).build());
-        if (!connectorRef.isBlank()) {
-          req.setConnectorId(rid(resolveConnectorId(connectorRef)));
-        }
+        boolean showChildren = hasFlag(args, "--children");
+        boolean json = hasFlag(args, "--json");
+        boolean verbose = hasFlag(args, "--verbose");
+        String connectorId = connectorRef.isBlank() ? "" : rid(resolveConnectorId(connectorRef));
+        List<JobState> states = new ArrayList<>();
         for (String token : csvList(stateArg)) {
           JobState state = parseJobState(token);
           if (state != JobState.JS_UNSPECIFIED) {
-            req.addStates(state);
+            states.add(state);
           }
         }
-        var resp = reconcileControl.listReconcileJobs(req.build());
-        if (resp.getJobsList().isEmpty()) {
+        List<GetReconcileJobResponse> jobs = listReconcileJobs(connectorId, states, pageSize);
+        if (jobs.isEmpty()) {
           out.println("no reconcile jobs");
           return;
         }
-        for (GetReconcileJobResponse job : resp.getJobsList()) {
-          printReconcileJobSummary(job);
+        Map<String, List<GetReconcileJobResponse>> childrenByParent =
+            jobs.stream()
+                .filter(job -> !job.getParentJobId().isBlank())
+                .collect(Collectors.groupingBy(GetReconcileJobResponse::getParentJobId));
+        List<GetReconcileJobResponse> topLevelJobs =
+            jobs.stream().filter(this::isTopLevelReconcileJob).toList();
+        if (json) {
+          if (showChildren) {
+            List<GetReconcileJobResponse> all = new ArrayList<>();
+            for (GetReconcileJobResponse job : topLevelJobs) {
+              all.add(job);
+              all.addAll(childrenByParent.getOrDefault(job.getJobId(), List.of()));
+            }
+            printJsonArray(all);
+          } else {
+            printJsonArray(topLevelJobs);
+          }
+          return;
         }
-        if (resp.hasPage() && !resp.getPage().getNextPageToken().isBlank()) {
-          out.println("next_page_token=" + resp.getPage().getNextPageToken());
+        if (!verbose) {
+          out.printf(
+              "%-8s  %-8s  %-11s  %8s  %-20s  %s%n",
+              "JOB", "STATE", "MODE", "DURATION", "TABLES", "MESSAGE");
+        }
+        for (GetReconcileJobResponse job : topLevelJobs) {
+          printReconcileJobSummary(job, verbose);
+          printReconcileChildSummary(childrenByParent.get(job.getJobId()));
+          if (showChildren) {
+            if (!verbose && !childrenByParent.getOrDefault(job.getJobId(), List.of()).isEmpty()) {
+              out.printf("  %-8s  %-32s  %8s  %s%n", "STATE", "TABLE", "DURATION", "MESSAGE");
+            }
+            for (GetReconcileJobResponse child :
+                childrenByParent.getOrDefault(job.getJobId(), List.of())) {
+              printReconcileJobSummary(child, verbose);
+            }
+          }
+        }
+        if (!showChildren && !childrenByParent.isEmpty()) {
+          out.println("tip: use --children to show table jobs");
         }
       }
       case "cancel" -> {
@@ -2172,7 +2287,7 @@ public class Shell implements Runnable {
                     .build());
         out.println("cancelled=" + resp.getCancelled());
         if (resp.hasJob()) {
-          printReconcileJob(resp.getJob());
+          printReconcileJob(resp.getJob(), false);
         }
       }
       case "settings" -> cmdReconcilerSettings(args.subList(1, args.size()));
@@ -3449,6 +3564,23 @@ public class Shell implements Runnable {
     }
   }
 
+  private void printJsonArray(List<? extends com.google.protobuf.MessageOrBuilder> messages) {
+    out.println("[");
+    for (int i = 0; i < messages.size(); i++) {
+      try {
+        out.print(jsonPrinter().print(messages.get(i)));
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException("failed to render protobuf as json", e);
+      }
+      if (i + 1 < messages.size()) {
+        out.println(",");
+      } else {
+        out.println();
+      }
+    }
+    out.println("]");
+  }
+
   private JsonFormat.Printer jsonPrinter() {
     return JsonFormat.printer().includingDefaultValueFields();
   }
@@ -3927,54 +4059,409 @@ public class Shell implements Runnable {
     };
   }
 
-  private void printReconcileJobSummary(GetReconcileJobResponse job) {
-    out.printf(
-        "job_id=%s connector_id=%s state=%s mode=%s duration_ms=%d scanned=%d changed=%d"
-            + " snapshots=%d stats=%d errors=%d%n",
-        job.getJobId(),
-        job.getConnectorId(),
-        job.getState().name(),
-        job.getFullRescan() ? "full" : "incremental",
-        job.getDurationMs(),
-        job.getTablesScanned(),
-        job.getTablesChanged(),
-        job.getSnapshotsProcessed(),
-        job.getStatsProcessed(),
-        job.getErrors());
-    if (job.getMessage() != null && !job.getMessage().isBlank()) {
-      out.println("message: " + job.getMessage());
+  private ExecutionClass parseExecutionClass(String s) {
+    if (s == null || s.isBlank()) {
+      return ExecutionClass.EC_UNSPECIFIED;
     }
+    return switch (s.trim().toUpperCase(Locale.ROOT).replace('-', '_')) {
+      case "DEFAULT", "EC_DEFAULT" -> ExecutionClass.EC_DEFAULT;
+      case "INTERACTIVE", "EC_INTERACTIVE" -> ExecutionClass.EC_INTERACTIVE;
+      case "BATCH", "EC_BATCH" -> ExecutionClass.EC_BATCH;
+      case "HEAVY", "EC_HEAVY" -> ExecutionClass.EC_HEAVY;
+      default -> throw new IllegalArgumentException("invalid execution class: " + s);
+    };
   }
 
-  private void printReconcileJob(GetReconcileJobResponse job) {
+  private void printReconcileJobSummary(GetReconcileJobResponse job, boolean verbose) {
+    if (verbose) {
+      printReconcileJobSummaryVerbose(job);
+      return;
+    }
+    if (isTopLevelReconcileJob(job)) {
+      out.printf(
+          "%-8s  %-8s  %-11s  %8s  %-20s  %s%n",
+          shortJobId(job.getJobId()),
+          formatJobStateCompact(job.getState()),
+          job.getFullRescan() ? "full" : "incremental",
+          formatDurationCompact(job.getDurationMs()),
+          formatTableSummary(job),
+          summarizeJobMessage(job.getMessage()));
+      String message = summarizeJobMessage(job.getMessage());
+      if (message.isBlank() && job.getErrors() > 0) {
+        out.println("  message: failed");
+      }
+      return;
+    }
+
     out.printf(
-        "job_id=%s connector_id=%s state=%s mode=%s started=%s finished=%s duration_ms=%d"
-            + " scanned=%d changed=%d snapshots=%d stats=%d errors=%d%n",
-        job.getJobId(),
-        job.getConnectorId(),
-        job.getState().name(),
+        "  %-8s  %-32s  %8s",
+        formatJobStateCompact(job.getState()),
+        formatTableTaskDisplay(job),
+        formatDurationCompact(job.getDurationMs()));
+    String message = summarizeChildJobMessage(job);
+    if (!message.isBlank()) {
+      out.print("  " + message);
+    }
+    out.println();
+  }
+
+  private void printReconcileJob(GetReconcileJobResponse job, boolean verbose) {
+    if (verbose) {
+      printReconcileJobVerbose(job);
+      return;
+    }
+    out.printf("job: %s%n", job.getJobId());
+    out.printf("  connector: %s%n", job.getConnectorId());
+    out.printf(
+        "  state: %s%n  kind: %s%n  mode: %s%n  duration: %s%n",
+        formatJobStateCompact(job.getState()),
+        formatJobKind(job.getKind()),
         job.getFullRescan() ? "full" : "incremental",
+        formatDurationCompact(job.getDurationMs()));
+    out.printf(
+        "  started: %s%n  finished: %s%n  scanned: %d  changed: %d  snapshots: %d  stats: %d  errors: %d%n",
         ts(job.getStartedAt()),
         ts(job.getFinishedAt()),
-        job.getDurationMs(),
         job.getTablesScanned(),
         job.getTablesChanged(),
         job.getSnapshotsProcessed(),
         job.getStatsProcessed(),
         job.getErrors());
+    if (hasInterestingRouting(job)) {
+      out.println("  routing: " + summarizeRouting(job));
+    }
     if (job.getMessage() != null && !job.getMessage().isBlank()) {
       var lines = splitErrorLines(job.getMessage());
       if (lines.isEmpty()) {
-        out.println("message: " + job.getMessage());
+        out.println("  message: " + job.getMessage());
       } else if (lines.size() == 1) {
-        out.println("message: " + lines.get(0));
+        out.println("  message: " + lines.get(0));
       } else {
-        out.println("message:");
+        out.println("  message:");
+        for (String line : lines) {
+          out.println("    - " + line);
+        }
+      }
+    }
+  }
+
+  private void printReconcileJobSummaryVerbose(GetReconcileJobResponse job) {
+    out.printf(
+        "job_id=%s connector_id=%s state=%s kind=%s mode=%s duration_ms=%d scanned=%d changed=%d snapshots=%d stats=%d errors=%d%n",
+        job.getJobId(),
+        job.getConnectorId(),
+        formatJobState(job.getState()),
+        formatJobKind(job.getKind()),
+        job.getFullRescan() ? "full" : "incremental",
+        job.getDurationMs(),
+        job.getTablesScanned(),
+        job.getTablesChanged(),
+        job.getSnapshotsProcessed(),
+        job.getStatsProcessed(),
+        job.getErrors());
+    out.println("routing: " + summarizeRoutingVerbose(job));
+    String message = summarizeJobMessage(job.getMessage());
+    if (!message.isBlank()) {
+      out.println("message: " + message);
+    }
+  }
+
+  private void printReconcileJobVerbose(GetReconcileJobResponse job) {
+    printReconcileJobSummaryVerbose(job);
+    out.printf("started_at=%s finished_at=%s%n", ts(job.getStartedAt()), ts(job.getFinishedAt()));
+    if (job.getMessage() != null && !job.getMessage().isBlank()) {
+      var lines = splitErrorLines(job.getMessage());
+      if (lines.size() > 1) {
+        out.println("message_detail:");
         for (String line : lines) {
           out.println("  - " + line);
         }
       }
     }
+  }
+
+  private String summarizeRoutingVerbose(GetReconcileJobResponse job) {
+    String parent =
+        job.getParentJobId() == null || job.getParentJobId().isBlank() ? "-" : job.getParentJobId();
+    String executor =
+        job.getExecutorId() == null || job.getExecutorId().isBlank() ? "-" : job.getExecutorId();
+    String table = job.hasTableTask() ? formatTableTaskShort(job) : "-";
+    return "parent_job_id="
+        + parent
+        + " executor_id="
+        + executor
+        + " policy="
+        + formatExecutionPolicy(job.getExecutionPolicy())
+        + " table="
+        + table;
+  }
+
+  private String formatJobKind(ReconcileJobKind kind) {
+    if (kind == null || kind == ReconcileJobKind.RJK_UNSPECIFIED) {
+      return "unspecified";
+    }
+    return kind.name().replace("RJK_", "").toLowerCase(Locale.ROOT);
+  }
+
+  private String formatJobStateCompact(JobState state) {
+    if (state == null || state == JobState.JS_UNSPECIFIED) {
+      return "unknown";
+    }
+    return switch (state) {
+      case JS_SUCCEEDED -> "done";
+      case JS_FAILED -> "failed";
+      case JS_QUEUED -> "queued";
+      case JS_RUNNING -> "running";
+      case JS_CANCELLING -> "stopping";
+      case JS_CANCELLED -> "stopped";
+      default -> "unknown";
+    };
+  }
+
+  private String formatJobState(JobState state) {
+    if (state == null || state == JobState.JS_UNSPECIFIED) {
+      return "unspecified";
+    }
+    return state.name().replace("JS_", "").toLowerCase(Locale.ROOT);
+  }
+
+  private String formatExecutionPolicy(ExecutionPolicy policy) {
+    if (policy == null) {
+      return "";
+    }
+    List<String> parts = new ArrayList<>();
+    if (policy.getExecutionClass() != ExecutionClass.EC_UNSPECIFIED) {
+      parts.add(
+          "class=" + policy.getExecutionClass().name().replace("EC_", "").toLowerCase(Locale.ROOT));
+    }
+    if (!policy.getLane().isBlank()) {
+      parts.add("lane=" + policy.getLane());
+    }
+    if (!policy.getAttributesMap().isEmpty()) {
+      String attrs =
+          policy.getAttributesMap().entrySet().stream()
+              .map(e -> e.getKey() + "=" + e.getValue())
+              .collect(Collectors.joining(","));
+      parts.add("attrs=" + attrs);
+    }
+    return String.join(" ", parts);
+  }
+
+  private String formatTableTask(GetReconcileJobResponse job) {
+    if (!job.hasTableTask()) {
+      return "";
+    }
+    var tableTask = job.getTableTask();
+    if (tableTask.getSourceTable().isBlank()
+        && tableTask.getSourceNamespace().isBlank()
+        && tableTask.getDestinationTableDisplayName().isBlank()) {
+      return "";
+    }
+    String source =
+        tableTask.getSourceNamespace().isBlank()
+            ? tableTask.getSourceTable()
+            : tableTask.getSourceNamespace() + "." + tableTask.getSourceTable();
+    if (tableTask.getDestinationTableDisplayName().isBlank()) {
+      return source;
+    }
+    return source + "->" + tableTask.getDestinationTableDisplayName();
+  }
+
+  private boolean isTopLevelReconcileJob(GetReconcileJobResponse job) {
+    return job.getParentJobId().isBlank();
+  }
+
+  private void printReconcileChildSummary(List<GetReconcileJobResponse> children) {
+    if (children == null || children.isEmpty()) {
+      return;
+    }
+    Map<JobState, Long> counts =
+        children.stream()
+            .collect(
+                Collectors.groupingBy(
+                    GetReconcileJobResponse::getState, LinkedHashMap::new, Collectors.counting()));
+    String summary =
+        List.of(
+                JobState.JS_RUNNING,
+                JobState.JS_QUEUED,
+                JobState.JS_SUCCEEDED,
+                JobState.JS_FAILED,
+                JobState.JS_CANCELLING,
+                JobState.JS_CANCELLED)
+            .stream()
+            .filter(state -> counts.getOrDefault(state, 0L) > 0)
+            .map(state -> counts.get(state) + " " + formatJobStateCompact(state))
+            .collect(Collectors.joining(", "));
+    if (!summary.isBlank()) {
+      out.println("children: " + summary);
+    }
+  }
+
+  private String summarizeRouting(GetReconcileJobResponse job) {
+    List<String> parts = new ArrayList<>();
+    if (!job.getParentJobId().isBlank()) {
+      parts.add("parent=" + shortJobId(job.getParentJobId()));
+    }
+    if (!job.getExecutorId().isBlank() && !"default_reconciler".equals(job.getExecutorId())) {
+      parts.add("executor=" + job.getExecutorId());
+    }
+    String executionPolicy = formatExecutionPolicy(job.getExecutionPolicy());
+    if (!executionPolicy.isBlank() && !"class=default".equals(executionPolicy)) {
+      parts.add("policy=" + executionPolicy);
+    }
+    String tableTask = formatTableTask(job);
+    if (!tableTask.isBlank()) {
+      parts.add("table=" + tableTask);
+    }
+    return String.join(" ", parts);
+  }
+
+  private boolean hasInterestingRouting(GetReconcileJobResponse job) {
+    if (!job.getParentJobId().isBlank()) {
+      return true;
+    }
+    if (!job.getExecutorId().isBlank() && !"default_reconciler".equals(job.getExecutorId())) {
+      return true;
+    }
+    String executionPolicy = formatExecutionPolicy(job.getExecutionPolicy());
+    if (!executionPolicy.isBlank() && !"class=default".equals(executionPolicy)) {
+      return true;
+    }
+    return !formatTableTask(job).isBlank();
+  }
+
+  private String summarizeJobMessage(String msg) {
+    List<String> lines = splitErrorLines(msg);
+    if (lines.isEmpty()) {
+      return "";
+    }
+    String first =
+        lines
+            .get(0)
+            .replace("RuntimeException: ", "")
+            .replace("Partial failure (errors=1):", "partial failure")
+            .replace("Processing table ", "");
+    if (lines.size() == 1) {
+      return simplifyJobMessage(first);
+    }
+    String second = lines.get(1);
+    if (second.startsWith("ns=") || second.startsWith("grpc=")) {
+      return simplifyJobMessage(first + " " + second);
+    }
+    return simplifyJobMessage(first);
+  }
+
+  private String formatTableTaskShort(GetReconcileJobResponse job) {
+    String tableTask = formatTableTask(job);
+    if (tableTask.isBlank()) {
+      return formatJobKind(job.getKind());
+    }
+    return tableTask;
+  }
+
+  private String formatTableTaskDisplay(GetReconcileJobResponse job) {
+    if (!job.hasTableTask()) {
+      return formatJobKind(job.getKind());
+    }
+    var tableTask = job.getTableTask();
+    String source = tableTask.getSourceTable();
+    String dest = tableTask.getDestinationTableDisplayName();
+    if (!dest.isBlank()) {
+      if (source.isBlank() || source.equals(dest)) {
+        return dest;
+      }
+      return source + "->" + dest;
+    }
+    if (!source.isBlank()) {
+      return source;
+    }
+    return formatJobKind(job.getKind());
+  }
+
+  private String formatTableSummary(GetReconcileJobResponse job) {
+    long done = job.getTablesChanged();
+    long total = job.getTablesScanned();
+    long failed = job.getErrors();
+    if (failed > 0) {
+      return "%d done, %d failed".formatted(done, failed);
+    }
+    if (total > done) {
+      return "%d done, %d queued".formatted(done, total - done);
+    }
+    return "%d done".formatted(done);
+  }
+
+  private String summarizeChildJobMessage(GetReconcileJobResponse job) {
+    if (job.getState() == JobState.JS_SUCCEEDED) {
+      return "";
+    }
+    String msg = summarizeJobMessage(job.getMessage());
+    if (!msg.isBlank()) {
+      return msg;
+    }
+    return switch (job.getState()) {
+      case JS_QUEUED -> "queued";
+      case JS_RUNNING -> "running";
+      case JS_FAILED -> "failed";
+      case JS_CANCELLING -> "stopping";
+      case JS_CANCELLED -> "stopped";
+      default -> "";
+    };
+  }
+
+  private String simplifyJobMessage(String msg) {
+    if (msg == null || msg.isBlank()) {
+      return "";
+    }
+    String simplified =
+        msg.replace("BadRequestException: ", "")
+            .replace("Malformed request: ", "")
+            .replace("The specified key does not exist.", "key does not exist")
+            .replace("partial failure ", "")
+            .trim();
+    int tableIdx = simplified.indexOf("table=");
+    if (tableIdx >= 0) {
+      int valueStart = tableIdx + "table=".length();
+      int valueEnd = simplified.indexOf(' ', valueStart);
+      if (valueEnd < 0) {
+        valueEnd = simplified.length();
+      }
+      String table = simplified.substring(valueStart, valueEnd);
+      int dot = table.lastIndexOf('.');
+      if (dot >= 0 && dot + 1 < table.length()) {
+        table = table.substring(dot + 1);
+      }
+      String remainder = simplified.substring(valueEnd).trim();
+      while (remainder.startsWith(":")) {
+        remainder = remainder.substring(1).trim();
+      }
+      simplified = table + (remainder.isBlank() ? "" : ": " + remainder);
+    }
+    return simplified;
+  }
+
+  private static String shortJobId(String jobId) {
+    if (jobId == null || jobId.isBlank()) {
+      return "-";
+    }
+    return jobId.length() <= 8 ? jobId : jobId.substring(0, 8);
+  }
+
+  private static String formatDurationCompact(long durationMs) {
+    if (durationMs <= 0) {
+      return "0s";
+    }
+    long totalSeconds = durationMs / 1000;
+    long seconds = totalSeconds % 60;
+    long minutes = (totalSeconds / 60) % 60;
+    long hours = totalSeconds / 3600;
+    if (hours > 0) {
+      return "%dh%02dm".formatted(hours, minutes);
+    }
+    if (minutes > 0) {
+      return "%dm%02ds".formatted(minutes, seconds);
+    }
+    return "%ds".formatted(seconds);
   }
 
   private void printReconcilerSettings(GetReconcilerSettingsResponse settings) {

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -244,6 +244,11 @@ public class Shell implements Runnable {
   String sessionHeaderName;
 
   @CommandLine.Option(
+      names = {"--account-header"},
+      description = "Account header name for dev mode (default: x-floe-account)")
+  String accountHeaderName;
+
+  @CommandLine.Option(
       names = {"--oidc-token-url"},
       description = "OIDC token endpoint URL (or set FLOECAT_OIDC_TOKEN_URL)")
   String oidcTokenUrl;
@@ -705,6 +710,9 @@ public class Shell implements Runnable {
     }
     if (sessionHeaderName == null || sessionHeaderName.isBlank()) {
       sessionHeaderName = "x-floe-session";
+    }
+    if (accountHeaderName == null || accountHeaderName.isBlank()) {
+      accountHeaderName = "x-floe-account";
     }
     if (currentAccountId == null || currentAccountId.isBlank()) {
       currentAccountId = accountId;
@@ -4183,6 +4191,12 @@ public class Shell implements Runnable {
           if (!session.isBlank()) {
             headers.put(
                 Metadata.Key.of(sessionHeaderName, Metadata.ASCII_STRING_MARSHALLER), session);
+          }
+
+          String account = currentAccountId == null ? "" : currentAccountId.trim();
+          if (!account.isBlank()) {
+            headers.put(
+                Metadata.Key.of(accountHeaderName, Metadata.ASCII_STRING_MARSHALLER), account);
           }
 
           super.start(responseListener, headers);

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
@@ -27,6 +27,7 @@ import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.catalog.rpc.TableStats;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.connector.common.ConnectorPlanningSupport;
 import ai.floedb.floecat.connector.common.ConnectorStatsViewBuilder;
 import ai.floedb.floecat.connector.common.GenericStatsEngine;
 import ai.floedb.floecat.connector.common.StatsEngine;
@@ -92,6 +93,11 @@ abstract class DeltaConnector implements FloecatConnector {
   @Override
   public ConnectorFormat format() {
     return ConnectorFormat.CF_DELTA;
+  }
+
+  @Override
+  public List<PlannedTableTask> planTableTasks(TablePlanningRequest request) {
+    return ConnectorPlanningSupport.planTableTasks(request, this::listTables);
   }
 
   @Override

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/FloecatConnectorDefaultChainTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/FloecatConnectorDefaultChainTest.java
@@ -60,6 +60,11 @@ class FloecatConnectorDefaultChainTest {
     }
 
     @Override
+    public List<PlannedTableTask> planTableTasks(TablePlanningRequest request) {
+      return List.of();
+    }
+
+    @Override
     public TableDescriptor describe(String namespaceFq, String tableName) {
       throw new UnsupportedOperationException();
     }

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
@@ -970,7 +970,7 @@ public abstract class IcebergConnector implements FloecatConnector {
 
   static boolean parseNdvEnabled(Map<String, String> options) {
     if (options != null) {
-      String v = options.getOrDefault("stats.ndv.enabled", "true");
+      String v = options.getOrDefault("stats.ndv.enabled", "false");
       return !v.equalsIgnoreCase("false");
     }
     return false;

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
@@ -27,6 +27,7 @@ import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.catalog.rpc.TableStats;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.connector.common.ConnectorPlanningSupport;
 import ai.floedb.floecat.connector.common.ConnectorStatsViewBuilder;
 import ai.floedb.floecat.connector.common.GenericStatsEngine;
 import ai.floedb.floecat.connector.common.StatsEngine;
@@ -129,6 +130,11 @@ public abstract class IcebergConnector implements FloecatConnector {
 
   @Override
   public abstract List<String> listTables(String namespaceFq);
+
+  @Override
+  public List<PlannedTableTask> planTableTasks(TablePlanningRequest request) {
+    return ConnectorPlanningSupport.planTableTasks(request, this::listTables);
+  }
 
   @Override
   public TableDescriptor describe(String namespaceFq, String tableName) {

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/ConnectorPlanningSupport.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/ConnectorPlanningSupport.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.common;
+
+import ai.floedb.floecat.connector.spi.FloecatConnector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public final class ConnectorPlanningSupport {
+  private ConnectorPlanningSupport() {}
+
+  public static List<FloecatConnector.PlannedTableTask> planTableTasks(
+      FloecatConnector.TablePlanningRequest request, Function<String, List<String>> listTables) {
+    if (request == null) {
+      return List.of();
+    }
+
+    String sourceNamespaceFq = requireNonBlank(request.sourceNamespaceFq(), "source namespace");
+    String destinationNamespaceFq = blankToNull(request.destinationNamespaceFq());
+    if (!matchesNamespaceFilter(destinationNamespaceFq, request.destinationNamespacePaths())) {
+      throw new IllegalArgumentException(
+          "Connector destination namespace "
+              + destinationNamespaceFq
+              + " does not match requested scope");
+    }
+
+    List<String> sourceTables =
+        blankToNull(request.sourceTable()) != null
+            ? List.of(request.sourceTable())
+            : listTables.apply(sourceNamespaceFq);
+    String destinationTableDisplayHint = blankToNull(request.destinationTableDisplayHint());
+    String destinationTableFilter = blankToNull(request.destinationTableDisplayName());
+
+    List<FloecatConnector.PlannedTableTask> planned = new ArrayList<>();
+    for (String sourceTable : sourceTables) {
+      String destinationTableDisplayName =
+          destinationTableDisplayHint != null ? destinationTableDisplayHint : sourceTable;
+      if (destinationTableFilter != null
+          && !destinationTableFilter.equals(destinationTableDisplayName)) {
+        continue;
+      }
+      planned.add(
+          new FloecatConnector.PlannedTableTask(
+              sourceNamespaceFq, sourceTable, destinationTableDisplayName));
+    }
+    return List.copyOf(planned);
+  }
+
+  private static boolean matchesNamespaceFilter(
+      String namespaceFq, List<List<String>> destinationNamespacePaths) {
+    if (destinationNamespacePaths == null || destinationNamespacePaths.isEmpty()) {
+      return true;
+    }
+    if (namespaceFq == null || namespaceFq.isBlank()) {
+      return false;
+    }
+    for (List<String> path : destinationNamespacePaths) {
+      if (String.join(".", path).equals(namespaceFq)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String requireNonBlank(String value, String fieldName) {
+    String normalized = blankToNull(value);
+    if (normalized == null) {
+      throw new IllegalArgumentException(fieldName + " is required");
+    }
+    return normalized;
+  }
+
+  private static String blankToNull(String value) {
+    return value == null || value.isBlank() ? null : value;
+  }
+}

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
@@ -70,6 +70,9 @@ public interface FloecatConnector extends Closeable {
     return enumerateSnapshotsWithStats(namespaceFq, tableName, destinationTableId, includeColumns);
   }
 
+  /** Plans table-scoped reconcile work for this connector. */
+  List<PlannedTableTask> planTableTasks(TablePlanningRequest request);
+
   /**
    * Returns per-snapshot constraints for a table snapshot, if available.
    *
@@ -127,6 +130,38 @@ public interface FloecatConnector extends Closeable {
         boolean includeStatistics, Set<Long> knownSnapshotIds, Set<Long> targetSnapshotIds) {
       return new SnapshotEnumerationOptions(
           includeStatistics, false, knownSnapshotIds, targetSnapshotIds);
+    }
+  }
+
+  record TablePlanningRequest(
+      String sourceNamespaceFq,
+      String sourceTable,
+      String destinationNamespaceFq,
+      String destinationTableDisplayHint,
+      List<List<String>> destinationNamespacePaths,
+      String destinationTableDisplayName) {
+    public TablePlanningRequest {
+      destinationNamespacePaths =
+          destinationNamespacePaths == null
+              ? List.of()
+              : destinationNamespacePaths.stream()
+                  .filter(path -> path != null && !path.isEmpty())
+                  .map(List::copyOf)
+                  .toList();
+    }
+  }
+
+  record PlannedTableTask(
+      String sourceNamespaceFq, String sourceTable, String destinationTableDisplayName) {
+    public PlannedTableTask {
+      sourceNamespaceFq = sourceNamespaceFq == null ? "" : sourceNamespaceFq;
+      sourceTable = sourceTable == null ? "" : sourceTable;
+      destinationTableDisplayName =
+          destinationTableDisplayName == null ? "" : destinationTableDisplayName;
+    }
+
+    public PlannedTableTask(String sourceNamespaceFq, String sourceTable) {
+      this(sourceNamespaceFq, sourceTable, "");
     }
   }
 

--- a/core/proto/src/main/proto/floecat/reconciler/reconciler.proto
+++ b/core/proto/src/main/proto/floecat/reconciler/reconciler.proto
@@ -37,6 +37,20 @@ enum CaptureMode {
   CM_STATS_ONLY = 3;
 }
 
+enum ExecutionClass {
+  EC_UNSPECIFIED = 0;
+  EC_DEFAULT = 1;
+  EC_INTERACTIVE = 2;
+  EC_BATCH = 3;
+  EC_HEAVY = 4;
+}
+
+message ExecutionPolicy {
+  ExecutionClass execution_class = 1;
+  string lane = 2;
+  map<string, string> attributes = 3;
+}
+
 message CaptureNowRequest {
   CaptureScope scope = 1;
   CaptureMode mode = 2;
@@ -53,10 +67,99 @@ message StartCaptureRequest {
   CaptureScope scope = 1;
   CaptureMode mode = 2;
   bool full_rescan = 3;
+  ExecutionPolicy execution_policy = 4;
 }
 
 message StartCaptureResponse {
   string job_id = 1;
+}
+
+message LeasedReconcileJob {
+  string job_id = 1;
+  ai.floedb.floecat.common.ResourceId connector_id = 2;
+  CaptureMode mode = 3;
+  bool full_rescan = 4;
+  CaptureScope scope = 5;
+  string lease_epoch = 6;
+  ExecutionPolicy execution_policy = 7;
+  string pinned_executor_id = 8;
+  string executor_id = 9;
+}
+
+message LeaseReconcileJobRequest {
+  string executor_id = 1;
+  repeated ExecutionClass execution_classes = 2;
+  repeated string lanes = 3;
+}
+
+message LeaseReconcileJobResponse {
+  bool found = 1;
+  LeasedReconcileJob job = 2;
+}
+
+message RenewReconcileLeaseRequest {
+  string job_id = 1;
+  string lease_epoch = 2;
+}
+
+message RenewReconcileLeaseResponse {
+  bool renewed = 1;
+  bool cancellation_requested = 2;
+}
+
+message StartLeasedReconcileJobRequest {
+  string job_id = 1;
+  string lease_epoch = 2;
+  string executor_id = 3;
+}
+
+message StartLeasedReconcileJobResponse {}
+
+message ReportReconcileProgressRequest {
+  string job_id = 1;
+  string lease_epoch = 2;
+  uint64 tables_scanned = 3;
+  uint64 tables_changed = 4;
+  uint64 errors = 5;
+  uint64 snapshots_processed = 6;
+  uint64 stats_processed = 7;
+  string message = 8;
+}
+
+message ReportReconcileProgressResponse {
+  bool lease_valid = 1;
+  bool cancellation_requested = 2;
+}
+
+enum ReconcileCompletionState {
+  RCS_UNSPECIFIED = 0;
+  RCS_SUCCEEDED = 1;
+  RCS_FAILED = 2;
+  RCS_CANCELLED = 3;
+}
+
+message CompleteLeasedReconcileJobRequest {
+  string job_id = 1;
+  string lease_epoch = 2;
+  ReconcileCompletionState state = 3;
+  uint64 tables_scanned = 4;
+  uint64 tables_changed = 5;
+  uint64 errors = 6;
+  uint64 snapshots_processed = 7;
+  uint64 stats_processed = 8;
+  string message = 9;
+}
+
+message CompleteLeasedReconcileJobResponse {
+  bool accepted = 1;
+}
+
+message GetReconcileCancellationRequest {
+  string job_id = 1;
+}
+
+message GetReconcileCancellationResponse {
+  bool cancellation_requested = 1;
 }
 
 message GetReconcileJobRequest {
@@ -77,6 +180,8 @@ message GetReconcileJobResponse {
   uint64 snapshots_processed = 11;
   uint64 stats_processed = 12;
   uint64 duration_ms = 13;
+  ExecutionPolicy execution_policy = 14;
+  string executor_id = 15;
 }
 
 message ListReconcileJobsRequest {
@@ -142,4 +247,17 @@ service ReconcileControl {
   rpc GetReconcilerSettings(GetReconcilerSettingsRequest) returns (GetReconcilerSettingsResponse);
   rpc UpdateReconcilerSettings(UpdateReconcilerSettingsRequest)
       returns (UpdateReconcilerSettingsResponse);
+}
+
+service ReconcileExecutorControl {
+  rpc LeaseReconcileJob(LeaseReconcileJobRequest) returns (LeaseReconcileJobResponse);
+  rpc RenewReconcileLease(RenewReconcileLeaseRequest) returns (RenewReconcileLeaseResponse);
+  rpc StartLeasedReconcileJob(StartLeasedReconcileJobRequest)
+      returns (StartLeasedReconcileJobResponse);
+  rpc ReportReconcileProgress(ReportReconcileProgressRequest)
+      returns (ReportReconcileProgressResponse);
+  rpc CompleteLeasedReconcileJob(CompleteLeasedReconcileJobRequest)
+      returns (CompleteLeasedReconcileJobResponse);
+  rpc GetReconcileCancellation(GetReconcileCancellationRequest)
+      returns (GetReconcileCancellationResponse);
 }

--- a/core/proto/src/main/proto/floecat/reconciler/reconciler.proto
+++ b/core/proto/src/main/proto/floecat/reconciler/reconciler.proto
@@ -45,6 +45,19 @@ enum ExecutionClass {
   EC_HEAVY = 4;
 }
 
+enum ReconcileJobKind {
+  RJK_UNSPECIFIED = 0;
+  RJK_EXEC_CONNECTOR = 1;
+  RJK_PLAN_CONNECTOR = 2;
+  RJK_EXEC_TABLE = 3;
+}
+
+message ReconcileTableTask {
+  string source_namespace = 1;
+  string source_table = 2;
+  string destination_table_display_name = 3;
+}
+
 message ExecutionPolicy {
   ExecutionClass execution_class = 1;
   string lane = 2;
@@ -84,12 +97,16 @@ message LeasedReconcileJob {
   ExecutionPolicy execution_policy = 7;
   string pinned_executor_id = 8;
   string executor_id = 9;
+  ReconcileJobKind kind = 10;
+  ReconcileTableTask table_task = 11;
+  string parent_job_id = 12;
 }
 
 message LeaseReconcileJobRequest {
   string executor_id = 1;
   repeated ExecutionClass execution_classes = 2;
   repeated string lanes = 3;
+  repeated ReconcileJobKind job_kinds = 4;
 }
 
 message LeaseReconcileJobResponse {
@@ -182,6 +199,9 @@ message GetReconcileJobResponse {
   uint64 duration_ms = 13;
   ExecutionPolicy execution_policy = 14;
   string executor_id = 15;
+  ReconcileJobKind kind = 16;
+  string parent_job_id = 17;
+  ReconcileTableTask table_task = 18;
 }
 
 message ListReconcileJobsRequest {

--- a/core/proto/src/main/proto/floecat/transaction/transaction.proto
+++ b/core/proto/src/main/proto/floecat/transaction/transaction.proto
@@ -116,6 +116,7 @@ message TransactionIntent {
   string blob_uri = 4;
   optional int64 expected_version = 5;
   google.protobuf.Timestamp created_at = 6;
+  optional string expected_owned_name_pointer_key = 7;
   optional string apply_error_code = 20;
   optional string apply_error_message = 21;
   optional int64 apply_error_expected_version = 22;

--- a/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/NameRefNormalizer.java
+++ b/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/NameRefNormalizer.java
@@ -32,16 +32,31 @@ public final class NameRefNormalizer {
     if (ref.hasResourceId()) {
       builder.setResourceId(ref.getResourceId());
     }
-    String catalog = normalizeSegment(ref.getCatalog());
+    String catalog = normalizeDisplayName(ref.getCatalog());
     if (!catalog.isBlank()) {
       builder.setCatalog(catalog);
     }
     builder.addAllPath(normalizePath(ref.getPathList()));
-    String name = normalizeSegment(ref.getName());
+    String name = normalizeDisplayName(ref.getName());
     if (!name.isBlank()) {
       builder.setName(name);
     }
     return builder.build();
+  }
+
+  public static String normalizeDisplayName(String input) {
+    if (input == null) {
+      return "";
+    }
+    String normalized = Normalizer.normalize(input.strip(), Normalizer.Form.NFKC);
+    return normalized.replaceAll("\\s+", " ");
+  }
+
+  public static List<String> normalizeNamespacePath(String namespaceFq) {
+    if (namespaceFq == null || namespaceFq.isBlank()) {
+      return List.of();
+    }
+    return normalizePath(List.of(namespaceFq.split("\\.")));
   }
 
   private static List<String> normalizePath(List<String> segments) {
@@ -53,19 +68,11 @@ public final class NameRefNormalizer {
       if (segment == null) {
         continue;
       }
-      String value = normalizeSegment(segment);
+      String value = normalizeDisplayName(segment);
       if (!value.isBlank()) {
         normalized.add(value);
       }
     }
     return normalized;
-  }
-
-  private static String normalizeSegment(String input) {
-    if (input == null) {
-      return "";
-    }
-    String normalized = Normalizer.normalize(input.trim(), Normalizer.Form.NFKC);
-    return normalized.replaceAll("\\s+", " ");
   }
 }

--- a/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcilerBackend.java
+++ b/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcilerBackend.java
@@ -78,13 +78,21 @@ public interface ReconcilerBackend {
   /**
    * Creates a view with the given spec if it does not already exist. The idempotency key is used
    * for deduplication across reconciler runs: if a prior call succeeded with the same key, the
-   * existing view is returned without modification. Returns the resource ID of the newly-created
-   * view, or {@link ResourceId#getDefaultInstance()} if the view already exists (idempotent match
-   * or name conflict).
+   * existing view is returned without modification.
    *
    * <p>Note: existing views are <em>not</em> updated on re-sync; this is a create-only operation.
    */
-  ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey);
+  default ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+    return ensureViewDetailed(ctx, spec, idempotencyKey).resourceId();
+  }
+
+  EnsureViewResult ensureViewDetailed(ReconcileContext ctx, ViewSpec spec, String idempotencyKey);
+
+  record EnsureViewResult(ResourceId resourceId, boolean created) {
+    public EnsureViewResult {
+      resourceId = resourceId == null ? ResourceId.getDefaultInstance() : resourceId;
+    }
+  }
 
   record TableSpecDescriptor(
       String namespaceFq,

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/Keys.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/Keys.java
@@ -53,6 +53,21 @@ public final class Keys {
     return new KvStore.Key(partitionKey, sortKey);
   }
 
+  public static String accountRootPrefix(String accountId) {
+    String aid = req("account_id", accountId);
+    return String.format("/accounts/%s/", encodeSegment(aid));
+  }
+
+  public static String transactionDeleteSentinelUri(
+      String accountId, String txId, String targetPointerKey) {
+    String aid = req("account_id", accountId);
+    String xid = req("tx_id", txId);
+    String key = req("target_pointer_key", targetPointerKey);
+    return String.format(
+        "/accounts/%s/transactions/%s/delete/%s",
+        encodeSegment(aid), encodeSegment(xid), encodeSegment(key));
+  }
+
   public static String snapshotPointerById(String accountId, String tableId, long snapshotId) {
     String aid = req("account_id", accountId);
     String tid = req("table_id", tableId);

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KeysTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KeysTest.java
@@ -80,4 +80,12 @@ public class KeysTest {
         "/accounts/acct%20id/tx-outbox/dead-letter/0000000000000000123/table%20id/tx%20id",
         Keys.tableCommitOutboxDeadLetterPointer(123L, "acct id", "table id", "tx id"));
   }
+
+  @Test
+  void transactionDeleteSentinelUriUsesPathSafeEncoding() {
+    assertEquals(
+        "/accounts/acct%20id/transactions/tx%20id/delete/%2Faccounts%2Facct%2520id%2Ftables%2Ftable%2520id%2Fsnapshots%2Fby-id%2F0000000000000000007",
+        Keys.transactionDeleteSentinelUri(
+            "acct id", "tx id", Keys.snapshotPointerById("acct id", "table id", 7L)));
+  }
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,9 +21,35 @@ services:
     ports:
       - "${FLOECAT_SERVICE_PORT:-9100}:9100"
     environment:
+      QUARKUS_PROFILE: ${QUARKUS_PROFILE_SERVICE:-}
       FLOECAT_HTTP_HOST: "0.0.0.0"
       FLOECAT_HTTP_PORT: "9100"
       JAVA_TOOL_OPTIONS: "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
+    networks:
+      - floecat
+    volumes:
+      - ${HOME}/.aws:/root/.aws:ro
+      - ${HOME}/.aws:/home/jboss/.aws:ro
+
+  executor:
+    image: ${FLOECAT_SERVICE_IMAGE:-floecat-service:local}
+    pull_policy: ${FLOECAT_PULL_POLICY:-never}
+    env_file:
+      - ${FLOECAT_ENV_FILE:-./env.localstack}
+    environment:
+      QUARKUS_PROFILE: ${QUARKUS_PROFILE_EXECUTOR:-reconciler-executor}
+      FLOECAT_GRPC_HOST: "service"
+      FLOECAT_GRPC_PORT: "9100"
+      FLOECAT_RECONCILER_SCHEDULER_ENABLED: "false"
+      FLOECAT_RECONCILER_REMOTE_EXECUTOR_ENABLED: "true"
+      FLOECAT_RECONCILER_DEFAULT_EXECUTOR_ENABLED: "true"
+      FLOECAT_RECONCILER_BACKEND: "remote"
+      FLOECAT_RECONCILER_AUTO_ENABLED: "false"
+      JAVA_TOOL_OPTIONS: "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
+    depends_on:
+      - service
+    profiles:
+      - reconciler-executor
     networks:
       - floecat
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     ports:
       - "${FLOECAT_SERVICE_PORT:-9100}:9100"
     environment:
-      QUARKUS_PROFILE: ${QUARKUS_PROFILE_SERVICE:-dev}
       FLOECAT_HTTP_HOST: "0.0.0.0"
       FLOECAT_HTTP_PORT: "9100"
       JAVA_TOOL_OPTIONS: "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -179,6 +179,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: POLARIS
       POSTGRES_INITDB_ARGS: "--encoding UTF8 --data-checksums"
+    tmpfs:
+      - /var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -250,6 +252,8 @@ services:
     pull_policy: if_not_present
     ports:
       - "${FLOECAT_UNITY_HOST_PORT:-8083}:8080"
+    tmpfs:
+      - /home/unitycatalog/etc/logs
     profiles:
       - unity
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "${FLOECAT_SERVICE_PORT:-9100}:9100"
     environment:
-      QUARKUS_PROFILE: ${QUARKUS_PROFILE_SERVICE:-}
+      QUARKUS_PROFILE: ${QUARKUS_PROFILE_SERVICE:-dev}
       FLOECAT_HTTP_HOST: "0.0.0.0"
       FLOECAT_HTTP_PORT: "9100"
       JAVA_TOOL_OPTIONS: "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"

--- a/docs/connectors-spi.md
+++ b/docs/connectors-spi.md
@@ -15,6 +15,8 @@ Unity Catalog, etc.), translating its schemas, snapshots, and metrics into Floec
   - `format()` → `ConnectorFormat` (ICEBERG, DELTA, etc.).
   - `listNamespaces()`.
   - `listTables(namespaceFq)`.
+  - `planTableTasks(...)` → connector-owned planning hook that emits table-scoped reconcile work.
+    Connectors are responsible for upstream table discovery and scope application during planning.
   - `describe(namespaceFq, tableName)` → `TableDescriptor` with location, schema JSON, partition
     keys, and properties.
   - `enumerateSnapshotsWithStats(...)` → `SnapshotBundle`s containing per-snapshot table/column/file stats.
@@ -98,6 +100,7 @@ interface FloecatConnector extends Closeable {
   ConnectorFormat format();
   List<String> listNamespaces();
   List<String> listTables(String namespaceFq);
+  List<PlannedTableTask> planTableTasks(TablePlanningRequest request);
   TableDescriptor describe(String namespaceFq, String tableName);
   List<SnapshotBundle> enumerateSnapshotsWithStats(...);
 }
@@ -139,14 +142,15 @@ maps so downstream APIs can mirror Iceberg’s REST contract.
 ```
 ConnectorFactory.create(ConnectorConfig)
   → FloecatConnector (opens upstream clients, auth providers)
-      → listNamespaces/listTables → service repo ensures namespace/table existence
+      → planTableTasks/listTables → reconciler derives executable table tasks
       → describe → Table specs persisted with upstream references
       → enumerateSnapshotsWithStats → StatsRepository writes Table/Column/File stats per snapshot
   ← close() cleans up HTTP/S3/DB connections
 ```
 `ConnectorFactory.create` is invoked both in `ConnectorsImpl.validate` (short-lived) and in the
 reconciler (long-running); connectors must tolerate repeated instantiation and release resources in
-`close()`.
+`close()`. Planning is now part of the connector contract rather than reconciler-owned fallback
+logic.
 
 ## Configuration & Extensibility
 - To add a new connector type, implement `FloecatConnector` plus a factory and annotate it so CDI can
@@ -160,8 +164,9 @@ reconciler (long-running); connectors must tolerate repeated instantiation and r
   from RPC input, invokes `ConnectorFactory.create`, calls `listNamespaces()` to ensure the upstream
   responds, then closes the connector.
 - **Reconciliation run** – `ReconcilerService` constructs a connector inside a try-with-resources
-  block, iterates `listTables`, calls `enumerateSnapshotsWithStats`, and writes the returned
-  `SnapshotBundle`s (table stats + column stats) through the service’s gRPC API.
+  block, asks the connector to plan table tasks, then executes each task by calling
+  `describe` and `enumerateSnapshotsWithStats`, writing the returned `SnapshotBundle`s (table
+  stats + column stats) through the service’s gRPC API.
 - **Query lifecycle** – `QueryService.FetchScanBundle` fetch file lists pinned to the requested snapshot
 directly from table and file statistics stored in the catalog (via TableStatisticsService).
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -91,7 +91,8 @@ Notes:
   `QUARKUS_PROFILE_SERVICE=reconciler-control`. The compose file pins `executor` to
   `QUARKUS_PROFILE_EXECUTOR=reconciler-executor` by default. That keeps the public APIs,
   durable queue ownership, and automatic scheduling on the `service` container while disabling
-  local execution there.
+  local table execution there. In this default split profile the planner remains on the control
+  plane, and remote executor replicas lease only executable table work.
 - `executor` uses the same image but sets:
   `FLOECAT_RECONCILER_SCHEDULER_ENABLED=false`,
   `FLOECAT_RECONCILER_REMOTE_EXECUTOR_ENABLED=true`,

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -63,6 +63,54 @@ make compose-up COMPOSE_ENV_FILE=./env.localstack-oidc COMPOSE_PROFILES=localsta
 make compose-down COMPOSE_ENV_FILE=./env.localstack-oidc COMPOSE_PROFILES=localstack-oidc
 ```
 
+### Split reconciler mode
+
+The same service image can now run as a control-plane node or as a remote executor node.
+
+Run a control plane plus one executor node:
+
+```bash
+QUARKUS_PROFILE_SERVICE=reconciler-control \
+FLOECAT_ENV_FILE=./env.localstack \
+COMPOSE_PROFILES=localstack,reconciler-executor \
+docker compose -f docker/docker-compose.yml up -d
+```
+
+Run a control plane plus three executor nodes:
+
+```bash
+QUARKUS_PROFILE_SERVICE=reconciler-control \
+FLOECAT_ENV_FILE=./env.localstack \
+COMPOSE_PROFILES=localstack,reconciler-executor \
+docker compose -f docker/docker-compose.yml up -d --scale executor=3
+```
+
+Notes:
+
+- For a true split deployment, run `service` as the control plane by setting
+  `QUARKUS_PROFILE_SERVICE=reconciler-control`. The compose file pins `executor` to
+  `QUARKUS_PROFILE_EXECUTOR=reconciler-executor` by default. That keeps the public APIs,
+  durable queue ownership, and automatic scheduling on the `service` container while disabling
+  local execution there.
+- `executor` uses the same image but sets:
+  `FLOECAT_RECONCILER_SCHEDULER_ENABLED=false`,
+  `FLOECAT_RECONCILER_REMOTE_EXECUTOR_ENABLED=true`,
+  `FLOECAT_RECONCILER_DEFAULT_EXECUTOR_ENABLED=true`,
+  `FLOECAT_RECONCILER_BACKEND=remote`,
+  and `FLOECAT_RECONCILER_AUTO_ENABLED=false`.
+- `docker compose --scale executor=3` starts three identical executor replicas. Each replica
+  connects to `service:9100`, leases work independently, and heartbeats/completes jobs through
+  the control-plane RPCs. No executor leader election is required.
+- Both services must share the same blob/kv backend configuration.
+- If your control plane requires an authorization token for remote reconciler calls, set `FLOECAT_RECONCILER_AUTHORIZATION_TOKEN` in the env file or shell before `docker compose up`.
+
+In Kubernetes or another orchestrator, the equivalent shape is:
+
+- 1 `service` replica with `QUARKUS_PROFILE=reconciler-control`
+- 3 executor replicas with `QUARKUS_PROFILE=reconciler-executor`
+- Shared durable blob/kv configuration for all 4 pods
+- Executor gRPC client target pointed at the control-plane service DNS name and port
+
 Interactive CLI in a container:
 
 ```bash
@@ -125,6 +173,11 @@ Common configuration knobs:
   plus `FLOECAT_GATEWAY_STORAGE_CREDENTIAL_PROPERTIES_S3_ENDPOINT` and
   `FLOECAT_GATEWAY_STORAGE_CREDENTIAL_PROPERTIES_S3_PATH_STYLE_ACCESS` for non-default endpoints.
 - **Seed/fixtures**: `FLOECAT_SEED_ENABLED`, `FLOECAT_SEED_MODE`, `FLOECAT_FIXTURES_USE_AWS_S3`.
+- **Reconciler split deployment**:
+  `FLOECAT_RECONCILER_SCHEDULER_ENABLED`, `FLOECAT_RECONCILER_REMOTE_EXECUTOR_ENABLED`,
+  `FLOECAT_RECONCILER_DEFAULT_EXECUTOR_ENABLED`, `FLOECAT_RECONCILER_BACKEND`,
+  `FLOECAT_RECONCILER_AUTHORIZATION_HEADER`, `FLOECAT_RECONCILER_AUTHORIZATION_TOKEN`,
+  `QUARKUS_PROFILE_SERVICE`, `QUARKUS_PROFILE_EXECUTOR`.
 
 Where variables are consumed (all `FLOECAT_*`):
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -55,6 +55,33 @@ Flags:
 
 ## Observability & Operations
 
+### Reconciler deployment modes
+
+The reconciler can now run in three shapes from the same artifact:
+
+- **All-in-one**: default profile; public APIs, durable queue ownership, and local executor polling stay in one runtime.
+- **Control plane**: `QUARKUS_PROFILE=reconciler-control`; owns the queue, automatic enqueue, public reconcile APIs, and executor-control RPCs.
+- **Executor plane**: `QUARKUS_PROFILE=reconciler-executor`; disables local queue ownership and automatic scheduling, then leases work remotely from the control plane over gRPC.
+
+Key reconciler mode flags live in `service/src/main/resources/application.properties`:
+
+```properties
+floecat.reconciler.scheduler.enabled
+floecat.reconciler.remote-executor.enabled
+floecat.reconciler.executor.default.enabled
+floecat.reconciler.backend
+floecat.reconciler.authorization.header
+floecat.reconciler.authorization.token
+```
+
+Recommended split deployment:
+
+- Control plane: `QUARKUS_PROFILE=reconciler-control`
+- Executor plane: `QUARKUS_PROFILE=reconciler-executor`
+- Shared settings: same blob/kv backend, same reconcile auth token, executor nodes pointed at the control-plane gRPC host/port
+
+To scale executors horizontally, add more executor-plane instances. They greedily lease eligible jobs from the shared durable queue, so no leader election is required at the executor layer.
+
 - **Logging** – JSON console logs plus rotating files under `log/`. Audit logs route gRPC request
   summaries to `log/audit.json`; see [`docs/log.md`](log.md).
 - **Metrics** – Micrometer/Prometheus exporters expose gRPC, storage, and GC metrics at the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -69,6 +69,10 @@ Key reconciler mode flags live in `service/src/main/resources/application.proper
 floecat.reconciler.scheduler.enabled
 floecat.reconciler.remote-executor.enabled
 floecat.reconciler.executor.default.enabled
+floecat.reconciler.executor.planner.enabled
+floecat.reconciler.auto.execution-class
+floecat.reconciler.auto.execution-lane
+floecat.reconciler.auto.pinned-executor-id
 floecat.reconciler.backend
 floecat.reconciler.authorization.header
 floecat.reconciler.authorization.token

--- a/docs/reconciler.md
+++ b/docs/reconciler.md
@@ -3,50 +3,67 @@
 ## Overview
 The `reconciler/` module automates ingestion from upstream connectors. It manages a queue of
 reconciliation jobs, leases work to workers, instantiates connectors via the SPI, and calls the
-service’s gRPC APIs to create tables, snapshots, statistics, and scan bundles.
+service's gRPC APIs to create tables, snapshots, statistics, and scan bundles.
 
 This component decouples connector execution from the main service so that long-running scans do not
 block gRPC threads. The service submits capture jobs via `ReconcileControl.StartCapture`, which
-creates jobs in the reconciler’s store.
+creates jobs in the reconciler's store.
 
 ## Architecture & Responsibilities
-- **`ReconcileJobStore`** – Interface abstracting job persistence and leasing. In service runtime,
+- **`ReconcileJobStore`** - Interface abstracting job persistence and leasing. In service runtime,
   the default is the durable implementation (`DurableReconcileJobStore`) selected by
   `floecat.reconciler.job-store=durable`; in-memory (`InMemoryReconcileJobStore`) remains available
   for lightweight/local usage when `floecat.reconciler.job-store=memory`.
-- **`ReconcilerScheduler`** – Quarkus scheduled bean that polls the job store, leases a job,
-  transitions it to running, invokes `ReconcilerService` in phases, and records success/failure stats.
-- **`ReconcilerService`** – Core orchestration:
-  1. Resolves connector metadata via the service’s `Connectors` RPC.
+- **Control plane** - `ReconcileControlImpl` enqueues/inspects/cancels jobs and
+  `ReconcileExecutorControlImpl` exposes lease/heartbeat/progress/completion RPCs to executor nodes.
+- **`ConnectorPlanningReconcileExecutor`** - Planner executor that expands connector-scoped plan
+  jobs into concrete table execution jobs.
+- **`ReconcilerScheduler`** - Local in-process executor poller used for all-in-one deployments.
+  It leases from the local job store, transitions jobs to running, invokes a `ReconcileExecutor`,
+  and records success/failure stats.
+- **`RemoteReconcileExecutorPoller`** - Remote executor-node poller that leases jobs over gRPC from
+  the control plane and executes them locally via the same `ReconcileExecutor` SPI.
+- **`ReconcileExecutor`** - Execution SPI. `DefaultReconcileExecutor` handles table execution jobs,
+  while the planner executor handles connector planning jobs.
+- **`ReconcilerService`** - Core orchestration:
+  1. Resolves connector metadata via the service's `Connectors` RPC.
   2. Ensures destination catalogs/namespaces/tables exist (creating them if needed).
   3. Instantiates the connector via `ConnectorFactory`.
-  4. Iterates upstream tables, ingests snapshots + stats, and updates connectors with resolved
-     destination IDs.
+  4. Delegates planning to the connector SPI or ingests one table task during execution.
   5. Handles incremental vs full-rescan logic.
   6. Supports explicit capture modes:
      - `METADATA_ONLY`: advances/creates table + snapshot state without writing stats.
      - `STATS_ONLY`: writes stats only.
      - `METADATA_AND_STATS`: ingests both metadata and stats in one pass.
-- **`GrpcClients`** – Provides blocking stubs for all service RPCs (Catalog, Namespace, Table,
+- **`GrpcClients`** - Provides blocking stubs for all service RPCs (Catalog, Namespace, Table,
   Snapshot, Statistics, Directory, Connectors).
-- **`NameParts`** – Utility for parsing namespace/table names.
+- **`NameRefNormalizer`** - Shared utility for canonical catalog/name/display-name normalization
+  used by both reconciler and service-side backends.
 
 ## Public API / Surface Area
-While the reconciler itself runs as an internal Quarkus app, it exposes behaviour through the
-reconcile control RPCs:
-- `ReconcileControl.StartCapture(connector_id, full_rescan)` – Enqueues a job via `ReconcileJobStore`.
-- `ReconcileControl.GetReconcileJob(job_id)` – Reads job status, mirroring the store’s fields
-  (`state`, `message`, `tables_scanned`, `tables_changed`, `errors`).
+User-facing behaviour continues to flow through the reconcile control RPCs:
+- `ReconcileControl.StartCapture(connector_id, full_rescan)` - Enqueues a connector planning job and
+  returns that top-level reconcile handle.
+- `ReconcileControl.GetReconcileJob(job_id)` - For ordinary jobs, reads the stored job record. For a
+  `PLAN_CONNECTOR` job, it aggregates child `EXEC_TABLE` jobs so the returned status/progress reflects
+  the overall reconcile run rather than only the planning phase.
+- `ReconcileControl.CancelReconcileJob(job_id)` - Cancels the addressed job. For a `PLAN_CONNECTOR`
+  job, cancellation cascades to child `EXEC_TABLE` jobs that have already been enqueued.
 
-Internally, the scheduler exposes `pollEvery` via `@Scheduled` (default every second).
+Executor-facing behaviour is now a separate internal RPC surface:
+- `ReconcileExecutorControl.LeaseReconcileJob` - Leases one eligible job for an executor id.
+- `ReconcileExecutorControl.RenewReconcileLease` - Heartbeats a leased job and returns cancellation state.
+- `ReconcileExecutorControl.ReportReconcileProgress` - Reports progress and doubles as a heartbeat.
+- `ReconcileExecutorControl.CompleteLeasedReconcileJob` - Writes a terminal job state.
+- `ReconcileExecutorControl.GetReconcileCancellation` - Allows executor-side cancellation polling.
 
 ## Important Internal Details
-- **Destination binding** – When reconciling, the service ensures the connector’s declared
+- **Destination binding** - When reconciling, the service ensures the connector's declared
   destination catalog/namespace/table IDs align with actual resources. Any mismatch triggers a
   `ConnectorState` update or raises conflicts.
-- **Statistics ingestion** – Table stats plus column/file stats are streamed one request per item via
+- **Statistics ingestion** - Table stats plus column/file stats are streamed one request per item via
   `PutColumnStats` / `PutFileColumnStats`, keeping a single idempotency key per table/snapshot.
-- **Snapshot constraints ingestion** – Reconciler ingests snapshot constraints through
+- **Snapshot constraints ingestion** - Reconciler ingests snapshot constraints through
   `PutTableConstraints` after snapshot/stats handling.
   - Behavior is intentionally strict (not best-effort): constraint extraction/write failures fail
     the current table reconcile, including when table stats were already captured.
@@ -55,50 +72,94 @@ Internally, the scheduler exposes `pollEvery` via `@Scheduled` (default every se
     tracking is introduced here).
   - Idempotency keys are derived from `SnapshotConstraints.toByteArray()` (byte-level,
     order-sensitive payload hashing), not semantic normalization.
-- **Mode-aware behavior** – In `STATS_ONLY`, destination-table misses are treated as skip/no-op
+- **Mode-aware behavior** - In `STATS_ONLY`, destination-table misses are treated as skip/no-op
   rather than job-fatal errors.
-- **Error handling** – Exceptions inside the per-table loop are caught, logged, and recorded in the
+- **Error handling** - Exceptions inside the per-table loop are caught, logged, and recorded in the
   job summary (`errors++`). The job proceeds to the next table, incrementing `scanned` regardless of
   success.
-- **Job leasing** – `DurableReconcileJobStore` leases from persisted ready pointers, marks jobs
+- **Job kinds** - The queue now stores explicit work types:
+  - `PLAN_CONNECTOR` discovers concrete work for one connector reconcile.
+  - `EXEC_TABLE` executes one table-scoped reconcile task.
+  - `EXEC_CONNECTOR` remains available for broad connector execution and compatibility paths.
+- **Job leasing** - `DurableReconcileJobStore` leases from persisted ready pointers, marks jobs
   running/succeeded/failed through CAS updates, and reclaims expired leases on a best-effort interval.
   Failed jobs are retried with backoff up to configured attempt limits before terminal failure.
-- **Durable pointer model** – Durable reconcile queue pointers (`/reconcile/jobs/by-id`,
+- **Durable pointer model** - Durable reconcile queue pointers (`/reconcile/jobs/by-id`,
   `/accounts/by-id/reconcile/jobs/by-id`, `/accounts/by-id/reconcile/jobs/ready`, and
   `/reconcile/dedupe`) are blob-backed and store the current reconcile job JSON blob URI. When a
   job state transition writes a new canonical blob version, the store CAS-updates lookup/ready/dedupe
-  pointers to the same blob URI.
-- **GC ownership** – `ReconcileJobGc` remains responsible for reconcile lifecycle cleanup (terminal-state
+  pointers to the same blob URI. Readers are expected to resolve the current blob through those
+  pointers rather than caching blob URIs directly; old blobs may be deleted once the pointer set has
+  been moved forward.
+- **GC ownership** - `ReconcileJobGc` remains responsible for reconcile lifecycle cleanup (terminal-state
   queue/dedupe cleanup and retention-based deletion of old durable job records). `PointerGc` handles
   structural orphan cleanup, but it does not enforce reconcile retention/state policy.
 
-### Backend selection
+### Backend selection and deployment modes
 - `floecat.reconciler.backend` (default `local`) selects which backend implementation `ReconcilerService`
   uses. Set it to `remote` when the reconciler runs as a separate process and must talk to the service
   over gRPC. In remote mode the reconciler uses `floecat.reconciler.authorization.header`/`token` to send
   an authorization header on every call. Per-request tokens supplied via `ReconcileContext` override the
-  static token, so the precedence is: request-scoped token → configured token → no header.
+  static token, so the precedence is: request-scoped token -> configured token -> no header.
+- `QUARKUS_PROFILE=reconciler-control` turns the runtime into a control-plane node:
+  queue ownership, public reconcile APIs, local planner, planner executor enabled, no executor polling.
+- `QUARKUS_PROFILE=reconciler-executor` turns the runtime into a remote executor node:
+  no local queue polling, no planner auto-enqueue, no planner executor, `ReconcilerService` talks to the
+  control plane over gRPC, and the node greedily leases eligible work through `ReconcileExecutorControl`.
+- Without one of those profiles, the default runtime remains all-in-one for local/dev use.
 
 ## Data Flow & Lifecycle
+```text
+Connector StartCapture / auto planner tick -> ReconcileJobStore.enqueuePlan
+  -> control plane persists PLAN_CONNECTOR job + routing policy
+  -> planner-capable executor leases plan work
+      -> local mode: ReconcilerScheduler -> jobs.leaseNext(...)
+      -> remote mode: RemoteReconcileExecutorPoller -> ReconcileExecutorControl.LeaseReconcileJob(...)
+  -> ConnectorPlanningReconcileExecutor.execute(...)
+      -> ReconcilerService.planTableTasks(...)
+      -> ReconcileJobStore.enqueueTableExecution(...) for each discovered table
+  -> executor plane leases EXEC_TABLE work
+  -> ReconcileExecutor.execute(...)
+      -> DefaultReconcileExecutor -> ReconcilerService.reconcile(..., tableTask, ...)
+          -> Connectors.GetConnector -> ConnectorConfig
+          -> Ensure destination catalog/namespace/table
+          -> ConnectorFactory.create + try-with-resources
+              -> describe / enumerateSnapshotsWithStats
+              -> ingest snapshots/stats via service RPCs
+          -> Update connector destination IDs if missing
+  -> executor plane heartbeats + reports progress
+  -> control plane writes success/failure/cancelled terminal state
 ```
-Connector StartCapture → ReconcileJobStore.enqueue
-  → ReconcilerScheduler.pollOnce
-      → jobs.leaseNext (returns account + connector IDs)
-      → markRunning
-      → ReconcilerService.reconcile (capture mode on leased job)
-          → Connectors.GetConnector → ConnectorConfig
-          → Ensure destination catalog/namespace/table
-          → ConnectorFactory.create + try-with-resources
-              → listTables / describe / enumerateSnapshotsWithStats
-              → ingest snapshots/stats via service RPCs
-          → Update connector destination IDs if missing
-      → markSucceeded or markFailed
-```
-Jobs include `fullRescan` and track `tablesScanned`, `tablesChanged`, `errors`. `ReconcilerScheduler`
-uses an `AtomicBoolean` guard to prevent concurrent runs within the same instance.
+
+Jobs include `fullRescan` and track `tablesScanned`, `tablesChanged`, `errors`. Planning jobs fan
+out table tasks, but the public `StartCapture` / `GetReconcileJob` / `CancelReconcileJob` contract
+still treats the `PLAN_CONNECTOR` job id as the top-level reconcile handle by aggregating or
+cascading over child jobs in the service layer. `ReconcilerScheduler` uses an `AtomicBoolean`
+guard to prevent concurrent runs within the same instance.
+
+Planning ownership is connector-first: the planner executor calls `FloecatConnector.planTableTasks`
+to discover executable table work. Connectors own upstream table discovery and scope application;
+the reconciler no longer contains fallback planning logic for expanding namespaces into table tasks.
+
+Planner routing is intentionally different from table-execution routing: `PLAN_CONNECTOR` jobs run
+wherever a planner executor is present, regardless of execution lane, while the child `EXEC_TABLE`
+jobs carry the actual execution policy (execution class, lane, optional pinned executor id) that
+local or remote workers enforce later.
+
+Local scheduling also resolves work per executor capability tuple, not by unioning all local
+executor capabilities together. Each executor advertises its own execution classes, lanes, executor
+id, and job kinds, and the scheduler leases against that exact capability set before dispatch.
 
 ## Configuration & Extensibility
 - Scheduling cadence via `reconciler.pollEvery` (defaults to `1s`).
+- Execution routing:
+  - `floecat.reconciler.scheduler.enabled`
+  - `floecat.reconciler.remote-executor.enabled`
+  - `floecat.reconciler.executor.planner.enabled`
+  - `floecat.reconciler.executor.default.enabled`
+  - `floecat.reconciler.auto.execution-class`
+  - `floecat.reconciler.auto.execution-lane`
+  - `floecat.reconciler.auto.pinned-executor-id`
 - Job store selection:
   - `floecat.reconciler.job-store=durable` (service default) uses persisted queue records plus
     retry/lease tuning via:
@@ -113,12 +174,11 @@ uses an `AtomicBoolean` guard to prevent concurrent runs within the same instanc
   scheduler.
 
 ## Examples & Scenarios
-- **Full rescan** – Operator triggers `connector trigger demo-glue --full`. The job store enqueues a
-  full scan, scheduler leases it, and runs the requested capture mode across the full upstream
-  history. The job transitions to `JS_SUCCEEDED` once the pass completes.
-- **Incremental run** – Without `--full`, `ReconcilerService` restricts its work to the connector’s
-  configured `source.table` (if set) and only ingests new snapshots (parents already known via
-  `SnapshotRepository`).
+- **Full rescan** - Operator triggers `connector trigger demo-glue --full`. The job store enqueues a
+  connector planning job, the planner emits one table execution job per eligible table, and
+  executors run those table jobs across the full upstream history.
+- **Incremental run** - Without `--full`, planning still discovers eligible tables for the connector's
+  configured source namespace, and each table execution job ingests only new snapshots.
 
 ## Cross-References
 - Connector SPI details: [`docs/connectors-spi.md`](connectors-spi.md)

--- a/protocol-gateway/iceberg-rest/src/it/java/ai/floedb/floecat/gateway/iceberg/rest/IcebergRestFixtureIT.java
+++ b/protocol-gateway/iceberg-rest/src/it/java/ai/floedb/floecat/gateway/iceberg/rest/IcebergRestFixtureIT.java
@@ -1854,7 +1854,7 @@ class IcebergRestFixtureIT {
       ListColumnStatsResponse columnStats =
           awaitColumnStats(tableId, current, Duration.ofSeconds(30));
       Assertions.assertFalse(
-          columnStats.getColumnsList().isEmpty(), "Column NDV statistics must be available");
+          columnStats.getColumnsList().isEmpty(), "Column statistics must be available");
       columnStats
           .getColumnsList()
           .forEach(
@@ -1864,36 +1864,38 @@ class IcebergRestFixtureIT {
                 Assertions.assertFalse(
                     col.getLogicalType().isBlank(),
                     () -> "Logical type should be populated for " + col.getColumnName());
-                Assertions.assertTrue(
-                    col.hasNdv(), "NDV must be present for " + col.getColumnName());
-                Assertions.assertTrue(
-                    col.getNdv().hasApprox() || col.getNdv().hasExact(),
-                    () -> "NDV should contain exact or approx estimate for " + col.getColumnName());
-                if (col.getNdv().hasApprox()) {
-                  var approx = col.getNdv().getApprox();
+                if (col.hasNdv()) {
                   Assertions.assertTrue(
-                      approx.getEstimate() > 0.0d,
-                      () -> "Approximate NDV must be positive for " + col.getColumnName());
-                  Assertions.assertTrue(
-                      approx.getRowsSeen() > 0,
-                      () -> "rows-seen must be positive for " + col.getColumnName());
-                  Assertions.assertTrue(
-                      approx.getRowsTotal() >= approx.getRowsSeen(),
-                      () -> "rows-total must be >= rows-seen for " + col.getColumnName());
+                      col.getNdv().hasApprox() || col.getNdv().hasExact(),
+                      () -> "NDV should contain exact or approx estimate for " + col.getColumnName());
+                  if (col.getNdv().hasApprox()) {
+                    var approx = col.getNdv().getApprox();
+                    Assertions.assertTrue(
+                        approx.getEstimate() > 0.0d,
+                        () -> "Approximate NDV must be positive for " + col.getColumnName());
+                    Assertions.assertTrue(
+                        approx.getRowsSeen() > 0,
+                        () -> "rows-seen must be positive for " + col.getColumnName());
+                    Assertions.assertTrue(
+                        approx.getRowsTotal() >= approx.getRowsSeen(),
+                        () -> "rows-total must be >= rows-seen for " + col.getColumnName());
+                    Assertions.assertFalse(
+                        approx.getMethod().isBlank(),
+                        () -> "NDV method must be set for " + col.getColumnName());
+                  }
                   Assertions.assertFalse(
-                      approx.getMethod().isBlank(),
-                      () -> "NDV method must be set for " + col.getColumnName());
+                      col.getNdv().getSketchesList().isEmpty(),
+                      () -> "Sketch metadata must be present for " + col.getColumnName());
+                  col.getNdv()
+                      .getSketchesList()
+                      .forEach(
+                          sketch ->
+                              Assertions.assertFalse(
+                                  sketch.getType().isBlank(),
+                                  () ->
+                                      "Sketch type must be set for column "
+                                          + col.getColumnName()));
                 }
-                Assertions.assertFalse(
-                    col.getNdv().getSketchesList().isEmpty(),
-                    () -> "Sketch metadata must be present for " + col.getColumnName());
-                col.getNdv()
-                    .getSketchesList()
-                    .forEach(
-                        sketch ->
-                            Assertions.assertFalse(
-                                sketch.getType().isBlank(),
-                                () -> "Sketch type must be set for column " + col.getColumnName()));
               });
     }
   }

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/api/request/MetricsRequests.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/api/request/MetricsRequests.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.gateway.iceberg.rest.api.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import java.util.Map;
 
@@ -34,7 +35,7 @@ public final class MetricsRequests {
       @JsonProperty("schema-id") Integer schemaId,
       @JsonProperty("projected-field-ids") List<Integer> projectedFieldIds,
       @JsonProperty("projected-field-names") List<String> projectedFieldNames,
-      @JsonProperty("filter") Map<String, Object> filter,
+      @JsonProperty("filter") JsonNode filter,
       Map<String, MetricValue> metrics,
       Map<String, String> metadata) {}
 

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/common/TableMetadataViews.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/common/TableMetadataViews.java
@@ -146,6 +146,31 @@ public final class TableMetadataViews {
       return this;
     }
 
+    public Builder refs(Map<String, Object> value) {
+      this.refs = value;
+      return this;
+    }
+
+    public Builder snapshotLog(List<Map<String, Object>> value) {
+      this.snapshotLog = value;
+      return this;
+    }
+
+    public Builder metadataLog(List<Map<String, Object>> value) {
+      this.metadataLog = value;
+      return this;
+    }
+
+    public Builder statistics(List<Map<String, Object>> value) {
+      this.statistics = value;
+      return this;
+    }
+
+    public Builder partitionStatistics(List<Map<String, Object>> value) {
+      this.partitionStatistics = value;
+      return this;
+    }
+
     public Builder snapshots(List<Map<String, Object>> value) {
       this.snapshots = value;
       return this;

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/catalog/TableGatewaySupport.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/catalog/TableGatewaySupport.java
@@ -363,14 +363,7 @@ public class TableGatewaySupport {
       if (response == null || !response.hasSnapshot()) {
         return null;
       }
-      var snapshot = response.getSnapshot();
-      Long propertySnapshotId = propertyLong(table.getPropertiesMap(), "current-snapshot-id");
-      if (propertySnapshotId != null
-          && propertySnapshotId > 0
-          && snapshot.getSnapshotId() != propertySnapshotId) {
-        return loadSnapshotById(table.getResourceId(), propertySnapshotId);
-      }
-      return SnapshotMetadataUtil.parseSnapshotMetadata(snapshot);
+      return SnapshotMetadataUtil.parseSnapshotMetadata(response.getSnapshot());
     } catch (StatusRuntimeException primaryFailure) {
       return loadSnapshotByProperty(table);
     }

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitMetadataMutator.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitMetadataMutator.java
@@ -273,8 +273,7 @@ public class TableCommitMetadataMutator {
         merged.isEmpty() ? List.of() : List.copyOf(merged.values());
     Long requestSequence = parsed.maxSnapshotSequenceNumber();
     Long snapshotSequence = maxSequenceFromSnapshots(updatedSnapshots);
-    Long existingSequence = metadata.lastSequenceNumber();
-    Long maxSequence = maxNonNull(snapshotSequence, requestSequence, existingSequence);
+    Long maxSequence = maxNonNull(snapshotSequence, requestSequence);
     Integer formatVersion =
         normalizeFormatVersionForSnapshots(metadata.formatVersion(), requestSequence);
     Map<String, String> props =
@@ -282,6 +281,7 @@ public class TableCommitMetadataMutator {
             ? new LinkedHashMap<>()
             : new LinkedHashMap<>(metadata.properties());
     Long currentSnapshotId = desiredCurrentSnapshotId(metadata, parsed, updatedSnapshots, props);
+    Map<String, Object> refs = mergeSnapshotRefs(metadata.refs(), parsed, currentSnapshotId);
     if (maxSequence != null && maxSequence > 0) {
       props.put("last-sequence-number", Long.toString(maxSequence));
     }
@@ -304,6 +304,11 @@ public class TableCommitMetadataMutator {
         metadata.schemas(),
         metadata.partitionSpecs(),
         metadata.sortOrders(),
+        refs,
+        metadata.snapshotLog(),
+        metadata.metadataLog(),
+        metadata.statistics(),
+        metadata.partitionStatistics(),
         updatedSnapshots);
   }
 
@@ -353,6 +358,52 @@ public class TableCommitMetadataMutator {
       List<Map<String, Object>> partitionSpecs,
       List<Map<String, Object>> sortOrders,
       List<Map<String, Object>> snapshots) {
+    return copyMetadata(
+        base,
+        formatVersion,
+        location,
+        metadataLocation,
+        properties,
+        lastColumnId,
+        currentSchemaId,
+        defaultSpecId,
+        lastPartitionId,
+        defaultSortOrderId,
+        currentSnapshotId,
+        lastSequenceNumber,
+        schemas,
+        partitionSpecs,
+        sortOrders,
+        base.refs(),
+        base.snapshotLog(),
+        base.metadataLog(),
+        base.statistics(),
+        base.partitionStatistics(),
+        snapshots);
+  }
+
+  private TableMetadataView copyMetadata(
+      TableMetadataView base,
+      Integer formatVersion,
+      String location,
+      String metadataLocation,
+      Map<String, String> properties,
+      Integer lastColumnId,
+      Integer currentSchemaId,
+      Integer defaultSpecId,
+      Integer lastPartitionId,
+      Integer defaultSortOrderId,
+      Long currentSnapshotId,
+      Long lastSequenceNumber,
+      List<Map<String, Object>> schemas,
+      List<Map<String, Object>> partitionSpecs,
+      List<Map<String, Object>> sortOrders,
+      Map<String, Object> refs,
+      List<Map<String, Object>> snapshotLog,
+      List<Map<String, Object>> metadataLog,
+      List<Map<String, Object>> statistics,
+      List<Map<String, Object>> partitionStatistics,
+      List<Map<String, Object>> snapshots) {
     return TableMetadataViews.copy(base)
         .formatVersion(formatVersion)
         .location(location)
@@ -368,6 +419,11 @@ public class TableCommitMetadataMutator {
         .schemas(schemas)
         .partitionSpecs(partitionSpecs)
         .sortOrders(sortOrders)
+        .refs(refs)
+        .snapshotLog(snapshotLog)
+        .metadataLog(metadataLog)
+        .statistics(statistics)
+        .partitionStatistics(partitionStatistics)
         .snapshots(snapshots)
         .build();
   }
@@ -450,18 +506,66 @@ public class TableCommitMetadataMutator {
       CommitUpdateInspector.Parsed parsed,
       List<Map<String, Object>> updatedSnapshots,
       Map<String, String> props) {
-    Long propertyCurrentSnapshotId = parseLong(props.get("current-snapshot-id"));
-    if (propertyCurrentSnapshotId != null && propertyCurrentSnapshotId >= 0) {
-      return propertyCurrentSnapshotId;
-    }
     Long requestedMainRefSnapshotId = parsed == null ? null : parsed.requestedMainRefSnapshotId();
     if (requestedMainRefSnapshotId != null && requestedMainRefSnapshotId >= 0) {
       return requestedMainRefSnapshotId;
+    }
+    Long propertyCurrentSnapshotId = parseLong(props.get("current-snapshot-id"));
+    if (propertyCurrentSnapshotId != null && propertyCurrentSnapshotId >= 0) {
+      return propertyCurrentSnapshotId;
     }
     if (metadata.currentSnapshotId() == null) {
       return latestSnapshotId(updatedSnapshots);
     }
     return metadata.currentSnapshotId();
+  }
+
+  private Map<String, Object> mergeSnapshotRefs(
+      Map<String, Object> existingRefs,
+      CommitUpdateInspector.Parsed parsed,
+      Long currentSnapshotId) {
+    Map<String, Object> refs = new LinkedHashMap<>();
+    if (existingRefs != null && !existingRefs.isEmpty()) {
+      refs.putAll(existingRefs);
+    }
+    if (parsed != null) {
+      for (CommitUpdateInspector.SnapshotRefMutation mutation : parsed.snapshotRefMutations()) {
+        if (mutation == null) {
+          continue;
+        }
+        String refName = mutation.refName();
+        if (refName == null || refName.isBlank()) {
+          continue;
+        }
+        if (mutation.remove()) {
+          refs.remove(refName);
+          continue;
+        }
+        Long snapshotId = mutation.snapshotId();
+        if (snapshotId == null || snapshotId < 0) {
+          continue;
+        }
+        Map<String, Object> ref = new LinkedHashMap<>();
+        ref.put("snapshot-id", snapshotId);
+        ref.put(
+            "type",
+            mutation.type() == null || mutation.type().isBlank() ? "branch" : mutation.type());
+        if (mutation.maxRefAgeMs() != null) {
+          ref.put("max-ref-age-ms", mutation.maxRefAgeMs());
+        }
+        if (mutation.maxSnapshotAgeMs() != null) {
+          ref.put("max-snapshot-age-ms", mutation.maxSnapshotAgeMs());
+        }
+        if (mutation.minSnapshotsToKeep() != null) {
+          ref.put("min-snapshots-to-keep", mutation.minSnapshotsToKeep());
+        }
+        refs.put(refName, Map.copyOf(ref));
+      }
+    }
+    if (currentSnapshotId != null && currentSnapshotId >= 0) {
+      refs.put("main", Map.of("snapshot-id", currentSnapshotId, "type", "branch"));
+    }
+    return Map.copyOf(refs);
   }
 
   private Long latestSnapshotId(List<Map<String, Object>> snapshots) {

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitOutboxService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitOutboxService.java
@@ -68,8 +68,6 @@ public class TableCommitOutboxService {
       if (item == null || item.pendingKey() == null || item.pendingKey().isBlank()) {
         continue;
       }
-      boolean pruned =
-          sideEffectService.pruneRemovedSnapshots(item.tableId(), item.removedSnapshotIds());
       boolean statsCaptured =
           sideEffectService.runPostCommitStatsSyncAttempt(
               tableSupport,
@@ -77,7 +75,7 @@ public class TableCommitOutboxService {
               item.namespacePath(),
               item.tableName(),
               item.addedSnapshotIds());
-      if (pruned && statsCaptured) {
+      if (statsCaptured) {
         clearPending(item.pendingKey());
       } else {
         markPendingForRetryOrDeadLetter(

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitSideEffectService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitSideEffectService.java
@@ -16,32 +16,28 @@
 
 package ai.floedb.floecat.gateway.iceberg.rest.services.table;
 
-import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.gateway.iceberg.rest.services.catalog.TableGatewaySupport;
-import ai.floedb.floecat.gateway.iceberg.rest.services.metadata.SnapshotUpdateService;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 import java.util.List;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class TableCommitSideEffectService {
   private static final Logger LOG = Logger.getLogger(TableCommitSideEffectService.class);
-  @Inject SnapshotUpdateService snapshotUpdateService;
 
   public boolean runPostCommitStatsSyncAttempt(
       TableGatewaySupport tableSupport,
-      ResourceId connectorId,
+      ai.floedb.floecat.common.rpc.ResourceId connectorId,
       List<String> namespacePath,
       String tableName,
       List<Long> snapshotIds) {
     return runStatsSyncAttempt(
-        tableSupport, connectorId, namespacePath, tableName, snapshotIds, true);
+        tableSupport, connectorId, namespacePath, tableName, snapshotIds, false);
   }
 
   private boolean runStatsSyncAttempt(
       TableGatewaySupport tableSupport,
-      ResourceId connectorId,
+      ai.floedb.floecat.common.rpc.ResourceId connectorId,
       List<String> namespacePath,
       String tableName,
       List<Long> snapshotIds,
@@ -66,19 +62,6 @@ public class TableCommitSideEffectService {
           connectorId.getId(),
           namespacePath == null ? "<null>" : String.join(".", namespacePath),
           tableName);
-      return false;
-    }
-  }
-
-  public boolean pruneRemovedSnapshots(ResourceId tableId, List<Long> snapshotIds) {
-    if (tableId == null || snapshotIds == null || snapshotIds.isEmpty()) {
-      return true;
-    }
-    try {
-      snapshotUpdateService.deleteSnapshots(tableId, snapshotIds);
-      return true;
-    } catch (RuntimeException e) {
-      LOG.warnf(e, "Snapshot prune failed tableId=%s snapshotIds=%s", tableId.getId(), snapshotIds);
       return false;
     }
   }

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TablePropertyService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TablePropertyService.java
@@ -417,6 +417,7 @@ public class TablePropertyService {
     syncLongProperty(props, "current-snapshot-id", metadata.currentSnapshotId());
     putStringProperty(props, "table-uuid", metadata.tableUuid());
     putStringProperty(props, "location", metadata.location());
+    syncRefProperty(props, metadata.refs());
     return plannedTable.toBuilder().clearProperties().putAllProperties(props).build();
   }
 
@@ -450,6 +451,39 @@ public class TablePropertyService {
       return;
     }
     props.put(key, Long.toString(value));
+  }
+
+  private void syncRefProperty(Map<String, String> props, Map<String, Object> refs) {
+    if (props == null) {
+      return;
+    }
+    if (refs == null || refs.isEmpty()) {
+      props.remove(RefPropertyUtil.PROPERTY_KEY);
+      return;
+    }
+    Map<String, Map<String, Object>> encoded = new LinkedHashMap<>();
+    refs.forEach(
+        (name, value) -> {
+          if (name == null || name.isBlank() || !(value instanceof Map<?, ?> rawRef)) {
+            return;
+          }
+          Map<String, Object> ref = new LinkedHashMap<>();
+          rawRef.forEach(
+              (k, v) -> {
+                if (k instanceof String key && v != null) {
+                  ref.put(key, v);
+                }
+              });
+          if (!ref.isEmpty()) {
+            encoded.put(name, Map.copyOf(ref));
+          }
+        });
+    String encodedRefs = RefPropertyUtil.encode(encoded);
+    if (encodedRefs == null || encodedRefs.isBlank()) {
+      props.remove(RefPropertyUtil.PROPERTY_KEY);
+      return;
+    }
+    props.put(RefPropertyUtil.PROPERTY_KEY, encodedRefs);
   }
 
   // TableMappingUtil provides asString.

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitService.java
@@ -404,7 +404,14 @@ public class TransactionCommitService {
 
       SnapshotChangePlan snapshotChangePlan =
           planAtomicSnapshotChanges(
-              accountId, plan.tableId(), tableForTx, tableSupport, plan.updates(), alreadyApplied);
+              accountId,
+              txId,
+              plan.tableId(),
+              tableForTx,
+              tableSupport,
+              plan.updates(),
+              removedSnapshotIds,
+              alreadyApplied);
       if (snapshotChangePlan.error() != null) {
         maybeAbortOpenTransaction(currentState, txId, "snapshot metadata planning failed");
         return snapshotChangePlan.error();
@@ -446,14 +453,6 @@ public class TransactionCommitService {
       outboxItems.add(commitOutboxService.toWorkItem(pendingKey, journal));
     }
 
-    List<TableCommitOutboxService.WorkItem> outboxWorkItems =
-        alreadyApplied
-            ? loadReplayWorkItems(accountId, txId, txCreatedAtMs, requestHash, planned)
-            : new ArrayList<>();
-    if (!alreadyApplied) {
-      outboxWorkItems = outboxItems;
-    }
-
     boolean applied = isCommitAccepted(currentState);
     if (!applied) {
       if (currentState == TransactionState.TS_OPEN) {
@@ -489,7 +488,7 @@ public class TransactionCommitService {
                 : TransactionState.TS_UNSPECIFIED;
         if (isCommitAccepted(commitState)) {
           applied = true;
-          // Commit applied; continue with best-effort outbox processing.
+          // Commit applied; durable outbox processing happens asynchronously.
         } else {
           if (isDeterministicFailedState(commitState)) {
             return IcebergErrorResponses.failure(
@@ -514,7 +513,7 @@ public class TransactionCommitService {
         if (isRetryableCommitAbort(commitFailure)) {
           if (waitForAppliedState(txId)) {
             applied = true;
-            // Apply eventually succeeded; continue with best-effort outbox processing.
+            // Apply eventually succeeded; durable outbox processing happens asynchronously.
           } else {
             return IcebergErrorResponses.failure(
                 "transaction commit failed",
@@ -540,14 +539,6 @@ public class TransactionCommitService {
           Response.Status.SERVICE_UNAVAILABLE);
     }
 
-    if (!outboxWorkItems.isEmpty()) {
-      try {
-        commitOutboxService.processPendingNow(tableSupport, outboxWorkItems);
-      } catch (RuntimeException e) {
-        LOG.warnf(e, "Best-effort outbox processing failed for tx=%s", txId);
-      }
-    }
-
     return Response.noContent().build();
   }
 
@@ -564,59 +555,6 @@ public class TransactionCommitService {
       ai.floedb.floecat.catalog.rpc.Table table,
       List<Map<String, Object>> updates,
       long expectedVersion) {}
-
-  private List<TableCommitOutboxService.WorkItem> loadReplayWorkItems(
-      String accountId,
-      String txId,
-      long txCreatedAtMs,
-      String requestHash,
-      List<PlannedChange> planned) {
-    if (txId == null || txId.isBlank() || planned == null || planned.isEmpty()) {
-      return List.of();
-    }
-    List<TableCommitOutboxService.WorkItem> out = new ArrayList<>();
-    for (var plan : planned) {
-      ResourceId scopedTableId = scopeTableIdWithAccount(plan.tableId(), accountId);
-      if (scopedTableId == null || scopedTableId.getId().isBlank()) {
-        continue;
-      }
-      String pendingKey =
-          Keys.tableCommitOutboxPendingPointer(
-              txCreatedAtMs, accountId, scopedTableId.getId(), txId);
-      if (!commitOutboxService.isPending(pendingKey)) {
-        continue;
-      }
-      try {
-        var journal = commitJournalService.get(accountId, scopedTableId.getId(), txId).orElse(null);
-        if (journal == null) {
-          LOG.warnf(
-              "Skipping replay side effects for tx=%s tableId=%s; commit journal missing",
-              txId, scopedTableId.getId());
-          continue;
-        }
-        if (!requestHash.equals(journal.getRequestHash())) {
-          LOG.warnf(
-              "Skipping replay side effects for tx=%s tableId=%s; commit journal hash mismatch",
-              txId, scopedTableId.getId());
-          continue;
-        }
-        if (!journal.hasTableId() || journal.getTableName().isBlank()) {
-          LOG.warnf(
-              "Skipping replay side effects for tx=%s tableId=%s; commit journal incomplete",
-              txId, scopedTableId.getId());
-          continue;
-        }
-        out.add(commitOutboxService.toWorkItem(pendingKey, journal));
-      } catch (RuntimeException e) {
-        LOG.warnf(
-            e,
-            "Skipping replay side effects for tx=%s tableId=%s; commit journal unreadable",
-            txId,
-            scopedTableId.getId());
-      }
-    }
-    return out;
-  }
 
   private static String firstNonBlank(String... values) {
     if (values == null) {
@@ -711,12 +649,14 @@ public class TransactionCommitService {
 
   private SnapshotChangePlan planAtomicSnapshotChanges(
       String accountId,
+      String txId,
       ResourceId tableId,
       ai.floedb.floecat.catalog.rpc.Table table,
       TableGatewaySupport tableSupport,
       List<Map<String, Object>> updates,
+      List<Long> removedSnapshotIds,
       boolean alreadyApplied) {
-    if (alreadyApplied || tableId == null || updates == null || updates.isEmpty()) {
+    if (alreadyApplied || tableId == null) {
       return new SnapshotChangePlan(List.of(), null);
     }
     String resolvedAccountId = firstNonBlank(tableId.getAccountId(), accountId);
@@ -733,64 +673,135 @@ public class TransactionCommitService {
             ? tableId
             : tableId.toBuilder().setAccountId(resolvedAccountId).build();
     List<ai.floedb.floecat.transaction.rpc.TxChange> out = new ArrayList<>();
-    for (Map<String, Object> update : updates) {
-      String action = CommitUpdateInspector.actionOf(update);
-      if (!CommitUpdateInspector.ACTION_ADD_SNAPSHOT.equals(action)) {
-        continue;
-      }
-      Map<String, Object> snapshotMap = TableMappingUtil.asObjectMap(update.get("snapshot"));
-      if (snapshotMap == null || snapshotMap.isEmpty()) {
-        return new SnapshotChangePlan(
-            List.of(), IcebergErrorResponses.validation("add-snapshot requires snapshot"));
-      }
-      Long snapshotId = TableMappingUtil.asLong(snapshotMap.get("snapshot-id"));
-      if (snapshotId == null || snapshotId < 0) {
-        return new SnapshotChangePlan(
-            List.of(), IcebergErrorResponses.validation("add-snapshot requires snapshot-id"));
-      }
+    if (updates != null && !updates.isEmpty()) {
+      for (Map<String, Object> update : updates) {
+        String action = CommitUpdateInspector.actionOf(update);
+        if (!CommitUpdateInspector.ACTION_ADD_SNAPSHOT.equals(action)) {
+          continue;
+        }
+        Map<String, Object> snapshotMap = TableMappingUtil.asObjectMap(update.get("snapshot"));
+        if (snapshotMap == null || snapshotMap.isEmpty()) {
+          return new SnapshotChangePlan(
+              List.of(), IcebergErrorResponses.validation("add-snapshot requires snapshot"));
+        }
+        Long snapshotId = TableMappingUtil.asLong(snapshotMap.get("snapshot-id"));
+        if (snapshotId == null || snapshotId < 0) {
+          return new SnapshotChangePlan(
+              List.of(), IcebergErrorResponses.validation("add-snapshot requires snapshot-id"));
+        }
 
-      ai.floedb.floecat.catalog.rpc.Snapshot snapshot;
-      try {
-        snapshot =
-            fetchOrBuildSnapshotPayload(
-                scopedTableId, table, tableSupport, snapshotId, snapshotMap);
-      } catch (StatusRuntimeException e) {
-        return new SnapshotChangePlan(List.of(), mapPreCommitFailure(e));
-      } catch (RuntimeException e) {
-        return new SnapshotChangePlan(
-            List.of(),
-            IcebergErrorResponses.failure(
-                "failed to fetch or build snapshot payload",
-                "CommitStateUnknownException",
-                Response.Status.SERVICE_UNAVAILABLE));
-      }
+        ai.floedb.floecat.catalog.rpc.Snapshot snapshot;
+        try {
+          snapshot =
+              fetchOrBuildSnapshotPayload(
+                  scopedTableId, table, tableSupport, snapshotId, snapshotMap);
+        } catch (StatusRuntimeException e) {
+          return new SnapshotChangePlan(List.of(), mapPreCommitFailure(e));
+        } catch (RuntimeException e) {
+          return new SnapshotChangePlan(
+              List.of(),
+              IcebergErrorResponses.failure(
+                  "failed to fetch or build snapshot payload",
+                  "CommitStateUnknownException",
+                  Response.Status.SERVICE_UNAVAILABLE));
+        }
 
-      long upstreamCreatedMs =
-          snapshot.hasUpstreamCreatedAt()
-              ? Timestamps.toMillis(snapshot.getUpstreamCreatedAt())
-              : clockMillis();
-      String byIdKey =
-          Keys.snapshotPointerById(
-              resolvedAccountId, scopedTableId.getId(), snapshot.getSnapshotId());
-      String byTimeKey =
-          Keys.snapshotPointerByTime(
-              resolvedAccountId,
-              scopedTableId.getId(),
-              snapshot.getSnapshotId(),
-              upstreamCreatedMs);
-      ByteString payload = ByteString.copyFrom(snapshot.toByteArray());
-      out.add(
-          ai.floedb.floecat.transaction.rpc.TxChange.newBuilder()
-              .setTargetPointerKey(byIdKey)
-              .setPayload(payload)
-              .build());
-      out.add(
-          ai.floedb.floecat.transaction.rpc.TxChange.newBuilder()
-              .setTargetPointerKey(byTimeKey)
-              .setPayload(payload)
-              .build());
+        long upstreamCreatedMs =
+            snapshot.hasUpstreamCreatedAt()
+                ? Timestamps.toMillis(snapshot.getUpstreamCreatedAt())
+                : clockMillis();
+        String byIdKey =
+            Keys.snapshotPointerById(
+                resolvedAccountId, scopedTableId.getId(), snapshot.getSnapshotId());
+        String byTimeKey =
+            Keys.snapshotPointerByTime(
+                resolvedAccountId,
+                scopedTableId.getId(),
+                snapshot.getSnapshotId(),
+                upstreamCreatedMs);
+        ByteString payload = ByteString.copyFrom(snapshot.toByteArray());
+        out.add(
+            ai.floedb.floecat.transaction.rpc.TxChange.newBuilder()
+                .setTargetPointerKey(byIdKey)
+                .setPayload(payload)
+                .build());
+        out.add(
+            ai.floedb.floecat.transaction.rpc.TxChange.newBuilder()
+                .setTargetPointerKey(byTimeKey)
+                .setPayload(payload)
+                .build());
+      }
+    }
+    if (removedSnapshotIds != null && !removedSnapshotIds.isEmpty()) {
+      for (Long snapshotId : removedSnapshotIds) {
+        if (snapshotId == null || snapshotId < 0) {
+          continue;
+        }
+        ai.floedb.floecat.catalog.rpc.Snapshot snapshot;
+        try {
+          var resp =
+              grpcClient.getSnapshot(
+                  ai.floedb.floecat.catalog.rpc.GetSnapshotRequest.newBuilder()
+                      .setTableId(scopedTableId)
+                      .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(snapshotId).build())
+                      .build());
+          if (resp == null || !resp.hasSnapshot()) {
+            continue;
+          }
+          snapshot = resp.getSnapshot();
+        } catch (StatusRuntimeException e) {
+          if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
+            continue;
+          }
+          return new SnapshotChangePlan(List.of(), mapPreCommitFailure(e));
+        } catch (RuntimeException e) {
+          return new SnapshotChangePlan(
+              List.of(),
+              IcebergErrorResponses.failure(
+                  "failed to load snapshot payload for transactional delete",
+                  "CommitStateUnknownException",
+                  Response.Status.SERVICE_UNAVAILABLE));
+        }
+        long upstreamCreatedMs =
+            snapshot.hasUpstreamCreatedAt()
+                ? Timestamps.toMillis(snapshot.getUpstreamCreatedAt())
+                : clockMillis();
+        out.add(
+            snapshotDeleteChange(
+                resolvedAccountId,
+                txId,
+                scopedTableId.getId(),
+                snapshot.getSnapshotId(),
+                upstreamCreatedMs,
+                true));
+        out.add(
+            snapshotDeleteChange(
+                resolvedAccountId,
+                txId,
+                scopedTableId.getId(),
+                snapshot.getSnapshotId(),
+                upstreamCreatedMs,
+                false));
+      }
     }
     return new SnapshotChangePlan(out, null);
+  }
+
+  private ai.floedb.floecat.transaction.rpc.TxChange snapshotDeleteChange(
+      String accountId,
+      String txId,
+      String tableId,
+      long snapshotId,
+      long upstreamCreatedMs,
+      boolean byId) {
+    String targetPointerKey =
+        byId
+            ? Keys.snapshotPointerById(accountId, tableId, snapshotId)
+            : Keys.snapshotPointerByTime(accountId, tableId, snapshotId, upstreamCreatedMs);
+    return ai.floedb.floecat.transaction.rpc.TxChange.newBuilder()
+        .setTargetPointerKey(targetPointerKey)
+        .setIntendedBlobUri(Keys.transactionDeleteSentinelUri(accountId, txId, targetPointerKey))
+        .build();
   }
 
   private ai.floedb.floecat.catalog.rpc.Snapshot fetchOrBuildSnapshotPayload(

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitService.java
@@ -32,6 +32,7 @@ import ai.floedb.floecat.gateway.iceberg.rest.api.metadata.TableMetadataView;
 import ai.floedb.floecat.gateway.iceberg.rest.api.request.TableRequests;
 import ai.floedb.floecat.gateway.iceberg.rest.api.request.TransactionCommitRequest;
 import ai.floedb.floecat.gateway.iceberg.rest.common.CommitUpdateInspector;
+import ai.floedb.floecat.gateway.iceberg.rest.common.MetadataLocationUtil;
 import ai.floedb.floecat.gateway.iceberg.rest.common.RefPropertyUtil;
 import ai.floedb.floecat.gateway.iceberg.rest.common.TableMappingUtil;
 import ai.floedb.floecat.gateway.iceberg.rest.resources.common.CatalogRequestContext;
@@ -57,6 +58,7 @@ import io.grpc.protobuf.StatusProto;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -587,6 +589,10 @@ public class TransactionCommitService {
     }
     String requestedLocation =
         CommitUpdateInspector.inspectUpdates(updates).requestedMetadataLocation();
+    if (requestedLocation != null && !isValidExplicitMetadataLocation(requestedLocation)) {
+      return new PreMaterializedTable(
+          plannedTable, IcebergErrorResponses.validation("metadata-location must be a valid URI"));
+    }
     boolean skipMaterialization = requestedLocation != null;
     // Materialize metadata for every commit so metadata-location advances atomically with table
     // state, including snapshot-mutating updates.
@@ -623,7 +629,11 @@ public class TransactionCommitService {
     Table canonicalizedTable =
         tablePropertyService.applyCanonicalMetadataProperties(plannedTable, commitMetadata);
     if (skipMaterialization) {
-      return new PreMaterializedTable(canonicalizedTable, null);
+      return new PreMaterializedTable(
+          canonicalizedTable.toBuilder()
+              .putProperties(MetadataLocationUtil.PRIMARY_KEY, requestedLocation)
+              .build(),
+          null);
     }
     MaterializeMetadataResult result =
         materializationService.materializeMetadata(
@@ -645,6 +655,22 @@ public class TransactionCommitService {
     }
     return new PreMaterializedTable(
         canonicalizedTable.toBuilder().putProperties("metadata-location", location).build(), null);
+  }
+
+  private boolean isValidExplicitMetadataLocation(String metadataLocation) {
+    if (metadataLocation == null || metadataLocation.isBlank()) {
+      return false;
+    }
+    try {
+      URI uri = URI.create(metadataLocation);
+      if (uri.getScheme() == null || uri.getScheme().isBlank()) {
+        return false;
+      }
+      String directory = MetadataLocationUtil.metadataDirectory(metadataLocation);
+      return directory != null && !directory.isBlank();
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
   }
 
   private SnapshotChangePlan planAtomicSnapshotChanges(

--- a/protocol-gateway/iceberg-rest/src/main/resources/application.properties
+++ b/protocol-gateway/iceberg-rest/src/main/resources/application.properties
@@ -33,7 +33,6 @@ floecat.gateway.storage-credential.properties.type=${ICEBERG_STORAGE_TYPE:s3}
 floecat.gateway.storage-credential.properties.s3.access-key-id=${ICEBERG_STORAGE_KEY_ID:<access-id>}
 floecat.gateway.storage-credential.properties.s3.secret-access-key=${ICEBERG_STORAGE_SECRET:<secret-key>}
 floecat.gateway.storage-credential.properties.s3.region=${ICEBERG_STORAGE_REGION:${ICEBERG_DEFAULT_REGION:us-east-1}}
-floecat.gateway.storage-credential.properties.s3.endpoint=${FLOECAT_GATEWAY_STORAGE_CREDENTIAL_PROPERTIES_S3_ENDPOINT:}
 floecat.gateway.storage-credential.properties.s3.path-style-access=${FLOECAT_GATEWAY_STORAGE_CREDENTIAL_PROPERTIES_S3_PATH_STYLE_ACCESS:false}
 floecat.gateway.delta-compat.enabled=${FLOECAT_DELTA_COMPAT_ENABLED:false}
 floecat.gateway.delta-compat.read-only=${FLOECAT_DELTA_COMPAT_READ_ONLY:true}

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/resources/table/TableResourceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/resources/table/TableResourceTest.java
@@ -1446,4 +1446,31 @@ class TableResourceTest extends AbstractRestResourceTest {
         .then()
         .statusCode(204);
   }
+
+  @Test
+  void metricsScanReportWithBooleanFilterReturns204() {
+    ResourceId tableId = ResourceId.newBuilder().setId("cat:db:orders").build();
+    when(directoryStub.resolveTable(any()))
+        .thenReturn(ResolveTableResponse.newBuilder().setResourceId(tableId).build());
+
+    given()
+        .body(
+            """
+            {
+              "report-type":"scan",
+              "table-name":"orders",
+              "snapshot-id":1,
+              "filter":true,
+              "schema-id":1,
+              "projected-field-ids":[1],
+              "projected-field-names":["id"],
+              "metrics":{}
+            }
+            """)
+        .header("Content-Type", "application/json")
+        .when()
+        .post("/v1/foo/namespaces/db/tables/orders/metrics")
+        .then()
+        .statusCode(204);
+  }
 }

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/catalog/TableGatewaySupportTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/catalog/TableGatewaySupportTest.java
@@ -341,7 +341,7 @@ class TableGatewaySupportTest {
   }
 
   @Test
-  void loadCurrentMetadataFallsBackToSnapshotPropertyOnMismatchOrError() {
+  void loadCurrentMetadataPrefersCurrentSnapshotAndOnlyFallsBackOnError() {
     ResourceId tableId = ResourceId.newBuilder().setId("cat:db:orders").build();
     Table table =
         Table.newBuilder()
@@ -370,11 +370,8 @@ class TableGatewaySupportTest {
 
     IcebergMetadata loaded = support.loadCurrentMetadata(table);
 
-    assertEquals("t-99", loaded.getTableUuid());
-    ArgumentCaptor<GetSnapshotRequest> captor = ArgumentCaptor.forClass(GetSnapshotRequest.class);
-    verify(grpcClient, times(2)).getSnapshot(captor.capture());
-    assertEquals(tableId, captor.getAllValues().get(1).getTableId());
-    assertEquals(99L, captor.getAllValues().get(1).getSnapshot().getSnapshotId());
+    assertEquals("t-11", loaded.getTableUuid());
+    verify(grpcClient, times(1)).getSnapshot(any());
 
     when(grpcClient.getSnapshot(any()))
         .thenThrow(Status.UNAVAILABLE.asRuntimeException())
@@ -388,6 +385,10 @@ class TableGatewaySupportTest {
                 .build());
     IcebergMetadata recovered = support.loadCurrentMetadata(table);
     assertEquals("t-99", recovered.getTableUuid());
+    ArgumentCaptor<GetSnapshotRequest> captor = ArgumentCaptor.forClass(GetSnapshotRequest.class);
+    verify(grpcClient, times(3)).getSnapshot(captor.capture());
+    assertEquals(tableId, captor.getAllValues().get(2).getTableId());
+    assertEquals(99L, captor.getAllValues().get(2).getSnapshot().getSnapshotId());
   }
 
   @Test

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/catalog/TablePropertyServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/catalog/TablePropertyServiceTest.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.TableSpec;
 import ai.floedb.floecat.catalog.rpc.UpstreamRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.gateway.iceberg.rest.api.metadata.TableMetadataView;
 import ai.floedb.floecat.gateway.iceberg.rest.common.RefPropertyUtil;
 import ai.floedb.floecat.gateway.iceberg.rest.services.table.TablePropertyService;
 import com.google.protobuf.FieldMask;
@@ -226,6 +227,50 @@ class TablePropertyServiceTest {
     assertEquals(1, refs.size());
     assertEquals(33L, ((Number) refs.get("main").get("snapshot-id")).longValue());
     assertEquals(7, ((Number) refs.get("main").get("min-snapshots-to-keep")).intValue());
+  }
+
+  @Test
+  void applyCanonicalMetadataPropertiesNormalizesSnapshotAndRefPropertiesFromMetadata() {
+    Map<String, Map<String, Object>> staleRefs = new LinkedHashMap<>();
+    staleRefs.put("main", new LinkedHashMap<>(Map.of("snapshot-id", 10L, "type", "branch")));
+    Table plannedTable =
+        Table.newBuilder()
+            .putProperties("current-snapshot-id", "10")
+            .putProperties("last-sequence-number", "999")
+            .putProperties(RefPropertyUtil.PROPERTY_KEY, RefPropertyUtil.encode(staleRefs))
+            .build();
+    TableMetadataView metadata =
+        new TableMetadataView(
+            2,
+            "tbl-1",
+            "s3://floecat/iceberg/orders",
+            "s3://floecat/iceberg/orders/metadata/00002.metadata.json",
+            1L,
+            Map.of(),
+            2,
+            0,
+            0,
+            0,
+            0,
+            33L,
+            7L,
+            List.of(),
+            List.of(),
+            List.of(),
+            Map.of("main", Map.of("snapshot-id", 33L, "type", "branch")),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
+
+    Table updated = service.applyCanonicalMetadataProperties(plannedTable, metadata);
+
+    assertEquals("33", updated.getPropertiesMap().get("current-snapshot-id"));
+    assertEquals("7", updated.getPropertiesMap().get("last-sequence-number"));
+    Map<String, Map<String, Object>> refs =
+        RefPropertyUtil.decode(updated.getPropertiesMap().get(RefPropertyUtil.PROPERTY_KEY));
+    assertEquals(33L, ((Number) refs.get("main").get("snapshot-id")).longValue());
   }
 
   private Supplier<Table> tableSupplier() {

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitMetadataMutatorTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitMetadataMutatorTest.java
@@ -110,7 +110,7 @@ class TableCommitMetadataMutatorTest {
             "s3://floecat/iceberg/orders",
             "s3://floecat/iceberg/orders/metadata/00000-old.metadata.json",
             1L,
-            Map.of("current-snapshot-id", Long.toString(newSnapshotId), "format-version", "2"),
+            Map.of("current-snapshot-id", Long.toString(staleSnapshotId), "format-version", "2"),
             2,
             0,
             0,
@@ -159,6 +159,9 @@ class TableCommitMetadataMutatorTest {
 
     assertEquals(newSnapshotId, merged.currentSnapshotId());
     assertEquals(Long.toString(newSnapshotId), merged.properties().get("current-snapshot-id"));
+    assertEquals(
+        newSnapshotId,
+        ((Number) ((Map<?, ?>) merged.refs().get("main")).get("snapshot-id")).longValue());
   }
 
   @Test
@@ -222,5 +225,66 @@ class TableCommitMetadataMutatorTest {
     assertEquals(5, merged.defaultSortOrderId());
     assertEquals("1", merged.properties().get("current-schema-id"));
     assertEquals("2", merged.properties().get("last-column-id"));
+  }
+
+  @Test
+  void applyDoesNotPreserveStaleHigherLastSequenceNumberFromExistingMetadata() {
+    long newSnapshotId = 1772624629860L;
+    TableMetadataView metadata =
+        new TableMetadataView(
+            2,
+            "tbl-uuid",
+            "s3://floecat/iceberg/orders",
+            "s3://floecat/iceberg/orders/metadata/00000-old.metadata.json",
+            1L,
+            Map.of("last-sequence-number", "999", "format-version", "2"),
+            2,
+            0,
+            0,
+            0,
+            0,
+            null,
+            999L,
+            List.of(Map.of("schema-id", 0, "type", "struct", "fields", List.of())),
+            List.of(Map.of("spec-id", 0, "fields", List.of())),
+            List.of(Map.of("order-id", 0, "fields", List.of())),
+            Map.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
+
+    TableRequests.Commit request =
+        new TableRequests.Commit(
+            List.of(),
+            List.of(
+                Map.of(
+                    "action",
+                    "add-snapshot",
+                    "snapshot",
+                    Map.of(
+                        "snapshot-id",
+                        newSnapshotId,
+                        "timestamp-ms",
+                        1772624629860L,
+                        "sequence-number",
+                        7L,
+                        "summary",
+                        Map.of("operation", "append"))),
+                Map.of(
+                    "action",
+                    "set-snapshot-ref",
+                    "ref-name",
+                    "main",
+                    "snapshot-id",
+                    newSnapshotId,
+                    "type",
+                    "branch")));
+
+    TableMetadataView merged = mutator.apply(metadata, request);
+
+    assertEquals(7L, merged.lastSequenceNumber());
+    assertEquals("7", merged.properties().get("last-sequence-number"));
   }
 }

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitOutboxServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitOutboxServiceTest.java
@@ -64,7 +64,6 @@ class TableCommitOutboxServiceTest {
   void processPendingNowClearsMarkerOnSuccess() {
     ResourceId tableId = ResourceId.newBuilder().setAccountId("acct-1").setId("tbl-1").build();
     String pendingKey = Keys.tableCommitOutboxPendingPointer(123L, "acct-1", "tbl-1", "tx-1");
-    when(sideEffectService.pruneRemovedSnapshots(tableId, List.of(8L))).thenReturn(true);
     when(sideEffectService.runPostCommitStatsSyncAttempt(
             tableSupport, null, List.of("db"), "orders", List.of(7L)))
         .thenReturn(true);
@@ -87,7 +86,6 @@ class TableCommitOutboxServiceTest {
   void processPendingNowLeavesMarkerWhenSideEffectsFail() {
     ResourceId tableId = ResourceId.newBuilder().setAccountId("acct-1").setId("tbl-1").build();
     String pendingKey = Keys.tableCommitOutboxPendingPointer(123L, "acct-1", "tbl-1", "tx-1");
-    when(sideEffectService.pruneRemovedSnapshots(tableId, List.of())).thenReturn(true);
     when(sideEffectService.runPostCommitStatsSyncAttempt(
             tableSupport, null, List.of("db"), "orders", List.of(7L)))
         .thenReturn(false);
@@ -155,7 +153,6 @@ class TableCommitOutboxServiceTest {
                     .setTableName("orders")
                     .addAddedSnapshotIds(7L)
                     .build()));
-    when(sideEffectService.pruneRemovedSnapshots(any(), anyList())).thenReturn(true);
     when(sideEffectService.runPostCommitStatsSyncAttempt(
             tableSupport, null, List.of("db"), "orders", List.of(7L)))
         .thenReturn(true);
@@ -175,7 +172,6 @@ class TableCommitOutboxServiceTest {
   void processPendingNowMovesToDeadLetterAfterMaxAttempts() {
     ResourceId tableId = ResourceId.newBuilder().setAccountId("acct-1").setId("tbl-1").build();
     String pendingKey = Keys.tableCommitOutboxPendingPointer(123L, "acct-1", "tbl-1", "tx-1");
-    when(sideEffectService.pruneRemovedSnapshots(tableId, List.of())).thenReturn(true);
     when(sideEffectService.runPostCommitStatsSyncAttempt(
             tableSupport, null, List.of("db"), "orders", List.of(7L)))
         .thenReturn(false);

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitSideEffectServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TableCommitSideEffectServiceTest.java
@@ -59,7 +59,7 @@ class TableCommitSideEffectServiceTest {
 
     verify(tableSupport)
         .runSyncStatisticsCapture(
-            eq(connectorId), eq(List.of("db")), eq("orders"), eq(List.of(101L, 102L)), eq(true));
+            eq(connectorId), eq(List.of("db")), eq("orders"), eq(List.of(101L, 102L)), eq(false));
   }
 
   @Test
@@ -88,6 +88,6 @@ class TableCommitSideEffectServiceTest {
 
     verify(tableSupport)
         .runSyncStatisticsCapture(
-            eq(connectorId), eq(List.of("db")), eq("orders"), eq(List.of(101L, 102L)), eq(true));
+            eq(connectorId), eq(List.of("db")), eq("orders"), eq(List.of(101L, 102L)), eq(false));
   }
 }

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitServiceTest.java
@@ -985,6 +985,61 @@ class TransactionCommitServiceTest {
     assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
     verify(materializationService, never())
         .materializeMetadata(any(), any(), any(), any(), any(), any());
+    verify(grpcClient)
+        .prepareTransaction(
+            argThat(
+                prepare ->
+                    prepare.getChangesList().stream()
+                        .anyMatch(
+                            change ->
+                                change.hasTable()
+                                    && "s3://meta/original/00002.metadata.json"
+                                        .equals(
+                                            change
+                                                .getTable()
+                                                .getPropertiesMap()
+                                                .get("metadata-location")))));
+  }
+
+  @Test
+  void commitWithInvalidExplicitMetadataLocationReturnsValidationError() {
+    ResourceId tableId = ResourceId.newBuilder().setAccountId("acct-1").setId("tbl-id").build();
+    Table table =
+        Table.newBuilder()
+            .setResourceId(tableId)
+            .putProperties("metadata-location", "s3://meta/original/00002.metadata.json")
+            .build();
+    when(tableLifecycleService.getTableResponse(any()))
+        .thenReturn(
+            GetTableResponse.newBuilder()
+                .setTable(table)
+                .setMeta(MutationMeta.newBuilder().setPointerVersion(7L))
+                .build());
+    when(tableCommitPlanner.plan(any(), any(), any(), any()))
+        .thenReturn(new TableCommitPlanner.PlanResult(table, null));
+    when(grpcClient.beginTransaction(any()))
+        .thenReturn(
+            BeginTransactionResponse.newBuilder()
+                .setTransaction(Transaction.newBuilder().setTxId("tx-1"))
+                .build());
+    when(grpcClient.getTransaction(any()))
+        .thenReturn(
+            GetTransactionResponse.newBuilder()
+                .setTransaction(
+                    Transaction.newBuilder().setTxId("tx-1").setState(TransactionState.TS_OPEN))
+                .build());
+
+    Response response =
+        service.commit(
+            "pref",
+            "idem",
+            requestWithSetMetadataLocationAndAddSnapshot("not a uri", 123L),
+            tableSupport);
+
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    verify(materializationService, never())
+        .materializeMetadata(any(), any(), any(), any(), any(), any());
+    verify(grpcClient, never()).prepareTransaction(any());
   }
 
   @Test

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitServiceTest.java
@@ -61,6 +61,7 @@ import ai.floedb.floecat.storage.kv.Keys;
 import ai.floedb.floecat.transaction.rpc.BeginTransactionResponse;
 import ai.floedb.floecat.transaction.rpc.CommitTransactionResponse;
 import ai.floedb.floecat.transaction.rpc.GetTransactionResponse;
+import ai.floedb.floecat.transaction.rpc.PrepareTransactionRequest;
 import ai.floedb.floecat.transaction.rpc.PrepareTransactionResponse;
 import ai.floedb.floecat.transaction.rpc.Transaction;
 import ai.floedb.floecat.transaction.rpc.TransactionState;
@@ -79,6 +80,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -2774,6 +2776,72 @@ class TransactionCommitServiceTest {
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     verify(grpcClient, never()).prepareTransaction(any());
     verify(grpcClient, never()).commitTransaction(any());
+  }
+
+  @Test
+  void commitWithRemoveSnapshotsDeletesSnapshotPointersTransactionally() {
+    when(grpcClient.beginTransaction(any()))
+        .thenReturn(
+            BeginTransactionResponse.newBuilder()
+                .setTransaction(Transaction.newBuilder().setTxId("tx-1"))
+                .build());
+    when(grpcClient.getTransaction(any()))
+        .thenReturn(
+            GetTransactionResponse.newBuilder()
+                .setTransaction(
+                    Transaction.newBuilder().setTxId("tx-1").setState(TransactionState.TS_OPEN))
+                .build());
+    AtomicReference<PrepareTransactionRequest> prepared = new AtomicReference<>();
+    when(grpcClient.prepareTransaction(any()))
+        .thenAnswer(
+            invocation -> {
+              PrepareTransactionRequest request = invocation.getArgument(0);
+              prepared.set(request);
+              return PrepareTransactionResponse.newBuilder()
+                  .setTransaction(
+                      Transaction.newBuilder()
+                          .setTxId("tx-1")
+                          .setState(TransactionState.TS_PREPARED))
+                  .build();
+            });
+    when(grpcClient.commitTransaction(any()))
+        .thenReturn(
+            CommitTransactionResponse.newBuilder()
+                .setTransaction(
+                    Transaction.newBuilder().setTxId("tx-1").setState(TransactionState.TS_APPLIED))
+                .build());
+    when(grpcClient.getSnapshot(any()))
+        .thenReturn(
+            ai.floedb.floecat.catalog.rpc.GetSnapshotResponse.newBuilder()
+                .setSnapshot(
+                    Snapshot.newBuilder()
+                        .setSnapshotId(123L)
+                        .setUpstreamCreatedAt(com.google.protobuf.util.Timestamps.fromMillis(456L)))
+                .build());
+
+    Response response =
+        service.commit("pref", "idem", requestWithRemoveSnapshots(123L), tableSupport);
+
+    assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    PrepareTransactionRequest request = prepared.get();
+    assertEquals(
+        2L,
+        request.getChangesList().stream()
+            .filter(
+                change ->
+                    change.hasTargetPointerKey()
+                        && change.getTargetPointerKey().contains("/snapshots/")
+                        && change.hasIntendedBlobUri())
+            .count());
+    assertEquals(
+        2L,
+        request.getChangesList().stream()
+            .filter(
+                change ->
+                    change.hasTargetPointerKey()
+                        && change.getTargetPointerKey().contains("/snapshots/")
+                        && change.getIntendedBlobUri().contains("/delete/"))
+            .count());
   }
 
   private TransactionCommitRequest request() {

--- a/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitServiceTest.java
+++ b/protocol-gateway/iceberg-rest/src/test/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TransactionCommitServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.rpc.GetSnapshotResponse;
 import ai.floedb.floecat.catalog.rpc.GetTableResponse;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.Table;
@@ -66,6 +67,7 @@ import ai.floedb.floecat.transaction.rpc.TransactionState;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.Timestamps;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
@@ -1149,7 +1151,7 @@ class TransactionCommitServiceTest {
                                 change ->
                                     change.hasTargetPointerKey()
                                         && change.getTargetPointerKey().contains("/snapshots/"))));
-    verify(commitOutboxService).processPendingNow(eq(tableSupport), any());
+    verify(commitOutboxService, never()).processPendingNow(any(), any());
   }
 
   @Test
@@ -1202,15 +1204,7 @@ class TransactionCommitServiceTest {
     Response response = service.commit("pref", "idem", requestWithAddSnapshot(123L), tableSupport);
 
     assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
-    verify(commitOutboxService)
-        .processPendingNow(
-            eq(tableSupport),
-            argThat(
-                items ->
-                    items != null
-                        && items.size() == 1
-                        && items.get(0) instanceof TableCommitOutboxService.WorkItem item
-                        && List.of(123L).equals(item.addedSnapshotIds())));
+    verify(commitOutboxService, never()).processPendingNow(any(), any());
   }
 
   @Test
@@ -1835,17 +1829,7 @@ class TransactionCommitServiceTest {
     Response response = service.commit("pref", "idem", requestWithAddSnapshot(123L), tableSupport);
 
     assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
-    verify(commitOutboxService)
-        .processPendingNow(
-            eq(tableSupport),
-            argThat(
-                items ->
-                    items != null
-                        && items.size() == 1
-                        && items.get(0) instanceof TableCommitOutboxService.WorkItem item
-                        && "tbl-id".equals(item.tableId().getId())
-                        && List.of(123L).equals(item.addedSnapshotIds())
-                        && List.of(0L).equals(item.removedSnapshotIds())));
+    verify(commitOutboxService, never()).processPendingNow(any(), any());
   }
 
   @Test
@@ -2433,15 +2417,7 @@ class TransactionCommitServiceTest {
                                         && change
                                             .getTargetPointerKey()
                                             .endsWith("/snapshots/by-id/0000000000000000000"))));
-    verify(commitOutboxService)
-        .processPendingNow(
-            eq(tableSupport),
-            argThat(
-                items ->
-                    items != null
-                        && items.size() == 1
-                        && items.get(0) instanceof TableCommitOutboxService.WorkItem item
-                        && List.of(0L).equals(item.addedSnapshotIds())));
+    verify(commitOutboxService, never()).processPendingNow(any(), any());
   }
 
   @Test
@@ -2463,6 +2439,15 @@ class TransactionCommitServiceTest {
                 .setTransaction(
                     Transaction.newBuilder().setTxId("tx-1").setState(TransactionState.TS_PREPARED))
                 .build());
+    when(grpcClient.getSnapshot(any()))
+        .thenReturn(
+            GetSnapshotResponse.newBuilder()
+                .setSnapshot(
+                    Snapshot.newBuilder()
+                        .setSnapshotId(0L)
+                        .setUpstreamCreatedAt(Timestamps.fromMillis(123L))
+                        .build())
+                .build());
     when(grpcClient.commitTransaction(any()))
         .thenReturn(
             CommitTransactionResponse.newBuilder()
@@ -2474,15 +2459,20 @@ class TransactionCommitServiceTest {
         service.commit("pref", "idem", requestWithRemoveSnapshots(0L), tableSupport);
 
     assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
-    verify(commitOutboxService)
-        .processPendingNow(
-            eq(tableSupport),
+    verify(grpcClient)
+        .prepareTransaction(
             argThat(
-                items ->
-                    items != null
-                        && items.size() == 1
-                        && items.get(0) instanceof TableCommitOutboxService.WorkItem item
-                        && List.of(0L).equals(item.removedSnapshotIds())));
+                prepare ->
+                    prepare != null
+                        && prepare.getChangesList().stream()
+                                .filter(
+                                    change ->
+                                        change.hasTargetPointerKey()
+                                            && change.hasIntendedBlobUri()
+                                            && change.getIntendedBlobUri().contains("/delete/"))
+                                .count()
+                            == 2));
+    verify(commitOutboxService, never()).processPendingNow(any(), any());
   }
 
   @Test

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ConnectorPlanningReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ConnectorPlanningReconcileExecutor.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class ConnectorPlanningReconcileExecutor implements ReconcileExecutor {
+  private final ReconcilerService reconcilerService;
+  private final ReconcileJobStore jobs;
+  private final boolean enabled;
+  private final String executionPinnedExecutorId;
+
+  @Inject
+  public ConnectorPlanningReconcileExecutor(
+      ReconcilerService reconcilerService,
+      ReconcileJobStore jobs,
+      @ConfigProperty(name = "floecat.reconciler.executor.planner.enabled", defaultValue = "true")
+          boolean enabled) {
+    this.reconcilerService = reconcilerService;
+    this.jobs = jobs;
+    this.enabled = enabled;
+    this.executionPinnedExecutorId =
+        ConfigProvider.getConfig()
+            .getOptionalValue("floecat.reconciler.auto.pinned-executor-id", String.class)
+            .map(String::trim)
+            .orElse("");
+  }
+
+  @Override
+  public String id() {
+    return "planner_reconciler";
+  }
+
+  @Override
+  public boolean enabled() {
+    return enabled;
+  }
+
+  @Override
+  public int priority() {
+    return 10;
+  }
+
+  @Override
+  public Set<ReconcileJobKind> supportedJobKinds() {
+    return EnumSet.of(ReconcileJobKind.PLAN_CONNECTOR);
+  }
+
+  @Override
+  public Set<String> supportedLanes() {
+    // Planner jobs always run wherever the planner executor is present; the child table jobs
+    // carry the actual execution lane policy that remote/local workers enforce later.
+    return Set.of();
+  }
+
+  @Override
+  public boolean supportsLane(String lane) {
+    return true;
+  }
+
+  @Override
+  public boolean supports(ReconcileJobStore.LeasedJob lease) {
+    return lease != null && lease.jobKind == ReconcileJobKind.PLAN_CONNECTOR;
+  }
+
+  @Override
+  public ExecutionResult execute(ExecutionContext context) {
+    var lease = context.lease();
+    var connectorId =
+        ResourceId.newBuilder()
+            .setAccountId(lease.accountId)
+            .setId(lease.connectorId)
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    var principal =
+        PrincipalContext.newBuilder()
+            .setAccountId(lease.accountId)
+            .setSubject("reconciler.planner")
+            .setCorrelationId("reconcile-plan-" + lease.jobId)
+            .build();
+    long planned = 0L;
+
+    try {
+      List<ai.floedb.floecat.reconciler.jobs.ReconcileTableTask> tasks =
+          reconcilerService.planTableTasks(principal, connectorId, lease.scope, null);
+      for (var task : tasks) {
+        if (context.shouldStop().getAsBoolean()) {
+          return ExecutionResult.cancelled(planned, 0, 0, 0, 0, "Cancelled");
+        }
+        jobs.enqueueTableExecution(
+            lease.accountId,
+            lease.connectorId,
+            lease.fullRescan,
+            lease.captureMode,
+            lease.scope,
+            task,
+            lease.executionPolicy,
+            lease.jobId,
+            executionPinnedExecutorId);
+        planned++;
+        context
+            .progressListener()
+            .onProgress(
+                planned,
+                0,
+                0,
+                0,
+                0,
+                "Planned table " + task.sourceNamespace() + "." + task.sourceTable());
+      }
+      return ExecutionResult.success(planned, 0, 0, 0, 0, "Planned " + planned + " table jobs");
+    } catch (Exception e) {
+      String message = e.getMessage();
+      if (message == null || message.isBlank()) {
+        message = e.getClass().getSimpleName();
+      }
+      return ExecutionResult.failure(
+          planned,
+          0,
+          1,
+          0,
+          0,
+          planned > 0
+              ? "Planning failed after enqueuing " + planned + " table jobs: " + message
+              : "Planning failed: " + message,
+          e);
+    }
+  }
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/DefaultReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/DefaultReconcileExecutor.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/** Default executor that preserves the existing in-process ReconcilerService execution path. */
+@ApplicationScoped
+public class DefaultReconcileExecutor implements ReconcileExecutor {
+  private final ReconcilerService reconcilerService;
+  private final boolean enabled;
+
+  @Inject
+  public DefaultReconcileExecutor(
+      ReconcilerService reconcilerService,
+      @ConfigProperty(name = "floecat.reconciler.executor.default.enabled", defaultValue = "true")
+          boolean enabled) {
+    this.reconcilerService = reconcilerService;
+    this.enabled = enabled;
+  }
+
+  @Override
+  public String id() {
+    return "default_reconciler";
+  }
+
+  @Override
+  public boolean enabled() {
+    return enabled;
+  }
+
+  @Override
+  public ExecutionResult execute(ExecutionContext context) {
+    var lease = context.lease();
+    var connectorId =
+        ResourceId.newBuilder()
+            .setAccountId(lease.accountId)
+            .setId(lease.connectorId)
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+
+    var principal =
+        PrincipalContext.newBuilder()
+            .setAccountId(lease.accountId)
+            .setSubject("reconciler.scheduler")
+            .setCorrelationId("reconciler-job-" + lease.jobId)
+            .build();
+
+    ReconcilerService.Result result =
+        reconcilerService.reconcile(
+            principal,
+            connectorId,
+            lease.fullRescan,
+            lease.scope,
+            lease.captureMode,
+            null,
+            context.shouldStop(),
+            context.progressListener()::onProgress);
+
+    if (result.cancelled()) {
+      return ExecutionResult.cancelled(
+          result.scanned,
+          result.changed,
+          result.errors,
+          result.snapshotsProcessed,
+          result.statsProcessed,
+          result.message());
+    }
+    if (!result.ok()) {
+      return ExecutionResult.failure(
+          result.scanned,
+          result.changed,
+          result.errors,
+          result.snapshotsProcessed,
+          result.statsProcessed,
+          result.message(),
+          result.error);
+    }
+    return ExecutionResult.success(
+        result.scanned,
+        result.changed,
+        result.errors,
+        result.snapshotsProcessed,
+        result.statsProcessed,
+        result.message());
+  }
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/DefaultReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/DefaultReconcileExecutor.java
@@ -19,9 +19,12 @@ package ai.floedb.floecat.reconciler.impl;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.EnumSet;
+import java.util.Set;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /** Default executor that preserves the existing in-process ReconcilerService execution path. */
@@ -50,6 +53,18 @@ public class DefaultReconcileExecutor implements ReconcileExecutor {
   }
 
   @Override
+  public Set<ReconcileJobKind> supportedJobKinds() {
+    return EnumSet.of(ReconcileJobKind.EXEC_CONNECTOR, ReconcileJobKind.EXEC_TABLE);
+  }
+
+  @Override
+  public boolean supports(ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeasedJob lease) {
+    return lease != null
+        && (lease.jobKind == ReconcileJobKind.EXEC_CONNECTOR
+            || lease.jobKind == ReconcileJobKind.EXEC_TABLE);
+  }
+
+  @Override
   public ExecutionResult execute(ExecutionContext context) {
     var lease = context.lease();
     var connectorId =
@@ -74,6 +89,7 @@ public class DefaultReconcileExecutor implements ReconcileExecutor {
             lease.scope,
             lease.captureMode,
             null,
+            lease.tableTask,
             context.shouldStop(),
             context.progressListener()::onProgress);
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -77,10 +77,10 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.MetadataUtils;
-import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.grpc.GrpcClient;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -91,8 +91,8 @@ import java.util.Optional;
 import java.util.Set;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-@IfBuildProperty(name = "floecat.reconciler.backend", stringValue = "remote")
 @ApplicationScoped
+@Typed(GrpcReconcilerBackend.class)
 public class GrpcReconcilerBackend implements ReconcilerBackend {
   private static final Metadata.Key<String> AUTHORIZATION =
       Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.catalog.rpc.FileColumnStats;
 import ai.floedb.floecat.catalog.rpc.GetNamespaceRequest;
 import ai.floedb.floecat.catalog.rpc.GetSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.GetTableStatsRequest;
+import ai.floedb.floecat.catalog.rpc.ListFileColumnStatsRequest;
 import ai.floedb.floecat.catalog.rpc.ListSnapshotsRequest;
 import ai.floedb.floecat.catalog.rpc.LookupCatalogRequest;
 import ai.floedb.floecat.catalog.rpc.MutinyTableStatisticsServiceGrpc;
@@ -345,15 +346,29 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
   @Override
   public boolean statsAlreadyCaptured(ReconcileContext ctx, ResourceId tableId, long snapshotId) {
     try {
-      var response =
+      var tableStatsResponse =
           statistics(ctx)
               .getTableStats(
                   GetTableStatsRequest.newBuilder()
                       .setTableId(tableId)
                       .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(snapshotId).build())
                       .build());
-      var stats = response.getStats();
-      return stats.hasTableId() && stats.getSnapshotId() == snapshotId;
+      var stats = tableStatsResponse.getStats();
+      if (!stats.hasTableId() || stats.getSnapshotId() != snapshotId) {
+        return false;
+      }
+      if (stats.getDataFileCount() <= 0) {
+        return true;
+      }
+      var fileStatsResponse =
+          statistics(ctx)
+              .listFileColumnStats(
+                  ListFileColumnStatsRequest.newBuilder()
+                      .setTableId(tableId)
+                      .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(snapshotId).build())
+                      .setPage(PageRequest.newBuilder().setPageSize(1).build())
+                      .build());
+      return fileStatsResponse.hasPage() && fileStatsResponse.getPage().getTotalSize() > 0;
     } catch (StatusRuntimeException e) {
       if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
         return false;

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -511,20 +511,49 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
   }
 
   @Override
-  public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+  public EnsureViewResult ensureViewDetailed(
+      ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
     CreateViewRequest.Builder request = CreateViewRequest.newBuilder().setSpec(spec);
     if (idempotencyKey != null && !idempotencyKey.isBlank()) {
       request.setIdempotency(IdempotencyKey.newBuilder().setKey(idempotencyKey).build());
     }
     try {
-      return view(ctx).createView(request.build()).getView().getResourceId();
+      ResourceId viewId = view(ctx).createView(request.build()).getView().getResourceId();
+      return new EnsureViewResult(viewId, true);
     } catch (StatusRuntimeException e) {
       if (e.getStatus().getCode() == Status.Code.ALREADY_EXISTS) {
-        // View already exists without a matching idempotency key; treat as success.
-        return ResourceId.getDefaultInstance();
+        return new EnsureViewResult(resolveExistingViewId(ctx, spec), false);
       }
       throw e;
     }
+  }
+
+  private ResourceId resolveExistingViewId(ReconcileContext ctx, ViewSpec spec) {
+    String normalizedName = NameRefNormalizer.normalizeDisplayName(spec.getDisplayName());
+    String token = "";
+    while (true) {
+      var response =
+          view(ctx)
+              .listViews(
+                  ai.floedb.floecat.catalog.rpc.ListViewsRequest.newBuilder()
+                      .setNamespaceId(spec.getNamespaceId())
+                      .setPage(
+                          PageRequest.newBuilder().setPageSize(200).setPageToken(token).build())
+                      .build());
+      for (var view : response.getViewsList()) {
+        if (normalizedName.equals(NameRefNormalizer.normalizeDisplayName(view.getDisplayName()))) {
+          return view.getResourceId();
+        }
+      }
+      String nextToken = response.getPage().getNextPageToken();
+      if (nextToken == null || nextToken.isBlank()) {
+        break;
+      }
+      token = nextToken;
+    }
+    throw new IllegalStateException(
+        "View already exists but could not be resolved by normalized name: "
+            + spec.getDisplayName());
   }
 
   @Override
@@ -677,13 +706,8 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
             .setTableDisplayName(descriptor.sourceTable())
             .setFormat(toTableFormat(descriptor.connectorFormat()))
             .setColumnIdAlgorithm(descriptor.columnIdAlgorithm());
-    if (descriptor.sourceNamespace() != null && !descriptor.sourceNamespace().isBlank()) {
-      for (String seg : descriptor.sourceNamespace().split("\\.")) {
-        if (!seg.isBlank()) {
-          builder.addNamespacePath(seg);
-        }
-      }
-    }
+    builder.addAllNamespacePath(
+        NameRefNormalizer.normalizeNamespacePath(descriptor.sourceNamespace()));
     if (descriptor.partitionKeys() != null) {
       builder.addAllPartitionKeys(descriptor.partitionKeys());
     }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClient.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClient.java
@@ -21,8 +21,10 @@ import ai.floedb.floecat.connector.rpc.NamespacePath;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.rpc.CompleteLeasedReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.GetReconcileCancellationRequest;
 import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobRequest;
@@ -73,6 +75,10 @@ class GrpcRemoteReconcileExecutorClient implements RemoteReconcileExecutorClient
                             .map(GrpcRemoteReconcileExecutorClient::toProtoExecutionClass)
                             .toList())
                     .addAllLanes(executor.supportedLanes())
+                    .addAllJobKinds(
+                        executor.supportedJobKinds().stream()
+                            .map(GrpcRemoteReconcileExecutorClient::toProtoJobKind)
+                            .toList())
                     .build());
     if (!response.getFound()) {
       return Optional.empty();
@@ -186,7 +192,10 @@ class GrpcRemoteReconcileExecutorClient implements RemoteReconcileExecutorClient
         fromProtoExecutionPolicy(job.getExecutionPolicy()),
         job.getLeaseEpoch(),
         job.getPinnedExecutorId(),
-        job.getExecutorId());
+        job.getExecutorId(),
+        fromProtoJobKind(job.getKind()),
+        fromProtoTableTask(job.getTableTask()),
+        job.getParentJobId());
   }
 
   private static CaptureMode fromProtoCaptureMode(
@@ -236,6 +245,35 @@ class GrpcRemoteReconcileExecutorClient implements RemoteReconcileExecutorClient
       case FAILED -> ReconcileCompletionState.RCS_FAILED;
       case CANCELLED -> ReconcileCompletionState.RCS_CANCELLED;
     };
+  }
+
+  private static ai.floedb.floecat.reconciler.rpc.ReconcileJobKind toProtoJobKind(
+      ReconcileJobKind jobKind) {
+    return switch (jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR : jobKind) {
+      case PLAN_CONNECTOR -> ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_PLAN_CONNECTOR;
+      case EXEC_TABLE -> ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_TABLE;
+      case EXEC_CONNECTOR -> ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_CONNECTOR;
+    };
+  }
+
+  private static ReconcileJobKind fromProtoJobKind(
+      ai.floedb.floecat.reconciler.rpc.ReconcileJobKind jobKind) {
+    return switch (jobKind) {
+      case RJK_PLAN_CONNECTOR -> ReconcileJobKind.PLAN_CONNECTOR;
+      case RJK_EXEC_TABLE -> ReconcileJobKind.EXEC_TABLE;
+      case RJK_EXEC_CONNECTOR, RJK_UNSPECIFIED, UNRECOGNIZED -> ReconcileJobKind.EXEC_CONNECTOR;
+    };
+  }
+
+  private static ReconcileTableTask fromProtoTableTask(
+      ai.floedb.floecat.reconciler.rpc.ReconcileTableTask tableTask) {
+    if (tableTask == null) {
+      return ReconcileTableTask.empty();
+    }
+    return ReconcileTableTask.of(
+        tableTask.getSourceNamespace(),
+        tableTask.getSourceTable(),
+        tableTask.getDestinationTableDisplayName());
   }
 
   private <T extends AbstractStub<T>> T withHeaders(T stub, String correlationId) {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClient.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClient.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.rpc.CompleteLeasedReconcileJobRequest;
+import ai.floedb.floecat.reconciler.rpc.GetReconcileCancellationRequest;
+import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobRequest;
+import ai.floedb.floecat.reconciler.rpc.ReconcileCompletionState;
+import ai.floedb.floecat.reconciler.rpc.ReconcileExecutorControlGrpc;
+import ai.floedb.floecat.reconciler.rpc.RenewReconcileLeaseRequest;
+import ai.floedb.floecat.reconciler.rpc.ReportReconcileProgressRequest;
+import ai.floedb.floecat.reconciler.rpc.StartLeasedReconcileJobRequest;
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import io.grpc.Metadata;
+import io.grpc.stub.AbstractStub;
+import io.grpc.stub.MetadataUtils;
+import io.quarkus.grpc.GrpcClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Optional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+class GrpcRemoteReconcileExecutorClient implements RemoteReconcileExecutorClient {
+  private static final Metadata.Key<String> AUTHORIZATION =
+      Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> CORRELATION_ID =
+      Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
+
+  private final Optional<String> headerName;
+  private final Optional<String> staticToken;
+
+  GrpcRemoteReconcileExecutorClient(
+      @ConfigProperty(name = "floecat.reconciler.authorization.header") Optional<String> headerName,
+      @ConfigProperty(name = "floecat.reconciler.authorization.token")
+          Optional<String> staticToken) {
+    this.headerName = headerName.map(String::trim).filter(v -> !v.isBlank());
+    this.staticToken = staticToken.map(String::trim).filter(v -> !v.isBlank());
+  }
+
+  @GrpcClient("floecat")
+  ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub executorControl;
+
+  @Override
+  public Optional<RemoteLeasedJob> lease(ReconcileExecutor executor) {
+    var response =
+        withHeaders(executorControl, "reconcile-lease-" + executor.id())
+            .leaseReconcileJob(
+                LeaseReconcileJobRequest.newBuilder()
+                    .setExecutorId(executor.id())
+                    .addAllExecutionClasses(
+                        executor.supportedExecutionClasses().stream()
+                            .map(GrpcRemoteReconcileExecutorClient::toProtoExecutionClass)
+                            .toList())
+                    .addAllLanes(executor.supportedLanes())
+                    .build());
+    if (!response.getFound()) {
+      return Optional.empty();
+    }
+    return Optional.of(new RemoteLeasedJob(fromProtoLease(response.getJob())));
+  }
+
+  @Override
+  public void start(RemoteLeasedJob lease, String executorId) {
+    withHeaders(executorControl, correlationId(lease))
+        .startLeasedReconcileJob(
+            StartLeasedReconcileJobRequest.newBuilder()
+                .setJobId(lease.lease().jobId)
+                .setLeaseEpoch(lease.lease().leaseEpoch)
+                .setExecutorId(executorId)
+                .build());
+  }
+
+  @Override
+  public LeaseHeartbeat renew(RemoteLeasedJob lease) {
+    var response =
+        withHeaders(executorControl, correlationId(lease))
+            .renewReconcileLease(
+                RenewReconcileLeaseRequest.newBuilder()
+                    .setJobId(lease.lease().jobId)
+                    .setLeaseEpoch(lease.lease().leaseEpoch)
+                    .build());
+    return new LeaseHeartbeat(response.getRenewed(), response.getCancellationRequested());
+  }
+
+  @Override
+  public LeaseHeartbeat reportProgress(
+      RemoteLeasedJob lease,
+      long scanned,
+      long changed,
+      long errors,
+      long snapshotsProcessed,
+      long statsProcessed,
+      String message) {
+    var response =
+        withHeaders(executorControl, correlationId(lease))
+            .reportReconcileProgress(
+                ReportReconcileProgressRequest.newBuilder()
+                    .setJobId(lease.lease().jobId)
+                    .setLeaseEpoch(lease.lease().leaseEpoch)
+                    .setTablesScanned(scanned)
+                    .setTablesChanged(changed)
+                    .setErrors(errors)
+                    .setSnapshotsProcessed(snapshotsProcessed)
+                    .setStatsProcessed(statsProcessed)
+                    .setMessage(message == null ? "" : message)
+                    .build());
+    return new LeaseHeartbeat(response.getLeaseValid(), response.getCancellationRequested());
+  }
+
+  @Override
+  public CompletionResult complete(
+      RemoteLeasedJob lease,
+      RemoteLeasedJob.CompletionState state,
+      long scanned,
+      long changed,
+      long errors,
+      long snapshotsProcessed,
+      long statsProcessed,
+      String message) {
+    var response =
+        withHeaders(executorControl, correlationId(lease))
+            .completeLeasedReconcileJob(
+                CompleteLeasedReconcileJobRequest.newBuilder()
+                    .setJobId(lease.lease().jobId)
+                    .setLeaseEpoch(lease.lease().leaseEpoch)
+                    .setState(toProtoCompletionState(state))
+                    .setTablesScanned(scanned)
+                    .setTablesChanged(changed)
+                    .setErrors(errors)
+                    .setSnapshotsProcessed(snapshotsProcessed)
+                    .setStatsProcessed(statsProcessed)
+                    .setMessage(message == null ? "" : message)
+                    .build());
+    return new CompletionResult(response.getAccepted());
+  }
+
+  @Override
+  public boolean cancellationRequested(RemoteLeasedJob lease) {
+    return withHeaders(executorControl, correlationId(lease))
+        .getReconcileCancellation(
+            GetReconcileCancellationRequest.newBuilder().setJobId(lease.lease().jobId).build())
+        .getCancellationRequested();
+  }
+
+  private static ai.floedb.floecat.reconciler.rpc.ExecutionClass toProtoExecutionClass(
+      ReconcileExecutionClass executionClass) {
+    return switch (executionClass) {
+      case INTERACTIVE -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_INTERACTIVE;
+      case BATCH -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_BATCH;
+      case HEAVY -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_HEAVY;
+      case DEFAULT -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_DEFAULT;
+    };
+  }
+
+  private static ReconcileJobStore.LeasedJob fromProtoLease(
+      ai.floedb.floecat.reconciler.rpc.LeasedReconcileJob job) {
+    ResourceId connectorId = job.getConnectorId();
+    return new ReconcileJobStore.LeasedJob(
+        job.getJobId(),
+        connectorId.getAccountId(),
+        connectorId.getId(),
+        job.getFullRescan(),
+        fromProtoCaptureMode(job.getMode()),
+        fromProtoScope(job.getScope()),
+        fromProtoExecutionPolicy(job.getExecutionPolicy()),
+        job.getLeaseEpoch(),
+        job.getPinnedExecutorId(),
+        job.getExecutorId());
+  }
+
+  private static CaptureMode fromProtoCaptureMode(
+      ai.floedb.floecat.reconciler.rpc.CaptureMode captureMode) {
+    return switch (captureMode) {
+      case CM_METADATA_ONLY -> CaptureMode.METADATA_ONLY;
+      case CM_STATS_ONLY -> CaptureMode.STATS_ONLY;
+      case CM_METADATA_AND_STATS, CM_UNSPECIFIED, UNRECOGNIZED -> CaptureMode.METADATA_AND_STATS;
+    };
+  }
+
+  private static ReconcileScope fromProtoScope(
+      ai.floedb.floecat.reconciler.rpc.CaptureScope scope) {
+    if (scope == null) {
+      return ReconcileScope.empty();
+    }
+    return ReconcileScope.of(
+        scope.getDestinationNamespacePathsList().stream()
+            .map(NamespacePath::getSegmentsList)
+            .map(java.util.List::copyOf)
+            .toList(),
+        scope.getDestinationTableDisplayName(),
+        scope.getDestinationTableColumnsList(),
+        scope.getDestinationSnapshotIdsList());
+  }
+
+  private static ReconcileExecutionPolicy fromProtoExecutionPolicy(
+      ai.floedb.floecat.reconciler.rpc.ExecutionPolicy policy) {
+    if (policy == null) {
+      return ReconcileExecutionPolicy.defaults();
+    }
+    return ReconcileExecutionPolicy.of(
+        switch (policy.getExecutionClass()) {
+          case EC_INTERACTIVE -> ReconcileExecutionClass.INTERACTIVE;
+          case EC_BATCH -> ReconcileExecutionClass.BATCH;
+          case EC_HEAVY -> ReconcileExecutionClass.HEAVY;
+          case EC_DEFAULT, EC_UNSPECIFIED, UNRECOGNIZED -> ReconcileExecutionClass.DEFAULT;
+        },
+        policy.getLane(),
+        policy.getAttributesMap());
+  }
+
+  private static ReconcileCompletionState toProtoCompletionState(
+      RemoteLeasedJob.CompletionState state) {
+    return switch (state) {
+      case SUCCEEDED -> ReconcileCompletionState.RCS_SUCCEEDED;
+      case FAILED -> ReconcileCompletionState.RCS_FAILED;
+      case CANCELLED -> ReconcileCompletionState.RCS_CANCELLED;
+    };
+  }
+
+  private <T extends AbstractStub<T>> T withHeaders(T stub, String correlationId) {
+    return stub.withInterceptors(
+        MetadataUtils.newAttachHeadersInterceptor(metadata(correlationId)));
+  }
+
+  private Metadata metadata(String correlationId) {
+    Metadata metadata = new Metadata();
+    metadata.put(CORRELATION_ID, correlationId == null ? "" : correlationId);
+    staticToken.ifPresent(value -> metadata.put(authHeaderKey(), withBearerPrefix(value)));
+    return metadata;
+  }
+
+  private Metadata.Key<String> authHeaderKey() {
+    if (headerName.isPresent() && !"authorization".equalsIgnoreCase(headerName.get())) {
+      return Metadata.Key.of(headerName.get(), Metadata.ASCII_STRING_MARSHALLER);
+    }
+    return AUTHORIZATION;
+  }
+
+  private static String withBearerPrefix(String token) {
+    if (token.regionMatches(true, 0, "bearer ", 0, 7)) {
+      return token;
+    }
+    return "Bearer " + token;
+  }
+
+  private static String correlationId(RemoteLeasedJob lease) {
+    return "reconcile-job-" + lease.lease().jobId;
+  }
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/** Resolves the executor that should execute a leased reconcile job. */
+@ApplicationScoped
+public class ReconcileExecutorRegistry {
+  private final List<ReconcileExecutor> executors;
+
+  @Inject
+  public ReconcileExecutorRegistry(Instance<ReconcileExecutor> executors) {
+    this(executors == null ? List.of() : executors.stream().toList());
+  }
+
+  ReconcileExecutorRegistry(List<ReconcileExecutor> executors) {
+    this.executors =
+        (executors == null ? List.<ReconcileExecutor>of() : executors)
+            .stream()
+                .filter(ReconcileExecutor::enabled)
+                .sorted(
+                    Comparator.comparingInt(ReconcileExecutor::priority)
+                        .thenComparing(ReconcileExecutor::id))
+                .toList();
+  }
+
+  public Optional<ReconcileExecutor> executorFor(ReconcileJobStore.LeasedJob lease) {
+    if (lease != null && lease.pinnedExecutorId != null && !lease.pinnedExecutorId.isBlank()) {
+      return executors.stream()
+          .filter(executor -> lease.pinnedExecutorId.equals(executor.id()))
+          .filter(
+              executor -> executor.supportsExecutionClass(lease.executionPolicy.executionClass()))
+          .filter(executor -> executor.supportsLane(lease.executionPolicy.lane()))
+          .filter(executor -> executor.supports(lease))
+          .findFirst();
+    }
+    return executors.stream()
+        .filter(executor -> executor.supportsExecutionClass(lease.executionPolicy.executionClass()))
+        .filter(executor -> executor.supportsLane(lease.executionPolicy.lane()))
+        .filter(executor -> executor.supports(lease))
+        .findFirst();
+  }
+
+  public List<ReconcileExecutor> orderedExecutors() {
+    return executors;
+  }
+
+  public ReconcileJobStore.LeaseRequest leaseRequest() {
+    Set<ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass> executionClasses =
+        executors.stream()
+            .flatMap(executor -> executor.supportedExecutionClasses().stream())
+            .collect(
+                java.util.stream.Collectors.toCollection(
+                    () ->
+                        EnumSet.noneOf(
+                            ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass.class)));
+    Set<String> lanes =
+        executors.stream()
+            .flatMap(executor -> executor.supportedLanes().stream())
+            .map(lane -> lane == null ? "" : lane.trim())
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    Set<String> executorIds =
+        executors.stream()
+            .map(ReconcileExecutor::id)
+            .map(executorId -> executorId == null ? "" : executorId.trim())
+            .filter(executorId -> !executorId.isEmpty())
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    return ReconcileJobStore.LeaseRequest.of(executionClasses, lanes, executorIds);
+  }
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -52,6 +53,7 @@ public class ReconcileExecutorRegistry {
     if (lease != null && lease.pinnedExecutorId != null && !lease.pinnedExecutorId.isBlank()) {
       return executors.stream()
           .filter(executor -> lease.pinnedExecutorId.equals(executor.id()))
+          .filter(executor -> executor.supportsJobKind(lease.jobKind))
           .filter(
               executor -> executor.supportsExecutionClass(lease.executionPolicy.executionClass()))
           .filter(executor -> executor.supportsLane(lease.executionPolicy.lane()))
@@ -59,6 +61,7 @@ public class ReconcileExecutorRegistry {
           .findFirst();
     }
     return executors.stream()
+        .filter(executor -> executor.supportsJobKind(lease.jobKind))
         .filter(executor -> executor.supportsExecutionClass(lease.executionPolicy.executionClass()))
         .filter(executor -> executor.supportsLane(lease.executionPolicy.lane()))
         .filter(executor -> executor.supports(lease))
@@ -89,6 +92,12 @@ public class ReconcileExecutorRegistry {
             .map(executorId -> executorId == null ? "" : executorId.trim())
             .filter(executorId -> !executorId.isEmpty())
             .collect(java.util.stream.Collectors.toUnmodifiableSet());
-    return ReconcileJobStore.LeaseRequest.of(executionClasses, lanes, executorIds);
+    Set<ReconcileJobKind> jobKinds =
+        executors.stream()
+            .flatMap(executor -> executor.supportedJobKinds().stream())
+            .collect(
+                java.util.stream.Collectors.toCollection(
+                    () -> EnumSet.noneOf(ReconcileJobKind.class)));
+    return ReconcileJobStore.LeaseRequest.of(executionClasses, lanes, executorIds, jobKinds);
   }
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerScheduler.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerScheduler.java
@@ -30,6 +30,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -131,26 +132,41 @@ public class ReconcilerScheduler {
       return;
     }
     try {
-      ReconcileJobStore.LeaseRequest leaseRequest = executorRegistry.leaseRequest();
       while (reserveWorkerSlot()) {
-        Optional<ReconcileJobStore.LeasedJob> leaseOpt;
+        Optional<LeaseAssignment> assignmentOpt;
         try {
-          leaseOpt = jobs.leaseNext(leaseRequest);
+          assignmentOpt = leaseNextAssignment();
         } catch (Exception e) {
           inFlight.decrementAndGet();
           LOG.errorf(e, "leaseNext() threw unexpectedly; releasing worker slot");
           return;
         }
-        var lease = leaseOpt.orElse(null);
-        if (lease == null) {
+        var assignment = assignmentOpt.orElse(null);
+        if (assignment == null) {
           inFlight.decrementAndGet();
           return;
         }
-        submitLease(lease);
+        submitLease(assignment);
       }
     } finally {
       polling.set(false);
     }
+  }
+
+  private Optional<LeaseAssignment> leaseNextAssignment() {
+    for (ReconcileExecutor executor : executorRegistry.orderedExecutors()) {
+      Optional<ReconcileJobStore.LeasedJob> lease =
+          jobs.leaseNext(
+              ReconcileJobStore.LeaseRequest.of(
+                  executor.supportedExecutionClasses(),
+                  executor.supportedLanes(),
+                  Set.of(executor.id()),
+                  executor.supportedJobKinds()));
+      if (lease.isPresent()) {
+        return Optional.of(new LeaseAssignment(executor, lease.get()));
+      }
+    }
+    return Optional.empty();
   }
 
   private boolean reserveWorkerSlot() {
@@ -165,7 +181,7 @@ public class ReconcilerScheduler {
     }
   }
 
-  private void submitLease(ReconcileJobStore.LeasedJob lease) {
+  private void submitLease(LeaseAssignment assignment) {
     ExecutorService executor = workers;
     if (executor == null) {
       inFlight.decrementAndGet();
@@ -175,7 +191,7 @@ public class ReconcilerScheduler {
       executor.submit(
           () -> {
             try {
-              runLease(lease);
+              runLease(assignment);
             } finally {
               inFlight.decrementAndGet();
             }
@@ -187,6 +203,19 @@ public class ReconcilerScheduler {
   }
 
   void runLease(ReconcileJobStore.LeasedJob lease) {
+    ReconcileExecutor executor =
+        executorRegistry
+            .executorFor(lease)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No reconcile executor available for lease " + lease.jobId));
+    runLease(new LeaseAssignment(executor, lease));
+  }
+
+  private void runLease(LeaseAssignment assignment) {
+    ReconcileExecutor executor = assignment.executor();
+    ReconcileJobStore.LeasedJob lease = assignment.lease();
     cancellations.register(lease.jobId, Thread.currentThread());
     long started = System.currentTimeMillis();
     long leaseMs =
@@ -208,6 +237,7 @@ public class ReconcilerScheduler {
     boolean[] cancellationRequested = {false};
     AtomicBoolean leaseValid = new AtomicBoolean(true);
     AtomicBoolean interrupted = new AtomicBoolean(false);
+    ProgressSnapshot progress = new ProgressSnapshot();
     BooleanSupplier heartbeat =
         () -> {
           if (!leaseValid.get()) {
@@ -247,13 +277,6 @@ public class ReconcilerScheduler {
       return;
     }
     try {
-      ReconcileExecutor executor =
-          executorRegistry
-              .executorFor(lease)
-              .orElseThrow(
-                  () ->
-                      new IllegalStateException(
-                          "No reconcile executor available for lease " + lease.jobId));
       jobs.markRunning(lease.jobId, lease.leaseEpoch, System.currentTimeMillis(), executor.id());
       jobs.markProgress(lease.jobId, lease.leaseEpoch, 0, 0, 0, 0, 0, "Running reconcile");
       BooleanSupplier shouldStop =
@@ -282,6 +305,8 @@ public class ReconcilerScheduler {
                     if (!heartbeat.getAsBoolean()) {
                       return;
                     }
+                    progress.update(
+                        scanned, changed, errors, snapshotsProcessed, statsProcessed, message);
                     jobs.markProgress(
                         lease.jobId,
                         lease.leaseEpoch,
@@ -378,26 +403,108 @@ public class ReconcilerScheduler {
     } catch (Exception e) {
       if (!leaseValid.get()) {
         long now = System.currentTimeMillis();
-        emitOutcome(lease, "lease_lost", now - started, 0, 0, 0, 0, 0, "lease_lost");
+        emitOutcome(
+            lease,
+            "lease_lost",
+            now - started,
+            progress.scanned,
+            progress.changed,
+            progress.errors,
+            progress.snapshotsProcessed,
+            progress.statsProcessed,
+            "lease_lost");
       } else {
         boolean cancelledOnError = cancelRequested.getAsBoolean();
         if (cancelledOnError) {
           long now = System.currentTimeMillis();
-          jobs.markCancelled(lease.jobId, lease.leaseEpoch, now, "Cancelled", 0, 0, 0, 0, 0);
-          emitOutcome(lease, "cancelled", now - started, 0, 0, 0, 0, 0, null);
+          jobs.markCancelled(
+              lease.jobId,
+              lease.leaseEpoch,
+              now,
+              progress.message.isBlank() ? "Cancelled" : progress.message,
+              progress.scanned,
+              progress.changed,
+              progress.errors,
+              progress.snapshotsProcessed,
+              progress.statsProcessed);
+          emitOutcome(
+              lease,
+              "cancelled",
+              now - started,
+              progress.scanned,
+              progress.changed,
+              progress.errors,
+              progress.snapshotsProcessed,
+              progress.statsProcessed,
+              null);
         } else if (Thread.currentThread().isInterrupted() || interrupted.get()) {
           long now = System.currentTimeMillis();
-          emitOutcome(lease, "interrupted", now - started, 0, 0, 0, 0, 0, "interrupted");
+          emitOutcome(
+              lease,
+              "interrupted",
+              now - started,
+              progress.scanned,
+              progress.changed,
+              progress.errors,
+              progress.snapshotsProcessed,
+              progress.statsProcessed,
+              "interrupted");
         } else {
           var msg = describeFailure(e);
           long now = System.currentTimeMillis();
-          jobs.markFailed(lease.jobId, lease.leaseEpoch, now, msg, 0, 0, 1, 0, 0);
-          emitOutcome(lease, "failed", now - started, 0, 0, 1, 0, 0, normalizeReason(e), msg);
+          long errorCount = Math.max(1L, progress.errors);
+          jobs.markFailed(
+              lease.jobId,
+              lease.leaseEpoch,
+              now,
+              msg,
+              progress.scanned,
+              progress.changed,
+              errorCount,
+              progress.snapshotsProcessed,
+              progress.statsProcessed);
+          emitOutcome(
+              lease,
+              "failed",
+              now - started,
+              progress.scanned,
+              progress.changed,
+              errorCount,
+              progress.snapshotsProcessed,
+              progress.statsProcessed,
+              normalizeReason(e),
+              msg);
         }
       }
     } finally {
       cancellations.unregister(lease.jobId, Thread.currentThread());
       Thread.interrupted();
+    }
+  }
+
+  private record LeaseAssignment(ReconcileExecutor executor, ReconcileJobStore.LeasedJob lease) {}
+
+  private static final class ProgressSnapshot {
+    long scanned;
+    long changed;
+    long errors;
+    long snapshotsProcessed;
+    long statsProcessed;
+    String message = "";
+
+    void update(
+        long scanned,
+        long changed,
+        long errors,
+        long snapshotsProcessed,
+        long statsProcessed,
+        String message) {
+      this.scanned = scanned;
+      this.changed = changed;
+      this.errors = errors;
+      this.snapshotsProcessed = snapshotsProcessed;
+      this.statsProcessed = statsProcessed;
+      this.message = message == null ? "" : message;
     }
   }
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerScheduler.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerScheduler.java
@@ -16,10 +16,8 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
-import ai.floedb.floecat.common.rpc.PrincipalContext;
-import ai.floedb.floecat.common.rpc.ResourceId;
-import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
 import ai.floedb.floecat.telemetry.MetricId;
 import ai.floedb.floecat.telemetry.MetricType;
 import ai.floedb.floecat.telemetry.Observability;
@@ -38,6 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -84,10 +83,14 @@ public class ReconcilerScheduler {
   private static final int DEFAULT_MAX_PARALLELISM = 1;
 
   @Inject ReconcileJobStore jobs;
-  @Inject ReconcilerService reconcilerService;
+  @Inject ReconcileExecutorRegistry executorRegistry;
   @Inject ReconcileCancellationRegistry cancellations;
   @Inject Observability observability;
   @Inject Config config;
+
+  @ConfigProperty(name = "floecat.reconciler.scheduler.enabled", defaultValue = "true")
+  boolean schedulerEnabled;
+
   private static final Logger LOG = Logger.getLogger(ReconcilerScheduler.class);
 
   private final AtomicBoolean polling = new AtomicBoolean(false);
@@ -97,6 +100,9 @@ public class ReconcilerScheduler {
 
   @PostConstruct
   void init() {
+    if (!schedulerEnabled) {
+      return;
+    }
     maxParallelism =
         Math.max(
             1,
@@ -118,14 +124,18 @@ public class ReconcilerScheduler {
       every = "{reconciler.pollEvery:1s}",
       concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
   void pollOnce() {
+    if (!schedulerEnabled || executorRegistry.orderedExecutors().isEmpty()) {
+      return;
+    }
     if (!polling.compareAndSet(false, true)) {
       return;
     }
     try {
+      ReconcileJobStore.LeaseRequest leaseRequest = executorRegistry.leaseRequest();
       while (reserveWorkerSlot()) {
         Optional<ReconcileJobStore.LeasedJob> leaseOpt;
         try {
-          leaseOpt = jobs.leaseNext();
+          leaseOpt = jobs.leaseNext(leaseRequest);
         } catch (Exception e) {
           inFlight.decrementAndGet();
           LOG.errorf(e, "leaseNext() threw unexpectedly; releasing worker slot");
@@ -176,7 +186,7 @@ public class ReconcilerScheduler {
     }
   }
 
-  private void runLease(ReconcileJobStore.LeasedJob lease) {
+  void runLease(ReconcileJobStore.LeasedJob lease) {
     cancellations.register(lease.jobId, Thread.currentThread());
     long started = System.currentTimeMillis();
     long leaseMs =
@@ -236,34 +246,27 @@ public class ReconcilerScheduler {
       emitOutcome(lease, "lease_lost", now - started, 0, 0, 0, 0, 0, "lease_lost");
       return;
     }
-    jobs.markRunning(lease.jobId, lease.leaseEpoch, System.currentTimeMillis());
-    jobs.markProgress(lease.jobId, lease.leaseEpoch, 0, 0, 0, 0, 0, "Running reconcile");
-    BooleanSupplier shouldStop =
-        () -> {
-          if (!leaseValid.get()) {
-            return true;
-          }
-          if (Thread.currentThread().isInterrupted()) {
-            interrupted.set(true);
-            return true;
-          }
-          return cancelRequested.getAsBoolean();
-        };
-
     try {
-      var connectorId =
-          ResourceId.newBuilder()
-              .setAccountId(lease.accountId)
-              .setId(lease.connectorId)
-              .setKind(ResourceKind.RK_CONNECTOR)
-              .build();
-
-      var principal =
-          PrincipalContext.newBuilder()
-              .setAccountId(lease.accountId)
-              .setSubject("reconciler.scheduler")
-              .setCorrelationId("reconciler-job-" + lease.jobId)
-              .build();
+      ReconcileExecutor executor =
+          executorRegistry
+              .executorFor(lease)
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "No reconcile executor available for lease " + lease.jobId));
+      jobs.markRunning(lease.jobId, lease.leaseEpoch, System.currentTimeMillis(), executor.id());
+      jobs.markProgress(lease.jobId, lease.leaseEpoch, 0, 0, 0, 0, 0, "Running reconcile");
+      BooleanSupplier shouldStop =
+          () -> {
+            if (!leaseValid.get()) {
+              return true;
+            }
+            if (Thread.currentThread().isInterrupted()) {
+              interrupted.set(true);
+              return true;
+            }
+            return cancelRequested.getAsBoolean();
+          };
       if (cancelRequested.getAsBoolean()) {
         long now = System.currentTimeMillis();
         jobs.markCancelled(lease.jobId, lease.leaseEpoch, now, "Cancelled", 0, 0, 0, 0, 0);
@@ -271,28 +274,24 @@ public class ReconcilerScheduler {
         return;
       }
       var result =
-          reconcilerService.reconcile(
-              principal,
-              connectorId,
-              lease.fullRescan,
-              lease.scope,
-              lease.captureMode,
-              null,
-              shouldStop,
-              (scanned, changed, errors, snapshotsProcessed, statsProcessed, message) -> {
-                if (!heartbeat.getAsBoolean()) {
-                  return;
-                }
-                jobs.markProgress(
-                    lease.jobId,
-                    lease.leaseEpoch,
-                    scanned,
-                    changed,
-                    errors,
-                    snapshotsProcessed,
-                    statsProcessed,
-                    message);
-              });
+          executor.execute(
+              new ReconcileExecutor.ExecutionContext(
+                  lease,
+                  shouldStop,
+                  (scanned, changed, errors, snapshotsProcessed, statsProcessed, message) -> {
+                    if (!heartbeat.getAsBoolean()) {
+                      return;
+                    }
+                    jobs.markProgress(
+                        lease.jobId,
+                        lease.leaseEpoch,
+                        scanned,
+                        changed,
+                        errors,
+                        snapshotsProcessed,
+                        statsProcessed,
+                        message);
+                  }));
       long finished = System.currentTimeMillis();
       long totalSnapshots = result.snapshotsProcessed;
       long totalStats = result.statsProcessed;
@@ -311,12 +310,12 @@ public class ReconcilerScheduler {
         return;
       }
       boolean cancelledNow = cancelRequested.getAsBoolean();
-      if (result.cancelled() || cancelledNow) {
+      if (result.cancelled || cancelledNow) {
         jobs.markCancelled(
             lease.jobId,
             lease.leaseEpoch,
             finished,
-            result.message(),
+            result.message,
             result.scanned,
             result.changed,
             result.errors,
@@ -339,7 +338,7 @@ public class ReconcilerScheduler {
             lease.jobId,
             lease.leaseEpoch,
             finished,
-            result.message(),
+            result.message,
             result.scanned,
             result.changed,
             result.errors,
@@ -355,7 +354,7 @@ public class ReconcilerScheduler {
             totalSnapshots,
             totalStats,
             null,
-            result.message());
+            result.message);
         return;
       }
       jobs.markSucceeded(

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -16,8 +16,6 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
-import static ai.floedb.floecat.reconciler.util.NameParts.split;
-
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
 import ai.floedb.floecat.catalog.rpc.ColumnStats;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
@@ -44,6 +42,7 @@ import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.query.rpc.SchemaDescriptor;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.spi.NameRefNormalizer;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
@@ -159,6 +158,74 @@ public class ReconcilerService {
         NO_PROGRESS);
   }
 
+  public List<ReconcileTableTask> planTableTasks(
+      PrincipalContext principal,
+      ResourceId connectorId,
+      ReconcileScope scopeIn,
+      String bearerToken) {
+    ReconcileScope scope = scopeIn == null ? ReconcileScope.empty() : scopeIn;
+    ReconcileContext ctx = buildContext(principal, Optional.ofNullable(bearerToken));
+
+    final Connector stored = backend.lookupConnector(ctx, connectorId);
+    if (stored.getState() != ConnectorState.CS_ACTIVE) {
+      throw new IllegalStateException("Connector not ACTIVE: " + connectorId.getId());
+    }
+
+    final SourceSelector source =
+        stored.hasSource() ? stored.getSource() : SourceSelector.getDefaultInstance();
+    final DestinationTarget dest =
+        stored.hasDestination() ? stored.getDestination() : DestinationTarget.getDefaultInstance();
+    var cfg = applyIcebergOverrides(ConnectorConfigMapper.fromProto(stored));
+    var resolved = resolveCredentials(cfg, stored.getAuth(), connectorId);
+
+    try (FloecatConnector connector = connectorOpener.open(resolved)) {
+      final String sourceNsFq;
+      if (source.hasNamespace() && !source.getNamespace().getSegmentsList().isEmpty()) {
+        sourceNsFq = fq(source.getNamespace().getSegmentsList());
+      } else {
+        throw new IllegalArgumentException("connector.source.namespace is required");
+      }
+
+      final String destNsFq;
+      if (dest.hasNamespaceId()) {
+        destNsFq = resolveNamespaceFq(ctx, dest.getNamespaceId());
+      } else {
+        destNsFq =
+            (dest.hasNamespace() && !dest.getNamespace().getSegmentsList().isEmpty())
+                ? fq(dest.getNamespace().getSegmentsList())
+                : sourceNsFq;
+      }
+
+      final String tableDisplayHint =
+          (dest.getTableDisplayName() != null && !dest.getTableDisplayName().isBlank())
+              ? dest.getTableDisplayName()
+              : null;
+
+      return connector
+          .planTableTasks(
+              new FloecatConnector.TablePlanningRequest(
+                  sourceNsFq,
+                  source.getTable(),
+                  destNsFq,
+                  tableDisplayHint,
+                  scope.destinationNamespacePaths(),
+                  scope.destinationTableDisplayName()))
+          .stream()
+          .map(
+              task ->
+                  ReconcileTableTask.of(
+                      task.sourceNamespaceFq(),
+                      task.sourceTable(),
+                      task.destinationTableDisplayName()))
+          .toList();
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to plan reconcile tasks for connector " + connectorId.getId(), e);
+    }
+  }
+
   public Result reconcile(
       PrincipalContext principal,
       ResourceId connectorId,
@@ -168,7 +235,31 @@ public class ReconcilerService {
       String bearerToken,
       BooleanSupplier cancelRequested,
       ProgressListener progress) {
+    return reconcile(
+        principal,
+        connectorId,
+        fullRescan,
+        scopeIn,
+        captureMode,
+        bearerToken,
+        ReconcileTableTask.empty(),
+        cancelRequested,
+        progress);
+  }
+
+  public Result reconcile(
+      PrincipalContext principal,
+      ResourceId connectorId,
+      boolean fullRescan,
+      ReconcileScope scopeIn,
+      CaptureMode captureMode,
+      String bearerToken,
+      ReconcileTableTask tableTask,
+      BooleanSupplier cancelRequested,
+      ProgressListener progress) {
     ReconcileScope scope = scopeIn == null ? ReconcileScope.empty() : scopeIn;
+    ReconcileTableTask effectiveTableTask =
+        tableTask == null ? ReconcileTableTask.empty() : tableTask;
     long scanned = 0;
     long changed = 0;
     long errors = 0;
@@ -223,6 +314,20 @@ public class ReconcilerService {
         return new Result(
             0, 0, 1, 0, 0, new IllegalArgumentException("connector.source.namespace is required"));
       }
+      if (!effectiveTableTask.sourceNamespace().isBlank()
+          && !effectiveTableTask.sourceNamespace().equals(sourceNsFq)) {
+        return new Result(
+            0,
+            0,
+            1,
+            0,
+            0,
+            new IllegalArgumentException(
+                "Planned source namespace "
+                    + effectiveTableTask.sourceNamespace()
+                    + " does not match connector source namespace "
+                    + sourceNsFq));
+      }
 
       final String destNsFq;
       final ResourceId destNamespaceId;
@@ -259,9 +364,11 @@ public class ReconcilerService {
       }
 
       final List<String> tables =
-          (source.getTable() != null && !source.getTable().isBlank())
-              ? List.of(source.getTable())
-              : connector.listTables(sourceNsFq);
+          (!effectiveTableTask.sourceTable().isBlank())
+              ? List.of(effectiveTableTask.sourceTable())
+              : (source.getTable() != null && !source.getTable().isBlank())
+                  ? List.of(source.getTable())
+                  : connector.listTables(sourceNsFq);
 
       if (tables.isEmpty()) {
         // A views-only namespace is valid; let the view pass proceed.
@@ -269,7 +376,7 @@ public class ReconcilerService {
             "No tables found in source namespace %s; connector may have views only.", sourceNsFq);
       }
 
-      final boolean singleTableMode = tables.size() == 1;
+      final boolean singleTableMode = effectiveTableTask.isEmpty() && tables.size() == 1;
       final Set<String> includeSelectors = effectiveSelectors(scope, source);
 
       final String tableDisplayHint =
@@ -284,7 +391,9 @@ public class ReconcilerService {
           var upstream = connector.describe(sourceNsFq, srcTable);
 
           final String destTableDisplay =
-              (tableDisplayHint != null) ? tableDisplayHint : upstream.tableName();
+              !effectiveTableTask.destinationTableDisplayName().isBlank()
+                  ? effectiveTableTask.destinationTableDisplayName()
+                  : (tableDisplayHint != null) ? tableDisplayHint : upstream.tableName();
 
           if (!scope.acceptsTable(scopeNamespaceFq, destTableDisplay)) {
             continue;
@@ -360,7 +469,12 @@ public class ReconcilerService {
                   includeStats,
                   knownSnapshotIds,
                   targetSnapshotIds,
-                  progressOut);
+                  progressOut,
+                  scanned,
+                  changed,
+                  errors,
+                  snapshotsProcessed,
+                  statsProcessed);
 
           IngestCounts ingestCounts =
               ingestAllSnapshotsAndStatsFiltered(
@@ -415,83 +529,84 @@ public class ReconcilerService {
       }
 
       if (!matchedScope && scope.hasTableFilter()) {
-        // Record the miss as an error but do NOT return — the view pass must still run.
-        // A table filter is table-scoped; views are always reconciled regardless.
+        // Record the miss as an error but do NOT return. Table filters are table-scoped by
+        // contract, and connector-scoped view reconciliation still runs afterward.
         errors++;
         errSummaries.add("No tables matched scope: " + scope.destinationTableDisplayName());
       }
 
-      // View reconciliation pass — runs after tables; scope filter is table-only so all views sync.
-      // Note: existing views are not updated on re-sync (create-only idempotent operation).
-      List<FloecatConnector.ViewDescriptor> viewDescriptors;
-      try {
-        viewDescriptors = connector.listViewDescriptors(sourceNsFq);
-      } catch (Exception e) {
-        viewDescriptors = List.of();
-        errors++;
-        errSummaries.add("listViewDescriptors(" + sourceNsFq + "): " + rootCauseMessage(e));
-      }
-      for (FloecatConnector.ViewDescriptor view : viewDescriptors) {
+      if (effectiveTableTask.isEmpty()) {
+        // View reconciliation remains connector-scoped to avoid replaying the same namespace
+        // views once per table when connector planning fans work out to table jobs.
+        List<FloecatConnector.ViewDescriptor> viewDescriptors;
         try {
-          if (view.sql() == null || view.sql().isBlank()) {
-            continue;
-          }
-
-          List<SchemaColumn> outputColumns;
-          if (view.schemaJson() != null && !view.schemaJson().isBlank()) {
-            SchemaDescriptor schema =
-                schemaMapper.mapRaw(
-                    ColumnIdAlgorithm.CID_PATH_ORDINAL,
-                    toTableFormat(connector.format()),
-                    view.schemaJson(),
-                    Set.of());
-            outputColumns =
-                schema.getColumnsList().stream()
-                    .filter(SchemaColumn::getLeaf)
-                    .map(
-                        c ->
-                            SchemaColumn.newBuilder()
-                                .setName(c.getName())
-                                .setNullable(c.getNullable())
-                                .setLogicalType(c.getLogicalType())
-                                .build())
-                    .toList();
-          } else {
-            outputColumns = List.of();
-          }
-          if (outputColumns.isEmpty()) {
-            continue;
-          }
-
-          scanned++;
-          ViewSpec viewSpec =
-              ViewSpec.newBuilder()
-                  .setCatalogId(destCatalogId)
-                  .setNamespaceId(destNamespaceId)
-                  .setDisplayName(view.name())
-                  .setSql(view.sql())
-                  .setDialect(view.dialect() != null ? view.dialect() : "")
-                  .addAllCreationSearchPath(
-                      view.searchPath() != null ? view.searchPath() : List.of())
-                  .addAllOutputColumns(outputColumns)
-                  .build();
-          String idempotencyKey = destNsFq + "." + view.name();
-          ResourceId viewId = backend.ensureView(ctx, viewSpec, idempotencyKey);
-          // Only count genuinely new views; ALREADY_EXISTS returns getDefaultInstance() (empty id).
-          if (!viewId.getId().isEmpty()) {
-            changed++;
-          }
+          viewDescriptors = connector.listViewDescriptors(sourceNsFq);
         } catch (Exception e) {
+          viewDescriptors = List.of();
           errors++;
-          errSummaries.add(
-              "dest-ns="
-                  + scopeNamespaceFq
-                  + " source-view="
-                  + sourceNsFq
-                  + "."
-                  + view.name()
-                  + " : "
-                  + rootCauseMessage(e));
+          errSummaries.add("listViewDescriptors(" + sourceNsFq + "): " + rootCauseMessage(e));
+        }
+        for (FloecatConnector.ViewDescriptor view : viewDescriptors) {
+          try {
+            if (view.sql() == null || view.sql().isBlank()) {
+              continue;
+            }
+
+            List<SchemaColumn> outputColumns;
+            if (view.schemaJson() != null && !view.schemaJson().isBlank()) {
+              SchemaDescriptor schema =
+                  schemaMapper.mapRaw(
+                      ColumnIdAlgorithm.CID_PATH_ORDINAL,
+                      toTableFormat(connector.format()),
+                      view.schemaJson(),
+                      Set.of());
+              outputColumns =
+                  schema.getColumnsList().stream()
+                      .filter(SchemaColumn::getLeaf)
+                      .map(
+                          c ->
+                              SchemaColumn.newBuilder()
+                                  .setName(c.getName())
+                                  .setNullable(c.getNullable())
+                                  .setLogicalType(c.getLogicalType())
+                                  .build())
+                      .toList();
+            } else {
+              outputColumns = List.of();
+            }
+            if (outputColumns.isEmpty()) {
+              continue;
+            }
+
+            scanned++;
+            ViewSpec viewSpec =
+                ViewSpec.newBuilder()
+                    .setCatalogId(destCatalogId)
+                    .setNamespaceId(destNamespaceId)
+                    .setDisplayName(view.name())
+                    .setSql(view.sql())
+                    .setDialect(view.dialect() != null ? view.dialect() : "")
+                    .addAllCreationSearchPath(
+                        view.searchPath() != null ? view.searchPath() : List.of())
+                    .addAllOutputColumns(outputColumns)
+                    .build();
+            String idempotencyKey = destNsFq + "." + view.name();
+            var ensureResult = backend.ensureViewDetailed(ctx, viewSpec, idempotencyKey);
+            if (ensureResult.created()) {
+              changed++;
+            }
+          } catch (Exception e) {
+            errors++;
+            errSummaries.add(
+                "dest-ns="
+                    + scopeNamespaceFq
+                    + " source-view="
+                    + sourceNsFq
+                    + "."
+                    + view.name()
+                    + " : "
+                    + rootCauseMessage(e));
+          }
         }
       }
 
@@ -526,19 +641,23 @@ public class ReconcilerService {
       if (e instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
-      return new Result(scanned, changed, errors, snapshotsProcessed, statsProcessed, e);
+      return failureResult(
+          scanned, changed, errors, snapshotsProcessed, statsProcessed, errSummaries, e);
     }
   }
 
   private ResourceId ensureNamespace(
       ReconcileContext ctx, ResourceId catalogId, String namespaceFq) {
-    var parts = split(namespaceFq);
+    List<String> segments = namespaceSegments(namespaceFq);
+    if (segments.isEmpty()) {
+      throw new IllegalArgumentException("namespaceFq must not be blank");
+    }
     String catalogName = backend.lookupCatalogName(ctx, catalogId);
     NameRef nameRef =
         NameRef.newBuilder()
             .setCatalog(catalogName)
-            .addAllPath(parts.parents)
-            .setName(parts.leaf)
+            .addAllPath(segments.subList(0, segments.size() - 1))
+            .setName(segments.get(segments.size() - 1))
             .build();
     NameRef normalized = NameRefNormalizer.normalize(nameRef);
     return backend.ensureNamespace(ctx, catalogId, normalized);
@@ -572,7 +691,7 @@ public class ReconcilerService {
     NameRef tableRef =
         NameRef.newBuilder()
             .setCatalog(catalogName)
-            .addAllPath(List.of(landingView.namespaceFq().split("\\.")))
+            .addAllPath(namespaceSegments(landingView.namespaceFq()))
             .setName(landingView.tableName())
             .build();
     return backend.ensureTable(
@@ -619,7 +738,7 @@ public class ReconcilerService {
     NameRef tableRef =
         NameRef.newBuilder()
             .setCatalog(catalogName)
-            .addAllPath(List.of(namespaceFq.split("\\.")))
+            .addAllPath(namespaceSegments(namespaceFq))
             .setName(tableDisplay)
             .build();
     return backend.lookupTable(ctx, NameRefNormalizer.normalize(tableRef));
@@ -727,14 +846,34 @@ public class ReconcilerService {
       boolean includeStats,
       Set<Long> existingSnapshotIds,
       Set<Long> targetSnapshotIds,
-      ProgressListener progress) {
+      ProgressListener progress,
+      long scanned,
+      long changed,
+      long errors,
+      long snapshotsProcessed,
+      long statsProcessed) {
     if (bundles == null || bundles.isEmpty() || fullRescan) {
       return filterBundlesForSnapshotScope(
-          bundles == null ? List.of() : bundles, targetSnapshotIds, progress);
+          bundles == null ? List.of() : bundles,
+          targetSnapshotIds,
+          progress,
+          scanned,
+          changed,
+          errors,
+          snapshotsProcessed,
+          statsProcessed);
     }
 
     List<FloecatConnector.SnapshotBundle> scoped =
-        filterBundlesForSnapshotScope(bundles, targetSnapshotIds, progress);
+        filterBundlesForSnapshotScope(
+            bundles,
+            targetSnapshotIds,
+            progress,
+            scanned,
+            changed,
+            errors,
+            snapshotsProcessed,
+            statsProcessed);
     if (includeStats) {
       return scoped;
     }
@@ -760,11 +899,11 @@ public class ReconcilerService {
     }
     if (skipped > 0) {
       progress.onProgress(
-          0,
-          0,
-          0,
-          0,
-          0,
+          scanned,
+          changed,
+          errors,
+          snapshotsProcessed,
+          statsProcessed,
           "Incremental reconcile skipped " + skipped + " already-ingested snapshots");
     }
     return filtered;
@@ -773,7 +912,12 @@ public class ReconcilerService {
   private List<FloecatConnector.SnapshotBundle> filterBundlesForSnapshotScope(
       List<FloecatConnector.SnapshotBundle> bundles,
       Set<Long> targetSnapshotIds,
-      ProgressListener progress) {
+      ProgressListener progress,
+      long scanned,
+      long changed,
+      long errors,
+      long snapshotsProcessed,
+      long statsProcessed) {
     if (bundles == null
         || bundles.isEmpty()
         || targetSnapshotIds == null
@@ -794,14 +938,48 @@ public class ReconcilerService {
     }
     if (skipped > 0) {
       progress.onProgress(
-          0,
-          0,
-          0,
-          0,
-          0,
+          scanned,
+          changed,
+          errors,
+          snapshotsProcessed,
+          statsProcessed,
           "Reconcile skipped " + skipped + " snapshots outside explicit snapshot scope");
     }
     return filtered;
+  }
+
+  private static List<String> namespaceSegments(String namespaceFq) {
+    return NameRefNormalizer.normalizeNamespacePath(namespaceFq);
+  }
+
+  private static Result failureResult(
+      long scanned,
+      long changed,
+      long errors,
+      long snapshotsProcessed,
+      long statsProcessed,
+      List<String> errSummaries,
+      Exception error) {
+    if (errSummaries == null || errSummaries.isEmpty()) {
+      return new Result(scanned, changed, errors, snapshotsProcessed, statsProcessed, error);
+    }
+    String baseMessage = rootCauseMessage(error);
+    var summary = new StringBuilder();
+    summary.append("Failure");
+    if (baseMessage != null && !baseMessage.isBlank()) {
+      summary.append(": ").append(baseMessage);
+    }
+    summary.append(" (errors=").append(errors).append("):");
+    for (String s : errSummaries) {
+      summary.append("\n - ").append(s);
+    }
+    return new Result(
+        scanned,
+        changed,
+        errors,
+        snapshotsProcessed,
+        statsProcessed,
+        new RuntimeException(summary.toString(), error));
   }
 
   private static Set<Long> knownSnapshotIdsForEnumeration(

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -339,7 +339,11 @@ public class ReconcilerService {
           Set<Long> knownSnapshotIds =
               fullRescan ? Set.of() : backend.existingSnapshotIds(ctx, destTableId);
           Set<Long> enumerationKnownSnapshotIds =
-              knownSnapshotIdsForEnumeration(fullRescan, knownSnapshotIds);
+              knownSnapshotIdsForEnumeration(
+                  fullRescan,
+                  includeStats,
+                  knownSnapshotIds,
+                  snapshotId -> backend.statsAlreadyCaptured(ctx, destTableId, snapshotId));
           var upstreamBundles =
               connector.enumerateSnapshotsWithStats(
                   sourceNsFq,
@@ -801,11 +805,32 @@ public class ReconcilerService {
   }
 
   private static Set<Long> knownSnapshotIdsForEnumeration(
-      boolean fullRescan, Set<Long> knownSnapshotIds) {
+      boolean fullRescan,
+      boolean includeStats,
+      Set<Long> knownSnapshotIds,
+      LongPredicate statsAlreadyCaptured) {
     if (fullRescan || knownSnapshotIds == null || knownSnapshotIds.isEmpty()) {
       return Set.of();
     }
-    return Set.copyOf(knownSnapshotIds);
+    if (!includeStats) {
+      return Set.copyOf(knownSnapshotIds);
+    }
+    if (statsAlreadyCaptured == null) {
+      return Set.of();
+    }
+    Set<Long> fullyCaptured = new LinkedHashSet<>();
+    for (Long snapshotId : knownSnapshotIds) {
+      if (snapshotId == null || snapshotId < 0) {
+        continue;
+      }
+      if (statsAlreadyCaptured.test(snapshotId)) {
+        fullyCaptured.add(snapshotId);
+      }
+    }
+    if (fullyCaptured.isEmpty()) {
+      return Set.of();
+    }
+    return Set.copyOf(fullyCaptured);
   }
 
   private static boolean tableChanged(List<FloecatConnector.SnapshotBundle> bundles) {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteLeasedJob.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteLeasedJob.java
@@ -13,16 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package ai.floedb.floecat.reconciler.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import java.util.Objects;
 
-import org.junit.jupiter.api.Test;
+record RemoteLeasedJob(ReconcileJobStore.LeasedJob lease) {
+  RemoteLeasedJob {
+    lease = Objects.requireNonNull(lease, "lease");
+  }
 
-class ReconcilerBackendAnnotationTest {
-  @Test
-  void remoteBackendIsNotBuildTimeGated() {
-    assertThat(GrpcReconcilerBackend.class.getAnnotations())
-        .noneMatch(annotation -> annotation.annotationType().getName().endsWith("IfBuildProperty"));
+  enum CompletionState {
+    SUCCEEDED,
+    FAILED,
+    CANCELLED
   }
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorClient.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorClient.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import java.util.Optional;
+
+interface RemoteReconcileExecutorClient {
+  Optional<RemoteLeasedJob> lease(ReconcileExecutor executor);
+
+  void start(RemoteLeasedJob lease, String executorId);
+
+  LeaseHeartbeat renew(RemoteLeasedJob lease);
+
+  LeaseHeartbeat reportProgress(
+      RemoteLeasedJob lease,
+      long scanned,
+      long changed,
+      long errors,
+      long snapshotsProcessed,
+      long statsProcessed,
+      String message);
+
+  CompletionResult complete(
+      RemoteLeasedJob lease,
+      RemoteLeasedJob.CompletionState state,
+      long scanned,
+      long changed,
+      long errors,
+      long snapshotsProcessed,
+      long statsProcessed,
+      String message);
+
+  boolean cancellationRequested(RemoteLeasedJob lease);
+
+  record LeaseHeartbeat(boolean leaseValid, boolean cancellationRequested) {}
+
+  record CompletionResult(boolean accepted) {}
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class RemoteReconcileExecutorPoller {
+  private static final long DEFAULT_LEASE_HEARTBEAT_MS = 2_000L;
+  private static final long MIN_LEASE_HEARTBEAT_MS = 1_000L;
+  private static final long MIN_CANCEL_CHECK_MS = 500L;
+  private static final int DEFAULT_MAX_PARALLELISM = 1;
+
+  @Inject ReconcileExecutorRegistry executorRegistry;
+  @Inject RemoteReconcileExecutorClient client;
+  @Inject Config config;
+
+  @ConfigProperty(name = "floecat.reconciler.remote-executor.enabled", defaultValue = "false")
+  boolean remoteExecutorEnabled;
+
+  private static final Logger LOG = Logger.getLogger(RemoteReconcileExecutorPoller.class);
+
+  private final AtomicBoolean polling = new AtomicBoolean(false);
+  private final AtomicInteger inFlight = new AtomicInteger(0);
+  private volatile int maxParallelism = DEFAULT_MAX_PARALLELISM;
+  private volatile ExecutorService workers;
+
+  @PostConstruct
+  void init() {
+    if (!remoteExecutorEnabled) {
+      return;
+    }
+    maxParallelism =
+        Math.max(
+            1,
+            config
+                .getOptionalValue("reconciler.max-parallelism", Integer.class)
+                .orElse(DEFAULT_MAX_PARALLELISM));
+    workers = Executors.newFixedThreadPool(maxParallelism);
+  }
+
+  @PreDestroy
+  void destroy() {
+    ExecutorService executor = workers;
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+
+  @Scheduled(
+      every = "{reconciler.pollEvery:1s}",
+      concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+  void pollOnce() {
+    if (!remoteExecutorEnabled || executorRegistry.orderedExecutors().isEmpty()) {
+      return;
+    }
+    if (!polling.compareAndSet(false, true)) {
+      return;
+    }
+    try {
+      while (reserveWorkerSlot()) {
+        Optional<LeaseAssignment> assignment = leaseNextAssignment();
+        if (assignment.isEmpty()) {
+          inFlight.decrementAndGet();
+          return;
+        }
+        submitAssignment(assignment.get());
+      }
+    } finally {
+      polling.set(false);
+    }
+  }
+
+  private Optional<LeaseAssignment> leaseNextAssignment() {
+    for (ReconcileExecutor executor : executorRegistry.orderedExecutors()) {
+      Optional<RemoteLeasedJob> lease = client.lease(executor);
+      if (lease.isPresent()) {
+        return Optional.of(new LeaseAssignment(executor, lease.get()));
+      }
+    }
+    return Optional.empty();
+  }
+
+  private boolean reserveWorkerSlot() {
+    while (true) {
+      int current = inFlight.get();
+      if (current >= maxParallelism) {
+        return false;
+      }
+      if (inFlight.compareAndSet(current, current + 1)) {
+        return true;
+      }
+    }
+  }
+
+  private void submitAssignment(LeaseAssignment assignment) {
+    ExecutorService executor = workers;
+    if (executor == null) {
+      inFlight.decrementAndGet();
+      return;
+    }
+    try {
+      executor.submit(
+          () -> {
+            try {
+              runLease(assignment);
+            } finally {
+              inFlight.decrementAndGet();
+            }
+          });
+    } catch (RuntimeException e) {
+      inFlight.decrementAndGet();
+      throw e;
+    }
+  }
+
+  void runLease(LeaseAssignment assignment) {
+    ReconcileExecutor executor = assignment.executor();
+    RemoteLeasedJob remoteLease = assignment.lease();
+    var lease = remoteLease.lease();
+    long started = System.currentTimeMillis();
+    long leaseMs =
+        Math.max(
+            1_000L,
+            config
+                .getOptionalValue("floecat.reconciler.job-store.lease-ms", Long.class)
+                .orElse(30_000L));
+    long suggestedHeartbeatMs = Math.max(MIN_LEASE_HEARTBEAT_MS, leaseMs / 3L);
+    long heartbeatEveryMs =
+        Math.max(
+            MIN_LEASE_HEARTBEAT_MS,
+            config
+                .getOptionalValue("reconciler.lease-heartbeat-ms", Long.class)
+                .orElse(Math.max(DEFAULT_LEASE_HEARTBEAT_MS, suggestedHeartbeatMs)));
+    long[] nextHeartbeatAtMs = {started};
+    long cancelCheckEveryMs = Math.max(MIN_CANCEL_CHECK_MS, heartbeatEveryMs / 2L);
+    long[] nextCancelCheckAtMs = {started};
+    AtomicBoolean leaseValid = new AtomicBoolean(true);
+    AtomicBoolean cancellationRequested = new AtomicBoolean(false);
+    AtomicBoolean interrupted = new AtomicBoolean(false);
+
+    BooleanSupplier heartbeat =
+        () -> {
+          if (!leaseValid.get()) {
+            return false;
+          }
+          long now = System.currentTimeMillis();
+          if (now < nextHeartbeatAtMs[0]) {
+            return true;
+          }
+          RemoteReconcileExecutorClient.LeaseHeartbeat response = client.renew(remoteLease);
+          leaseValid.set(response.leaseValid());
+          cancellationRequested.set(response.cancellationRequested());
+          nextHeartbeatAtMs[0] = now + heartbeatEveryMs;
+          return response.leaseValid();
+        };
+
+    BooleanSupplier shouldStop =
+        () -> {
+          if (Thread.currentThread().isInterrupted()) {
+            interrupted.set(true);
+            return true;
+          }
+          if (!heartbeat.getAsBoolean()) {
+            return true;
+          }
+          long now = System.currentTimeMillis();
+          if (now >= nextCancelCheckAtMs[0]) {
+            cancellationRequested.set(client.cancellationRequested(remoteLease));
+            nextCancelCheckAtMs[0] = now + cancelCheckEveryMs;
+          }
+          return cancellationRequested.get();
+        };
+
+    try {
+      client.start(remoteLease, executor.id());
+      if (shouldStop.getAsBoolean()) {
+        completeIfPossible(
+            remoteLease, RemoteLeasedJob.CompletionState.CANCELLED, 0, 0, 0, 0, 0, "Cancelled");
+        return;
+      }
+      var result =
+          executor.execute(
+              new ReconcileExecutor.ExecutionContext(
+                  lease,
+                  shouldStop,
+                  (scanned, changed, errors, snapshotsProcessed, statsProcessed, message) -> {
+                    if (!leaseValid.get()) {
+                      return;
+                    }
+                    RemoteReconcileExecutorClient.LeaseHeartbeat response =
+                        client.reportProgress(
+                            remoteLease,
+                            scanned,
+                            changed,
+                            errors,
+                            snapshotsProcessed,
+                            statsProcessed,
+                            message);
+                    leaseValid.set(response.leaseValid());
+                    cancellationRequested.set(response.cancellationRequested());
+                  }));
+      if (!leaseValid.get()) {
+        LOG.warnf("Remote reconcile lease lost for job %s executor=%s", lease.jobId, executor.id());
+        return;
+      }
+      if (result.cancelled || cancellationRequested.get()) {
+        completeIfPossible(
+            remoteLease,
+            RemoteLeasedJob.CompletionState.CANCELLED,
+            result.scanned,
+            result.changed,
+            result.errors,
+            result.snapshotsProcessed,
+            result.statsProcessed,
+            result.message);
+        return;
+      }
+      if (!result.ok()) {
+        completeIfPossible(
+            remoteLease,
+            RemoteLeasedJob.CompletionState.FAILED,
+            result.scanned,
+            result.changed,
+            result.errors,
+            result.snapshotsProcessed,
+            result.statsProcessed,
+            result.message);
+        return;
+      }
+      completeIfPossible(
+          remoteLease,
+          RemoteLeasedJob.CompletionState.SUCCEEDED,
+          result.scanned,
+          result.changed,
+          result.errors,
+          result.snapshotsProcessed,
+          result.statsProcessed,
+          result.message);
+      LOG.infof(
+          "Remote reconcile job outcome account=%s connector=%s executor=%s result=succeeded duration_ms=%d",
+          lease.accountId,
+          lease.connectorId,
+          executor.id(),
+          Math.max(0L, System.currentTimeMillis() - started));
+    } catch (Exception e) {
+      if (leaseValid.get() && !interrupted.get()) {
+        completeIfPossible(
+            remoteLease,
+            cancellationRequested.get()
+                ? RemoteLeasedJob.CompletionState.CANCELLED
+                : RemoteLeasedJob.CompletionState.FAILED,
+            0,
+            0,
+            cancellationRequested.get() ? 0 : 1,
+            0,
+            0,
+            describeFailure(e));
+      }
+      LOG.errorf(
+          e,
+          "Remote reconcile execution failed for job %s executor=%s",
+          lease.jobId,
+          executor.id());
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  private void completeIfPossible(
+      RemoteLeasedJob lease,
+      RemoteLeasedJob.CompletionState state,
+      long scanned,
+      long changed,
+      long errors,
+      long snapshotsProcessed,
+      long statsProcessed,
+      String message) {
+    RemoteReconcileExecutorClient.CompletionResult result =
+        client.complete(
+            lease, state, scanned, changed, errors, snapshotsProcessed, statsProcessed, message);
+    if (!result.accepted()) {
+      LOG.warnf("Remote reconcile completion rejected for job %s", lease.lease().jobId);
+    }
+  }
+
+  private static String describeFailure(Throwable t) {
+    if (t == null) {
+      return "Unknown error";
+    }
+    String msg = t.getMessage();
+    if (msg == null || msg.isBlank()) {
+      return t.getClass().getSimpleName();
+    }
+    return t.getClass().getSimpleName() + ": " + msg;
+  }
+
+  record LeaseAssignment(ReconcileExecutor executor, RemoteLeasedJob lease) {}
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
@@ -166,6 +166,7 @@ public class RemoteReconcileExecutorPoller {
     AtomicBoolean leaseValid = new AtomicBoolean(true);
     AtomicBoolean cancellationRequested = new AtomicBoolean(false);
     AtomicBoolean interrupted = new AtomicBoolean(false);
+    ProgressSnapshot progress = new ProgressSnapshot();
 
     BooleanSupplier heartbeat =
         () -> {
@@ -216,6 +217,7 @@ public class RemoteReconcileExecutorPoller {
                     if (!leaseValid.get()) {
                       return;
                     }
+                    progress.update(scanned, changed, errors, snapshotsProcessed, statsProcessed);
                     RemoteReconcileExecutorClient.LeaseHeartbeat response =
                         client.reportProgress(
                             remoteLease,
@@ -273,16 +275,18 @@ public class RemoteReconcileExecutorPoller {
           Math.max(0L, System.currentTimeMillis() - started));
     } catch (Exception e) {
       if (leaseValid.get() && !interrupted.get()) {
+        long errorCount =
+            cancellationRequested.get() ? progress.errors : Math.max(1L, progress.errors);
         completeIfPossible(
             remoteLease,
             cancellationRequested.get()
                 ? RemoteLeasedJob.CompletionState.CANCELLED
                 : RemoteLeasedJob.CompletionState.FAILED,
-            0,
-            0,
-            cancellationRequested.get() ? 0 : 1,
-            0,
-            0,
+            progress.scanned,
+            progress.changed,
+            errorCount,
+            progress.snapshotsProcessed,
+            progress.statsProcessed,
             describeFailure(e));
       }
       LOG.errorf(
@@ -321,6 +325,23 @@ public class RemoteReconcileExecutorPoller {
       return t.getClass().getSimpleName();
     }
     return t.getClass().getSimpleName() + ": " + msg;
+  }
+
+  private static final class ProgressSnapshot {
+    long scanned;
+    long changed;
+    long errors;
+    long snapshotsProcessed;
+    long statsProcessed;
+
+    void update(
+        long scanned, long changed, long errors, long snapshotsProcessed, long statsProcessed) {
+      this.scanned = scanned;
+      this.changed = changed;
+      this.errors = errors;
+      this.snapshotsProcessed = snapshotsProcessed;
+      this.statsProcessed = statsProcessed;
+    }
   }
 
   record LeaseAssignment(ReconcileExecutor executor, RemoteLeasedJob lease) {}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileExecutionClass.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileExecutionClass.java
@@ -13,16 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.floedb.floecat.reconciler.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
+package ai.floedb.floecat.reconciler.jobs;
 
-import org.junit.jupiter.api.Test;
+public enum ReconcileExecutionClass {
+  DEFAULT,
+  INTERACTIVE,
+  BATCH,
+  HEAVY;
 
-class ReconcilerBackendAnnotationTest {
-  @Test
-  void remoteBackendIsNotBuildTimeGated() {
-    assertThat(GrpcReconcilerBackend.class.getAnnotations())
-        .noneMatch(annotation -> annotation.annotationType().getName().endsWith("IfBuildProperty"));
+  public static ReconcileExecutionClass fromString(String value) {
+    if (value == null || value.isBlank()) {
+      return DEFAULT;
+    }
+    try {
+      return ReconcileExecutionClass.valueOf(value.trim().toUpperCase());
+    } catch (IllegalArgumentException ignored) {
+      return DEFAULT;
+    }
   }
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileExecutionPolicy.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileExecutionPolicy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.jobs;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public record ReconcileExecutionPolicy(
+    ReconcileExecutionClass executionClass, String lane, Map<String, String> attributes) {
+  private static final ReconcileExecutionPolicy DEFAULT_POLICY =
+      new ReconcileExecutionPolicy(ReconcileExecutionClass.DEFAULT, "", Map.of());
+
+  public ReconcileExecutionPolicy {
+    executionClass = executionClass == null ? ReconcileExecutionClass.DEFAULT : executionClass;
+    lane = lane == null ? "" : lane.trim();
+
+    Map<String, String> normalized = new TreeMap<>();
+    if (attributes != null) {
+      for (var entry : attributes.entrySet()) {
+        String key = entry.getKey();
+        if (key == null || key.isBlank()) {
+          continue;
+        }
+        normalized.put(key.trim(), entry.getValue() == null ? "" : entry.getValue().trim());
+      }
+    }
+    attributes = Map.copyOf(normalized);
+  }
+
+  public static ReconcileExecutionPolicy defaults() {
+    return DEFAULT_POLICY;
+  }
+
+  public static ReconcileExecutionPolicy of(
+      ReconcileExecutionClass executionClass, String lane, Map<String, String> attributes) {
+    if ((executionClass == null || executionClass == ReconcileExecutionClass.DEFAULT)
+        && (lane == null || lane.isBlank())
+        && (attributes == null || attributes.isEmpty())) {
+      return DEFAULT_POLICY;
+    }
+    return new ReconcileExecutionPolicy(executionClass, lane, attributes);
+  }
+
+  public boolean isDefaultPolicy() {
+    return executionClass == ReconcileExecutionClass.DEFAULT
+        && lane.isBlank()
+        && attributes.isEmpty();
+  }
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobKind.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobKind.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.jobs;
+
+public enum ReconcileJobKind {
+  EXEC_CONNECTOR,
+  PLAN_CONNECTOR,
+  EXEC_TABLE;
+
+  public static ReconcileJobKind fromString(String value) {
+    if (value == null || value.isBlank()) {
+      return EXEC_CONNECTOR;
+    }
+    try {
+      return ReconcileJobKind.valueOf(value.trim());
+    } catch (IllegalArgumentException ignored) {
+      return EXEC_CONNECTOR;
+    }
+  }
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
@@ -17,17 +17,36 @@
 package ai.floedb.floecat.reconciler.jobs;
 
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 public interface ReconcileJobStore {
+  default String enqueue(
+      String accountId,
+      String connectorId,
+      boolean fullRescan,
+      CaptureMode captureMode,
+      ReconcileScope scope) {
+    return enqueue(
+        accountId,
+        connectorId,
+        fullRescan,
+        captureMode,
+        scope,
+        ReconcileExecutionPolicy.defaults(),
+        "");
+  }
+
   String enqueue(
       String accountId,
       String connectorId,
       boolean fullRescan,
       CaptureMode captureMode,
-      ReconcileScope scope);
+      ReconcileScope scope,
+      ReconcileExecutionPolicy executionPolicy,
+      String pinnedExecutorId);
 
   Optional<ReconcileJob> get(String accountId, String jobId);
 
@@ -40,11 +59,15 @@ public interface ReconcileJobStore {
 
   QueueStats queueStats();
 
-  Optional<LeasedJob> leaseNext();
+  default Optional<LeasedJob> leaseNext() {
+    return leaseNext(LeaseRequest.all());
+  }
+
+  Optional<LeasedJob> leaseNext(LeaseRequest request);
 
   boolean renewLease(String jobId, String leaseEpoch);
 
-  void markRunning(String jobId, String leaseEpoch, long startedAtMs);
+  void markRunning(String jobId, String leaseEpoch, long startedAtMs, String executorId);
 
   void markProgress(
       String jobId,
@@ -107,6 +130,8 @@ public interface ReconcileJobStore {
     public final long snapshotsProcessed;
     public final long statsProcessed;
     public final ReconcileScope scope;
+    public final ReconcileExecutionPolicy executionPolicy;
+    public final String executorId;
 
     public ReconcileJob(
         String jobId,
@@ -123,7 +148,9 @@ public interface ReconcileJobStore {
         CaptureMode captureMode,
         long snapshotsProcessed,
         long statsProcessed,
-        ReconcileScope scope) {
+        ReconcileScope scope,
+        ReconcileExecutionPolicy executionPolicy,
+        String executorId) {
       this.jobId = jobId;
       this.accountId = accountId;
       this.connectorId = connectorId;
@@ -139,6 +166,9 @@ public interface ReconcileJobStore {
       this.snapshotsProcessed = snapshotsProcessed;
       this.statsProcessed = statsProcessed;
       this.scope = scope == null ? ReconcileScope.empty() : scope;
+      this.executionPolicy =
+          executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy;
+      this.executorId = executorId == null ? "" : executorId;
     }
   }
 
@@ -149,7 +179,10 @@ public interface ReconcileJobStore {
     public final boolean fullRescan;
     public final CaptureMode captureMode;
     public final ReconcileScope scope;
+    public final ReconcileExecutionPolicy executionPolicy;
     public final String leaseEpoch;
+    public final String pinnedExecutorId;
+    public final String executorId;
 
     public LeasedJob(
         String jobId,
@@ -158,14 +191,21 @@ public interface ReconcileJobStore {
         boolean fullRescan,
         CaptureMode captureMode,
         ReconcileScope scope,
-        String leaseEpoch) {
+        ReconcileExecutionPolicy executionPolicy,
+        String leaseEpoch,
+        String pinnedExecutorId,
+        String executorId) {
       this.jobId = jobId;
       this.accountId = accountId;
       this.connectorId = connectorId;
       this.fullRescan = fullRescan;
       this.captureMode = captureMode == null ? CaptureMode.METADATA_AND_STATS : captureMode;
       this.scope = scope == null ? ReconcileScope.empty() : scope;
+      this.executionPolicy =
+          executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy;
       this.leaseEpoch = leaseEpoch == null ? "" : leaseEpoch;
+      this.pinnedExecutorId = pinnedExecutorId == null ? "" : pinnedExecutorId;
+      this.executorId = executorId == null ? "" : executorId;
     }
   }
 
@@ -190,6 +230,64 @@ public interface ReconcileJobStore {
       this.running = Math.max(0L, running);
       this.cancelling = Math.max(0L, cancelling);
       this.oldestQueuedCreatedAtMs = Math.max(0L, oldestQueuedCreatedAtMs);
+    }
+  }
+
+  final class LeaseRequest {
+    public final Set<ReconcileExecutionClass> executionClasses;
+    public final Set<String> lanes;
+    public final Set<String> executorIds;
+
+    public LeaseRequest(
+        Set<ReconcileExecutionClass> executionClasses, Set<String> lanes, Set<String> executorIds) {
+      this.executionClasses =
+          executionClasses == null
+              ? Set.of()
+              : EnumSet.copyOf(
+                  executionClasses.isEmpty()
+                      ? EnumSet.noneOf(ReconcileExecutionClass.class)
+                      : executionClasses);
+      this.lanes =
+          lanes == null
+              ? Set.of()
+              : lanes.stream()
+                  .map(lane -> lane == null ? "" : lane.trim())
+                  .collect(java.util.stream.Collectors.toUnmodifiableSet());
+      this.executorIds =
+          executorIds == null
+              ? Set.of()
+              : executorIds.stream()
+                  .map(executorId -> executorId == null ? "" : executorId.trim())
+                  .filter(executorId -> !executorId.isEmpty())
+                  .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+
+    public static LeaseRequest all() {
+      return new LeaseRequest(Set.of(), Set.of(), Set.of());
+    }
+
+    public static LeaseRequest of(
+        Set<ReconcileExecutionClass> executionClasses, Set<String> lanes) {
+      return new LeaseRequest(executionClasses, lanes, Set.of());
+    }
+
+    public static LeaseRequest of(
+        Set<ReconcileExecutionClass> executionClasses, Set<String> lanes, Set<String> executorIds) {
+      return new LeaseRequest(executionClasses, lanes, executorIds);
+    }
+
+    public boolean matches(ReconcileExecutionPolicy policy, String pinnedExecutorId) {
+      ReconcileExecutionPolicy effective =
+          policy == null ? ReconcileExecutionPolicy.defaults() : policy;
+      boolean classMatches =
+          executionClasses.isEmpty() || executionClasses.contains(effective.executionClass());
+      boolean laneMatches = lanes.isEmpty() || lanes.contains(effective.lane());
+      String effectivePinnedExecutorId = pinnedExecutorId == null ? "" : pinnedExecutorId.trim();
+      boolean executorMatches =
+          effectivePinnedExecutorId.isEmpty()
+              || executorIds.isEmpty()
+              || executorIds.contains(effectivePinnedExecutorId);
+      return classMatches && laneMatches && executorMatches;
     }
   }
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
@@ -35,7 +35,10 @@ public interface ReconcileJobStore {
         fullRescan,
         captureMode,
         scope,
+        ReconcileJobKind.EXEC_CONNECTOR,
+        ReconcileTableTask.empty(),
         ReconcileExecutionPolicy.defaults(),
+        "",
         "");
   }
 
@@ -45,8 +48,76 @@ public interface ReconcileJobStore {
       boolean fullRescan,
       CaptureMode captureMode,
       ReconcileScope scope,
+      ReconcileJobKind jobKind,
+      ReconcileTableTask tableTask,
       ReconcileExecutionPolicy executionPolicy,
+      String parentJobId,
       String pinnedExecutorId);
+
+  default String enqueue(
+      String accountId,
+      String connectorId,
+      boolean fullRescan,
+      CaptureMode captureMode,
+      ReconcileScope scope,
+      ReconcileExecutionPolicy executionPolicy,
+      String pinnedExecutorId) {
+    return enqueue(
+        accountId,
+        connectorId,
+        fullRescan,
+        captureMode,
+        scope,
+        ReconcileJobKind.EXEC_CONNECTOR,
+        ReconcileTableTask.empty(),
+        executionPolicy,
+        "",
+        pinnedExecutorId);
+  }
+
+  default String enqueuePlan(
+      String accountId,
+      String connectorId,
+      boolean fullRescan,
+      CaptureMode captureMode,
+      ReconcileScope scope,
+      ReconcileExecutionPolicy executionPolicy,
+      String pinnedExecutorId) {
+    return enqueue(
+        accountId,
+        connectorId,
+        fullRescan,
+        captureMode,
+        scope,
+        ReconcileJobKind.PLAN_CONNECTOR,
+        ReconcileTableTask.empty(),
+        executionPolicy,
+        "",
+        pinnedExecutorId);
+  }
+
+  default String enqueueTableExecution(
+      String accountId,
+      String connectorId,
+      boolean fullRescan,
+      CaptureMode captureMode,
+      ReconcileScope scope,
+      ReconcileTableTask tableTask,
+      ReconcileExecutionPolicy executionPolicy,
+      String parentJobId,
+      String pinnedExecutorId) {
+    return enqueue(
+        accountId,
+        connectorId,
+        fullRescan,
+        captureMode,
+        scope,
+        ReconcileJobKind.EXEC_TABLE,
+        tableTask,
+        executionPolicy,
+        parentJobId,
+        pinnedExecutorId);
+  }
 
   Optional<ReconcileJob> get(String accountId, String jobId);
 
@@ -132,6 +203,9 @@ public interface ReconcileJobStore {
     public final ReconcileScope scope;
     public final ReconcileExecutionPolicy executionPolicy;
     public final String executorId;
+    public final ReconcileJobKind jobKind;
+    public final ReconcileTableTask tableTask;
+    public final String parentJobId;
 
     public ReconcileJob(
         String jobId,
@@ -150,7 +224,10 @@ public interface ReconcileJobStore {
         long statsProcessed,
         ReconcileScope scope,
         ReconcileExecutionPolicy executionPolicy,
-        String executorId) {
+        String executorId,
+        ReconcileJobKind jobKind,
+        ReconcileTableTask tableTask,
+        String parentJobId) {
       this.jobId = jobId;
       this.accountId = accountId;
       this.connectorId = connectorId;
@@ -169,6 +246,9 @@ public interface ReconcileJobStore {
       this.executionPolicy =
           executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy;
       this.executorId = executorId == null ? "" : executorId;
+      this.jobKind = jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR : jobKind;
+      this.tableTask = tableTask == null ? ReconcileTableTask.empty() : tableTask;
+      this.parentJobId = parentJobId == null ? "" : parentJobId;
     }
   }
 
@@ -183,6 +263,9 @@ public interface ReconcileJobStore {
     public final String leaseEpoch;
     public final String pinnedExecutorId;
     public final String executorId;
+    public final ReconcileJobKind jobKind;
+    public final ReconcileTableTask tableTask;
+    public final String parentJobId;
 
     public LeasedJob(
         String jobId,
@@ -194,7 +277,10 @@ public interface ReconcileJobStore {
         ReconcileExecutionPolicy executionPolicy,
         String leaseEpoch,
         String pinnedExecutorId,
-        String executorId) {
+        String executorId,
+        ReconcileJobKind jobKind,
+        ReconcileTableTask tableTask,
+        String parentJobId) {
       this.jobId = jobId;
       this.accountId = accountId;
       this.connectorId = connectorId;
@@ -206,6 +292,9 @@ public interface ReconcileJobStore {
       this.leaseEpoch = leaseEpoch == null ? "" : leaseEpoch;
       this.pinnedExecutorId = pinnedExecutorId == null ? "" : pinnedExecutorId;
       this.executorId = executorId == null ? "" : executorId;
+      this.jobKind = jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR : jobKind;
+      this.tableTask = tableTask == null ? ReconcileTableTask.empty() : tableTask;
+      this.parentJobId = parentJobId == null ? "" : parentJobId;
     }
   }
 
@@ -237,9 +326,13 @@ public interface ReconcileJobStore {
     public final Set<ReconcileExecutionClass> executionClasses;
     public final Set<String> lanes;
     public final Set<String> executorIds;
+    public final Set<ReconcileJobKind> jobKinds;
 
     public LeaseRequest(
-        Set<ReconcileExecutionClass> executionClasses, Set<String> lanes, Set<String> executorIds) {
+        Set<ReconcileExecutionClass> executionClasses,
+        Set<String> lanes,
+        Set<String> executorIds,
+        Set<ReconcileJobKind> jobKinds) {
       this.executionClasses =
           executionClasses == null
               ? Set.of()
@@ -260,34 +353,51 @@ public interface ReconcileJobStore {
                   .map(executorId -> executorId == null ? "" : executorId.trim())
                   .filter(executorId -> !executorId.isEmpty())
                   .collect(java.util.stream.Collectors.toUnmodifiableSet());
+      this.jobKinds =
+          jobKinds == null
+              ? Set.of()
+              : EnumSet.copyOf(
+                  jobKinds.isEmpty() ? EnumSet.noneOf(ReconcileJobKind.class) : jobKinds);
     }
 
     public static LeaseRequest all() {
-      return new LeaseRequest(Set.of(), Set.of(), Set.of());
+      return new LeaseRequest(Set.of(), Set.of(), Set.of(), Set.of());
     }
 
     public static LeaseRequest of(
         Set<ReconcileExecutionClass> executionClasses, Set<String> lanes) {
-      return new LeaseRequest(executionClasses, lanes, Set.of());
+      return new LeaseRequest(executionClasses, lanes, Set.of(), Set.of());
     }
 
     public static LeaseRequest of(
         Set<ReconcileExecutionClass> executionClasses, Set<String> lanes, Set<String> executorIds) {
-      return new LeaseRequest(executionClasses, lanes, executorIds);
+      return new LeaseRequest(executionClasses, lanes, executorIds, Set.of());
     }
 
-    public boolean matches(ReconcileExecutionPolicy policy, String pinnedExecutorId) {
+    public static LeaseRequest of(
+        Set<ReconcileExecutionClass> executionClasses,
+        Set<String> lanes,
+        Set<String> executorIds,
+        Set<ReconcileJobKind> jobKinds) {
+      return new LeaseRequest(executionClasses, lanes, executorIds, jobKinds);
+    }
+
+    public boolean matches(
+        ReconcileExecutionPolicy policy, String pinnedExecutorId, ReconcileJobKind jobKind) {
       ReconcileExecutionPolicy effective =
           policy == null ? ReconcileExecutionPolicy.defaults() : policy;
+      ReconcileJobKind effectiveJobKind =
+          jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR : jobKind;
       boolean classMatches =
           executionClasses.isEmpty() || executionClasses.contains(effective.executionClass());
       boolean laneMatches = lanes.isEmpty() || lanes.contains(effective.lane());
+      boolean kindMatches = jobKinds.isEmpty() || jobKinds.contains(effectiveJobKind);
       String effectivePinnedExecutorId = pinnedExecutorId == null ? "" : pinnedExecutorId.trim();
       boolean executorMatches =
           effectivePinnedExecutorId.isEmpty()
               || executorIds.isEmpty()
               || executorIds.contains(effectivePinnedExecutorId);
-      return classMatches && laneMatches && executorMatches;
+      return classMatches && laneMatches && kindMatches && executorMatches;
     }
   }
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileTableTask.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileTableTask.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.jobs;
+
+public record ReconcileTableTask(
+    String sourceNamespace, String sourceTable, String destinationTableDisplayName) {
+  public ReconcileTableTask {
+    sourceNamespace = sourceNamespace == null ? "" : sourceNamespace.trim();
+    sourceTable = sourceTable == null ? "" : sourceTable.trim();
+    destinationTableDisplayName =
+        destinationTableDisplayName == null ? "" : destinationTableDisplayName.trim();
+  }
+
+  public static ReconcileTableTask of(String sourceNamespace, String sourceTable) {
+    return of(sourceNamespace, sourceTable, "");
+  }
+
+  public static ReconcileTableTask of(
+      String sourceNamespace, String sourceTable, String destinationTableDisplayName) {
+    if ((sourceNamespace == null || sourceNamespace.isBlank())
+        && (sourceTable == null || sourceTable.isBlank())
+        && (destinationTableDisplayName == null || destinationTableDisplayName.isBlank())) {
+      return empty();
+    }
+    return new ReconcileTableTask(sourceNamespace, sourceTable, destinationTableDisplayName);
+  }
+
+  public static ReconcileTableTask empty() {
+    return new ReconcileTableTask("", "", "");
+  }
+
+  public boolean isEmpty() {
+    return sourceNamespace.isBlank()
+        && sourceTable.isBlank()
+        && destinationTableDisplayName.isBlank();
+  }
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.reconciler.jobs.impl;
 
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import io.quarkus.arc.properties.IfBuildProperty;
@@ -39,6 +40,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
   private final Map<String, ReconcileJob> jobs = new ConcurrentHashMap<>();
   private final Map<String, Long> createdAtMs = new ConcurrentHashMap<>();
   private final Map<String, String> leaseEpochs = new ConcurrentHashMap<>();
+  private final Map<String, String> pinnedExecutors = new ConcurrentHashMap<>();
   private final ConcurrentLinkedQueue<String> ready = new ConcurrentLinkedQueue<>();
   private final Set<String> leased = ConcurrentHashMap.newKeySet();
 
@@ -48,7 +50,9 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
       String connectorId,
       boolean fullRescan,
       CaptureMode captureMode,
-      ReconcileScope scope) {
+      ReconcileScope scope,
+      ReconcileExecutionPolicy executionPolicy,
+      String pinnedExecutorId) {
     String id = UUID.randomUUID().toString();
     createdAtMs.put(id, System.currentTimeMillis());
     var job =
@@ -67,8 +71,11 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
             captureMode,
             0,
             0,
-            scope);
+            scope,
+            executionPolicy,
+            "");
     jobs.put(id, job);
+    pinnedExecutors.put(id, pinnedExecutorId == null ? "" : pinnedExecutorId.trim());
     ready.add(id);
     return id;
   }
@@ -147,8 +154,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
   }
 
   @Override
-  public Optional<LeasedJob> leaseNext() {
-    for (; ; ) {
+  public Optional<LeasedJob> leaseNext(LeaseRequest request) {
+    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
+    int attempts = Math.max(1, ready.size());
+    for (int i = 0; i < attempts; i++) {
       String jobId = ready.poll();
       if (jobId == null) {
         return Optional.empty();
@@ -164,6 +173,11 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
         continue;
       }
 
+      if (!effective.matches(job.executionPolicy, pinnedExecutors.getOrDefault(jobId, ""))) {
+        ready.add(jobId);
+        continue;
+      }
+
       if (leased.add(jobId)) {
         String leaseEpoch = UUID.randomUUID().toString();
         leaseEpochs.put(jobId, leaseEpoch);
@@ -175,9 +189,13 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
                 job.fullRescan,
                 job.captureMode,
                 job.scope,
-                leaseEpoch));
+                job.executionPolicy,
+                leaseEpoch,
+                pinnedExecutors.getOrDefault(jobId, ""),
+                job.executorId));
       }
     }
+    return Optional.empty();
   }
 
   @Override
@@ -193,7 +211,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
   }
 
   @Override
-  public void markRunning(String jobId, String leaseEpoch, long startedAtMs) {
+  public void markRunning(String jobId, String leaseEpoch, long startedAtMs, String executorId) {
     jobs.computeIfPresent(
         jobId,
         (id, job) -> {
@@ -215,7 +233,9 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               job.captureMode,
               job.snapshotsProcessed,
               job.statsProcessed,
-              job.scope);
+              job.scope,
+              job.executionPolicy,
+              executorId);
         });
   }
 
@@ -255,7 +275,9 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               job.captureMode,
               snapshotsProcessed,
               statsProcessed,
-              job.scope);
+              job.scope,
+              job.executionPolicy,
+              job.executorId);
         });
   }
 
@@ -279,6 +301,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
           }
           leased.remove(id);
           leaseEpochs.remove(id);
+          pinnedExecutors.remove(id);
           return new ReconcileJob(
               job.jobId,
               job.accountId,
@@ -294,7 +317,9 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               job.captureMode,
               snapshotsProcessed,
               statsProcessed,
-              job.scope);
+              job.scope,
+              job.executionPolicy,
+              job.executorId);
         });
   }
 
@@ -320,6 +345,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
           }
           leased.remove(id);
           leaseEpochs.remove(id);
+          pinnedExecutors.remove(id);
           return new ReconcileJob(
               job.jobId,
               job.accountId,
@@ -335,7 +361,9 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               job.captureMode,
               snapshotsProcessed,
               statsProcessed,
-              job.scope);
+              job.scope,
+              job.executionPolicy,
+              job.executorId);
         });
   }
 
@@ -368,10 +396,13 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
                 job.captureMode,
                 job.snapshotsProcessed,
                 job.statsProcessed,
-                job.scope);
+                job.scope,
+                job.executionPolicy,
+                job.executorId);
           }
           leased.remove(id);
           leaseEpochs.remove(id);
+          pinnedExecutors.remove(id);
           return new ReconcileJob(
               job.jobId,
               job.accountId,
@@ -387,7 +418,9 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               job.captureMode,
               job.snapshotsProcessed,
               job.statsProcessed,
-              job.scope);
+              job.scope,
+              job.executionPolicy,
+              job.executorId);
         });
     var current = jobs.get(jobId);
     if (current == null) {
@@ -431,6 +464,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
           leased.remove(id);
           leaseEpochs.remove(id);
           ready.remove(id);
+          pinnedExecutors.remove(id);
           return new ReconcileJob(
               job.jobId,
               job.accountId,
@@ -446,7 +480,9 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               job.captureMode,
               snapshotsProcessed,
               statsProcessed,
-              job.scope);
+              job.scope,
+              job.executionPolicy,
+              job.executorId);
         });
   }
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
@@ -18,8 +18,10 @@ package ai.floedb.floecat.reconciler.jobs.impl;
 
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
@@ -51,7 +53,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
       boolean fullRescan,
       CaptureMode captureMode,
       ReconcileScope scope,
+      ReconcileJobKind jobKind,
+      ReconcileTableTask tableTask,
       ReconcileExecutionPolicy executionPolicy,
+      String parentJobId,
       String pinnedExecutorId) {
     String id = UUID.randomUUID().toString();
     createdAtMs.put(id, System.currentTimeMillis());
@@ -73,7 +78,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
             0,
             scope,
             executionPolicy,
-            "");
+            "",
+            jobKind,
+            tableTask,
+            parentJobId);
     jobs.put(id, job);
     pinnedExecutors.put(id, pinnedExecutorId == null ? "" : pinnedExecutorId.trim());
     ready.add(id);
@@ -173,7 +181,8 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
         continue;
       }
 
-      if (!effective.matches(job.executionPolicy, pinnedExecutors.getOrDefault(jobId, ""))) {
+      if (!effective.matches(
+          job.executionPolicy, pinnedExecutors.getOrDefault(jobId, ""), job.jobKind)) {
         ready.add(jobId);
         continue;
       }
@@ -192,7 +201,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
                 job.executionPolicy,
                 leaseEpoch,
                 pinnedExecutors.getOrDefault(jobId, ""),
-                job.executorId));
+                job.executorId,
+                job.jobKind,
+                job.tableTask,
+                job.parentJobId));
       }
     }
     return Optional.empty();
@@ -235,7 +247,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               job.statsProcessed,
               job.scope,
               job.executionPolicy,
-              executorId);
+              executorId,
+              job.jobKind,
+              job.tableTask,
+              job.parentJobId);
         });
   }
 
@@ -277,7 +292,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               statsProcessed,
               job.scope,
               job.executionPolicy,
-              job.executorId);
+              job.executorId,
+              job.jobKind,
+              job.tableTask,
+              job.parentJobId);
         });
   }
 
@@ -319,7 +337,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               statsProcessed,
               job.scope,
               job.executionPolicy,
-              job.executorId);
+              job.executorId,
+              job.jobKind,
+              job.tableTask,
+              job.parentJobId);
         });
   }
 
@@ -363,7 +384,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               statsProcessed,
               job.scope,
               job.executionPolicy,
-              job.executorId);
+              job.executorId,
+              job.jobKind,
+              job.tableTask,
+              job.parentJobId);
         });
   }
 
@@ -398,7 +422,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
                 job.statsProcessed,
                 job.scope,
                 job.executionPolicy,
-                job.executorId);
+                job.executorId,
+                job.jobKind,
+                job.tableTask,
+                job.parentJobId);
           }
           leased.remove(id);
           leaseEpochs.remove(id);
@@ -420,7 +447,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               job.statsProcessed,
               job.scope,
               job.executionPolicy,
-              job.executorId);
+              job.executorId,
+              job.jobKind,
+              job.tableTask,
+              job.parentJobId);
         });
     var current = jobs.get(jobId);
     if (current == null) {
@@ -482,7 +512,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
               statsProcessed,
               job.scope,
               job.executionPolicy,
-              job.executorId);
+              job.executorId,
+              job.jobKind,
+              job.tableTask,
+              job.parentJobId);
         });
   }
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcileExecutor.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.spi;
+
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Executes a leased reconcile job.
+ *
+ * <p>The scheduler owns lease management and terminal state writes. Executors only execute the job
+ * body and report progress/results.
+ */
+public interface ReconcileExecutor {
+  String id();
+
+  default boolean enabled() {
+    return true;
+  }
+
+  default int priority() {
+    return 100;
+  }
+
+  default boolean supports(ReconcileJobStore.LeasedJob lease) {
+    return true;
+  }
+
+  default Set<ReconcileExecutionClass> supportedExecutionClasses() {
+    return EnumSet.allOf(ReconcileExecutionClass.class);
+  }
+
+  default Set<String> supportedLanes() {
+    return Set.of("");
+  }
+
+  default boolean supportsExecutionClass(ReconcileExecutionClass executionClass) {
+    return supportedExecutionClasses().contains(executionClass);
+  }
+
+  default boolean supportsLane(String lane) {
+    return supportedLanes().contains(lane == null ? "" : lane.trim());
+  }
+
+  ExecutionResult execute(ExecutionContext context);
+
+  @FunctionalInterface
+  interface ProgressListener {
+    void onProgress(
+        long scanned,
+        long changed,
+        long errors,
+        long snapshotsProcessed,
+        long statsProcessed,
+        String message);
+  }
+
+  record ExecutionContext(
+      ReconcileJobStore.LeasedJob lease,
+      BooleanSupplier shouldStop,
+      ProgressListener progressListener) {
+    public ExecutionContext {
+      lease = Objects.requireNonNull(lease, "lease");
+      shouldStop = Objects.requireNonNull(shouldStop, "shouldStop");
+      progressListener = Objects.requireNonNull(progressListener, "progressListener");
+    }
+  }
+
+  final class ExecutionResult {
+    public final long scanned;
+    public final long changed;
+    public final long errors;
+    public final long snapshotsProcessed;
+    public final long statsProcessed;
+    public final boolean cancelled;
+    public final String message;
+    public final Exception error;
+
+    private ExecutionResult(
+        long scanned,
+        long changed,
+        long errors,
+        long snapshotsProcessed,
+        long statsProcessed,
+        boolean cancelled,
+        String message,
+        Exception error) {
+      this.scanned = scanned;
+      this.changed = changed;
+      this.errors = errors;
+      this.snapshotsProcessed = snapshotsProcessed;
+      this.statsProcessed = statsProcessed;
+      this.cancelled = cancelled;
+      this.message = message == null ? "" : message;
+      this.error = error;
+    }
+
+    public static ExecutionResult success(
+        long scanned,
+        long changed,
+        long errors,
+        long snapshotsProcessed,
+        long statsProcessed,
+        String message) {
+      return new ExecutionResult(
+          scanned, changed, errors, snapshotsProcessed, statsProcessed, false, message, null);
+    }
+
+    public static ExecutionResult cancelled(
+        long scanned,
+        long changed,
+        long errors,
+        long snapshotsProcessed,
+        long statsProcessed,
+        String message) {
+      return new ExecutionResult(
+          scanned, changed, errors, snapshotsProcessed, statsProcessed, true, message, null);
+    }
+
+    public static ExecutionResult failure(
+        long scanned,
+        long changed,
+        long errors,
+        long snapshotsProcessed,
+        long statsProcessed,
+        String message,
+        Exception error) {
+      return new ExecutionResult(
+          scanned, changed, errors, snapshotsProcessed, statsProcessed, false, message, error);
+    }
+
+    public boolean ok() {
+      return !cancelled && error == null;
+    }
+  }
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcileExecutor.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.reconciler.spi;
 
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import java.util.EnumSet;
 import java.util.Objects;
@@ -48,12 +49,21 @@ public interface ReconcileExecutor {
     return EnumSet.allOf(ReconcileExecutionClass.class);
   }
 
+  default Set<ReconcileJobKind> supportedJobKinds() {
+    return EnumSet.allOf(ReconcileJobKind.class);
+  }
+
   default Set<String> supportedLanes() {
     return Set.of("");
   }
 
   default boolean supportsExecutionClass(ReconcileExecutionClass executionClass) {
     return supportedExecutionClasses().contains(executionClass);
+  }
+
+  default boolean supportsJobKind(ReconcileJobKind jobKind) {
+    return supportedJobKinds()
+        .contains(jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR : jobKind);
   }
 
   default boolean supportsLane(String lane) {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ConnectorPlanningReconcileExecutorTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ConnectorPlanningReconcileExecutorTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class ConnectorPlanningReconcileExecutorTest {
+
+  @Test
+  void executeFansOutTableJobs() throws Exception {
+    var reconcilerService = mock(ReconcilerService.class);
+    var jobs = mock(ReconcileJobStore.class);
+    var executor = new ConnectorPlanningReconcileExecutor(reconcilerService, jobs, true);
+
+    var scope = ReconcileScope.empty();
+    var executionPolicy = ReconcileExecutionPolicy.defaults();
+    var lease =
+        new ReconcileJobStore.LeasedJob(
+            "job-1",
+            "acct",
+            "connector",
+            false,
+            ReconcilerService.CaptureMode.METADATA_AND_STATS,
+            scope,
+            executionPolicy,
+            "lease-1",
+            "",
+            "default_reconciler",
+            ReconcileJobKind.PLAN_CONNECTOR,
+            ReconcileTableTask.empty(),
+            "");
+
+    when(reconcilerService.planTableTasks(any(), any(), eq(scope), eq(null)))
+        .thenReturn(
+            List.of(
+                ReconcileTableTask.of("ns", "table_a"), ReconcileTableTask.of("ns", "table_b")));
+
+    var scanned = new AtomicLong();
+    var result =
+        executor.execute(
+            new ReconcileExecutor.ExecutionContext(
+                lease,
+                () -> false,
+                (s, changed, errors, snapshotsProcessed, statsProcessed, message) ->
+                    scanned.set(s)));
+
+    assertTrue(result.ok());
+    assertEquals(2L, result.scanned);
+    assertEquals(2L, scanned.get());
+    verify(jobs, times(1))
+        .enqueueTableExecution(
+            "acct",
+            "connector",
+            false,
+            ReconcilerService.CaptureMode.METADATA_AND_STATS,
+            scope,
+            ReconcileTableTask.of("ns", "table_a"),
+            executionPolicy,
+            "job-1",
+            "");
+    verify(jobs, times(1))
+        .enqueueTableExecution(
+            "acct",
+            "connector",
+            false,
+            ReconcilerService.CaptureMode.METADATA_AND_STATS,
+            scope,
+            ReconcileTableTask.of("ns", "table_b"),
+            executionPolicy,
+            "job-1",
+            "");
+  }
+
+  @Test
+  void executeUsesConfiguredPinnedExecutorForChildTableJobs() throws Exception {
+    var reconcilerService = mock(ReconcilerService.class);
+    var jobs = mock(ReconcileJobStore.class);
+    System.setProperty("floecat.reconciler.auto.pinned-executor-id", "remote-executor");
+    try {
+      var executor = new ConnectorPlanningReconcileExecutor(reconcilerService, jobs, true);
+
+      var lease =
+          new ReconcileJobStore.LeasedJob(
+              "job-1",
+              "acct",
+              "connector",
+              false,
+              ReconcilerService.CaptureMode.METADATA_AND_STATS,
+              ReconcileScope.empty(),
+              ReconcileExecutionPolicy.defaults(),
+              "lease-1",
+              "planner_reconciler",
+              "planner_reconciler",
+              ReconcileJobKind.PLAN_CONNECTOR,
+              ReconcileTableTask.empty(),
+              "");
+
+      when(reconcilerService.planTableTasks(any(), any(), any(), eq(null)))
+          .thenReturn(List.of(ReconcileTableTask.of("ns", "table_a")));
+
+      executor.execute(
+          new ReconcileExecutor.ExecutionContext(
+              lease,
+              () -> false,
+              (s, changed, errors, snapshotsProcessed, statsProcessed, message) -> {}));
+
+      verify(jobs)
+          .enqueueTableExecution(
+              "acct",
+              "connector",
+              false,
+              ReconcilerService.CaptureMode.METADATA_AND_STATS,
+              ReconcileScope.empty(),
+              ReconcileTableTask.of("ns", "table_a"),
+              ReconcileExecutionPolicy.defaults(),
+              "job-1",
+              "remote-executor");
+    } finally {
+      System.clearProperty("floecat.reconciler.auto.pinned-executor-id");
+    }
+  }
+
+  @Test
+  void plannerExecutorSupportsAnyLaneForPlanJobs() {
+    var executor =
+        new ConnectorPlanningReconcileExecutor(
+            mock(ReconcilerService.class), mock(ReconcileJobStore.class), true);
+
+    assertTrue(executor.supportedLanes().isEmpty());
+    assertTrue(executor.supportsLane(""));
+    assertTrue(executor.supportsLane("remote"));
+    assertTrue(executor.supportsLane("custom-lane"));
+  }
+
+  @Test
+  void executePreservesPartialProgressWhenFanOutFails() throws Exception {
+    var reconcilerService = mock(ReconcilerService.class);
+    var jobs = mock(ReconcileJobStore.class);
+    var executor = new ConnectorPlanningReconcileExecutor(reconcilerService, jobs, true);
+
+    var scope = ReconcileScope.empty();
+    var executionPolicy = ReconcileExecutionPolicy.defaults();
+    var lease =
+        new ReconcileJobStore.LeasedJob(
+            "job-1",
+            "acct",
+            "connector",
+            false,
+            ReconcilerService.CaptureMode.METADATA_AND_STATS,
+            scope,
+            executionPolicy,
+            "lease-1",
+            "",
+            "default_reconciler",
+            ReconcileJobKind.PLAN_CONNECTOR,
+            ReconcileTableTask.empty(),
+            "");
+
+    var first = ReconcileTableTask.of("ns", "table_a");
+    var second = ReconcileTableTask.of("ns", "table_b");
+    when(reconcilerService.planTableTasks(any(), any(), eq(scope), eq(null)))
+        .thenReturn(List.of(first, second));
+    doThrow(new RuntimeException("boom"))
+        .when(jobs)
+        .enqueueTableExecution(
+            eq("acct"),
+            eq("connector"),
+            eq(false),
+            eq(ReconcilerService.CaptureMode.METADATA_AND_STATS),
+            eq(scope),
+            eq(second),
+            eq(executionPolicy),
+            eq("job-1"),
+            eq(""));
+
+    var result =
+        executor.execute(
+            new ReconcileExecutor.ExecutionContext(
+                lease,
+                () -> false,
+                (s, changed, errors, snapshotsProcessed, statsProcessed, message) -> {}));
+
+    assertFalse(result.ok());
+    assertEquals(1L, result.scanned);
+    assertEquals(1L, result.errors);
+    assertTrue(result.message.contains("after enqueuing 1 table jobs"));
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FloecatConnectorCompatibilityTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FloecatConnectorCompatibilityTest.java
@@ -77,6 +77,11 @@ class FloecatConnectorCompatibilityTest {
     }
 
     @Override
+    public List<PlannedTableTask> planTableTasks(TablePlanningRequest request) {
+      return List.of();
+    }
+
+    @Override
     public TableDescriptor describe(String namespaceFq, String tableName) {
       return new TableDescriptor(
           namespaceFq, tableName, "", "{}", List.of(), null, java.util.Map.of());

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendTest.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.reconciler.spi.NameRefNormalizer;
 import org.junit.jupiter.api.Test;
 
 class GrpcReconcilerBackendTest {
@@ -184,5 +185,30 @@ class GrpcReconcilerBackendTest {
         .isEqualTo(ForeignKeyMatchOption.FK_MATCH_OPTION_UNSPECIFIED);
     assertThat(emitted.getUpdateRule()).isEqualTo(ForeignKeyActionRule.FK_ACTION_RULE_UNSPECIFIED);
     assertThat(emitted.getDeleteRule()).isEqualTo(ForeignKeyActionRule.FK_ACTION_RULE_UNSPECIFIED);
+  }
+
+  @Test
+  void normalizeNamespacePathTrimsCollapsesAndDropsBlankSegments() {
+    assertThat(NameRefNormalizer.normalizeNamespacePath("  parent . \u2003 child  .   "))
+        .containsExactly("parent", "child");
+  }
+
+  @Test
+  void normalizeDisplayNameMatchesNameRefNormalization() {
+    assertThat(NameRefNormalizer.normalizeDisplayName("  orders\u2003view  "))
+        .isEqualTo("orders view");
+
+    NameRef normalized =
+        NameRefNormalizer.normalize(
+            NameRef.newBuilder()
+                .setCatalog("  cat  ")
+                .addPath(" parent ")
+                .addPath("\u2003child ")
+                .setName("  orders\u2003view ")
+                .build());
+
+    assertThat(normalized.getCatalog()).isEqualTo("cat");
+    assertThat(normalized.getPathList()).containsExactly("parent", "child");
+    assertThat(normalized.getName()).isEqualTo("orders view");
   }
 }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReconcileExecutorRegistryTest {
+
+  @Test
+  void selectsLowestPrioritySupportingExecutor() {
+    ReconcileJobStore.LeasedJob lease = defaultLease(ReconcileExecutionPolicy.defaults(), "");
+
+    ReconcileExecutor fallback = new TestExecutor("fallback", 100, true);
+    ReconcileExecutor preferred = new TestExecutor("preferred", 10, true);
+
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(List.of(fallback, preferred));
+
+    assertThat(registry.executorFor(lease)).isPresent();
+    assertThat(registry.executorFor(lease).orElseThrow().id()).isEqualTo("preferred");
+  }
+
+  @Test
+  void skipsUnsupportedExecutor() {
+    ReconcileJobStore.LeasedJob lease = defaultLease(ReconcileExecutionPolicy.defaults(), "");
+
+    ReconcileExecutor unsupported = new TestExecutor("unsupported", 1, false);
+    ReconcileExecutor supported = new TestExecutor("supported", 2, true);
+
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(List.of(unsupported, supported));
+
+    assertThat(registry.executorFor(lease)).isPresent();
+    assertThat(registry.executorFor(lease).orElseThrow().id()).isEqualTo("supported");
+  }
+
+  @Test
+  void returnsEmptyWhenNoExecutorSupportsLease() {
+    ReconcileJobStore.LeasedJob lease = defaultLease(ReconcileExecutionPolicy.defaults(), "");
+
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(List.of(new TestExecutor("unsupported", 1, false)));
+
+    assertThat(registry.executorFor(lease)).isEmpty();
+  }
+
+  @Test
+  void explicitExecutorIdWinsOverPriorityFallback() {
+    ReconcileJobStore.LeasedJob lease = defaultLease(ReconcileExecutionPolicy.defaults(), "named");
+
+    ReconcileExecutor preferredByPriority = new TestExecutor("preferred", 1, true);
+    ReconcileExecutor explicitlyNamed = new TestExecutor("named", 100, true);
+
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(List.of(preferredByPriority, explicitlyNamed));
+
+    assertThat(registry.executorFor(lease)).isPresent();
+    assertThat(registry.executorFor(lease).orElseThrow().id()).isEqualTo("named");
+  }
+
+  @Test
+  void explicitExecutorIdDoesNotSilentlyFallBackWhenMissing() {
+    ReconcileJobStore.LeasedJob lease = defaultLease(ReconcileExecutionPolicy.defaults(), "named");
+
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(List.of(new TestExecutor("other", 1, true)));
+
+    assertThat(registry.executorFor(lease)).isEmpty();
+  }
+
+  @Test
+  void executionPolicyClassAndLaneConstrainSelection() {
+    ReconcileJobStore.LeasedJob lease =
+        defaultLease(
+            ReconcileExecutionPolicy.of(ReconcileExecutionClass.HEAVY, "remote", Map.of()), "");
+
+    ReconcileExecutor wrongLane = new TestExecutor("wrong-lane", 1, true, true, false, true);
+    ReconcileExecutor matching = new TestExecutor("matching", 2, true, true, true, true);
+
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(List.of(wrongLane, matching));
+
+    assertThat(registry.executorFor(lease)).isPresent();
+    assertThat(registry.executorFor(lease).orElseThrow().id()).isEqualTo("matching");
+  }
+
+  @Test
+  void leaseRequestAggregatesSupportedClassesAndLanes() {
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(
+            List.of(
+                new TestExecutor("default", 1, true, true, false, true),
+                new TestExecutor("remote", 2, true, false, true, true)));
+
+    var request = registry.leaseRequest();
+
+    assertThat(request.executionClasses)
+        .contains(
+            ReconcileExecutionClass.DEFAULT,
+            ReconcileExecutionClass.INTERACTIVE,
+            ReconcileExecutionClass.BATCH,
+            ReconcileExecutionClass.HEAVY);
+    assertThat(request.lanes).contains("", "remote");
+    assertThat(request.executorIds).contains("default", "remote");
+  }
+
+  @Test
+  void disabledExecutorsAreExcludedFromRoutingAndLeaseAggregation() {
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(
+            List.of(
+                new TestExecutor("disabled", 1, true, true, true, false),
+                new TestExecutor("enabled", 2, true, true, true, true)));
+
+    assertThat(registry.orderedExecutors())
+        .extracting(ReconcileExecutor::id)
+        .containsExactly("enabled");
+    assertThat(registry.leaseRequest().executorIds).containsExactly("enabled");
+  }
+
+  private static ReconcileJobStore.LeasedJob defaultLease(
+      ReconcileExecutionPolicy executionPolicy, String pinnedExecutorId) {
+    return new ReconcileJobStore.LeasedJob(
+        "job-1",
+        "acct",
+        "connector",
+        false,
+        CaptureMode.METADATA_AND_STATS,
+        ReconcileScope.empty(),
+        executionPolicy,
+        "lease-1",
+        pinnedExecutorId,
+        "");
+  }
+
+  private record TestExecutor(
+      String id,
+      int priority,
+      boolean supports,
+      boolean supportsHeavy,
+      boolean supportsRemoteLane,
+      boolean enabled)
+      implements ReconcileExecutor {
+
+    private TestExecutor(String id, int priority, boolean supports) {
+      this(id, priority, supports, true, true, true);
+    }
+
+    @Override
+    public boolean supports(ReconcileJobStore.LeasedJob lease) {
+      return supports;
+    }
+
+    @Override
+    public boolean enabled() {
+      return enabled;
+    }
+
+    @Override
+    public boolean supportsExecutionClass(ReconcileExecutionClass executionClass) {
+      return executionClass != ReconcileExecutionClass.HEAVY || supportsHeavy;
+    }
+
+    @Override
+    public boolean supportsLane(String lane) {
+      return lane == null || lane.isBlank() || (supportsRemoteLane && "remote".equals(lane));
+    }
+
+    @Override
+    public java.util.Set<ReconcileExecutionClass> supportedExecutionClasses() {
+      java.util.EnumSet<ReconcileExecutionClass> classes =
+          java.util.EnumSet.of(
+              ReconcileExecutionClass.DEFAULT,
+              ReconcileExecutionClass.INTERACTIVE,
+              ReconcileExecutionClass.BATCH);
+      if (supportsHeavy) {
+        classes.add(ReconcileExecutionClass.HEAVY);
+      }
+      return classes;
+    }
+
+    @Override
+    public java.util.Set<String> supportedLanes() {
+      return supportsRemoteLane ? java.util.Set.of("", "remote") : java.util.Set.of("");
+    }
+
+    @Override
+    public ExecutionResult execute(ExecutionContext context) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
@@ -20,8 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
 import java.util.List;
 import java.util.Map;
@@ -153,6 +155,9 @@ class ReconcileExecutorRegistryTest {
         executionPolicy,
         "lease-1",
         pinnedExecutorId,
+        "",
+        ReconcileJobKind.EXEC_CONNECTOR,
+        ReconcileTableTask.empty(),
         "");
   }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerActivationTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerActivationTest.java
@@ -19,10 +19,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-class ReconcilerBackendAnnotationTest {
+class ReconcilerActivationTest {
+
   @Test
-  void remoteBackendIsNotBuildTimeGated() {
-    assertThat(GrpcReconcilerBackend.class.getAnnotations())
+  void schedulerIsNotBuildTimeGated() {
+    assertThat(ReconcilerScheduler.class.getAnnotations())
+        .noneMatch(annotation -> annotation.annotationType().getName().endsWith("IfBuildProperty"));
+  }
+
+  @Test
+  void defaultExecutorIsNotBuildTimeGated() {
+    assertThat(DefaultReconcileExecutor.class.getAnnotations())
+        .noneMatch(annotation -> annotation.annotationType().getName().endsWith("IfBuildProperty"));
+  }
+
+  @Test
+  void remotePollerIsNotBuildTimeGated() {
+    assertThat(RemoteReconcileExecutorPoller.class.getAnnotations())
         .noneMatch(annotation -> annotation.annotationType().getName().endsWith("IfBuildProperty"));
   }
 }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerSchedulerTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerSchedulerTest.java
@@ -23,7 +23,10 @@ import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
 import java.util.EnumSet;
 import java.util.Optional;
@@ -52,9 +55,11 @@ class ReconcilerSchedulerTest {
 
     var executor = mock(ReconcileExecutor.class);
     when(executor.enabled()).thenReturn(true);
+    when(executor.id()).thenReturn("test-executor");
     when(executor.supportedExecutionClasses())
         .thenReturn(EnumSet.allOf(ReconcileExecutionClass.class));
     when(executor.supportedLanes()).thenReturn(java.util.Set.of(""));
+    when(executor.supportedJobKinds()).thenReturn(EnumSet.allOf(ReconcileJobKind.class));
 
     var scheduler = new ReconcilerScheduler();
     // jobs is package-private (@Inject with no access modifier)
@@ -71,6 +76,75 @@ class ReconcilerSchedulerTest {
   }
 
   @Test
+  void pollOnceLeasesPerExecutorCapabilitiesInsteadOfUnioningThem() {
+    var jobStore = mock(ReconcileJobStore.class);
+
+    var localExecutor = mock(ReconcileExecutor.class);
+    when(localExecutor.enabled()).thenReturn(true);
+    when(localExecutor.id()).thenReturn("local");
+    when(localExecutor.supportedExecutionClasses())
+        .thenReturn(EnumSet.of(ReconcileExecutionClass.DEFAULT));
+    when(localExecutor.supportedLanes()).thenReturn(java.util.Set.of(""));
+    when(localExecutor.supportedJobKinds()).thenReturn(EnumSet.of(ReconcileJobKind.EXEC_CONNECTOR));
+
+    var remoteExecutor = mock(ReconcileExecutor.class);
+    when(remoteExecutor.enabled()).thenReturn(true);
+    when(remoteExecutor.id()).thenReturn("remote");
+    when(remoteExecutor.supportedExecutionClasses())
+        .thenReturn(EnumSet.of(ReconcileExecutionClass.HEAVY));
+    when(remoteExecutor.supportedLanes()).thenReturn(java.util.Set.of("remote"));
+    when(remoteExecutor.supportedJobKinds()).thenReturn(EnumSet.of(ReconcileJobKind.EXEC_TABLE));
+
+    var remoteLease =
+        new ReconcileJobStore.LeasedJob(
+            "job-remote",
+            "acct",
+            "connector",
+            false,
+            ReconcilerService.CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.of(
+                ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of()),
+            "lease-remote",
+            "",
+            "",
+            ReconcileJobKind.EXEC_TABLE,
+            ReconcileTableTask.of("ns", "table_a"),
+            "");
+
+    when(jobStore.leaseNext(
+            org.mockito.ArgumentMatchers.argThat(
+                request ->
+                    request != null
+                        && request.executionClasses.equals(
+                            EnumSet.of(ReconcileExecutionClass.DEFAULT))
+                        && request.lanes.equals(java.util.Set.of(""))
+                        && request.executorIds.equals(java.util.Set.of("local"))
+                        && request.jobKinds.equals(EnumSet.of(ReconcileJobKind.EXEC_CONNECTOR)))))
+        .thenReturn(Optional.empty());
+    when(jobStore.leaseNext(
+            org.mockito.ArgumentMatchers.argThat(
+                request ->
+                    request != null
+                        && request.executionClasses.equals(
+                            EnumSet.of(ReconcileExecutionClass.HEAVY))
+                        && request.lanes.equals(java.util.Set.of("remote"))
+                        && request.executorIds.equals(java.util.Set.of("remote"))
+                        && request.jobKinds.equals(EnumSet.of(ReconcileJobKind.EXEC_TABLE)))))
+        .thenReturn(Optional.of(remoteLease), Optional.empty());
+
+    var scheduler = new ReconcilerScheduler();
+    scheduler.jobs = jobStore;
+    scheduler.executorRegistry =
+        new ReconcileExecutorRegistry(java.util.List.of(localExecutor, remoteExecutor));
+    scheduler.schedulerEnabled = true;
+
+    scheduler.pollOnce();
+
+    verify(jobStore, times(4)).leaseNext(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
   void runLeaseDispatchesThroughExecutorRegistry() {
     var jobStore = mock(ReconcileJobStore.class);
     var executor = mock(ReconcileExecutor.class);
@@ -80,6 +154,7 @@ class ReconcilerSchedulerTest {
     when(executor.supportedLanes()).thenReturn(java.util.Set.of(""));
     when(executor.supports(org.mockito.ArgumentMatchers.any())).thenReturn(true);
     when(executor.supportsExecutionClass(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.supportsJobKind(org.mockito.ArgumentMatchers.any())).thenReturn(true);
     when(executor.supportsLane(org.mockito.ArgumentMatchers.any())).thenReturn(true);
     when(executor.id()).thenReturn("default_reconciler");
     var registry = new ReconcileExecutorRegistry(java.util.List.of(executor));
@@ -104,6 +179,9 @@ class ReconcilerSchedulerTest {
             ReconcileExecutionPolicy.defaults(),
             "lease-1",
             "",
+            "",
+            ReconcileJobKind.EXEC_CONNECTOR,
+            ReconcileTableTask.empty(),
             "");
 
     when(executor.execute(org.mockito.ArgumentMatchers.any()))
@@ -138,5 +216,68 @@ class ReconcilerSchedulerTest {
             org.mockito.ArgumentMatchers.anyLong(),
             org.mockito.ArgumentMatchers.anyLong(),
             org.mockito.ArgumentMatchers.anyLong());
+  }
+
+  @Test
+  void runLeasePreservesReportedProgressWhenExecutorThrows() {
+    var jobStore = mock(ReconcileJobStore.class);
+    var executor = mock(ReconcileExecutor.class);
+    when(executor.enabled()).thenReturn(true);
+    when(executor.supportedExecutionClasses())
+        .thenReturn(EnumSet.allOf(ReconcileExecutionClass.class));
+    when(executor.supportedLanes()).thenReturn(java.util.Set.of(""));
+    when(executor.supports(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.supportsExecutionClass(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.supportsJobKind(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.supportsLane(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.id()).thenReturn("default_reconciler");
+    var registry = new ReconcileExecutorRegistry(java.util.List.of(executor));
+
+    var scheduler = new ReconcilerScheduler();
+    scheduler.jobs = jobStore;
+    scheduler.executorRegistry = registry;
+    scheduler.cancellations = new ReconcileCancellationRegistry();
+    scheduler.config = mock(Config.class);
+    when(scheduler.config.getOptionalValue(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.eq(Long.class)))
+        .thenReturn(Optional.empty());
+
+    var lease =
+        new ReconcileJobStore.LeasedJob(
+            "job-1",
+            "acct",
+            "connector",
+            false,
+            ReconcilerService.CaptureMode.METADATA_AND_STATS,
+            ai.floedb.floecat.reconciler.jobs.ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "lease-1",
+            "",
+            "",
+            ReconcileJobKind.EXEC_CONNECTOR,
+            ReconcileTableTask.empty(),
+            "");
+
+    when(executor.execute(org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(
+            invocation -> {
+              ReconcileExecutor.ExecutionContext context = invocation.getArgument(0);
+              context.progressListener().onProgress(5, 3, 0, 7, 11, "working");
+              throw new RuntimeException("boom");
+            });
+
+    scheduler.runLease(lease);
+
+    verify(jobStore)
+        .markFailed(
+            org.mockito.ArgumentMatchers.eq("job-1"),
+            org.mockito.ArgumentMatchers.eq("lease-1"),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.contains("RuntimeException"),
+            org.mockito.ArgumentMatchers.eq(5L),
+            org.mockito.ArgumentMatchers.eq(3L),
+            org.mockito.ArgumentMatchers.eq(1L),
+            org.mockito.ArgumentMatchers.eq(7L),
+            org.mockito.ArgumentMatchers.eq(11L));
   }
 }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerSchedulerTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerSchedulerTest.java
@@ -16,12 +16,18 @@
 package ai.floedb.floecat.reconciler.impl;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import java.util.EnumSet;
 import java.util.Optional;
+import org.eclipse.microprofile.config.Config;
 import org.junit.jupiter.api.Test;
 
 class ReconcilerSchedulerTest {
@@ -40,19 +46,97 @@ class ReconcilerSchedulerTest {
   @Test
   void pollOnceReleasesWorkerSlotWhenLeaseNextThrows() throws Exception {
     var jobStore = mock(ReconcileJobStore.class);
-    when(jobStore.leaseNext())
+    when(jobStore.leaseNext(org.mockito.ArgumentMatchers.any()))
         .thenThrow(new RuntimeException("simulated StorageNotFoundException"))
         .thenReturn(Optional.empty());
+
+    var executor = mock(ReconcileExecutor.class);
+    when(executor.enabled()).thenReturn(true);
+    when(executor.supportedExecutionClasses())
+        .thenReturn(EnumSet.allOf(ReconcileExecutionClass.class));
+    when(executor.supportedLanes()).thenReturn(java.util.Set.of(""));
 
     var scheduler = new ReconcilerScheduler();
     // jobs is package-private (@Inject with no access modifier)
     scheduler.jobs = jobStore;
+    scheduler.executorRegistry = new ReconcileExecutorRegistry(java.util.List.of(executor));
+    scheduler.schedulerEnabled = true;
     // maxParallelism defaults to 1 (DEFAULT_MAX_PARALLELISM); workers stays null so submitLease()
     // would immediately release any slot it acquires — but we never reach submitLease() here.
 
     scheduler.pollOnce(); // leaseNext() throws → slot must be released
     scheduler.pollOnce(); // must reach leaseNext() again (slot was freed)
 
-    verify(jobStore, times(2)).leaseNext();
+    verify(jobStore, times(2)).leaseNext(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void runLeaseDispatchesThroughExecutorRegistry() {
+    var jobStore = mock(ReconcileJobStore.class);
+    var executor = mock(ReconcileExecutor.class);
+    when(executor.enabled()).thenReturn(true);
+    when(executor.supportedExecutionClasses())
+        .thenReturn(EnumSet.allOf(ReconcileExecutionClass.class));
+    when(executor.supportedLanes()).thenReturn(java.util.Set.of(""));
+    when(executor.supports(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.supportsExecutionClass(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.supportsLane(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.id()).thenReturn("default_reconciler");
+    var registry = new ReconcileExecutorRegistry(java.util.List.of(executor));
+
+    var scheduler = new ReconcilerScheduler();
+    scheduler.jobs = jobStore;
+    scheduler.executorRegistry = registry;
+    scheduler.cancellations = new ReconcileCancellationRegistry();
+    scheduler.config = mock(Config.class);
+    when(scheduler.config.getOptionalValue(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.eq(Long.class)))
+        .thenReturn(Optional.empty());
+
+    var lease =
+        new ReconcileJobStore.LeasedJob(
+            "job-1",
+            "acct",
+            "connector",
+            false,
+            ReconcilerService.CaptureMode.METADATA_AND_STATS,
+            ai.floedb.floecat.reconciler.jobs.ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "lease-1",
+            "",
+            "");
+
+    when(executor.execute(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(ReconcileExecutor.ExecutionResult.success(2, 1, 0, 3, 4, "OK"));
+
+    scheduler.runLease(lease);
+
+    verify(executor, times(1)).execute(org.mockito.ArgumentMatchers.any());
+    verify(jobStore, times(1))
+        .markRunning(
+            org.mockito.ArgumentMatchers.eq("job-1"),
+            org.mockito.ArgumentMatchers.eq("lease-1"),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.eq("default_reconciler"));
+    verify(jobStore, times(1))
+        .markSucceeded(
+            org.mockito.ArgumentMatchers.eq("job-1"),
+            org.mockito.ArgumentMatchers.eq("lease-1"),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.eq(2L),
+            org.mockito.ArgumentMatchers.eq(1L),
+            org.mockito.ArgumentMatchers.eq(3L),
+            org.mockito.ArgumentMatchers.eq(4L));
+    verify(jobStore, never())
+        .markFailed(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong());
   }
 }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -44,6 +44,7 @@ import ai.floedb.floecat.connector.spi.CredentialResolver;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
 import com.google.protobuf.ByteString;
@@ -101,6 +102,250 @@ class ReconcilerServiceTest {
     assertThat(result.errors).isEqualTo(1);
     assertThat(result.error).isInstanceOf(IllegalStateException.class);
     assertThat(result.error.getMessage()).contains("Connector not ACTIVE");
+  }
+
+  @Test
+  void planTableTasksDelegatesPlanningToConnector() {
+    service.backend =
+        new DefaultBackend() {
+          @Override
+          public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+            return activeConnector();
+          }
+
+          @Override
+          public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+            return "dest_ns";
+          }
+        };
+    service.connectorOpener =
+        cfg ->
+            new FakeConnector(List.of()) {
+              @Override
+              public List<PlannedTableTask> planTableTasks(TablePlanningRequest request) {
+                assertThat(request.sourceNamespaceFq()).isEqualTo("src_cat.src_ns");
+                assertThat(request.destinationNamespaceFq()).isEqualTo("dest_ns");
+                assertThat(request.destinationNamespacePaths()).isEmpty();
+                return List.of(new PlannedTableTask("planned_ns", "planned_table"));
+              }
+            };
+
+    var tasks = service.planTableTasks(principal, connectorId, ReconcileScope.empty(), null);
+
+    assertThat(tasks).containsExactly(ReconcileTableTask.of("planned_ns", "planned_table"));
+  }
+
+  @Test
+  void reconcilePreservesAccumulatedSummariesWhenOuterFailureOccurs() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("table-outer-failure")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    service.backend =
+        new DefaultBackend() {
+          @Override
+          public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+            return activeConnector();
+          }
+
+          @Override
+          public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+            return "dest_cat";
+          }
+
+          @Override
+          public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+            return "dest_ns";
+          }
+
+          @Override
+          public ResourceId ensureTable(
+              ReconcileContext ctx,
+              ResourceId namespaceId,
+              NameRef table,
+              TableSpecDescriptor descriptor) {
+            return tableId;
+          }
+
+          @Override
+          public void updateConnectorDestination(
+              ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
+        };
+
+    service.connectorOpener =
+        cfg ->
+            new FakeConnector(List.of()) {
+              @Override
+              public List<String> listTables(String namespaceFq) {
+                return List.of("tbl");
+              }
+
+              @Override
+              public TableDescriptor describe(String namespaceFq, String tableName) {
+                return new TableDescriptor(
+                    namespaceFq,
+                    tableName,
+                    "s3://bucket/path",
+                    "{\"type\":\"struct\",\"fields\":[]}",
+                    List.of(),
+                    ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
+                    Map.of());
+              }
+
+              @Override
+              public List<SnapshotBundle> enumerateSnapshotsWithStats(
+                  String namespaceFq,
+                  String tableName,
+                  ResourceId destinationTableId,
+                  Set<String> includeColumns,
+                  SnapshotEnumerationOptions options) {
+                return List.of();
+              }
+
+              @Override
+              public List<FloecatConnector.ViewDescriptor> listViewDescriptors(String namespaceFq) {
+                throw new RuntimeException("view-list-fail");
+              }
+
+              @Override
+              public void close() {
+                throw new RuntimeException("close-fail");
+              }
+            };
+
+    var result = service.reconcile(principal, connectorId, false, null);
+
+    assertThat(result.ok()).isFalse();
+    assertThat(result.error).isNotNull();
+    assertThat(result.error.getMessage()).contains("close-fail");
+    assertThat(result.error.getMessage())
+        .contains("listViewDescriptors(src_cat.src_ns): RuntimeException: view-list-fail");
+  }
+
+  @Test
+  void reconcileSkipProgressRetainsCurrentCounters() {
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("table-skip-progress")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    service.backend =
+        new DefaultBackend() {
+          @Override
+          public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+            return activeConnector();
+          }
+
+          @Override
+          public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+            return "dest_cat";
+          }
+
+          @Override
+          public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+            return "dest_ns";
+          }
+
+          @Override
+          public ResourceId ensureTable(
+              ReconcileContext ctx,
+              ResourceId namespaceId,
+              NameRef table,
+              TableSpecDescriptor descriptor) {
+            return tableId;
+          }
+
+          @Override
+          public Set<Long> existingSnapshotIds(ReconcileContext ctx, ResourceId ignoredTableId) {
+            return Set.of(42L);
+          }
+
+          @Override
+          public void updateConnectorDestination(
+              ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
+        };
+
+    service.connectorOpener =
+        cfg ->
+            new FakeConnector(List.of()) {
+              @Override
+              public List<String> listTables(String namespaceFq) {
+                return List.of("tbl");
+              }
+
+              @Override
+              public TableDescriptor describe(String namespaceFq, String tableName) {
+                return new TableDescriptor(
+                    namespaceFq,
+                    tableName,
+                    "s3://bucket/path",
+                    "{\"type\":\"struct\",\"fields\":[]}",
+                    List.of(),
+                    ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
+                    Map.of());
+              }
+
+              @Override
+              public List<SnapshotBundle> enumerateSnapshotsWithStats(
+                  String namespaceFq,
+                  String tableName,
+                  ResourceId destinationTableId,
+                  Set<String> includeColumns,
+                  SnapshotEnumerationOptions options) {
+                return List.of(
+                    new SnapshotBundle(
+                        42L,
+                        0L,
+                        Instant.now().toEpochMilli(),
+                        null,
+                        List.of(),
+                        List.of(),
+                        null,
+                        null,
+                        0L,
+                        null,
+                        Map.of(),
+                        0,
+                        Map.of()));
+              }
+            };
+
+    var progressEvents = new ArrayList<String>();
+    var result =
+        service.reconcile(
+            principal,
+            connectorId,
+            false,
+            null,
+            ReconcilerService.CaptureMode.METADATA_ONLY,
+            null,
+            () -> false,
+            (scanned, changed, errors, snapshotsProcessed, statsProcessed, message) ->
+                progressEvents.add(
+                    scanned
+                        + "|"
+                        + changed
+                        + "|"
+                        + errors
+                        + "|"
+                        + snapshotsProcessed
+                        + "|"
+                        + statsProcessed
+                        + "|"
+                        + message));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(progressEvents)
+        .anySatisfy(
+            event -> {
+              assertThat(event)
+                  .contains("1|0|0|0|0|Incremental reconcile skipped 1 already-ingested snapshots");
+            });
   }
 
   @Test
@@ -961,7 +1206,8 @@ class ReconcilerServiceTest {
     }
 
     @Override
-    public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+    public ReconcilerBackend.EnsureViewResult ensureViewDetailed(
+        ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
       throw new UnsupportedOperationException();
     }
   }
@@ -1242,7 +1488,12 @@ class ReconcilerServiceTest {
             boolean.class,
             Set.class,
             Set.class,
-            ReconcilerService.ProgressListener.class);
+            ReconcilerService.ProgressListener.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class);
     method.setAccessible(true);
     return method.invoke(
         service,
@@ -1252,7 +1503,12 @@ class ReconcilerServiceTest {
         includeStats,
         existingSnapshotIds,
         targetSnapshotIds,
-        (ReconcilerService.ProgressListener) (s, c, e, sp, stp, m) -> {});
+        (ReconcilerService.ProgressListener) (s, c, e, sp, stp, m) -> {},
+        0L,
+        0L,
+        0L,
+        0L,
+        0L);
   }
 
   private static Object invokeKnownSnapshotIdsForEnumeration(
@@ -1406,11 +1662,12 @@ class ReconcilerServiceTest {
     var capturingBackend =
         new ViewCapturingBackend(activeConnector()) {
           @Override
-          public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+          public ReconcilerBackend.EnsureViewResult ensureViewDetailed(
+              ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
             if ("dest_ns.bad_view".equals(idempotencyKey)) {
               throw new RuntimeException("backend error for " + spec.getDisplayName());
             }
-            return super.ensureView(ctx, spec, idempotencyKey);
+            return super.ensureViewDetailed(ctx, spec, idempotencyKey);
           }
         };
     service.backend = capturingBackend;
@@ -1440,14 +1697,16 @@ class ReconcilerServiceTest {
             "{\"type\":\"struct\",\"fields\":"
                 + "[{\"name\":\"x\",\"type\":\"int\",\"nullable\":false}]}");
 
-    // ensureView returns getDefaultInstance() — signals ALREADY_EXISTS.
+    // ensureView returns the existing ID and marks the operation as not-created.
     var capturingBackend =
         new ViewCapturingBackend(activeConnector()) {
           @Override
-          public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+          public ReconcilerBackend.EnsureViewResult ensureViewDetailed(
+              ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
             capturedViews.add(spec);
             capturedIdempotencyKeys.add(idempotencyKey);
-            return ResourceId.getDefaultInstance(); // empty id → already exists
+            return new ReconcilerBackend.EnsureViewResult(
+                ResourceId.newBuilder().setId("existing-view").build(), false);
           }
         };
     service.backend = capturingBackend;
@@ -1496,6 +1755,130 @@ class ReconcilerServiceTest {
     assertThat(capturingBackend.capturedViews.get(0).getDisplayName()).isEqualTo("revenue_view");
   }
 
+  @Test
+  void tableTaskExecutionSkipsViewPassAndConnectorDestinationUpdate() {
+    class CapturingBackend extends DefaultBackend {
+      int ensuredTables = 0;
+      int ensuredViews = 0;
+      int destinationUpdates = 0;
+
+      @Override
+      public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+        return activeConnector();
+      }
+
+      @Override
+      public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+        return "dest_cat";
+      }
+
+      @Override
+      public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+        return "dest_ns";
+      }
+
+      @Override
+      public ResourceId ensureTable(
+          ReconcileContext ctx,
+          ResourceId namespaceId,
+          NameRef table,
+          TableSpecDescriptor descriptor) {
+        ensuredTables++;
+        return ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("table-" + ensuredTables)
+            .build();
+      }
+
+      @Override
+      public boolean statsAlreadyCaptured(
+          ReconcileContext ctx, ResourceId ignoredTableId, long snapshotId) {
+        return false;
+      }
+
+      @Override
+      public void updateConnectorDestination(
+          ReconcileContext ctx, ResourceId ignoredConnectorId, DestinationTarget destination) {
+        destinationUpdates++;
+      }
+
+      @Override
+      public ReconcilerBackend.EnsureViewResult ensureViewDetailed(
+          ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+        ensuredViews++;
+        return new ReconcilerBackend.EnsureViewResult(
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setKind(ResourceKind.RK_VIEW)
+                .setId("view-" + ensuredViews)
+                .build(),
+            true);
+      }
+    }
+
+    FloecatConnector.ViewDescriptor viewDesc =
+        new FloecatConnector.ViewDescriptor(
+            "src_cat.src_ns",
+            "revenue_view",
+            "SELECT amount FROM sales",
+            "spark",
+            List.of("src_ns"),
+            "{\"type\":\"struct\",\"fields\":"
+                + "[{\"name\":\"amount\",\"type\":\"double\",\"nullable\":true}]}");
+
+    var backend = new CapturingBackend();
+    service.backend = backend;
+    service.connectorOpener =
+        cfg ->
+            new FakeConnector(List.of(viewDesc)) {
+              @Override
+              public List<String> listTables(String namespaceFq) {
+                return List.of("table_a", "table_b");
+              }
+
+              @Override
+              public TableDescriptor describe(String namespaceFq, String tableName) {
+                return new TableDescriptor(
+                    namespaceFq,
+                    tableName,
+                    "s3://bucket/path",
+                    "{\"type\":\"struct\",\"fields\":[]}",
+                    List.of(),
+                    ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm.CID_PATH_ORDINAL,
+                    Map.of());
+              }
+
+              @Override
+              public List<SnapshotBundle> enumerateSnapshotsWithStats(
+                  String namespaceFq,
+                  String tableName,
+                  ResourceId destinationTableId,
+                  Set<String> includeColumns,
+                  SnapshotEnumerationOptions options) {
+                return List.of();
+              }
+            };
+
+    var result =
+        service.reconcile(
+            principal,
+            connectorId,
+            true,
+            null,
+            ReconcilerService.CaptureMode.METADATA_AND_STATS,
+            null,
+            ReconcileTableTask.of("src_cat.src_ns", "table_a", "shared_dest"),
+            () -> false,
+            (s, c, e, sp, stp, m) -> {});
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.scanned).isEqualTo(1);
+    assertThat(backend.ensuredTables).isEqualTo(1);
+    assertThat(backend.ensuredViews).isEqualTo(0);
+    assertThat(backend.destinationUpdates).isEqualTo(0);
+  }
+
   /** A minimal {@link Connector} proto configured as CS_ACTIVE with source + destination. */
   private Connector activeConnector() {
     ResourceId destCatalogId = ResourceId.newBuilder().setAccountId("acct").setId("cat-1").build();
@@ -1516,8 +1899,9 @@ class ReconcilerServiceTest {
   }
 
   /**
-   * Backend that tracks {@link #ensureView} calls and provides enough plumbing for the view pass to
-   * run end-to-end (no table snapshots needed since FakeConnector returns empty tables list).
+   * Backend that tracks {@link #ensureViewDetailed} calls and provides enough plumbing for the view
+   * pass to run end-to-end (no table snapshots needed since FakeConnector returns empty tables
+   * list).
    */
   private static class ViewCapturingBackend extends DefaultBackend {
     private final Connector connector;
@@ -1544,10 +1928,12 @@ class ReconcilerServiceTest {
     }
 
     @Override
-    public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+    public ReconcilerBackend.EnsureViewResult ensureViewDetailed(
+        ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
       capturedViews.add(spec);
       capturedIdempotencyKeys.add(idempotencyKey);
-      return ResourceId.newBuilder().setId("view-1").build();
+      return new ReconcilerBackend.EnsureViewResult(
+          ResourceId.newBuilder().setId("view-1").build(), true);
     }
 
     @Override
@@ -1585,6 +1971,11 @@ class ReconcilerServiceTest {
 
     @Override
     public List<String> listTables(String namespaceFq) {
+      return List.of();
+    }
+
+    @Override
+    public List<PlannedTableTask> planTableTasks(TablePlanningRequest request) {
       return List.of();
     }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.LongPredicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -1164,22 +1165,38 @@ class ReconcilerServiceTest {
   }
 
   @Test
-  void knownSnapshotIdsForEnumerationPrunesAllIncrementalRuns() throws Exception {
+  void knownSnapshotIdsForEnumerationKeepsKnownSnapshotsForMetadataOnlyRuns() throws Exception {
     @SuppressWarnings("unchecked")
     Set<Long> metadataOnly =
-        (Set<Long>) invokeKnownSnapshotIdsForEnumeration(false, Set.of(10L, 11L));
+        (Set<Long>)
+            invokeKnownSnapshotIdsForEnumeration(false, false, Set.of(10L, 11L), id -> false);
     @SuppressWarnings("unchecked")
-    Set<Long> metadataAndStats =
-        (Set<Long>) invokeKnownSnapshotIdsForEnumeration(false, Set.of(10L, 11L));
-    @SuppressWarnings("unchecked")
-    Set<Long> statsOnly = (Set<Long>) invokeKnownSnapshotIdsForEnumeration(false, Set.of(10L, 11L));
-    @SuppressWarnings("unchecked")
-    Set<Long> fullRescan = (Set<Long>) invokeKnownSnapshotIdsForEnumeration(true, Set.of(10L, 11L));
+    Set<Long> fullRescan =
+        (Set<Long>)
+            invokeKnownSnapshotIdsForEnumeration(true, false, Set.of(10L, 11L), id -> false);
 
     assertThat(metadataOnly).containsExactlyInAnyOrder(10L, 11L);
-    assertThat(metadataAndStats).containsExactlyInAnyOrder(10L, 11L);
-    assertThat(statsOnly).containsExactlyInAnyOrder(10L, 11L);
     assertThat(fullRescan).isEmpty();
+  }
+
+  @Test
+  void knownSnapshotIdsForEnumerationKeepsKnownSnapshotsWithoutStatsEnumerable() throws Exception {
+    @SuppressWarnings("unchecked")
+    Set<Long> statsOnly =
+        (Set<Long>)
+            invokeKnownSnapshotIdsForEnumeration(false, true, Set.of(10L, 11L), id -> false);
+
+    assertThat(statsOnly).isEmpty();
+  }
+
+  @Test
+  void knownSnapshotIdsForEnumerationPrunesOnlyKnownSnapshotsWithCapturedStats() throws Exception {
+    @SuppressWarnings("unchecked")
+    Set<Long> statsOnly =
+        (Set<Long>)
+            invokeKnownSnapshotIdsForEnumeration(false, true, Set.of(10L, 11L), id -> id == 10L);
+
+    assertThat(statsOnly).containsExactly(10L);
   }
 
   @Test
@@ -1239,12 +1256,20 @@ class ReconcilerServiceTest {
   }
 
   private static Object invokeKnownSnapshotIdsForEnumeration(
-      boolean fullRescan, Set<Long> existingSnapshotIds) throws Exception {
+      boolean fullRescan,
+      boolean includeStats,
+      Set<Long> existingSnapshotIds,
+      LongPredicate statsAlreadyCaptured)
+      throws Exception {
     Method method =
         ReconcilerService.class.getDeclaredMethod(
-            "knownSnapshotIdsForEnumeration", boolean.class, Set.class);
+            "knownSnapshotIdsForEnumeration",
+            boolean.class,
+            boolean.class,
+            Set.class,
+            LongPredicate.class);
     method.setAccessible(true);
-    return method.invoke(null, fullRescan, existingSnapshotIds);
+    return method.invoke(null, fullRescan, includeStats, existingSnapshotIds, statsAlreadyCaptured);
   }
 
   private static boolean invokeTableChanged(List<FloecatConnector.SnapshotBundle> bundles)

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPollerTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPollerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class RemoteReconcileExecutorPollerTest {
+  private RemoteReconcileExecutorPoller poller;
+
+  @AfterEach
+  void tearDown() {
+    if (poller != null) {
+      poller.destroy();
+    }
+  }
+
+  @Test
+  void pollOnceLeasesAndExecutesRemoteJob() throws Exception {
+    RemoteReconcileExecutorClient client = mock(RemoteReconcileExecutorClient.class);
+    CountDownLatch completed = new CountDownLatch(1);
+    ReconcileExecutor executor =
+        new ReconcileExecutor() {
+          @Override
+          public String id() {
+            return "default_reconciler";
+          }
+
+          @Override
+          public ExecutionResult execute(ExecutionContext context) {
+            context.progressListener().onProgress(1, 1, 0, 2, 3, "working");
+            return ExecutionResult.success(4, 2, 0, 2, 3, "done");
+          }
+        };
+
+    poller = new RemoteReconcileExecutorPoller();
+    poller.client = client;
+    poller.executorRegistry = new ReconcileExecutorRegistry(List.of(executor));
+    poller.config = ConfigProvider.getConfig();
+    poller.remoteExecutorEnabled = true;
+    poller.init();
+
+    RemoteLeasedJob lease =
+        new RemoteLeasedJob(
+            new ReconcileJobStore.LeasedJob(
+                "job-1",
+                "acct",
+                "connector-1",
+                false,
+                CaptureMode.METADATA_AND_STATS,
+                ReconcileScope.empty(),
+                ReconcileExecutionPolicy.defaults(),
+                "lease-1",
+                "",
+                ""));
+
+    when(client.lease(eq(executor)))
+        .thenReturn(java.util.Optional.of(lease), java.util.Optional.empty());
+    when(client.renew(any()))
+        .thenReturn(new RemoteReconcileExecutorClient.LeaseHeartbeat(true, false));
+    when(client.cancellationRequested(any())).thenReturn(false);
+    when(client.reportProgress(any(), eq(1L), eq(1L), eq(0L), eq(2L), eq(3L), eq("working")))
+        .thenReturn(new RemoteReconcileExecutorClient.LeaseHeartbeat(true, false));
+    when(client.complete(
+            any(),
+            eq(RemoteLeasedJob.CompletionState.SUCCEEDED),
+            eq(4L),
+            eq(2L),
+            eq(0L),
+            eq(2L),
+            eq(3L),
+            eq("done")))
+        .thenAnswer(
+            invocation -> {
+              completed.countDown();
+              return new RemoteReconcileExecutorClient.CompletionResult(true);
+            });
+
+    poller.pollOnce();
+
+    assertTrue(completed.await(5, TimeUnit.SECONDS));
+    verify(client).start(lease, "default_reconciler");
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPollerTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPollerTest.java
@@ -25,8 +25,10 @@ import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.spi.ReconcileExecutor;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -82,6 +84,9 @@ class RemoteReconcileExecutorPollerTest {
                 ReconcileExecutionPolicy.defaults(),
                 "lease-1",
                 "",
+                "",
+                ReconcileJobKind.EXEC_CONNECTOR,
+                ReconcileTableTask.empty(),
                 ""));
 
     when(client.lease(eq(executor)))
@@ -110,5 +115,74 @@ class RemoteReconcileExecutorPollerTest {
 
     assertTrue(completed.await(5, TimeUnit.SECONDS));
     verify(client).start(lease, "default_reconciler");
+  }
+
+  @Test
+  void pollOnceCompletesFailureWithLastReportedProgress() throws Exception {
+    RemoteReconcileExecutorClient client = mock(RemoteReconcileExecutorClient.class);
+    CountDownLatch completed = new CountDownLatch(1);
+    ReconcileExecutor executor =
+        new ReconcileExecutor() {
+          @Override
+          public String id() {
+            return "default_reconciler";
+          }
+
+          @Override
+          public ExecutionResult execute(ExecutionContext context) {
+            context.progressListener().onProgress(5, 3, 0, 7, 11, "working");
+            throw new RuntimeException("boom");
+          }
+        };
+
+    poller = new RemoteReconcileExecutorPoller();
+    poller.client = client;
+    poller.executorRegistry = new ReconcileExecutorRegistry(List.of(executor));
+    poller.config = ConfigProvider.getConfig();
+    poller.remoteExecutorEnabled = true;
+    poller.init();
+
+    RemoteLeasedJob lease =
+        new RemoteLeasedJob(
+            new ReconcileJobStore.LeasedJob(
+                "job-1",
+                "acct",
+                "connector-1",
+                false,
+                CaptureMode.METADATA_AND_STATS,
+                ReconcileScope.empty(),
+                ReconcileExecutionPolicy.defaults(),
+                "lease-1",
+                "",
+                "",
+                ReconcileJobKind.EXEC_CONNECTOR,
+                ReconcileTableTask.empty(),
+                ""));
+
+    when(client.lease(eq(executor)))
+        .thenReturn(java.util.Optional.of(lease), java.util.Optional.empty());
+    when(client.renew(any()))
+        .thenReturn(new RemoteReconcileExecutorClient.LeaseHeartbeat(true, false));
+    when(client.cancellationRequested(any())).thenReturn(false);
+    when(client.reportProgress(any(), eq(5L), eq(3L), eq(0L), eq(7L), eq(11L), eq("working")))
+        .thenReturn(new RemoteReconcileExecutorClient.LeaseHeartbeat(true, false));
+    when(client.complete(
+            any(),
+            eq(RemoteLeasedJob.CompletionState.FAILED),
+            eq(5L),
+            eq(3L),
+            eq(1L),
+            eq(7L),
+            eq(11L),
+            eq("RuntimeException: boom")))
+        .thenAnswer(
+            invocation -> {
+              completed.countDown();
+              return new RemoteReconcileExecutorClient.CompletionResult(true);
+            });
+
+    poller.pollOnce();
+
+    assertTrue(completed.await(5, TimeUnit.SECONDS));
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
@@ -481,7 +481,7 @@ public abstract class BaseServiceImpl {
       return "";
     }
 
-    String t = Normalizer.normalize(in.trim(), Normalizer.Form.NFKC);
+    String t = Normalizer.normalize(in.strip(), Normalizer.Form.NFKC);
     t = t.replaceAll("\\s+", " ");
     return t;
   }

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
@@ -50,6 +50,10 @@ public class BlockingInboundContextInterceptor implements ServerInterceptor {
       @ConfigProperty(name = "floecat.interceptor.session.header") Optional<String> sessionHeader,
       @ConfigProperty(name = "floecat.interceptor.authorization.header")
           Optional<String> authorizationHeader,
+      @ConfigProperty(
+              name = "floecat.interceptor.dev-account.header",
+              defaultValue = "x-floe-account")
+          Optional<String> devAccountHeader,
       @ConfigProperty(name = "floecat.auth.mode", defaultValue = "oidc") String authMode,
       @ConfigProperty(
               name = "floecat.interceptor.session.account-claim",
@@ -67,6 +71,7 @@ public class BlockingInboundContextInterceptor implements ServerInterceptor {
             validateAccount,
             sessionHeader,
             authorizationHeader,
+            devAccountHeader,
             authMode,
             accountClaimName,
             roleClaimName);

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundCallContextHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundCallContextHelper.java
@@ -75,6 +75,7 @@ public final class InboundCallContextHelper {
   private final boolean validateAccount;
   private final Optional<String> sessionHeader;
   private final Optional<String> authorizationHeader;
+  private final Optional<String> devAccountHeader;
   private final AuthMode authMode;
   private final String accountClaimName;
   private final String roleClaimName;
@@ -87,6 +88,7 @@ public final class InboundCallContextHelper {
       boolean validateAccount,
       Optional<String> sessionHeader,
       Optional<String> authorizationHeader,
+      Optional<String> devAccountHeader,
       String authMode,
       String accountClaimName,
       String roleClaimName) {
@@ -95,6 +97,7 @@ public final class InboundCallContextHelper {
     this.validateAccount = validateAccount;
     this.sessionHeader = sessionHeader.filter(h -> !h.isBlank());
     this.authorizationHeader = authorizationHeader.filter(h -> !h.isBlank());
+    this.devAccountHeader = devAccountHeader.filter(h -> !h.isBlank());
     this.authMode = AuthMode.fromString(authMode);
     this.accountClaimName = accountClaimName;
     this.roleClaimName = roleClaimName;
@@ -169,7 +172,7 @@ public final class InboundCallContextHelper {
 
   private ResolvedPrincipal resolvePrincipal(Function<String, String> h, String queryIdHeader) {
     return switch (authMode) {
-      case DEV -> new ResolvedPrincipal(devContext(), "");
+      case DEV -> new ResolvedPrincipal(devContext(h), "");
       case OIDC -> {
         if (this.sessionHeader.isPresent()) {
           ensureOidcConfigured("session");
@@ -422,17 +425,43 @@ public final class InboundCallContextHelper {
   //  Dev mode
   // -------------------------------------------------------------------------
 
-  private PrincipalContext devContext() {
-    String displayName = "t-0001";
+  private PrincipalContext devContext(Function<String, String> headerReader) {
     String id =
-        accountRepository
-            .getByName(displayName)
-            .map(account -> account.getResourceId().getId())
-            .orElseGet(this::firstAccountIdOrRandom);
+        readHeaderValue(headerReader, devAccountHeader)
+            .map(this::resolveDevAccountId)
+            .orElseGet(this::defaultDevAccountId);
     PrincipalContext.Builder builder =
         PrincipalContext.newBuilder().setAccountId(id).setSubject("dev-user").setLocale("en");
     RolePermissions.permissionsForRoles(List.of(), true).forEach(builder::addPermissions);
     return builder.build();
+  }
+
+  private String resolveDevAccountId(String token) {
+    String value = token.trim();
+    if (value.isEmpty()) {
+      return defaultDevAccountId();
+    }
+    if (looksLikeUuid(value)) {
+      validateAccount(value);
+      return value;
+    }
+
+    return accountRepository
+        .getByName(value)
+        .map(account -> account.getResourceId().getId())
+        .orElseThrow(
+            () ->
+                Status.UNAUTHENTICATED
+                    .withDescription("invalid or unknown account: " + value)
+                    .asRuntimeException());
+  }
+
+  private String defaultDevAccountId() {
+    String displayName = "t-0001";
+    return accountRepository
+        .getByName(displayName)
+        .map(account -> account.getResourceId().getId())
+        .orElseGet(this::firstAccountIdOrRandom);
   }
 
   private String firstAccountIdOrRandom() {
@@ -475,6 +504,15 @@ public final class InboundCallContextHelper {
 
   private static boolean isBlank(String s) {
     return s == null || s.isBlank();
+  }
+
+  private static boolean looksLikeUuid(String value) {
+    try {
+      UUID.fromString(value);
+      return true;
+    } catch (IllegalArgumentException ignored) {
+      return false;
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
@@ -84,6 +84,7 @@ public class InboundContextInterceptor {
       boolean validateAccount,
       Optional<String> sessionHeader,
       Optional<String> authorizationHeader,
+      Optional<String> devAccountHeader,
       String authMode,
       String accountClaimName,
       String roleClaimName) {
@@ -94,15 +95,17 @@ public class InboundContextInterceptor {
             validateAccount,
             sessionHeader,
             authorizationHeader,
+            devAccountHeader,
             authMode,
             accountClaimName,
             roleClaimName);
 
     LOG.infof(
         "InboundContextInterceptor ready: sessionHeader=%s authorizationHeader=%s"
-            + " authMode=%s validateAccount=%s",
+            + " devAccountHeader=%s authMode=%s validateAccount=%s",
         sessionHeader.filter(h -> !h.isBlank()).orElse("<disabled>"),
         authorizationHeader.filter(h -> !h.isBlank()).orElse("<disabled>"),
+        devAccountHeader.filter(h -> !h.isBlank()).orElse("<disabled>"),
         authMode,
         validateAccount);
   }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
@@ -344,7 +344,14 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
 
   @Override
   public boolean statsAlreadyCaptured(ReconcileContext ctx, ResourceId tableId, long snapshotId) {
-    return statsRepository.getTableStats(tableId, snapshotId).isPresent();
+    var tableStats = statsRepository.getTableStats(tableId, snapshotId).orElse(null);
+    if (tableStats == null) {
+      return false;
+    }
+    if (tableStats.getDataFileCount() <= 0) {
+      return true;
+    }
+    return statsRepository.countFileStats(tableId, snapshotId) > 0;
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
@@ -53,8 +53,8 @@ import ai.floedb.floecat.service.repo.impl.StatsRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import com.google.protobuf.Timestamp;
-import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -64,8 +64,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-@IfBuildProperty(name = "floecat.reconciler.backend", stringValue = "local", enableIfMissing = true)
 @ApplicationScoped
+@Typed(DirectReconcilerBackend.class)
 public class DirectReconcilerBackend extends BaseServiceImpl implements ReconcilerBackend {
 
   @Inject CatalogRepository catalogRepo;

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackend.java
@@ -38,6 +38,7 @@ import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
 import ai.floedb.floecat.connector.spi.ConnectorFormat;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
+import ai.floedb.floecat.reconciler.spi.NameRefNormalizer;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend.TableSpecDescriptor;
@@ -159,8 +160,8 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
                         corrId, NAMESPACE, Map.of("namespace_id", namespaceId.getId())));
 
     var catalogId = namespace.getCatalogId();
-    String displayName = mustNonEmpty(descriptor.displayName(), "table.display_name", corrId);
-    String normalized = normalizeName(displayName);
+    String normalized =
+        mustNonEmpty(normalizeName(descriptor.displayName()), "table.display_name", corrId);
     Map<String, String> properties =
         descriptor.properties() != null ? descriptor.properties() : Map.of();
     List<String> partitionKeys =
@@ -197,7 +198,8 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
   }
 
   @Override
-  public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+  public EnsureViewResult ensureViewDetailed(
+      ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
     String corrId = ctx.correlationId();
     String accountId = ctx.principal().getAccountId();
     var namespace =
@@ -209,11 +211,11 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
                         corrId, NAMESPACE, Map.of("namespace_id", spec.getNamespaceId().getId())));
     String catalogId = namespace.getCatalogId().getId();
     String namespaceId = spec.getNamespaceId().getId();
-    String normalized = normalizeName(spec.getDisplayName());
+    String normalized = NameRefNormalizer.normalizeDisplayName(spec.getDisplayName());
 
     var existing = viewRepo.getByName(accountId, catalogId, namespaceId, normalized);
     if (existing.isPresent()) {
-      return ResourceId.getDefaultInstance(); // already exists — idempotent
+      return new EnsureViewResult(existing.get().getResourceId(), false);
     }
 
     var view =
@@ -230,7 +232,7 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
             .putAllProperties(spec.getPropertiesMap())
             .build();
     viewRepo.create(view);
-    return view.getResourceId();
+    return new EnsureViewResult(view.getResourceId(), true);
   }
 
   private UpstreamRef buildUpstream(TableSpecDescriptor descriptor, List<String> partitionKeys) {
@@ -242,13 +244,8 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
             .setFormat(toTableFormat(descriptor.connectorFormat()))
             .setColumnIdAlgorithm(descriptor.columnIdAlgorithm());
 
-    if (descriptor.sourceNamespace() != null && !descriptor.sourceNamespace().isBlank()) {
-      for (String seg : descriptor.sourceNamespace().split("\\.")) {
-        if (!seg.isBlank()) {
-          builder.addNamespacePath(seg);
-        }
-      }
-    }
+    builder.addAllNamespacePath(
+        NameRefNormalizer.normalizeNamespacePath(descriptor.sourceNamespace()));
     builder.addAllPartitionKeys(partitionKeys);
     return builder.build();
   }
@@ -258,13 +255,12 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
     if (tableRef == null) {
       return Optional.empty();
     }
+    NameRef normalizedTable = NameRefNormalizer.normalize(tableRef);
     String accountId = ctx.principal().getAccountId();
-    String catalogName = tableRef.getCatalog();
+    String catalogName = normalizedTable.getCatalog();
     if (catalogName == null || catalogName.isBlank()) {
       return Optional.empty();
     }
-
-    catalogName = normalizeName(catalogName);
 
     var catalogOpt = catalogRepo.getByName(accountId, catalogName);
     if (catalogOpt.isEmpty()) {
@@ -272,7 +268,7 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
     }
     String catalogId = catalogOpt.get().getResourceId().getId();
 
-    List<String> path = new ArrayList<>(normalizedSegments(tableRef.getPathList()));
+    List<String> path = new ArrayList<>(normalizedTable.getPathList());
     if (path.isEmpty()) {
       return Optional.empty();
     }
@@ -283,13 +279,12 @@ public class DirectReconcilerBackend extends BaseServiceImpl implements Reconcil
     }
     ResourceId namespaceId = namespaceOpt.get().getResourceId();
 
-    String tableName = tableRef.getName();
+    String tableName = normalizedTable.getName();
     if (tableName == null || tableName.isBlank()) {
       return Optional.empty();
     }
-    String normalized = normalizeName(tableName);
 
-    var table = tableRepo.getByName(accountId, catalogId, namespaceId.getId(), normalized);
+    var table = tableRepo.getByName(accountId, catalogId, namespaceId.getId(), tableName);
     return table.map(Table::getResourceId);
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
@@ -24,6 +24,8 @@ import ai.floedb.floecat.connector.rpc.ReconcileMode;
 import ai.floedb.floecat.reconciler.impl.ReconcileCancellationRegistry;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.rpc.CancelReconcileJobRequest;
@@ -183,7 +185,9 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
                             connectorId.getId(),
                             request.getFullRescan(),
                             mapCaptureMode(request.getMode()),
-                            scopeFromRequest(request));
+                            scopeFromRequest(request),
+                            executionPolicyFromRequest(request),
+                            "");
                     observeReconcileCounter(
                         ServiceMetrics.Reconcile.START_CAPTURE,
                         "start_capture",
@@ -249,6 +253,8 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
                         .setSnapshotsProcessed(job.snapshotsProcessed)
                         .setStatsProcessed(job.statsProcessed)
                         .setDurationMs(durationMs(job))
+                        .setExecutionPolicy(toProtoExecutionPolicy(job.executionPolicy))
+                        .setExecutorId(job.executorId)
                         .build();
                   } catch (RuntimeException e) {
                     observeReconcileRequestCounter(
@@ -597,6 +603,41 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
         .setSnapshotsProcessed(job.snapshotsProcessed)
         .setStatsProcessed(job.statsProcessed)
         .setDurationMs(durationMs(job))
+        .setExecutionPolicy(toProtoExecutionPolicy(job.executionPolicy))
+        .setExecutorId(job.executorId)
+        .build();
+  }
+
+  private static ReconcileExecutionPolicy executionPolicyFromRequest(StartCaptureRequest request) {
+    if (request == null || !request.hasExecutionPolicy()) {
+      return ReconcileExecutionPolicy.defaults();
+    }
+    var policy = request.getExecutionPolicy();
+    return ReconcileExecutionPolicy.of(
+        switch (policy.getExecutionClass()) {
+          case EC_INTERACTIVE -> ReconcileExecutionClass.INTERACTIVE;
+          case EC_BATCH -> ReconcileExecutionClass.BATCH;
+          case EC_HEAVY -> ReconcileExecutionClass.HEAVY;
+          case EC_DEFAULT, EC_UNSPECIFIED, UNRECOGNIZED -> ReconcileExecutionClass.DEFAULT;
+        },
+        policy.getLane(),
+        policy.getAttributesMap());
+  }
+
+  private static ai.floedb.floecat.reconciler.rpc.ExecutionPolicy toProtoExecutionPolicy(
+      ReconcileExecutionPolicy policy) {
+    ReconcileExecutionPolicy effective =
+        policy == null ? ReconcileExecutionPolicy.defaults() : policy;
+    return ai.floedb.floecat.reconciler.rpc.ExecutionPolicy.newBuilder()
+        .setExecutionClass(
+            switch (effective.executionClass()) {
+              case INTERACTIVE -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_INTERACTIVE;
+              case BATCH -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_BATCH;
+              case HEAVY -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_HEAVY;
+              case DEFAULT -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_DEFAULT;
+            })
+        .setLane(effective.lane())
+        .putAllAttributes(effective.attributes())
         .build();
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
@@ -26,8 +26,10 @@ import ai.floedb.floecat.reconciler.impl.ReconcilerService;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.rpc.CancelReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.CancelReconcileJobResponse;
 import ai.floedb.floecat.reconciler.rpc.CaptureNowRequest;
@@ -62,9 +64,11 @@ import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.jboss.logging.Logger;
 
@@ -180,13 +184,13 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
                                     Map.of("id", connectorId.getId())));
 
                     var jobId =
-                        jobs.enqueue(
+                        jobs.enqueuePlan(
                             connectorId.getAccountId(),
                             connectorId.getId(),
                             request.getFullRescan(),
                             mapCaptureMode(request.getMode()),
                             scopeFromRequest(request),
-                            executionPolicyFromRequest(request),
+                            mapExecutionPolicy(request.getExecutionPolicy()),
                             "");
                     observeReconcileCounter(
                         ServiceMetrics.Reconcile.START_CAPTURE,
@@ -233,29 +237,11 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
                                         correlationId,
                                         GeneratedErrorMessages.MessageKey.JOB,
                                         Map.of("id", request.getJobId())));
+                    job = aggregateIfPlanJob(principalContext.getAccountId(), job);
 
                     observeReconcileRequestCounter(
                         ServiceMetrics.Reconcile.GET_JOB, "get_reconcile_job", "success", null);
-                    return GetReconcileJobResponse.newBuilder()
-                        .setJobId(job.jobId)
-                        .setConnectorId(job.connectorId)
-                        .setState(toProtoState(job.state))
-                        .setMessage(job.message == null ? "" : job.message)
-                        .setStartedAt(Timestamps.fromMillis(job.startedAtMs))
-                        .setFinishedAt(
-                            job.finishedAtMs == 0
-                                ? Timestamps.fromMillis(0)
-                                : Timestamps.fromMillis(job.finishedAtMs))
-                        .setTablesScanned(job.tablesScanned)
-                        .setTablesChanged(job.tablesChanged)
-                        .setErrors(job.errors)
-                        .setFullRescan(job.fullRescan)
-                        .setSnapshotsProcessed(job.snapshotsProcessed)
-                        .setStatsProcessed(job.statsProcessed)
-                        .setDurationMs(durationMs(job))
-                        .setExecutionPolicy(toProtoExecutionPolicy(job.executionPolicy))
-                        .setExecutorId(job.executorId)
-                        .build();
+                    return toResponse(job);
                   } catch (RuntimeException e) {
                     observeReconcileRequestCounter(
                         ServiceMetrics.Reconcile.GET_JOB,
@@ -304,7 +290,8 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
                         ServiceMetrics.Reconcile.LIST_JOBS, "list_reconcile_jobs", "success", null);
                     var builder = ListReconcileJobsResponse.newBuilder();
                     for (var job : page.jobs) {
-                      builder.addJobs(toResponse(job));
+                      builder.addJobs(
+                          toResponse(aggregateIfPlanJob(principalContext.getAccountId(), job)));
                     }
                     builder.setPage(
                         PageResponse.newBuilder()
@@ -349,6 +336,17 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
                           GeneratedErrorMessages.MessageKey.JOB,
                           Map.of("id", request.getJobId()));
                     }
+                    var cancelledJob = cancelled.get();
+                    cancelChildJobs(
+                        principalContext.getAccountId(), cancelledJob, request.getReason());
+                    cancelled =
+                        jobs.get(principalContext.getAccountId(), request.getJobId())
+                            .map(job -> aggregateIfPlanJob(principalContext.getAccountId(), job))
+                            .or(
+                                () ->
+                                    Optional.of(
+                                        aggregateIfPlanJob(
+                                            principalContext.getAccountId(), cancelledJob)));
                     if ("JS_CANCELLING".equals(cancelled.get().state)) {
                       cancellations.requestCancel(cancelled.get().jobId);
                     }
@@ -510,6 +508,39 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
     return request == null ? ReconcileScope.empty() : scopeFromCaptureScope(request.getScope());
   }
 
+  private static ReconcileExecutionPolicy mapExecutionPolicy(
+      ai.floedb.floecat.reconciler.rpc.ExecutionPolicy policy) {
+    if (policy == null) {
+      return ReconcileExecutionPolicy.defaults();
+    }
+    return ReconcileExecutionPolicy.of(
+        switch (policy.getExecutionClass()) {
+          case EC_INTERACTIVE -> ReconcileExecutionClass.INTERACTIVE;
+          case EC_BATCH -> ReconcileExecutionClass.BATCH;
+          case EC_HEAVY -> ReconcileExecutionClass.HEAVY;
+          case EC_DEFAULT, EC_UNSPECIFIED, UNRECOGNIZED -> ReconcileExecutionClass.DEFAULT;
+        },
+        policy.getLane(),
+        policy.getAttributesMap());
+  }
+
+  private static ai.floedb.floecat.reconciler.rpc.ExecutionPolicy toProtoExecutionPolicy(
+      ReconcileExecutionPolicy policy) {
+    ReconcileExecutionPolicy effective =
+        policy == null ? ReconcileExecutionPolicy.defaults() : policy;
+    return ai.floedb.floecat.reconciler.rpc.ExecutionPolicy.newBuilder()
+        .setExecutionClass(
+            switch (effective.executionClass()) {
+              case INTERACTIVE -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_INTERACTIVE;
+              case BATCH -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_BATCH;
+              case HEAVY -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_HEAVY;
+              case DEFAULT -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_DEFAULT;
+            })
+        .setLane(effective.lane())
+        .putAllAttributes(effective.attributes())
+        .build();
+  }
+
   private static ReconcileScope scopeFromCaptureScope(CaptureScope scope) {
     if (scope == null) {
       return ReconcileScope.empty();
@@ -585,6 +616,133 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
     };
   }
 
+  private ReconcileJobStore.ReconcileJob aggregateIfPlanJob(
+      String accountId, ReconcileJobStore.ReconcileJob job) {
+    if (job == null || job.jobKind != ReconcileJobKind.PLAN_CONNECTOR) {
+      return job;
+    }
+    List<ReconcileJobStore.ReconcileJob> children = childJobsFor(accountId, job);
+    if (children.isEmpty()) {
+      return job;
+    }
+
+    String state = aggregateState(job, children);
+    String message =
+        children.stream()
+            .filter(child -> child.message != null && !child.message.isBlank())
+            .filter(child -> !"JS_SUCCEEDED".equals(child.state))
+            .map(child -> child.jobId + ": " + child.message)
+            .findFirst()
+            .orElse(job.message);
+    long startedAtMs =
+        children.stream()
+            .mapToLong(child -> child.startedAtMs)
+            .filter(v -> v > 0L)
+            .min()
+            .orElse(job.startedAtMs);
+    long finishedAtMs =
+        isTerminalState(state)
+            ? children.stream()
+                .mapToLong(child -> child.finishedAtMs)
+                .max()
+                .orElse(job.finishedAtMs)
+            : 0L;
+    long tablesScanned = children.stream().mapToLong(child -> child.tablesScanned).sum();
+    long tablesChanged = children.stream().mapToLong(child -> child.tablesChanged).sum();
+    long errors = children.stream().mapToLong(child -> child.errors).sum();
+    long snapshotsProcessed = children.stream().mapToLong(child -> child.snapshotsProcessed).sum();
+    long statsProcessed = children.stream().mapToLong(child -> child.statsProcessed).sum();
+    String executorId =
+        children.stream()
+            .map(child -> child.executorId == null ? "" : child.executorId)
+            .filter(v -> !v.isBlank())
+            .findFirst()
+            .orElse(job.executorId);
+
+    return new ReconcileJobStore.ReconcileJob(
+        job.jobId,
+        job.accountId,
+        job.connectorId,
+        state,
+        message,
+        startedAtMs,
+        finishedAtMs,
+        tablesScanned,
+        tablesChanged,
+        errors,
+        job.fullRescan,
+        job.captureMode,
+        snapshotsProcessed,
+        statsProcessed,
+        job.scope,
+        job.executionPolicy,
+        executorId,
+        job.jobKind,
+        job.tableTask,
+        job.parentJobId);
+  }
+
+  private List<ReconcileJobStore.ReconcileJob> childJobsFor(
+      String accountId, ReconcileJobStore.ReconcileJob planJob) {
+    if (planJob == null || planJob.jobKind != ReconcileJobKind.PLAN_CONNECTOR) {
+      return List.of();
+    }
+    List<ReconcileJobStore.ReconcileJob> out = new ArrayList<>();
+    String nextToken = "";
+    do {
+      var page = jobs.list(accountId, 200, nextToken, planJob.connectorId, Set.of());
+      for (var candidate : page.jobs) {
+        if (planJob.jobId.equals(candidate.parentJobId)) {
+          out.add(candidate);
+        }
+      }
+      nextToken = page.nextPageToken;
+    } while (nextToken != null && !nextToken.isBlank());
+    return List.copyOf(out);
+  }
+
+  private void cancelChildJobs(
+      String accountId, ReconcileJobStore.ReconcileJob job, String reason) {
+    if (job == null || job.jobKind != ReconcileJobKind.PLAN_CONNECTOR) {
+      return;
+    }
+    for (var child : childJobsFor(accountId, job)) {
+      var cancelled = jobs.cancel(accountId, child.jobId, reason);
+      if (cancelled.isPresent() && "JS_CANCELLING".equals(cancelled.get().state)) {
+        cancellations.requestCancel(cancelled.get().jobId);
+      }
+    }
+  }
+
+  private static String aggregateState(
+      ReconcileJobStore.ReconcileJob planJob, List<ReconcileJobStore.ReconcileJob> children) {
+    if (children.stream().anyMatch(child -> "JS_CANCELLING".equals(child.state))) {
+      return "JS_CANCELLING";
+    }
+    if (children.stream().anyMatch(child -> "JS_RUNNING".equals(child.state))) {
+      return "JS_RUNNING";
+    }
+    if (children.stream().anyMatch(child -> "JS_QUEUED".equals(child.state))) {
+      return "JS_QUEUED";
+    }
+    if (children.stream().anyMatch(child -> "JS_FAILED".equals(child.state))) {
+      return "JS_FAILED";
+    }
+    if (children.stream().anyMatch(child -> "JS_CANCELLED".equals(child.state))) {
+      return "JS_CANCELLED";
+    }
+    if ("JS_FAILED".equals(planJob.state) || "JS_CANCELLED".equals(planJob.state)) {
+      return planJob.state;
+    }
+    return "JS_SUCCEEDED";
+  }
+
+  private static boolean isTerminalState(String state) {
+    return "JS_SUCCEEDED".equals(state)
+        || "JS_FAILED".equals(state)
+        || "JS_CANCELLED".equals(state);
+  }
+
   private static GetReconcileJobResponse toResponse(ReconcileJobStore.ReconcileJob job) {
     return GetReconcileJobResponse.newBuilder()
         .setJobId(job.jobId)
@@ -604,40 +762,29 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
         .setStatsProcessed(job.statsProcessed)
         .setDurationMs(durationMs(job))
         .setExecutionPolicy(toProtoExecutionPolicy(job.executionPolicy))
-        .setExecutorId(job.executorId)
+        .setExecutorId(job.executorId == null ? "" : job.executorId)
+        .setKind(toProtoJobKind(job.jobKind))
+        .setParentJobId(job.parentJobId == null ? "" : job.parentJobId)
+        .setTableTask(toProtoTableTask(job.tableTask))
         .build();
   }
 
-  private static ReconcileExecutionPolicy executionPolicyFromRequest(StartCaptureRequest request) {
-    if (request == null || !request.hasExecutionPolicy()) {
-      return ReconcileExecutionPolicy.defaults();
-    }
-    var policy = request.getExecutionPolicy();
-    return ReconcileExecutionPolicy.of(
-        switch (policy.getExecutionClass()) {
-          case EC_INTERACTIVE -> ReconcileExecutionClass.INTERACTIVE;
-          case EC_BATCH -> ReconcileExecutionClass.BATCH;
-          case EC_HEAVY -> ReconcileExecutionClass.HEAVY;
-          case EC_DEFAULT, EC_UNSPECIFIED, UNRECOGNIZED -> ReconcileExecutionClass.DEFAULT;
-        },
-        policy.getLane(),
-        policy.getAttributesMap());
+  private static ai.floedb.floecat.reconciler.rpc.ReconcileJobKind toProtoJobKind(
+      ReconcileJobKind jobKind) {
+    return switch (jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR : jobKind) {
+      case PLAN_CONNECTOR -> ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_PLAN_CONNECTOR;
+      case EXEC_TABLE -> ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_TABLE;
+      case EXEC_CONNECTOR -> ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_CONNECTOR;
+    };
   }
 
-  private static ai.floedb.floecat.reconciler.rpc.ExecutionPolicy toProtoExecutionPolicy(
-      ReconcileExecutionPolicy policy) {
-    ReconcileExecutionPolicy effective =
-        policy == null ? ReconcileExecutionPolicy.defaults() : policy;
-    return ai.floedb.floecat.reconciler.rpc.ExecutionPolicy.newBuilder()
-        .setExecutionClass(
-            switch (effective.executionClass()) {
-              case INTERACTIVE -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_INTERACTIVE;
-              case BATCH -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_BATCH;
-              case HEAVY -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_HEAVY;
-              case DEFAULT -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_DEFAULT;
-            })
-        .setLane(effective.lane())
-        .putAllAttributes(effective.attributes())
+  private static ai.floedb.floecat.reconciler.rpc.ReconcileTableTask toProtoTableTask(
+      ReconcileTableTask tableTask) {
+    ReconcileTableTask effective = tableTask == null ? ReconcileTableTask.empty() : tableTask;
+    return ai.floedb.floecat.reconciler.rpc.ReconcileTableTask.newBuilder()
+        .setSourceNamespace(effective.sourceNamespace())
+        .setSourceTable(effective.sourceTable())
+        .setDestinationTableDisplayName(effective.destinationTableDisplayName())
         .build();
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.impl;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.rpc.CompleteLeasedReconcileJobRequest;
+import ai.floedb.floecat.reconciler.rpc.CompleteLeasedReconcileJobResponse;
+import ai.floedb.floecat.reconciler.rpc.GetReconcileCancellationRequest;
+import ai.floedb.floecat.reconciler.rpc.GetReconcileCancellationResponse;
+import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobRequest;
+import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobResponse;
+import ai.floedb.floecat.reconciler.rpc.LeasedReconcileJob;
+import ai.floedb.floecat.reconciler.rpc.ReconcileCompletionState;
+import ai.floedb.floecat.reconciler.rpc.ReconcileExecutorControl;
+import ai.floedb.floecat.reconciler.rpc.RenewReconcileLeaseRequest;
+import ai.floedb.floecat.reconciler.rpc.RenewReconcileLeaseResponse;
+import ai.floedb.floecat.reconciler.rpc.ReportReconcileProgressRequest;
+import ai.floedb.floecat.reconciler.rpc.ReportReconcileProgressResponse;
+import ai.floedb.floecat.reconciler.rpc.StartLeasedReconcileJobRequest;
+import ai.floedb.floecat.reconciler.rpc.StartLeasedReconcileJobResponse;
+import ai.floedb.floecat.service.common.BaseServiceImpl;
+import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import java.util.EnumSet;
+import java.util.Set;
+
+@GrpcService
+public class ReconcileExecutorControlImpl extends BaseServiceImpl
+    implements ReconcileExecutorControl {
+
+  @Inject PrincipalProvider principalProvider;
+  @Inject Authorizer authz;
+  @Inject ReconcileJobStore jobs;
+
+  @Override
+  public Uni<LeaseReconcileJobResponse> leaseReconcileJob(LeaseReconcileJobRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var principalContext = principalProvider.get();
+              authz.require(principalContext, "connector.manage");
+              String corr = principalContext.getCorrelationId();
+              String executorId = mustNonEmpty(request.getExecutorId(), "executor_id", corr);
+              var leaseRequest =
+                  ReconcileJobStore.LeaseRequest.of(
+                      executionClassesFrom(request), lanesFrom(request), Set.of(executorId));
+              var lease = jobs.leaseNext(leaseRequest);
+              if (lease.isEmpty()) {
+                return LeaseReconcileJobResponse.newBuilder().setFound(false).build();
+              }
+              return LeaseReconcileJobResponse.newBuilder()
+                  .setFound(true)
+                  .setJob(toProtoLease(lease.get()))
+                  .build();
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<RenewReconcileLeaseResponse> renewReconcileLease(RenewReconcileLeaseRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var principalContext = principalProvider.get();
+              authz.require(principalContext, "connector.manage");
+              String corr = principalContext.getCorrelationId();
+              String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
+              boolean renewed = jobs.renewLease(jobId, leaseEpoch);
+              return RenewReconcileLeaseResponse.newBuilder()
+                  .setRenewed(renewed)
+                  .setCancellationRequested(jobs.isCancellationRequested(jobId))
+                  .build();
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<StartLeasedReconcileJobResponse> startLeasedReconcileJob(
+      StartLeasedReconcileJobRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var principalContext = principalProvider.get();
+              authz.require(principalContext, "connector.manage");
+              String corr = principalContext.getCorrelationId();
+              String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
+              String executorId = mustNonEmpty(request.getExecutorId(), "executor_id", corr);
+              jobs.markRunning(jobId, leaseEpoch, System.currentTimeMillis(), executorId);
+              return StartLeasedReconcileJobResponse.getDefaultInstance();
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<ReportReconcileProgressResponse> reportReconcileProgress(
+      ReportReconcileProgressRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var principalContext = principalProvider.get();
+              authz.require(principalContext, "connector.manage");
+              String corr = principalContext.getCorrelationId();
+              String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
+              boolean leaseValid = jobs.renewLease(jobId, leaseEpoch);
+              if (leaseValid) {
+                jobs.markProgress(
+                    jobId,
+                    leaseEpoch,
+                    request.getTablesScanned(),
+                    request.getTablesChanged(),
+                    request.getErrors(),
+                    request.getSnapshotsProcessed(),
+                    request.getStatsProcessed(),
+                    request.getMessage());
+              }
+              return ReportReconcileProgressResponse.newBuilder()
+                  .setLeaseValid(leaseValid)
+                  .setCancellationRequested(jobs.isCancellationRequested(jobId))
+                  .build();
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<CompleteLeasedReconcileJobResponse> completeLeasedReconcileJob(
+      CompleteLeasedReconcileJobRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var principalContext = principalProvider.get();
+              authz.require(principalContext, "connector.manage");
+              String corr = principalContext.getCorrelationId();
+              String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
+              if (request.getState() == ReconcileCompletionState.RCS_UNSPECIFIED
+                  || request.getState() == ReconcileCompletionState.UNRECOGNIZED) {
+                throw GrpcErrors.invalidArgument(corr, null, java.util.Map.of("field", "state"));
+              }
+              boolean leaseValid = jobs.renewLease(jobId, leaseEpoch);
+              if (!leaseValid) {
+                return CompleteLeasedReconcileJobResponse.newBuilder().setAccepted(false).build();
+              }
+              long finishedAtMs = System.currentTimeMillis();
+              switch (request.getState()) {
+                case RCS_SUCCEEDED ->
+                    jobs.markSucceeded(
+                        jobId,
+                        leaseEpoch,
+                        finishedAtMs,
+                        request.getTablesScanned(),
+                        request.getTablesChanged(),
+                        request.getSnapshotsProcessed(),
+                        request.getStatsProcessed());
+                case RCS_FAILED ->
+                    jobs.markFailed(
+                        jobId,
+                        leaseEpoch,
+                        finishedAtMs,
+                        request.getMessage(),
+                        request.getTablesScanned(),
+                        request.getTablesChanged(),
+                        request.getErrors(),
+                        request.getSnapshotsProcessed(),
+                        request.getStatsProcessed());
+                case RCS_CANCELLED ->
+                    jobs.markCancelled(
+                        jobId,
+                        leaseEpoch,
+                        finishedAtMs,
+                        request.getMessage(),
+                        request.getTablesScanned(),
+                        request.getTablesChanged(),
+                        request.getErrors(),
+                        request.getSnapshotsProcessed(),
+                        request.getStatsProcessed());
+                case RCS_UNSPECIFIED, UNRECOGNIZED ->
+                    throw GrpcErrors.invalidArgument(
+                        corr, null, java.util.Map.of("field", "state"));
+              }
+              return CompleteLeasedReconcileJobResponse.newBuilder().setAccepted(true).build();
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<GetReconcileCancellationResponse> getReconcileCancellation(
+      GetReconcileCancellationRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var principalContext = principalProvider.get();
+              authz.require(principalContext, "connector.manage");
+              String corr = principalContext.getCorrelationId();
+              String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              return GetReconcileCancellationResponse.newBuilder()
+                  .setCancellationRequested(jobs.isCancellationRequested(jobId))
+                  .build();
+            }),
+        correlationId());
+  }
+
+  private static Set<ReconcileExecutionClass> executionClassesFrom(
+      LeaseReconcileJobRequest request) {
+    EnumSet<ReconcileExecutionClass> executionClasses =
+        EnumSet.noneOf(ReconcileExecutionClass.class);
+    if (request == null) {
+      return executionClasses;
+    }
+    for (var executionClass : request.getExecutionClassesList()) {
+      switch (executionClass) {
+        case EC_INTERACTIVE -> executionClasses.add(ReconcileExecutionClass.INTERACTIVE);
+        case EC_BATCH -> executionClasses.add(ReconcileExecutionClass.BATCH);
+        case EC_HEAVY -> executionClasses.add(ReconcileExecutionClass.HEAVY);
+        case EC_DEFAULT, EC_UNSPECIFIED, UNRECOGNIZED ->
+            executionClasses.add(ReconcileExecutionClass.DEFAULT);
+      }
+    }
+    return executionClasses;
+  }
+
+  private static Set<String> lanesFrom(LeaseReconcileJobRequest request) {
+    if (request == null) {
+      return Set.of();
+    }
+    return request.getLanesList().stream()
+        .map(lane -> lane == null ? "" : lane.trim())
+        .collect(java.util.stream.Collectors.toUnmodifiableSet());
+  }
+
+  private static LeasedReconcileJob toProtoLease(ReconcileJobStore.LeasedJob lease) {
+    return LeasedReconcileJob.newBuilder()
+        .setJobId(lease.jobId)
+        .setConnectorId(
+            ResourceId.newBuilder()
+                .setAccountId(lease.accountId)
+                .setKind(ResourceKind.RK_CONNECTOR)
+                .setId(lease.connectorId)
+                .build())
+        .setMode(toProtoCaptureMode(lease.captureMode))
+        .setFullRescan(lease.fullRescan)
+        .setScope(toProtoScope(lease))
+        .setLeaseEpoch(lease.leaseEpoch)
+        .setExecutionPolicy(toProtoExecutionPolicy(lease.executionPolicy))
+        .setPinnedExecutorId(lease.pinnedExecutorId)
+        .setExecutorId(lease.executorId)
+        .build();
+  }
+
+  private static ai.floedb.floecat.reconciler.rpc.CaptureMode toProtoCaptureMode(
+      CaptureMode captureMode) {
+    return switch (captureMode == null ? CaptureMode.METADATA_AND_STATS : captureMode) {
+      case METADATA_ONLY -> ai.floedb.floecat.reconciler.rpc.CaptureMode.CM_METADATA_ONLY;
+      case STATS_ONLY -> ai.floedb.floecat.reconciler.rpc.CaptureMode.CM_STATS_ONLY;
+      case METADATA_AND_STATS -> ai.floedb.floecat.reconciler.rpc.CaptureMode.CM_METADATA_AND_STATS;
+    };
+  }
+
+  private static ai.floedb.floecat.reconciler.rpc.ExecutionPolicy toProtoExecutionPolicy(
+      ReconcileExecutionPolicy policy) {
+    ReconcileExecutionPolicy effective =
+        policy == null ? ReconcileExecutionPolicy.defaults() : policy;
+    return ai.floedb.floecat.reconciler.rpc.ExecutionPolicy.newBuilder()
+        .setExecutionClass(
+            switch (effective.executionClass()) {
+              case INTERACTIVE -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_INTERACTIVE;
+              case BATCH -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_BATCH;
+              case HEAVY -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_HEAVY;
+              case DEFAULT -> ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_DEFAULT;
+            })
+        .setLane(effective.lane())
+        .putAllAttributes(effective.attributes())
+        .build();
+  }
+
+  private static ai.floedb.floecat.reconciler.rpc.CaptureScope toProtoScope(
+      ReconcileJobStore.LeasedJob lease) {
+    ReconcileScope scope =
+        lease == null || lease.scope == null ? ReconcileScope.empty() : lease.scope;
+    var builder =
+        ai.floedb.floecat.reconciler.rpc.CaptureScope.newBuilder()
+            .setConnectorId(
+                ResourceId.newBuilder()
+                    .setAccountId(lease.accountId)
+                    .setKind(ResourceKind.RK_CONNECTOR)
+                    .setId(lease.connectorId)
+                    .build())
+            .setDestinationTableDisplayName(scope.destinationTableDisplayName());
+    for (var namespacePath : scope.destinationNamespacePaths()) {
+      builder.addDestinationNamespacePaths(
+          NamespacePath.newBuilder().addAllSegments(namespacePath).build());
+    }
+    builder.addAllDestinationTableColumns(scope.destinationTableColumns());
+    builder.addAllDestinationSnapshotIds(scope.destinationSnapshotIds());
+    return builder.build();
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
@@ -22,8 +22,10 @@ import ai.floedb.floecat.connector.rpc.NamespacePath;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.rpc.CompleteLeasedReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.CompleteLeasedReconcileJobResponse;
 import ai.floedb.floecat.reconciler.rpc.GetReconcileCancellationRequest;
@@ -68,7 +70,10 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               String executorId = mustNonEmpty(request.getExecutorId(), "executor_id", corr);
               var leaseRequest =
                   ReconcileJobStore.LeaseRequest.of(
-                      executionClassesFrom(request), lanesFrom(request), Set.of(executorId));
+                      executionClassesFrom(request),
+                      lanesFrom(request),
+                      Set.of(executorId),
+                      jobKindsFrom(request));
               var lease = jobs.leaseNext(leaseRequest);
               if (lease.isEmpty()) {
                 return LeaseReconcileJobResponse.newBuilder().setFound(false).build();
@@ -255,6 +260,22 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
         .collect(java.util.stream.Collectors.toUnmodifiableSet());
   }
 
+  private static Set<ReconcileJobKind> jobKindsFrom(LeaseReconcileJobRequest request) {
+    EnumSet<ReconcileJobKind> jobKinds = EnumSet.noneOf(ReconcileJobKind.class);
+    if (request == null) {
+      return jobKinds;
+    }
+    for (var jobKind : request.getJobKindsList()) {
+      switch (jobKind) {
+        case RJK_PLAN_CONNECTOR -> jobKinds.add(ReconcileJobKind.PLAN_CONNECTOR);
+        case RJK_EXEC_TABLE -> jobKinds.add(ReconcileJobKind.EXEC_TABLE);
+        case RJK_EXEC_CONNECTOR, RJK_UNSPECIFIED, UNRECOGNIZED ->
+            jobKinds.add(ReconcileJobKind.EXEC_CONNECTOR);
+      }
+    }
+    return jobKinds;
+  }
+
   private static LeasedReconcileJob toProtoLease(ReconcileJobStore.LeasedJob lease) {
     return LeasedReconcileJob.newBuilder()
         .setJobId(lease.jobId)
@@ -271,6 +292,28 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
         .setExecutionPolicy(toProtoExecutionPolicy(lease.executionPolicy))
         .setPinnedExecutorId(lease.pinnedExecutorId)
         .setExecutorId(lease.executorId)
+        .setKind(toProtoJobKind(lease.jobKind))
+        .setParentJobId(lease.parentJobId)
+        .setTableTask(toProtoTableTask(lease.tableTask))
+        .build();
+  }
+
+  private static ai.floedb.floecat.reconciler.rpc.ReconcileJobKind toProtoJobKind(
+      ReconcileJobKind jobKind) {
+    return switch (jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR : jobKind) {
+      case PLAN_CONNECTOR -> ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_PLAN_CONNECTOR;
+      case EXEC_TABLE -> ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_TABLE;
+      case EXEC_CONNECTOR -> ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_CONNECTOR;
+    };
+  }
+
+  private static ai.floedb.floecat.reconciler.rpc.ReconcileTableTask toProtoTableTask(
+      ReconcileTableTask tableTask) {
+    ReconcileTableTask effective = tableTask == null ? ReconcileTableTask.empty() : tableTask;
+    return ai.floedb.floecat.reconciler.rpc.ReconcileTableTask.newBuilder()
+        .setSourceNamespace(effective.sourceNamespace())
+        .setSourceTable(effective.sourceTable())
+        .setDestinationTableDisplayName(effective.destinationTableDisplayName())
         .build();
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/RuntimeSelectedReconcilerBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/RuntimeSelectedReconcilerBackend.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.impl;
+
+import ai.floedb.floecat.catalog.rpc.ColumnStats;
+import ai.floedb.floecat.catalog.rpc.FileColumnStats;
+import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
+import ai.floedb.floecat.catalog.rpc.TableStats;
+import ai.floedb.floecat.catalog.rpc.ViewSpec;
+import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.query.rpc.SnapshotPin;
+import ai.floedb.floecat.reconciler.impl.GrpcReconcilerBackend;
+import ai.floedb.floecat.reconciler.spi.ReconcileContext;
+import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
+import com.google.protobuf.Timestamp;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class RuntimeSelectedReconcilerBackend implements ReconcilerBackend {
+  private final ReconcilerBackend delegate;
+
+  @Inject
+  public RuntimeSelectedReconcilerBackend(
+      DirectReconcilerBackend directBackend,
+      GrpcReconcilerBackend grpcBackend,
+      @ConfigProperty(name = "floecat.reconciler.backend", defaultValue = "local") String backend) {
+    this.delegate =
+        "remote".equalsIgnoreCase(backend == null ? "" : backend.trim())
+            ? grpcBackend
+            : directBackend;
+  }
+
+  @Override
+  public ResourceId ensureNamespace(ReconcileContext ctx, ResourceId catalogId, NameRef namespace) {
+    return delegate.ensureNamespace(ctx, catalogId, namespace);
+  }
+
+  @Override
+  public ResourceId ensureTable(
+      ReconcileContext ctx, ResourceId namespaceId, NameRef table, TableSpecDescriptor descriptor) {
+    return delegate.ensureTable(ctx, namespaceId, table, descriptor);
+  }
+
+  @Override
+  public Optional<ResourceId> lookupTable(ReconcileContext ctx, NameRef table) {
+    return delegate.lookupTable(ctx, table);
+  }
+
+  @Override
+  public SnapshotPin snapshotPinFor(
+      ReconcileContext ctx, ResourceId tableId, SnapshotRef ref, Optional<Timestamp> asOf) {
+    return delegate.snapshotPinFor(ctx, tableId, ref, asOf);
+  }
+
+  @Override
+  public Optional<Snapshot> fetchSnapshot(
+      ReconcileContext ctx, ResourceId tableId, long snapshotId) {
+    return delegate.fetchSnapshot(ctx, tableId, snapshotId);
+  }
+
+  @Override
+  public Set<Long> existingSnapshotIds(ReconcileContext ctx, ResourceId tableId) {
+    return delegate.existingSnapshotIds(ctx, tableId);
+  }
+
+  @Override
+  public void ingestSnapshot(ReconcileContext ctx, ResourceId tableId, Snapshot snapshot) {
+    delegate.ingestSnapshot(ctx, tableId, snapshot);
+  }
+
+  @Override
+  public boolean statsAlreadyCaptured(ReconcileContext ctx, ResourceId tableId, long snapshotId) {
+    return delegate.statsAlreadyCaptured(ctx, tableId, snapshotId);
+  }
+
+  @Override
+  public void putTableStats(ReconcileContext ctx, ResourceId tableId, TableStats stats) {
+    delegate.putTableStats(ctx, tableId, stats);
+  }
+
+  @Override
+  public void putColumnStats(ReconcileContext ctx, List<ColumnStats> stats) {
+    delegate.putColumnStats(ctx, stats);
+  }
+
+  @Override
+  public void putFileColumnStats(ReconcileContext ctx, List<FileColumnStats> stats) {
+    delegate.putFileColumnStats(ctx, stats);
+  }
+
+  @Override
+  public void putSnapshotConstraints(
+      ReconcileContext ctx, ResourceId tableId, long snapshotId, SnapshotConstraints constraints) {
+    delegate.putSnapshotConstraints(ctx, tableId, snapshotId, constraints);
+  }
+
+  @Override
+  public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+    return delegate.lookupCatalogName(ctx, catalogId);
+  }
+
+  @Override
+  public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+    return delegate.resolveNamespaceFq(ctx, namespaceId);
+  }
+
+  @Override
+  public Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId) {
+    return delegate.lookupConnector(ctx, connectorId);
+  }
+
+  @Override
+  public void updateConnectorDestination(
+      ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {
+    delegate.updateConnectorDestination(ctx, connectorId, destination);
+  }
+
+  @Override
+  public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+    return delegate.ensureView(ctx, spec, idempotencyKey);
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/RuntimeSelectedReconcilerBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/RuntimeSelectedReconcilerBackend.java
@@ -140,7 +140,8 @@ public class RuntimeSelectedReconcilerBackend implements ReconcilerBackend {
   }
 
   @Override
-  public ResourceId ensureView(ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
-    return delegate.ensureView(ctx, spec, idempotencyKey);
+  public EnsureViewResult ensureViewDetailed(
+      ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
+    return delegate.ensureViewDetailed(ctx, spec, idempotencyKey);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -20,8 +20,11 @@ import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
+import ai.floedb.floecat.service.common.Canonicalizer;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.storage.errors.StorageNotFoundException;
 import ai.floedb.floecat.storage.spi.BlobStore;
@@ -130,14 +133,30 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       boolean fullRescan,
       CaptureMode captureMode,
       ReconcileScope incomingScope,
+      ReconcileJobKind jobKind,
+      ReconcileTableTask tableTask,
       ReconcileExecutionPolicy executionPolicy,
+      String parentJobId,
       String pinnedExecutorId) {
     ReconcileScope scope = incomingScope == null ? ReconcileScope.empty() : incomingScope;
+    ReconcileJobKind effectiveJobKind = jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR : jobKind;
+    ReconcileTableTask effectiveTableTask =
+        tableTask == null ? ReconcileTableTask.empty() : tableTask;
     ReconcileExecutionPolicy policy =
         executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy;
-    String laneKey = laneKey(connectorId, scope);
+    String laneKey = laneKey(connectorId, scope, effectiveJobKind, effectiveTableTask);
     String dedupeKey =
-        dedupeKey(accountId, connectorId, fullRescan, captureMode, scope, policy, pinnedExecutorId);
+        dedupeKey(
+            accountId,
+            connectorId,
+            fullRescan,
+            captureMode,
+            scope,
+            effectiveJobKind,
+            effectiveTableTask,
+            policy,
+            parentJobId,
+            pinnedExecutorId);
     String dedupePointerKey = Keys.reconcileDedupePointer(accountId, hashValue(dedupeKey));
 
     for (int attempt = 0; attempt < CAS_MAX; attempt++) {
@@ -168,7 +187,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
               fullRescan,
               captureMode,
               scope,
+              effectiveJobKind,
+              effectiveTableTask,
               policy,
+              parentJobId,
               pinnedExecutorId,
               laneKey,
               dedupeKey,
@@ -745,6 +767,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
           canonicalPointerKey, currentPointer.getVersion(), nextPointer)) {
         syncIndexPointers(nextRecord, currentPointer.getBlobUri(), nextBlobUri);
         if (!currentPointer.getBlobUri().equals(nextBlobUri)) {
+          // The pointer graph is the durable source of truth. Readers are expected to resolve the
+          // latest canonical/secondary pointers before dereferencing blobs, so old blob URIs are
+          // not stable externally-cacheable addresses once the pointer swap has committed.
           blobStore.delete(currentPointer.getBlobUri());
         }
         return;
@@ -810,6 +835,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       if (pointerStore.compareAndSet(
           canonicalPointerKey, currentPointer.getVersion(), nextPointer)) {
         syncIndexPointers(current, currentPointer.getBlobUri(), nextBlobUri);
+        // The pointer graph is the durable source of truth. Readers are expected to resolve the
+        // latest canonical/secondary pointers before dereferencing blobs, so old blob URIs are
+        // not stable externally-cacheable addresses once the pointer swap has committed.
         blobStore.delete(currentPointer.getBlobUri());
         return true;
       }
@@ -887,6 +915,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       if (pointerStore.compareAndSet(
           canonicalPointerKey, currentPointer.getVersion(), nextPointer)) {
         syncIndexPointers(current, currentPointer.getBlobUri(), nextBlobUri);
+        // The pointer graph is the durable source of truth. Readers are expected to resolve the
+        // latest canonical/secondary pointers before dereferencing blobs, so old blob URIs are
+        // not stable externally-cacheable addresses once the pointer swap has committed.
         blobStore.delete(currentPointer.getBlobUri());
         return Optional.of(
             new LeasedJob(
@@ -899,7 +930,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
                 current.executionPolicy(),
                 current.leaseEpoch,
                 current.pinnedExecutorId(),
-                current.executorId()));
+                current.executorId(),
+                current.jobKind(),
+                current.tableTask(),
+                current.parentJobId()));
       }
 
       blobStore.delete(nextBlobUri);
@@ -1103,7 +1137,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     }
     var record = readRecord(canonicalPointer);
     return record.isPresent()
-        && effective.matches(record.get().executionPolicy(), record.get().pinnedExecutorId());
+        && effective.matches(
+            record.get().executionPolicy(),
+            record.get().pinnedExecutorId(),
+            record.get().jobKind());
   }
 
   private ReconcileJob toPublicJob(StoredReconcileJob stored) {
@@ -1124,7 +1161,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         stored.statsProcessed,
         stored.toScope(),
         stored.executionPolicy(),
-        stored.executorId());
+        stored.executorId(),
+        stored.jobKind(),
+        stored.tableTask(),
+        stored.parentJobId());
   }
 
   private boolean upsertReadyPointer(String readyPointerKey, String blobUri) {
@@ -1384,14 +1424,30 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     };
   }
 
-  private static String laneKey(String connectorId, ReconcileScope scope) {
+  private static String laneKey(
+      String connectorId,
+      ReconcileScope scope,
+      ReconcileJobKind jobKind,
+      ReconcileTableTask tableTask) {
+    String destinationTableDisplayName =
+        tableTask != null && !tableTask.destinationTableDisplayName().isBlank()
+            ? tableTask.destinationTableDisplayName()
+            : scope.destinationTableDisplayName();
     String namespace =
-        scope.destinationNamespacePaths().isEmpty()
-            ? "*"
-            : String.join(".", scope.destinationNamespacePaths().get(0));
+        tableTask != null && !tableTask.sourceNamespace().isBlank()
+            ? tableTask.sourceNamespace()
+            : scope.destinationNamespacePaths().isEmpty()
+                ? "*"
+                : String.join(".", scope.destinationNamespacePaths().get(0));
     String table =
-        scope.destinationTableDisplayName() == null ? "*" : scope.destinationTableDisplayName();
-    return connectorId + "|" + namespace + "|" + table;
+        destinationTableDisplayName != null && !destinationTableDisplayName.isBlank()
+            ? destinationTableDisplayName
+            : tableTask != null && !tableTask.sourceTable().isBlank()
+                ? tableTask.sourceTable()
+                : scope.destinationTableDisplayName() == null
+                    ? "*"
+                    : scope.destinationTableDisplayName();
+    return connectorId + "|" + jobKind.name() + "|" + namespace + "|" + table;
   }
 
   private static String dedupeKey(
@@ -1400,7 +1456,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       boolean fullRescan,
       CaptureMode captureMode,
       ReconcileScope scope,
+      ReconcileJobKind jobKind,
+      ReconcileTableTask tableTask,
       ReconcileExecutionPolicy executionPolicy,
+      String parentJobId,
       String pinnedExecutorId) {
     String namespaces =
         scope.destinationNamespacePaths().stream()
@@ -1413,36 +1472,69 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     String columns =
         scope.destinationTableColumns().stream().sorted().reduce((a, b) -> a + "," + b).orElse("");
     String snapshots =
-        scope.destinationSnapshotIds().stream()
-            .map(String::valueOf)
-            .sorted()
-            .reduce((a, b) -> a + "," + b)
-            .orElse("");
+        scope.destinationSnapshotIds().stream().sorted().map(String::valueOf).toList().toString();
     ReconcileExecutionPolicy policy =
         executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy;
-    return accountId
-        + "|"
-        + connectorId
-        + "|"
-        + (fullRescan ? "full" : "incr")
-        + "|"
-        + (captureMode == null ? CaptureMode.METADATA_AND_STATS.name() : captureMode.name())
-        + "|"
-        + namespaces
-        + "|"
-        + table
-        + "|"
-        + columns
-        + "|"
-        + snapshots
-        + "|"
-        + policy.executionClass().name()
-        + "|"
-        + policy.lane()
-        + "|"
-        + policy.attributes()
-        + "|"
-        + (pinnedExecutorId == null ? "" : pinnedExecutorId.trim());
+    Canonicalizer canonicalizer = new Canonicalizer();
+    canonicalizer
+        .scalar("account_id", accountId)
+        .scalar("connector_id", connectorId)
+        .scalar(
+            "job_kind", (jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR.name() : jobKind.name()))
+        .scalar("full_rescan", fullRescan)
+        .scalar(
+            "capture_mode",
+            captureMode == null ? CaptureMode.METADATA_AND_STATS.name() : captureMode.name())
+        .scalar("table_task.source_namespace", tableTask == null ? "" : tableTask.sourceNamespace())
+        .scalar("table_task.source_table", tableTask == null ? "" : tableTask.sourceTable())
+        .scalar(
+            "table_task.destination_table_display_name",
+            tableTask == null ? "" : tableTask.destinationTableDisplayName())
+        .scalar("scope.namespaces", namespaces)
+        .scalar("scope.table", table)
+        .scalar("scope.columns", columns)
+        .scalar("scope.snapshots", snapshots)
+        .scalar("policy.execution_class", policy.executionClass().name())
+        .scalar("policy.lane", policy.lane())
+        .map("policy.attributes", policy.attributes())
+        .scalar("parent_job_id", parentJobId == null ? "" : parentJobId.trim())
+        .scalar("pinned_executor_id", pinnedExecutorId == null ? "" : pinnedExecutorId.trim());
+    return new String(canonicalizer.bytes(), StandardCharsets.UTF_8);
+  }
+
+  private static ListCursor decodeListCursor(String pageToken) {
+    if (pageToken == null || pageToken.isBlank()) {
+      return new ListCursor("", 0);
+    }
+    if (!pageToken.startsWith(LIST_TOKEN_V1_PREFIX)) {
+      return new ListCursor(pageToken, 0);
+    }
+    try {
+      String decoded =
+          new String(
+              Base64.getUrlDecoder().decode(pageToken.substring(LIST_TOKEN_V1_PREFIX.length())),
+              StandardCharsets.UTF_8);
+      int separator = decoded.indexOf('\n');
+      if (separator < 0) {
+        return new ListCursor(decoded, 0);
+      }
+      String storeToken = decoded.substring(0, separator);
+      int skip = Integer.parseInt(decoded.substring(separator + 1));
+      return new ListCursor(storeToken, Math.max(0, skip));
+    } catch (RuntimeException e) {
+      return new ListCursor(pageToken, 0);
+    }
+  }
+
+  private static String encodeListCursor(String storeToken, int skip) {
+    if (skip <= 0) {
+      return storeToken == null ? "" : storeToken;
+    }
+    String payload = (storeToken == null ? "" : storeToken) + "\n" + skip;
+    return LIST_TOKEN_V1_PREFIX
+        + Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
   }
 
   private static String hashValue(String value) {
@@ -1512,11 +1604,12 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
             .withoutPadding()
             .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
   }
-
   static final class StoredReconcileJob {
     public String jobId;
     public String accountId;
     public String connectorId;
+    public String jobKind;
+    public String parentJobId;
     public boolean fullRescan;
     public String captureMode;
     public String executionClass;
@@ -1524,8 +1617,11 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     public java.util.Map<String, String> executionAttributes = java.util.Map.of();
     public String pinnedExecutorId;
     public String executorId;
-    public List<List<String>> destinationNamespacePaths = List.of();
+    public String sourceNamespace;
+    public String sourceTable;
+    public String taskDestinationTableDisplayName;
     public String destinationTableDisplayName;
+    public List<List<String>> destinationNamespacePaths = List.of();
     public List<String> destinationTableColumns = List.of();
     public List<Long> destinationSnapshotIds = List.of();
 
@@ -1562,7 +1658,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         boolean fullRescan,
         CaptureMode captureMode,
         ReconcileScope scope,
+        ReconcileJobKind jobKind,
+        ReconcileTableTask tableTask,
         ReconcileExecutionPolicy executionPolicy,
+        String parentJobId,
         String pinnedExecutorId,
         String laneKey,
         String dedupeKey,
@@ -1572,6 +1671,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       rec.jobId = jobId;
       rec.accountId = accountId;
       rec.connectorId = connectorId;
+      rec.jobKind = (jobKind == null ? ReconcileJobKind.EXEC_CONNECTOR : jobKind).name();
+      rec.parentJobId = parentJobId == null ? "" : parentJobId.trim();
       rec.fullRescan = fullRescan;
       rec.captureMode = (captureMode == null ? CaptureMode.METADATA_AND_STATS : captureMode).name();
       ReconcileExecutionPolicy policy =
@@ -1581,6 +1682,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       rec.executionAttributes = policy.attributes();
       rec.pinnedExecutorId = pinnedExecutorId == null ? "" : pinnedExecutorId.trim();
       rec.executorId = "";
+      ReconcileTableTask effectiveTask = tableTask == null ? ReconcileTableTask.empty() : tableTask;
+      rec.sourceNamespace = effectiveTask.sourceNamespace();
+      rec.sourceTable = effectiveTask.sourceTable();
+      rec.taskDestinationTableDisplayName = effectiveTask.destinationTableDisplayName();
       rec.destinationNamespacePaths = scope.destinationNamespacePaths();
       rec.destinationTableDisplayName = scope.destinationTableDisplayName();
       rec.destinationTableColumns = scope.destinationTableColumns();
@@ -1616,6 +1721,14 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
           destinationSnapshotIds);
     }
 
+    ReconcileJobKind jobKind() {
+      return ReconcileJobKind.fromString(jobKind);
+    }
+
+    ReconcileTableTask tableTask() {
+      return ReconcileTableTask.of(sourceNamespace, sourceTable, taskDestinationTableDisplayName);
+    }
+
     ReconcileExecutionPolicy executionPolicy() {
       return ReconcileExecutionPolicy.of(
           ReconcileExecutionClass.fromString(executionClass), executionLane, executionAttributes);
@@ -1627,6 +1740,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
 
     String executorId() {
       return executorId == null ? "" : executorId;
+    }
+
+    String parentJobId() {
+      return parentJobId == null ? "" : parentJobId;
     }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -58,6 +58,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   private static final int DEFAULT_READY_SCAN_LIMIT = 128;
   private static final int FALLBACK_SCAN_MAX_PAGES = 200;
   private static final int CAS_MAX = 16;
+  private static final String LIST_TOKEN_V1_PREFIX = "v1:";
 
   @Inject PointerStore pointerStore;
   @Inject BlobStore blobStore;
@@ -239,7 +240,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       String connectorId,
       java.util.Set<String> states) {
     int limit = Math.max(1, pageSize);
-    String token = pageToken == null ? "" : pageToken;
+    ListCursor cursor = decodeListCursor(pageToken);
+    String token = cursor.storeToken();
+    int skip = cursor.skip();
     List<ReconcileJob> out = new java.util.ArrayList<>(limit);
     String nextToken = "";
     while (out.size() < limit) {
@@ -250,7 +253,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       if (pointers.isEmpty()) {
         break;
       }
-      for (int i = 0; i < pointers.size(); i++) {
+      int startIndex = Math.min(skip, pointers.size());
+      skip = 0;
+      for (int i = startIndex; i < pointers.size(); i++) {
         Pointer ptr = pointers.get(i);
         var rec = readRecord(ptr);
         if (rec.isEmpty()) {
@@ -266,7 +271,13 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         out.add(job);
         if (out.size() >= limit) {
           boolean hasMore = i + 1 < pointers.size() || next.length() > 0;
-          nextToken = hasMore ? ptr.getKey() : "";
+          if (!hasMore) {
+            nextToken = "";
+          } else if (i + 1 < pointers.size()) {
+            nextToken = encodeListCursor(token, i + 1);
+          } else {
+            nextToken = next.toString();
+          }
           break;
         }
       }
@@ -1040,15 +1051,14 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
           continue;
         }
 
-        if (!pointerStore.compareAndDelete(candidate.getKey(), candidate.getVersion())) {
-          continue;
-        }
-
         var readyTarget = decodeReadyPointerTarget(candidate.getKey());
         if (readyTarget == null) {
           continue;
         }
         if (!matchesLeaseRequest(readyTarget.canonicalPointerKey(), request)) {
+          continue;
+        }
+        if (!pointerStore.compareAndDelete(candidate.getKey(), candidate.getVersion())) {
           continue;
         }
         var leased = leaseCanonical(readyTarget.canonicalPointerKey(), candidate.getKey(), nowMs);
@@ -1465,6 +1475,43 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   }
 
   private record ReadyPointerTarget(String canonicalPointerKey) {}
+
+  private record ListCursor(String storeToken, int skip) {}
+
+  private static ListCursor decodeListCursor(String pageToken) {
+    if (pageToken == null || pageToken.isBlank()) {
+      return new ListCursor("", 0);
+    }
+    if (!pageToken.startsWith(LIST_TOKEN_V1_PREFIX)) {
+      return new ListCursor(pageToken, 0);
+    }
+    try {
+      String decoded =
+          new String(
+              Base64.getUrlDecoder().decode(pageToken.substring(LIST_TOKEN_V1_PREFIX.length())),
+              StandardCharsets.UTF_8);
+      int separator = decoded.indexOf('\n');
+      if (separator < 0) {
+        return new ListCursor(decoded, 0);
+      }
+      String storeToken = decoded.substring(0, separator);
+      int skip = Integer.parseInt(decoded.substring(separator + 1));
+      return new ListCursor(storeToken, Math.max(0, skip));
+    } catch (RuntimeException e) {
+      return new ListCursor(pageToken, 0);
+    }
+  }
+
+  private static String encodeListCursor(String storeToken, int skip) {
+    if (skip <= 0) {
+      return storeToken == null ? "" : storeToken;
+    }
+    String payload = (storeToken == null ? "" : storeToken) + "\n" + skip;
+    return LIST_TOKEN_V1_PREFIX
+        + Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+  }
 
   static final class StoredReconcileJob {
     public String jobId;

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -18,6 +18,8 @@ package ai.floedb.floecat.service.reconciler.jobs;
 
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.service.repo.model.Keys;
@@ -126,10 +128,15 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       String connectorId,
       boolean fullRescan,
       CaptureMode captureMode,
-      ReconcileScope incomingScope) {
+      ReconcileScope incomingScope,
+      ReconcileExecutionPolicy executionPolicy,
+      String pinnedExecutorId) {
     ReconcileScope scope = incomingScope == null ? ReconcileScope.empty() : incomingScope;
+    ReconcileExecutionPolicy policy =
+        executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy;
     String laneKey = laneKey(connectorId, scope);
-    String dedupeKey = dedupeKey(accountId, connectorId, fullRescan, captureMode, scope);
+    String dedupeKey =
+        dedupeKey(accountId, connectorId, fullRescan, captureMode, scope, policy, pinnedExecutorId);
     String dedupePointerKey = Keys.reconcileDedupePointer(accountId, hashValue(dedupeKey));
 
     for (int attempt = 0; attempt < CAS_MAX; attempt++) {
@@ -160,6 +167,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
               fullRescan,
               captureMode,
               scope,
+              policy,
+              pinnedExecutorId,
               laneKey,
               dedupeKey,
               now,
@@ -317,9 +326,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   }
 
   @Override
-  public Optional<LeasedJob> leaseNext() {
+  public Optional<LeasedJob> leaseNext(LeaseRequest request) {
+    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
     long now = System.currentTimeMillis();
-    var leased = leaseReadyDue(now);
+    var leased = leaseReadyDue(now, effective);
     if (leased.isPresent()) {
       return leased;
     }
@@ -327,7 +337,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     // Reclaim is best-effort recovery work; do not block ready leasing on potentially expensive
     // scans.
     reclaimExpiredLeasesIfDue(now);
-    return leaseReadyDue(System.currentTimeMillis());
+    return leaseReadyDue(System.currentTimeMillis(), effective);
   }
 
   @Override
@@ -340,7 +350,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   }
 
   @Override
-  public void markRunning(String jobId, String leaseEpoch, long startedAtMs) {
+  public void markRunning(String jobId, String leaseEpoch, long startedAtMs, String executorId) {
     mutateByJobId(
         jobId,
         existing -> {
@@ -352,6 +362,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
           if (existing.startedAtMs <= 0L) {
             existing.startedAtMs = startedAtMs;
           }
+          existing.executorId = executorId == null ? "" : executorId;
           return existing;
         });
   }
@@ -472,6 +483,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
           long now = System.currentTimeMillis();
           existing.state = "JS_QUEUED";
           existing.message = message == null ? "Retrying" : message;
+          existing.executorId = "";
           existing.nextAttemptAtMs = now + backoffMs(existing.attempt);
           existing.finishedAtMs = 0L;
           String readyKey =
@@ -873,7 +885,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
                 current.fullRescan,
                 current.captureMode(),
                 current.toScope(),
-                current.leaseEpoch));
+                current.executionPolicy(),
+                current.leaseEpoch,
+                current.pinnedExecutorId(),
+                current.executorId()));
       }
 
       blobStore.delete(nextBlobUri);
@@ -966,6 +981,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
                 record.state = wasCancelling ? "JS_CANCELLING" : "JS_QUEUED";
                 record.message =
                     wasCancelling ? "Lease expired while cancelling" : "Lease expired; requeued";
+                if (!wasCancelling) {
+                  record.executorId = "";
+                }
                 record.leaseOwner = null;
                 record.leaseEpoch = null;
                 record.leaseExpiresAtMs = 0L;
@@ -1004,7 +1022,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     }
   }
 
-  private Optional<LeasedJob> leaseReadyDue(long nowMs) {
+  private Optional<LeasedJob> leaseReadyDue(long nowMs, LeaseRequest request) {
     String token = "";
     int pages = 0;
     while (true) {
@@ -1028,6 +1046,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
 
         var readyTarget = decodeReadyPointerTarget(candidate.getKey());
         if (readyTarget == null) {
+          continue;
+        }
+        if (!matchesLeaseRequest(readyTarget.canonicalPointerKey(), request)) {
           continue;
         }
         var leased = leaseCanonical(readyTarget.canonicalPointerKey(), candidate.getKey(), nowMs);
@@ -1064,6 +1085,17 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     return record;
   }
 
+  private boolean matchesLeaseRequest(String canonicalPointerKey, LeaseRequest request) {
+    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
+    Pointer canonicalPointer = pointerStore.get(canonicalPointerKey).orElse(null);
+    if (canonicalPointer == null) {
+      return false;
+    }
+    var record = readRecord(canonicalPointer);
+    return record.isPresent()
+        && effective.matches(record.get().executionPolicy(), record.get().pinnedExecutorId());
+  }
+
   private ReconcileJob toPublicJob(StoredReconcileJob stored) {
     return new ReconcileJob(
         stored.jobId,
@@ -1080,7 +1112,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         stored.captureMode(),
         stored.snapshotsProcessed,
         stored.statsProcessed,
-        stored.toScope());
+        stored.toScope(),
+        stored.executionPolicy(),
+        stored.executorId());
   }
 
   private boolean upsertReadyPointer(String readyPointerKey, String blobUri) {
@@ -1355,7 +1389,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       String connectorId,
       boolean fullRescan,
       CaptureMode captureMode,
-      ReconcileScope scope) {
+      ReconcileScope scope,
+      ReconcileExecutionPolicy executionPolicy,
+      String pinnedExecutorId) {
     String namespaces =
         scope.destinationNamespacePaths().stream()
             .map(path -> String.join(".", path))
@@ -1372,6 +1408,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
             .sorted()
             .reduce((a, b) -> a + "," + b)
             .orElse("");
+    ReconcileExecutionPolicy policy =
+        executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy;
     return accountId
         + "|"
         + connectorId
@@ -1386,7 +1424,15 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         + "|"
         + columns
         + "|"
-        + snapshots;
+        + snapshots
+        + "|"
+        + policy.executionClass().name()
+        + "|"
+        + policy.lane()
+        + "|"
+        + policy.attributes()
+        + "|"
+        + (pinnedExecutorId == null ? "" : pinnedExecutorId.trim());
   }
 
   private static String hashValue(String value) {
@@ -1426,7 +1472,11 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     public String connectorId;
     public boolean fullRescan;
     public String captureMode;
-
+    public String executionClass;
+    public String executionLane;
+    public java.util.Map<String, String> executionAttributes = java.util.Map.of();
+    public String pinnedExecutorId;
+    public String executorId;
     public List<List<String>> destinationNamespacePaths = List.of();
     public String destinationTableDisplayName;
     public List<String> destinationTableColumns = List.of();
@@ -1465,6 +1515,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         boolean fullRescan,
         CaptureMode captureMode,
         ReconcileScope scope,
+        ReconcileExecutionPolicy executionPolicy,
+        String pinnedExecutorId,
         String laneKey,
         String dedupeKey,
         long now,
@@ -1475,6 +1527,13 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       rec.connectorId = connectorId;
       rec.fullRescan = fullRescan;
       rec.captureMode = (captureMode == null ? CaptureMode.METADATA_AND_STATS : captureMode).name();
+      ReconcileExecutionPolicy policy =
+          executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy;
+      rec.executionClass = policy.executionClass().name();
+      rec.executionLane = policy.lane();
+      rec.executionAttributes = policy.attributes();
+      rec.pinnedExecutorId = pinnedExecutorId == null ? "" : pinnedExecutorId.trim();
+      rec.executorId = "";
       rec.destinationNamespacePaths = scope.destinationNamespacePaths();
       rec.destinationTableDisplayName = scope.destinationTableDisplayName();
       rec.destinationTableColumns = scope.destinationTableColumns();
@@ -1508,6 +1567,19 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
           destinationTableDisplayName,
           destinationTableColumns,
           destinationSnapshotIds);
+    }
+
+    ReconcileExecutionPolicy executionPolicy() {
+      return ReconcileExecutionPolicy.of(
+          ReconcileExecutionClass.fromString(executionClass), executionLane, executionAttributes);
+    }
+
+    String pinnedExecutorId() {
+      return pinnedExecutorId == null ? "" : pinnedExecutorId;
+    }
+
+    String executorId() {
+      return executorId == null ? "" : executorId;
     }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -1502,41 +1502,6 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     return new String(canonicalizer.bytes(), StandardCharsets.UTF_8);
   }
 
-  private static ListCursor decodeListCursor(String pageToken) {
-    if (pageToken == null || pageToken.isBlank()) {
-      return new ListCursor("", 0);
-    }
-    if (!pageToken.startsWith(LIST_TOKEN_V1_PREFIX)) {
-      return new ListCursor(pageToken, 0);
-    }
-    try {
-      String decoded =
-          new String(
-              Base64.getUrlDecoder().decode(pageToken.substring(LIST_TOKEN_V1_PREFIX.length())),
-              StandardCharsets.UTF_8);
-      int separator = decoded.indexOf('\n');
-      if (separator < 0) {
-        return new ListCursor(decoded, 0);
-      }
-      String storeToken = decoded.substring(0, separator);
-      int skip = Integer.parseInt(decoded.substring(separator + 1));
-      return new ListCursor(storeToken, Math.max(0, skip));
-    } catch (RuntimeException e) {
-      return new ListCursor(pageToken, 0);
-    }
-  }
-
-  private static String encodeListCursor(String storeToken, int skip) {
-    if (skip <= 0) {
-      return storeToken == null ? "" : storeToken;
-    }
-    String payload = (storeToken == null ? "" : storeToken) + "\n" + skip;
-    return LIST_TOKEN_V1_PREFIX
-        + Base64.getUrlEncoder()
-            .withoutPadding()
-            .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
-  }
-
   private static String hashValue(String value) {
     try {
       MessageDigest digest = MessageDigest.getInstance("SHA-256");
@@ -1604,6 +1569,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
             .withoutPadding()
             .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
   }
+
   static final class StoredReconcileJob {
     public String jobId;
     public String accountId;

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
@@ -21,6 +21,8 @@ import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.ReconcileMode;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.service.gc.ReconcileJobGcScheduler;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
@@ -193,6 +195,16 @@ public class ReconcilePlannerScheduler {
     return plannerCursor;
   }
 
+  ReconcileExecutionPolicy autoExecutionPolicy() {
+    var cfg = ConfigProvider.getConfig();
+    return ReconcileExecutionPolicy.of(
+        ReconcileExecutionClass.fromString(
+            cfg.getOptionalValue("floecat.reconciler.auto.execution-class", String.class)
+                .orElse("DEFAULT")),
+        cfg.getOptionalValue("floecat.reconciler.auto.execution-lane", String.class).orElse(""),
+        java.util.Map.of());
+  }
+
   long nowMs() {
     return System.currentTimeMillis();
   }
@@ -235,12 +247,14 @@ public class ReconcilePlannerScheduler {
     }
 
     try {
-      jobs.enqueue(
+      jobs.enqueuePlan(
           connector.getResourceId().getAccountId(),
           connector.getResourceId().getId(),
           fullRescan,
           CaptureMode.METADATA_AND_STATS,
-          ai.floedb.floecat.reconciler.jobs.ReconcileScope.empty());
+          ai.floedb.floecat.reconciler.jobs.ReconcileScope.empty(),
+          autoExecutionPolicy(),
+          "");
       lastEnqueueMs.put(key, now);
       observePlannerEnqueue("enqueued", mode, null);
     } catch (RuntimeException e) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -165,6 +165,15 @@ public final class Keys {
     return String.format("/accounts/%s/transactions/%s/transaction/", encode(tid), encode(tx));
   }
 
+  public static String transactionDeleteSentinelUri(
+      String accountId, String txId, String targetPointerKey) {
+    String tid = req("account_id", accountId);
+    String tx = req("tx_id", txId);
+    String key = req("target_pointer_key", targetPointerKey);
+    return String.format(
+        "/accounts/%s/transactions/%s/delete/%s", encode(tid), encode(tx), encode(key));
+  }
+
   public static String transactionIntentPointerByTarget(String accountId, String targetPointerKey) {
     String tid = req("account_id", accountId);
     String key = req("target_pointer_key", targetPointerKey);

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
@@ -276,6 +276,14 @@ public class TransactionIntentApplierSupport {
           null);
     }
 
+    if (isDeleteSentinel(intent)) {
+      if (current == null) {
+        return ApplyOutcome.applied();
+      }
+      long expected = intent.hasExpectedVersion() ? intent.getExpectedVersion() : actualVersion;
+      return addOp(new PointerStore.CasDelete(pointerKey, expected), pointerKey, touchedKeys, ops);
+    }
+
     if (current != null && intent.getBlobUri().equals(current.getBlobUri())) {
       return ApplyOutcome.applied();
     }
@@ -291,6 +299,23 @@ public class TransactionIntentApplierSupport {
         new PointerStore.CasUpsert(pointerKey, expected, next), pointerKey, touchedKeys, ops);
   }
 
+  private boolean isDeleteSentinel(TransactionIntent intent) {
+    if (intent == null
+        || intent.getBlobUri().isBlank()
+        || intent.getAccountId().isBlank()
+        || intent.getTxId().isBlank()
+        || intent.getTargetPointerKey().isBlank()) {
+      return false;
+    }
+    try {
+      return Keys.transactionDeleteSentinelUri(
+              intent.getAccountId(), intent.getTxId(), intent.getTargetPointerKey())
+          .equals(intent.getBlobUri());
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
   private ApplyOutcome planTableIntentOps(
       TransactionIntent intent, List<PointerStore.CasOp> ops, Set<String> touchedKeys) {
     String pointerKey = intent.getTargetPointerKey();
@@ -303,6 +328,10 @@ public class TransactionIntentApplierSupport {
           intent.getExpectedVersion(),
           actualVersion,
           null);
+    }
+
+    if (isDeleteSentinel(intent)) {
+      return planTableDeleteIntentOps(intent, current, actualVersion, ops, touchedKeys);
     }
 
     Table nextTable = readTable(intent.getBlobUri());
@@ -365,6 +394,46 @@ public class TransactionIntentApplierSupport {
       }
     }
     return ApplyOutcome.applied();
+  }
+
+  private ApplyOutcome planTableDeleteIntentOps(
+      TransactionIntent intent,
+      Pointer current,
+      long actualVersion,
+      List<PointerStore.CasOp> ops,
+      Set<String> touchedKeys) {
+    if (current == null) {
+      return ApplyOutcome.applied();
+    }
+
+    Table currentTable = readTable(current.getBlobUri());
+    if (currentTable == null || !currentTable.hasResourceId()) {
+      return ApplyOutcome.retryable("NAME_POINTER_READ_FAILED", "current table pointer missing");
+    }
+    ApplyOutcome targetValidation =
+        validateTableIntentTarget(intent.getTargetPointerKey(), currentTable);
+    if (targetValidation.status != ApplyStatus.APPLIED) {
+      return targetValidation;
+    }
+
+    long expected = intent.hasExpectedVersion() ? intent.getExpectedVersion() : actualVersion;
+    ApplyOutcome deletePrimary =
+        addOp(
+            new PointerStore.CasDelete(intent.getTargetPointerKey(), expected),
+            intent.getTargetPointerKey(),
+            touchedKeys,
+            ops);
+    if (deletePrimary.status != ApplyStatus.APPLIED) {
+      return deletePrimary;
+    }
+
+    String nameKey =
+        Keys.tablePointerByName(
+            currentTable.getResourceId().getAccountId(),
+            currentTable.getCatalogId().getId(),
+            currentTable.getNamespaceId().getId(),
+            currentTable.getDisplayName());
+    return buildOwnedNameDeleteOp(nameKey, currentTable.getResourceId().getId(), touchedKeys, ops);
   }
 
   private ApplyOutcome validateTableIntentTarget(String pointerKey, Table nextTable) {

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.transaction.impl;
 
+import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.Precondition;
@@ -55,9 +56,12 @@ import com.google.protobuf.util.Timestamps;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.jboss.logging.Logger;
 
@@ -66,6 +70,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
 
   private static final Logger LOG = Logger.getLogger(TransactionsServiceImpl.class);
   private static final int MAX_POINTER_TXN_OPS = 100;
+  private static final int TABLE_NAME_REPLAY_SCAN_PAGE_SIZE = 200;
 
   @Inject TransactionRepository txRepo;
   @Inject TransactionIntentRepository intentRepo;
@@ -422,6 +427,10 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
               .setBlobUri(planned.blobUri())
               .setCreatedAt(now)
               .setExpectedVersion(planned.expectedVersion());
+      if (planned.expectedOwnedNamePointerKey() != null
+          && !planned.expectedOwnedNamePointerKey().isBlank()) {
+        intentBuilder.setExpectedOwnedNamePointerKey(planned.expectedOwnedNamePointerKey());
+      }
       TransactionIntent intent = intentBuilder.build();
       intents.add(intent);
     }
@@ -578,7 +587,21 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         return false;
       }
       var ptr = pointerStore.get(intent.getTargetPointerKey()).orElse(null);
-      if (ptr == null || !intent.getBlobUri().equals(ptr.getBlobUri())) {
+      if (isDeleteSentinelBlobUri(
+          intent.getAccountId(),
+          intent.getTxId(),
+          intent.getTargetPointerKey(),
+          intent.getBlobUri())) {
+        if (isTableByIdPointer(intent.getTargetPointerKey())) {
+          if (!tableDeleteAlreadyApplied(intent)) {
+            return false;
+          }
+          continue;
+        }
+        if (ptr != null) {
+          return false;
+        }
+      } else if (ptr == null || !intent.getBlobUri().equals(ptr.getBlobUri())) {
         return false;
       }
     }
@@ -600,7 +623,10 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
               : null;
       expected.add(
           new IntentFingerprint(
-              planned.targetPointerKey(), planned.blobUri(), explicitExpectedVersion));
+              planned.targetPointerKey(),
+              planned.blobUri(),
+              explicitExpectedVersion,
+              planned.expectedOwnedNamePointerKey()));
     }
     expected.sort(Comparator.comparing(IntentFingerprint::targetPointerKey));
 
@@ -614,7 +640,12 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
       IntentFingerprint exp = expected.get(i);
       TransactionIntent actual = existing.get(i);
       if (!exp.targetPointerKey().equals(actual.getTargetPointerKey())
-          || !exp.blobUri().equals(actual.getBlobUri())) {
+          || !exp.blobUri().equals(actual.getBlobUri())
+          || !Objects.equals(
+              exp.expectedOwnedNamePointerKey(),
+              actual.hasExpectedOwnedNamePointerKey()
+                  ? actual.getExpectedOwnedNamePointerKey()
+                  : null)) {
         throw new IllegalArgumentException(
             "prepare request does not match already-prepared transaction intents");
       }
@@ -644,6 +675,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     }
 
     String blobUri;
+    String expectedOwnedNamePointerKey = null;
     byte[] inlineBytes = null;
     String inlineContentType = null;
     switch (change.getChangePayloadCase()) {
@@ -655,6 +687,15 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         if (!blobUri.startsWith(Keys.accountRootPrefix(accountId))) {
           throw new IllegalArgumentException(
               "intended_blob_uri outside account scope for " + pointerKey);
+        }
+        if (looksLikeDeleteSentinelBlobUri(accountId, blobUri)
+            && !isDeleteSentinelBlobUri(accountId, txId, pointerKey, blobUri)) {
+          throw new IllegalArgumentException(
+              "intended_blob_uri delete sentinel does not match target for " + pointerKey);
+        }
+        if (isDeleteSentinelBlobUri(accountId, txId, pointerKey, blobUri)
+            && isTableByIdPointer(pointerKey)) {
+          expectedOwnedNamePointerKey = expectedOwnedTableNamePointerKey(pointerKey, true);
         }
       }
       case TABLE -> {
@@ -692,7 +733,13 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
           throw new IllegalArgumentException(
               "unknown payload type for " + pointerKey + ": " + change.getChangePayloadCase());
     }
-    return new PlannedIntent(pointerKey, blobUri, expectedVersion, inlineBytes, inlineContentType);
+    return new PlannedIntent(
+        pointerKey,
+        blobUri,
+        expectedVersion,
+        inlineBytes,
+        inlineContentType,
+        expectedOwnedNamePointerKey);
   }
 
   private PlannedIntent planIntentForReplayMatch(String accountId, String txId, TxChange change) {
@@ -701,6 +748,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     String pointerKey = target.pointerKey();
 
     String blobUri;
+    String expectedOwnedNamePointerKey = null;
     switch (change.getChangePayloadCase()) {
       case INTENDED_BLOB_URI -> {
         blobUri = change.getIntendedBlobUri().trim();
@@ -710,6 +758,15 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         if (!blobUri.startsWith(Keys.accountRootPrefix(accountId))) {
           throw new IllegalArgumentException(
               "intended_blob_uri outside account scope for " + pointerKey);
+        }
+        if (looksLikeDeleteSentinelBlobUri(accountId, blobUri)
+            && !isDeleteSentinelBlobUri(accountId, txId, pointerKey, blobUri)) {
+          throw new IllegalArgumentException(
+              "intended_blob_uri delete sentinel does not match target for " + pointerKey);
+        }
+        if (isDeleteSentinelBlobUri(accountId, txId, pointerKey, blobUri)
+            && isTableByIdPointer(pointerKey)) {
+          expectedOwnedNamePointerKey = expectedOwnedTableNamePointerKey(pointerKey, true);
         }
       }
       case TABLE -> {
@@ -743,7 +800,159 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
           throw new IllegalArgumentException(
               "unknown payload type for " + pointerKey + ": " + change.getChangePayloadCase());
     }
-    return new PlannedIntent(pointerKey, blobUri, 0L, null, null);
+    return new PlannedIntent(pointerKey, blobUri, 0L, null, null, expectedOwnedNamePointerKey);
+  }
+
+  private boolean looksLikeDeleteSentinelBlobUri(String accountId, String blobUri) {
+    if (accountId == null || accountId.isBlank() || blobUri == null || blobUri.isBlank()) {
+      return false;
+    }
+    return blobUri.startsWith(Keys.accountRootPrefix(accountId) + "transactions/")
+        && blobUri.contains("/delete/");
+  }
+
+  private boolean isDeleteSentinelBlobUri(
+      String accountId, String txId, String targetPointerKey, String blobUri) {
+    if (!looksLikeDeleteSentinelBlobUri(accountId, blobUri)
+        || txId == null
+        || txId.isBlank()
+        || targetPointerKey == null
+        || targetPointerKey.isBlank()) {
+      return false;
+    }
+    try {
+      return Keys.transactionDeleteSentinelUri(accountId, txId, targetPointerKey).equals(blobUri);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  private boolean isTableByIdPointer(String pointerKey) {
+    return pointerKey != null && pointerKey.contains("/tables/by-id/");
+  }
+
+  private boolean tableDeleteAlreadyApplied(TransactionIntent intent) {
+    if (intent == null || !isTableByIdPointer(intent.getTargetPointerKey())) {
+      return false;
+    }
+    if (pointerStore.get(intent.getTargetPointerKey()).isPresent()) {
+      return false;
+    }
+    String tableId = tableIdFromByIdPointer(intent.getTargetPointerKey());
+    if (tableId == null || tableId.isBlank()) {
+      return false;
+    }
+    if (!intent.hasExpectedOwnedNamePointerKey()
+        || intent.getExpectedOwnedNamePointerKey().isBlank()) {
+      return noOwnedNamePointerReferencesTable(intent.getAccountId(), tableId);
+    }
+    return ownedNamePointerCleared(intent.getExpectedOwnedNamePointerKey(), tableId);
+  }
+
+  private boolean ownedNamePointerCleared(String pointerKey, String expectedTableId) {
+    var pointer = pointerStore.get(pointerKey).orElse(null);
+    if (pointer == null || pointer.getBlobUri().isBlank()) {
+      return true;
+    }
+    Table table = readTable(pointer.getBlobUri());
+    if (table == null || !table.hasResourceId()) {
+      return false;
+    }
+    return !expectedTableId.equals(table.getResourceId().getId());
+  }
+
+  private boolean noOwnedNamePointerReferencesTable(String accountId, String expectedTableId) {
+    if (accountId == null
+        || accountId.isBlank()
+        || expectedTableId == null
+        || expectedTableId.isBlank()) {
+      return false;
+    }
+    String prefix = Keys.catalogRootPrefix(accountId);
+    String token = "";
+    while (true) {
+      StringBuilder next = new StringBuilder();
+      List<Pointer> pointers =
+          pointerStore.listPointersByPrefix(prefix, TABLE_NAME_REPLAY_SCAN_PAGE_SIZE, token, next);
+      for (Pointer pointer : pointers) {
+        String key = pointer.getKey();
+        if (key == null || !key.contains(Keys.SEG_TABLES_BY_NAME)) {
+          continue;
+        }
+        if (pointer.getBlobUri().isBlank()) {
+          continue;
+        }
+        Table table = readTable(pointer.getBlobUri());
+        if (table == null || !table.hasResourceId()) {
+          return false;
+        }
+        if (expectedTableId.equals(table.getResourceId().getId())) {
+          return false;
+        }
+      }
+      token = next.toString();
+      if (token.isEmpty()) {
+        return true;
+      }
+    }
+  }
+
+  private String tableIdFromByIdPointer(String pointerKey) {
+    if (!isTableByIdPointer(pointerKey)) {
+      return null;
+    }
+    int idx = pointerKey.lastIndexOf("/tables/by-id/");
+    if (idx < 0) {
+      return null;
+    }
+    String encoded = pointerKey.substring(idx + "/tables/by-id/".length());
+    return encoded.isBlank() ? null : URLDecoder.decode(encoded, StandardCharsets.UTF_8);
+  }
+
+  private String expectedOwnedTableNamePointerKey(
+      String tableByIdPointerKey, boolean requireReadable) {
+    var pointer = pointerStore.get(tableByIdPointerKey).orElse(null);
+    if (pointer == null || pointer.getBlobUri().isBlank()) {
+      return null;
+    }
+    Table table = readTable(pointer.getBlobUri());
+    if (table == null || !table.hasResourceId()) {
+      if (requireReadable) {
+        throw new IllegalArgumentException(
+            "current table pointer is unreadable for delete " + tableByIdPointerKey);
+      }
+      return null;
+    }
+    validateCurrentTablePointerTarget(tableByIdPointerKey, table);
+    return Keys.tablePointerByName(
+        table.getResourceId().getAccountId(),
+        table.getCatalogId().getId(),
+        table.getNamespaceId().getId(),
+        table.getDisplayName());
+  }
+
+  private void validateCurrentTablePointerTarget(String pointerKey, Table table) {
+    if (table == null || !table.hasResourceId()) {
+      throw new IllegalArgumentException("current table pointer is unreadable for " + pointerKey);
+    }
+    String expectedPointerKey =
+        Keys.tablePointerById(table.getResourceId().getAccountId(), table.getResourceId().getId());
+    if (!expectedPointerKey.equals(pointerKey)) {
+      throw new IllegalArgumentException(
+          "current table pointer target does not match payload for " + pointerKey);
+    }
+  }
+
+  private Table readTable(String blobUri) {
+    if (blobUri == null || blobUri.isBlank()) {
+      return null;
+    }
+    try {
+      byte[] bytes = blobStore.get(blobUri);
+      return bytes == null ? null : Table.parseFrom(bytes);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   private void annotateIntentApplyFailure(
@@ -966,21 +1175,21 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     return isExpired(owner, now);
   }
 
-  private boolean isTableByIdPointer(String pointerKey) {
-    return pointerKey != null && pointerKey.contains("/tables/by-id/");
-  }
-
   private record ResolvedTxTarget(String pointerKey, ResourceId tableId) {}
 
   private record IntentFingerprint(
-      String targetPointerKey, String blobUri, Long explicitExpectedVersion) {}
+      String targetPointerKey,
+      String blobUri,
+      Long explicitExpectedVersion,
+      String expectedOwnedNamePointerKey) {}
 
   private record PlannedIntent(
       String targetPointerKey,
       String blobUri,
       long expectedVersion,
       byte[] inlineBytes,
-      String inlineContentType) {}
+      String inlineContentType,
+      String expectedOwnedNamePointerKey) {}
 
   private record PendingBlob(String uri, byte[] bytes, String contentType) {}
 }

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -108,8 +108,13 @@ floecat.reconciler.job-store.ready-scan-limit=${FLOECAT_RECONCILER_JOB_STORE_REA
 floecat.reconciler.authorization.header=${FLOECAT_RECONCILER_AUTHORIZATION_HEADER:authorization}
 floecat.reconciler.authorization.token=${FLOECAT_RECONCILER_AUTHORIZATION_TOKEN:}
 # Reconciler deployment mode toggles.
+# Control-plane-only nodes can disable the polling scheduler.
 floecat.reconciler.scheduler.enabled=${FLOECAT_RECONCILER_SCHEDULER_ENABLED:true}
+# Executor-plane nodes can replace the built-in executor with a custom implementation.
 floecat.reconciler.executor.default.enabled=${FLOECAT_RECONCILER_DEFAULT_EXECUTOR_ENABLED:true}
+floecat.reconciler.executor.planner.enabled=${FLOECAT_RECONCILER_PLANNER_EXECUTOR_ENABLED:true}
+# Remote executor-plane nodes poll the control plane over gRPC instead of leasing from the local store.
+# Typical remote executor profile: scheduler.enabled=false, remote-executor.enabled=true.
 floecat.reconciler.remote-executor.enabled=${FLOECAT_RECONCILER_REMOTE_EXECUTOR_ENABLED:false}
 reconciler.max-parallelism=${FLOECAT_RECONCILER_MAX_PARALLELISM:1}
 floecat.reconciler.auto.enabled=${FLOECAT_RECONCILER_AUTO_ENABLED:true}
@@ -117,6 +122,9 @@ floecat.reconciler.auto.tick-every=${FLOECAT_RECONCILER_AUTO_TICK_EVERY:30s}
 floecat.reconciler.auto.max-tick-millis=${FLOECAT_RECONCILER_AUTO_MAX_TICK_MILLIS:4000}
 floecat.reconciler.auto.accounts-page-size=${FLOECAT_RECONCILER_AUTO_ACCOUNTS_PAGE_SIZE:50}
 floecat.reconciler.auto.connectors-page-size=${FLOECAT_RECONCILER_AUTO_CONNECTORS_PAGE_SIZE:200}
+# Routing policy for planner-enqueued jobs.
+floecat.reconciler.auto.execution-class=${FLOECAT_RECONCILER_AUTO_EXECUTION_CLASS:DEFAULT}
+floecat.reconciler.auto.execution-lane=${FLOECAT_RECONCILER_AUTO_EXECUTION_LANE:}
 floecat.reconciler.default-interval=${FLOECAT_RECONCILER_DEFAULT_INTERVAL:10m}
 floecat.reconciler.default-mode=${FLOECAT_RECONCILER_DEFAULT_MODE:RM_INCREMENTAL}
 
@@ -124,12 +132,14 @@ floecat.reconciler.default-mode=${FLOECAT_RECONCILER_DEFAULT_MODE:RM_INCREMENTAL
 %reconciler-control.floecat.reconciler.scheduler.enabled=true
 %reconciler-control.floecat.reconciler.remote-executor.enabled=false
 %reconciler-control.floecat.reconciler.executor.default.enabled=false
+%reconciler-control.floecat.reconciler.executor.planner.enabled=true
 %reconciler-control.floecat.reconciler.backend=local
 %reconciler-control.floecat.reconciler.auto.enabled=true
 
 %reconciler-executor.floecat.reconciler.scheduler.enabled=false
 %reconciler-executor.floecat.reconciler.remote-executor.enabled=true
 %reconciler-executor.floecat.reconciler.executor.default.enabled=true
+%reconciler-executor.floecat.reconciler.executor.planner.enabled=false
 %reconciler-executor.floecat.reconciler.backend=remote
 %reconciler-executor.floecat.reconciler.auto.enabled=false
 ## logging

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -104,6 +104,13 @@ floecat.reconciler.job-store.max-backoff-ms=${FLOECAT_RECONCILER_JOB_STORE_MAX_B
 floecat.reconciler.job-store.lease-ms=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MS:30000}
 floecat.reconciler.job-store.reclaim-interval-ms=${FLOECAT_RECONCILER_JOB_STORE_RECLAIM_INTERVAL_MS:5000}
 floecat.reconciler.job-store.ready-scan-limit=${FLOECAT_RECONCILER_JOB_STORE_READY_SCAN_LIMIT:128}
+# Reconciler remote-executor and remote-backend auth.
+floecat.reconciler.authorization.header=${FLOECAT_RECONCILER_AUTHORIZATION_HEADER:authorization}
+floecat.reconciler.authorization.token=${FLOECAT_RECONCILER_AUTHORIZATION_TOKEN:}
+# Reconciler deployment mode toggles.
+floecat.reconciler.scheduler.enabled=${FLOECAT_RECONCILER_SCHEDULER_ENABLED:true}
+floecat.reconciler.executor.default.enabled=${FLOECAT_RECONCILER_DEFAULT_EXECUTOR_ENABLED:true}
+floecat.reconciler.remote-executor.enabled=${FLOECAT_RECONCILER_REMOTE_EXECUTOR_ENABLED:false}
 reconciler.max-parallelism=${FLOECAT_RECONCILER_MAX_PARALLELISM:1}
 floecat.reconciler.auto.enabled=${FLOECAT_RECONCILER_AUTO_ENABLED:true}
 floecat.reconciler.auto.tick-every=${FLOECAT_RECONCILER_AUTO_TICK_EVERY:30s}
@@ -112,6 +119,19 @@ floecat.reconciler.auto.accounts-page-size=${FLOECAT_RECONCILER_AUTO_ACCOUNTS_PA
 floecat.reconciler.auto.connectors-page-size=${FLOECAT_RECONCILER_AUTO_CONNECTORS_PAGE_SIZE:200}
 floecat.reconciler.default-interval=${FLOECAT_RECONCILER_DEFAULT_INTERVAL:10m}
 floecat.reconciler.default-mode=${FLOECAT_RECONCILER_DEFAULT_MODE:RM_INCREMENTAL}
+
+# Reconciler deployment profiles.
+%reconciler-control.floecat.reconciler.scheduler.enabled=true
+%reconciler-control.floecat.reconciler.remote-executor.enabled=false
+%reconciler-control.floecat.reconciler.executor.default.enabled=false
+%reconciler-control.floecat.reconciler.backend=local
+%reconciler-control.floecat.reconciler.auto.enabled=true
+
+%reconciler-executor.floecat.reconciler.scheduler.enabled=false
+%reconciler-executor.floecat.reconciler.remote-executor.enabled=true
+%reconciler-executor.floecat.reconciler.executor.default.enabled=true
+%reconciler-executor.floecat.reconciler.backend=remote
+%reconciler-executor.floecat.reconciler.auto.enabled=false
 ## logging
 quarkus.log.console.json.enabled=true
 quarkus.log.console.json.log-format=default

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -271,6 +271,10 @@ floecat.stats.batch.max-scan-pages=${FLOECAT_STATS_BATCH_MAX_SCAN_PAGES:5}
 # Audience validation (aud claim)
 # quarkus.oidc.token.audience=floecat-service
 #
+# Dev-mode account override header. Used only when floecat.auth.mode=dev.
+# The CLI sends this automatically from the selected in-shell account.
+# floecat.interceptor.dev-account.header=x-floe-account
+#
 
 quarkus.oidc.tenant-enabled=false
 floecat.auth.mode=dev

--- a/service/src/test/java/ai/floedb/floecat/connector/dummy/DummyConnector.java
+++ b/service/src/test/java/ai/floedb/floecat/connector/dummy/DummyConnector.java
@@ -93,6 +93,46 @@ public final class DummyConnector implements FloecatConnector {
   }
 
   @Override
+  public List<PlannedTableTask> planTableTasks(TablePlanningRequest request) {
+    if (request == null
+        || request.sourceNamespaceFq() == null
+        || request.sourceNamespaceFq().isBlank()) {
+      throw new IllegalArgumentException("source namespace is required");
+    }
+    if (!matchesNamespaceFilter(
+        request.destinationNamespaceFq(), request.destinationNamespacePaths())) {
+      throw new IllegalArgumentException("requested scope does not match destination namespace");
+    }
+
+    List<String> sourceTables =
+        request.sourceTable() != null && !request.sourceTable().isBlank()
+            ? List.of(request.sourceTable())
+            : listTables(request.sourceNamespaceFq());
+    String destinationTableHint =
+        request.destinationTableDisplayHint() != null
+                && !request.destinationTableDisplayHint().isBlank()
+            ? request.destinationTableDisplayHint()
+            : null;
+    String destinationTableFilter =
+        request.destinationTableDisplayName() != null
+                && !request.destinationTableDisplayName().isBlank()
+            ? request.destinationTableDisplayName()
+            : null;
+
+    List<PlannedTableTask> planned = new ArrayList<>();
+    for (String sourceTable : sourceTables) {
+      String destinationTableName =
+          destinationTableHint != null ? destinationTableHint : sourceTable;
+      if (destinationTableFilter != null && !destinationTableFilter.equals(destinationTableName)) {
+        continue;
+      }
+      planned.add(
+          new PlannedTableTask(request.sourceNamespaceFq(), sourceTable, destinationTableName));
+    }
+    return List.copyOf(planned);
+  }
+
+  @Override
   public TableDescriptor describe(String namespaceFq, String tableName) {
     String schemaJson =
         """
@@ -271,4 +311,20 @@ public final class DummyConnector implements FloecatConnector {
 
   @Override
   public void close() {}
+
+  private static boolean matchesNamespaceFilter(
+      String namespaceFq, List<List<String>> destinationNamespacePaths) {
+    if (destinationNamespacePaths == null || destinationNamespacePaths.isEmpty()) {
+      return true;
+    }
+    if (namespaceFq == null || namespaceFq.isBlank()) {
+      return false;
+    }
+    for (List<String> path : destinationNamespacePaths) {
+      if (String.join(".", path).equals(namespaceFq)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
@@ -39,6 +39,7 @@ import ai.floedb.floecat.connector.spi.ConnectorFactory;
 import ai.floedb.floecat.gateway.iceberg.rest.common.TestDeltaFixtures;
 import ai.floedb.floecat.gateway.iceberg.rest.common.TestS3Fixtures;
 import ai.floedb.floecat.reconciler.impl.ReconcilerScheduler;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.rpc.CaptureMode;
 import ai.floedb.floecat.reconciler.rpc.CaptureScope;
@@ -62,6 +63,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -912,7 +914,7 @@ public class ConnectorIT {
     ReconcileJobStore.ReconcileJob job;
     for (; ; ) {
       job = jobs.get(jobId).orElse(null);
-      if (job != null && ("JS_SUCCEEDED".equals(job.state) || "JS_FAILED".equals(job.state))) {
+      if (job != null && isTerminal(job.state)) {
         break;
       }
       if (System.nanoTime() > deadline) {
@@ -921,7 +923,102 @@ public class ConnectorIT {
       Thread.sleep(250);
     }
 
-    return job;
+    if (job == null || job.jobKind != ReconcileJobKind.PLAN_CONNECTOR) {
+      return job;
+    }
+
+    return awaitAggregatePlanJob(job, deadline);
+  }
+
+  private ReconcileJobStore.ReconcileJob awaitAggregatePlanJob(
+      ReconcileJobStore.ReconcileJob planJob, long deadlineNanos) throws Exception {
+    List<ReconcileJobStore.ReconcileJob> childJobs = List.of();
+    for (; ; ) {
+      childJobs = childJobsFor(planJob);
+      if (!childJobs.isEmpty() && childJobs.stream().allMatch(job -> isTerminal(job.state))) {
+        break;
+      }
+      if ("JS_FAILED".equals(planJob.state) || "JS_CANCELLED".equals(planJob.state)) {
+        return planJob;
+      }
+      if (System.nanoTime() > deadlineNanos) {
+        break;
+      }
+      Thread.sleep(250);
+    }
+
+    if (childJobs.isEmpty()) {
+      return planJob;
+    }
+
+    boolean failed = childJobs.stream().anyMatch(job -> "JS_FAILED".equals(job.state));
+    boolean cancelled = childJobs.stream().anyMatch(job -> "JS_CANCELLED".equals(job.state));
+    String state = failed ? "JS_FAILED" : (cancelled ? "JS_CANCELLED" : "JS_SUCCEEDED");
+    String message =
+        childJobs.stream()
+            .filter(job -> job.message != null && !job.message.isBlank())
+            .filter(job -> !"JS_SUCCEEDED".equals(job.state))
+            .map(job -> job.jobId + ": " + job.message)
+            .findFirst()
+            .orElse(planJob.message);
+
+    long startedAtMs =
+        childJobs.stream()
+            .mapToLong(job -> job.startedAtMs)
+            .filter(v -> v > 0L)
+            .min()
+            .orElse(planJob.startedAtMs);
+    long finishedAtMs =
+        childJobs.stream().mapToLong(job -> job.finishedAtMs).max().orElse(planJob.finishedAtMs);
+    long tablesScanned = childJobs.stream().mapToLong(job -> job.tablesScanned).sum();
+    long tablesChanged = childJobs.stream().mapToLong(job -> job.tablesChanged).sum();
+    long errors = childJobs.stream().mapToLong(job -> job.errors).sum();
+    long snapshotsProcessed = childJobs.stream().mapToLong(job -> job.snapshotsProcessed).sum();
+    long statsProcessed = childJobs.stream().mapToLong(job -> job.statsProcessed).sum();
+
+    return new ReconcileJobStore.ReconcileJob(
+        planJob.jobId,
+        planJob.accountId,
+        planJob.connectorId,
+        state,
+        message,
+        startedAtMs,
+        finishedAtMs,
+        tablesScanned,
+        tablesChanged,
+        errors,
+        planJob.fullRescan,
+        planJob.captureMode,
+        snapshotsProcessed,
+        statsProcessed,
+        planJob.scope,
+        planJob.executionPolicy,
+        planJob.executorId,
+        planJob.jobKind,
+        planJob.tableTask,
+        planJob.parentJobId);
+  }
+
+  private List<ReconcileJobStore.ReconcileJob> childJobsFor(
+      ReconcileJobStore.ReconcileJob planJob) {
+    List<ReconcileJobStore.ReconcileJob> out = new ArrayList<>();
+    String nextToken = "";
+    do {
+      var page = jobs.list(planJob.accountId, 200, nextToken, planJob.connectorId, Set.of());
+      for (var candidate : page.jobs) {
+        if (planJob.jobId.equals(candidate.parentJobId)) {
+          out.add(candidate);
+        }
+      }
+      nextToken = page.nextPageToken;
+    } while (nextToken != null && !nextToken.isBlank());
+    return out;
+  }
+
+  private static boolean isTerminal(String state) {
+    return "JS_SUCCEEDED".equals(state)
+        || "JS_FAILED".equals(state)
+        || "JS_CANCELLED".equals(state);
   }
 
   private static final class UcStubServer implements AutoCloseable {

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
@@ -49,6 +49,7 @@ import ai.floedb.floecat.reconciler.rpc.StartCaptureRequest;
 import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
 import ai.floedb.floecat.service.repo.impl.*;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
+import ai.floedb.floecat.service.repo.impl.StatsRepository;
 import ai.floedb.floecat.service.util.TestDataResetter;
 import ai.floedb.floecat.service.util.TestSupport;
 import com.google.protobuf.FieldMask;
@@ -96,6 +97,7 @@ public class ConnectorIT {
   @Inject NamespaceRepository namespaces;
   @Inject TableRepository tables;
   @Inject SnapshotRepository snaps;
+  @Inject StatsRepository statsRepository;
   @Inject TestDataResetter resetter;
   @Inject SeedRunner seeder;
 
@@ -419,6 +421,109 @@ public class ConnectorIT {
     assertEquals(0L, incrementalJob.snapshotsProcessed, "incremental should find no new snapshots");
     assertEquals(0L, incrementalJob.statsProcessed, "incremental should process no new stats");
     assertEquals(snapshotCountAfterFull, snaps.count(table.getResourceId()));
+  }
+
+  @Test
+  void icebergFixtureIncrementalReconcileBackfillsMissingStatsForExistingSnapshot()
+      throws Exception {
+    TestS3Fixtures.seedFixturesOnce();
+
+    var accountId = seedAccountId;
+    TestSupport.createCatalog(catalogService, "cat-iceberg-backfill-stats", "");
+
+    var dest =
+        DestinationTarget.newBuilder()
+            .setCatalogDisplayName("cat-iceberg-backfill-stats")
+            .setNamespace(NamespacePath.newBuilder().addSegments("iceberg").build())
+            .setTableDisplayName("trino_test")
+            .build();
+
+    var props = new HashMap<String, String>();
+    props.putAll(
+        TestS3Fixtures.fileIoProperties(
+            TestS3Fixtures.bucketPath().getParent().toAbsolutePath().toString()));
+    props.put(
+        "external.metadata-location",
+        TestS3Fixtures.bucketUri(
+            "metadata/00002-503f4508-3824-4cb6-bdf1-4bd6bf5a0ade.metadata.json"));
+    props.put("external.namespace", "fixtures.simple");
+    props.put("external.table-name", "trino_test");
+    props.put("stats.ndv.enabled", "false");
+    props.put("iceberg.source", "filesystem");
+
+    var conn =
+        TestSupport.createConnector(
+            connectors,
+            ConnectorSpec.newBuilder()
+                .setDisplayName("fixture-iceberg-backfill-stats")
+                .setKind(ConnectorKind.CK_ICEBERG)
+                .setUri(TestS3Fixtures.bucketUri(null))
+                .setSource(source(List.of("fixtures", "simple")))
+                .setDestination(dest)
+                .setAuth(AuthConfig.newBuilder().setScheme("none").build())
+                .putAllProperties(props)
+                .build());
+
+    var fullJob = runReconcile(conn.getResourceId(), true);
+    assertNotNull(fullJob);
+    assertEquals("JS_SUCCEEDED", fullJob.state, () -> "job failed: " + fullJob.message);
+    assertTrue(fullJob.fullRescan);
+    assertTrue(fullJob.snapshotsProcessed > 0, "expected full reconcile to process snapshots");
+    assertTrue(fullJob.statsProcessed > 0, "expected full reconcile to process stats");
+
+    var catId =
+        catalogs
+            .getByName(accountId.getId(), "cat-iceberg-backfill-stats")
+            .orElseThrow()
+            .getResourceId();
+    var ns =
+        namespaces.getByPath(accountId.getId(), catId.getId(), List.of("iceberg")).orElseThrow();
+    var table =
+        tables
+            .getByName(accountId.getId(), catId.getId(), ns.getResourceId().getId(), "trino_test")
+            .orElseThrow();
+
+    long currentSnapshotId =
+        snaps.getCurrentSnapshot(table.getResourceId()).orElseThrow().getSnapshotId();
+    assertTrue(currentSnapshotId > 0, "expected a current snapshot after full reconcile");
+    assertTrue(
+        statsRepository.deleteAllStatsForSnapshot(table.getResourceId(), currentSnapshotId),
+        "expected stats deletion for current snapshot to succeed");
+
+    var emptyFileResp =
+        statsService.listFileColumnStats(
+            ListFileColumnStatsRequest.newBuilder()
+                .setTableId(table.getResourceId())
+                .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(currentSnapshotId).build())
+                .setPage(PageRequest.newBuilder().setPageSize(200))
+                .build());
+    assertEquals(
+        0,
+        emptyFileResp.getFileColumnsCount(),
+        "expected current snapshot file stats to be absent before backfill");
+
+    var incrementalJob = runReconcile(conn.getResourceId(), false);
+    assertNotNull(incrementalJob);
+    assertEquals(
+        "JS_SUCCEEDED", incrementalJob.state, () -> "job failed: " + incrementalJob.message);
+    assertFalse(incrementalJob.fullRescan);
+    assertTrue(
+        incrementalJob.snapshotsProcessed > 0,
+        "incremental should revisit existing snapshot when stats are missing");
+    assertTrue(
+        incrementalJob.statsProcessed > 0,
+        "incremental should regenerate stats for existing snapshot when missing");
+
+    var restoredFileResp =
+        statsService.listFileColumnStats(
+            ListFileColumnStatsRequest.newBuilder()
+                .setTableId(table.getResourceId())
+                .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(currentSnapshotId).build())
+                .setPage(PageRequest.newBuilder().setPageSize(200))
+                .build());
+    assertTrue(
+        restoredFileResp.getFileColumnsCount() > 0,
+        "expected current snapshot file stats to be restored by incremental reconcile");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/DirectReconcilerBackendTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.reconciler.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
@@ -26,6 +27,7 @@ import ai.floedb.floecat.catalog.rpc.Namespace;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.TableStats;
+import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
@@ -45,6 +47,7 @@ import ai.floedb.floecat.service.repo.impl.StatsRepository;
 import ai.floedb.floecat.service.testsupport.FakeCatalogRepository;
 import ai.floedb.floecat.service.testsupport.FakeNamespaceRepository;
 import ai.floedb.floecat.service.testsupport.FakeTableRepository;
+import ai.floedb.floecat.service.testsupport.FakeViewRepository;
 import ai.floedb.floecat.service.testsupport.SnapshotTestSupport;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
@@ -65,6 +68,7 @@ class DirectReconcilerBackendTest {
   private FakeCatalogRepository catalogRepo;
   private FakeNamespaceRepository namespaceRepo;
   private FakeTableRepository tableRepo;
+  private FakeViewRepository viewRepo;
   private SnapshotTestSupport.FakeSnapshotRepository snapshotRepo;
   private StatsRepository statsRepository;
   private SnapshotHelper snapshotHelper;
@@ -81,6 +85,7 @@ class DirectReconcilerBackendTest {
     catalogRepo = new FakeCatalogRepository();
     namespaceRepo = new FakeNamespaceRepository();
     tableRepo = new FakeTableRepository();
+    viewRepo = new FakeViewRepository();
     snapshotRepo = new SnapshotTestSupport.FakeSnapshotRepository();
     statsRepository =
         StatsRepository.forTesting(new InMemoryPointerStore(), new InMemoryBlobStore(), 64, 200, 5);
@@ -91,6 +96,7 @@ class DirectReconcilerBackendTest {
     backend.catalogRepo = catalogRepo;
     backend.namespaceRepo = namespaceRepo;
     backend.tableRepo = tableRepo;
+    backend.viewRepo = viewRepo;
     backend.snapshotRepo = snapshotRepo;
     backend.statsRepository = statsRepository;
     backend.snapshotHelper = snapshotHelper;
@@ -161,6 +167,7 @@ class DirectReconcilerBackendTest {
     assertThat(table.getDisplayName()).isEqualTo("orders");
     assertThat(table.getSchemaJson()).isEqualTo("{}");
     assertThat(table.getUpstream().getConnectorId().getId()).isEqualTo(connectorId.getId());
+    assertThat(table.getUpstream().getNamespacePathList()).containsExactly("source", "ns");
   }
 
   @Test
@@ -240,6 +247,103 @@ class DirectReconcilerBackendTest {
 
     Table updated = tableRepo.getById(tableId).orElseThrow();
     assertThat(updated).isEqualTo(before);
+  }
+
+  @Test
+  void ensureTableValidatesNormalizedDisplayName() {
+    TableSpecDescriptor invalidDescriptor =
+        new TableSpecDescriptor(
+            "parent",
+            "\u2003\u2003",
+            "{}",
+            Map.of(),
+            List.of(),
+            ColumnIdAlgorithm.CID_FIELD_ID,
+            ConnectorFormat.CF_ICEBERG,
+            connectorId,
+            "uri",
+            "source.ns",
+            "source_table");
+
+    assertThatThrownBy(
+            () -> backend.ensureTable(ctx, namespaceId, referenceNameRef(), invalidDescriptor))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void ensureViewReturnsExistingResourceIdWithoutMarkingCreated() {
+    var spec =
+        ai.floedb.floecat.catalog.rpc.ViewSpec.newBuilder()
+            .setCatalogId(catalogId)
+            .setNamespaceId(namespaceId)
+            .setDisplayName("orders_view")
+            .setSql("select 1")
+            .setDialect("spark")
+            .addOutputColumns(
+                ai.floedb.floecat.query.rpc.SchemaColumn.newBuilder().setName("c1").setOrdinal(1))
+            .build();
+
+    ResourceId existingId =
+        ResourceId.newBuilder()
+            .setAccountId(ACCOUNT)
+            .setKind(ResourceKind.RK_VIEW)
+            .setId("view-1")
+            .build();
+    viewRepo.put(
+        View.newBuilder()
+            .setResourceId(existingId)
+            .setCatalogId(catalogId)
+            .setNamespaceId(namespaceId)
+            .setDisplayName("orders_view")
+            .setSql("select 1")
+            .setDialect("spark")
+            .addOutputColumns(
+                ai.floedb.floecat.query.rpc.SchemaColumn.newBuilder().setName("c1").setOrdinal(1))
+            .build(),
+        MutationMeta.newBuilder().setPointerVersion(1).setEtag("v1").build());
+
+    var existing = backend.ensureViewDetailed(ctx, spec, "parent.child.orders_view");
+
+    assertThat(existing.created()).isFalse();
+    assertThat(existing.resourceId()).isEqualTo(existingId);
+  }
+
+  @Test
+  void ensureViewMatchesExistingIdUsingSharedNormalization() {
+    var spec =
+        ai.floedb.floecat.catalog.rpc.ViewSpec.newBuilder()
+            .setCatalogId(catalogId)
+            .setNamespaceId(namespaceId)
+            .setDisplayName("  orders\u2003view  ")
+            .setSql("select 1")
+            .setDialect("spark")
+            .addOutputColumns(
+                ai.floedb.floecat.query.rpc.SchemaColumn.newBuilder().setName("c1").setOrdinal(1))
+            .build();
+
+    ResourceId existingId =
+        ResourceId.newBuilder()
+            .setAccountId(ACCOUNT)
+            .setKind(ResourceKind.RK_VIEW)
+            .setId("view-normalized")
+            .build();
+    viewRepo.put(
+        View.newBuilder()
+            .setResourceId(existingId)
+            .setCatalogId(catalogId)
+            .setNamespaceId(namespaceId)
+            .setDisplayName("orders view")
+            .setSql("select 1")
+            .setDialect("spark")
+            .addOutputColumns(
+                ai.floedb.floecat.query.rpc.SchemaColumn.newBuilder().setName("c1").setOrdinal(1))
+            .build(),
+        MutationMeta.newBuilder().setPointerVersion(1).setEtag("v1").build());
+
+    var existing = backend.ensureViewDetailed(ctx, spec, "parent.child.orders_view");
+
+    assertThat(existing.created()).isFalse();
+    assertThat(existing.resourceId()).isEqualTo(existingId);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
@@ -20,8 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
@@ -31,9 +33,17 @@ import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.NamespacePath;
 import ai.floedb.floecat.reconciler.impl.ReconcileCancellationRegistry;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService;
+import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
+import ai.floedb.floecat.reconciler.rpc.CancelReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.CaptureNowRequest;
 import ai.floedb.floecat.reconciler.rpc.CaptureScope;
+import ai.floedb.floecat.reconciler.rpc.GetReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.StartCaptureRequest;
 import ai.floedb.floecat.service.reconciler.jobs.ReconcilerSettingsStore;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
@@ -41,6 +51,7 @@ import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -120,6 +131,298 @@ class ReconcileControlImplTest {
                     .indefinitely());
 
     assertEquals(Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode());
+  }
+
+  @Test
+  void startCapturePassesExecutionPolicyToQueue() {
+    when(service.jobs.enqueuePlan(
+            eq("acct"),
+            eq("connector-1"),
+            eq(false),
+            eq(CaptureMode.METADATA_AND_STATS),
+            any(ReconcileScope.class),
+            eq(
+                ReconcileExecutionPolicy.of(
+                    ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of())),
+            eq("")))
+        .thenReturn("job-123");
+
+    var response =
+        service
+            .startCapture(
+                StartCaptureRequest.newBuilder()
+                    .setScope(CaptureScope.newBuilder().setConnectorId(connectorId()).build())
+                    .setExecutionPolicy(
+                        ai.floedb.floecat.reconciler.rpc.ExecutionPolicy.newBuilder()
+                            .setExecutionClass(
+                                ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_HEAVY)
+                            .setLane("remote")
+                            .build())
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals("job-123", response.getJobId());
+    verify(service.jobs)
+        .enqueuePlan(
+            eq("acct"),
+            eq("connector-1"),
+            eq(false),
+            eq(CaptureMode.METADATA_AND_STATS),
+            any(ReconcileScope.class),
+            eq(
+                ReconcileExecutionPolicy.of(
+                    ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of())),
+            eq(""));
+  }
+
+  @Test
+  void getReconcileJobIncludesExecutionPolicyAndExecutorId() {
+    when(service.jobs.get("acct", "job-123"))
+        .thenReturn(
+            Optional.of(
+                new ReconcileJobStore.ReconcileJob(
+                    "job-123",
+                    "acct",
+                    "connector-1",
+                    "JS_QUEUED",
+                    "",
+                    0L,
+                    0L,
+                    0L,
+                    0L,
+                    0L,
+                    false,
+                    CaptureMode.METADATA_AND_STATS,
+                    0L,
+                    0L,
+                    ReconcileScope.empty(),
+                    ReconcileExecutionPolicy.of(
+                        ReconcileExecutionClass.INTERACTIVE,
+                        "remote",
+                        java.util.Map.of("tier", "gold")),
+                    "remote-executor",
+                    ReconcileJobKind.EXEC_CONNECTOR,
+                    ReconcileTableTask.empty(),
+                    "")));
+
+    var response =
+        service
+            .getReconcileJob(GetReconcileJobRequest.newBuilder().setJobId("job-123").build())
+            .await()
+            .indefinitely();
+
+    assertEquals(
+        ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_INTERACTIVE,
+        response.getExecutionPolicy().getExecutionClass());
+    assertEquals("remote", response.getExecutionPolicy().getLane());
+    assertEquals("gold", response.getExecutionPolicy().getAttributesOrThrow("tier"));
+    assertEquals("remote-executor", response.getExecutorId());
+  }
+
+  @Test
+  void getReconcileJobAggregatesPlanChildren() {
+    var planJob =
+        new ReconcileJobStore.ReconcileJob(
+            "plan-1",
+            "acct",
+            "connector-1",
+            "JS_SUCCEEDED",
+            "Planned 2 table jobs",
+            10L,
+            20L,
+            0L,
+            0L,
+            0L,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            0L,
+            0L,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "",
+            ReconcileJobKind.PLAN_CONNECTOR,
+            ReconcileTableTask.empty(),
+            "");
+    var childQueued =
+        new ReconcileJobStore.ReconcileJob(
+            "child-1",
+            "acct",
+            "connector-1",
+            "JS_QUEUED",
+            "Queued",
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            0L,
+            0L,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "",
+            ReconcileJobKind.EXEC_TABLE,
+            ReconcileTableTask.of("ns", "table_a"),
+            "plan-1");
+    var childRunning =
+        new ReconcileJobStore.ReconcileJob(
+            "child-2",
+            "acct",
+            "connector-1",
+            "JS_RUNNING",
+            "Running",
+            100L,
+            0L,
+            3L,
+            1L,
+            0L,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            7L,
+            11L,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "default_reconciler",
+            ReconcileJobKind.EXEC_TABLE,
+            ReconcileTableTask.of("ns", "table_b"),
+            "plan-1");
+
+    when(service.jobs.get("acct", "plan-1")).thenReturn(Optional.of(planJob));
+    when(service.jobs.list("acct", 200, "", "connector-1", java.util.Set.of()))
+        .thenReturn(
+            new ReconcileJobStore.ReconcileJobPage(
+                List.of(planJob, childQueued, childRunning), ""));
+
+    var response =
+        service
+            .getReconcileJob(GetReconcileJobRequest.newBuilder().setJobId("plan-1").build())
+            .await()
+            .indefinitely();
+
+    assertEquals(ai.floedb.floecat.reconciler.rpc.JobState.JS_RUNNING, response.getState());
+    assertEquals(3L, response.getTablesScanned());
+    assertEquals(1L, response.getTablesChanged());
+    assertEquals(7L, response.getSnapshotsProcessed());
+    assertEquals(11L, response.getStatsProcessed());
+    assertEquals("default_reconciler", response.getExecutorId());
+  }
+
+  @Test
+  void cancelReconcileJobCancelsPlanChildren() {
+    var planCancelling =
+        new ReconcileJobStore.ReconcileJob(
+            "plan-1",
+            "acct",
+            "connector-1",
+            "JS_CANCELLING",
+            "Cancelling",
+            10L,
+            0L,
+            0L,
+            0L,
+            0L,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            0L,
+            0L,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "",
+            ReconcileJobKind.PLAN_CONNECTOR,
+            ReconcileTableTask.empty(),
+            "");
+    var childQueued =
+        new ReconcileJobStore.ReconcileJob(
+            "child-1",
+            "acct",
+            "connector-1",
+            "JS_QUEUED",
+            "Queued",
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            0L,
+            0L,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "",
+            ReconcileJobKind.EXEC_TABLE,
+            ReconcileTableTask.of("ns", "table_a"),
+            "plan-1");
+    var childCancelling =
+        new ReconcileJobStore.ReconcileJob(
+            "child-2",
+            "acct",
+            "connector-1",
+            "JS_CANCELLING",
+            "Cancelling",
+            100L,
+            0L,
+            0L,
+            0L,
+            0L,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            0L,
+            0L,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "default_reconciler",
+            ReconcileJobKind.EXEC_TABLE,
+            ReconcileTableTask.of("ns", "table_b"),
+            "plan-1");
+    var childCancelled =
+        new ReconcileJobStore.ReconcileJob(
+            "child-1",
+            "acct",
+            "connector-1",
+            "JS_CANCELLED",
+            "stop",
+            0L,
+            200L,
+            0L,
+            0L,
+            0L,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            0L,
+            0L,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "",
+            ReconcileJobKind.EXEC_TABLE,
+            ReconcileTableTask.of("ns", "table_a"),
+            "plan-1");
+
+    when(service.jobs.cancel("acct", "plan-1", "stop")).thenReturn(Optional.of(planCancelling));
+    when(service.jobs.list("acct", 200, "", "connector-1", java.util.Set.of()))
+        .thenReturn(
+            new ReconcileJobStore.ReconcileJobPage(
+                List.of(planCancelling, childQueued, childCancelling), ""));
+    when(service.jobs.cancel("acct", "child-1", "stop")).thenReturn(Optional.of(childCancelled));
+    when(service.jobs.cancel("acct", "child-2", "stop")).thenReturn(Optional.of(childCancelling));
+    when(service.jobs.get("acct", "plan-1")).thenReturn(Optional.of(planCancelling));
+
+    var response =
+        service
+            .cancelReconcileJob(
+                CancelReconcileJobRequest.newBuilder().setJobId("plan-1").setReason("stop").build())
+            .await()
+            .indefinitely();
+
+    verify(service.jobs).cancel("acct", "child-1", "stop");
+    verify(service.jobs).cancel("acct", "child-2", "stop");
+    verify(service.cancellations).requestCancel("child-2");
+    verify(service.cancellations).requestCancel("plan-1");
+    assertEquals(true, response.getCancelled());
+    assertEquals(
+        ai.floedb.floecat.reconciler.rpc.JobState.JS_CANCELLING, response.getJob().getState());
   }
 
   private static ResourceId connectorId() {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
@@ -31,8 +31,10 @@ import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.rpc.CompleteLeasedReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.GetReconcileCancellationRequest;
 import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobRequest;
@@ -82,6 +84,9 @@ class ReconcileExecutorControlImplTest {
                         ReconcileExecutionClass.HEAVY, "remote", Map.of("tier", "gold")),
                     "lease-1",
                     "remote-executor",
+                    "",
+                    ReconcileJobKind.EXEC_CONNECTOR,
+                    ReconcileTableTask.empty(),
                     "")));
 
     var response =

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.rpc.CompleteLeasedReconcileJobRequest;
+import ai.floedb.floecat.reconciler.rpc.GetReconcileCancellationRequest;
+import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobRequest;
+import ai.floedb.floecat.reconciler.rpc.ReconcileCompletionState;
+import ai.floedb.floecat.reconciler.rpc.RenewReconcileLeaseRequest;
+import ai.floedb.floecat.reconciler.rpc.ReportReconcileProgressRequest;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ReconcileExecutorControlImplTest {
+  private ReconcileExecutorControlImpl service;
+
+  @BeforeEach
+  void setUp() {
+    service = new ReconcileExecutorControlImpl();
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.jobs = mock(ReconcileJobStore.class);
+
+    PrincipalContext principalContext = mock(PrincipalContext.class);
+    when(service.principalProvider.get()).thenReturn(principalContext);
+    when(principalContext.getCorrelationId()).thenReturn("corr");
+    doNothing().when(service.authz).require(any(), eq("connector.manage"));
+  }
+
+  @Test
+  void leaseReconcileJobUsesExecutorAwareLeaseFilterAndMapsLease() {
+    when(service.jobs.leaseNext(any()))
+        .thenReturn(
+            Optional.of(
+                new ReconcileJobStore.LeasedJob(
+                    "job-1",
+                    "acct",
+                    "connector-1",
+                    false,
+                    CaptureMode.METADATA_AND_STATS,
+                    ReconcileScope.of(
+                        java.util.List.of(java.util.List.of("db")),
+                        "orders",
+                        java.util.List.of("id"),
+                        java.util.List.of(10L)),
+                    ReconcileExecutionPolicy.of(
+                        ReconcileExecutionClass.HEAVY, "remote", Map.of("tier", "gold")),
+                    "lease-1",
+                    "remote-executor",
+                    "")));
+
+    var response =
+        service
+            .leaseReconcileJob(
+                LeaseReconcileJobRequest.newBuilder()
+                    .setExecutorId("remote-executor")
+                    .addExecutionClasses(ai.floedb.floecat.reconciler.rpc.ExecutionClass.EC_HEAVY)
+                    .addLanes("remote")
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertTrue(response.getFound());
+    assertEquals("job-1", response.getJob().getJobId());
+    assertEquals("connector-1", response.getJob().getConnectorId().getId());
+    assertEquals("orders", response.getJob().getScope().getDestinationTableDisplayName());
+    assertEquals("remote-executor", response.getJob().getPinnedExecutorId());
+    verify(service.jobs)
+        .leaseNext(
+            argThat(
+                request ->
+                    request != null
+                        && request.executionClasses.contains(ReconcileExecutionClass.HEAVY)
+                        && request.lanes.contains("remote")
+                        && request.executorIds.contains("remote-executor")));
+  }
+
+  @Test
+  void renewReconcileLeaseReturnsCancellationSignal() {
+    when(service.jobs.renewLease("job-1", "lease-1")).thenReturn(true);
+    when(service.jobs.isCancellationRequested("job-1")).thenReturn(true);
+
+    var response =
+        service
+            .renewReconcileLease(
+                RenewReconcileLeaseRequest.newBuilder()
+                    .setJobId("job-1")
+                    .setLeaseEpoch("lease-1")
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertTrue(response.getRenewed());
+    assertTrue(response.getCancellationRequested());
+  }
+
+  @Test
+  void reportReconcileProgressActsAsHeartbeat() {
+    when(service.jobs.renewLease("job-1", "lease-1")).thenReturn(true);
+
+    var response =
+        service
+            .reportReconcileProgress(
+                ReportReconcileProgressRequest.newBuilder()
+                    .setJobId("job-1")
+                    .setLeaseEpoch("lease-1")
+                    .setTablesScanned(4)
+                    .setTablesChanged(2)
+                    .setErrors(1)
+                    .setSnapshotsProcessed(3)
+                    .setStatsProcessed(5)
+                    .setMessage("working")
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertTrue(response.getLeaseValid());
+    verify(service.jobs).markProgress("job-1", "lease-1", 4, 2, 1, 3, 5, "working");
+  }
+
+  @Test
+  void completeLeasedReconcileJobMarksSucceeded() {
+    when(service.jobs.renewLease("job-1", "lease-1")).thenReturn(true);
+
+    var response =
+        service
+            .completeLeasedReconcileJob(
+                CompleteLeasedReconcileJobRequest.newBuilder()
+                    .setJobId("job-1")
+                    .setLeaseEpoch("lease-1")
+                    .setState(ReconcileCompletionState.RCS_SUCCEEDED)
+                    .setTablesScanned(7)
+                    .setTablesChanged(3)
+                    .setSnapshotsProcessed(2)
+                    .setStatsProcessed(9)
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertTrue(response.getAccepted());
+    verify(service.jobs)
+        .markSucceeded(eq("job-1"), eq("lease-1"), anyLong(), eq(7L), eq(3L), eq(2L), eq(9L));
+  }
+
+  @Test
+  void getReconcileCancellationReadsQueueState() {
+    when(service.jobs.isCancellationRequested("job-1")).thenReturn(true);
+
+    var response =
+        service
+            .getReconcileCancellation(
+                GetReconcileCancellationRequest.newBuilder().setJobId("job-1").build())
+            .await()
+            .indefinitely();
+
+    assertTrue(response.getCancellationRequested());
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcilerBackendAnnotationTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcilerBackendAnnotationTest.java
@@ -17,16 +17,12 @@ package ai.floedb.floecat.service.reconciler.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.quarkus.arc.properties.IfBuildProperty;
 import org.junit.jupiter.api.Test;
 
 class ReconcilerBackendAnnotationTest {
   @Test
-  void localBackendEnablesIfMissing() {
-    IfBuildProperty annotation = DirectReconcilerBackend.class.getAnnotation(IfBuildProperty.class);
-    assertThat(annotation).isNotNull();
-    assertThat(annotation.name()).isEqualTo("floecat.reconciler.backend");
-    assertThat(annotation.stringValue()).isEqualTo("local");
-    assertThat(annotation.enableIfMissing()).isTrue();
+  void directBackendIsNotBuildTimeGated() {
+    assertThat(DirectReconcilerBackend.class.getAnnotations())
+        .noneMatch(annotation -> annotation.annotationType().getName().endsWith("IfBuildProperty"));
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/RuntimeSelectedReconcilerBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/RuntimeSelectedReconcilerBackendTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import ai.floedb.floecat.reconciler.impl.GrpcReconcilerBackend;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class RuntimeSelectedReconcilerBackendTest {
+
+  @Test
+  void selectsGrpcBackendWhenConfiguredRemote() {
+    DirectReconcilerBackend direct = mock(DirectReconcilerBackend.class);
+    GrpcReconcilerBackend grpc = mock(GrpcReconcilerBackend.class);
+
+    RuntimeSelectedReconcilerBackend backend =
+        new RuntimeSelectedReconcilerBackend(direct, grpc, "remote");
+
+    assertThat(delegateOf(backend)).isSameAs(grpc);
+  }
+
+  @Test
+  void defaultsToDirectBackend() {
+    DirectReconcilerBackend direct = mock(DirectReconcilerBackend.class);
+    GrpcReconcilerBackend grpc = mock(GrpcReconcilerBackend.class);
+
+    RuntimeSelectedReconcilerBackend backend =
+        new RuntimeSelectedReconcilerBackend(direct, grpc, "local");
+
+    assertThat(delegateOf(backend)).isSameAs(direct);
+  }
+
+  private static Object delegateOf(RuntimeSelectedReconcilerBackend backend) {
+    try {
+      Field field = RuntimeSelectedReconcilerBackend.class.getDeclaredField("delegate");
+      field.setAccessible(true);
+      return field.get(backend);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -25,9 +25,11 @@ import ai.floedb.floecat.common.rpc.BlobHeader;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.ReconcileJob;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.storage.errors.StorageNotFoundException;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
@@ -109,6 +111,39 @@ class DurableReconcileJobStoreTest {
   }
 
   @Test
+  void enqueueDedupesEquivalentExecutionPolicyAttributesRegardlessOfMapOrder() {
+    store.init();
+    ReconcileScope scope = ReconcileScope.of(List.of(List.of("ns")), "tbl", List.of("c1"));
+    java.util.LinkedHashMap<String, String> ordered = new java.util.LinkedHashMap<>();
+    ordered.put("tier", "gold");
+    ordered.put("pool", "etl");
+
+    String first =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            scope,
+            ReconcileExecutionPolicy.of(ReconcileExecutionClass.HEAVY, "remote", ordered),
+            "");
+    java.util.LinkedHashMap<String, String> reordered = new java.util.LinkedHashMap<>();
+    reordered.put("pool", "etl");
+    reordered.put("tier", "gold");
+    String second =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            scope,
+            ReconcileExecutionPolicy.of(ReconcileExecutionClass.HEAVY, "remote", reordered),
+            "");
+
+    assertEquals(first, second);
+  }
+
+  @Test
   void leaseNextFiltersByExecutionPolicy() {
     store.init();
 
@@ -177,6 +212,75 @@ class DurableReconcileJobStoreTest {
 
     assertEquals(jobId, lease.jobId);
     assertEquals("remote-b", lease.pinnedExecutorId);
+  }
+
+  @Test
+  void leaseNextRespectsPinnedExecutorIdForPlannerJobs() {
+    store.init();
+
+    String plannerJobId =
+        store.enqueuePlan(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "planner-b");
+
+    var lease =
+        store.leaseNext(
+            ReconcileJobStore.LeaseRequest.of(
+                java.util.EnumSet.of(ReconcileExecutionClass.DEFAULT),
+                java.util.Set.of(""),
+                java.util.Set.of("planner-a"),
+                java.util.EnumSet.of(ReconcileJobKind.PLAN_CONNECTOR)));
+
+    assertTrue(lease.isEmpty());
+
+    var matchingLease =
+        store
+            .leaseNext(
+                ReconcileJobStore.LeaseRequest.of(
+                    java.util.EnumSet.of(ReconcileExecutionClass.DEFAULT),
+                    java.util.Set.of(""),
+                    java.util.Set.of("planner-b"),
+                    java.util.EnumSet.of(ReconcileJobKind.PLAN_CONNECTOR)))
+            .orElseThrow();
+
+    assertEquals(plannerJobId, matchingLease.jobId);
+    assertEquals("planner-b", matchingLease.pinnedExecutorId);
+    assertEquals(ReconcileJobKind.PLAN_CONNECTOR, matchingLease.jobKind);
+  }
+
+  @Test
+  void enqueueTableExecutionDoesNotDedupeAcrossParentJobs() {
+    store.init();
+
+    String first =
+        store.enqueueTableExecution(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.empty(),
+            ReconcileTableTask.of("ns", "table_a"),
+            ReconcileExecutionPolicy.defaults(),
+            "plan-1",
+            "");
+    String second =
+        store.enqueueTableExecution(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.empty(),
+            ReconcileTableTask.of("ns", "table_a"),
+            ReconcileExecutionPolicy.defaults(),
+            "plan-2",
+            "");
+
+    assertNotEquals(first, second);
   }
 
   @Test
@@ -314,6 +418,48 @@ class DurableReconcileJobStoreTest {
     var seen = List.of(firstPage.jobs.get(0).jobId, secondPage.jobs.get(0).jobId);
     assertTrue(seen.contains(first));
     assertTrue(seen.contains(second));
+  }
+
+  @Test
+  void listPaginationDoesNotDuplicateEntriesAcrossMultiplePages() {
+    store.init();
+
+    String first =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.of(List.of(List.of("ns1")), "t1", List.of()));
+    String second =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.of(List.of(List.of("ns2")), "t2", List.of()));
+    String third =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.of(List.of(List.of("ns3")), "t3", List.of()));
+
+    var page1 = store.list(ACCOUNT_ID, 1, "", CONNECTOR_ID, java.util.Set.of());
+    var page2 = store.list(ACCOUNT_ID, 1, page1.nextPageToken, CONNECTOR_ID, java.util.Set.of());
+    var page3 = store.list(ACCOUNT_ID, 1, page2.nextPageToken, CONNECTOR_ID, java.util.Set.of());
+
+    assertEquals(1, page1.jobs.size());
+    assertEquals(1, page2.jobs.size());
+    assertEquals(1, page3.jobs.size());
+
+    java.util.Set<String> seen =
+        java.util.Set.of(page1.jobs.get(0).jobId, page2.jobs.get(0).jobId, page3.jobs.get(0).jobId);
+    assertEquals(3, seen.size());
+    assertTrue(seen.contains(first));
+    assertTrue(seen.contains(second));
+    assertTrue(seen.contains(third));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -23,6 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.common.rpc.BlobHeader;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.ReconcileJob;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.service.repo.model.Keys;
@@ -78,6 +81,105 @@ class DurableReconcileJobStoreTest {
   }
 
   @Test
+  void enqueueDoesNotDedupeAcrossDifferentExecutionPolicies() {
+    store.init();
+    ReconcileScope scope = ReconcileScope.of(List.of(List.of("ns")), "tbl", List.of("c1"));
+
+    String first =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            scope,
+            ReconcileExecutionPolicy.of(ReconcileExecutionClass.DEFAULT, "", java.util.Map.of()),
+            "");
+    String second =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            scope,
+            ReconcileExecutionPolicy.of(
+                ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of()),
+            "");
+
+    assertNotEquals(first, second);
+  }
+
+  @Test
+  void leaseNextFiltersByExecutionPolicy() {
+    store.init();
+
+    store.enqueue(
+        ACCOUNT_ID,
+        "conn-default",
+        false,
+        CaptureMode.METADATA_AND_STATS,
+        ReconcileScope.empty(),
+        ReconcileExecutionPolicy.defaults(),
+        "");
+    String remoteJobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            "conn-remote",
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.of(
+                ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of()),
+            "");
+
+    var remoteLease =
+        store
+            .leaseNext(
+                ReconcileJobStore.LeaseRequest.of(
+                    java.util.EnumSet.of(ReconcileExecutionClass.HEAVY),
+                    java.util.Set.of("remote")))
+            .orElseThrow();
+
+    assertEquals(remoteJobId, remoteLease.jobId);
+    assertEquals("remote", remoteLease.executionPolicy.lane());
+  }
+
+  @Test
+  void leaseNextRespectsPinnedExecutorId() {
+    store.init();
+
+    store.enqueue(
+        ACCOUNT_ID,
+        "conn-a",
+        false,
+        CaptureMode.METADATA_AND_STATS,
+        ReconcileScope.empty(),
+        ReconcileExecutionPolicy.of(ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of()),
+        "remote-a");
+    String jobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            "conn-b",
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.of(
+                ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of()),
+            "remote-b");
+
+    var lease =
+        store
+            .leaseNext(
+                ReconcileJobStore.LeaseRequest.of(
+                    java.util.EnumSet.of(ReconcileExecutionClass.HEAVY),
+                    java.util.Set.of("remote"),
+                    java.util.Set.of("remote-b")))
+            .orElseThrow();
+
+    assertEquals(jobId, lease.jobId);
+    assertEquals("remote-b", lease.pinnedExecutorId);
+  }
+
+  @Test
   void successfulJobClearsDedupeAndAllowsFreshEnqueue() {
     store.init();
     ReconcileScope scope = ReconcileScope.of(List.of(List.of("ns")), "tbl", List.of());
@@ -104,6 +206,36 @@ class DurableReconcileJobStoreTest {
     ReconcileJob job = store.get(jobId).orElseThrow();
     assertEquals(List.of(0L, 3L), job.scope.destinationSnapshotIds());
     assertTrue(job.scope.hasSnapshotFilter());
+  }
+
+  @Test
+  void enqueuePreservesExecutionPolicyAndPinnedExecutorAcrossLeaseAndAssignment() {
+    store.init();
+
+    String jobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.empty(),
+            ReconcileExecutionPolicy.of(
+                ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of("tier", "gold")),
+            "remote-executor");
+
+    ReconcileJob job = store.get(jobId).orElseThrow();
+    assertEquals(ReconcileExecutionClass.HEAVY, job.executionPolicy.executionClass());
+    assertEquals("remote", job.executionPolicy.lane());
+    assertEquals("gold", job.executionPolicy.attributes().get("tier"));
+    assertEquals("", job.executorId);
+
+    var lease = store.leaseNext().orElseThrow();
+    assertEquals(jobId, lease.jobId);
+    assertEquals("remote-executor", lease.pinnedExecutorId);
+    assertEquals(ReconcileExecutionClass.HEAVY, lease.executionPolicy.executionClass());
+
+    store.markRunning(lease.jobId, lease.leaseEpoch, System.currentTimeMillis(), "remote-executor");
+    assertEquals("remote-executor", store.get(jobId).orElseThrow().executorId);
   }
 
   @Test
@@ -222,7 +354,8 @@ class DurableReconcileJobStoreTest {
             CaptureMode.METADATA_AND_STATS,
             ReconcileScope.empty());
     var firstLease = store.leaseNext().orElseThrow();
-    store.markRunning(firstLease.jobId, firstLease.leaseEpoch, System.currentTimeMillis());
+    store.markRunning(
+        firstLease.jobId, firstLease.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
     store.cancel(ACCOUNT_ID, jobId, "stop");
     assertEquals("JS_CANCELLING", store.get(jobId).orElseThrow().state);
 
@@ -259,7 +392,8 @@ class DurableReconcileJobStoreTest {
             CaptureMode.METADATA_AND_STATS,
             ReconcileScope.empty());
     var firstLease = store.leaseNext().orElseThrow();
-    store.markRunning(firstLease.jobId, firstLease.leaseEpoch, System.currentTimeMillis());
+    store.markRunning(
+        firstLease.jobId, firstLease.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
     store.cancel(ACCOUNT_ID, jobId, "stop");
 
     // Cancel should poke lease expiry, allowing reclaim well before the original 5s lease.
@@ -284,7 +418,8 @@ class DurableReconcileJobStoreTest {
             CaptureMode.METADATA_AND_STATS,
             ReconcileScope.empty());
     var lease = store.leaseNext().orElseThrow();
-    store.markRunning(lease.jobId, lease.leaseEpoch, System.currentTimeMillis());
+    store.markRunning(
+        lease.jobId, lease.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
 
     Thread.sleep(500L);
     assertTrue(store.renewLease(jobId, lease.leaseEpoch));
@@ -308,7 +443,8 @@ class DurableReconcileJobStoreTest {
             CaptureMode.METADATA_AND_STATS,
             ReconcileScope.empty());
     var lease = store.leaseNext().orElseThrow();
-    store.markRunning(lease.jobId, lease.leaseEpoch, System.currentTimeMillis());
+    store.markRunning(
+        lease.jobId, lease.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
 
     assertTrue(!store.renewLease(jobId, "stale-epoch"));
   }
@@ -343,11 +479,15 @@ class DurableReconcileJobStoreTest {
         ACCOUNT_ID, "conn-c", false, CaptureMode.METADATA_AND_STATS, ReconcileScope.empty());
 
     var firstLease = store.leaseNext().orElseThrow();
-    store.markRunning(firstLease.jobId, firstLease.leaseEpoch, System.currentTimeMillis());
+    store.markRunning(
+        firstLease.jobId, firstLease.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
 
     var cancellingLease = store.leaseNext().orElseThrow();
     store.markRunning(
-        cancellingLease.jobId, cancellingLease.leaseEpoch, System.currentTimeMillis());
+        cancellingLease.jobId,
+        cancellingLease.leaseEpoch,
+        System.currentTimeMillis(),
+        "default_reconciler");
     store.cancel(ACCOUNT_ID, cancellingLease.jobId, "stop");
 
     var stats = store.queueStats();

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
@@ -21,7 +21,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.account.rpc.Account;
@@ -31,6 +33,8 @@ import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.ReconcileMode;
 import ai.floedb.floecat.connector.rpc.ReconcilePolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
@@ -48,7 +52,8 @@ class ReconcilePlannerSchedulerTest {
     scheduler.jobs = mock(ReconcileJobStore.class);
 
     List<String> enqueued = new ArrayList<>();
-    when(scheduler.jobs.enqueue(anyString(), anyString(), anyBoolean(), any(), any()))
+    when(scheduler.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
         .thenAnswer(
             invocation -> {
               enqueued.add(invocation.getArgument(1, String.class));
@@ -106,7 +111,8 @@ class ReconcilePlannerSchedulerTest {
 
     List<String> enqueued = new ArrayList<>();
     List<String> connectorTokens = new ArrayList<>();
-    when(scheduler.jobs.enqueue(anyString(), anyString(), anyBoolean(), any(), any()))
+    when(scheduler.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
         .thenAnswer(
             invocation -> {
               enqueued.add(invocation.getArgument(1, String.class));
@@ -154,7 +160,8 @@ class ReconcilePlannerSchedulerTest {
     scheduler.jobs = mock(ReconcileJobStore.class);
 
     List<String> enqueued = new ArrayList<>();
-    when(scheduler.jobs.enqueue(anyString(), anyString(), anyBoolean(), any(), any()))
+    when(scheduler.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
         .thenAnswer(
             invocation -> {
               enqueued.add(invocation.getArgument(1, String.class));
@@ -186,7 +193,8 @@ class ReconcilePlannerSchedulerTest {
     scheduler.jobs = mock(ReconcileJobStore.class);
 
     List<String> enqueued = new ArrayList<>();
-    when(scheduler.jobs.enqueue(anyString(), anyString(), anyBoolean(), any(), any()))
+    when(scheduler.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
         .thenAnswer(
             invocation -> {
               enqueued.add(invocation.getArgument(1, String.class));
@@ -221,7 +229,8 @@ class ReconcilePlannerSchedulerTest {
     scheduler.jobs = mock(ReconcileJobStore.class);
 
     List<String> enqueued = new ArrayList<>();
-    when(scheduler.jobs.enqueue(anyString(), anyString(), anyBoolean(), any(), any()))
+    when(scheduler.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
         .thenAnswer(
             invocation -> {
               enqueued.add(invocation.getArgument(1, String.class));
@@ -239,6 +248,38 @@ class ReconcilePlannerSchedulerTest {
     scheduler.runPlannerPass(100L, 10, 10, 1L, ReconcileMode.RM_INCREMENTAL);
 
     assertEquals(List.of("conn-enabled"), enqueued);
+  }
+
+  @Test
+  void runPlannerPassLeavesPlanJobsUnpinned() {
+    TestScheduler scheduler = new TestScheduler();
+    scheduler.accounts = mock(AccountRepository.class);
+    scheduler.connectors = mock(ConnectorRepository.class);
+    scheduler.jobs = mock(ReconcileJobStore.class);
+    scheduler.autoExecutionPolicy =
+        ReconcileExecutionPolicy.of(ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of());
+
+    when(scheduler.accounts.list(anyInt(), anyString(), any()))
+        .thenReturn(List.of(account("acct-a", "alpha")));
+    when(scheduler.connectors.list(anyString(), anyInt(), anyString(), any()))
+        .thenReturn(List.of(connector("acct-a", "conn-a1", "alpha-1")));
+    when(scheduler.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
+        .thenReturn("job-1");
+
+    scheduler.runPlannerPass(100L, 10, 10, 1L, ReconcileMode.RM_INCREMENTAL);
+
+    verify(scheduler.jobs)
+        .enqueuePlan(
+            eq("acct-a"),
+            eq("conn-a1"),
+            eq(false),
+            any(),
+            any(),
+            eq(
+                ReconcileExecutionPolicy.of(
+                    ReconcileExecutionClass.HEAVY, "remote", java.util.Map.of())),
+            eq(""));
   }
 
   private static Account account(String accountId, String displayName) {
@@ -270,10 +311,16 @@ class ReconcilePlannerSchedulerTest {
 
   private static final class TestScheduler extends ReconcilePlannerScheduler {
     private long nowMs;
+    private ReconcileExecutionPolicy autoExecutionPolicy = ReconcileExecutionPolicy.defaults();
 
     @Override
     long nowMs() {
       return nowMs++;
+    }
+
+    @Override
+    ReconcileExecutionPolicy autoExecutionPolicy() {
+      return autoExecutionPolicy;
     }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
@@ -52,4 +52,12 @@ class KeysTest {
         "/accounts/acct%20id/tables/table%20id/snapshots/0000000000000000007/stats/constraints",
         Keys.snapshotConstraintsStatsPointer("acct id", "table id", 7L));
   }
+
+  @Test
+  void transactionDeleteSentinelUriUsesPathSafeEncoding() {
+    assertEquals(
+        "/accounts/acct%20id/transactions/tx%20id/delete/%2Faccounts%2Facct%2520id%2Ftables%2Ftable%2520id%2Fsnapshots%2Fby-id%2F0000000000000000007",
+        Keys.transactionDeleteSentinelUri(
+            "acct id", "tx id", Keys.snapshotPointerById("acct id", "table id", 7L)));
+  }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
@@ -166,6 +166,92 @@ class TransactionIntentApplierSupportTest {
   }
 
   @Test
+  void applyTransactionDeletesNonTablePointerWhenDeleteSentinelIsUsed() throws Exception {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var intentRepo = new TransactionIntentRepository(pointers, blobs);
+
+    var support = new TransactionIntentApplierSupport();
+    inject(support, "pointerStore", pointers);
+    inject(support, "blobStore", blobs);
+
+    String accountId = "acct";
+    String targetKey = Keys.snapshotPointerById(accountId, "table-1", 7L);
+    pointers.compareAndSet(
+        targetKey,
+        0L,
+        Pointer.newBuilder().setKey(targetKey).setBlobUri("/blob/snap-7").setVersion(1L).build());
+
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId(accountId)
+            .setTxId("tx-1")
+            .setTargetPointerKey(targetKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri(accountId, "tx-1", targetKey))
+            .setExpectedVersion(1L)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    var outcome = support.applyTransactionBestEffort(List.of(intent), intentRepo);
+
+    assertEquals(TransactionIntentApplierSupport.ApplyStatus.APPLIED, outcome.status());
+    assertTrue(pointers.get(targetKey).isEmpty(), "delete intent should remove the target pointer");
+  }
+
+  @Test
+  void applyTransactionDeletesTablePointerAndOwnedNamePointerWhenDeleteSentinelIsUsed()
+      throws Exception {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var intentRepo = new TransactionIntentRepository(pointers, blobs);
+
+    var support = new TransactionIntentApplierSupport();
+    inject(support, "pointerStore", pointers);
+    inject(support, "blobStore", blobs);
+
+    String accountId = "acct";
+    String catalogId = "cat-1";
+    String namespaceId = "ns-1";
+    String tableId = "table-1";
+    String blobUri = "/accounts/acct/tables/table-1/table/blob.pb";
+    String byIdKey = Keys.tablePointerById(accountId, tableId);
+    String byNameKey = Keys.tablePointerByName(accountId, catalogId, namespaceId, "orders");
+
+    Table table =
+        Table.newBuilder()
+            .setResourceId(ResourceId.newBuilder().setAccountId(accountId).setId(tableId))
+            .setCatalogId(ResourceId.newBuilder().setAccountId(accountId).setId(catalogId))
+            .setNamespaceId(ResourceId.newBuilder().setAccountId(accountId).setId(namespaceId))
+            .setDisplayName("orders")
+            .build();
+    blobs.put(blobUri, table.toByteArray(), "application/x-protobuf");
+    pointers.compareAndSet(
+        byIdKey,
+        0L,
+        Pointer.newBuilder().setKey(byIdKey).setBlobUri(blobUri).setVersion(1L).build());
+    pointers.compareAndSet(
+        byNameKey,
+        0L,
+        Pointer.newBuilder().setKey(byNameKey).setBlobUri(blobUri).setVersion(1L).build());
+
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId(accountId)
+            .setTxId("tx-1")
+            .setTargetPointerKey(byIdKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri(accountId, "tx-1", byIdKey))
+            .setExpectedVersion(1L)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    var outcome = support.applyTransactionBestEffort(List.of(intent), intentRepo);
+
+    assertEquals(TransactionIntentApplierSupport.ApplyStatus.APPLIED, outcome.status());
+    assertTrue(pointers.get(byIdKey).isEmpty(), "table by-id pointer should be removed");
+    assertTrue(pointers.get(byNameKey).isEmpty(), "owned table by-name pointer should be removed");
+  }
+
+  @Test
   void applyTransactionReportsNamePointerConflictWithoutPartialApply() throws Exception {
     var pointers = new InMemoryPointerStore();
     var blobs = new InMemoryBlobStore();

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
@@ -252,6 +252,50 @@ class TransactionIntentApplierSupportTest {
   }
 
   @Test
+  void applyTransactionRejectsTableDeleteWhenCurrentByIdBlobTargetsDifferentTable()
+      throws Exception {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var intentRepo = new TransactionIntentRepository(pointers, blobs);
+
+    var support = new TransactionIntentApplierSupport();
+    inject(support, "pointerStore", pointers);
+    inject(support, "blobStore", blobs);
+
+    String accountId = "acct";
+    String byIdKey = Keys.tablePointerById(accountId, "table-a");
+    String wrongBlobUri = "/accounts/acct/tables/table-b/table/blob.pb";
+    Table wrongTable =
+        Table.newBuilder()
+            .setResourceId(ResourceId.newBuilder().setAccountId(accountId).setId("table-b"))
+            .setCatalogId(ResourceId.newBuilder().setAccountId(accountId).setId("cat-1"))
+            .setNamespaceId(ResourceId.newBuilder().setAccountId(accountId).setId("ns-1"))
+            .setDisplayName("orders-b")
+            .build();
+    blobs.put(wrongBlobUri, wrongTable.toByteArray(), "application/x-protobuf");
+    pointers.compareAndSet(
+        byIdKey,
+        0L,
+        Pointer.newBuilder().setKey(byIdKey).setBlobUri(wrongBlobUri).setVersion(1L).build());
+
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId(accountId)
+            .setTxId("tx-1")
+            .setTargetPointerKey(byIdKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri(accountId, "tx-1", byIdKey))
+            .setExpectedVersion(1L)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    var outcome = support.applyTransactionBestEffort(List.of(intent), intentRepo);
+
+    assertEquals(TransactionIntentApplierSupport.ApplyStatus.CONFLICT, outcome.status());
+    assertEquals("TABLE_INTENT_TARGET_MISMATCH", outcome.errorCode());
+    assertTrue(pointers.get(byIdKey).isPresent(), "mismatched table delete must not remove by-id");
+  }
+
+  @Test
   void applyTransactionReportsNamePointerConflictWithoutPartialApply() throws Exception {
     var pointers = new InMemoryPointerStore();
     var blobs = new InMemoryBlobStore();

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
@@ -996,7 +996,7 @@ class TransactionsServiceImplTest {
                     .setKey(targetKey)
                     .setBlobUri(tableBlobUri)
                     .setVersion(7L)
-            .build()));
+                    .build()));
     when(blobStore.get(tableBlobUri)).thenReturn(table.toByteArray());
     when(intentRepo.getByTarget(accountId, targetKey)).thenReturn(Optional.empty());
     when(txRepo.metaFor(accountId, txId))

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.Precondition;
@@ -38,6 +39,7 @@ import ai.floedb.floecat.service.repo.impl.TransactionRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.transaction.impl.TransactionIntentApplierSupport;
 import ai.floedb.floecat.service.transaction.impl.TransactionsServiceImpl;
+import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.transaction.rpc.CommitTransactionRequest;
 import ai.floedb.floecat.transaction.rpc.PrepareTransactionRequest;
 import ai.floedb.floecat.transaction.rpc.Transaction;
@@ -591,6 +593,122 @@ class TransactionsServiceImplTest {
 
     assertEquals(TransactionState.TS_PREPARED, prepared.getState());
     verify(txRepo, never()).update(any(), anyLong());
+  }
+
+  @Test
+  void prepareTableDeleteIntentStoresExpectedOwnedNamePointerKey() throws Exception {
+    var service = new TransactionsServiceImpl();
+    var txRepo = Mockito.mock(TransactionRepository.class);
+    var intentRepo = Mockito.mock(TransactionIntentRepository.class);
+    var pointerStore = Mockito.mock(ai.floedb.floecat.storage.spi.PointerStore.class);
+    var blobStore = Mockito.mock(BlobStore.class);
+
+    inject(service, "txRepo", txRepo);
+    inject(service, "intentRepo", intentRepo);
+    inject(service, "pointerStore", pointerStore);
+    inject(service, "blobStore", blobStore);
+
+    String accountId = "acct";
+    String txId = "tx-1";
+    String tableId = "table-1";
+    String targetKey = Keys.tablePointerById(accountId, tableId);
+    String tableBlobUri = Keys.tableBlobUri(accountId, tableId, "sha");
+    Transaction txn =
+        Transaction.newBuilder()
+            .setAccountId(accountId)
+            .setTxId(txId)
+            .setState(TransactionState.TS_OPEN)
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .build();
+    Table table =
+        Table.newBuilder()
+            .setResourceId(ResourceId.newBuilder().setAccountId(accountId).setId(tableId))
+            .setCatalogId(ResourceId.newBuilder().setAccountId(accountId).setId("cat-1"))
+            .setNamespaceId(ResourceId.newBuilder().setAccountId(accountId).setId("ns-1"))
+            .setDisplayName("orders")
+            .build();
+
+    when(txRepo.getById(accountId, txId)).thenReturn(Optional.of(txn));
+    when(pointerStore.get(targetKey))
+        .thenReturn(
+            Optional.of(
+                Pointer.newBuilder()
+                    .setKey(targetKey)
+                    .setBlobUri(tableBlobUri)
+                    .setVersion(7L)
+                    .build()));
+    when(blobStore.get(tableBlobUri)).thenReturn(table.toByteArray());
+    when(intentRepo.getByTarget(accountId, targetKey)).thenReturn(Optional.empty());
+    when(txRepo.metaFor(accountId, txId))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(1L).build());
+    when(txRepo.update(
+            argThat(
+                updated -> updated != null && updated.getState() == TransactionState.TS_PREPARED),
+            anyLong()))
+        .thenReturn(true);
+
+    var request =
+        PrepareTransactionRequest.newBuilder()
+            .setTxId(txId)
+            .addChanges(
+                TxChange.newBuilder()
+                    .setTableId(
+                        ResourceId.newBuilder()
+                            .setAccountId(accountId)
+                            .setId(tableId)
+                            .setKind(ResourceKind.RK_TABLE))
+                    .setIntendedBlobUri(
+                        Keys.transactionDeleteSentinelUri(accountId, txId, targetKey)))
+            .build();
+
+    Transaction prepared =
+        invokePreparePrivate(service, accountId, request, Timestamps.fromMillis(10));
+
+    assertEquals(TransactionState.TS_PREPARED, prepared.getState());
+    verify(intentRepo)
+        .create(
+            argThat(
+                intent ->
+                    intent.getTargetPointerKey().equals(targetKey)
+                        && intent
+                            .getBlobUri()
+                            .equals(Keys.transactionDeleteSentinelUri(accountId, txId, targetKey))
+                        && intent
+                            .getExpectedOwnedNamePointerKey()
+                            .equals(
+                                Keys.tablePointerByName(accountId, "cat-1", "ns-1", "orders"))));
+  }
+
+  @Test
+  void intentsAlreadyAppliedTreatsTableDeleteSentinelAsAppliedWhenPointersAreCleared()
+      throws Exception {
+    var service = new TransactionsServiceImpl();
+    var pointerStore = Mockito.mock(ai.floedb.floecat.storage.spi.PointerStore.class);
+
+    inject(service, "pointerStore", pointerStore);
+
+    String accountId = "acct";
+    String txId = "tx-1";
+    String tableId = "table-1";
+    String targetKey = Keys.tablePointerById(accountId, tableId);
+    String nameKey = Keys.tablePointerByName(accountId, "cat-1", "ns-1", "orders");
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId(accountId)
+            .setTxId(txId)
+            .setTargetPointerKey(targetKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri(accountId, txId, targetKey))
+            .setExpectedOwnedNamePointerKey(nameKey)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    when(pointerStore.get(targetKey)).thenReturn(Optional.empty());
+    when(pointerStore.get(nameKey)).thenReturn(Optional.empty());
+
+    Method m = TransactionsServiceImpl.class.getDeclaredMethod("intentsAlreadyApplied", List.class);
+    m.setAccessible(true);
+
+    assertTrue((Boolean) m.invoke(service, List.of(intent)));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.transaction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -39,6 +40,8 @@ import ai.floedb.floecat.service.repo.impl.TransactionRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.transaction.impl.TransactionIntentApplierSupport;
 import ai.floedb.floecat.service.transaction.impl.TransactionsServiceImpl;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.transaction.rpc.CommitTransactionRequest;
 import ai.floedb.floecat.transaction.rpc.PrepareTransactionRequest;
@@ -48,6 +51,7 @@ import ai.floedb.floecat.transaction.rpc.TransactionState;
 import ai.floedb.floecat.transaction.rpc.TxChange;
 import com.google.protobuf.util.Timestamps;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
@@ -418,6 +422,362 @@ class TransactionsServiceImplTest {
   }
 
   @Test
+  void commitApplyingConflictFinalizesAppliedWhenDeleteIntentAlreadyApplied() throws Exception {
+    var service = new TransactionsServiceImpl();
+    var txRepo = Mockito.mock(TransactionRepository.class);
+    var intentRepo = Mockito.mock(TransactionIntentRepository.class);
+    var applier = Mockito.mock(TransactionIntentApplierSupport.class);
+    var pointerStore = Mockito.mock(ai.floedb.floecat.storage.spi.PointerStore.class);
+
+    inject(service, "txRepo", txRepo);
+    inject(service, "intentRepo", intentRepo);
+    inject(service, "intentApplierSupport", applier);
+    inject(service, "pointerStore", pointerStore);
+
+    Transaction txn =
+        Transaction.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setState(TransactionState.TS_APPLYING)
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .build();
+    String targetKey = Keys.snapshotPointerById("acct", "table-1", 7L);
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setTargetPointerKey(targetKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri("acct", "tx-1", targetKey))
+            .setExpectedOwnedNamePointerKey(
+                Keys.tablePointerByName("acct", "cat-1", "ns-1", "orders"))
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    when(txRepo.getById("acct", "tx-1")).thenReturn(Optional.of(txn), Optional.of(txn));
+    when(intentRepo.listByTx("acct", "tx-1")).thenReturn(List.of(intent));
+    when(intentRepo.getByTarget("acct", targetKey)).thenReturn(Optional.of(intent));
+    when(applier.applyTransactionBestEffort(List.of(intent), intentRepo))
+        .thenReturn(
+            TransactionIntentApplierSupport.ApplyOutcome.conflict(
+                "EXPECTED_VERSION_MISMATCH", "pointer version changed", 1L, 2L, null));
+    when(pointerStore.get(targetKey)).thenReturn(Optional.empty());
+    when(txRepo.metaFor("acct", "tx-1"))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(22L).build());
+    when(txRepo.update(
+            argThat(
+                updated -> updated != null && updated.getState() == TransactionState.TS_APPLIED),
+            anyLong()))
+        .thenReturn(true);
+    when(intentRepo.deleteBothIndicesBestEffort(intent)).thenReturn(true);
+
+    Transaction committed =
+        invokeCommitPrivate(
+            service,
+            "acct",
+            CommitTransactionRequest.newBuilder().setTxId("tx-1").build(),
+            Timestamps.fromMillis(10));
+
+    assertEquals(TransactionState.TS_APPLIED, committed.getState());
+    verify(intentRepo).deleteBothIndicesBestEffort(intent);
+  }
+
+  @Test
+  void commitApplyingConflictDoesNotFinalizeAppliedForTableDeleteIntentOnPrimaryAbsence()
+      throws Exception {
+    var service = new TransactionsServiceImpl();
+    var txRepo = Mockito.mock(TransactionRepository.class);
+    var intentRepo = Mockito.mock(TransactionIntentRepository.class);
+    var applier = Mockito.mock(TransactionIntentApplierSupport.class);
+    var pointerStore = Mockito.mock(ai.floedb.floecat.storage.spi.PointerStore.class);
+    var blobStore = Mockito.mock(BlobStore.class);
+
+    inject(service, "txRepo", txRepo);
+    inject(service, "intentRepo", intentRepo);
+    inject(service, "intentApplierSupport", applier);
+    inject(service, "pointerStore", pointerStore);
+    inject(service, "blobStore", blobStore);
+
+    Transaction txn =
+        Transaction.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setState(TransactionState.TS_APPLYING)
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .build();
+    String targetKey = Keys.tablePointerById("acct", "table-1");
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setTargetPointerKey(targetKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri("acct", "tx-1", targetKey))
+            .setExpectedOwnedNamePointerKey(
+                Keys.tablePointerByName("acct", "cat-1", "ns-1", "orders"))
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    when(txRepo.getById("acct", "tx-1")).thenReturn(Optional.of(txn), Optional.of(txn));
+    when(intentRepo.listByTx("acct", "tx-1")).thenReturn(List.of(intent));
+    when(intentRepo.getByTarget("acct", targetKey)).thenReturn(Optional.of(intent));
+    when(applier.applyTransactionBestEffort(List.of(intent), intentRepo))
+        .thenReturn(
+            TransactionIntentApplierSupport.ApplyOutcome.conflict(
+                "EXPECTED_VERSION_MISMATCH", "pointer version changed", 1L, 2L, null));
+    when(pointerStore.get(targetKey)).thenReturn(Optional.empty());
+    String lingeringNameKey = Keys.tablePointerByName("acct", "cat-1", "ns-1", "orders");
+    String lingeringBlobUri = "/accounts/acct/tables/table-1/table/blob.pb";
+    when(pointerStore.get(lingeringNameKey))
+        .thenReturn(
+            Optional.of(
+                Pointer.newBuilder()
+                    .setKey(lingeringNameKey)
+                    .setBlobUri(lingeringBlobUri)
+                    .setVersion(1L)
+                    .build()));
+    when(blobStore.get(lingeringBlobUri))
+        .thenReturn(
+            Table.newBuilder()
+                .setResourceId(ResourceId.newBuilder().setAccountId("acct").setId("table-1"))
+                .setCatalogId(ResourceId.newBuilder().setAccountId("acct").setId("cat-1"))
+                .setNamespaceId(ResourceId.newBuilder().setAccountId("acct").setId("ns-1"))
+                .setDisplayName("orders")
+                .build()
+                .toByteArray());
+    when(txRepo.metaFor("acct", "tx-1"))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(23L).build());
+    when(txRepo.update(
+            argThat(
+                updated ->
+                    updated != null
+                        && updated.getState() == TransactionState.TS_APPLY_FAILED_CONFLICT),
+            anyLong()))
+        .thenReturn(true);
+    when(intentRepo.update(
+            argThat(
+                candidate ->
+                    candidate.getTxId().equals(intent.getTxId())
+                        && candidate.getTargetPointerKey().equals(intent.getTargetPointerKey())
+                        && candidate.hasApplyErrorAt())))
+        .thenReturn(true);
+
+    Transaction committed =
+        invokeCommitPrivate(
+            service,
+            "acct",
+            CommitTransactionRequest.newBuilder().setTxId("tx-1").build(),
+            Timestamps.fromMillis(10));
+
+    assertEquals(TransactionState.TS_APPLY_FAILED_CONFLICT, committed.getState());
+    verify(intentRepo, never()).deleteBothIndicesBestEffort(intent);
+  }
+
+  @Test
+  void commitApplyingConflictFinalizesAppliedForTableDeleteIntentWhenBothPointersAreGone()
+      throws Exception {
+    var service = new TransactionsServiceImpl();
+    var txRepo = Mockito.mock(TransactionRepository.class);
+    var intentRepo = Mockito.mock(TransactionIntentRepository.class);
+    var applier = Mockito.mock(TransactionIntentApplierSupport.class);
+    var pointerStore = Mockito.mock(ai.floedb.floecat.storage.spi.PointerStore.class);
+    var blobStore = Mockito.mock(BlobStore.class);
+
+    inject(service, "txRepo", txRepo);
+    inject(service, "intentRepo", intentRepo);
+    inject(service, "intentApplierSupport", applier);
+    inject(service, "pointerStore", pointerStore);
+    inject(service, "blobStore", blobStore);
+
+    Transaction txn =
+        Transaction.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setState(TransactionState.TS_APPLYING)
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .build();
+    String targetKey = Keys.tablePointerById("acct", "table-1");
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setTargetPointerKey(targetKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri("acct", "tx-1", targetKey))
+            .setExpectedOwnedNamePointerKey(
+                Keys.tablePointerByName("acct", "cat-1", "ns-1", "orders"))
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    when(txRepo.getById("acct", "tx-1")).thenReturn(Optional.of(txn), Optional.of(txn));
+    when(intentRepo.listByTx("acct", "tx-1")).thenReturn(List.of(intent));
+    when(intentRepo.getByTarget("acct", targetKey)).thenReturn(Optional.of(intent));
+    when(applier.applyTransactionBestEffort(List.of(intent), intentRepo))
+        .thenReturn(
+            TransactionIntentApplierSupport.ApplyOutcome.conflict(
+                "EXPECTED_VERSION_MISMATCH", "pointer version changed", 1L, 2L, null));
+    when(pointerStore.get(targetKey)).thenReturn(Optional.empty());
+    when(pointerStore.get(Keys.tablePointerByName("acct", "cat-1", "ns-1", "orders")))
+        .thenReturn(Optional.empty());
+    when(txRepo.metaFor("acct", "tx-1"))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(24L).build());
+    when(txRepo.update(
+            argThat(
+                updated -> updated != null && updated.getState() == TransactionState.TS_APPLIED),
+            anyLong()))
+        .thenReturn(true);
+    when(intentRepo.deleteBothIndicesBestEffort(intent)).thenReturn(true);
+
+    Transaction committed =
+        invokeCommitPrivate(
+            service,
+            "acct",
+            CommitTransactionRequest.newBuilder().setTxId("tx-1").build(),
+            Timestamps.fromMillis(10));
+
+    assertEquals(TransactionState.TS_APPLIED, committed.getState());
+    verify(intentRepo).deleteBothIndicesBestEffort(intent);
+  }
+
+  @Test
+  void commitApplyingConflictDoesNotFinalizeAppliedForTableDeleteWhenOwnedNameBlobIsUnreadable()
+      throws Exception {
+    var service = new TransactionsServiceImpl();
+    var txRepo = Mockito.mock(TransactionRepository.class);
+    var intentRepo = Mockito.mock(TransactionIntentRepository.class);
+    var applier = Mockito.mock(TransactionIntentApplierSupport.class);
+    var pointerStore = Mockito.mock(ai.floedb.floecat.storage.spi.PointerStore.class);
+    var blobStore = Mockito.mock(BlobStore.class);
+
+    inject(service, "txRepo", txRepo);
+    inject(service, "intentRepo", intentRepo);
+    inject(service, "intentApplierSupport", applier);
+    inject(service, "pointerStore", pointerStore);
+    inject(service, "blobStore", blobStore);
+
+    Transaction txn =
+        Transaction.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setState(TransactionState.TS_APPLYING)
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .build();
+    String targetKey = Keys.tablePointerById("acct", "table-1");
+    String nameKey = Keys.tablePointerByName("acct", "cat-1", "ns-1", "orders");
+    String unreadableBlobUri = "/accounts/acct/tables/table-1/table/corrupt.pb";
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setTargetPointerKey(targetKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri("acct", "tx-1", targetKey))
+            .setExpectedOwnedNamePointerKey(nameKey)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    when(txRepo.getById("acct", "tx-1")).thenReturn(Optional.of(txn), Optional.of(txn));
+    when(intentRepo.listByTx("acct", "tx-1")).thenReturn(List.of(intent));
+    when(intentRepo.getByTarget("acct", targetKey)).thenReturn(Optional.of(intent));
+    when(applier.applyTransactionBestEffort(List.of(intent), intentRepo))
+        .thenReturn(
+            TransactionIntentApplierSupport.ApplyOutcome.conflict(
+                "EXPECTED_VERSION_MISMATCH", "pointer version changed", 1L, 2L, null));
+    when(pointerStore.get(targetKey)).thenReturn(Optional.empty());
+    when(pointerStore.get(nameKey))
+        .thenReturn(
+            Optional.of(
+                Pointer.newBuilder()
+                    .setKey(nameKey)
+                    .setBlobUri(unreadableBlobUri)
+                    .setVersion(1L)
+                    .build()));
+    when(blobStore.get(unreadableBlobUri)).thenThrow(new RuntimeException("corrupt blob"));
+    when(txRepo.metaFor("acct", "tx-1"))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(25L).build());
+    when(txRepo.update(
+            argThat(
+                updated ->
+                    updated != null
+                        && updated.getState() == TransactionState.TS_APPLY_FAILED_CONFLICT),
+            anyLong()))
+        .thenReturn(true);
+    when(intentRepo.update(
+            argThat(
+                candidate ->
+                    candidate.getTxId().equals(intent.getTxId())
+                        && candidate.getTargetPointerKey().equals(intent.getTargetPointerKey())
+                        && candidate.hasApplyErrorAt())))
+        .thenReturn(true);
+
+    Transaction committed =
+        invokeCommitPrivate(
+            service,
+            "acct",
+            CommitTransactionRequest.newBuilder().setTxId("tx-1").build(),
+            Timestamps.fromMillis(10));
+
+    assertEquals(TransactionState.TS_APPLY_FAILED_CONFLICT, committed.getState());
+    verify(intentRepo, never()).deleteBothIndicesBestEffort(intent);
+  }
+
+  @Test
+  void commitApplyingConflictFinalizesAppliedForTableDeleteWhenPrimaryWasAlreadyAbsentAtPrepare()
+      throws Exception {
+    var service = new TransactionsServiceImpl();
+    var txRepo = Mockito.mock(TransactionRepository.class);
+    var intentRepo = Mockito.mock(TransactionIntentRepository.class);
+    var applier = Mockito.mock(TransactionIntentApplierSupport.class);
+    var pointerStore = new InMemoryPointerStore();
+    var blobStore = new InMemoryBlobStore();
+
+    inject(service, "txRepo", txRepo);
+    inject(service, "intentRepo", intentRepo);
+    inject(service, "intentApplierSupport", applier);
+    inject(service, "pointerStore", pointerStore);
+    inject(service, "blobStore", blobStore);
+
+    Transaction txn =
+        Transaction.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setState(TransactionState.TS_APPLYING)
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .build();
+    String targetKey = Keys.tablePointerById("acct", "table-1");
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setTargetPointerKey(targetKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri("acct", "tx-1", targetKey))
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    when(txRepo.getById("acct", "tx-1")).thenReturn(Optional.of(txn), Optional.of(txn));
+    when(intentRepo.listByTx("acct", "tx-1")).thenReturn(List.of(intent));
+    when(intentRepo.getByTarget("acct", targetKey)).thenReturn(Optional.of(intent));
+    when(applier.applyTransactionBestEffort(List.of(intent), intentRepo))
+        .thenReturn(
+            TransactionIntentApplierSupport.ApplyOutcome.conflict(
+                "EXPECTED_VERSION_MISMATCH", "pointer version changed", 1L, 2L, null));
+    when(txRepo.metaFor("acct", "tx-1"))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(26L).build());
+    when(txRepo.update(
+            argThat(
+                updated -> updated != null && updated.getState() == TransactionState.TS_APPLIED),
+            anyLong()))
+        .thenReturn(true);
+    when(intentRepo.deleteBothIndicesBestEffort(intent)).thenReturn(true);
+
+    Transaction committed =
+        invokeCommitPrivate(
+            service,
+            "acct",
+            CommitTransactionRequest.newBuilder().setTxId("tx-1").build(),
+            Timestamps.fromMillis(10));
+
+    assertEquals(TransactionState.TS_APPLIED, committed.getState());
+    verify(intentRepo).deleteBothIndicesBestEffort(intent);
+  }
+
+  @Test
   void commitApplyingIgnoresExpiryAndFinalizesApplied() throws Exception {
     var service = new TransactionsServiceImpl();
     var txRepo = Mockito.mock(TransactionRepository.class);
@@ -636,7 +996,7 @@ class TransactionsServiceImplTest {
                     .setKey(targetKey)
                     .setBlobUri(tableBlobUri)
                     .setVersion(7L)
-                    .build()));
+            .build()));
     when(blobStore.get(tableBlobUri)).thenReturn(table.toByteArray());
     when(intentRepo.getByTarget(accountId, targetKey)).thenReturn(Optional.empty());
     when(txRepo.metaFor(accountId, txId))
@@ -680,6 +1040,80 @@ class TransactionsServiceImplTest {
   }
 
   @Test
+  void prepareAlreadyPreparedTableDeleteRequiresMatchingOwnedNamePointerMetadata()
+      throws Exception {
+    var service = new TransactionsServiceImpl();
+    var txRepo = Mockito.mock(TransactionRepository.class);
+    var intentRepo = Mockito.mock(TransactionIntentRepository.class);
+    var pointerStore = Mockito.mock(ai.floedb.floecat.storage.spi.PointerStore.class);
+    var blobStore = Mockito.mock(BlobStore.class);
+
+    inject(service, "txRepo", txRepo);
+    inject(service, "intentRepo", intentRepo);
+    inject(service, "pointerStore", pointerStore);
+    inject(service, "blobStore", blobStore);
+
+    String accountId = "acct";
+    String txId = "tx-1";
+    String tableId = "table-1";
+    String targetKey = Keys.tablePointerById(accountId, tableId);
+    String blobUri = "/accounts/acct/tables/table-1/table/blob.pb";
+    Transaction txn =
+        Transaction.newBuilder()
+            .setAccountId(accountId)
+            .setTxId(txId)
+            .setState(TransactionState.TS_PREPARED)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .setExpiresAt(Timestamps.fromMillis(60_000))
+            .build();
+    TransactionIntent storedIntent =
+        TransactionIntent.newBuilder()
+            .setAccountId(accountId)
+            .setTxId(txId)
+            .setTargetPointerKey(targetKey)
+            .setBlobUri(Keys.transactionDeleteSentinelUri(accountId, txId, targetKey))
+            .setExpectedOwnedNamePointerKey(
+                Keys.tablePointerByName(accountId, "cat-1", "ns-1", "old-name"))
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    when(txRepo.getById(accountId, txId)).thenReturn(Optional.of(txn));
+    when(intentRepo.listByTx(accountId, txId)).thenReturn(List.of(storedIntent));
+    when(pointerStore.get(targetKey))
+        .thenReturn(
+            Optional.of(
+                Pointer.newBuilder().setKey(targetKey).setBlobUri(blobUri).setVersion(7L).build()));
+    when(blobStore.get(blobUri))
+        .thenReturn(
+            Table.newBuilder()
+                .setResourceId(ResourceId.newBuilder().setAccountId(accountId).setId(tableId))
+                .setCatalogId(ResourceId.newBuilder().setAccountId(accountId).setId("cat-1"))
+                .setNamespaceId(ResourceId.newBuilder().setAccountId(accountId).setId("ns-1"))
+                .setDisplayName("new-name")
+                .build()
+                .toByteArray());
+
+    var request =
+        PrepareTransactionRequest.newBuilder()
+            .setTxId(txId)
+            .addChanges(
+                TxChange.newBuilder()
+                    .setTableId(
+                        ResourceId.newBuilder()
+                            .setAccountId(accountId)
+                            .setId(tableId)
+                            .setKind(ResourceKind.RK_TABLE))
+                    .setIntendedBlobUri(
+                        Keys.transactionDeleteSentinelUri(accountId, txId, targetKey)))
+            .build();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> invokePreparePrivate(service, accountId, request, Timestamps.fromMillis(10)));
+  }
+
+  @Test
   void intentsAlreadyAppliedTreatsTableDeleteSentinelAsAppliedWhenPointersAreCleared()
       throws Exception {
     var service = new TransactionsServiceImpl();
@@ -709,6 +1143,123 @@ class TransactionsServiceImplTest {
     m.setAccessible(true);
 
     assertTrue((Boolean) m.invoke(service, List.of(intent)));
+  }
+
+  @Test
+  void prepareTableDeleteFailsWhenCurrentTablePointerBlobIsUnreadable() throws Exception {
+    var service = new TransactionsServiceImpl();
+    var txRepo = Mockito.mock(TransactionRepository.class);
+    var intentRepo = Mockito.mock(TransactionIntentRepository.class);
+    var pointerStore = Mockito.mock(ai.floedb.floecat.storage.spi.PointerStore.class);
+    var blobStore = Mockito.mock(BlobStore.class);
+
+    inject(service, "txRepo", txRepo);
+    inject(service, "intentRepo", intentRepo);
+    inject(service, "pointerStore", pointerStore);
+    inject(service, "blobStore", blobStore);
+
+    String accountId = "acct";
+    String txId = "tx-1";
+    String tableId = "table-1";
+    String targetKey = Keys.tablePointerById(accountId, tableId);
+    String blobUri = "/accounts/acct/tables/table-1/table/blob.pb";
+    Transaction txn =
+        Transaction.newBuilder()
+            .setAccountId(accountId)
+            .setTxId(txId)
+            .setState(TransactionState.TS_OPEN)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .setExpiresAt(Timestamps.fromMillis(60_000))
+            .build();
+
+    when(txRepo.getById(accountId, txId)).thenReturn(Optional.of(txn));
+    when(pointerStore.get(targetKey))
+        .thenReturn(
+            Optional.of(
+                Pointer.newBuilder().setKey(targetKey).setBlobUri(blobUri).setVersion(7L).build()));
+    when(blobStore.get(blobUri)).thenReturn(null);
+
+    var request =
+        PrepareTransactionRequest.newBuilder()
+            .setTxId(txId)
+            .addChanges(
+                TxChange.newBuilder()
+                    .setTableId(
+                        ResourceId.newBuilder()
+                            .setAccountId(accountId)
+                            .setId(tableId)
+                            .setKind(ResourceKind.RK_TABLE))
+                    .setIntendedBlobUri(
+                        Keys.transactionDeleteSentinelUri(accountId, txId, targetKey)))
+            .build();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> invokePreparePrivate(service, accountId, request, Timestamps.fromMillis(10)));
+    verify(intentRepo, never()).create(any());
+  }
+
+  @Test
+  void prepareTableDeleteFailsWhenCurrentTablePointerBlobTargetsDifferentTable() throws Exception {
+    var service = new TransactionsServiceImpl();
+    var txRepo = Mockito.mock(TransactionRepository.class);
+    var intentRepo = Mockito.mock(TransactionIntentRepository.class);
+    var pointerStore = Mockito.mock(ai.floedb.floecat.storage.spi.PointerStore.class);
+    var blobStore = Mockito.mock(BlobStore.class);
+
+    inject(service, "txRepo", txRepo);
+    inject(service, "intentRepo", intentRepo);
+    inject(service, "pointerStore", pointerStore);
+    inject(service, "blobStore", blobStore);
+
+    String accountId = "acct";
+    String txId = "tx-1";
+    String targetKey = Keys.tablePointerById(accountId, "table-1");
+    String blobUri = "/accounts/acct/tables/table-2/table/blob.pb";
+    Transaction txn =
+        Transaction.newBuilder()
+            .setAccountId(accountId)
+            .setTxId(txId)
+            .setState(TransactionState.TS_OPEN)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .setExpiresAt(Timestamps.fromMillis(60_000))
+            .build();
+
+    when(txRepo.getById(accountId, txId)).thenReturn(Optional.of(txn));
+    when(pointerStore.get(targetKey))
+        .thenReturn(
+            Optional.of(
+                Pointer.newBuilder().setKey(targetKey).setBlobUri(blobUri).setVersion(7L).build()));
+    when(blobStore.get(blobUri))
+        .thenReturn(
+            Table.newBuilder()
+                .setResourceId(ResourceId.newBuilder().setAccountId(accountId).setId("table-2"))
+                .setCatalogId(ResourceId.newBuilder().setAccountId(accountId).setId("cat-1"))
+                .setNamespaceId(ResourceId.newBuilder().setAccountId(accountId).setId("ns-1"))
+                .setDisplayName("orders")
+                .build()
+                .toByteArray());
+
+    var request =
+        PrepareTransactionRequest.newBuilder()
+            .setTxId(txId)
+            .addChanges(
+                TxChange.newBuilder()
+                    .setTableId(
+                        ResourceId.newBuilder()
+                            .setAccountId(accountId)
+                            .setId("table-1")
+                            .setKind(ResourceKind.RK_TABLE))
+                    .setIntendedBlobUri(
+                        Keys.transactionDeleteSentinelUri(accountId, txId, targetKey)))
+            .build();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> invokePreparePrivate(service, accountId, request, Timestamps.fromMillis(10)));
+    verify(intentRepo, never()).create(any());
   }
 
   @Test
@@ -759,14 +1310,19 @@ class TransactionsServiceImplTest {
       CommitTransactionRequest request,
       com.google.protobuf.Timestamp now)
       throws Exception {
-    Method m =
-        TransactionsServiceImpl.class.getDeclaredMethod(
-            "commitTransaction",
-            String.class,
-            CommitTransactionRequest.class,
-            com.google.protobuf.Timestamp.class);
-    m.setAccessible(true);
-    return (Transaction) m.invoke(service, accountId, request, now);
+    try {
+      Method m =
+          TransactionsServiceImpl.class.getDeclaredMethod(
+              "commitTransaction",
+              String.class,
+              CommitTransactionRequest.class,
+              com.google.protobuf.Timestamp.class);
+      m.setAccessible(true);
+      return (Transaction) m.invoke(service, accountId, request, now);
+    } catch (InvocationTargetException e) {
+      rethrowReflectiveCause(e);
+      throw e;
+    }
   }
 
   private static Transaction invokePreparePrivate(
@@ -775,24 +1331,44 @@ class TransactionsServiceImplTest {
       PrepareTransactionRequest request,
       com.google.protobuf.Timestamp now)
       throws Exception {
-    Method m =
-        TransactionsServiceImpl.class.getDeclaredMethod(
-            "prepareTransaction",
-            String.class,
-            PrepareTransactionRequest.class,
-            com.google.protobuf.Timestamp.class);
-    m.setAccessible(true);
-    return (Transaction) m.invoke(service, accountId, request, now);
+    try {
+      Method m =
+          TransactionsServiceImpl.class.getDeclaredMethod(
+              "prepareTransaction",
+              String.class,
+              PrepareTransactionRequest.class,
+              com.google.protobuf.Timestamp.class);
+      m.setAccessible(true);
+      return (Transaction) m.invoke(service, accountId, request, now);
+    } catch (InvocationTargetException e) {
+      rethrowReflectiveCause(e);
+      throw e;
+    }
   }
 
   private static Transaction invokeAbortExpired(
       TransactionsServiceImpl service, Transaction txn, com.google.protobuf.Timestamp now)
       throws Exception {
-    Method m =
-        TransactionsServiceImpl.class.getDeclaredMethod(
-            "abortExpired", Transaction.class, com.google.protobuf.Timestamp.class);
-    m.setAccessible(true);
-    return (Transaction) m.invoke(service, txn, now);
+    try {
+      Method m =
+          TransactionsServiceImpl.class.getDeclaredMethod(
+              "abortExpired", Transaction.class, com.google.protobuf.Timestamp.class);
+      m.setAccessible(true);
+      return (Transaction) m.invoke(service, txn, now);
+    } catch (InvocationTargetException e) {
+      rethrowReflectiveCause(e);
+      throw e;
+    }
+  }
+
+  private static void rethrowReflectiveCause(InvocationTargetException e) throws Exception {
+    Throwable cause = e.getCause();
+    if (cause instanceof Exception ex) {
+      throw ex;
+    }
+    if (cause instanceof Error err) {
+      throw err;
+    }
   }
 
   private static void inject(Object target, String field, Object value) throws Exception {

--- a/tools/compose-smoke.sh
+++ b/tools/compose-smoke.sh
@@ -101,6 +101,7 @@ wait_for_connector_job() {
   local attempt
   local out
   local state
+  local normalized_state
 
   if [ -z "$job_id" ]; then
     echo "[FAIL] $label missing reconcile job id"
@@ -111,12 +112,22 @@ wait_for_connector_job() {
     out=$(run_cli_script "$compose_cmd" "account t-0001
 connector job $job_id
 quit")
-    state=$(printf "%s\n" "$out" | sed -n 's/.*state=\([A-Z_]*\).*/\1/p' | head -n1)
-    if [ "$state" = "JS_SUCCEEDED" ]; then
+    state=$(
+      printf "%s\n" "$out" \
+        | sed -n \
+            -e 's/.*state=\([A-Z_]*\).*/\1/p' \
+            -e 's/^[[:space:]]*state:[[:space:]]*\([[:alnum:]_-]*\).*/\1/p' \
+        | head -n1
+    )
+    normalized_state=$(printf "%s" "${state:-}" | tr '[:lower:]-' '[:upper:]_')
+    if [ "$normalized_state" = "JS_SUCCEEDED" ] || [ "$normalized_state" = "DONE" ]; then
       echo "[PASS] $label job succeeded ($job_id)"
       return 0
     fi
-    if [ "$state" = "JS_FAILED" ] || [ "$state" = "JS_CANCELLED" ]; then
+    if [ "$normalized_state" = "JS_FAILED" ] \
+      || [ "$normalized_state" = "JS_CANCELLED" ] \
+      || [ "$normalized_state" = "FAILED" ] \
+      || [ "$normalized_state" = "STOPPED" ]; then
       echo "$out"
       echo "[FAIL] $label job terminal state=$state ($job_id)"
       return 1

--- a/tools/compose-smoke.sh
+++ b/tools/compose-smoke.sh
@@ -76,7 +76,20 @@ should_run_client() {
 run_cli_script() {
   local compose_cmd="$1"
   local script="$2"
-  printf "%s\n" "$script" | eval "$compose_cmd run --rm -T cli"
+  local out
+  if ! out=$(printf "%s\n" "$script" | eval "$compose_cmd run --rm -T --no-deps cli" 2>&1); then
+    printf "%s\n" "$out" \
+      | sed \
+          -e '/^\[\+\] Creating /d' \
+          -e '/^[[:space:]]*✔ Container .* Running[0-9.]*s$/d' \
+          -e '/^[[:space:]]*Container .* Running[0-9.]*s$/d'
+    return 1
+  fi
+  printf "%s\n" "$out" \
+    | sed \
+        -e '/^\[\+\] Creating /d' \
+        -e '/^[[:space:]]*✔ Container .* Running[0-9.]*s$/d' \
+        -e '/^[[:space:]]*Container .* Running[0-9.]*s$/d'
 }
 
 wait_for_connector_job() {
@@ -170,6 +183,7 @@ assert_table_stats_available() {
   local snapshot_ids
   local last_out=""
 
+  echo "==> [SMOKE] waiting for stats for $table_fqn (retries=$retries sleep=${sleep_seconds}s)"
   for attempt in $(seq 1 "$retries"); do
     out=$(run_cli_script "$compose_cmd" "account t-0001
 stats files $table_fqn --current --limit 5
@@ -199,6 +213,9 @@ quit")
       fi
     done
 
+    if [ "$attempt" -eq 1 ] || [ $((attempt % 5)) -eq 0 ] || [ "$attempt" -eq "$retries" ]; then
+      echo "==> [SMOKE] stats not ready for $table_fqn yet (attempt $attempt/$retries)"
+    fi
     sleep "$sleep_seconds"
   done
 
@@ -977,6 +994,21 @@ print(
 run_sql("DROP TABLE iceberg.trino_merge_smoke")
 run_sql("DROP TABLE IF EXISTS iceberg.trino_mutation_smoke")
 run_sql("CREATE TABLE iceberg.trino_mutation_smoke (id INTEGER, v VARCHAR)")
+
+
+def latest_mutation_snapshot(*exclude_snapshot_ids):
+    filters = ["snapshot_id IS NOT NULL", "parent_id IS NOT NULL"]
+    for snapshot_id in exclude_snapshot_ids:
+        filters.append(f"snapshot_id <> {int(snapshot_id)}")
+    return scalar(
+        "SELECT CAST(snapshot_id AS VARCHAR) "
+        "FROM iceberg.\"trino_mutation_smoke$snapshots\" "
+        f"WHERE {' AND '.join(filters)} "
+        "ORDER BY committed_at DESC NULLS LAST, snapshot_id DESC "
+        "LIMIT 1"
+    )
+
+
 print(
     scalar(
         "SELECT 'mut_after_create=' || CAST(COUNT(*) AS VARCHAR) "
@@ -984,10 +1016,7 @@ print(
     )
 )
 run_sql("INSERT INTO iceberg.trino_mutation_smoke VALUES (1, 'a'), (2, 'b'), (3, 'c')")
-insert_snapshot_id = scalar(
-    "SELECT CAST(snapshot_id AS VARCHAR) "
-    "FROM iceberg.\"trino_mutation_smoke$snapshots\" ORDER BY committed_at DESC LIMIT 1"
-)
+insert_snapshot_id = latest_mutation_snapshot()
 print(
     scalar(
         "SELECT 'mut_after_insert=' || CAST(COUNT(*) AS VARCHAR) || ',' || "
@@ -996,10 +1025,7 @@ print(
     )
 )
 run_sql("DELETE FROM iceberg.trino_mutation_smoke WHERE id = 2")
-delete_snapshot_id = scalar(
-    "SELECT CAST(snapshot_id AS VARCHAR) "
-    "FROM iceberg.\"trino_mutation_smoke$snapshots\" ORDER BY committed_at DESC LIMIT 1"
-)
+delete_snapshot_id = latest_mutation_snapshot(insert_snapshot_id)
 print(
     scalar(
         "SELECT 'mut_after_delete=' || CAST(COUNT(*) AS VARCHAR) || ',' || "
@@ -1008,10 +1034,7 @@ print(
     )
 )
 run_sql("UPDATE iceberg.trino_mutation_smoke SET v = 'c2' WHERE id = 3")
-update_snapshot_id = scalar(
-    "SELECT CAST(snapshot_id AS VARCHAR) "
-    "FROM iceberg.\"trino_mutation_smoke$snapshots\" ORDER BY committed_at DESC LIMIT 1"
-)
+update_snapshot_id = latest_mutation_snapshot(insert_snapshot_id, delete_snapshot_id)
 print(
     scalar(
         "SELECT 'mut_after_update=' || CAST(COUNT(*) AS VARCHAR) || ',' || "
@@ -1188,7 +1211,7 @@ PY
   echo "==> [SMOKE][PASS] mode=$label"
 }
 
-SMOKE_MODES=${COMPOSE_SMOKE_MODES:-inmem,localstack,localstack-oidc}
+SMOKE_MODES=${COMPOSE_SMOKE_MODES:-localstack,localstack-oidc}
 echo "==> [COMPOSE] smoke modes=$SMOKE_MODES"
 
 IFS=',' read -r -a mode_list <<< "$SMOKE_MODES"

--- a/tools/compose-smoke.sh
+++ b/tools/compose-smoke.sh
@@ -20,6 +20,7 @@ COMPOSE_SMOKE_SAVE_LOG_DIR_DEFAULT=${COMPOSE_SMOKE_SAVE_LOG_DIR:-target/compose-
 COMPOSE_SMOKE_KEEP_ON_FAIL=${COMPOSE_SMOKE_KEEP_ON_FAIL:-false}
 COMPOSE_SMOKE_KEEP_ON_EXIT=${COMPOSE_SMOKE_KEEP_ON_EXIT:-false}
 COMPOSE_SMOKE_CLIENTS=${COMPOSE_SMOKE_CLIENTS:-duckdb,trino}
+COMPOSE_SMOKE_DUCKDB_IMAGE=${COMPOSE_SMOKE_DUCKDB_IMAGE:-duckdb/duckdb:1.4.4}
 COMPOSE_SMOKE_UPSTREAM_ICEBERG_IMPORT=${COMPOSE_SMOKE_UPSTREAM_ICEBERG_IMPORT:-true}
 COMPOSE_SMOKE_UPSTREAM_ICEBERG_URI=${COMPOSE_SMOKE_UPSTREAM_ICEBERG_URI:-http://polaris:8181/api/catalog}
 COMPOSE_SMOKE_UPSTREAM_ICEBERG_SOURCE_NS=${COMPOSE_SMOKE_UPSTREAM_ICEBERG_SOURCE_NS:-sales}
@@ -735,7 +736,7 @@ quit")
     local duckdb_query="SELECT 'duckdb_smoke_ok' AS status; SELECT 'call_center=' || CAST(COUNT(*) AS VARCHAR) AS check FROM iceberg_floecat.delta.call_center; SELECT 'my_local_delta_table=' || CAST(COUNT(*) AS VARCHAR) AS check FROM iceberg_floecat.delta.my_local_delta_table; SELECT 'my_local_nonnull_name=' || CAST(COUNT(name) AS VARCHAR) AS check FROM iceberg_floecat.delta.my_local_delta_table; SELECT 'dv_demo_delta=' || CAST(COUNT(*) AS VARCHAR) AS check FROM iceberg_floecat.delta.dv_demo_delta; SELECT 'dv_content=' || CAST(MIN(id) AS VARCHAR) || ',' || CAST(MAX(id) AS VARCHAR) || ',' || MIN(v) || ',' || MAX(v) AS check FROM iceberg_floecat.delta.dv_demo_delta; SELECT 'empty_join=' || CAST(COUNT(*) AS VARCHAR) AS check FROM iceberg_floecat.iceberg.trino_types i JOIN iceberg_floecat.delta.call_center d ON 1=0; DROP TABLE IF EXISTS iceberg_floecat.iceberg.duckdb_ctas_smoke; CREATE TABLE iceberg_floecat.iceberg.duckdb_ctas_smoke AS SELECT * FROM iceberg_floecat.delta.call_center LIMIT 5; SELECT 'ctas_count=' || CAST(COUNT(*) AS VARCHAR) AS check FROM iceberg_floecat.iceberg.duckdb_ctas_smoke; DROP TABLE iceberg_floecat.iceberg.duckdb_ctas_smoke; DROP TABLE IF EXISTS iceberg_floecat.iceberg.duckdb_mutation_smoke; CREATE TABLE iceberg_floecat.iceberg.duckdb_mutation_smoke (id INTEGER, v VARCHAR); SELECT 'mut_after_create=' || CAST(COUNT(*) AS VARCHAR) AS check FROM iceberg_floecat.iceberg.duckdb_mutation_smoke; INSERT INTO iceberg_floecat.iceberg.duckdb_mutation_smoke VALUES (1, 'a'), (2, 'b'), (3, 'c'); SELECT 'mut_after_insert=' || CAST(COUNT(*) AS VARCHAR) || ',' || CAST(SUM(id) AS VARCHAR) || ',' || MIN(v) || ',' || MAX(v) AS check FROM iceberg_floecat.iceberg.duckdb_mutation_smoke; DELETE FROM iceberg_floecat.iceberg.duckdb_mutation_smoke WHERE id = 2; SELECT 'mut_after_delete=' || CAST(COUNT(*) AS VARCHAR) || ',' || CAST(SUM(id) AS VARCHAR) || ',' || MIN(v) || ',' || MAX(v) AS check FROM iceberg_floecat.iceberg.duckdb_mutation_smoke; UPDATE iceberg_floecat.iceberg.duckdb_mutation_smoke SET v = 'c2' WHERE id = 3; SELECT 'mut_after_update=' || CAST(COUNT(*) AS VARCHAR) || ',' || CAST(SUM(id) AS VARCHAR) || ',' || MIN(v) || ',' || MAX(v) AS check FROM iceberg_floecat.iceberg.duckdb_mutation_smoke;"
 
     local duckdb_out
-    if ! duckdb_out=$(docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+    if ! duckdb_out=$(docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
       duckdb -c "$duckdb_bootstrap $duckdb_query" 2>&1); then
       echo "$duckdb_out"
       echo "[FAIL] $label duckdb command failed"
@@ -756,7 +757,7 @@ quit")
     assert_contains "$label duckdb mutation update" "$duckdb_out" "mut_after_update=2,4,a,c2"
 
     local duckdb_rename_out
-    if duckdb_rename_out=$(docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+    if duckdb_rename_out=$(docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
       duckdb -c "$duckdb_bootstrap DROP TABLE IF EXISTS iceberg_floecat.iceberg.duckdb_rename_dst_smoke; DROP TABLE IF EXISTS iceberg_floecat.iceberg.duckdb_rename_src_smoke; CREATE TABLE iceberg_floecat.iceberg.duckdb_rename_src_smoke (id INTEGER, v VARCHAR); INSERT INTO iceberg_floecat.iceberg.duckdb_rename_src_smoke VALUES (1, 'x'); ALTER TABLE iceberg_floecat.iceberg.duckdb_rename_src_smoke RENAME TO duckdb_rename_dst_smoke; SELECT 'rename_row_count=' || CAST(COUNT(*) AS VARCHAR) AS check FROM iceberg_floecat.iceberg.duckdb_rename_dst_smoke; DROP TABLE iceberg_floecat.iceberg.duckdb_rename_dst_smoke;" 2>&1); then
       echo "$duckdb_rename_out"
       assert_contains "$label duckdb rename row count" "$duckdb_rename_out" "rename_row_count=1"
@@ -765,12 +766,12 @@ quit")
       assert_contains_any "$label duckdb rename unsupported" "$duckdb_rename_out" \
         "Not implemented Error: Alter Schema Entry" \
         "Not implemented Error: Alter table type not supported: RENAME_TABLE"
-      docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+      docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
         duckdb -c "$duckdb_bootstrap DROP TABLE IF EXISTS iceberg_floecat.iceberg.duckdb_rename_dst_smoke; DROP TABLE IF EXISTS iceberg_floecat.iceberg.duckdb_rename_src_smoke;" >/dev/null 2>&1 || true
     fi
 
     local duckdb_namespace_out
-    if duckdb_namespace_out=$(docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+    if duckdb_namespace_out=$(docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
       duckdb -c "$duckdb_bootstrap CREATE SCHEMA IF NOT EXISTS iceberg_floecat.duckdb_ns_smoke; SELECT 'ns_create_ok=1' AS check; DROP SCHEMA iceberg_floecat.duckdb_ns_smoke; SELECT 'ns_drop_ok=1' AS check;" 2>&1); then
       echo "$duckdb_namespace_out"
       assert_contains "$label duckdb namespace create" "$duckdb_namespace_out" "ns_create_ok=1"
@@ -782,7 +783,7 @@ quit")
 
     local duckdb_snapshots_out
     local duckdb_snapshots_query_fn="COPY (SELECT snapshot_id FROM iceberg_snapshots('iceberg_floecat.iceberg.duckdb_mutation_smoke') ORDER BY timestamp_ms DESC) TO '/dev/stdout' (FORMAT CSV, HEADER FALSE);"
-    if ! duckdb_snapshots_out=$(docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+    if ! duckdb_snapshots_out=$(docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
       duckdb -csv -c "$duckdb_bootstrap $duckdb_snapshots_query_fn" 2>&1); then
       echo "$duckdb_snapshots_out"
       echo "[FAIL] $label duckdb time travel snapshot discovery failed"
@@ -801,7 +802,7 @@ quit")
 
     local duckdb_tt_query="SELECT 'mut_tt_after_insert=' || CAST(COUNT(*) AS VARCHAR) || ',' || CAST(SUM(id) AS VARCHAR) || ',' || MIN(v) || ',' || MAX(v) AS check FROM iceberg_floecat.iceberg.duckdb_mutation_smoke AT (VERSION => ${duckdb_snapshot_insert_id}); SELECT 'mut_tt_after_delete=' || CAST(COUNT(*) AS VARCHAR) || ',' || CAST(SUM(id) AS VARCHAR) || ',' || MIN(v) || ',' || MAX(v) AS check FROM iceberg_floecat.iceberg.duckdb_mutation_smoke AT (VERSION => ${duckdb_snapshot_delete_id}); SELECT 'mut_tt_after_update=' || CAST(COUNT(*) AS VARCHAR) || ',' || CAST(SUM(id) AS VARCHAR) || ',' || MIN(v) || ',' || MAX(v) AS check FROM iceberg_floecat.iceberg.duckdb_mutation_smoke AT (VERSION => ${duckdb_snapshot_update_id});"
     local duckdb_tt_out
-    if ! duckdb_tt_out=$(docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+    if ! duckdb_tt_out=$(docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
       duckdb -c "$duckdb_bootstrap $duckdb_tt_query" 2>&1); then
       echo "$duckdb_tt_out"
       echo "[FAIL] $label duckdb time travel query failed"
@@ -819,7 +820,7 @@ quit")
       "$COMPOSE_SMOKE_ICEBERG_FORMAT_MATRIX_STATS_SLEEP_SECONDS"
 
     local alter_out
-    if alter_out=$(docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+    if alter_out=$(docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
       duckdb -c "$duckdb_bootstrap ALTER TABLE iceberg_floecat.iceberg.duckdb_mutation_smoke ADD COLUMN note VARCHAR; SELECT 'mut_after_alter=' || CAST(COUNT(*) AS VARCHAR) || ',' || CAST(COUNT(note) AS VARCHAR) AS check FROM iceberg_floecat.iceberg.duckdb_mutation_smoke; DROP TABLE iceberg_floecat.iceberg.duckdb_mutation_smoke;" 2>&1); then
       echo "$alter_out"
       assert_contains "$label duckdb mutation alter" "$alter_out" "mut_after_alter=2,0"
@@ -828,12 +829,12 @@ quit")
       assert_contains_any "$label duckdb mutation alter unsupported" "$alter_out" \
         "Not implemented Error: Alter Schema Entry" \
         "Not implemented Error: Alter table type not supported:"
-      docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+      docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
         duckdb -c "$duckdb_bootstrap DROP TABLE IF EXISTS iceberg_floecat.iceberg.duckdb_mutation_smoke;" >/dev/null 2>&1 || true
     fi
 
     local drop_check_out
-    if drop_check_out=$(docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+    if drop_check_out=$(docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
       duckdb -c "$duckdb_bootstrap SELECT COUNT(*) FROM iceberg_floecat.iceberg.duckdb_ctas_smoke;" 2>&1); then
       echo "$drop_check_out"
       echo "[FAIL] $label duckdb drop table verification failed (table still queryable)"
@@ -846,7 +847,7 @@ quit")
     if is_truthy "$COMPOSE_SMOKE_ICEBERG_FORMAT_MATRIX"; then
       echo "==> [SMOKE] duckdb iceberg format-version matrix (v1,v2)"
       local duckdb_fmt_out
-      if ! duckdb_fmt_out=$(docker run --rm --network "${compose_project}_floecat" duckdb/duckdb:latest \
+      if ! duckdb_fmt_out=$(docker run --rm --network "${compose_project}_floecat" "$COMPOSE_SMOKE_DUCKDB_IMAGE" \
         duckdb -c "$duckdb_bootstrap DROP TABLE IF EXISTS iceberg_floecat.iceberg.duckdb_fmt_v1_smoke; DROP TABLE IF EXISTS iceberg_floecat.iceberg.duckdb_fmt_v2_smoke; CREATE TABLE iceberg_floecat.iceberg.duckdb_fmt_v1_smoke (id INTEGER, v VARCHAR) WITH (format_version=1); INSERT INTO iceberg_floecat.iceberg.duckdb_fmt_v1_smoke VALUES (101, 'duckdb_v1'); SELECT 'duckdb_fmt_v1_count=' || CAST(COUNT(*) AS VARCHAR) || ',' || CAST(SUM(id) AS VARCHAR) || ',' || MIN(v) || ',' || MAX(v) AS check FROM iceberg_floecat.iceberg.duckdb_fmt_v1_smoke; CREATE TABLE iceberg_floecat.iceberg.duckdb_fmt_v2_smoke (id INTEGER, v VARCHAR) WITH (format_version=2); INSERT INTO iceberg_floecat.iceberg.duckdb_fmt_v2_smoke VALUES (201, 'duckdb_v2'); SELECT 'duckdb_fmt_v2_count=' || CAST(COUNT(*) AS VARCHAR) || ',' || CAST(SUM(id) AS VARCHAR) || ',' || MIN(v) || ',' || MAX(v) AS check FROM iceberg_floecat.iceberg.duckdb_fmt_v2_smoke;" 2>&1); then
         echo "$duckdb_fmt_out"
         echo "[FAIL] $label duckdb format-version matrix command failed"


### PR DESCRIPTION
## Summary

This PR separates connector planning from table execution in the reconciler, enabling split control-plane and executor deployments while preserving the existing top-level jobs. It also strengthens durable queue behavior, execution routing, progress reporting, name normalization, and test coverage so planning, leasing, retries, cancellation, and remote execution behave more consistently and predictably.

## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [X] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

