### PR TITLE
Treat DynamoDB TransactionConflict as retryable in txnWriteCas

### DIFF
--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -398,14 +398,25 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
         .onFailure(TransactionCanceledException.class)
         .recoverWithItem(
             t -> {
-              // Return false only for conditional check failure; otherwise rethrow.
+              // Return false for retryable conflicts; throw on unexpected reasons.
               TransactionCanceledException ex = (TransactionCanceledException) t;
+              boolean sawRetryable = false;
               if (ex.cancellationReasons() != null) {
                 for (var r : ex.cancellationReasons()) {
-                  if (r != null && "ConditionalCheckFailed".equals(r.code())) {
-                    return false;
+                  if (r == null || "None".equals(r.code())) {
+                    continue;
                   }
+                  if ("ConditionalCheckFailed".equals(r.code())
+                      || "TransactionConflict".equals(r.code())) {
+                    sawRetryable = true;
+                    continue;
+                  }
+                  // Non-retryable reason — abort immediately
+                  throw ex;
                 }
+              }
+              if (sawRetryable) {
+                return false;
               }
               throw ex;
             });

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
@@ -447,9 +447,45 @@ public class DynamoDbKvStoreTest {
   }
 
   @Test
-  void txnWriteCas_returns_false_with_mixed_cancellation_reasons() {
+  void txnWriteCas_rethrows_when_mixed_with_non_retryable_reason() {
     FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
     handler.setCancellationReasonCodes(List.of("Other", "ConditionalCheckFailed"));
+    DynamoDbKvStore store = newStore(handler);
+
+    var ops =
+        List.<KvStore.TxnOp>of(
+            new KvStore.TxnPut(record("pk1", "sk1", "K", "v", 1L, Map.of()), 0L));
+    assertThrows(RuntimeException.class, () -> store.txnWriteCas(ops).await().indefinitely());
+  }
+
+  @Test
+  void txnWriteCas_returns_false_on_transaction_conflict() {
+    FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
+    handler.setCancellationReasonCodes(List.of("TransactionConflict"));
+    DynamoDbKvStore store = newStore(handler);
+
+    var ops =
+        List.<KvStore.TxnOp>of(
+            new KvStore.TxnPut(record("pk1", "sk1", "K", "v", 1L, Map.of()), 0L));
+    assertFalse(store.txnWriteCas(ops).await().indefinitely());
+  }
+
+  @Test
+  void txnWriteCas_returns_false_with_none_and_retryable_reasons() {
+    FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
+    handler.setCancellationReasonCodes(List.of("None", "ConditionalCheckFailed"));
+    DynamoDbKvStore store = newStore(handler);
+
+    var ops =
+        List.<KvStore.TxnOp>of(
+            new KvStore.TxnPut(record("pk1", "sk1", "K", "v", 1L, Map.of()), 0L));
+    assertFalse(store.txnWriteCas(ops).await().indefinitely());
+  }
+
+  @Test
+  void txnWriteCas_returns_false_with_mixed_retryable_reasons() {
+    FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
+    handler.setCancellationReasonCodes(List.of("TransactionConflict", "ConditionalCheckFailed"));
     DynamoDbKvStore store = newStore(handler);
 
     var ops =


### PR DESCRIPTION
DynamoDB returns TransactionConflict when concurrent transactions touch the same item (e.g. RESET ALL racing with updateLastActivity). Previously only ConditionalCheckFailed was treated as a CAS miss (returning false); TransactionConflict was rethrown as an unrecoverable XX000/UNKNOWN error.

Now both reasons return false from txnWriteCas, which lets SessionCache.updateWithRetry handle the conflict: it refreshes the session from DynamoDB and retries the mutation (up to 3 attempts by default, configured via app.session.update-retries).

Fixes: eng-floe/core#1060

## Testing

Describe how this was validated.

- Tests executed against staging environment are now passing.

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)
