### PR TITLE
[FIX] Storage key encoding: RFC3986 path-segment normalization + secrets key hardening

### DIFF
--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/Keys.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/Keys.java
@@ -15,7 +15,6 @@
  */
 package ai.floedb.floecat.storage.kv;
 
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 public final class Keys {
@@ -38,15 +37,48 @@ public final class Keys {
   }
 
   public static String encodeSegment(String value) {
-    return URLEncoder.encode(req("segment", value), StandardCharsets.UTF_8).replace("+", "%20");
+    String segment = req("segment", value);
+    byte[] bytes = segment.getBytes(StandardCharsets.UTF_8);
+    StringBuilder out = new StringBuilder(bytes.length * 3);
+    for (byte b : bytes) {
+      int ch = b & 0xFF;
+      if (isUnreserved(ch)) {
+        out.append((char) ch);
+      } else {
+        out.append('%');
+        out.append(Character.toUpperCase(Character.forDigit((ch >>> 4) & 0x0F, 16)));
+        out.append(Character.toUpperCase(Character.forDigit(ch & 0x0F, 16)));
+      }
+    }
+    return out.toString();
   }
 
   public static String join(String... parts) {
-    return SEP + String.join(SEP, parts);
+    if (parts == null) {
+      throw new IllegalArgumentException("key arg 'parts' is null");
+    }
+    if (parts.length == 0) {
+      return SEP;
+    }
+    String[] encoded = new String[parts.length];
+    for (int i = 0; i < parts.length; i++) {
+      encoded[i] = encodeSegment(req("parts[" + i + "]", parts[i]));
+    }
+    return SEP + String.join(SEP, encoded);
   }
 
   public static String prefix(String... parts) {
     return join(parts) + SEP;
+  }
+
+  private static boolean isUnreserved(int ch) {
+    return (ch >= 'A' && ch <= 'Z')
+        || (ch >= 'a' && ch <= 'z')
+        || (ch >= '0' && ch <= '9')
+        || ch == '-'
+        || ch == '.'
+        || ch == '_'
+        || ch == '~';
   }
 
   public static KvStore.Key key(String partitionKey, String sortKey) {

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -33,11 +33,11 @@ public interface KvStore {
     @Override
     public String toString() {
       if (partitionKey == null || partitionKey.isEmpty() || partitionKey.equals(Keys.SEP)) {
-        return Keys.join(sortKey);
+        return Keys.SEP + sortKey;
       } else if (sortKey == null || sortKey.isEmpty() || sortKey.equals(Keys.SEP)) {
-        return Keys.join(partitionKey);
+        return Keys.SEP + partitionKey;
       }
-      return Keys.join(partitionKey, sortKey);
+      return Keys.SEP + partitionKey + Keys.SEP + sortKey;
     }
   }
 

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/secrets/SecretsManager.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/secrets/SecretsManager.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.storage.secrets;
 
+import ai.floedb.floecat.storage.kv.Keys;
 import java.util.Optional;
 
 public interface SecretsManager {
@@ -31,7 +32,12 @@ public interface SecretsManager {
     requireNonBlank(accountId, "accountId");
     requireNonBlank(secretType, "secretType");
     requireNonBlank(secretId, "secretId");
-    return "accounts/" + accountId + "/" + secretType + "/" + secretId;
+    return "accounts/"
+        + Keys.encodeSegment(accountId)
+        + "/"
+        + Keys.encodeSegment(secretType)
+        + "/"
+        + Keys.encodeSegment(secretId);
   }
 
   private static void requireNonBlank(String value, String name) {

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KeysTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KeysTest.java
@@ -16,6 +16,7 @@
 package ai.floedb.floecat.storage.kv;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ public class KeysTest {
 
   @Test
   void join_with_empty_parts() {
-    assertEquals("//b", Keys.join("", "b"));
+    assertThrows(IllegalArgumentException.class, () -> Keys.join("", "b"));
   }
 
   @Test
@@ -50,7 +51,7 @@ public class KeysTest {
 
   @Test
   void join_allows_double_slashes_in_parts() {
-    assertEquals("/a//b", Keys.join("a/", "b"));
+    assertEquals("/a%2F/b", Keys.join("a/", "b"));
   }
 
   @Test
@@ -58,5 +59,18 @@ public class KeysTest {
     assertEquals(
         "/accounts/acct%20id/tables/table%20id/snapshots/by-id/0000000000000000000",
         Keys.snapshotPointerById("acct id", "table id", 0L));
+  }
+
+  @Test
+  void encodeSegmentUsesRfc3986PathSegmentRules() {
+    assertEquals("a%20b", Keys.encodeSegment("a b"));
+    assertEquals("a%2Bb", Keys.encodeSegment("a+b"));
+    assertEquals("a%2Fb", Keys.encodeSegment("a/b"));
+    assertEquals("a%25b", Keys.encodeSegment("a%b"));
+  }
+
+  @Test
+  void joinEncodesSegments() {
+    assertEquals("/a%2Fb/c%20d", Keys.join("a/b", "c d"));
   }
 }

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/secrets/SecretsManagerTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/secrets/SecretsManagerTest.java
@@ -30,6 +30,12 @@ class SecretsManagerTest {
   }
 
   @Test
+  void buildSecretKey_encodes_segments_as_path_safe_values() {
+    String key = SecretsManager.buildSecretKey("acct 1", "type+group", "id/with%chars");
+    assertEquals("accounts/acct%201/type%2Bgroup/id%2Fwith%25chars", key);
+  }
+
+  @Test
   void buildSecretKey_rejects_blank_parts() {
     assertThrows(
         IllegalArgumentException.class, () -> SecretsManager.buildSecretKey(null, "t", "id"));

--- a/reconciler/pom.xml
+++ b/reconciler/pom.xml
@@ -50,6 +50,12 @@
 
     <dependency>
       <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-storage-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
       <artifactId>floecat-connectors-iceberg</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -59,6 +59,7 @@ import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
 import ai.floedb.floecat.stats.spi.StatsCaptureResult;
 import ai.floedb.floecat.stats.spi.StatsExecutionMode;
 import ai.floedb.floecat.stats.spi.StatsTriggerResult;
+import ai.floedb.floecat.storage.kv.Keys;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
@@ -66,8 +67,6 @@ import io.grpc.StatusRuntimeException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -1747,7 +1746,7 @@ public class ReconcilerService {
   }
 
   private String encodePathSegment(String value) {
-    return URLEncoder.encode(value == null ? "" : value, StandardCharsets.UTF_8);
+    return Keys.encodeSegment(value == null ? "" : value);
   }
 
   private ReconcileContext buildContext(PrincipalContext principal, Optional<String> bearerToken) {

--- a/service/src/main/java/ai/floedb/floecat/service/gc/PointerGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/PointerGc.java
@@ -23,7 +23,6 @@ import ai.floedb.floecat.storage.spi.PointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -465,6 +464,6 @@ public class PointerGc {
   }
 
   private static String encode(String value) {
-    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    return Keys.encodeSegment(value);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -1729,7 +1729,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     if (value == null || value.isBlank()) {
       return "";
     }
-    return java.net.URLEncoder.encode(value, StandardCharsets.UTF_8);
+    return Keys.encodeSegment(value);
   }
 
   private static String parentPointerKey(String accountId, String parentJobId, String jobId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -16,8 +16,6 @@
 
 package ai.floedb.floecat.service.repo.model;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 
@@ -71,8 +69,8 @@ public final class Keys {
   }
 
   private static String encode(String s) {
-    return URLEncoder.encode(Objects.requireNonNull(s, "encode value"), StandardCharsets.UTF_8)
-        .replace("+", "%20");
+    return ai.floedb.floecat.storage.kv.Keys.encodeSegment(
+        Objects.requireNonNull(s, "encode value"));
   }
 
   public static String encodeSegment(String s) {

--- a/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
@@ -38,4 +38,19 @@ class KeysTest {
         "/accounts/acct%20id/tables/table%20id/snapshots/0000000000000000007/stats/constraints",
         Keys.snapshotConstraintsStatsPointer("acct id", "table id", 7L));
   }
+
+  @Test
+  void encodeSegmentUsesRfc3986PathSegmentRules() {
+    assertEquals("a%20b", Keys.encodeSegment("a b"));
+    assertEquals("a%2Bb", Keys.encodeSegment("a+b"));
+    assertEquals("a%2Fb", Keys.encodeSegment("a/b"));
+    assertEquals("a%25b", Keys.encodeSegment("a%b"));
+  }
+
+  @Test
+  void transactionDeleteSentinelEncodesOpaquePointerKey() {
+    assertEquals(
+        "/accounts/acct/transactions/tx/delete/%2Faccounts%2Fa%2Fb",
+        Keys.transactionDeleteSentinelUri("acct", "tx", "/accounts/a/b"));
+  }
 }

--- a/storage/common/src/test/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManagerIT.java
+++ b/storage/common/src/test/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManagerIT.java
@@ -72,6 +72,23 @@ class NotProdSecretsManagerIT {
         record.key().sortKey());
   }
 
+  @Test
+  void key_encodes_reserved_characters() {
+    Fixture fixture =
+        new Fixture(
+            new InMemoryKvStore(), "acct 1", "connectors+type", "conn/9%", "alpha".getBytes());
+    NotProdSecretsManager manager = fixture.manager();
+    manager.put(fixture.accountId, fixture.secretType, fixture.secretId, fixture.payload);
+
+    KvStore.Key expectedKey =
+        new KvStore.Key(
+            "secrets",
+            SecretsManager.buildSecretKey(fixture.accountId, fixture.secretType, fixture.secretId));
+    KvStore.Record record = fixture.kv.getRecord(expectedKey);
+    assertNotNull(record);
+    assertEquals("accounts/acct%201/connectors%2Btype/conn%2F9%25", record.key().sortKey());
+  }
+
   private static final class Fixture {
     final InMemoryKvStore kv;
     final String accountId;


### PR DESCRIPTION
## Summary 

This PR fixes path/key encoding correctness by replacing form-style encoding semantics with RFC3986 path-segment encoding in key construction paths, and applies the same rule to secret key identity construction.
Fixes: https://github.com/eng-floe/floecat/issues/259 

## Why
`URLEncoder` semantics are for form/query encoding, not URI path segments. That can produce inconsistent key generation for reserved characters (`+`, `%`, `/`, space), and cause subtle pointer/key mismatches.

## Key changes

1. Core storage key encoding normalization  
- `encodeSegment(...)` now uses RFC3986 unreserved rules.
- `join(...)` now encodes each segment (instead of trusting raw parts).
- `prefix(...)` inherits safe encoded behavior from `join(...)`.

2. Reuse canonical encoder across service/reconciler  
- Updated service/reconciler key-adjacent call sites to reuse canonical segment encoding

3. Secrets key path hardening  
- `buildSecretKey(...)` now encodes each segment via path-safe encoding.


## Behavioral examples (now guaranteed)
- `"a b"` → `a%20b`  
- `"a+b"` → `a%2Bb`  
- `"a/b"` → `a%2Fb`  
- `"a%b"` → `a%25b`

## Out of scope / intentionally unchanged
`URLEncoder` usages that are form/query-specific (OAuth/token form bodies, query-string helpers) remain unchanged.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [ ] No breaking changes
- [x] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)