### PR TITLE
GetUserObjects: timing/debug observability + chunked resolution/pinning performance fixes

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
@@ -33,8 +33,8 @@ import io.quarkus.grpc.GlobalInterceptor;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.lang.reflect.Method;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -81,7 +81,8 @@ public class RpcLoggingInterceptor implements ServerInterceptor {
             if (nonBlank(correlationId)) {
               nextTrailers.put(CORRELATION_ID_KEY, correlationId);
             }
-            logCall(status, nextTrailers, method, durationMs, logCorrelationId, logQueryIdRef.get());
+            logCall(
+                status, nextTrailers, method, durationMs, logCorrelationId, logQueryIdRef.get());
             super.close(status, nextTrailers);
           }
         };

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
@@ -17,10 +17,13 @@
 package ai.floedb.floecat.service.error.impl;
 
 import ai.floedb.floecat.common.rpc.Error;
+import ai.floedb.floecat.service.context.impl.InboundCallContextHelper;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import com.google.protobuf.Any;
+import com.google.protobuf.Message;
 import com.google.rpc.Status;
 import io.grpc.ForwardingServerCall;
+import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
@@ -29,6 +32,8 @@ import io.grpc.protobuf.StatusProto;
 import io.quarkus.grpc.GlobalInterceptor;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeUnit;
 import org.jboss.logging.Logger;
 
