### PR TITLE
Handle capture-now child cancellation and avoid terminalizing interrupted reconcile jobs

### DIFF
--- a/protocol-gateway/iceberg-rest/src/it/java/ai/floedb/floecat/gateway/iceberg/rest/IcebergRestFixtureIT.java
+++ b/protocol-gateway/iceberg-rest/src/it/java/ai/floedb/floecat/gateway/iceberg/rest/IcebergRestFixtureIT.java
@@ -1818,6 +1818,7 @@ class IcebergRestFixtureIT {
                             .build())
                     .setMode(CaptureMode.CM_STATS_ONLY)
                     .setFullRescan(true)
+                    .setMaxWait(com.google.protobuf.Duration.newBuilder().setSeconds(30).build())
                     .build());
             stub.startCapture(
                 StartCaptureRequest.newBuilder()

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerScheduler.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerScheduler.java
@@ -195,25 +195,6 @@ public class ReconcilerScheduler {
   }
 
   void runLease(ReconcileJobStore.LeasedJob lease) {
-    ReconcileExecutor executor =
-        executorRegistry
-            .executorFor(lease)
-            .or(
-                () ->
-                    executorRegistry.orderedExecutors().stream()
-                        .filter(candidate -> candidate.supportsJobKind(lease.jobKind))
-                        .filter(
-                            candidate ->
-                                candidate.supportsExecutionClass(
-                                    lease.executionPolicy.executionClass()))
-                        .filter(candidate -> candidate.supportsLane(lease.executionPolicy.lane()))
-                        .filter(candidate -> candidate.supports(lease))
-                        .findFirst())
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "No reconcile executor available for lease " + lease.jobId));
-    cancellations.register(lease.jobId, Thread.currentThread());
     long started = System.currentTimeMillis();
     long leaseMs =
         Math.max(
@@ -235,6 +216,7 @@ public class ReconcilerScheduler {
     AtomicBoolean leaseValid = new AtomicBoolean(true);
     AtomicBoolean interrupted = new AtomicBoolean(false);
     ProgressSnapshot progress = new ProgressSnapshot();
+    ReconcileExecutor executor = null;
     BooleanSupplier heartbeat =
         () -> {
           if (!leaseValid.get()) {
@@ -255,12 +237,8 @@ public class ReconcilerScheduler {
           return true;
         };
 
-    BooleanSupplier cancelRequested =
+    BooleanSupplier cancellationRequestedInStore =
         () -> {
-          if (Thread.currentThread().isInterrupted()) {
-            interrupted.set(true);
-            return true;
-          }
           long now = System.currentTimeMillis();
           if (now >= nextCancelCheckAtMs[0]) {
             cancellationRequested[0] = jobs.isCancellationRequested(lease.jobId);
@@ -268,12 +246,39 @@ public class ReconcilerScheduler {
           }
           return cancellationRequested[0];
         };
+    BooleanSupplier cancelRequested =
+        () -> {
+          if (Thread.currentThread().isInterrupted()) {
+            interrupted.set(true);
+            return true;
+          }
+          return cancellationRequestedInStore.getAsBoolean();
+        };
     if (!heartbeat.getAsBoolean()) {
       long now = System.currentTimeMillis();
       emitOutcome(lease, "lease_lost", now - started, 0, 0, 0, 0, 0, 0, 0, "lease_lost");
       return;
     }
     try {
+      executor =
+          executorRegistry
+              .executorFor(lease)
+              .or(
+                  () ->
+                      executorRegistry.orderedExecutors().stream()
+                          .filter(candidate -> candidate.supportsJobKind(lease.jobKind))
+                          .filter(
+                              candidate ->
+                                  candidate.supportsExecutionClass(
+                                      lease.executionPolicy.executionClass()))
+                          .filter(candidate -> candidate.supportsLane(lease.executionPolicy.lane()))
+                          .filter(candidate -> candidate.supports(lease))
+                          .findFirst())
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "No reconcile executor available for lease " + lease.jobId));
+      cancellations.register(lease.jobId, Thread.currentThread());
       jobs.markRunning(lease.jobId, lease.leaseEpoch, System.currentTimeMillis(), executor.id());
       jobs.markProgress(lease.jobId, lease.leaseEpoch, 0, 0, 0, 0, 0, 0, 0, "Running reconcile");
       BooleanSupplier shouldStop =
@@ -287,7 +292,7 @@ public class ReconcilerScheduler {
             }
             return cancelRequested.getAsBoolean();
           };
-      if (cancelRequested.getAsBoolean()) {
+      if (cancellationRequestedInStore.getAsBoolean()) {
         long now = System.currentTimeMillis();
         jobs.markCancelled(lease.jobId, lease.leaseEpoch, now, "Cancelled", 0, 0, 0, 0, 0, 0, 0);
         emitOutcome(lease, "cancelled", now - started, 0, 0, 0, 0, 0, 0, 0, null);
@@ -349,8 +354,24 @@ public class ReconcilerScheduler {
             "lease_lost");
         return;
       }
-      boolean cancelledNow = cancelRequested.getAsBoolean();
+      boolean interruptedNow = Thread.currentThread().isInterrupted() || interrupted.get();
+      boolean cancelledNow = cancellationRequestedInStore.getAsBoolean();
       if (result.cancelled || cancelledNow) {
+        if (!cancelledNow && interruptedNow) {
+          emitOutcome(
+              lease,
+              "lease_lost",
+              finished - started,
+              result.tablesScanned,
+              result.tablesChanged,
+              result.viewsScanned,
+              result.viewsChanged,
+              result.errors,
+              totalSnapshots,
+              totalStats,
+              "interrupted");
+          return;
+        }
         jobs.markCancelled(
             lease.jobId,
             lease.leaseEpoch,
@@ -474,7 +495,8 @@ public class ReconcilerScheduler {
             progress.statsProcessed,
             "lease_lost");
       } else {
-        boolean cancelledOnError = cancelRequested.getAsBoolean();
+        boolean interruptedNow = Thread.currentThread().isInterrupted() || interrupted.get();
+        boolean cancelledOnError = cancellationRequestedInStore.getAsBoolean();
         if (cancelledOnError) {
           long now = System.currentTimeMillis();
           jobs.markCancelled(
@@ -502,11 +524,11 @@ public class ReconcilerScheduler {
               progress.snapshotsProcessed,
               progress.statsProcessed,
               null);
-        } else if (Thread.currentThread().isInterrupted() || interrupted.get()) {
+        } else if (interruptedNow) {
           long now = System.currentTimeMillis();
           emitOutcome(
               lease,
-              "interrupted",
+              "lease_lost",
               now - started,
               progress.tablesScanned,
               progress.tablesChanged,

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
@@ -23,8 +23,11 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
+import io.quarkus.arc.Arc;
 import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,12 +43,61 @@ import java.util.stream.Collectors;
     stringValue = "memory",
     enableIfMissing = true)
 public class InMemoryReconcileJobStore implements ReconcileJobStore {
+  private static final long DEFAULT_LEASE_MS = 30_000L;
+  private static final long DEFAULT_RECLAIM_INTERVAL_MS = 5_000L;
+  private static final long CANCEL_POKE_MAX_DELAY_MS = 1_000L;
+
   private final Map<String, ReconcileJob> jobs = new ConcurrentHashMap<>();
   private final Map<String, Long> createdAtMs = new ConcurrentHashMap<>();
   private final Map<String, String> leaseEpochs = new ConcurrentHashMap<>();
+  private final Map<String, Long> leaseExpiresAtMs = new ConcurrentHashMap<>();
   private final Map<String, String> pinnedExecutors = new ConcurrentHashMap<>();
   private final ConcurrentLinkedQueue<String> ready = new ConcurrentLinkedQueue<>();
   private final Set<String> leased = ConcurrentHashMap.newKeySet();
+  private volatile long leaseMs = DEFAULT_LEASE_MS;
+  private volatile long reclaimIntervalMs = DEFAULT_RECLAIM_INTERVAL_MS;
+  private volatile long lastReclaimAtMs;
+
+  public InMemoryReconcileJobStore() {
+    reloadConfig();
+  }
+
+  @PostConstruct
+  void init() {
+    reloadConfig();
+  }
+
+  private void reloadConfig() {
+    leaseMs = Math.max(1_000L, readLong("floecat.reconciler.job-store.lease-ms", DEFAULT_LEASE_MS));
+    reclaimIntervalMs =
+        Math.max(
+            1_000L,
+            readLong(
+                "floecat.reconciler.job-store.reclaim-interval-ms", DEFAULT_RECLAIM_INTERVAL_MS));
+  }
+
+  private long readLong(String key, long defaultValue) {
+    try {
+      var container = Arc.container();
+      if (container != null) {
+        var config = container.instance(org.eclipse.microprofile.config.Config.class);
+        if (config.isAvailable()) {
+          return config.get().getOptionalValue(key, Long.class).orElse(defaultValue);
+        }
+      }
+    } catch (RuntimeException ignored) {
+      // Fall back to system properties for plain unit construction.
+    }
+    String raw = System.getProperty(key);
+    if (raw == null || raw.isBlank()) {
+      return defaultValue;
+    }
+    try {
+      return Long.parseLong(raw.trim());
+    } catch (NumberFormatException ignored) {
+      return defaultValue;
+    }
+  }
 
   @Override
   public String enqueue(
@@ -184,6 +236,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
 
   @Override
   public Optional<LeasedJob> leaseNext(LeaseRequest request) {
+    reclaimExpiredLeasesIfDue(System.currentTimeMillis());
     LeaseRequest effective = request == null ? LeaseRequest.all() : request;
     int attempts = Math.max(1, ready.size());
     for (int i = 0; i < attempts; i++) {
@@ -198,7 +251,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
         continue;
       }
 
-      if (!"JS_QUEUED".equals(job.state)) {
+      if (!"JS_QUEUED".equals(job.state) && !"JS_CANCELLING".equals(job.state)) {
         continue;
       }
 
@@ -209,8 +262,10 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
       }
 
       if (leased.add(jobId)) {
+        long now = System.currentTimeMillis();
         String leaseEpoch = UUID.randomUUID().toString();
         leaseEpochs.put(jobId, leaseEpoch);
+        leaseExpiresAtMs.put(jobId, now + leaseMs);
         return Optional.of(
             new LeasedJob(
                 job.jobId,
@@ -234,6 +289,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
 
   @Override
   public boolean renewLease(String jobId, String leaseEpoch) {
+    long now = System.currentTimeMillis();
     var job = jobs.get(jobId);
     if (job == null) {
       return false;
@@ -241,7 +297,11 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
     if (!"JS_RUNNING".equals(job.state) && !"JS_CANCELLING".equals(job.state)) {
       return false;
     }
-    return hasActiveLease(jobId, leaseEpoch);
+    if (!hasActiveLease(jobId, leaseEpoch, now)) {
+      return false;
+    }
+    leaseExpiresAtMs.put(jobId, now + leaseMs);
+    return true;
   }
 
   @Override
@@ -351,6 +411,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
           }
           leased.remove(id);
           leaseEpochs.remove(id);
+          leaseExpiresAtMs.remove(id);
           pinnedExecutors.remove(id);
           return new ReconcileJob(
               job.jobId,
@@ -403,6 +464,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
           }
           leased.remove(id);
           leaseEpochs.remove(id);
+          leaseExpiresAtMs.remove(id);
           pinnedExecutors.remove(id);
           return new ReconcileJob(
               job.jobId,
@@ -446,6 +508,15 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
             return job;
           }
           if ("JS_RUNNING".equals(job.state)) {
+            long now = System.currentTimeMillis();
+            long cancelPokeExpiry = now + CANCEL_POKE_MAX_DELAY_MS;
+            leaseExpiresAtMs.compute(
+                id,
+                (ignored, expiry) ->
+                    expiry == null || expiry <= 0L
+                        ? cancelPokeExpiry
+                        : Math.min(expiry, cancelPokeExpiry));
+            ready.add(id);
             return new ReconcileJob(
                 job.jobId,
                 job.accountId,
@@ -473,6 +544,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
           }
           leased.remove(id);
           leaseEpochs.remove(id);
+          leaseExpiresAtMs.remove(id);
           pinnedExecutors.remove(id);
           return new ReconcileJob(
               job.jobId,
@@ -542,6 +614,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
           }
           leased.remove(id);
           leaseEpochs.remove(id);
+          leaseExpiresAtMs.remove(id);
           ready.remove(id);
           pinnedExecutors.remove(id);
           return new ReconcileJob(
@@ -571,8 +644,94 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
         });
   }
 
-  private boolean hasActiveLease(String jobId, String leaseEpoch) {
+  private boolean hasActiveLease(String jobId, String leaseEpoch, long nowMs) {
     String expected = leaseEpochs.get(jobId);
-    return expected != null && !expected.isBlank() && expected.equals(leaseEpoch);
+    Long expiry = leaseExpiresAtMs.get(jobId);
+    return expected != null
+        && !expected.isBlank()
+        && expected.equals(leaseEpoch)
+        && expiry != null
+        && expiry > nowMs;
+  }
+
+  private boolean hasActiveLease(String jobId, String leaseEpoch) {
+    return hasActiveLease(jobId, leaseEpoch, System.currentTimeMillis());
+  }
+
+  private synchronized void reclaimExpiredLeasesIfDue(long nowMs) {
+    if (nowMs - lastReclaimAtMs < reclaimIntervalMs) {
+      return;
+    }
+    lastReclaimAtMs = nowMs;
+    for (String jobId : new HashSet<>(leased)) {
+      Long expiry = leaseExpiresAtMs.get(jobId);
+      if (expiry == null || expiry <= 0L || expiry > nowMs) {
+        continue;
+      }
+      jobs.computeIfPresent(
+          jobId,
+          (id, job) -> {
+            if (!leased.remove(id)) {
+              return job;
+            }
+            leaseEpochs.remove(id);
+            leaseExpiresAtMs.remove(id);
+            if ("JS_RUNNING".equals(job.state)) {
+              ready.add(id);
+              return new ReconcileJob(
+                  job.jobId,
+                  job.accountId,
+                  job.connectorId,
+                  "JS_QUEUED",
+                  "Lease expired; requeued",
+                  job.startedAtMs,
+                  0L,
+                  job.tablesScanned,
+                  job.tablesChanged,
+                  job.viewsScanned,
+                  job.viewsChanged,
+                  job.errors,
+                  job.fullRescan,
+                  job.captureMode,
+                  job.snapshotsProcessed,
+                  job.statsProcessed,
+                  job.scope,
+                  job.executionPolicy,
+                  "",
+                  job.jobKind,
+                  job.tableTask,
+                  job.viewTask,
+                  job.parentJobId);
+            }
+            if ("JS_CANCELLING".equals(job.state)) {
+              ready.add(id);
+              return new ReconcileJob(
+                  job.jobId,
+                  job.accountId,
+                  job.connectorId,
+                  "JS_CANCELLING",
+                  "Lease expired while cancelling",
+                  job.startedAtMs,
+                  0L,
+                  job.tablesScanned,
+                  job.tablesChanged,
+                  job.viewsScanned,
+                  job.viewsChanged,
+                  job.errors,
+                  job.fullRescan,
+                  job.captureMode,
+                  job.snapshotsProcessed,
+                  job.statsProcessed,
+                  job.scope,
+                  job.executionPolicy,
+                  job.executorId,
+                  job.jobKind,
+                  job.tableTask,
+                  job.viewTask,
+                  job.parentJobId);
+            }
+            return job;
+          });
+    }
   }
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
@@ -312,12 +312,13 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
           if (!hasActiveLease(id, leaseEpoch)) {
             return job;
           }
+          boolean cancelling = "JS_CANCELLING".equals(job.state);
           return new ReconcileJob(
               job.jobId,
               job.accountId,
               job.connectorId,
-              "JS_RUNNING",
-              "Running",
+              cancelling ? "JS_CANCELLING" : "JS_RUNNING",
+              cancelling ? job.message : "Running",
               startedAtMs,
               0L,
               job.tablesScanned,

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
@@ -441,7 +441,8 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
           }
           if ("JS_SUCCEEDED".equals(job.state)
               || "JS_FAILED".equals(job.state)
-              || "JS_CANCELLED".equals(job.state)) {
+              || "JS_CANCELLED".equals(job.state)
+              || "JS_CANCELLING".equals(job.state)) {
             return job;
           }
           if ("JS_RUNNING".equals(job.state)) {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerSchedulerTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerSchedulerTest.java
@@ -352,9 +352,109 @@ class ReconcilerSchedulerTest {
             null,
             "");
 
-    org.junit.jupiter.api.Assertions.assertThrows(
-        IllegalStateException.class, () -> scheduler.runLease(lease));
+    scheduler.runLease(lease);
+
+    verify(jobStore, times(1))
+        .markFailed(
+            org.mockito.ArgumentMatchers.eq("job-1"),
+            org.mockito.ArgumentMatchers.eq("lease-1"),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.contains(
+                "No reconcile executor available for lease job-1"),
+            org.mockito.ArgumentMatchers.eq(0L),
+            org.mockito.ArgumentMatchers.eq(0L),
+            org.mockito.ArgumentMatchers.eq(0L),
+            org.mockito.ArgumentMatchers.eq(0L),
+            org.mockito.ArgumentMatchers.eq(1L),
+            org.mockito.ArgumentMatchers.eq(0L),
+            org.mockito.ArgumentMatchers.eq(0L));
     verify(wrongKind, never()).execute(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void runLeaseDoesNotTerminalizeJobWhenWorkerThreadIsInterrupted() {
+    var jobStore = mock(ReconcileJobStore.class);
+    var executor = mock(ReconcileExecutor.class);
+    when(executor.enabled()).thenReturn(true);
+    when(executor.supportedExecutionClasses())
+        .thenReturn(EnumSet.allOf(ReconcileExecutionClass.class));
+    when(executor.supportedJobKinds()).thenReturn(EnumSet.allOf(ReconcileJobKind.class));
+    when(executor.supportedLanes()).thenReturn(Set.of(""));
+    when(executor.supports(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.supportsJobKind(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.supportsExecutionClass(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.supportsLane(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+    when(executor.id()).thenReturn("default_reconciler");
+    var registry = new ReconcileExecutorRegistry(List.of(executor));
+
+    var scheduler = new ReconcilerScheduler();
+    scheduler.jobs = jobStore;
+    scheduler.executorRegistry = registry;
+    scheduler.cancellations = new ReconcileCancellationRegistry();
+    scheduler.config = mock(Config.class);
+    when(scheduler.config.getOptionalValue(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.eq(Long.class)))
+        .thenReturn(Optional.empty());
+
+    var lease =
+        new ReconcileJobStore.LeasedJob(
+            "job-1",
+            "acct",
+            "connector",
+            false,
+            ReconcilerService.CaptureMode.METADATA_AND_STATS,
+            ai.floedb.floecat.reconciler.jobs.ReconcileScope.empty(),
+            ReconcileExecutionPolicy.defaults(),
+            "lease-1",
+            "",
+            "");
+
+    when(executor.execute(org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(
+            ignored -> {
+              Thread.currentThread().interrupt();
+              throw new RuntimeException("interrupted");
+            });
+
+    scheduler.runLease(lease);
+
+    verify(jobStore, never())
+        .markCancelled(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong());
+    verify(jobStore, never())
+        .markFailed(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong());
+    verify(jobStore, never())
+        .markSucceeded(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong());
   }
 
   private static ReconcileJobStore.ReconcileJob childJob(String jobId, String parentJobId) {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.reconciler.jobs.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
@@ -75,5 +76,75 @@ class InMemoryReconcileJobStoreTest {
 
     assertEquals("JS_CANCELLING", stillCancelling.state);
     assertEquals("first stop", stillCancelling.message);
+  }
+
+  @Test
+  void leaseNextReclaimsExpiredRunningJobs() throws Exception {
+    String leaseMsKey = "floecat.reconciler.job-store.lease-ms";
+    String reclaimMsKey = "floecat.reconciler.job-store.reclaim-interval-ms";
+    String previousLeaseMs = System.getProperty(leaseMsKey);
+    String previousReclaimMs = System.getProperty(reclaimMsKey);
+    try {
+      System.setProperty(leaseMsKey, "1000");
+      System.setProperty(reclaimMsKey, "1000");
+
+      var store = new InMemoryReconcileJobStore();
+      String jobId =
+          store.enqueue(
+              "acct", "conn", false, CaptureMode.METADATA_AND_STATS, ReconcileScope.empty());
+      var lease = store.leaseNext().orElseThrow();
+      store.markRunning(jobId, lease.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
+
+      Thread.sleep(1150L);
+
+      var reclaimed = store.leaseNext().orElseThrow();
+      assertEquals(jobId, reclaimed.jobId);
+      var job = store.get("acct", jobId).orElseThrow();
+      assertEquals("JS_QUEUED", job.state);
+      assertEquals("Lease expired; requeued", job.message);
+    } finally {
+      restoreProperty(leaseMsKey, previousLeaseMs);
+      restoreProperty(reclaimMsKey, previousReclaimMs);
+    }
+  }
+
+  @Test
+  void leaseNextReclaimsExpiredCancellingJobs() throws Exception {
+    String leaseMsKey = "floecat.reconciler.job-store.lease-ms";
+    String reclaimMsKey = "floecat.reconciler.job-store.reclaim-interval-ms";
+    String previousLeaseMs = System.getProperty(leaseMsKey);
+    String previousReclaimMs = System.getProperty(reclaimMsKey);
+    try {
+      System.setProperty(leaseMsKey, "5000");
+      System.setProperty(reclaimMsKey, "1000");
+
+      var store = new InMemoryReconcileJobStore();
+      String jobId =
+          store.enqueue(
+              "acct", "conn", false, CaptureMode.METADATA_AND_STATS, ReconcileScope.empty());
+      var lease = store.leaseNext().orElseThrow();
+      store.markRunning(jobId, lease.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
+      store.cancel("acct", jobId, "stop");
+
+      Thread.sleep(1150L);
+
+      var reclaimed = store.leaseNext().orElseThrow();
+      assertEquals(jobId, reclaimed.jobId);
+      var job = store.get("acct", jobId).orElseThrow();
+      assertEquals("JS_CANCELLING", job.state);
+      assertEquals("Lease expired while cancelling", job.message);
+      assertTrue(store.isCancellationRequested(jobId));
+    } finally {
+      restoreProperty(leaseMsKey, previousLeaseMs);
+      restoreProperty(reclaimMsKey, previousReclaimMs);
+    }
+  }
+
+  private static void restoreProperty(String key, String value) {
+    if (value == null) {
+      System.clearProperty(key);
+      return;
+    }
+    System.setProperty(key, value);
   }
 }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
@@ -130,6 +130,8 @@ class InMemoryReconcileJobStoreTest {
 
       var reclaimed = store.leaseNext().orElseThrow();
       assertEquals(jobId, reclaimed.jobId);
+      store.markRunning(
+          reclaimed.jobId, reclaimed.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
       var job = store.get("acct", jobId).orElseThrow();
       assertEquals("JS_CANCELLING", job.state);
       assertEquals("Lease expired while cancelling", job.message);

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
@@ -55,4 +55,25 @@ class InMemoryReconcileJobStoreTest {
     assertEquals("dst_ns", failed.viewTask.destinationNamespace());
     assertEquals("dst_view", failed.viewTask.destinationViewDisplayName());
   }
+
+  @Test
+  void cancelIsIdempotentForCancellingJobs() {
+    var store = new InMemoryReconcileJobStore();
+    String jobId =
+        store.enqueue(
+            "acct", "conn", false, CaptureMode.METADATA_AND_STATS, ReconcileScope.empty());
+    var lease = store.leaseNext().orElseThrow();
+
+    store.markRunning(jobId, lease.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
+    store.cancel("acct", jobId, "first stop");
+    var cancelling = store.get("acct", jobId).orElseThrow();
+
+    assertEquals("JS_CANCELLING", cancelling.state);
+
+    store.cancel("acct", jobId, "second stop");
+    var stillCancelling = store.get("acct", jobId).orElseThrow();
+
+    assertEquals("JS_CANCELLING", stillCancelling.state);
+    assertEquals("first stop", stillCancelling.message);
+  }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
@@ -726,9 +726,30 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
   }
 
   private void requestCaptureNowCancellation(String accountId, String jobId, String reason) {
-    jobs.cancel(accountId, jobId, reason)
-        .filter(cancelled -> "JS_CANCELLING".equals(cancelled.state))
-        .ifPresent(cancelled -> cancellations.requestCancel(cancelled.jobId));
+    var cancelled = jobs.cancel(accountId, jobId, reason);
+    boolean cancelledViaActiveChildren = false;
+    if (cancelled.isEmpty()) {
+      var existing = jobs.get(accountId, jobId).orElse(null);
+      var effective = aggregateIfPlanJob(accountId, existing);
+      if (canCancelViaActiveChildren(existing, effective)) {
+        cancelChildJobs(accountId, existing, reason);
+        cancelledViaActiveChildren = true;
+        cancelled = jobs.get(accountId, jobId).map(job -> aggregateIfPlanJob(accountId, job));
+        if (cancelled.isEmpty()) {
+          cancelled = Optional.ofNullable(effective);
+        }
+      }
+    }
+    if (!cancelledViaActiveChildren) {
+      cancelled
+          .filter(job -> "JS_CANCELLING".equals(job.state))
+          .ifPresent(job -> cancellations.requestCancel(job.jobId));
+    }
+    if (!cancelledViaActiveChildren) {
+      cancelled
+          .filter(job -> job.jobKind == ReconcileJobKind.PLAN_CONNECTOR)
+          .ifPresent(job -> cancelChildJobs(accountId, job, reason));
+    }
   }
 
   private Duration effectiveCaptureNowWait(CaptureNowRequest request) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -431,8 +431,11 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
           if (!hasActiveLease(jobId, leaseEpoch, existing, "markRunning", false, true)) {
             return null;
           }
-          existing.state = "JS_RUNNING";
-          existing.message = "Running";
+          boolean cancelling = "JS_CANCELLING".equals(existing.state);
+          if (!cancelling) {
+            existing.state = "JS_RUNNING";
+            existing.message = "Running";
+          }
           if (existing.startedAtMs <= 0L) {
             existing.startedAtMs = startedAtMs;
           }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -604,7 +604,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     mutateByCanonicalPointer(
         loaded.get().canonicalPointerKey,
         existing -> {
-          if (isTerminalState(existing.state)) {
+          if (isTerminalState(existing.state) || "JS_CANCELLING".equals(existing.state)) {
             return existing;
           }
           if ("JS_RUNNING".equals(existing.state)) {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
@@ -271,6 +271,48 @@ class ReconcileControlImplTest {
   }
 
   @Test
+  void captureNowCancelsActiveChildrenWhenPlanJobAlreadySucceeded() {
+    var planJob = job("job-1", "JS_SUCCEEDED", 0, 0, 0, "");
+    when(service.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
+        .thenReturn("job-1");
+    when(service.jobs.get("acct", "job-1")).thenReturn(Optional.of(planJob), Optional.of(planJob));
+    when(service.jobs.cancel("acct", "job-1", "capture_now timed out while waiting for completion"))
+        .thenReturn(Optional.empty());
+    when(service.jobs.childJobs("acct", "job-1"))
+        .thenReturn(
+            java.util.List.of(
+                childJob("child-1", "JS_RUNNING", 0, 0, 0, "", "job-1"),
+                childJob("child-2", "JS_QUEUED", 0, 0, 0, "", "job-1")));
+    when(service.jobs.cancel(
+            "acct", "child-1", "capture_now timed out while waiting for completion"))
+        .thenReturn(
+            Optional.of(childJob("child-1", "JS_CANCELLING", 0, 0, 0, "timing out", "job-1")));
+    when(service.jobs.cancel(
+            "acct", "child-2", "capture_now timed out while waiting for completion"))
+        .thenReturn(
+            Optional.of(childJob("child-2", "JS_CANCELLED", 0, 0, 0, "timing out", "job-1")));
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            service
+                .captureNow(
+                    CaptureNowRequest.newBuilder()
+                        .setScope(CaptureScope.newBuilder().setConnectorId(connectorId()).build())
+                        .setMaxWait(Duration.newBuilder().setSeconds(0).setNanos(1_000_000).build())
+                        .build())
+                .await()
+                .indefinitely());
+
+    verify(service.jobs, times(1))
+        .cancel("acct", "child-1", "capture_now timed out while waiting for completion");
+    verify(service.jobs, times(1))
+        .cancel("acct", "child-2", "capture_now timed out while waiting for completion");
+    verify(service.cancellations, times(1)).requestCancel("child-1");
+  }
+
+  @Test
   void getReconcileJobPrefersFailedPlanStateOverQueuedChildren() {
     when(service.jobs.get("acct", "plan-1"))
         .thenReturn(Optional.of(job("plan-1", "JS_FAILED", 0, 0, 0, "planning failed")));

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -566,6 +566,15 @@ class DurableReconcileJobStoreTest {
     var secondLease = store.leaseNext().orElseThrow();
     assertEquals(jobId, secondLease.jobId);
     assertEquals("JS_CANCELLING", store.get(jobId).orElseThrow().state);
+
+    store.markRunning(
+        secondLease.jobId,
+        secondLease.leaseEpoch,
+        System.currentTimeMillis(),
+        "default_reconciler");
+    var stillCancelling = store.get(jobId).orElseThrow();
+    assertEquals("JS_CANCELLING", stillCancelling.state);
+    assertEquals("stop", stillCancelling.message);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -569,6 +569,31 @@ class DurableReconcileJobStoreTest {
   }
 
   @Test
+  void cancelIsIdempotentForCancellingJobs() {
+    store.init();
+
+    String jobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_STATS,
+            ReconcileScope.empty());
+    var lease = store.leaseNext().orElseThrow();
+    store.markRunning(
+        lease.jobId, lease.leaseEpoch, System.currentTimeMillis(), "default_reconciler");
+
+    store.cancel(ACCOUNT_ID, jobId, "first stop");
+    assertEquals("JS_CANCELLING", store.get(jobId).orElseThrow().state);
+
+    store.cancel(ACCOUNT_ID, jobId, "second stop");
+    var stillCancelling = store.get(jobId).orElseThrow();
+
+    assertEquals("JS_CANCELLING", stillCancelling.state);
+    assertEquals("first stop", stillCancelling.message);
+  }
+
+  @Test
   void renewLeaseExtendsLeaseAndDelaysReclaim() throws Exception {
     System.setProperty("floecat.reconciler.job-store.lease-ms", "2000");
     System.setProperty("floecat.reconciler.job-store.reclaim-interval-ms", "200");


### PR DESCRIPTION
## Summary

This fixes cancellation behavior across captureNow, the reconcile job stores, and the scheduler.

captureNow now falls back to cancelling active child EXEC jobs when the parent PLAN job has already succeeded but aggregated work is still in progress. Both job-store implementations also make repeated cancel(...) calls idempotent for JS_CANCELLING, so a second cancel no longer forces a premature JS_CANCELLED.

On the scheduler side, missing executors are now recorded as job failures instead of escaping, and plain worker-thread interrupts no longer mark jobs cancelled. Only explicit store-backed cancellation requests terminalize jobs as JS_CANCELLED; interrupt-driven worker shutdown now leaves recovery to lease expiry/reclaim.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
