### PR TITLE
(fix): ensure account_id is propagated.

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
@@ -87,25 +87,29 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
                     String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
                     var ctxOpt = queryStore.get(queryId);
                     if (ctxOpt.isEmpty()) {
-                      throw GrpcErrors.notFound(
-                          correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId));
+                      emitter.fail(
+                          GrpcErrors.notFound(
+                              correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId)));
+                      return;
                     }
 
                     QueryContext ctx = ctxOpt.get();
                     if (!ctx.isActive()) {
-                      throw GrpcErrors.preconditionFailed(
-                          correlationId,
-                          QUERY_NOT_ACTIVE,
-                          Map.of("query_id", queryId, "state", ctx.getState().name()));
+                      emitter.fail(
+                          GrpcErrors.preconditionFailed(
+                              correlationId,
+                              QUERY_NOT_ACTIVE,
+                              Map.of("query_id", queryId, "state", ctx.getState().name())));
+                      return;
                     }
 
-                    try {
-                      bundles.stream(correlationId, ctx, request.getTablesList())
-                          .subscribe()
-                          .with(emitter::emit, emitter::fail, emitter::complete);
-                    } catch (Throwable t) {
-                      emitter.fail(t);
-                    }
+                    var subscription =
+                        bundles.stream(correlationId, ctx, request.getTablesList())
+                            .subscribe()
+                            .with(emitter::emit, emitter::fail, emitter::complete);
+
+                    emitter.onTermination(subscription::cancel);
+                    emitter.onCancellation(subscription::cancel);
                   });
             })
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
@@ -78,14 +78,13 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
                     var contextCorrelationId = InboundContextInterceptor.CORR_KEY.get();
                     var principalCorrelationId = principalContext.getCorrelationId();
                     var correlationId =
-                            contextCorrelationId != null && !contextCorrelationId.isBlank()
-                                    ? contextCorrelationId
-                                    : principalCorrelationId;
+                        contextCorrelationId != null && !contextCorrelationId.isBlank()
+                            ? contextCorrelationId
+                            : principalCorrelationId;
                     correlationRef.set(correlationId == null ? "" : correlationId);
                     authz.require(principalContext, "catalog.read");
 
-                    String queryId =
-                        mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+                    String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
                     var ctxOpt = queryStore.get(queryId);
                     if (ctxOpt.isEmpty()) {
                       throw GrpcErrors.notFound(
@@ -101,8 +100,7 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
                     }
 
                     try {
-                      bundles
-                          .stream(correlationId, ctx, request.getTablesList())
+                      bundles.stream(correlationId, ctx, request.getTablesList())
                           .subscribe()
                           .with(emitter::emit, emitter::fail, emitter::complete);
                     } catch (Throwable t) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
@@ -64,43 +64,52 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
     AtomicBoolean failed = new AtomicBoolean(false);
     AtomicReference<String> correlationRef = new AtomicReference<>("");
     // Capture the incoming gRPC context so the principal/correlation-id stays available
-    // while authz/QueryContext lookup happen; the bundle builder itself is context-free.
+    // throughout the entire streaming response — including lazy item emission from the
+    // UserObjectBundleIterator, which calls principal.get() for name resolution.
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
 
     return Multi.createFrom()
-        .<UserObjectsBundleChunk>deferred(
-            () ->
-                grpcCtx.call(
-                    () -> {
-                      workStartNs.compareAndSet(0L, System.nanoTime());
-                      var principalContext = principal.get();
-                      var contextCorrelationId = InboundContextInterceptor.CORR_KEY.get();
-                      var principalCorrelationId = principalContext.getCorrelationId();
-                      var correlationId =
-                          contextCorrelationId != null && !contextCorrelationId.isBlank()
-                              ? contextCorrelationId
-                              : principalCorrelationId;
-                      correlationRef.set(correlationId == null ? "" : correlationId);
-                      authz.require(principalContext, "catalog.read");
+        .<UserObjectsBundleChunk>emitter(
+            emitter -> {
+              grpcCtx.run(
+                  () -> {
+                    workStartNs.compareAndSet(0L, System.nanoTime());
+                    var principalContext = principal.get();
+                    var contextCorrelationId = InboundContextInterceptor.CORR_KEY.get();
+                    var principalCorrelationId = principalContext.getCorrelationId();
+                    var correlationId =
+                            contextCorrelationId != null && !contextCorrelationId.isBlank()
+                                    ? contextCorrelationId
+                                    : principalCorrelationId;
+                    correlationRef.set(correlationId == null ? "" : correlationId);
+                    authz.require(principalContext, "catalog.read");
 
-                      String queryId =
-                          mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-                      var ctxOpt = queryStore.get(queryId);
-                      if (ctxOpt.isEmpty()) {
-                        throw GrpcErrors.notFound(
-                            correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId));
-                      }
+                    String queryId =
+                        mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+                    var ctxOpt = queryStore.get(queryId);
+                    if (ctxOpt.isEmpty()) {
+                      throw GrpcErrors.notFound(
+                          correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId));
+                    }
 
-                      QueryContext ctx = ctxOpt.get();
-                      if (!ctx.isActive()) {
-                        throw GrpcErrors.preconditionFailed(
-                            correlationId,
-                            QUERY_NOT_ACTIVE,
-                            Map.of("query_id", queryId, "state", ctx.getState().name()));
-                      }
+                    QueryContext ctx = ctxOpt.get();
+                    if (!ctx.isActive()) {
+                      throw GrpcErrors.preconditionFailed(
+                          correlationId,
+                          QUERY_NOT_ACTIVE,
+                          Map.of("query_id", queryId, "state", ctx.getState().name()));
+                    }
 
-                      return bundles.stream(correlationId, ctx, request.getTablesList());
-                    }))
+                    try {
+                      bundles
+                          .stream(correlationId, ctx, request.getTablesList())
+                          .subscribe()
+                          .with(emitter::emit, emitter::fail, emitter::complete);
+                    } catch (Throwable t) {
+                      emitter.fail(t);
+                    }
+                  });
+            })
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())
         .onCompletion()
         .invoke(() -> completed.set(true))