@@ -46,15 +51,28 @@ public class RpcLoggingInterceptor implements ServerInterceptor {
     final String method = call.getMethodDescriptor().getFullMethodName();
 
     String contextCorrelationId = InboundContextInterceptor.CORR_KEY.get();
+    String contextQueryId = InboundContextInterceptor.QUERY_KEY.get();
     String headerCorrelationId = headers.get(CORRELATION_ID_KEY);
+    String headerQueryId = headers.get(QUERY_ID_KEY);
     final String correlationId =
         nonBlank(contextCorrelationId)
             ? contextCorrelationId
             : nonBlank(headerCorrelationId) ? headerCorrelationId : "";
     final String logCorrelationId = nonBlank(correlationId) ? correlationId : MISSING;
+    final AtomicReference<String> logQueryIdRef =
+        new AtomicReference<>(chooseFirstNonBlank(contextQueryId, headerQueryId, MISSING));
 
     ServerCall<ReqT, RespT> forwarding =
         new ForwardingServerCall.SimpleForwardingServerCall<>(call) {
+          @Override
+          public void sendMessage(RespT message) {
+            String queryIdFromResponse = extractQueryId(message);
+            if (nonBlank(queryIdFromResponse)) {
+              logQueryIdRef.set(queryIdFromResponse);
+            }
+            super.sendMessage(message);
+          }
+
           @Override
           public void close(io.grpc.Status status, Metadata trailers) {
             long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
@@ -63,23 +81,36 @@ public class RpcLoggingInterceptor implements ServerInterceptor {
             if (nonBlank(correlationId)) {
               nextTrailers.put(CORRELATION_ID_KEY, correlationId);
             }
-            logCall(status, nextTrailers, method, durationMs, logCorrelationId);
+            logCall(status, nextTrailers, method, durationMs, logCorrelationId, logQueryIdRef.get());
             super.close(status, nextTrailers);
           }
         };
 
-    return next.startCall(forwarding, headers);
+    var delegate = next.startCall(forwarding, headers);
+    return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(delegate) {
+      @Override
+      public void onMessage(ReqT message) {
+        String queryIdFromMessage = extractQueryId(message);
+        if (nonBlank(queryIdFromMessage)) {
+          logQueryIdRef.set(queryIdFromMessage);
+        }
+        super.onMessage(message);
+      }
+    };
   }
 
   private static final Metadata.Key<String> CORRELATION_ID_KEY =
       Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> QUERY_ID_KEY =
+      Metadata.Key.of(InboundCallContextHelper.HEADER_QUERY_ID, Metadata.ASCII_STRING_MARSHALLER);
 
-  private void logCall(
+  void logCall(
       io.grpc.Status status,
       Metadata trailers,
       String method,
       long durationMs,
-      String logCorrelationId) {
+      String logCorrelationId,
+      String logQueryId) {
 
     Status statusProto = StatusProto.fromStatusAndTrailers(status, trailers);
     Error floecatError = extractFloecatError(statusProto);
@@ -105,6 +136,8 @@ public class RpcLoggingInterceptor implements ServerInterceptor {
             + appCode
             + " message_key="
             + messageKey
+            + " query_id="
+            + logQueryId
             + " correlation_id="
             + logCorrelationId
             + " duration_ms="
@@ -151,5 +184,39 @@ public class RpcLoggingInterceptor implements ServerInterceptor {
 
   private static boolean nonBlank(String value) {
     return value != null && !value.isBlank();
+  }
+
+  static String extractQueryId(Object message) {
+    if (message == null) {
+      return "";
+    }
+    if (message instanceof Message protoMessage) {
+      var queryField = protoMessage.getDescriptorForType().findFieldByName("query_id");
+      if (queryField != null) {
+        Object value = protoMessage.getField(queryField);
+        if (value instanceof String queryId && nonBlank(queryId)) {
+          return queryId;
+        }
+      }
+    }
+    try {
+      Method getter = message.getClass().getMethod("getQueryId");
+      Object value = getter.invoke(message);
+      if (value instanceof String queryId && nonBlank(queryId)) {
+        return queryId;
+      }
+    } catch (ReflectiveOperationException ignored) {
+      // Request does not expose a query_id field; keep existing value.
+    }
+    return "";
+  }
+
+  private static String chooseFirstNonBlank(String... values) {
+    for (String value : values) {
+      if (nonBlank(value)) {
+        return value;
+      }
+    }
+    return "";
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManager.java
@@ -51,7 +51,10 @@ public class GraphCacheManager {
   private final Cache<ResourceId, MutationMeta> metaCache;
 
   public GraphCacheManager(
-      boolean cacheEnabled, long cacheMaxSize, long metaCacheTtlSeconds, Observability observability) {
+      boolean cacheEnabled,
+      long cacheMaxSize,
+      long metaCacheTtlSeconds,
+      Observability observability) {
     this.graphCacheEnabled = cacheEnabled;
     this.metaCacheEnabled = metaCacheTtlSeconds > 0;
     this.cacheMaxSize = cacheMaxSize;

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManager.java
@@ -38,6 +38,10 @@ import java.util.concurrent.ConcurrentMap;
  * isolated between accounts while sharing the common configuration knobs (enable flag, max size,
  * TTL). It also exposes global gauges and per-account hit/miss counters so operators can understand
  * cache health across multi-account deployments.
+ *
+ * <p>Consistency model: the optional mutation-meta cache is best-effort and eventually consistent.
+ * After a write, callers may observe a stale pointer version for at most the configured meta cache
+ * TTL window.
  */
 public class GraphCacheManager {
 
@@ -46,6 +50,7 @@ public class GraphCacheManager {
   private final long cacheMaxSize;
   private final Observability observability;
   private final CacheMetrics cacheMetrics;
+  private final CacheMetrics metaCacheMetrics;
   private final ConcurrentMap<String, Cache<GraphCacheKey, GraphNode>> accountCaches =
       new ConcurrentHashMap<>();
   private final Cache<ResourceId, MutationMeta> metaCache;
@@ -68,10 +73,20 @@ public class GraphCacheManager {
             : null;
     this.cacheMetrics =
         new CacheMetrics(this.observability, "service", "graph-cache", "graph-cache");
+    this.metaCacheMetrics =
+        new CacheMetrics(this.observability, "service", "graph-cache", "graph-meta-cache");
     registerGauges();
     cacheMetrics.trackSize(
         () -> accountCaches.values().stream().mapToDouble(Cache::estimatedSize).sum(),
         "Estimated graph cache entries");
+    metaCacheMetrics.trackEnabled(
+        () -> metaCacheEnabled ? 1.0 : 0.0, "Graph metadata cache enabled");
+    metaCacheMetrics.trackMaxEntries(
+        () -> metaCacheEnabled ? (double) cacheMaxSize : 0.0,
+        "Graph metadata cache configured max entries");
+    metaCacheMetrics.trackSize(
+        () -> metaCacheEnabled && metaCache != null ? (double) metaCache.estimatedSize() : 0.0,
+        "Estimated graph metadata cache entries");
   }
 
   public GraphCacheManager(boolean cacheEnabled, long cacheMaxSize, Observability observability) {
@@ -126,7 +141,9 @@ public class GraphCacheManager {
     if (!metaCacheEnabled || metaCache == null) {
       return null;
     }
-    return metaCache.getIfPresent(id);
+    MutationMeta meta = metaCache.getIfPresent(id);
+    incrementMetaCounter(id.getAccountId(), meta != null);
+    return meta;
   }
 
   public void putMeta(ResourceId id, MutationMeta meta) {
@@ -158,6 +175,18 @@ public class GraphCacheManager {
       cacheMetrics.recordHit(accountTag);
     } else {
       cacheMetrics.recordMiss(accountTag);
+    }
+  }
+
+  private void incrementMetaCounter(String accountId, boolean hit) {
+    if (accountId == null || accountId.isBlank()) {
+      return;
+    }
+    Tag accountTag = Tag.of(TagKey.ACCOUNT, accountId);
+    if (hit) {
+      metaCacheMetrics.recordHit(accountTag);
+    } else {
+      metaCacheMetrics.recordMiss(accountTag);
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManager.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.metagraph.cache;
 
+import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.metagraph.cache.GraphCacheKey;
 import ai.floedb.floecat.metagraph.model.GraphNode;
@@ -40,17 +41,28 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class GraphCacheManager {
 
-  private final boolean cacheEnabled;
+  private final boolean graphCacheEnabled;
+  private final boolean metaCacheEnabled;
   private final long cacheMaxSize;
   private final Observability observability;
   private final CacheMetrics cacheMetrics;
   private final ConcurrentMap<String, Cache<GraphCacheKey, GraphNode>> accountCaches =
       new ConcurrentHashMap<>();
+  private final Cache<ResourceId, MutationMeta> metaCache;
 
-  public GraphCacheManager(boolean cacheEnabled, long cacheMaxSize, Observability observability) {
-    this.cacheEnabled = cacheEnabled;
+  public GraphCacheManager(
+      boolean cacheEnabled, long cacheMaxSize, long metaCacheTtlSeconds, Observability observability) {
+    this.graphCacheEnabled = cacheEnabled;
+    this.metaCacheEnabled = metaCacheTtlSeconds > 0;
     this.cacheMaxSize = cacheMaxSize;
     this.observability = Objects.requireNonNull(observability, "observability");
+    this.metaCache =
+        metaCacheEnabled
+            ? Caffeine.newBuilder()
+                .maximumSize(Math.max(1L, cacheMaxSize))
+                .expireAfterWrite(Duration.ofSeconds(metaCacheTtlSeconds))
+                .build()
+            : null;
     this.cacheMetrics =
         new CacheMetrics(this.observability, "service", "graph-cache", "graph-cache");
     registerGauges();
@@ -59,12 +71,16 @@ public class GraphCacheManager {
         "Estimated graph cache entries");
   }
 
+  public GraphCacheManager(boolean cacheEnabled, long cacheMaxSize, Observability observability) {
+    this(cacheEnabled, cacheMaxSize, 0L, observability);
+  }
+
   /**
    * Returns the cached node for the provided resource, or {@code null} when caching is disabled or
    * the entry is missing.
    */
   public GraphNode get(ResourceId id, GraphCacheKey key) {
-    if (!cacheEnabled) {
+    if (!graphCacheEnabled) {
       return null;
     }
     Cache<GraphCacheKey, GraphNode> cache = accountCache(id.getAccountId());
@@ -78,7 +94,7 @@ public class GraphCacheManager {
 
   /** Stores the resolved node inside the account cache. */
   public void put(ResourceId id, GraphCacheKey key, GraphNode node) {
-    if (!cacheEnabled || node == null) {
+    if (!graphCacheEnabled || node == null) {
       return;
     }
     Cache<GraphCacheKey, GraphNode> cache = accountCache(id.getAccountId());
@@ -89,16 +105,32 @@ public class GraphCacheManager {
 
   /** Evicts every cached version of the resource. */
   public void invalidate(ResourceId id) {
-    if (!cacheEnabled) {
-      return;
-    }
-    Cache<GraphCacheKey, GraphNode> cache = accountCaches.get(id.getAccountId());
-    if (cache != null) {
-      cache.asMap().keySet().removeIf(key -> key.id().equals(id));
-      if (cache.estimatedSize() == 0) {
-        accountCaches.remove(id.getAccountId(), cache);
+    if (graphCacheEnabled) {
+      Cache<GraphCacheKey, GraphNode> cache = accountCaches.get(id.getAccountId());
+      if (cache != null) {
+        cache.asMap().keySet().removeIf(key -> key.id().equals(id));
+        if (cache.estimatedSize() == 0) {
+          accountCaches.remove(id.getAccountId(), cache);
+        }
       }
     }
+    if (metaCacheEnabled && metaCache != null) {
+      metaCache.invalidate(id);
+    }
+  }
+
+  public MutationMeta getMeta(ResourceId id) {
+    if (!metaCacheEnabled || metaCache == null) {
+      return null;
+    }
+    return metaCache.getIfPresent(id);
+  }
+
+  public void putMeta(ResourceId id, MutationMeta meta) {
+    if (!metaCacheEnabled || metaCache == null || meta == null) {
+      return;
+    }
+    metaCache.put(id, meta);
   }
 
   private Cache<GraphCacheKey, GraphNode> accountCache(String accountId) {
@@ -127,9 +159,10 @@ public class GraphCacheManager {
   }
 
   private void registerGauges() {
-    cacheMetrics.trackEnabled(() -> cacheEnabled ? 1.0 : 0.0, "Graph cache enabled");
+    cacheMetrics.trackEnabled(() -> graphCacheEnabled ? 1.0 : 0.0, "Graph cache enabled");
     cacheMetrics.trackMaxEntries(
-        () -> cacheEnabled ? (double) cacheMaxSize : 0.0, "Graph cache configured max entries");
+        () -> graphCacheEnabled ? (double) cacheMaxSize : 0.0,
+        "Graph cache configured max entries");
     cacheMetrics.trackAccounts(() -> (double) accountCaches.size(), "Graph cache account count");
   }
 
@@ -137,14 +170,14 @@ public class GraphCacheManager {
     if (duration == null) {
       return;
     }
-    if (!cacheEnabled) {
+    if (!graphCacheEnabled) {
       return;
     }
     cacheMetrics.recordLoad(duration, true);
   }
 
   public void recordLoadFailure(Duration duration, Throwable error) {
-    if (duration == null || !cacheEnabled) {
+    if (duration == null || !graphCacheEnabled) {
       return;
     }
     cacheMetrics.recordLoadFailure(duration, error);

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -48,7 +48,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
@@ -70,9 +69,9 @@ public final class UserGraph {
   private final NodeLoader nodes;
   private final NameResolver names;
   private final FullyQualifiedResolver fq;
-  private SnapshotHelper snapshots;
-  private EngineHintManager hints;
-  private PrincipalProvider principal;
+  private final SnapshotHelper snapshots;
+  private final EngineHintManager hints;
+  private final PrincipalProvider principal;
 
   // ----------------------------------------------------------------------
   // Constructor
@@ -103,12 +102,9 @@ public final class UserGraph {
       PrincipalProvider principal,
       @ConfigProperty(name = "floecat.metadata.graph.cache-max-size", defaultValue = "50000")
           long cacheMaxSize,
+      @ConfigProperty(name = "floecat.metadata.graph.meta-cache-ttl-seconds", defaultValue = "2")
+          long metaCacheTtlSeconds,
       EngineHintManager engineHints) {
-
-    long metaCacheTtlSeconds =
-        ConfigProvider.getConfig()
-            .getOptionalValue("floecat.metadata.graph.meta-cache-ttl-seconds", Long.class)
-            .orElse(2L);
     this.cache =
         new GraphCacheManager(
             cacheMaxSize > 0, cacheMaxSize, Math.max(0L, metaCacheTtlSeconds), observability);
@@ -120,6 +116,30 @@ public final class UserGraph {
     this.principal = principal;
   }
 
+  /** TEST-ONLY constructor with explicit cache knobs. */
+  public UserGraph(
+      CatalogRepository catalogRepo,
+      NamespaceRepository nsRepo,
+      SnapshotRepository snapshotRepo,
+      TableRepository tableRepo,
+      ViewRepository viewRepo,
+      Observability observability,
+      PrincipalProvider principal,
+      long cacheMaxSize,
+      EngineHintManager engineHints) {
+    this(
+        catalogRepo,
+        nsRepo,
+        snapshotRepo,
+        tableRepo,
+        viewRepo,
+        observability,
+        principal,
+        cacheMaxSize,
+        2L,
+        engineHints);
+  }
+
   /** TEST-ONLY constructor */
   public UserGraph(
       CatalogRepository catalogRepo,
@@ -128,24 +148,22 @@ public final class UserGraph {
       TableRepository tableRepo,
       ViewRepository viewRepo,
       Observability observability) {
-
-    this.cache = new GraphCacheManager(true, 1024, 2L, observability);
-    this.nodes = new NodeLoader(catalogRepo, nsRepo, tableRepo, viewRepo);
-    this.names = new NameResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
-    this.fq = new FullyQualifiedResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
-
-    // Snapshot helper without gRPC client
-    this.snapshots = new SnapshotHelper(snapshotRepo);
-
-    this.principal =
+    this(
+        catalogRepo,
+        nsRepo,
+        snapshotRepo,
+        tableRepo,
+        viewRepo,
+        observability,
         new PrincipalProvider() {
           @Override
           public PrincipalContext get() {
             return PrincipalContext.newBuilder().setAccountId("account").build();
           }
-        };
-
-    this.hints = null;
+        },
+        1024L,
+        2L,
+        null);
   }
 
   public void invalidate(ResourceId id) {
@@ -621,17 +639,6 @@ public final class UserGraph {
     b.setName(relName);
     b.setResourceId(id);
     return b.build();
-  }
-
-  // ----------------------------------------------------------------------
-  // Dependency setters (for injection/configuration)
-  // ----------------------------------------------------------------------
-  public void setSnapshotHelper(SnapshotHelper helper) {
-    this.snapshots = helper;
-  }
-
-  public void setPrincipalProvider(PrincipalProvider principal) {
-    this.principal = principal;
   }
 
   // ----------------------------------------------------------------------

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
@@ -104,7 +105,13 @@ public final class UserGraph {
           long cacheMaxSize,
       EngineHintManager engineHints) {
 
-    this.cache = new GraphCacheManager(cacheMaxSize > 0, cacheMaxSize, observability);
+    long metaCacheTtlSeconds =
+        ConfigProvider.getConfig()
+            .getOptionalValue("floecat.metadata.graph.meta-cache-ttl-seconds", Long.class)
+            .orElse(2L);
+    this.cache =
+        new GraphCacheManager(
+            cacheMaxSize > 0, cacheMaxSize, Math.max(0L, metaCacheTtlSeconds), observability);
     this.nodes = new NodeLoader(catalogRepo, nsRepo, tableRepo, viewRepo);
     this.names = new NameResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
     this.fq = new FullyQualifiedResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
@@ -122,7 +129,7 @@ public final class UserGraph {
       ViewRepository viewRepo,
       Observability observability) {
 
-    this.cache = new GraphCacheManager(true, 1024, observability);
+    this.cache = new GraphCacheManager(true, 1024, 2L, observability);
     this.nodes = new NodeLoader(catalogRepo, nsRepo, tableRepo, viewRepo);
     this.names = new NameResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
     this.fq = new FullyQualifiedResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
@@ -232,10 +239,15 @@ public final class UserGraph {
   public Optional<GraphNode> resolve(ResourceId id) {
 
     // ----- Regular nodes (cached in graph) ------------------------------------
-    Optional<MutationMeta> metaOpt = nodes.mutationMeta(id);
-    if (metaOpt.isEmpty()) return Optional.empty();
-
-    MutationMeta meta = metaOpt.get();
+    MutationMeta meta = cache.getMeta(id);
+    if (meta == null) {
+      Optional<MutationMeta> metaOpt = nodes.mutationMeta(id);
+      if (metaOpt.isEmpty()) {
+        return Optional.empty();
+      }
+      meta = metaOpt.get();
+      cache.putMeta(id, meta);
+    }
     GraphCacheKey key = new GraphCacheKey(id, meta.getPointerVersion());
 
     GraphNode cached = cache.get(id, key);

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -21,11 +21,14 @@ import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.Messag
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.connector.common.resolver.LogicalSchemaMapper;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
 import ai.floedb.floecat.metagraph.model.GraphNode;
 import ai.floedb.floecat.metagraph.model.GraphNodeKind;
 import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.RelationNode;
+import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.ColumnFailure;
 import ai.floedb.floecat.query.rpc.ColumnFailureCode;
@@ -72,7 +75,9 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -83,6 +88,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -103,6 +109,7 @@ public class UserObjectBundleService {
   private final EngineContextProvider engineContext;
   private final boolean engineSpecificEnabled;
   private final StatsProviderFactory statsFactory;
+  private final LogicalSchemaMapper logicalSchemaMapper = new LogicalSchemaMapper();
   private final FlightEndpointRef floecatFlightEndpoint;
   private final long slowLogMs;
   private final boolean logTimingBreakdown;
@@ -245,13 +252,15 @@ public class UserObjectBundleService {
   private Optional<ResolvedRelation> selectResolvedRelation(
       String correlationId,
       TableReferenceCandidate candidate,
-      List<QueryInput> normalizedCandidates) {
+      List<QueryInput> normalizedCandidates,
+      Function<NameRef, Optional<ResourceId>> nameResolver,
+      Function<ResourceId, Optional<GraphNode>> nodeResolver) {
     for (QueryInput input : normalizedCandidates) {
-      ResourceId relationId = extractResourceId(correlationId, input);
+      ResourceId relationId = extractResourceId(input, nameResolver);
       if (relationId == null) {
         continue;
       }
-      Optional<GraphNode> node = overlay.resolve(relationId);
+      Optional<GraphNode> node = nodeResolver.apply(relationId);
       if (node.isEmpty()) {
         if (input.getTargetCase() == QueryInput.TargetCase.NAME) {
           throw new GraphNodeMissingException(
@@ -270,14 +279,15 @@ public class UserObjectBundleService {
     return Optional.empty();
   }
 
-  private ResourceId extractResourceId(String correlationId, QueryInput input) {
+  private ResourceId extractResourceId(
+      QueryInput input, Function<NameRef, Optional<ResourceId>> nameResolver) {
     switch (input.getTargetCase()) {
       case TABLE_ID:
         return input.getTableId();
       case VIEW_ID:
         return input.getViewId();
       case NAME:
-        return overlay.resolveName(correlationId, input.getName()).orElse(null);
+        return nameResolver.apply(input.getName()).orElse(null);
       default:
         return null;
     }
@@ -373,6 +383,8 @@ public class UserObjectBundleService {
     List<SchemaColumn> schemaColumns =
         relation.node() instanceof ViewNode view
             ? view.outputColumns()
+            : relation.node() instanceof UserTableNode userTable
+                ? logicalSchemaMapper.map(userTable).getColumnsList()
             : overlay.tableSchema(relation.node().id());
 
     List<SchemaColumn> pruned =
@@ -883,6 +895,10 @@ public class UserObjectBundleService {
   }
 
   private QueryInput buildCanonicalQueryInput(ResolvedRelation relation) {
+    // Built-in system relations are not version-pinned in query context snapshots.
+    if (relation.node().origin() == GraphNodeOrigin.SYSTEM) {
+      return null;
+    }
     QueryInput.Builder builder;
     GraphNodeKind kind = relation.node().kind();
     if (kind == GraphNodeKind.TABLE) {
@@ -1002,6 +1018,16 @@ public class UserObjectBundleService {
       RelationNode node,
       QueryInput selectedInput) {}
 
+  private record RelationCacheKey(
+      ResourceId relationId,
+      boolean wantsAllColumns,
+      List<String> initialColumns,
+      String engineKind,
+      String engineVersion,
+      SnapshotRef snapshotOverride) {}
+
+  private record NormalizedNameRef(String catalog, List<String> path, String name) {}
+
   private static final class GraphNodeMissingException extends RuntimeException {
     private final ResourceId relationId;
 
@@ -1023,9 +1049,16 @@ public class UserObjectBundleService {
     private final int resolutionCount;
     private final String defaultCatalog;
     private final StatsProvider statsProvider;
+    private final String engineKind;
+    private final String engineVersion;
 
     // Maintains the order inputs were resolved so the emitted chunk mirrors the request order.
     private final List<PendingItem> pending = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
+    private final Map<NormalizedNameRef, Optional<ResourceId>> nameResolutionCache = new HashMap<>();
+    private final Map<ResourceId, Optional<GraphNode>> nodeResolutionCache = new HashMap<>();
+    private final ArrayDeque<EagerBaseCursor> eagerBaseQueue = new ArrayDeque<>();
+    private final Set<String> eagerBaseSeen = new HashSet<>();
+    private final Map<RelationCacheKey, RelationInfo> relationInfoCache = new HashMap<>();
     private final TimingAccumulator timings = new TimingAccumulator();
     private final long streamStartNs = System.nanoTime();
     private SnapshotSet pendingChunkPins = SnapshotSet.getDefaultInstance();
@@ -1053,6 +1086,9 @@ public class UserObjectBundleService {
       this.resolutionCount = tables.size();
       this.defaultCatalog = defaultCatalog;
       this.statsProvider = statsFactory.forQuery(ctx, correlationId);
+      EngineContext requestEngine = engineContext.engineContext();
+      this.engineKind = requestEngine.normalizedKind();
+      this.engineVersion = requestEngine.normalizedVersion();
       if (LOG.isDebugEnabled()) {
         LOG.debugf(
             "Initialized bundle iterator query_id=%s correlation_id=%s resolution_count=%d"
@@ -1076,7 +1112,7 @@ public class UserObjectBundleService {
         return headerChunk(ctx.getQueryId(), seq++);
       }
 
-      if (pending.isEmpty() && nextInputIndex < resolutionCount) {
+      if (pending.isEmpty() && (nextInputIndex < resolutionCount || !eagerBaseQueue.isEmpty())) {
         fillPending();
       }
 
@@ -1100,13 +1136,15 @@ public class UserObjectBundleService {
 
     private void fillPending() {
       List<ResolvedRelation> toPin = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
+      drainEagerBaseTables(toPin);
       while (nextInputIndex < resolutionCount && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
         PendingItem item = resolveNextResolution();
         pending.add(item);
         if (item instanceof PendingFound found) {
           toPin.add(found.relation());
           if (found.relation().node() instanceof ViewNode view && !view.baseRelations().isEmpty()) {
-            injectEagerBaseTables(view, toPin);
+            eagerBaseQueue.addLast(new EagerBaseCursor(view));
+            drainEagerBaseTables(toPin);
           }
         }
       }
@@ -1125,26 +1163,45 @@ public class UserObjectBundleService {
      * {@link NameRef}, builds a synthetic {@link ResolvedRelation}, pins its snapshot, and adds it
      * to {@code pending} with {@code inputIndex = -1} to signal it was not explicitly requested.
      * Failures to resolve a NameRef are silently skipped (base_relations is a performance hint).
-     * Duplicate base-table IDs are deduplicated.
+     * Duplicate base-table IDs are deduplicated across the entire request stream. When a view has
+     * more base relations than fit in the current chunk, remaining base relations are carried over
+     * and emitted in subsequent chunks.
      */
-    private void injectEagerBaseTables(ViewNode view, List<ResolvedRelation> toPin) {
-      Set<String> seen = new HashSet<>();
-      for (NameRef baseRef : view.baseRelations()) {
+    private void drainEagerBaseTables(List<ResolvedRelation> toPin) {
+      while (pending.size() < MAX_RESOLUTIONS_PER_CHUNK && !eagerBaseQueue.isEmpty()) {
+        EagerBaseCursor cursor = eagerBaseQueue.peekFirst();
+        if (cursor == null) {
+          break;
+        }
+        if (drainEagerBaseCursor(cursor, toPin)) {
+          eagerBaseQueue.removeFirst();
+        }
+      }
+    }
+
+    private boolean drainEagerBaseCursor(EagerBaseCursor cursor, List<ResolvedRelation> toPin) {
+      List<NameRef> baseRelations = cursor.view.baseRelations();
+      while (cursor.nextBaseIndex < baseRelations.size()
+          && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
+        NameRef baseRef = baseRelations.get(cursor.nextBaseIndex++);
         long resolveStartNs = System.nanoTime();
         try {
-          NameRef enriched = ViewContextUtils.enrichForViewContext(baseRef, view, defaultCatalog);
-          Optional<ResourceId> baseIdOpt = overlay.resolveName(correlationId, enriched);
+          NameRef enriched =
+              ViewContextUtils.enrichForViewContext(baseRef, cursor.view, defaultCatalog);
+          Optional<ResourceId> baseIdOpt = resolveNameCached(enriched);
           if (baseIdOpt.isEmpty()) {
             continue;
           }
           ResourceId baseId = baseIdOpt.get();
-          if (!seen.add(baseId.getId())) {
+          String baseKey = pinKey(baseId);
+          if (eagerBaseSeen.contains(baseKey)) {
             continue; // deduplicate
           }
-          Optional<GraphNode> nodeOpt = overlay.resolve(baseId);
+          Optional<GraphNode> nodeOpt = resolveNodeCached(baseId);
           if (nodeOpt.isEmpty() || !(nodeOpt.get() instanceof RelationNode rel)) {
             continue;
           }
+          eagerBaseSeen.add(baseKey);
           QueryInput syntheticInput = QueryInput.newBuilder().setTableId(baseId).build();
           ResolvedRelation syntheticRelation =
               new ResolvedRelation(
@@ -1157,6 +1214,7 @@ public class UserObjectBundleService {
           resolveNanos += System.nanoTime() - resolveStartNs;
         }
       }
+      return cursor.nextBaseIndex >= baseRelations.size();
     }
 
     private PendingItem resolveNextResolution() {
@@ -1173,7 +1231,12 @@ public class UserObjectBundleService {
         List<QueryInput> normalized = normalizeCandidates(correlationId, candidate, defaultCatalog);
         try {
           Optional<ResolvedRelation> resolved =
-              selectResolvedRelation(correlationId, candidate, normalized);
+              selectResolvedRelation(
+                  correlationId,
+                  candidate,
+                  normalized,
+                  this::resolveNameCached,
+                  this::resolveNodeCached);
           if (resolved.isPresent()) {
             foundCount++;
             if (LOG.isTraceEnabled()) {
@@ -1254,6 +1317,17 @@ public class UserObjectBundleService {
           continue;
         }
         PendingFound found = (PendingFound) item;
+        RelationCacheKey cacheKey = relationCacheKey(found.relation());
+        RelationInfo cachedInfo = relationInfoCache.get(cacheKey);
+        if (cachedInfo != null) {
+          resolutions.add(
+              RelationResolution.newBuilder()
+                  .setInputIndex(found.inputIndex())
+                  .setStatus(ResolutionStatus.RESOLUTION_STATUS_FOUND)
+                  .setRelation(cachedInfo)
+                  .build());
+          continue;
+        }
         long statsBeforeNanos = timings.statsLookupNanos();
         long buildStartNs = System.nanoTime();
         RelationInfo info =
@@ -1261,6 +1335,7 @@ public class UserObjectBundleService {
         long buildNanos = System.nanoTime() - buildStartNs;
         long statsDeltaNanos = timings.statsLookupNanos() - statsBeforeNanos;
         relationBuildNanos += Math.max(0L, buildNanos - statsDeltaNanos);
+        relationInfoCache.put(cacheKey, info);
         resolutions.add(
             RelationResolution.newBuilder()
                 .setInputIndex(found.inputIndex())
@@ -1320,6 +1395,53 @@ public class UserObjectBundleService {
       }
     }
 
+    private RelationCacheKey relationCacheKey(ResolvedRelation relation) {
+      TableReferenceCandidate candidate = relation.candidate();
+      List<String> initialColumns =
+          candidate.getInitialColumnsCount() == 0
+              ? List.of()
+              : List.copyOf(candidate.getInitialColumnsList());
+      SnapshotRef snapshotOverride =
+          relation.selectedInput().hasSnapshot()
+              ? relation.selectedInput().getSnapshot()
+              : SnapshotRef.getDefaultInstance();
+      return new RelationCacheKey(
+          relation.relationId(),
+          candidate.getWantsAllColumns(),
+          initialColumns,
+          engineKind,
+          engineVersion,
+          snapshotOverride);
+    }
+
+    private Optional<ResourceId> resolveNameCached(NameRef ref) {
+      NormalizedNameRef key = normalizedNameRef(ref);
+      return nameResolutionCache.computeIfAbsent(
+          key, ignored -> overlay.resolveName(correlationId, ref));
+    }
+
+    private Optional<GraphNode> resolveNodeCached(ResourceId id) {
+      return nodeResolutionCache.computeIfAbsent(id, overlay::resolve);
+    }
+
+    private NormalizedNameRef normalizedNameRef(NameRef ref) {
+      List<String> normalizedPath = new ArrayList<>(ref.getPathCount());
+      for (String segment : ref.getPathList()) {
+        normalizedPath.add(normalizeNameToken(segment));
+      }
+      return new NormalizedNameRef(
+          normalizeNameToken(ref.getCatalog()),
+          List.copyOf(normalizedPath),
+          normalizeNameToken(ref.getName()));
+    }
+
+    private String normalizeNameToken(String token) {
+      if (token == null) {
+        return "";
+      }
+      return token.trim();
+    }
+
     /**
      * Represents inputs that are ready to be emitted. Keeping items in insertion order ensures we
      * re-emit resolutions in the same order the client requested them, even after buffering pins.
@@ -1361,6 +1483,15 @@ public class UserObjectBundleService {
 
       public ResolvedRelation relation() {
         return relation;
+      }
+    }
+
+    private static final class EagerBaseCursor {
+      private final ViewNode view;
+      private int nextBaseIndex;
+
+      private EagerBaseCursor(ViewNode view) {
+        this.view = view;
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -104,6 +104,8 @@ public class UserObjectBundleService {
   private final boolean engineSpecificEnabled;
   private final StatsProviderFactory statsFactory;
   private final FlightEndpointRef floecatFlightEndpoint;
+  private final long slowLogMs;
+  private final boolean logTimingBreakdown;
 
   private static void warnFlightHost(String flightHost, String quarkusProfile) {
     if (flightHost == null) {
@@ -142,7 +144,11 @@ public class UserObjectBundleService {
       @ConfigProperty(name = "floecat.flight.advertised-port", defaultValue = "80") int flightPort,
       @ConfigProperty(name = "quarkus.grpc.server.plain-text", defaultValue = "true")
           boolean grpcPlainText,
-      @ConfigProperty(name = "quarkus.profile", defaultValue = "prod") String quarkusProfile) {
+      @ConfigProperty(name = "quarkus.profile", defaultValue = "prod") String quarkusProfile,
+      @ConfigProperty(name = "floedb.catalog.bundle.slow-log-ms", defaultValue = "1000")
+          long slowLogMs,
+      @ConfigProperty(name = "floedb.catalog.bundle.log-timings", defaultValue = "false")
+          boolean logTimingBreakdown) {
     this.overlay = overlay;
     this.inputResolver = inputResolver;
     this.queryStore = queryStore;
@@ -156,7 +162,38 @@ public class UserObjectBundleService {
             .setPort(flightPort)
             .setTls(!grpcPlainText)
             .build();
+    this.slowLogMs = slowLogMs;
+    this.logTimingBreakdown = logTimingBreakdown;
     warnFlightHost(flightHost, quarkusProfile);
+  }
+
+  // Convenience constructor for tests that instantiate the service directly.
+  public UserObjectBundleService(
+      CatalogOverlay overlay,
+      QueryInputResolver inputResolver,
+      QueryContextStore queryStore,
+      StatsProviderFactory statsFactory,
+      EngineMetadataDecoratorProvider decoratorProvider,
+      EngineContextProvider engineContext,
+      boolean engineSpecificEnabled,
+      String flightHost,
+      int flightPort,
+      boolean grpcPlainText,
+      String quarkusProfile) {
+    this(
+        overlay,
+        inputResolver,
+        queryStore,
+        statsFactory,
+        decoratorProvider,
+        engineContext,
+        engineSpecificEnabled,
+        flightHost,
+        flightPort,
+        grpcPlainText,
+        quarkusProfile,
+        1_000L,
+        false);
   }
 
   public Multi<UserObjectsBundleChunk> stream(
@@ -166,7 +203,8 @@ public class UserObjectBundleService {
     List<TableReferenceCandidate> candidates = List.copyOf(tables);
     if (LOG.isDebugEnabled()) {
       LOG.debugf(
-          "GetUserObjects stream start query=%s correlation=%s candidates=%d default_catalog=%s",
+          "GetUserObjects stream start query_id=%s correlation_id=%s candidates=%d"
+              + " default_catalog=%s",
           ctx.getQueryId(), correlationId, candidates.size(), defaultCatalog);
     }
     return Multi.createFrom()
@@ -292,14 +330,27 @@ public class UserObjectBundleService {
     return UserObjectsBundleChunk.newBuilder().setQueryId(queryId).setSeq(seq).setEnd(end).build();
   }
 
+  private static final class TimingAccumulator {
+    private long statsLookupNanos;
+
+    private void addStatsLookupNanos(long nanos) {
+      statsLookupNanos += nanos;
+    }
+
+    private long statsLookupNanos() {
+      return statsLookupNanos;
+    }
+  }
+
   private RelationInfo buildRelation(
       String correlationId,
       ResolvedRelation relation,
       QueryContext queryContext,
-      StatsProvider statsProvider) {
+      StatsProvider statsProvider,
+      TimingAccumulator timings) {
     if (LOG.isDebugEnabled()) {
       LOG.debugf(
-          "Building relation bundle query=%s relation=%s kind=%s origin=%s",
+          "Building relation bundle query_id=%s relation=%s kind=%s origin=%s",
           queryContext.getQueryId(),
           relation.relationId(),
           relation.node().kind(),
@@ -353,10 +404,12 @@ public class UserObjectBundleService {
       }
     }
 
+    long statsLookupStartNs = System.nanoTime();
     statsProvider
         .tableStats(relation.relationId())
         .map(StatsProviderFactory::toRelationStats)
         .ifPresent(builder::setStats);
+    timings.addStatsLookupNanos(System.nanoTime() - statsLookupStartNs);
 
     // If this is a view, keep a mutable builder around for decoration.
     ViewDefinition.Builder viewBuilder = null;
@@ -736,6 +789,10 @@ public class UserObjectBundleService {
     return value == null ? "" : value;
   }
 
+  private static double nanosToMs(long nanos) {
+    return nanos / 1_000_000.0;
+  }
+
   private static void addEngineDetails(ColumnFailure.Builder failure, EngineContext ctx) {
     if (ctx == null) {
       return;
@@ -960,14 +1017,21 @@ public class UserObjectBundleService {
 
     // Maintains the order inputs were resolved so the emitted chunk mirrors the request order.
     private final List<PendingItem> pending = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
+    private final TimingAccumulator timings = new TimingAccumulator();
+    private final long streamStartNs = System.nanoTime();
     private SnapshotSet pendingChunkPins = SnapshotSet.getDefaultInstance();
 
     private int seq = 1;
     private int nextInputIndex = 0;
     private int foundCount = 0;
     private int notFoundCount = 0;
+    private int emittedResolutionChunks = 0;
     private boolean headerEmitted = false;
     private boolean endEmitted = false;
+    private long resolveNanos = 0L;
+    private long pinCollectNanos = 0L;
+    private long pinCommitNanos = 0L;
+    private long relationBuildNanos = 0L;
 
     UserObjectBundleIterator(
         String correlationId,
@@ -982,7 +1046,7 @@ public class UserObjectBundleService {
       this.statsProvider = statsFactory.forQuery(ctx, correlationId);
       if (LOG.isDebugEnabled()) {
         LOG.debugf(
-            "Initialized bundle iterator query=%s correlation=%s resolution_count=%d"
+            "Initialized bundle iterator query_id=%s correlation_id=%s resolution_count=%d"
                 + " default_catalog=%s",
             ctx.getQueryId(), correlationId, resolutionCount, defaultCatalog);
       }
@@ -998,7 +1062,7 @@ public class UserObjectBundleService {
       if (!headerEmitted) {
         headerEmitted = true;
         if (LOG.isDebugEnabled()) {
-          LOG.debugf("Emitting header chunk query=%s seq=%d", ctx.getQueryId(), seq);
+          LOG.debugf("Emitting header chunk query_id=%s seq=%d", ctx.getQueryId(), seq);
         }
         return headerChunk(ctx.getQueryId(), seq++);
       }
@@ -1013,9 +1077,10 @@ public class UserObjectBundleService {
 
       if (!endEmitted) {
         endEmitted = true;
+        logStreamTiming();
         if (LOG.isDebugEnabled()) {
           LOG.debugf(
-              "Emitting end chunk query=%s seq=%d resolutions=%d found=%d not_found=%d",
+              "Emitting end chunk query_id=%s seq=%d resolutions=%d found=%d not_found=%d",
               ctx.getQueryId(), seq, resolutionCount, foundCount, notFoundCount);
         }
         return endChunk(ctx.getQueryId(), seq++, resolutionCount, foundCount, notFoundCount);
@@ -1028,10 +1093,11 @@ public class UserObjectBundleService {
       while (nextInputIndex < resolutionCount && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
         PendingItem item = resolveNextResolution();
         pending.add(item);
-        if (item instanceof PendingFound found
-            && found.relation().node() instanceof ViewNode view
-            && !view.baseRelations().isEmpty()) {
-          injectEagerBaseTables(view);
+        if (item instanceof PendingFound found) {
+          collectPinsFor(found.relation());
+          if (found.relation().node() instanceof ViewNode view && !view.baseRelations().isEmpty()) {
+            injectEagerBaseTables(view);
+          }
         }
       }
     }
@@ -1046,97 +1112,115 @@ public class UserObjectBundleService {
     private void injectEagerBaseTables(ViewNode view) {
       Set<String> seen = new HashSet<>();
       for (NameRef baseRef : view.baseRelations()) {
-        NameRef enriched = ViewContextUtils.enrichForViewContext(baseRef, view, defaultCatalog);
-        Optional<ResourceId> baseIdOpt = overlay.resolveName(correlationId, enriched);
-        if (baseIdOpt.isEmpty()) {
-          continue;
+        long resolveStartNs = System.nanoTime();
+        try {
+          NameRef enriched = ViewContextUtils.enrichForViewContext(baseRef, view, defaultCatalog);
+          Optional<ResourceId> baseIdOpt = overlay.resolveName(correlationId, enriched);
+          if (baseIdOpt.isEmpty()) {
+            continue;
+          }
+          ResourceId baseId = baseIdOpt.get();
+          if (!seen.add(baseId.getId())) {
+            continue; // deduplicate
+          }
+          Optional<GraphNode> nodeOpt = overlay.resolve(baseId);
+          if (nodeOpt.isEmpty() || !(nodeOpt.get() instanceof RelationNode rel)) {
+            continue;
+          }
+          QueryInput syntheticInput = QueryInput.newBuilder().setTableId(baseId).build();
+          ResolvedRelation syntheticRelation =
+              new ResolvedRelation(
+                  TableReferenceCandidate.getDefaultInstance(), baseId, rel, syntheticInput);
+          collectPinsFor(syntheticRelation);
+          pending.add(new PendingFound(-1, syntheticRelation));
+        } finally {
+          resolveNanos += System.nanoTime() - resolveStartNs;
         }
-        ResourceId baseId = baseIdOpt.get();
-        if (!seen.add(baseId.getId())) {
-          continue; // deduplicate
-        }
-        Optional<GraphNode> nodeOpt = overlay.resolve(baseId);
-        if (nodeOpt.isEmpty() || !(nodeOpt.get() instanceof RelationNode rel)) {
-          continue;
-        }
-        QueryInput syntheticInput = QueryInput.newBuilder().setTableId(baseId).build();
-        ResolvedRelation syntheticRelation =
-            new ResolvedRelation(
-                TableReferenceCandidate.getDefaultInstance(), baseId, rel, syntheticInput);
-        accumulateChunkPins(collectSnapshotPins(correlationId, ctx, syntheticRelation));
-        pending.add(new PendingFound(-1, syntheticRelation));
+      }
+    }
+
+    private void collectPinsFor(ResolvedRelation relation) {
+      long pinStartNs = System.nanoTime();
+      try {
+        SnapshotSet pins = collectSnapshotPins(correlationId, ctx, relation);
+        accumulateChunkPins(pins);
+      } finally {
+        pinCollectNanos += System.nanoTime() - pinStartNs;
       }
     }
 
     private PendingItem resolveNextResolution() {
-      TableReferenceCandidate candidate = tables.get(nextInputIndex);
-      int inputIndex = nextInputIndex;
-      nextInputIndex++;
-      if (LOG.isTraceEnabled()) {
-        LOG.tracef(
-            "Resolving candidate query=%s input_index=%d candidate_count=%d",
-            ctx.getQueryId(), inputIndex, candidate.getCandidatesCount());
-      }
-      List<QueryInput> normalized = normalizeCandidates(correlationId, candidate, defaultCatalog);
+      long resolveStartNs = System.nanoTime();
       try {
-        Optional<ResolvedRelation> resolved =
-            selectResolvedRelation(correlationId, candidate, normalized);
-        if (resolved.isPresent()) {
-          ResolvedRelation relation = resolved.get();
-          SnapshotSet pins = collectSnapshotPins(correlationId, ctx, relation);
-          accumulateChunkPins(pins);
-          foundCount++;
-          if (LOG.isTraceEnabled()) {
-            LOG.tracef(
-                "Resolved candidate query=%s input_index=%d relation=%s pins=%d",
+        TableReferenceCandidate candidate = tables.get(nextInputIndex);
+        int inputIndex = nextInputIndex;
+        nextInputIndex++;
+        if (LOG.isTraceEnabled()) {
+          LOG.tracef(
+              "Resolving candidate query_id=%s input_index=%d candidate_count=%d",
+              ctx.getQueryId(), inputIndex, candidate.getCandidatesCount());
+        }
+        List<QueryInput> normalized = normalizeCandidates(correlationId, candidate, defaultCatalog);
+        try {
+          Optional<ResolvedRelation> resolved =
+              selectResolvedRelation(correlationId, candidate, normalized);
+          if (resolved.isPresent()) {
+            foundCount++;
+            if (LOG.isTraceEnabled()) {
+              LOG.tracef(
+                  "Resolved candidate query_id=%s input_index=%d relation=%s",
+                  ctx.getQueryId(),
+                  inputIndex,
+                  resolved.get().relationId());
+            }
+            return new PendingFound(inputIndex, resolved.get());
+          }
+        } catch (GraphNodeMissingException e) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debugf(
+                "Resolved candidate missing graph node query_id=%s input_index=%d resource_id=%s",
                 ctx.getQueryId(),
                 inputIndex,
-                relation.relationId(),
-                pins == null ? 0 : pins.getPinsCount());
+                e.relationId() == null ? "" : e.relationId().getId());
           }
-          return new PendingFound(inputIndex, relation);
+          ResolutionFailure failure =
+              ResolutionFailure.newBuilder()
+                  .setCode("catalog_bundle.graph.missing_node")
+                  .setMessage("relation resolved but missing from graph")
+                  .putDetails("resource_id", e.relationId().getId())
+                  .putDetails("default_catalog", defaultCatalog)
+                  .addAllAttempted(normalized)
+                  .build();
+          return new PendingResolved(
+              RelationResolution.newBuilder()
+                  .setInputIndex(inputIndex)
+                  .setStatus(ResolutionStatus.RESOLUTION_STATUS_ERROR)
+                  .setFailure(failure)
+                  .build());
         }
-      } catch (GraphNodeMissingException e) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debugf(
-              "Resolved candidate missing graph node query=%s input_index=%d resource_id=%s",
-              ctx.getQueryId(), inputIndex, e.relationId() == null ? "" : e.relationId().getId());
+        notFoundCount++;
+        if (LOG.isTraceEnabled()) {
+          LOG.tracef(
+              "Candidate not found query_id=%s input_index=%d attempted=%d",
+              ctx.getQueryId(), inputIndex, normalized.size());
         }
         ResolutionFailure failure =
             ResolutionFailure.newBuilder()
-                .setCode("catalog_bundle.graph.missing_node")
-                .setMessage("relation resolved but missing from graph")
-                .putDetails("resource_id", e.relationId().getId())
+                .setCode("catalog_bundle.relation_not_found")
+                .setMessage("relation not found")
+                .putDetails("candidate_count", Integer.toString(normalized.size()))
                 .putDetails("default_catalog", defaultCatalog)
                 .addAllAttempted(normalized)
                 .build();
         return new PendingResolved(
             RelationResolution.newBuilder()
                 .setInputIndex(inputIndex)
-                .setStatus(ResolutionStatus.RESOLUTION_STATUS_ERROR)
+                .setStatus(ResolutionStatus.RESOLUTION_STATUS_NOT_FOUND)
                 .setFailure(failure)
                 .build());
+      } finally {
+        resolveNanos += System.nanoTime() - resolveStartNs;
       }
-      notFoundCount++;
-      if (LOG.isTraceEnabled()) {
-        LOG.tracef(
-            "Candidate not found query=%s input_index=%d attempted=%d",
-            ctx.getQueryId(), inputIndex, normalized.size());
-      }
-      ResolutionFailure failure =
-          ResolutionFailure.newBuilder()
-              .setCode("catalog_bundle.relation_not_found")
-              .setMessage("relation not found")
-              .putDetails("candidate_count", Integer.toString(normalized.size()))
-              .putDetails("default_catalog", defaultCatalog)
-              .addAllAttempted(normalized)
-              .build();
-      return new PendingResolved(
-          RelationResolution.newBuilder()
-              .setInputIndex(inputIndex)
-              .setStatus(ResolutionStatus.RESOLUTION_STATUS_NOT_FOUND)
-              .setFailure(failure)
-              .build());
     }
 
     private UserObjectsBundleChunk flushResolutionChunk() {
@@ -1144,12 +1228,14 @@ public class UserObjectBundleService {
       pending.clear();
       if (LOG.isDebugEnabled()) {
         LOG.debugf(
-            "Flushing resolution chunk query=%s seq=%d pending_items=%d pending_pins=%d",
+            "Flushing resolution chunk query_id=%s seq=%d pending_items=%d pending_pins=%d",
             ctx.getQueryId(), seq, chunkItems.size(), pendingChunkPins.getPinsCount());
       }
       // Ensure pins are durable before accessing stats (which expect the QueryContext to be
       // pinned).
+      long pinCommitStartNs = System.nanoTime();
       commitChunkPins();
+      pinCommitNanos += System.nanoTime() - pinCommitStartNs;
       QueryContext liveCtx = queryStore.get(ctx.getQueryId()).orElse(ctx);
       List<RelationResolution> resolutions = new ArrayList<>(chunkItems.size());
       for (PendingItem item : chunkItems) {
@@ -1158,7 +1244,13 @@ public class UserObjectBundleService {
           continue;
         }
         PendingFound found = (PendingFound) item;
-        RelationInfo info = buildRelation(correlationId, found.relation(), liveCtx, statsProvider);
+        long statsBeforeNanos = timings.statsLookupNanos();
+        long buildStartNs = System.nanoTime();
+        RelationInfo info =
+            buildRelation(correlationId, found.relation(), liveCtx, statsProvider, timings);
+        long buildNanos = System.nanoTime() - buildStartNs;
+        long statsDeltaNanos = timings.statsLookupNanos() - statsBeforeNanos;
+        relationBuildNanos += Math.max(0L, buildNanos - statsDeltaNanos);
         resolutions.add(
             RelationResolution.newBuilder()
                 .setInputIndex(found.inputIndex())
@@ -1166,6 +1258,7 @@ public class UserObjectBundleService {
                 .setRelation(info)
                 .build());
       }
+      emittedResolutionChunks++;
       if (LOG.isDebugEnabled()) {
         int chunkFound = 0;
         int chunkNotFound = 0;
@@ -1179,10 +1272,42 @@ public class UserObjectBundleService {
           }
         }
         LOG.debugf(
-            "Resolved chunk query=%s seq=%d items=%d found=%d not_found=%d error=%d",
+            "Resolved chunk query_id=%s seq=%d items=%d found=%d not_found=%d error=%d",
             ctx.getQueryId(), seq, resolutions.size(), chunkFound, chunkNotFound, chunkError);
       }
       return resolutionsChunk(ctx.getQueryId(), seq++, resolutions);
+    }
+
+    private void logStreamTiming() {
+      long totalNanos = System.nanoTime() - streamStartNs;
+      double totalMs = nanosToMs(totalNanos);
+      boolean slow = totalMs >= slowLogMs;
+      if (!slow && !logTimingBreakdown) {
+        return;
+      }
+      String message =
+          String.format(
+              Locale.ROOT,
+              "GetUserObjects timings query_id=%s correlation_id=%s totalMs=%.1f candidates=%d"
+                  + " chunks=%d found=%d notFound=%d resolveMs=%.1f pinCollectMs=%.1f"
+                  + " pinCommitMs=%.1f relationBuildMs=%.1f statsLookupMs=%.1f",
+              ctx.getQueryId(),
+              correlationId,
+              totalMs,
+              resolutionCount,
+              emittedResolutionChunks,
+              foundCount,
+              notFoundCount,
+              nanosToMs(resolveNanos),
+              nanosToMs(pinCollectNanos),
+              nanosToMs(pinCommitNanos),
+              nanosToMs(relationBuildNanos),
+              nanosToMs(timings.statsLookupNanos()));
+      if (slow) {
+        LOG.warn(message);
+      } else {
+        LOG.debug(message);
+      }
     }
 
     /**
@@ -1243,7 +1368,7 @@ public class UserObjectBundleService {
       }
       if (LOG.isDebugEnabled()) {
         LOG.debugf(
-            "Committing chunk pins query=%s pin_count=%d",
+            "Committing chunk pins query_id=%s pin_count=%d",
             ctx.getQueryId(), pendingChunkPins.getPinsCount());
       }
       var updated =
@@ -1254,13 +1379,13 @@ public class UserObjectBundleService {
       if (updated.isEmpty()) {
         if (LOG.isDebugEnabled()) {
           LOG.debugf(
-              "Failed to commit chunk pins query=%s query context missing", ctx.getQueryId());
+              "Failed to commit chunk pins query_id=%s query context missing", ctx.getQueryId());
         }
         throw GrpcErrors.notFound(
             correlationId, QUERY_NOT_FOUND, Map.of("query_id", ctx.getQueryId()));
       }
       if (LOG.isDebugEnabled()) {
-        LOG.debugf("Committed chunk pins query=%s", ctx.getQueryId());
+        LOG.debugf("Committed chunk pins query_id=%s", ctx.getQueryId());
       }
     }
   }

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -283,17 +283,26 @@ public class UserObjectBundleService {
     }
   }
 
-  private SnapshotSet collectSnapshotPins(
-      String correlationId, QueryContext ctx, ResolvedRelation relation) {
-    QueryInput input = buildCanonicalQueryInput(relation);
-    if (input == null) {
+  private SnapshotSet collectChunkPins(
+      String correlationId, QueryContext ctx, List<ResolvedRelation> relations) {
+    if (relations == null || relations.isEmpty()) {
+      return SnapshotSet.getDefaultInstance();
+    }
+    List<QueryInput> inputs = new ArrayList<>(relations.size());
+    for (ResolvedRelation relation : relations) {
+      QueryInput input = buildCanonicalQueryInput(relation);
+      if (input != null) {
+        inputs.add(input);
+      }
+    }
+    if (inputs.isEmpty()) {
       return SnapshotSet.getDefaultInstance();
     }
     var asOfDefault = ctx.parseAsOfDefault(correlationId);
     var resolution =
         inputResolver.resolveInputs(
             correlationId,
-            List.of(input),
+            inputs,
             asOfDefault,
             Optional.of(ctx.getQueryDefaultCatalogId()));
     SnapshotSet incoming = resolution.snapshotSet();
@@ -1090,14 +1099,23 @@ public class UserObjectBundleService {
     }
 
     private void fillPending() {
+      List<ResolvedRelation> toPin = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
       while (nextInputIndex < resolutionCount && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
         PendingItem item = resolveNextResolution();
         pending.add(item);
         if (item instanceof PendingFound found) {
-          collectPinsFor(found.relation());
+          toPin.add(found.relation());
           if (found.relation().node() instanceof ViewNode view && !view.baseRelations().isEmpty()) {
-            injectEagerBaseTables(view);
+            injectEagerBaseTables(view, toPin);
           }
+        }
+      }
+      if (!toPin.isEmpty()) {
+        long pinStartNs = System.nanoTime();
+        try {
+          accumulateChunkPins(collectChunkPins(correlationId, ctx, toPin));
+        } finally {
+          pinCollectNanos += System.nanoTime() - pinStartNs;
         }
       }
     }
@@ -1109,7 +1127,7 @@ public class UserObjectBundleService {
      * Failures to resolve a NameRef are silently skipped (base_relations is a performance hint).
      * Duplicate base-table IDs are deduplicated.
      */
-    private void injectEagerBaseTables(ViewNode view) {
+    private void injectEagerBaseTables(ViewNode view, List<ResolvedRelation> toPin) {
       Set<String> seen = new HashSet<>();
       for (NameRef baseRef : view.baseRelations()) {
         long resolveStartNs = System.nanoTime();
@@ -1131,21 +1149,13 @@ public class UserObjectBundleService {
           ResolvedRelation syntheticRelation =
               new ResolvedRelation(
                   TableReferenceCandidate.getDefaultInstance(), baseId, rel, syntheticInput);
-          collectPinsFor(syntheticRelation);
+          // Base-table pins are already derived from the parent view candidate (including AS-OF
+          // overrides). Avoid re-adding a synthetic TABLE_ID pin here, which would otherwise
+          // resolve to CURRENT and can overwrite AS-OF pins in the same batch.
           pending.add(new PendingFound(-1, syntheticRelation));
         } finally {
           resolveNanos += System.nanoTime() - resolveStartNs;
         }
-      }
-    }
-
-    private void collectPinsFor(ResolvedRelation relation) {
-      long pinStartNs = System.nanoTime();
-      try {
-        SnapshotSet pins = collectSnapshotPins(correlationId, ctx, relation);
-        accumulateChunkPins(pins);
-      } finally {
-        pinCollectNanos += System.nanoTime() - pinStartNs;
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -151,9 +151,9 @@ public class UserObjectBundleService {
       @ConfigProperty(name = "quarkus.grpc.server.plain-text", defaultValue = "true")
           boolean grpcPlainText,
       @ConfigProperty(name = "quarkus.profile", defaultValue = "prod") String quarkusProfile,
-      @ConfigProperty(name = "floedb.catalog.bundle.slow-log-ms", defaultValue = "1000")
+      @ConfigProperty(name = "floecat.catalog.bundle.slow-log-ms", defaultValue = "1000")
           long slowLogMs,
-      @ConfigProperty(name = "floedb.catalog.bundle.log-timings", defaultValue = "false")
+      @ConfigProperty(name = "floecat.catalog.bundle.log-timings", defaultValue = "false")
           boolean logTimingBreakdown) {
     this.overlay = overlay;
     this.inputResolver = inputResolver;

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -71,7 +71,6 @@ import ai.floedb.floecat.systemcatalog.spi.decorator.RelationDecoration;
 import ai.floedb.floecat.systemcatalog.spi.decorator.ViewDecoration;
 import ai.floedb.floecat.types.LogicalType;
 import ai.floedb.floecat.types.LogicalTypeFormat;
-import com.google.protobuf.InvalidProtocolBufferException;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -371,8 +370,8 @@ public class UserObjectBundleService {
       QueryContext queryContext,
       StatsProvider statsProvider,
       TimingAccumulator timings) {
-    if (LOG.isDebugEnabled()) {
-      LOG.debugf(
+    if (LOG.isTraceEnabled()) {
+      LOG.tracef(
           "Building relation bundle query_id=%s relation=%s kind=%s origin=%s",
           queryContext.getQueryId(),
           relation.relationId(),
@@ -965,18 +964,7 @@ public class UserObjectBundleService {
   }
 
   private SnapshotSet parseSnapshotSet(QueryContext ctx, String correlationId) {
-    byte[] payload = ctx.getSnapshotSet();
-    if (payload == null || payload.length == 0) {
-      return SnapshotSet.getDefaultInstance();
-    }
-    try {
-      return SnapshotSet.parseFrom(payload);
-    } catch (InvalidProtocolBufferException e) {
-      throw GrpcErrors.internal(
-          correlationId,
-          CATALOG_BUNDLE_SNAPSHOT_PARSE_FAILED,
-          Map.of("query_id", ctx.getQueryId(), "error", e.getMessage()));
-    }
+    return ctx.parseSnapshotSet(correlationId);
   }
 
   private SnapshotSet mergeSnapshotSets(SnapshotSet existing, SnapshotSet incoming) {
@@ -1077,6 +1065,7 @@ public class UserObjectBundleService {
     private boolean headerEmitted = false;
     private boolean endEmitted = false;
     private long resolveNanos = 0L;
+    private long baseInjectNanos = 0L;
     private long pinCollectNanos = 0L;
     private long pinCommitNanos = 0L;
     private long relationBuildNanos = 0L;
@@ -1217,7 +1206,7 @@ public class UserObjectBundleService {
           // resolve to CURRENT and can overwrite AS-OF pins in the same batch.
           pending.add(new PendingFound(-1, syntheticRelation));
         } finally {
-          resolveNanos += System.nanoTime() - resolveStartNs;
+          baseInjectNanos += System.nanoTime() - resolveStartNs;
         }
       }
       return cursor.nextBaseIndex >= baseRelations.size();
@@ -1376,8 +1365,9 @@ public class UserObjectBundleService {
           String.format(
               Locale.ROOT,
               "GetUserObjects timings query_id=%s correlation_id=%s totalMs=%.1f candidates=%d"
-                  + " chunks=%d found=%d notFound=%d resolveMs=%.1f pinCollectMs=%.1f"
-                  + " pinCommitMs=%.1f relationBuildMs=%.1f statsLookupMs=%.1f",
+                  + " chunks=%d found=%d notFound=%d resolveMs=%.1f baseInjectMs=%.1f"
+                  + " pinCollectMs=%.1f pinCommitMs=%.1f relationBuildMs=%.1f"
+                  + " statsLookupMs=%.1f schedulingMs=%.1f",
               ctx.getQueryId(),
               correlationId,
               totalMs,
@@ -1386,10 +1376,21 @@ public class UserObjectBundleService {
               foundCount,
               notFoundCount,
               nanosToMs(resolveNanos),
+              nanosToMs(baseInjectNanos),
               nanosToMs(pinCollectNanos),
               nanosToMs(pinCommitNanos),
               nanosToMs(relationBuildNanos),
-              nanosToMs(timings.statsLookupNanos()));
+              nanosToMs(timings.statsLookupNanos()),
+              nanosToMs(
+                  Math.max(
+                      0L,
+                      totalNanos
+                          - resolveNanos
+                          - baseInjectNanos
+                          - pinCollectNanos
+                          - pinCommitNanos
+                          - relationBuildNanos
+                          - timings.statsLookupNanos())));
       if (slow) {
         LOG.warn(message);
       } else {
@@ -1520,10 +1521,8 @@ public class UserObjectBundleService {
               existing -> mergeSnapshotSet(existing, pendingChunkPins, correlationId));
       pendingChunkPins = SnapshotSet.getDefaultInstance();
       if (updated.isEmpty()) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debugf(
-              "Failed to commit chunk pins query_id=%s query context missing", ctx.getQueryId());
-        }
+        LOG.warnf(
+            "Failed to commit chunk pins query_id=%s query context missing", ctx.getQueryId());
         throw GrpcErrors.notFound(
             correlationId, QUERY_NOT_FOUND, Map.of("query_id", ctx.getQueryId()));
       }

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -294,7 +294,10 @@ public class UserObjectBundleService {
   }
 
   private SnapshotSet collectChunkPins(
-      String correlationId, QueryContext ctx, List<ResolvedRelation> relations) {
+      String correlationId,
+      QueryContext ctx,
+      List<ResolvedRelation> relations,
+      Map<ResourceId, SnapshotPin> currentSnapshotPinCache) {
     if (relations == null || relations.isEmpty()) {
       return SnapshotSet.getDefaultInstance();
     }
@@ -314,7 +317,8 @@ public class UserObjectBundleService {
             correlationId,
             inputs,
             asOfDefault,
-            Optional.of(ctx.getQueryDefaultCatalogId()));
+            Optional.of(ctx.getQueryDefaultCatalogId()),
+            currentSnapshotPinCache);
     SnapshotSet incoming = resolution.snapshotSet();
     return incoming == null ? SnapshotSet.getDefaultInstance() : incoming;
   }
@@ -385,7 +389,7 @@ public class UserObjectBundleService {
             ? view.outputColumns()
             : relation.node() instanceof UserTableNode userTable
                 ? logicalSchemaMapper.map(userTable).getColumnsList()
-            : overlay.tableSchema(relation.node().id());
+                : overlay.tableSchema(relation.node().id());
 
     List<SchemaColumn> pruned =
         UserObjectBundleUtils.pruneSchema(schemaColumns, relation.candidate(), correlationId);
@@ -1054,11 +1058,13 @@ public class UserObjectBundleService {
 
     // Maintains the order inputs were resolved so the emitted chunk mirrors the request order.
     private final List<PendingItem> pending = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
-    private final Map<NormalizedNameRef, Optional<ResourceId>> nameResolutionCache = new HashMap<>();
+    private final Map<NormalizedNameRef, Optional<ResourceId>> nameResolutionCache =
+        new HashMap<>();
     private final Map<ResourceId, Optional<GraphNode>> nodeResolutionCache = new HashMap<>();
     private final ArrayDeque<EagerBaseCursor> eagerBaseQueue = new ArrayDeque<>();
     private final Set<String> eagerBaseSeen = new HashSet<>();
     private final Map<RelationCacheKey, RelationInfo> relationInfoCache = new HashMap<>();
+    private final Map<ResourceId, SnapshotPin> currentSnapshotPinCache = new HashMap<>();
     private final TimingAccumulator timings = new TimingAccumulator();
     private final long streamStartNs = System.nanoTime();
     private SnapshotSet pendingChunkPins = SnapshotSet.getDefaultInstance();
@@ -1151,7 +1157,7 @@ public class UserObjectBundleService {
       if (!toPin.isEmpty()) {
         long pinStartNs = System.nanoTime();
         try {
-          accumulateChunkPins(collectChunkPins(correlationId, ctx, toPin));
+          accumulateChunkPins(collectChunkPins(correlationId, ctx, toPin, currentSnapshotPinCache));
         } finally {
           pinCollectNanos += System.nanoTime() - pinStartNs;
         }
@@ -1242,9 +1248,7 @@ public class UserObjectBundleService {
             if (LOG.isTraceEnabled()) {
               LOG.tracef(
                   "Resolved candidate query_id=%s input_index=%d relation=%s",
-                  ctx.getQueryId(),
-                  inputIndex,
-                  resolved.get().relationId());
+                  ctx.getQueryId(), inputIndex, resolved.get().relationId());
             }
             return new PendingFound(inputIndex, resolved.get());
           }
@@ -1252,9 +1256,7 @@ public class UserObjectBundleService {
           if (LOG.isDebugEnabled()) {
             LOG.debugf(
                 "Resolved candidate missing graph node query_id=%s input_index=%d resource_id=%s",
-                ctx.getQueryId(),
-                inputIndex,
-                e.relationId() == null ? "" : e.relationId().getId());
+                ctx.getQueryId(), inputIndex, e.relationId() == null ? "" : e.relationId().getId());
           }
           ResolutionFailure failure =
               ResolutionFailure.newBuilder()

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContext.java
@@ -314,7 +314,10 @@ public final class QueryContext {
         .findFirst();
   }
 
-  private SnapshotSet parseSnapshotSet(String correlationId) {
+  public SnapshotSet parseSnapshotSet(String correlationId) {
+    if (snapshotSet == null || snapshotSet.length == 0) {
+      return SnapshotSet.getDefaultInstance();
+    }
     // Memoize parsing: QueryContext is immutable, so caching is safe for the life of the instance.
     SnapshotSet cached = parsedSnapshotSet.get();
     if (cached != null) {
@@ -477,13 +480,18 @@ public final class QueryContext {
 
   private boolean tableIdMatches(ResourceId a, ResourceId b) {
     if (a == null || b == null) return false;
-
-    if (!isBlank(a.getAccountId())
-        && !isBlank(b.getAccountId())
-        && !Objects.equals(a.getAccountId(), b.getAccountId())) {
+    if (!Objects.equals(a.getId(), b.getId())) {
       return false;
     }
-    return Objects.equals(a.getId(), b.getId());
+    boolean aBlank = isBlank(a.getAccountId());
+    boolean bBlank = isBlank(b.getAccountId());
+    if (aBlank && bBlank) {
+      return true;
+    }
+    if (aBlank || bBlank) {
+      return false;
+    }
+    return Objects.equals(a.getAccountId(), b.getAccountId());
   }
 
   private static String requireNonEmpty(String v, String field) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryContext.java
@@ -101,6 +101,12 @@ public final class QueryContext {
   /** Cached parsed SnapshotSet for this immutable context instance (lazy). */
   private final transient AtomicReference<SnapshotSet> parsedSnapshotSet = new AtomicReference<>();
 
+  /**
+   * Cached parsed BeginQuery as-of default timestamp for this immutable context instance (lazy).
+   */
+  private final transient AtomicReference<java.util.Optional<Timestamp>> parsedAsOfDefault =
+      new AtomicReference<>();
+
   // ----------------------------------------------------------------------
   //  Construction
   // ----------------------------------------------------------------------
@@ -337,12 +343,21 @@ public final class QueryContext {
    * default.
    */
   public java.util.Optional<Timestamp> parseAsOfDefault(String correlationId) {
+    java.util.Optional<Timestamp> cached = parsedAsOfDefault.get();
+    if (cached != null) {
+      return cached;
+    }
     if (asOfDefault == null || asOfDefault.length == 0) {
-      return java.util.Optional.empty();
+      java.util.Optional<Timestamp> empty = java.util.Optional.empty();
+      parsedAsOfDefault.compareAndSet(null, empty);
+      return empty;
     }
 
     try {
-      return java.util.Optional.of(Timestamp.parseFrom(asOfDefault));
+      java.util.Optional<Timestamp> parsed =
+          java.util.Optional.of(Timestamp.parseFrom(asOfDefault));
+      parsedAsOfDefault.compareAndSet(null, parsed);
+      return parsed;
     } catch (InvalidProtocolBufferException e) {
       throw GrpcErrors.internal(
           correlationId, QUERY_AS_OF_DEFAULT_PARSE_FAILED, Map.of("query_id", queryId));

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
@@ -137,10 +137,7 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
               }
               L.okf(
                   "query_id=%s correlation_id=%s tables=%d dispatchMs=%.1f outcome=completed",
-                  request.getQueryId(),
-                  correlationRef.get(),
-                  request.getTablesCount(),
-                  dispatchMs);
+                  request.getQueryId(), correlationRef.get(), request.getTablesCount(), dispatchMs);
             });
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
@@ -24,6 +24,7 @@ import ai.floedb.floecat.query.rpc.UserObjectsService;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.catalog.UserObjectBundleService;
@@ -35,6 +36,9 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jboss.logging.Logger;
 
 @GrpcService
@@ -54,6 +58,11 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
   @Override
   public Multi<UserObjectsBundleChunk> getUserObjects(GetUserObjectsRequest request) {
     var L = LogHelper.start(LOG, "GetUserObjects");
+    long startNs = System.nanoTime();
+    AtomicLong workStartNs = new AtomicLong(0L);
+    AtomicBoolean completed = new AtomicBoolean(false);
+    AtomicBoolean failed = new AtomicBoolean(false);
+    AtomicReference<String> correlationRef = new AtomicReference<>("");
     // Capture the incoming gRPC context so the principal/correlation-id stays available
     // while authz/QueryContext lookup happen; the bundle builder itself is context-free.
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
@@ -63,8 +72,15 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
             () ->
                 grpcCtx.call(
                     () -> {
+                      workStartNs.compareAndSet(0L, System.nanoTime());
                       var principalContext = principal.get();
-                      var correlationId = principalContext.getCorrelationId();
+                      var contextCorrelationId = InboundContextInterceptor.CORR_KEY.get();
+                      var principalCorrelationId = principalContext.getCorrelationId();
+                      var correlationId =
+                          contextCorrelationId != null && !contextCorrelationId.isBlank()
+                              ? contextCorrelationId
+                              : principalCorrelationId;
+                      correlationRef.set(correlationId == null ? "" : correlationId);
                       authz.require(principalContext, "catalog.read");
 
                       String queryId =
@@ -86,9 +102,45 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
                       return bundles.stream(correlationId, ctx, request.getTablesList());
                     }))
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())
-        .onFailure()
-        .invoke(L::fail)
         .onCompletion()
-        .invoke(L::ok);
+        .invoke(() -> completed.set(true))
+        .onFailure()
+        .invoke(
+            t -> {
+              failed.set(true);
+              L.fail(t);
+            })
+        .onTermination()
+        .invoke(
+            () -> {
+              long workNs = workStartNs.get();
+              double dispatchMs = workNs <= 0L ? 0.0 : (workNs - startNs) / 1_000_000.0;
+              if (failed.get()) {
+                LOG.warnf(
+                    "op=GetUserObjects terminated query_id=%s correlation_id=%s tables=%d"
+                        + " dispatchMs=%.1f outcome=failed",
+                    request.getQueryId(),
+                    correlationRef.get(),
+                    request.getTablesCount(),
+                    dispatchMs);
+                return;
+              }
+              if (!completed.get()) {
+                LOG.warnf(
+                    "op=GetUserObjects terminated query_id=%s correlation_id=%s tables=%d"
+                        + " dispatchMs=%.1f outcome=cancelled",
+                    request.getQueryId(),
+                    correlationRef.get(),
+                    request.getTablesCount(),
+                    dispatchMs);
+                return;
+              }
+              L.okf(
+                  "query_id=%s correlation_id=%s tables=%d dispatchMs=%.1f outcome=completed",
+                  request.getQueryId(),
+                  correlationRef.get(),
+                  request.getTablesCount(),
+                  dispatchMs);
+            });
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -105,12 +105,18 @@ public class QueryInputResolver {
     final List<ResourceId> resolved = new ArrayList<>();
     // Keep insertion order (matching input order) while deduplicating by table ID.
     final Map<ResourceId, SnapshotPin> pinByTableId = new LinkedHashMap<>();
+    // Request-local cache for current-snapshot table pins (no override, no as-of).
+    final Map<ResourceId, SnapshotPin> currentSnapshotPinCache;
 
     ResolutionState(
-        String correlationId, Optional<Timestamp> asOfDefault, Optional<String> defaultCatalog) {
+        String correlationId,
+        Optional<Timestamp> asOfDefault,
+        Optional<String> defaultCatalog,
+        Map<ResourceId, SnapshotPin> currentSnapshotPinCache) {
       this.correlationId = correlationId;
       this.asOfDefault = asOfDefault;
       this.defaultCatalog = defaultCatalog;
+      this.currentSnapshotPinCache = currentSnapshotPinCache;
     }
   }
 
@@ -138,15 +144,27 @@ public class QueryInputResolver {
       List<QueryInput> inputs,
       Optional<Timestamp> asOfDefault,
       Optional<ResourceId> defaultCatalogId) {
+    return resolveInputs(
+        correlationId, inputs, asOfDefault, defaultCatalogId, new LinkedHashMap<>());
+  }
+
+  public ResolutionResult resolveInputs(
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      Map<ResourceId, SnapshotPin> currentSnapshotPinCache) {
 
     // Resolve catalog display-name once up-front — used to fill in blank catalog fields in
     // view base-relation NameRefs so they re-resolve exactly as they did at view-creation time.
     Optional<String> defaultCatalog =
         metadataGraph == null
             ? Optional.empty()
-            : defaultCatalogId.flatMap(id -> metadataGraph.catalog(id).map(CatalogNode::displayName));
+            : defaultCatalogId.flatMap(
+                id -> metadataGraph.catalog(id).map(CatalogNode::displayName));
 
-    var state = new ResolutionState(correlationId, asOfDefault, defaultCatalog);
+    var state =
+        new ResolutionState(correlationId, asOfDefault, defaultCatalog, currentSnapshotPinCache);
 
     for (QueryInput in : inputs) {
       SnapshotRef override = in.getSnapshot();
@@ -194,23 +212,51 @@ public class QueryInputResolver {
       return;
     }
 
-    mergePin(
-        state.pinByTableId, pinForResource(state.correlationId, rid, override, state.asOfDefault));
+    mergePin(state.pinByTableId, pinForResource(state, rid, override, state.asOfDefault));
   }
 
   private SnapshotPin pinForResource(
-      String correlationId, ResourceId rid, SnapshotRef override, Optional<Timestamp> asOfDefault) {
+      ResolutionState state,
+      ResourceId rid,
+      SnapshotRef override,
+      Optional<Timestamp> asOfDefault) {
     return switch (rid.getKind()) {
-      case RK_TABLE -> metadataGraph.snapshotPinFor(correlationId, rid, override, asOfDefault);
+      case RK_TABLE -> pinForTable(state, rid, override, asOfDefault);
       case RK_VIEW -> {
         // Views are not pinned directly. Dependency pinning is handled by the caller.
-        validateViewOverride(correlationId, rid, override);
+        validateViewOverride(state.correlationId, rid, override);
         yield null;
       }
       default ->
           throw GrpcErrors.invalidArgument(
-              correlationId, QUERY_INPUT_INVALID, Map.of("resource_id", rid.getId()));
+              state.correlationId, QUERY_INPUT_INVALID, Map.of("resource_id", rid.getId()));
     };
+  }
+
+  private SnapshotPin pinForTable(
+      ResolutionState state,
+      ResourceId rid,
+      SnapshotRef override,
+      Optional<Timestamp> asOfDefault) {
+    if (usesCurrentSnapshotFallback(override, asOfDefault)) {
+      SnapshotPin cached = state.currentSnapshotPinCache.get(rid);
+      if (cached != null) {
+        return cached;
+      }
+      SnapshotPin resolved =
+          metadataGraph.snapshotPinFor(state.correlationId, rid, override, asOfDefault);
+      state.currentSnapshotPinCache.put(rid, resolved);
+      return resolved;
+    }
+    return metadataGraph.snapshotPinFor(state.correlationId, rid, override, asOfDefault);
+  }
+
+  private boolean usesCurrentSnapshotFallback(
+      SnapshotRef override, Optional<Timestamp> asOfDefault) {
+    if (override != null && override.getWhichCase() != SnapshotRef.WhichCase.WHICH_NOT_SET) {
+      return false;
+    }
+    return asOfDefault.isEmpty();
   }
 
   private void validateViewOverride(String correlationId, ResourceId viewId, SnapshotRef override) {
@@ -238,8 +284,7 @@ public class QueryInputResolver {
       return;
     }
     if (relationId.getKind() == ResourceKind.RK_TABLE) {
-      mergePin(
-          state.pinByTableId, pinForResource(state.correlationId, relationId, null, effectiveAsOf));
+      mergePin(state.pinByTableId, pinForResource(state, relationId, null, effectiveAsOf));
       return;
     }
     metadataGraph

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -142,7 +142,9 @@ public class QueryInputResolver {
     // Resolve catalog display-name once up-front — used to fill in blank catalog fields in
     // view base-relation NameRefs so they re-resolve exactly as they did at view-creation time.
     Optional<String> defaultCatalog =
-        defaultCatalogId.flatMap(id -> metadataGraph.catalog(id).map(CatalogNode::displayName));
+        metadataGraph == null
+            ? Optional.empty()
+            : defaultCatalogId.flatMap(id -> metadataGraph.catalog(id).map(CatalogNode::displayName));
 
     var state = new ResolutionState(correlationId, asOfDefault, defaultCatalog);
 
@@ -231,7 +233,7 @@ public class QueryInputResolver {
       ResourceId relationId,
       Optional<Timestamp> effectiveAsOf,
       Set<String> seen) {
-    String key = relationId.getKind().name() + ":" + relationId.getId();
+    String key = pinKey(relationId);
     if (!seen.add(key)) {
       return;
     }
@@ -255,6 +257,10 @@ public class QueryInputResolver {
                     .ifPresent(rid -> collectBaseTables(state, rid, effectiveAsOf, seen));
               }
             });
+  }
+
+  private static String pinKey(ResourceId rid) {
+    return String.join(":", rid.getAccountId(), rid.getKind().name(), rid.getId());
   }
 
   private void mergePin(Map<ResourceId, SnapshotPin> pinByTableId, SnapshotPin pin) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
@@ -111,9 +111,6 @@ public class SnapshotRepository {
 
     String token = "";
     StringBuilder next = new StringBuilder();
-    Snapshot best = null;
-    boolean haveBest = false;
-    long bestCreatedMs = Long.MIN_VALUE;
     do {
       List<Snapshot> batch = repo.listByPrefix(prefix, 200, token, next);
       for (Snapshot snapshot : batch) {
@@ -126,7 +123,7 @@ public class SnapshotRepository {
       next.setLength(0);
     } while (!token.isEmpty());
 
-    return Optional.ofNullable(best);
+    return Optional.empty();
   }
 
   public List<Snapshot> list(

--- a/service/src/test/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptorTest.java
@@ -147,7 +147,8 @@ class RpcLoggingInterceptorTest {
 
   @Test
   void extractQueryIdSupportsNonProtobufGetter() {
-    assertEquals("getter-query-id", RpcLoggingInterceptor.extractQueryId(new GetterOnly("getter-query-id")));
+    assertEquals(
+        "getter-query-id", RpcLoggingInterceptor.extractQueryId(new GetterOnly("getter-query-id")));
     assertEquals("", RpcLoggingInterceptor.extractQueryId(new Object()));
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptorTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.error.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.floedb.floecat.query.rpc.GetUserObjectsRequest;
+import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
+import ai.floedb.floecat.service.context.impl.InboundCallContextHelper;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import io.grpc.protobuf.ProtoUtils;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class RpcLoggingInterceptorTest {
+
+  private static final MethodDescriptor<GetUserObjectsRequest, UserObjectsBundleChunk> METHOD =
+      MethodDescriptor.<GetUserObjectsRequest, UserObjectsBundleChunk>newBuilder()
+          .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+          .setFullMethodName("ai.floedb.floecat.query.UserObjectsService/GetUserObjects")
+          .setRequestMarshaller(ProtoUtils.marshaller(GetUserObjectsRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(UserObjectsBundleChunk.getDefaultInstance()))
+          .build();
+
+  private static final Metadata.Key<String> QUERY_ID_HEADER =
+      Metadata.Key.of(InboundCallContextHelper.HEADER_QUERY_ID, Metadata.ASCII_STRING_MARSHALLER);
+
+  @Test
+  void capturesQueryIdFromRequestMessage() {
+    CapturingRpcLoggingInterceptor interceptor = new CapturingRpcLoggingInterceptor();
+    AtomicReference<ServerCall<GetUserObjectsRequest, UserObjectsBundleChunk>> forwardedCall =
+        new AtomicReference<>();
+    RecordingServerCall<GetUserObjectsRequest, UserObjectsBundleChunk> underlying =
+        new RecordingServerCall<>(METHOD);
+
+    Context previous = Context.ROOT.attach();
+    try {
+      var listener =
+          interceptor.interceptCall(
+              underlying,
+              new Metadata(),
+              captureHandler(forwardedCall, new ServerCall.Listener<>() {}));
+      listener.onMessage(GetUserObjectsRequest.newBuilder().setQueryId("req-query-id").build());
+      forwardedCall.get().close(Status.OK, new Metadata());
+    } finally {
+      Context.ROOT.detach(previous);
+    }
+
+    assertEquals("req-query-id", interceptor.loggedQueryId());
+  }
+
+  @Test
+  void capturesQueryIdFromResponseMessageWhenRequestDoesNotCarryIt() {
+    CapturingRpcLoggingInterceptor interceptor = new CapturingRpcLoggingInterceptor();
+    AtomicReference<ServerCall<GetUserObjectsRequest, UserObjectsBundleChunk>> forwardedCall =
+        new AtomicReference<>();
+    RecordingServerCall<GetUserObjectsRequest, UserObjectsBundleChunk> underlying =
+        new RecordingServerCall<>(METHOD);
+
+    Context previous = Context.ROOT.attach();
+    try {
+      var listener =
+          interceptor.interceptCall(
+              underlying,
+              new Metadata(),
+              captureHandler(forwardedCall, new ServerCall.Listener<>() {}));
+      listener.onMessage(GetUserObjectsRequest.getDefaultInstance());
+      forwardedCall
+          .get()
+          .sendMessage(UserObjectsBundleChunk.newBuilder().setQueryId("resp-query-id").build());
+      forwardedCall.get().close(Status.OK, new Metadata());
+    } finally {
+      Context.ROOT.detach(previous);
+    }
+
+    assertEquals("resp-query-id", interceptor.loggedQueryId());
+  }
+
+  @Test
+  void fallsBackToHeaderQueryIdWhenContextAndMessagesDoNotProvideOne() {
+    CapturingRpcLoggingInterceptor interceptor = new CapturingRpcLoggingInterceptor();
+    AtomicReference<ServerCall<GetUserObjectsRequest, UserObjectsBundleChunk>> forwardedCall =
+        new AtomicReference<>();
+    RecordingServerCall<GetUserObjectsRequest, UserObjectsBundleChunk> underlying =
+        new RecordingServerCall<>(METHOD);
+    Metadata headers = new Metadata();
+    headers.put(QUERY_ID_HEADER, "header-query-id");
+
+    Context previous = Context.ROOT.attach();
+    try {
+      var listener =
+          interceptor.interceptCall(
+              underlying, headers, captureHandler(forwardedCall, new ServerCall.Listener<>() {}));
+      listener.onMessage(GetUserObjectsRequest.getDefaultInstance());
+      forwardedCall.get().close(Status.OK, new Metadata());
+    } finally {
+      Context.ROOT.detach(previous);
+    }
+
+    assertEquals("header-query-id", interceptor.loggedQueryId());
+  }
+
+  @Test
+  void contextQueryIdTakesPrecedenceOverHeaderQueryId() {
+    CapturingRpcLoggingInterceptor interceptor = new CapturingRpcLoggingInterceptor();
+    AtomicReference<ServerCall<GetUserObjectsRequest, UserObjectsBundleChunk>> forwardedCall =
+        new AtomicReference<>();
+    RecordingServerCall<GetUserObjectsRequest, UserObjectsBundleChunk> underlying =
+        new RecordingServerCall<>(METHOD);
+    Metadata headers = new Metadata();
+    headers.put(QUERY_ID_HEADER, "header-query-id");
+
+    Context context = Context.current().withValue(InboundContextInterceptor.QUERY_KEY, "ctx-query");
+    Context previous = context.attach();
+    try {
+      var listener =
+          interceptor.interceptCall(
+              underlying, headers, captureHandler(forwardedCall, new ServerCall.Listener<>() {}));
+      listener.onMessage(GetUserObjectsRequest.getDefaultInstance());
+      forwardedCall.get().close(Status.OK, new Metadata());
+    } finally {
+      context.detach(previous);
+    }
+
+    assertEquals("ctx-query", interceptor.loggedQueryId());
+  }
+
+  @Test
+  void extractQueryIdSupportsNonProtobufGetter() {
+    assertEquals("getter-query-id", RpcLoggingInterceptor.extractQueryId(new GetterOnly("getter-query-id")));
+    assertEquals("", RpcLoggingInterceptor.extractQueryId(new Object()));
+  }
+
+  private static <ReqT, RespT> ServerCallHandler<ReqT, RespT> captureHandler(
+      AtomicReference<ServerCall<ReqT, RespT>> forwardedCall, ServerCall.Listener<ReqT> delegate) {
+    return new ServerCallHandler<>() {
+      @Override
+      public ServerCall.Listener<ReqT> startCall(ServerCall<ReqT, RespT> call, Metadata headers) {
+        forwardedCall.set(call);
+        return delegate;
+      }
+    };
+  }
+
+  private static final class RecordingServerCall<ReqT, RespT> extends ServerCall<ReqT, RespT> {
+    private final MethodDescriptor<ReqT, RespT> method;
+
+    private RecordingServerCall(MethodDescriptor<ReqT, RespT> method) {
+      this.method = method;
+    }
+
+    @Override
+    public void request(int numMessages) {}
+
+    @Override
+    public void sendHeaders(Metadata headers) {}
+
+    @Override
+    public void sendMessage(RespT message) {}
+
+    @Override
+    public void close(Status status, Metadata trailers) {}
+
+    @Override
+    public boolean isCancelled() {
+      return false;
+    }
+
+    @Override
+    public MethodDescriptor<ReqT, RespT> getMethodDescriptor() {
+      return method;
+    }
+  }
+
+  private static final class CapturingRpcLoggingInterceptor extends RpcLoggingInterceptor {
+    private String loggedQueryId = "";
+
+    @Override
+    void logCall(
+        Status status,
+        Metadata trailers,
+        String method,
+        long durationMs,
+        String logCorrelationId,
+        String logQueryId) {
+      this.loggedQueryId = logQueryId;
+    }
+
+    private String loggedQueryId() {
+      return loggedQueryId;
+    }
+  }
+
+  private record GetterOnly(String queryId) {
+    public String getQueryId() {
+      return queryId;
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManagerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManagerTest.java
@@ -24,6 +24,7 @@ import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.cache.GraphCacheKey;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.service.testsupport.TestNodes;
+import ai.floedb.floecat.telemetry.Telemetry;
 import ai.floedb.floecat.telemetry.TestObservability;
 import com.google.protobuf.Timestamp;
 import java.time.Instant;
@@ -108,6 +109,28 @@ class GraphCacheManagerTest {
     manager.putMeta(tableId, mutationMeta(1L));
 
     assertThat(manager.getMeta(tableId)).isNull();
+  }
+
+  @Test
+  void metaCacheRecordsHitAndMissCounters() {
+    TestObservability metrics = new TestObservability();
+    GraphCacheManager manager = new GraphCacheManager(true, 10, 2L, metrics);
+    ResourceId tableId = rid("account", "tbl");
+
+    assertThat(manager.getMeta(tableId)).isNull();
+    manager.putMeta(tableId, mutationMeta(2L));
+    assertThat(manager.getMeta(tableId)).isNotNull();
+
+    assertThat(metrics.counterValue(Telemetry.Metrics.CACHE_MISSES)).isGreaterThan(0);
+    assertThat(metrics.counterValue(Telemetry.Metrics.CACHE_HITS)).isGreaterThan(0);
+    assertThat(metrics.counterTagHistory(Telemetry.Metrics.CACHE_HITS))
+        .anySatisfy(
+            tags ->
+                assertThat(tags)
+                    .anyMatch(
+                        tag ->
+                            Telemetry.TagKey.CACHE_NAME.equals(tag.key())
+                                && "graph-meta-cache".equals(tag.value())));
   }
 
   private UserTableNode tableNode(ResourceId tableId) {

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManagerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/cache/GraphCacheManagerTest.java
@@ -18,12 +18,15 @@ package ai.floedb.floecat.service.metagraph.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.cache.GraphCacheKey;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.service.testsupport.TestNodes;
 import ai.floedb.floecat.telemetry.TestObservability;
+import com.google.protobuf.Timestamp;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -84,6 +87,29 @@ class GraphCacheManagerTest {
     assertThat(disabled.get(tableId, key)).isNull();
   }
 
+  @Test
+  void metaCacheStoresAndInvalidatesEntries() {
+    GraphCacheManager manager = new GraphCacheManager(true, 10, 2L, new TestObservability());
+    ResourceId tableId = rid("account", "tbl");
+    MutationMeta meta = mutationMeta(7L);
+
+    assertThat(manager.getMeta(tableId)).isNull();
+    manager.putMeta(tableId, meta);
+    assertThat(manager.getMeta(tableId)).isEqualTo(meta);
+
+    manager.invalidate(tableId);
+    assertThat(manager.getMeta(tableId)).isNull();
+  }
+
+  @Test
+  void disabledMetaCacheIgnoresWrites() {
+    GraphCacheManager manager = new GraphCacheManager(true, 10, 0L, new TestObservability());
+    ResourceId tableId = rid("account", "tbl");
+    manager.putMeta(tableId, mutationMeta(1L));
+
+    assertThat(manager.getMeta(tableId)).isNull();
+  }
+
   private UserTableNode tableNode(ResourceId tableId) {
     return TestNodes.tableNode(tableId, "{}");
   }
@@ -93,6 +119,16 @@ class GraphCacheManagerTest {
         .setAccountId(accountId)
         .setId(id)
         .setKind(ResourceKind.RK_TABLE)
+        .build();
+  }
+
+  private static MutationMeta mutationMeta(long pointerVersion) {
+    return MutationMeta.newBuilder()
+        .setPointerVersion(pointerVersion)
+        .setUpdatedAt(
+            Timestamp.newBuilder()
+                .setSeconds(Instant.parse("2024-01-01T00:00:00Z").getEpochSecond())
+                .build())
         .build();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraphTest.java
@@ -193,11 +193,13 @@ class UserGraphTest {
     assertThat(first).isPresent();
     assertThat(second).containsSame(first.get());
     assertThat(tableRepository.getByIdCount(tableId)).isEqualTo(1);
+    assertThat(tableRepository.metaForSafeCount(tableId)).isEqualTo(1);
 
     graph.invalidate(tableId);
     Optional<UserTableNode> third = graph.table(tableId);
     assertThat(third).isPresent();
     assertThat(tableRepository.getByIdCount(tableId)).isEqualTo(2);
+    assertThat(tableRepository.metaForSafeCount(tableId)).isEqualTo(2);
   }
 
   @Test
@@ -224,16 +226,17 @@ class UserGraphTest {
     assertThat(tableRepository.getByIdCount(tableId)).isEqualTo(1);
 
     tableRepository.putMeta(tableId, mutationMeta(2L, Instant.parse("2024-06-01T00:00:00Z")));
+    graph.invalidate(tableId);
     graph.table(tableId);
     assertThat(tableRepository.getByIdCount(tableId)).isEqualTo(2);
 
-    graph.invalidate(tableId);
-
     tableRepository.putMeta(tableId, mutationMeta(1L, Instant.parse("2024-06-02T00:00:00Z")));
+    graph.invalidate(tableId);
     graph.table(tableId);
     assertThat(tableRepository.getByIdCount(tableId)).isEqualTo(3);
 
     tableRepository.putMeta(tableId, mutationMeta(2L, Instant.parse("2024-06-03T00:00:00Z")));
+    graph.invalidate(tableId);
     graph.table(tableId);
     assertThat(tableRepository.getByIdCount(tableId)).isEqualTo(4);
   }

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraphTest.java
@@ -37,7 +37,6 @@ import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
-import ai.floedb.floecat.service.metagraph.snapshot.SnapshotHelper;
 import ai.floedb.floecat.service.testsupport.FakeCatalogRepository;
 import ai.floedb.floecat.service.testsupport.FakeNamespaceRepository;
 import ai.floedb.floecat.service.testsupport.FakeTableRepository;
@@ -76,8 +75,8 @@ class UserGraphTest {
     tableRepository = new FakeTableRepository();
     viewRepository = new FakeViewRepository();
 
-    // Use the lightweight test-only constructor; it wires up a minimal graph
     observability = new TestObservability();
+    principalProvider = new FakePrincipalProvider("account");
     graph =
         new UserGraph(
             catalogRepository,
@@ -85,12 +84,10 @@ class UserGraphTest {
             snapshotRepository,
             tableRepository,
             viewRepository,
-            observability);
-
-    graph.setSnapshotHelper(new SnapshotHelper(snapshotRepository));
-
-    principalProvider = new FakePrincipalProvider("account");
-    graph.setPrincipalProvider(principalProvider);
+            observability,
+            principalProvider,
+            1024L,
+            null);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -24,6 +24,7 @@ import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.ColumnFailureCode;
@@ -365,6 +366,65 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void largeRequestSpansMultipleChunksInOrder() {
+    int totalCandidates = 30;
+    List<TableReferenceCandidate> candidates = new ArrayList<>(totalCandidates);
+    for (int i = 0; i < totalCandidates; i++) {
+      candidates.add(
+          TableReferenceCandidate.newBuilder()
+              .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+              .build());
+    }
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, candidates).collect().asList().await().indefinitely();
+
+    List<UserObjectsBundleChunk> resolutionChunks =
+        chunks.stream().filter(UserObjectsBundleChunk::hasResolutions).toList();
+    assertThat(resolutionChunks).hasSize(2);
+
+    List<Integer> actualInputIndexes = new ArrayList<>();
+    for (UserObjectsBundleChunk chunk : resolutionChunks) {
+      for (RelationResolution item : chunk.getResolutions().getItemsList()) {
+        actualInputIndexes.add(item.getInputIndex());
+      }
+    }
+    List<Integer> expectedInputIndexes = new ArrayList<>(totalCandidates);
+    for (int i = 0; i < totalCandidates; i++) {
+      expectedInputIndexes.add(i);
+    }
+    assertThat(actualInputIndexes).containsExactlyElementsOf(expectedInputIndexes);
+  }
+
+  @Test
+  void chunkSizeDoesNotExceedMax() {
+    int totalCandidates = 26;
+    List<TableReferenceCandidate> candidates = new ArrayList<>(totalCandidates);
+    for (int i = 0; i < totalCandidates; i++) {
+      candidates.add(
+          TableReferenceCandidate.newBuilder()
+              .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+              .build());
+    }
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, candidates).collect().asList().await().indefinitely();
+
+    List<UserObjectsBundleChunk> resolutionChunks =
+        chunks.stream().filter(UserObjectsBundleChunk::hasResolutions).toList();
+    assertThat(resolutionChunks).hasSize(2);
+    assertThat(resolutionChunks)
+        .allSatisfy(
+            chunk ->
+                assertThat(chunk.getResolutions().getItemsCount()).isLessThanOrEqualTo(25));
+    assertThat(
+            resolutionChunks.stream()
+                .mapToInt(chunk -> chunk.getResolutions().getItemsCount())
+                .sum())
+        .isEqualTo(totalCandidates);
+  }
+
+  @Test
   void commitSkippedWhenPinsEmpty() {
     QueryInputResolver emptyResolver =
         new QueryInputResolver() {
@@ -373,7 +433,8 @@ class UserObjectBundleServiceTest {
               String correlationId,
               List<QueryInput> inputs,
               Optional<Timestamp> asOfDefault,
-              Optional<ResourceId> defaultCatalogId) {
+              Optional<ResourceId> defaultCatalogId,
+              Map<ResourceId, SnapshotPin> currentSnapshotPinCache) {
             return new ResolutionResult(
                 List.of(inputs.get(0).getTableId()), SnapshotSet.getDefaultInstance(), null);
           }
@@ -438,6 +499,98 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void duplicateCandidatesForSameRelation() {
+    TableReferenceCandidate first =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+    TableReferenceCandidate second =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(first, second))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely();
+
+    List<RelationResolution> items = chunks.get(1).getResolutions().getItemsList();
+    assertThat(items).hasSize(2);
+    assertThat(items.get(0).getInputIndex()).isEqualTo(0);
+    assertThat(items.get(1).getInputIndex()).isEqualTo(1);
+    assertThat(items).allMatch(r -> r.getStatus() == ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(items).allMatch(r -> r.getRelation().getRelationId().equals(TABLE_A));
+  }
+
+  @Test
+  void sameTableWithDifferentSnapshotOverridesProducesDistinctRelationInfos() {
+    AtomicInteger relationDecorations = new AtomicInteger();
+    EngineMetadataDecoratorProvider provider =
+        ctx ->
+            Optional.of(
+                new EngineMetadataDecorator() {
+                  @Override
+                  public void decorateRelation(
+                      EngineContext ec,
+                      ai.floedb.floecat.systemcatalog.spi.decorator.RelationDecoration relation) {
+                    relationDecorations.incrementAndGet();
+                  }
+                });
+    UserObjectBundleService decoratedService =
+        new UserObjectBundleService(
+            overlay,
+            resolver,
+            queryStore,
+            statsFactory,
+            provider,
+            engineContextProvider,
+            true,
+            "localhost",
+            47470,
+            false,
+            "test");
+
+    TableReferenceCandidate first =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(
+                QueryInput.newBuilder()
+                    .setTableId(TABLE_A)
+                    .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(1L).build()))
+            .build();
+    TableReferenceCandidate second =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(
+                QueryInput.newBuilder()
+                    .setTableId(TABLE_A)
+                    .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(2L).build()))
+            .build();
+
+    EngineContext engineContext = EngineContext.of("pg", "16.0");
+    Context context =
+        Context.current().withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, engineContext);
+    Context previous = context.attach();
+    List<UserObjectsBundleChunk> chunks;
+    try {
+      chunks =
+          decoratedService.stream("cid", ctx, List.of(first, second))
+              .collect()
+              .asList()
+              .await()
+              .indefinitely();
+    } finally {
+      context.detach(previous);
+    }
+
+    List<RelationResolution> items = chunks.get(1).getResolutions().getItemsList();
+    assertThat(items).hasSize(2);
+    assertThat(items).allMatch(r -> r.getStatus() == ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(items).allMatch(r -> r.getRelation().getRelationId().equals(TABLE_A));
+    assertThat(relationDecorations.get()).isEqualTo(2);
+  }
+
+  @Test
   void relationStillResolvesWhenStatsMissing() {
     TableReferenceCandidate candidate =
         TableReferenceCandidate.newBuilder()
@@ -479,7 +632,7 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
-  void systemTableStatsAreSkippedWhenUnpinned() {
+  void systemTableStatsAreSkippedWhenUnpinned() throws Exception {
     overlay.registerTable(
         SYSTEM_TABLE,
         UserObjectBundleTestSupport.schemaFor("sys_id"),
@@ -507,6 +660,11 @@ class UserObjectBundleServiceTest {
     assertThat(relation.getRelationId()).isEqualTo(SYSTEM_TABLE);
     assertThat(relation.getOrigin()).isEqualTo(Origin.ORIGIN_BUILTIN);
     assertThat(relation.hasStats()).isFalse();
+    assertThat(queryStore.updateCount()).isEqualTo(0);
+    QueryContext updatedCtx = queryStore.get(ctx.getQueryId()).orElseThrow();
+    SnapshotSet snapshotSet = SnapshotSet.parseFrom(updatedCtx.getSnapshotSet());
+    assertThat(snapshotSet.getPinsList())
+        .noneMatch(pin -> pin.hasTableId() && pin.getTableId().equals(SYSTEM_TABLE));
   }
 
   @Test
@@ -676,6 +834,73 @@ class UserObjectBundleServiceTest {
     assertThat(resolution.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
     assertThat(resolution.getRelation().getRelationId()).isEqualTo(TABLE_A);
     assertThat(chunks.get(2).getEnd().getFoundCount()).isEqualTo(1);
+  }
+
+  @Test
+  void nameResolutionCachePreservesCaseSensitiveNames() {
+    ResourceId mixedCase =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("TABLE_MIXED")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    ResourceId lowerCase =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("TABLE_LOWER")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    overlay.registerTable(
+        mixedCase,
+        UserObjectBundleTestSupport.schemaFor("mixed_col"),
+        NameRef.newBuilder().setCatalog("cat").setName("TableX").build());
+    overlay.registerTable(
+        lowerCase,
+        UserObjectBundleTestSupport.schemaFor("lower_col"),
+        NameRef.newBuilder().setCatalog("cat").setName("tablex").build());
+
+    TableReferenceCandidate mixedCandidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(
+                QueryInput.newBuilder()
+                    .setName(NameRef.newBuilder().setCatalog("cat").setName("TableX").build()))
+            .build();
+    TableReferenceCandidate lowerCandidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(
+                QueryInput.newBuilder()
+                    .setName(NameRef.newBuilder().setCatalog("cat").setName("tablex").build()))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(mixedCandidate, lowerCandidate))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely();
+
+    RelationResolution first = chunks.get(1).getResolutions().getItems(0);
+    RelationResolution second = chunks.get(1).getResolutions().getItems(1);
+    assertThat(first.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(second.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(first.getRelation().getRelationId()).isEqualTo(mixedCase);
+    assertThat(second.getRelation().getRelationId()).isEqualTo(lowerCase);
+  }
+
+  @Test
+  void resolveIsCachedPerUniqueTableWithinChunk() {
+    TableReferenceCandidate first =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+    TableReferenceCandidate second =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    service.stream("cid", ctx, List.of(first, second)).collect().asList().await().indefinitely();
+
+    assertThat(overlay.resolveCount(TABLE_A)).isEqualTo(1);
   }
 
   @Test
@@ -1532,5 +1757,224 @@ class UserObjectBundleServiceTest {
     assertThat(basePin.hasAsOf()).isTrue();
     assertThat(basePin.getAsOf()).isEqualTo(asOf);
     assertThat(basePin.hasSnapshotId()).isFalse();
+  }
+
+  @Test
+  void viewBaseRelationWithUnresolvableNameSilentlySkipped() {
+    ResourceId viewId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("VIEW_UNRESOLVED_BASE")
+            .setKind(ResourceKind.RK_VIEW)
+            .build();
+    NameRef missingBase = NameRef.newBuilder().setCatalog("cat").setName("missing_base").build();
+    ViewNode viewNode =
+        new ViewNode(
+            viewId,
+            1L,
+            Instant.EPOCH,
+            DEFAULT_CATALOG,
+            ResourceId.getDefaultInstance(),
+            "view_unresolved_base",
+            "SELECT 1",
+            "spark",
+            List.of(SchemaColumn.newBuilder().setName("c").setNullable(true).build()),
+            List.of(missingBase),
+            List.of(),
+            GraphNodeOrigin.USER,
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            Map.of());
+    overlay.registerRelation(
+        viewId,
+        viewNode,
+        UserObjectBundleTestSupport.schemaFor("c"),
+        NameRef.newBuilder().setCatalog("cat").setName("view_unresolved_base").build());
+
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setViewId(viewId))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    RelationResolutions resolutions = chunks.get(1).getResolutions();
+    assertThat(resolutions.getItemsCount()).isEqualTo(1);
+    RelationResolution viewRes = resolutions.getItems(0);
+    assertThat(viewRes.getInputIndex()).isEqualTo(0);
+    assertThat(viewRes.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(viewRes.getRelation().getRelationId()).isEqualTo(viewId);
+  }
+
+  @Test
+  void sharedBaseTableEmittedOnce() {
+    ResourceId view1Id =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("VIEW_SHARED_1")
+            .setKind(ResourceKind.RK_VIEW)
+            .build();
+    ResourceId view2Id =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("VIEW_SHARED_2")
+            .setKind(ResourceKind.RK_VIEW)
+            .build();
+    ResourceId sharedBaseId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("BASE_SHARED")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    NameRef sharedBaseName = NameRef.newBuilder().setCatalog("cat").setName("base_shared").build();
+    overlay.registerTable(
+        sharedBaseId, UserObjectBundleTestSupport.schemaFor("base_col"), sharedBaseName);
+
+    ViewNode view1 =
+        new ViewNode(
+            view1Id,
+            1L,
+            Instant.EPOCH,
+            DEFAULT_CATALOG,
+            ResourceId.getDefaultInstance(),
+            "view_shared_1",
+            "SELECT base_col FROM cat.base_shared",
+            "spark",
+            List.of(SchemaColumn.newBuilder().setName("base_col").setNullable(true).build()),
+            List.of(sharedBaseName),
+            List.of(),
+            GraphNodeOrigin.USER,
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            Map.of());
+    ViewNode view2 =
+        new ViewNode(
+            view2Id,
+            1L,
+            Instant.EPOCH,
+            DEFAULT_CATALOG,
+            ResourceId.getDefaultInstance(),
+            "view_shared_2",
+            "SELECT base_col FROM cat.base_shared",
+            "spark",
+            List.of(SchemaColumn.newBuilder().setName("base_col").setNullable(true).build()),
+            List.of(sharedBaseName),
+            List.of(),
+            GraphNodeOrigin.USER,
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            Map.of());
+    overlay.registerRelation(
+        view1Id,
+        view1,
+        UserObjectBundleTestSupport.schemaFor("base_col"),
+        NameRef.newBuilder().setCatalog("cat").setName("view_shared_1").build());
+    overlay.registerRelation(
+        view2Id,
+        view2,
+        UserObjectBundleTestSupport.schemaFor("base_col"),
+        NameRef.newBuilder().setCatalog("cat").setName("view_shared_2").build());
+
+    List<TableReferenceCandidate> candidates =
+        List.of(
+            TableReferenceCandidate.newBuilder()
+                .addCandidates(QueryInput.newBuilder().setViewId(view1Id))
+                .build(),
+            TableReferenceCandidate.newBuilder()
+                .addCandidates(QueryInput.newBuilder().setViewId(view2Id))
+                .build());
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, candidates).collect().asList().await().indefinitely();
+
+    List<RelationResolution> resolutions =
+        chunks.get(1).getResolutions().getItemsList().stream().toList();
+    long sharedBaseCount =
+        resolutions.stream()
+            .filter(r -> r.getRelation().getRelationId().equals(sharedBaseId))
+            .count();
+    long syntheticSharedBaseCount =
+        resolutions.stream()
+            .filter(r -> r.getRelation().getRelationId().equals(sharedBaseId))
+            .filter(r -> r.getInputIndex() == -1)
+            .count();
+    assertThat(sharedBaseCount).isEqualTo(1);
+    assertThat(syntheticSharedBaseCount).isEqualTo(1);
+  }
+
+  @Test
+  void baseTableInjectionBoundedByChunkMax() {
+    ResourceId viewId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("VIEW_BOUNDED_BASES")
+            .setKind(ResourceKind.RK_VIEW)
+            .build();
+    List<NameRef> baseRefs = new ArrayList<>();
+    for (int i = 0; i < 30; i++) {
+      ResourceId baseId =
+          ResourceId.newBuilder()
+              .setAccountId("acct")
+              .setId("BASE_" + i)
+              .setKind(ResourceKind.RK_TABLE)
+              .build();
+      NameRef baseName = NameRef.newBuilder().setCatalog("cat").setName("base_" + i).build();
+      overlay.registerTable(baseId, UserObjectBundleTestSupport.schemaFor("c" + i), baseName);
+      baseRefs.add(baseName);
+    }
+    ViewNode viewNode =
+        new ViewNode(
+            viewId,
+            1L,
+            Instant.EPOCH,
+            DEFAULT_CATALOG,
+            ResourceId.getDefaultInstance(),
+            "view_bounded_bases",
+            "SELECT 1",
+            "spark",
+            List.of(SchemaColumn.newBuilder().setName("c").setNullable(true).build()),
+            baseRefs,
+            List.of(),
+            GraphNodeOrigin.USER,
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            Map.of());
+    overlay.registerRelation(
+        viewId,
+        viewNode,
+        UserObjectBundleTestSupport.schemaFor("c"),
+        NameRef.newBuilder().setCatalog("cat").setName("view_bounded_bases").build());
+
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setViewId(viewId))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    List<UserObjectsBundleChunk> resolutionChunks =
+        chunks.stream().filter(UserObjectsBundleChunk::hasResolutions).toList();
+    assertThat(resolutionChunks).hasSize(2);
+    assertThat(resolutionChunks)
+        .allSatisfy(
+            chunk ->
+                assertThat(chunk.getResolutions().getItemsCount()).isLessThanOrEqualTo(25));
+
+    List<RelationResolution> allResolutions =
+        resolutionChunks.stream().flatMap(c -> c.getResolutions().getItemsList().stream()).toList();
+    assertThat(allResolutions).hasSize(31); // 1 requested view + 30 eager bases
+    assertThat(
+            allResolutions.stream()
+                .filter(r -> r.getInputIndex() == 0 && r.getRelation().getRelationId().equals(viewId))
+                .count())
+        .isEqualTo(1);
+    assertThat(allResolutions.stream().filter(r -> r.getInputIndex() == -1).count()).isEqualTo(30);
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -415,8 +415,7 @@ class UserObjectBundleServiceTest {
     assertThat(resolutionChunks).hasSize(2);
     assertThat(resolutionChunks)
         .allSatisfy(
-            chunk ->
-                assertThat(chunk.getResolutions().getItemsCount()).isLessThanOrEqualTo(25));
+            chunk -> assertThat(chunk.getResolutions().getItemsCount()).isLessThanOrEqualTo(25));
     assertThat(
             resolutionChunks.stream()
                 .mapToInt(chunk -> chunk.getResolutions().getItemsCount())

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -68,6 +68,7 @@ import ai.floedb.floecat.systemcatalog.spi.decorator.EngineMetadataDecorator;
 import ai.floedb.floecat.systemcatalog.spi.decorator.EngineMetadataDecoratorProvider;
 import com.google.protobuf.Timestamp;
 import io.grpc.Context;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -188,6 +189,13 @@ class UserObjectBundleServiceTest {
             47470,
             false,
             "test");
+  }
+
+  private static void injectOverlay(QueryInputResolver resolver, FakeCatalogOverlay overlay)
+      throws Exception {
+    Field metadataGraph = QueryInputResolver.class.getDeclaredField("metadataGraph");
+    metadataGraph.setAccessible(true);
+    metadataGraph.set(resolver, overlay);
   }
 
   @Test
@@ -1422,7 +1430,107 @@ class UserObjectBundleServiceTest {
     assertThat(chunks.get(2).getEnd().getResolutionCount()).isEqualTo(1);
     assertThat(chunks.get(2).getEnd().getFoundCount()).isEqualTo(1);
 
-    // Resolver was called twice: once for the view pin, once for the base table pin
-    assertThat(resolver.recordedInputs()).hasSize(2);
+    // Resolver is called once for the view; base-table pins are derived from that view input.
+    assertThat(resolver.recordedInputs()).hasSize(1);
+  }
+
+  @Test
+  void viewAsOfOverrideKeepsAsOfPinForEagerBaseTable() throws Exception {
+    ResourceId viewId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("VIEW_AS_OF")
+            .setKind(ResourceKind.RK_VIEW)
+            .build();
+    ResourceId baseId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("BASE_AS_OF")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    NameRef baseNameRef = NameRef.newBuilder().setCatalog("cat").setName("base_as_of").build();
+    overlay.registerTable(baseId, UserObjectBundleTestSupport.schemaFor("base_col"), baseNameRef);
+
+    ViewNode viewNode =
+        new ViewNode(
+            viewId,
+            1L,
+            Instant.EPOCH,
+            DEFAULT_CATALOG,
+            ResourceId.getDefaultInstance(),
+            "view_as_of",
+            "SELECT base_col FROM cat.base_as_of",
+            "spark",
+            List.of(SchemaColumn.newBuilder().setName("base_col").setNullable(true).build()),
+            List.of(baseNameRef),
+            List.of(),
+            GraphNodeOrigin.USER,
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            Map.of());
+    overlay.registerRelation(
+        viewId,
+        viewNode,
+        UserObjectBundleTestSupport.schemaFor("base_col"),
+        NameRef.newBuilder().setCatalog("cat").setName("view_as_of").build());
+
+    QueryContext asOfCtx =
+        QueryContext.builder()
+            .queryId("q-view-asof")
+            .principal(ctx.getPrincipal())
+            .snapshotSet(SnapshotSet.getDefaultInstance().toByteArray())
+            .createdAtMs(ctx.getCreatedAtMs())
+            .expiresAtMs(ctx.getExpiresAtMs())
+            .state(QueryContext.State.ACTIVE)
+            .version(1)
+            .queryDefaultCatalogId(DEFAULT_CATALOG)
+            .build();
+    queryStore.seed(asOfCtx);
+
+    QueryInputResolver realResolver = new QueryInputResolver();
+    injectOverlay(realResolver, overlay);
+    UserObjectBundleService realService =
+        new UserObjectBundleService(
+            overlay,
+            realResolver,
+            queryStore,
+            statsFactory,
+            decoratorProvider,
+            engineContextProvider,
+            false,
+            "localhost",
+            47470,
+            false,
+            "test");
+
+    Timestamp asOf = Timestamp.newBuilder().setSeconds(1_700_000_000L).build();
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(
+                QueryInput.newBuilder()
+                    .setViewId(viewId)
+                    .setSnapshot(SnapshotRef.newBuilder().setAsOf(asOf).build()))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        realService.stream("cid", asOfCtx, List.of(candidate))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely();
+
+    assertThat(chunks.get(1).getResolutions().getItemsCount()).isEqualTo(2);
+    QueryContext updatedCtx = queryStore.get(asOfCtx.getQueryId()).orElseThrow();
+    SnapshotSet snapshotSet = SnapshotSet.parseFrom(updatedCtx.getSnapshotSet());
+    SnapshotPin basePin =
+        snapshotSet.getPinsList().stream()
+            .filter(pin -> pin.getTableId().equals(baseId))
+            .findFirst()
+            .orElseThrow();
+    assertThat(basePin.hasAsOf()).isTrue();
+    assertThat(basePin.getAsOf()).isEqualTo(asOf);
+    assertThat(basePin.hasSnapshotId()).isFalse();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -1963,15 +1963,15 @@ class UserObjectBundleServiceTest {
     assertThat(resolutionChunks).hasSize(2);
     assertThat(resolutionChunks)
         .allSatisfy(
-            chunk ->
-                assertThat(chunk.getResolutions().getItemsCount()).isLessThanOrEqualTo(25));
+            chunk -> assertThat(chunk.getResolutions().getItemsCount()).isLessThanOrEqualTo(25));
 
     List<RelationResolution> allResolutions =
         resolutionChunks.stream().flatMap(c -> c.getResolutions().getItemsList().stream()).toList();
     assertThat(allResolutions).hasSize(31); // 1 requested view + 30 eager bases
     assertThat(
             allResolutions.stream()
-                .filter(r -> r.getInputIndex() == 0 && r.getRelation().getRelationId().equals(viewId))
+                .filter(
+                    r -> r.getInputIndex() == 0 && r.getRelation().getRelationId().equals(viewId))
                 .count())
         .isEqualTo(1);
     assertThat(allResolutions.stream().filter(r -> r.getInputIndex() == -1).count()).isEqualTo(30);

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
@@ -69,6 +70,7 @@ public final class UserObjectBundleTestSupport {
     private final Map<String, NameRef> names = new HashMap<>();
     private final Map<String, CatalogNode> catalogs = new HashMap<>();
     private final Set<String> hidden = new HashSet<>();
+    private final Map<String, Integer> resolveCalls = new ConcurrentHashMap<>();
 
     public void clear() {
       nodes.clear();
@@ -76,6 +78,7 @@ public final class UserObjectBundleTestSupport {
       names.clear();
       catalogs.clear();
       hidden.clear();
+      resolveCalls.clear();
     }
 
     public void registerTable(
@@ -128,10 +131,15 @@ public final class UserObjectBundleTestSupport {
 
     @Override
     public Optional<GraphNode> resolve(ResourceId id) {
+      resolveCalls.merge(id.getAccountId() + ":" + id.getKind() + ":" + id.getId(), 1, Integer::sum);
       if (hidden.contains(id.getId())) {
         return Optional.empty();
       }
       return Optional.ofNullable(nodes.get(id.getId()));
+    }
+
+    public int resolveCount(ResourceId id) {
+      return resolveCalls.getOrDefault(id.getAccountId() + ":" + id.getKind() + ":" + id.getId(), 0);
     }
 
     @Override
@@ -353,13 +361,25 @@ public final class UserObjectBundleTestSupport {
         String correlationId,
         List<QueryInput> inputs,
         Optional<Timestamp> asOfDefault,
-        Optional<ResourceId> defaultCatalogId) {
-      calls.add(new ArrayList<>(inputs));
-      ResourceId rid = inputs.get(0).getTableId();
-      SnapshotPin pin =
-          SnapshotPin.newBuilder().setTableId(rid).setSnapshotId(nextSnapshotId++).build();
-      return new ResolutionResult(
-          List.of(rid), SnapshotSet.newBuilder().addPins(pin).build(), null);
+        Optional<ResourceId> defaultCatalogId,
+        Map<ResourceId, SnapshotPin> currentSnapshotPinCache) {
+      List<ResourceId> resolved = new ArrayList<>(inputs.size());
+      SnapshotSet.Builder pins = SnapshotSet.newBuilder();
+      for (QueryInput input : inputs) {
+        calls.add(List.of(input));
+        switch (input.getTargetCase()) {
+          case TABLE_ID -> {
+            ResourceId rid = input.getTableId();
+            resolved.add(rid);
+            pins.addPins(
+                SnapshotPin.newBuilder().setTableId(rid).setSnapshotId(nextSnapshotId++).build());
+          }
+          case VIEW_ID -> resolved.add(input.getViewId());
+          case NAME -> {}
+          default -> {}
+        }
+      }
+      return new ResolutionResult(resolved, pins.build(), null);
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -207,7 +207,23 @@ public final class UserObjectBundleTestSupport {
         ResourceId tableId,
         ai.floedb.floecat.common.rpc.SnapshotRef override,
         Optional<Timestamp> asOfDefault) {
-      throw unsupported();
+      SnapshotPin.Builder pin = SnapshotPin.newBuilder().setTableId(tableId);
+      if (override != null) {
+        if (override.hasSnapshotId()) {
+          pin.setSnapshotId(override.getSnapshotId());
+          return pin.build();
+        }
+        if (override.hasAsOf()) {
+          pin.setAsOf(override.getAsOf());
+          return pin.build();
+        }
+      }
+      if (asOfDefault.isPresent()) {
+        pin.setAsOf(asOfDefault.get());
+      } else {
+        pin.setSnapshotId(1L);
+      }
+      return pin.build();
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -45,8 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 import java.util.function.UnaryOperator;
@@ -131,7 +131,8 @@ public final class UserObjectBundleTestSupport {
 
     @Override
     public Optional<GraphNode> resolve(ResourceId id) {
-      resolveCalls.merge(id.getAccountId() + ":" + id.getKind() + ":" + id.getId(), 1, Integer::sum);
+      resolveCalls.merge(
+          id.getAccountId() + ":" + id.getKind() + ":" + id.getId(), 1, Integer::sum);
       if (hidden.contains(id.getId())) {
         return Optional.empty();
       }
@@ -139,7 +140,8 @@ public final class UserObjectBundleTestSupport {
     }
 
     public int resolveCount(ResourceId id) {
-      return resolveCalls.getOrDefault(id.getAccountId() + ":" + id.getKind() + ":" + id.getId(), 0);
+      return resolveCalls.getOrDefault(
+          id.getAccountId() + ":" + id.getKind() + ":" + id.getId(), 0);
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -626,6 +626,22 @@ public class QueryInputResolverTest {
     assertEquals(0, pins.get(0).getAsOf().getSeconds());
   }
 
+  @Test
+  void currentSnapshotPinCacheReusedAcrossResolveCalls() {
+    ResourceId tableId = rid("CACHE_TABLE");
+    metadataGraph.setCurrentSnapshot(tableId, 1234L);
+    QueryInput input = QueryInput.newBuilder().setTableId(tableId).build();
+    Map<ResourceId, SnapshotPin> cache = new HashMap<>();
+
+    resolver.resolveInputs("cid-a", List.of(input), Optional.empty(), Optional.empty(), cache);
+    resolver.resolveInputs("cid-b", List.of(input), Optional.empty(), Optional.empty(), cache);
+
+    long tablePinCalls =
+        metadataGraph.pinCalls().stream().filter(call -> call.tableId().equals(tableId)).count();
+    assertEquals(1L, tablePinCalls);
+    assertEquals(1, cache.size());
+  }
+
   // ----------------------------------------------------------------------
   // Base-relation enrichment (catalog + search-path fallback)
   // ----------------------------------------------------------------------

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/QueryContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/QueryContextTest.java
@@ -240,4 +240,66 @@ class QueryContextTest {
     assertEquals(asOf, first);
     assertSame(first, second);
   }
+
+  @Test
+  void parseSnapshotSetMemoized() {
+    ResourceId accountId = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT);
+    var pc = pc(accountId, "alice", "p-snapshot");
+    ResourceId tableId = TestSupport.rid(accountId.getId(), "tbl-snapshot", ResourceKind.RK_TABLE);
+    SnapshotSet snapshotSet =
+        SnapshotSet.newBuilder()
+            .addPins(SnapshotPin.newBuilder().setTableId(tableId).setSnapshotId(33).build())
+            .build();
+
+    var ctx =
+        QueryContext.newActive(
+            "p-snapshot",
+            pc,
+            null,
+            snapshotSet.toByteArray(),
+            null,
+            null,
+            500,
+            1,
+            ResourceId.newBuilder().setId("cat-it").build());
+
+    SnapshotSet first = ctx.parseSnapshotSet("corr-snapshot");
+    SnapshotSet second = ctx.parseSnapshotSet("corr-snapshot");
+
+    assertEquals(snapshotSet, first);
+    assertSame(first, second);
+  }
+
+  @Test
+  void requireSnapshotPinDoesNotMatchWhenAccountIsMissingOnOneSide() {
+    ResourceId accountId = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT);
+    var pc = pc(accountId, "alice", "p-account");
+    ResourceId pinnedWithAccount =
+        TestSupport.rid(accountId.getId(), "tbl-account", ResourceKind.RK_TABLE);
+    ResourceId lookupWithoutAccount =
+        ResourceId.newBuilder().setId("tbl-account").setKind(ResourceKind.RK_TABLE).build();
+
+    SnapshotSet snapshots =
+        SnapshotSet.newBuilder()
+            .addPins(
+                SnapshotPin.newBuilder().setTableId(pinnedWithAccount).setSnapshotId(11).build())
+            .build();
+    var ctx =
+        QueryContext.newActive(
+            "p-account",
+            pc,
+            null,
+            snapshots.toByteArray(),
+            null,
+            null,
+            500,
+            1,
+            ResourceId.newBuilder().setId("cat-it").build());
+
+    StatusRuntimeException err =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> ctx.requireSnapshotPin(lookupWithoutAccount, "corr-account"));
+    assertEquals(Status.Code.NOT_FOUND, err.getStatus().getCode());
+  }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/QueryContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/QueryContextTest.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.service.query.impl.QueryContext;
 import ai.floedb.floecat.service.util.TestSupport;
+import com.google.protobuf.Timestamp;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.time.Clock;
@@ -214,5 +215,29 @@ class QueryContextTest {
         assertThrows(
             StatusRuntimeException.class, () -> ctx.requireSnapshotPin(other, "corr-missing"));
     assertEquals(Status.Code.NOT_FOUND, err.getStatus().getCode());
+  }
+
+  @Test
+  void parseAsOfDefaultMemoized() {
+    ResourceId accountId = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT);
+    var pc = pc(accountId, "alice", "p-asof");
+    Timestamp asOf = Timestamp.newBuilder().setSeconds(1_701_000_000L).setNanos(123).build();
+    var ctx =
+        QueryContext.newActive(
+            "p-asof",
+            pc,
+            null,
+            SnapshotSet.getDefaultInstance().toByteArray(),
+            null,
+            asOf.toByteArray(),
+            500,
+            1,
+            ResourceId.newBuilder().setId("cat-it").build());
+
+    Timestamp first = ctx.parseAsOfDefault("corr-asof").orElseThrow();
+    Timestamp second = ctx.parseAsOfDefault("corr-asof").orElseThrow();
+
+    assertEquals(asOf, first);
+    assertSame(first, second);
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeTableRepository.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeTableRepository.java
@@ -34,6 +34,7 @@ public final class FakeTableRepository extends TableRepository {
   private final Map<ResourceId, Table> entries = new HashMap<>();
   private final Map<ResourceId, MutationMeta> metas = new HashMap<>();
   private final Map<ResourceId, Integer> gets = new HashMap<>();
+  private final Map<ResourceId, Integer> metaGets = new HashMap<>();
 
   public FakeTableRepository() {
     super(new InMemoryPointerStore(), new InMemoryBlobStore());
@@ -111,6 +112,7 @@ public final class FakeTableRepository extends TableRepository {
 
   @Override
   public MutationMeta metaForSafe(ResourceId id) {
+    metaGets.merge(id, 1, Integer::sum);
     MutationMeta meta = metas.get(id);
     if (meta == null) {
       throw new StorageNotFoundException("missing table meta");
@@ -120,6 +122,10 @@ public final class FakeTableRepository extends TableRepository {
 
   public int getByIdCount(ResourceId id) {
     return gets.getOrDefault(id, 0);
+  }
+
+  public int metaForSafeCount(ResourceId id) {
+    return metaGets.getOrDefault(id, 0);
   }
 
   private List<Table> matchingTables(String accountId, String catalogId, String namespaceId) {


### PR DESCRIPTION
## Summary 

This PR hardens `GetUserObjects` observability and addresses the main latency hotspots by batching work, reducing repeated KV/parse work, and adding request-local caching. It also fixes correctness edge cases discovered during repro-driven profiling.

## Why 
`GetUserObjects` showed high tail latency, with most time concentrated in:
- resolve
- pin collection
- relation build/stat lookup

The request path was doing repeated per-table work sequentially, with avoidable parse/cache misses and limited phase-level visibility.

## Key changes

1. **Observability and logging**
- Added robust phase timing breakdown with `query_id` + `correlation_id`.
- Added distinct phase fields (`resolveMs`, `baseInjectMs`, `pinCollectMs`, `pinCommitMs`, `relationBuildMs`, `statsLookupMs`, `schedulingMs`).
- Slow request logs at WARN, optional timing breakdown at DEBUG.
- Switched stream completion logging to termination-safe behavior.
- Improved failure visibility (missing query context during pin commit now WARN).

2. **Resolution/pinning performance**
- Batched snapshot pin resolution per chunk instead of per-table.
- Memoized parsed snapshot/as-of defaults in `QueryContext`.
- Added request-local caches in iterator for:
  - name resolution
  - node resolution
  - relation bundle reuse
  - current snapshot pins across chunks
- Added short-TTL mutation-meta cache in graph cache path to cut repeated pointer lookups.
- Removed redundant schema re-resolution during relation build.

3. **Correctness hardening**
- `RelationCacheKey` now includes snapshot override to avoid cross-snapshot cache aliasing.
- Eager base-table emission no longer re-adds synthetic pins that could override AS-OF semantics.
- Added carry-over behavior so eager base emission respects chunk limits without dropping remaining bases.
- Strengthened dedup/matching semantics (`pinKey` usage, account-safe table pin matching).
- Unified merge path to use memoized snapshot-set parsing.

4. **Config cleanup**
- Corrected config keys to `floecat.catalog.bundle.slow-log-ms` and `floecat.catalog.bundle.log-timings`.

## Tests
Added/updated focused coverage for:
- chunk boundaries and multi-chunk ordering
- eager base-table carry-over and dedup
- snapshot override correctness in relation cache keys
- AS-OF preservation with eager base emission
- query-context parse memoization and cache behavior
- logging and graph/meta cache instrumentation behavior

## Additional notes

- Meta cache TTL is configurable via `floecat.metadata.graph.meta-cache-ttl-seconds` (default 2s; set `0` to disable).
- Timing logs are controlled by:
  - `floecat.catalog.bundle.slow-log-ms`
  - `floecat.catalog.bundle.log-timings`

## Expected impact
- Significant reduction in `pinCollectMs` and `relationBuildMs`.
- Large reduction in warm-path `resolveMs`.
- Better per-query diagnostics with query/correlation IDs and non-overlapping timing phases.

On my local setup: 
- 1 request with 120 times the same table went from ~1400ms to 35ms
- 1 request with 16 distinct tables is now 50-70ms

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [x] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
