### PR TITLE
Fix missing giscus dialog in production

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build and sanity-check site
+        env:
+          JEKYLL_ENV: production
         run: make test-site
 
       - name: Deploy production site

--- a/tools/site/test-site.sh
+++ b/tools/site/test-site.sh
@@ -18,6 +18,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SITE_DIR="${ROOT_DIR}/site-src"
 SITE_OUT_DIR="${SITE_DIR}/_site"
 JEKYLL_PAGES_IMAGE="${JEKYLL_PAGES_IMAGE:-jekyll/jekyll:pages}"
+JEKYLL_ENVIRONMENT="${JEKYLL_ENV:-}"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "ERROR: docker is required for test-site"
@@ -28,6 +29,7 @@ echo "==> [SITE] building website with Jekyll (${JEKYLL_PAGES_IMAGE})"
 docker run --rm \
   -e "JEKYLL_UID=$(id -u)" \
   -e "JEKYLL_GID=$(id -g)" \
+  ${JEKYLL_ENVIRONMENT:+-e "JEKYLL_ENV=${JEKYLL_ENVIRONMENT}"} \
   -v "${SITE_DIR}:/srv/jekyll" \
   "${JEKYLL_PAGES_IMAGE}" \
   jekyll build


### PR DESCRIPTION
## Summary

The giscus dialog is missing from the production pages. This fix sets JEKYLL_ENV to production. 
## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