--- a/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.query.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -31,10 +32,14 @@ import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import io.grpc.Context;
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import java.util.concurrent.Flow.Subscription;
 
 /**
  * Verifies that the gRPC principal context is propagated to the worker thread during streaming item
@@ -141,5 +146,118 @@ class UserObjectsServiceImplTest {
         ACCOUNT_ID,
         observedAccountId.get(),
         "principal.get() on the executor thread should see the gRPC context's accountId");
+  }
+
+  @Test
+  void cancellingOuterStreamCancelsInnerBundleSubscription() throws Exception {
+    // Set up a bundle service that emits items slowly, so we can cancel mid-stream.
+    // We track whether the inner subscription was cancelled.
+    CountDownLatch innerCancelled = new CountDownLatch(1);
+    CountDownLatch firstItemEmitted = new CountDownLatch(1);
+    PrincipalProvider principalProvider = new PrincipalProvider();
+
+    UserObjectBundleService mockBundles = Mockito.mock(UserObjectBundleService.class);
+    Mockito.when(
+            mockBundles.stream(
+                Mockito.anyString(), Mockito.any(QueryContext.class), Mockito.anyList()))
+        .thenReturn(
+            Multi.createFrom()
+                .<UserObjectsBundleChunk>emitter(
+                    innerEmitter -> {
+                      // Emit one item immediately, then wait — simulating a long-running stream.
+                      innerEmitter.emit(UserObjectsBundleChunk.getDefaultInstance());
+                      firstItemEmitted.countDown();
+                      // Register cancellation callback so we can assert it was called.
+                      innerEmitter.onTermination(innerCancelled::countDown);
+                    }));
+
+    // Set up query context store with an active context
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    QueryContext queryContext =
+        QueryContext.builder()
+            .queryId("q-cancel")
+            .principal(
+                PrincipalContext.newBuilder()
+                    .setAccountId(ACCOUNT_ID)
+                    .setSubject("tester")
+                    .addPermissions("catalog.read")
+                    .build())
+            .snapshotSet(new byte[0])
+            .createdAtMs(1)
+            .expiresAtMs(Long.MAX_VALUE)
+            .state(QueryContext.State.ACTIVE)
+            .version(1)
+            .queryDefaultCatalogId(
+                ResourceId.newBuilder()
+                    .setAccountId(ACCOUNT_ID)
+                    .setId("cat")
+                    .setKind(ResourceKind.RK_CATALOG)
+                    .build())
+            .build();
+    store.seed(queryContext);
+
+    // Wire up the service
+    UserObjectsServiceImpl service = new UserObjectsServiceImpl();
+    service.principal = principalProvider;
+    service.authz = new Authorizer();
+    service.queryStore = store;
+    service.bundles = mockBundles;
+
+    // Build request
+    GetUserObjectsRequest request =
+        GetUserObjectsRequest.newBuilder()
+            .setQueryId("q-cancel")
+            .addTables(TableReferenceCandidate.getDefaultInstance())
+            .build();
+
+    // Subscribe within a gRPC context, then cancel after the first item arrives.
+    PrincipalContext principal =
+        PrincipalContext.newBuilder()
+            .setAccountId(ACCOUNT_ID)
+            .setSubject("tester")
+            .addPermissions("catalog.read")
+            .build();
+    Context grpcCtx = Context.current().withValue(PrincipalProvider.KEY, principal);
+    Context previous = grpcCtx.attach();
+    try {
+      AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
+      CountDownLatch itemReceived = new CountDownLatch(1);
+
+      service
+          .getUserObjects(request)
+          .subscribe()
+          .withSubscriber(
+              new MultiSubscriber<UserObjectsBundleChunk>() {
+                @Override
+                public void onItem(UserObjectsBundleChunk item) {
+                  itemReceived.countDown();
+                }
+
+                @Override
+                public void onFailure(Throwable failure) {}
+
+                @Override
+                public void onCompletion() {}
+
+                @Override
+                public void onSubscribe(Subscription s) {
+                  subscriptionRef.set(s);
+                  s.request(Long.MAX_VALUE);
+                }
+              });
+
+      // Wait for the first item to be emitted, then cancel.
+      assertTrue(
+          itemReceived.await(5, TimeUnit.SECONDS), "Timed out waiting for first item emission");
+      subscriptionRef.get().cancel();
+
+      // Give cancellation a moment to propagate through the reactive pipeline.
+      assertTrue(
+          innerCancelled.await(5, TimeUnit.SECONDS),
+          "Inner bundle subscription should have been cancelled when the outer stream was cancelled");
+    } finally {
+      grpcCtx.detach(previous);
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
@@ -1,0 +1,129 @@
+package ai.floedb.floecat.service.query.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.query.rpc.GetUserObjectsRequest;
+import ai.floedb.floecat.query.rpc.TableReferenceCandidate;
+import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
+import ai.floedb.floecat.service.query.catalog.UserObjectBundleService;
+import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import io.grpc.Context;
+import io.smallrye.mutiny.Multi;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Verifies that the gRPC principal context is propagated to the worker thread during streaming item
+ * emission in {@link UserObjectsServiceImpl#getUserObjects}. Without the {@code grpcCtx.run()}
+ * wrapping the entire subscription, {@code principal.get()} on the executor thread returns the
+ * default (empty) {@link PrincipalContext}, causing {@code requireAccountId()} to fail with "key
+ * arg 'account_id' is null/blank".
+ */
+class UserObjectsServiceImplTest {
+
+  private static final String ACCOUNT_ID = "test-account-id";
+
+  @Test
+  void principalContextIsAvailableDuringItemEmission() {
+    // Set up a mock UserObjectBundleService whose stream() reads principal.get() on the
+    // calling thread — simulating what UserGraph.requireAccountId() does during name resolution.
+    AtomicReference<String> observedAccountId = new AtomicReference<>();
+    PrincipalProvider principalProvider = new PrincipalProvider();
+
+    UserObjectBundleService mockBundles = Mockito.mock(UserObjectBundleService.class);
+    Mockito.when(
+            mockBundles.stream(
+                Mockito.anyString(), Mockito.any(QueryContext.class), Mockito.anyList()))
+        .thenAnswer(
+                _ -> {
+              // This runs inside grpcCtx.call/run — context should be set.
+              // Return a Multi that reads principal.get() during item emission (on the
+              // executor thread). This is the critical path that fails without the fix.
+              return Multi.createFrom()
+                  .items(UserObjectsBundleChunk.getDefaultInstance())
+                  .onItem()
+                  .invoke(
+                          _ -> {
+                        // This lambda runs during item emission on the executor thread.
+                        // Without the fix, the gRPC context has already been detached so
+                        // principal.get() returns the default instance with empty accountId.
+                        PrincipalContext ctx = principalProvider.get();
+                        observedAccountId.set(ctx.getAccountId());
+                      });
+            });
+
+    // Set up query context store with a test context
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    QueryContext queryContext =
+        QueryContext.builder()
+            .queryId("q-1")
+            .principal(
+                PrincipalContext.newBuilder()
+                    .setAccountId(ACCOUNT_ID)
+                    .setSubject("tester")
+                    .addPermissions("catalog.read")
+                    .build())
+            .snapshotSet(new byte[0])
+            .createdAtMs(1)
+            .expiresAtMs(Long.MAX_VALUE)
+            .state(QueryContext.State.ACTIVE)
+            .version(1)
+            .queryDefaultCatalogId(
+                ResourceId.newBuilder()
+                    .setAccountId(ACCOUNT_ID)
+                    .setId("cat")
+                    .setKind(ResourceKind.RK_CATALOG)
+                    .build())
+            .build();
+    store.seed(queryContext);
+
+    // Wire up the service
+    UserObjectsServiceImpl service = new UserObjectsServiceImpl();
+    service.principal = principalProvider;
+    service.authz = new Authorizer();
+    service.queryStore = store;
+    service.bundles = mockBundles;
+
+    // Build request
+    GetUserObjectsRequest request =
+        GetUserObjectsRequest.newBuilder()
+            .setQueryId("q-1")
+            .addTables(TableReferenceCandidate.getDefaultInstance())
+            .build();
+
+    // Set the gRPC principal context (simulating what floecat's interceptor does) and invoke.
+    // The context is set on the TEST thread; getUserObjects() runs the Multi on an executor
+    // thread. The fix ensures the context is propagated to that executor thread.
+    PrincipalContext principal =
+        PrincipalContext.newBuilder()
+            .setAccountId(ACCOUNT_ID)
+            .setSubject("tester")
+            .addPermissions("catalog.read")
+            .build();
+    Context grpcCtx = Context.current().withValue(PrincipalProvider.KEY, principal);
+    Context previous = grpcCtx.attach();
+    try {
+      List<UserObjectsBundleChunk> chunks =
+          service.getUserObjects(request).collect().asList().await().indefinitely();
+      assertFalse(chunks.isEmpty(), "Expected at least one chunk");
+    } finally {
+      grpcCtx.detach(previous);
+    }
+
+    // The critical assertion: principal.get().getAccountId() during item emission
+    // must return the account from the gRPC context, not empty string.
+    assertEquals(
+        ACCOUNT_ID,
+        observedAccountId.get(),
+        "principal.get() on the executor thread should see the gRPC context's accountId");
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
@@ -35,11 +35,11 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import java.util.concurrent.Flow.Subscription;
 
 /**
  * Verifies that the gRPC principal context is propagated to the worker thread during streaming item

--- a/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ai.floedb.floecat.service.query.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +59,7 @@ class UserObjectsServiceImplTest {
             mockBundles.stream(
                 Mockito.anyString(), Mockito.any(QueryContext.class), Mockito.anyList()))
         .thenAnswer(
-                _ -> {
+            _ -> {
               // This runs inside grpcCtx.call/run — context should be set.
               // Return a Multi that reads principal.get() during item emission (on the
               // executor thread). This is the critical path that fails without the fix.
@@ -51,7 +67,7 @@ class UserObjectsServiceImplTest {
                   .items(UserObjectsBundleChunk.getDefaultInstance())
                   .onItem()
                   .invoke(
-                          _ -> {
+                      _ -> {
                         // This lambda runs during item emission on the executor thread.
                         // Without the fix, the gRPC context has already been detached so
                         // principal.get() returns the default instance with empty accountId.


### PR DESCRIPTION


## Summary
The old code used deferred(() -> grpcCtx.call(...)) which attached the gRPC context only during the supplier execution. The lazy Multi returned by bundles.stream() was then consumed after the context detached, so principal.get() on the worker thread returned PrincipalContext.getDefaultInstance() with empty accountId. The fix uses an emitter that keeps the gRPC context attached via grpcCtx.run() for the entire subscription lifecycle — the bundles.stream() items are emitted inside the run block, so principal.get() always finds the correct context.

## Type of Change

- [x] fix (bug fix)
- [x] test (adds/updates tests)
## Testing

Unit test added that demonstrates the issue. `make test-e2e` in private repo was failing previously before this fix. Now passes with the fix.

- [x] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)