### PR TITLE
CI: Scope checks on actual files changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
   detect-core-changes:
     name: detect-core-changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       core_changed: ${{ steps.detect.outputs.core_changed }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,38 +33,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BEFORE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-
-          # Non-core files owned by website/docs workflows. If all changed files
-          # match this set, core CI jobs can be skipped safely.
-          non_core_re='^(site-src/|docs/|mkdocs\.yml$|\.markdownlint-cli2\.yaml$|lighthouserc\.json$|tools/site/|\.github/workflows/pages\.yml$)'
-
-          core_changed=true
-          changed_files=""
-
-          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
-            if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
-              changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)"
-            fi
-          elif [[ "${EVENT_NAME}" == "push" && -n "${BEFORE_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
-            git fetch --no-tags --depth=1 origin "${BEFORE_SHA}" || true
-            if git cat-file -e "${BEFORE_SHA}^{commit}" >/dev/null 2>&1; then
-              changed_files="$(git diff --name-only "${BEFORE_SHA}...${HEAD_SHA}" || true)"
-            fi
-          fi
-
-          if [[ -n "${changed_files}" ]]; then
-            if echo "${changed_files}" | grep -qEv "${non_core_re}"; then
-              core_changed=true
-            else
-              core_changed=false
-            fi
-          fi
-
-          echo "core_changed=${core_changed}" >> "${GITHUB_OUTPUT}"
-          echo "Detected core_changed=${core_changed}"
+        run: ./tools/ci/detect-core-changes.sh
 
   gitleaks:
     if: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,53 @@ on:
         type: string
 
 jobs:
+  detect-core-changes:
+    name: detect-core-changes
+    runs-on: ubuntu-latest
+    outputs:
+      core_changed: ${{ steps.detect.outputs.core_changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect core-code changes
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Non-core files owned by website/docs workflows. If all changed files
+          # match this set, core CI jobs can be skipped safely.
+          non_core_re='^(site-src/|docs/|mkdocs\.yml$|\.markdownlint-cli2\.yaml$|lighthouserc\.json$|tools/site/|\.github/workflows/pages\.yml$)'
+
+          core_changed=true
+          changed_files=""
+
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
+            if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
+              changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)"
+            fi
+          elif [[ "${EVENT_NAME}" == "push" && -n "${BEFORE_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+            git fetch --no-tags --depth=1 origin "${BEFORE_SHA}" || true
+            if git cat-file -e "${BEFORE_SHA}^{commit}" >/dev/null 2>&1; then
+              changed_files="$(git diff --name-only "${BEFORE_SHA}...${HEAD_SHA}" || true)"
+            fi
+          fi
+
+          if [[ -n "${changed_files}" ]]; then
+            if echo "${changed_files}" | grep -qEv "${non_core_re}"; then
+              core_changed=true
+            else
+              core_changed=false
+            fi
+          fi
+
+          echo "core_changed=${core_changed}" >> "${GITHUB_OUTPUT}"
+          echo "Detected core_changed=${core_changed}"
+
   gitleaks:
     if: false
     name: gitleaks
@@ -43,6 +90,8 @@ jobs:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   ci-core:
+    needs: detect-core-changes
+    if: needs.detect-core-changes.outputs.core_changed == 'true'
     name: ci-core
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -83,6 +132,8 @@ jobs:
         run: make check-pbtxt-format
 
   ci-localstack:
+    needs: detect-core-changes
+    if: needs.detect-core-changes.outputs.core_changed == 'true'
     name: ci-localstack
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -166,6 +217,8 @@ jobs:
         run: make localstack-down
 
   docker-smoke:
+    needs: detect-core-changes
+    if: needs.detect-core-changes.outputs.core_changed == 'true'
     name: docker-smoke (${{ matrix.label }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -226,10 +279,13 @@ jobs:
 
   publish-images:
     name: publish-images
-    needs: [ci-core, ci-localstack, docker-smoke]
+    needs: [detect-core-changes, ci-core, ci-localstack, docker-smoke]
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_preview == 'true')
+      needs.detect-core-changes.outputs.core_changed == 'true' &&
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_preview == 'true')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,38 +34,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BEFORE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-
-          # Non-core files owned by website/docs workflows. If all changed files
-          # match this set, CodeQL can skip PR/push runs for faster turnaround.
-          non_core_re='^(site-src/|docs/|mkdocs\.yml$|\.markdownlint-cli2\.yaml$|lighthouserc\.json$|tools/site/|\.github/workflows/pages\.yml$)'
-
-          core_changed=true
-          changed_files=""
-
-          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
-            if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
-              changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)"
-            fi
-          elif [[ "${EVENT_NAME}" == "push" && -n "${BEFORE_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
-            git fetch --no-tags --depth=1 origin "${BEFORE_SHA}" || true
-            if git cat-file -e "${BEFORE_SHA}^{commit}" >/dev/null 2>&1; then
-              changed_files="$(git diff --name-only "${BEFORE_SHA}...${HEAD_SHA}" || true)"
-            fi
-          fi
-
-          if [[ -n "${changed_files}" ]]; then
-            if echo "${changed_files}" | grep -qEv "${non_core_re}"; then
-              core_changed=true
-            else
-              core_changed=false
-            fi
-          fi
-
-          echo "core_changed=${core_changed}" >> "${GITHUB_OUTPUT}"
-          echo "Detected core_changed=${core_changed}"
+        run: ./tools/ci/detect-core-changes.sh
 
   analyze:
     needs: detect-core-changes

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,8 @@ jobs:
   detect-core-changes:
     name: detect-core-changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       core_changed: ${{ steps.detect.outputs.core_changed }}
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,56 @@ on:
     - cron: '27 23 * * 2'
 
 jobs:
+  detect-core-changes:
+    name: detect-core-changes
+    runs-on: ubuntu-latest
+    outputs:
+      core_changed: ${{ steps.detect.outputs.core_changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect core-code changes
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Non-core files owned by website/docs workflows. If all changed files
+          # match this set, CodeQL can skip PR/push runs for faster turnaround.
+          non_core_re='^(site-src/|docs/|mkdocs\.yml$|\.markdownlint-cli2\.yaml$|lighthouserc\.json$|tools/site/|\.github/workflows/pages\.yml$)'
+
+          core_changed=true
+          changed_files=""
+
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
+            if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
+              changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)"
+            fi
+          elif [[ "${EVENT_NAME}" == "push" && -n "${BEFORE_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+            git fetch --no-tags --depth=1 origin "${BEFORE_SHA}" || true
+            if git cat-file -e "${BEFORE_SHA}^{commit}" >/dev/null 2>&1; then
+              changed_files="$(git diff --name-only "${BEFORE_SHA}...${HEAD_SHA}" || true)"
+            fi
+          fi
+
+          if [[ -n "${changed_files}" ]]; then
+            if echo "${changed_files}" | grep -qEv "${non_core_re}"; then
+              core_changed=true
+            else
+              core_changed=false
+            fi
+          fi
+
+          echo "core_changed=${core_changed}" >> "${GITHUB_OUTPUT}"
+          echo "Detected core_changed=${core_changed}"
+
   analyze:
+    needs: detect-core-changes
+    if: github.event_name == 'schedule' || needs.detect-core-changes.outputs.core_changed == 'true'
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
     paths:
       - "site-src/**"
       - "docs/**"
@@ -70,6 +70,8 @@ jobs:
     name: Detect changed content areas
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       site: ${{ steps.detect.outputs.site }}
       docs: ${{ steps.detect.outputs.docs }}
@@ -351,6 +353,11 @@ jobs:
       always() &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        github.event.action == 'closed' ||
+        needs.changes.outputs.site == 'true' ||
+        needs.changes.outputs.docs == 'true'
+      ) &&
       needs.pr-markdown-lint.result != 'failure' &&
       needs.pr-site-check.result != 'failure' &&
       needs.pr-docs-check.result != 'failure'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - "site-src/**"
       - "docs/**"
-      - "Makefile"
       - "mkdocs.yml"
       - ".markdownlint-cli2.yaml"
       - ".github/workflows/pages.yml"
@@ -17,7 +16,6 @@ on:
     paths:
       - "site-src/**"
       - "docs/**"
-      - "Makefile"
       - "mkdocs.yml"
       - ".markdownlint-cli2.yaml"
       - ".github/workflows/pages.yml"
@@ -106,7 +104,7 @@ jobs:
             changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)"
 
             # Shared website/docs infrastructure -> run both area checks.
-            if echo "${changed}" | grep -qE '^(tools/site/|Makefile$|lighthouserc\.json$|\.github/workflows/pages\.yml$|\.markdownlint-cli2\.yaml$)'; then
+            if echo "${changed}" | grep -qE '^(tools/site/|lighthouserc\.json$|\.github/workflows/pages\.yml$|\.markdownlint-cli2\.yaml$)'; then
               site=true
               docs=true
             fi
@@ -126,9 +124,34 @@ jobs:
           echo "docs=${docs}" >> "${GITHUB_OUTPUT}"
           echo "Detected: site=${site} docs=${docs}"
 
+  pr-markdown-lint:
+    name: Markdown lint
+    needs: changes
+    if: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.action != 'closed' &&
+          (needs.changes.outputs.site == 'true' || needs.changes.outputs.docs == 'true') }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pages-pr-lint-${{ github.event.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Markdown lint
+        run: ./tools/site/lint-markdown.sh
+
   pr-site-check:
     name: Site checks
-    needs: changes
+    needs: [changes, pr-markdown-lint]
     if: >-
       ${{ github.event_name == 'pull_request' &&
           github.event.action != 'closed' &&
@@ -154,9 +177,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-
-      - name: Markdown lint
-        run: ./tools/site/lint-markdown.sh
 
       - name: Build Jekyll site
         run: make test-site-jekyll
@@ -233,7 +253,7 @@ jobs:
 
   pr-docs-check:
     name: Docs checks
-    needs: changes
+    needs: [changes, pr-markdown-lint]
     if: >-
       ${{ github.event_name == 'pull_request' &&
           github.event.action != 'closed' &&
@@ -259,9 +279,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-
-      - name: Markdown lint
-        run: ./tools/site/lint-markdown.sh
 
       - name: Build docs
         run: make test-site-docs
@@ -329,11 +346,12 @@ jobs:
 
   pr-preview:
     name: PR preview deploy
-    needs: [changes, pr-site-check, pr-docs-check]
+    needs: [changes, pr-markdown-lint, pr-site-check, pr-docs-check]
     if: |
       always() &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.pr-markdown-lint.result != 'failure' &&
       needs.pr-site-check.result != 'failure' &&
       needs.pr-docs-check.result != 'failure'
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -68,68 +68,123 @@ jobs:
           REPO: ${{ github.repository }}
         run: node ./tools/site/sync-blog-discussions.mjs --site-dir site-src
 
-  pr-build-check:
-    name: Pages build check
+  changes:
+    name: Detect changed content areas
     if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    outputs:
+      site: ${{ steps.detect.outputs.site }}
+      docs: ${{ steps.detect.outputs.docs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect changed areas
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+          PR_ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+
+          site=false
+          docs=false
+
+          if [[ "${PR_ACTION}" == "closed" ]]; then
+            echo "site=false" >> "${GITHUB_OUTPUT}"
+            echo "docs=false" >> "${GITHUB_OUTPUT}"
+            echo "Detected: site=false docs=false (closed PR event)"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
+          if ! git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
+            site=true
+            docs=true
+          else
+            changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)"
+
+            # Shared website/docs infrastructure -> run both area checks.
+            if echo "${changed}" | grep -qE '^(tools/site/|Makefile$|lighthouserc\.json$|\.github/workflows/pages\.yml$|\.markdownlint-cli2\.yaml$)'; then
+              site=true
+              docs=true
+            fi
+
+            # Website/Jekyll content.
+            if echo "${changed}" | grep -qE '^site-src/'; then
+              site=true
+            fi
+
+            # Repository docs/MkDocs content.
+            if echo "${changed}" | grep -qE '^(docs/|mkdocs\.yml$)'; then
+              docs=true
+            fi
+          fi
+
+          echo "site=${site}" >> "${GITHUB_OUTPUT}"
+          echo "docs=${docs}" >> "${GITHUB_OUTPUT}"
+          echo "Detected: site=${site} docs=${docs}"
+
+  pr-site-check:
+    name: Site checks
+    needs: changes
+    if: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.action != 'closed' &&
+          needs.changes.outputs.site == 'true' }}
     runs-on: ubuntu-latest
     env:
       DOCS_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
     concurrency:
-      group: pages-pr-${{ github.event.number }}
+      group: pages-pr-site-${{ github.event.number }}
       cancel-in-progress: true
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Ruby
-        if: github.event.action != 'closed'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"
 
       - name: Setup Node
-        if: github.event.action != 'closed'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
       - name: Markdown lint
-        if: github.event.action != 'closed'
         run: ./tools/site/lint-markdown.sh
 
-      - name: Build and sanity-check site
-        if: github.event.action != 'closed'
-        run: make test-site
+      - name: Build Jekyll site
+        run: make test-site-jekyll
 
       - name: Validate blog discussion sync plan
-        if: github.event.action != 'closed'
         run: node ./tools/site/sync-blog-discussions.mjs --site-dir site-src --dry-run
 
-      - name: Prepare Preview Root
-        if: github.event.action != 'closed'
+      - name: Prepare Site Preview Root
         run: |
           rm -rf /tmp/floecat-preview-root
           mkdir -p /tmp/floecat-preview-root/floecat
           cp -a ./site-src/_site/. /tmp/floecat-preview-root/floecat/
 
-      - name: Resolve Page Validation Paths
-        if: github.event.action != 'closed'
+      - name: Resolve Site Validation Paths
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.sha }}
         run: |
+          set -euo pipefail
+
           {
             echo "/floecat/"
             echo "/floecat/blog/"
-            echo "/floecat/documentation/"
-          } > /tmp/page-validation-paths.txt
+          } > /tmp/site-validation-paths.txt
 
           git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
           if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
-            git diff --name-status --find-renames --diff-filter=ACMR "${BASE_SHA}...${HEAD_SHA}" -- site-src docs mkdocs.yml \
+            git diff --name-status --find-renames --diff-filter=ACMR "${BASE_SHA}...${HEAD_SHA}" -- site-src \
               | awk 'NF {print $NF}' > /tmp/site-changed-paths.txt
             {
               sed -nE 's#^site-src/_posts/([0-9]{4})-([0-9]{2})-([0-9]{2})-(.+)\.md$#/floecat/\1/\2/\3/\4.html#p' /tmp/site-changed-paths.txt
@@ -139,29 +194,23 @@ jobs:
                 -e 's#^site-src/([^_/][^/]*)\.md$#/floecat/\1/#p' \
                 /tmp/site-changed-paths.txt
               sed -nE 's#^site-src/(.+)/index\.md$#/floecat/\1/#p' /tmp/site-changed-paths.txt
-              sed -nE 's#^docs/index\.md$#/floecat/documentation/#p' /tmp/site-changed-paths.txt
-              sed -nE 's#^docs/(.+)/index\.md$#/floecat/documentation/\1/#p' /tmp/site-changed-paths.txt
-              sed -nE 's#^docs/(.+)\.md$#/floecat/documentation/\1/#p' /tmp/site-changed-paths.txt \
-                | grep -vE '^/floecat/documentation/index/$|^/floecat/documentation/.+/index/$'
-            } | awk 'NF' >> /tmp/page-validation-paths.txt
+            } | awk 'NF' >> /tmp/site-validation-paths.txt
           fi
 
-          LC_ALL=C sort -u -o /tmp/page-validation-paths.txt /tmp/page-validation-paths.txt
-          echo "Page validation paths:"
-          cat /tmp/page-validation-paths.txt
+          LC_ALL=C sort -u -o /tmp/site-validation-paths.txt /tmp/site-validation-paths.txt
+          echo "Site validation paths:"
+          cat /tmp/site-validation-paths.txt
 
-          sed -E 's#^#http://127.0.0.1:8082#' /tmp/page-validation-paths.txt > /tmp/lighthouse-urls.txt
-          node -e "const fs=require('fs');const cfg=JSON.parse(fs.readFileSync('lighthouserc.json','utf8'));const urls=fs.readFileSync('/tmp/lighthouse-urls.txt','utf8').split(/\r?\n/).map(s=>s.trim()).filter(Boolean);cfg.ci.collect.url=urls;fs.writeFileSync('/tmp/lighthouserc.pr.json', JSON.stringify(cfg,null,2));"
+          sed -E 's#^#http://127.0.0.1:8082#' /tmp/site-validation-paths.txt > /tmp/lighthouse-site-urls.txt
+          node -e "const fs=require('fs');const cfg=JSON.parse(fs.readFileSync('lighthouserc.json','utf8'));const urls=fs.readFileSync('/tmp/lighthouse-site-urls.txt','utf8').split(/\r?\n/).map(s=>s.trim()).filter(Boolean);cfg.ci.collect.url=urls;fs.writeFileSync('/tmp/lighthouserc.site.pr.json',JSON.stringify(cfg,null,2));"
 
-      - name: Playwright smoke check
-        if: github.event.action != 'closed'
+      - name: Playwright smoke check (site)
         env:
           PLAYWRIGHT_CHANNEL: chrome
-          SITE_E2E_PATHS_FILE: /tmp/page-validation-paths.txt
+          SITE_E2E_PATHS_FILE: /tmp/site-validation-paths.txt
         run: ./tools/site/test-site-e2e.sh
 
-      - name: Check HTML
-        if: github.event.action != 'closed'
+      - name: Check HTML (site)
         run: |
           gem install html-proofer -v "~> 5.0" --no-document
           htmlproofer /tmp/floecat-preview-root \
@@ -169,33 +218,140 @@ jobs:
             --ignore-urls "/^#/,/^mailto:/,/^tel:/,/^javascript:/,/^\.\.\//" \
             --allow-missing-href
 
-      - name: Lighthouse CI
-        if: github.event.action != 'closed'
+      - name: Lighthouse CI (site)
         run: |
           npm install -g @lhci/cli@0.15.x
-          lhci autorun --config=/tmp/lighthouserc.pr.json
+          lhci autorun --config=/tmp/lighthouserc.site.pr.json
 
-      - name: Upload Lighthouse Artifacts
-        if: always() && github.event.action != 'closed'
+      - name: Upload Lighthouse Artifacts (site)
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: lighthouse-reports
+          name: lighthouse-reports-site
           if-no-files-found: ignore
           path: ./.lighthouseci
 
-      - name: Upload PR Preview Artifact
-        id: upload_pr_preview
-        if: always() && github.event.action != 'closed'
+  pr-docs-check:
+    name: Docs checks
+    needs: changes
+    if: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.action != 'closed' &&
+          needs.changes.outputs.docs == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      DOCS_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    concurrency:
+      group: pages-pr-docs-${{ github.event.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Markdown lint
+        run: ./tools/site/lint-markdown.sh
+
+      - name: Build docs
+        run: make test-site-docs
+
+      - name: Prepare Docs Preview Root
+        run: |
+          rm -rf /tmp/floecat-preview-root
+          mkdir -p /tmp/floecat-preview-root/floecat/documentation
+          cp -a ./site-src/_site/documentation/. /tmp/floecat-preview-root/floecat/documentation/
+
+      - name: Resolve Docs Validation Paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          echo "/floecat/documentation/" > /tmp/docs-validation-paths.txt
+
+          git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
+          if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
+            git diff --name-status --find-renames --diff-filter=ACMR "${BASE_SHA}...${HEAD_SHA}" -- docs mkdocs.yml \
+              | awk 'NF {print $NF}' > /tmp/docs-changed-paths.txt
+            {
+              sed -nE 's#^docs/index\.md$#/floecat/documentation/#p' /tmp/docs-changed-paths.txt
+              sed -nE 's#^docs/(.+)/index\.md$#/floecat/documentation/\1/#p' /tmp/docs-changed-paths.txt
+              sed -nE 's#^docs/(.+)\.md$#/floecat/documentation/\1/#p' /tmp/docs-changed-paths.txt \
+                | grep -vE '^/floecat/documentation/index/$|^/floecat/documentation/.+/index/$' || true
+            } | awk 'NF' >> /tmp/docs-validation-paths.txt
+          fi
+
+          LC_ALL=C sort -u -o /tmp/docs-validation-paths.txt /tmp/docs-validation-paths.txt
+          echo "Docs validation paths:"
+          cat /tmp/docs-validation-paths.txt
+
+          sed -E 's#^#http://127.0.0.1:8082#' /tmp/docs-validation-paths.txt > /tmp/lighthouse-docs-urls.txt
+          node -e "const fs=require('fs');const cfg=JSON.parse(fs.readFileSync('lighthouserc.json','utf8'));const urls=fs.readFileSync('/tmp/lighthouse-docs-urls.txt','utf8').split(/\r?\n/).map(s=>s.trim()).filter(Boolean);cfg.ci.collect.url=urls;fs.writeFileSync('/tmp/lighthouserc.docs.pr.json',JSON.stringify(cfg,null,2));"
+
+      - name: Playwright smoke check (docs)
+        env:
+          PLAYWRIGHT_CHANNEL: chrome
+          SITE_E2E_PATHS_FILE: /tmp/docs-validation-paths.txt
+        run: ./tools/site/test-site-e2e.sh
+
+      - name: Check HTML (docs)
+        run: |
+          gem install html-proofer -v "~> 5.0" --no-document
+          htmlproofer /tmp/floecat-preview-root \
+            --disable-external \
+            --ignore-urls "/^#/,/^mailto:/,/^tel:/,/^javascript:/,/^\.\.\//" \
+            --allow-missing-href
+
+      - name: Lighthouse CI (docs)
+        run: |
+          npm install -g @lhci/cli@0.15.x
+          lhci autorun --config=/tmp/lighthouserc.docs.pr.json
+
+      - name: Upload Lighthouse Artifacts (docs)
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pages-preview
-          if-no-files-found: warn
-          path: /tmp/floecat-preview-root
-          retention-days: 7
+          name: lighthouse-reports-docs
+          if-no-files-found: ignore
+          path: ./.lighthouseci
 
-      - name: Build PR Preview Site
+  pr-preview:
+    name: PR preview deploy
+    needs: [changes, pr-site-check, pr-docs-check]
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.pr-site-check.result != 'failure' &&
+      needs.pr-docs-check.result != 'failure'
+    runs-on: ubuntu-latest
+    env:
+      DOCS_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    concurrency:
+      group: pages-pr-preview-${{ github.event.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build PR Preview Site (with PR baseurl)
         id: build_pr_preview
-        if: always() && github.event.action != 'closed'
+        if: github.event.action != 'closed'
         env:
           PR_NUMBER: ${{ github.event.number }}
           JEKYLL_PAGES_IMAGE: jekyll/jekyll:pages
@@ -220,8 +376,18 @@ jobs:
 
           ./tools/site/build-docs.sh --output-dir "${PREVIEW_OUT}/documentation"
 
+      - name: Upload PR Preview Artifact
+        id: upload_pr_preview
+        if: github.event.action != 'closed' && steps.build_pr_preview.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pages-preview
+          if-no-files-found: warn
+          path: /tmp/floecat-pr-preview-site
+          retention-days: 7
+
       - name: Deploy PR Preview
-        if: always() && github.event.action != 'closed' && steps.build_pr_preview.outcome == 'success' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.action != 'closed' && steps.build_pr_preview.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -229,7 +395,7 @@ jobs:
         run: ./tools/site/publish-gh-pages.sh deploy-pr --source-dir /tmp/floecat-pr-preview-site --pr-number "${PR_NUMBER}"
 
       - name: Remove PR Preview
-        if: always() && github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.action == 'closed'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -237,7 +403,7 @@ jobs:
         run: ./tools/site/publish-gh-pages.sh remove-pr --pr-number "${PR_NUMBER}"
 
       - name: Comment PR Preview Link
-        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        if: always()
         uses: actions/github-script@v7
         env:
           PREVIEW_ARTIFACT_URL: ${{ steps.upload_pr_preview.outputs.artifact-url }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["**"]
     paths:
       - "site-src/**"
       - "docs/**"

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ LOCALSTACK_TEST_GOAL := $(if $(strip $(TEST)),test,verify)
 LOCALSTACK_TEST_SKIP_ITS := $(if $(strip $(TEST)),-DskipITs=true,)
 LOCALSTACK_TEST_PROJECTS := $(if $(strip $(TEST)),service,service,protocol-gateway/iceberg-rest,client-cli)
 TEST_RECONCILER_PROPS := -Dfloecat.reconciler.worker.auth.required=false
+SITE_MAKEFILE ?= tools/site/make/site.mk
 
 DOCKER_COMPOSE ?= docker compose
 DOCKER_COMPOSE_MAIN ?= $(DOCKER_COMPOSE) -f docker/docker-compose.yml
@@ -291,6 +292,10 @@ SEED_PROPS := \
 	-Dfloecat.fixtures.use-aws-s3=false
 endif
 
+# Site/docs targets are maintained in a separate fragment so website workflow
+# changes stay isolated from core Java/runtime targets.
+include $(SITE_MAKEFILE)
+
 # ===================================================
 # Aggregates
 # ===================================================
@@ -334,19 +339,7 @@ $(TEST_SUPPORT_JAR): $(shell find core/storage-spi/src/test -type f -name '*.jav
 # - test: in-memory stores (fast default)
 # - test-localstack: fixtures + catalog LocalStack
 # ===================================================
-.PHONY: test-site test-site-e2e lint-markdown site-preview test test-localstack unit-test integration-test verify
-
-test-site:
-	@./tools/site/test-site.sh
-
-test-site-e2e: test-site
-	@./tools/site/test-site-e2e.sh
-
-lint-markdown:
-	@./tools/site/lint-markdown.sh
-
-site-preview:
-	@./tools/site/serve-site.sh
+.PHONY: test test-localstack unit-test integration-test verify
 
 test: $(PROTO_JAR) keycloak-up
 	@bash -c 'set -euo pipefail; \

--- a/tools/ci/detect-core-changes.sh
+++ b/tools/ci/detect-core-changes.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright 2026 Yellowbrick Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+# Shared change detection for workflows that should skip heavy core checks when
+# a PR/push only touches website/docs files.
+#
+# Required env:
+#   EVENT_NAME  (github.event_name)
+#   HEAD_SHA    (github.sha)
+#
+# Optional env:
+#   BASE_SHA    (github.event.pull_request.base.sha)
+#   BEFORE_SHA  (github.event.before)
+#   CORE_NON_CORE_REGEX (override default non-core matcher)
+#
+# Output:
+#   core_changed=true|false written to $GITHUB_OUTPUT when available.
+
+EVENT_NAME="${EVENT_NAME:-}"
+BASE_SHA="${BASE_SHA:-}"
+BEFORE_SHA="${BEFORE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-}"
+NON_CORE_RE="${CORE_NON_CORE_REGEX:-^(site-src/|docs/|mkdocs\.yml$|\.markdownlint-cli2\.yaml$|lighthouserc\.json$|tools/site/|\.github/workflows/pages\.yml$)}"
+
+core_changed=true
+changed_files=""
+
+if [[ "${EVENT_NAME}" == "pull_request" && -n "${BASE_SHA}" ]]; then
+  git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
+  if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
+    changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)"
+  fi
+elif [[ "${EVENT_NAME}" == "push" && -n "${BEFORE_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+  git fetch --no-tags --depth=1 origin "${BEFORE_SHA}" || true
+  if git cat-file -e "${BEFORE_SHA}^{commit}" >/dev/null 2>&1; then
+    changed_files="$(git diff --name-only "${BEFORE_SHA}...${HEAD_SHA}" || true)"
+  fi
+fi
+
+if [[ -n "${changed_files}" ]]; then
+  if echo "${changed_files}" | grep -qEv "${NON_CORE_RE}"; then
+    core_changed=true
+  else
+    core_changed=false
+  fi
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "core_changed=${core_changed}" >> "${GITHUB_OUTPUT}"
+fi
+echo "Detected core_changed=${core_changed}"

--- a/tools/site/make/site.mk
+++ b/tools/site/make/site.mk
@@ -1,0 +1,31 @@
+# Copyright 2026 Yellowbrick Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Site/docs targets intentionally live outside the root Makefile so
+# documentation and website automation can evolve independently from
+# core runtime/build targets.
+
+.PHONY: test-site test-site-e2e lint-markdown site-preview
+
+test-site: # website sanity build (Jekyll + docs output checks)
+	@./tools/site/test-site.sh
+
+test-site-e2e: test-site # Playwright smoke checks for rendered site pages
+	@./tools/site/test-site-e2e.sh
+
+lint-markdown: # markdown lint for docs/ and site-src markdown
+	@./tools/site/lint-markdown.sh
+
+site-preview: # local live preview for /floecat and /floecat/documentation
+	@./tools/site/serve-site.sh

--- a/tools/site/make/site.mk
+++ b/tools/site/make/site.mk
@@ -16,10 +16,16 @@
 # documentation and website automation can evolve independently from
 # core runtime/build targets.
 
-.PHONY: test-site test-site-e2e lint-markdown site-preview
+.PHONY: test-site test-site-jekyll test-site-docs test-site-e2e lint-markdown site-preview
 
 test-site: # website sanity build (Jekyll + docs output checks)
 	@./tools/site/test-site.sh
+
+test-site-jekyll: # Jekyll-only build + website output checks
+	@./tools/site/test-site-jekyll.sh
+
+test-site-docs: # docs-only build + documentation output checks
+	@./tools/site/test-site-docs.sh
 
 test-site-e2e: test-site # Playwright smoke checks for rendered site pages
 	@./tools/site/test-site-e2e.sh

--- a/tools/site/test-site-docs.sh
+++ b/tools/site/test-site-docs.sh
@@ -16,14 +16,11 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SITE_OUT_DIR="${ROOT_DIR}/site-src/_site"
+DOCS_OUT_DIR="${SITE_OUT_DIR}/documentation"
 
-# Full site validation = Jekyll site + rendered docs tree.
-"${ROOT_DIR}/tools/site/test-site-jekyll.sh"
-"${ROOT_DIR}/tools/site/test-site-docs.sh"
+echo "==> [DOCS] building repository docs under /documentation/"
+"${ROOT_DIR}/tools/site/build-docs.sh" --output-dir "${DOCS_OUT_DIR}"
 
-echo "==> [SITE] checking combined output"
-test -f "${SITE_OUT_DIR}/documentation/index.html" || {
-  echo "missing ${SITE_OUT_DIR}/documentation/index.html"
-  exit 1
-}
-echo "==> [SITE] basic checks passed"
+echo "==> [DOCS] checking expected docs output files"
+test -f "${DOCS_OUT_DIR}/index.html" || { echo "missing ${DOCS_OUT_DIR}/index.html"; exit 1; }
+echo "==> [DOCS] docs checks passed"

--- a/tools/site/test-site-e2e.sh
+++ b/tools/site/test-site-e2e.sh
@@ -43,8 +43,8 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 1
 fi
 
-if [[ ! -f "${SITE_OUT_DIR}/index.html" ]]; then
-  echo "ERROR: ${SITE_OUT_DIR}/index.html missing. Run 'make test-site' first."
+if [[ ! -f "${SITE_OUT_DIR}/index.html" && ! -f "${SITE_OUT_DIR}/documentation/index.html" ]]; then
+  echo "ERROR: expected site output missing (need index.html or documentation/index.html). Run 'make test-site' or area-specific build first."
   exit 1
 fi
 

--- a/tools/site/test-site-jekyll.sh
+++ b/tools/site/test-site-jekyll.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2026 Yellowbrick Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SITE_DIR="${ROOT_DIR}/site-src"
+SITE_OUT_DIR="${SITE_DIR}/_site"
+JEKYLL_PAGES_IMAGE="${JEKYLL_PAGES_IMAGE:-jekyll/jekyll:pages}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker is required for test-site-jekyll"
+  exit 1
+fi
+
+echo "==> [SITE] building website with Jekyll (${JEKYLL_PAGES_IMAGE})"
+docker run --rm \
+  -e "JEKYLL_UID=$(id -u)" \
+  -e "JEKYLL_GID=$(id -g)" \
+  -v "${SITE_DIR}:/srv/jekyll" \
+  "${JEKYLL_PAGES_IMAGE}" \
+  jekyll build
+
+echo "==> [SITE] checking expected Jekyll output files"
+test -f "${SITE_OUT_DIR}/index.html" || { echo "missing ${SITE_OUT_DIR}/index.html"; exit 1; }
+test -f "${SITE_OUT_DIR}/blog/index.html" || { echo "missing ${SITE_OUT_DIR}/blog/index.html"; exit 1; }
+test -f "${SITE_OUT_DIR}/robots.txt" || { echo "missing ${SITE_OUT_DIR}/robots.txt"; exit 1; }
+echo "==> [SITE] jekyll checks passed"

--- a/tools/site/test-site-jekyll.sh
+++ b/tools/site/test-site-jekyll.sh
@@ -28,6 +28,7 @@ echo "==> [SITE] building website with Jekyll (${JEKYLL_PAGES_IMAGE})"
 docker run --rm \
   -e "JEKYLL_UID=$(id -u)" \
   -e "JEKYLL_GID=$(id -g)" \
+  -e "JEKYLL_ENV=${JEKYLL_ENV:-development}" \
   -v "${SITE_DIR}:/srv/jekyll" \
   "${JEKYLL_PAGES_IMAGE}" \
   jekyll build


### PR DESCRIPTION
### Summary
This PR scopes CI by changed area and splits site/docs validation so we only run expensive checks when relevant.

### What changed
1. Added shared core-change detector used by both CI and CodeQL.
2. Updated `ci` workflow to skip core jobs when a PR only touches site/docs assets.
3. Updated `CodeQL Advanced` workflow to skip on site/docs-only changes (still runs on schedule).
4. Split Pages PR checks into area-aware jobs:
- `changes`
- `pr-markdown-lint` (shared, runs once)
- `pr-site-check`
- `pr-docs-check`
- `pr-preview`

5. Split site Make targets/scripts so Jekyll and docs checks can run independently:
- `test-site-jekyll`
- `test-site-docs`
- `test-site` (composed/full)

### Why
- Faster PR feedback.
- Less CI noise/flakiness on unrelated changes.
- Cleaner ownership between core runtime CI and website/docs CI.
- Preview lifecycle remains intact (deploy on open PR, teardown on close).

---

## CI Matrix 

| PR change scope | ci / ci-core | ci / ci-localstack | ci / docker-smoke | CodeQL Advanced / Analyze | Deploy GitHub Pages / Markdown lint | Deploy GitHub Pages / Site checks | Deploy GitHub Pages / Docs checks | Deploy GitHub Pages / PR preview deploy |
|---|---|---|---|---|---|---|---|---|
| Core/runtime code (non-site/docs) | ✅ | ✅ | ✅ | ✅ | ⏭️ | ⏭️ | ⏭️ | ⏭️ |
| `site-src/**` only | ⏭️ | ⏭️ | ⏭️ | ⏭️ | ✅ | ✅ | ⏭️ | ✅ |
| `docs/**` / `mkdocs.yml` only | ⏭️ | ⏭️ | ⏭️ | ⏭️ | ✅ | ⏭️ | ✅ | ✅ |
| Both site + docs | ⏭️ | ⏭️ | ⏭️ | ⏭️ | ✅ | ✅ | ✅ | ✅ |
| Shared site/docs infra (`tools/site/**`, `lighthouserc.json`, `pages.yml`, `.markdownlint-cli2.yaml`) | ⏭️ | ⏭️ | ⏭️ | ⏭️ | ✅ | ✅ | ✅ | ✅ |
| Mixed core + site/docs | ✅ | ✅ | ✅ | ✅ | ✅ | ✅/⏭️* | ✅/⏭️* | ✅ |
| PR closed event (same-repo PR) | (no new core jobs) | (no new core jobs) | (no new core jobs) | (no new core jobs) | ⏭️ | ⏭️ | ⏭️ | ✅ (remove preview) |

`*` depends on which area changed (`site` and/or `docs`).

---

## Non-PR behavior


| Event | What runs |
|---|---|
| Push to `main` with core changes | `ci` core jobs + `CodeQL` analyze |
| Push to `main` with site/docs changes | Pages workflow `publish-main` (build + deploy gh-pages) |
| Push to `main` with mixed core + site/docs changes | Both core CI/CodeQL and Pages publish-main |
| `CodeQL` scheduled run | Always runs analyze (independent of changed files) |
| `ci` manual dispatch (`publish_preview=true`) | Runs core CI path and can publish preview images |


---

## Notes
- `gitleaks` job remains explicitly disabled (`if: false`), unchanged by this PR.
- PR preview deploy/cleanup is restricted to same-repo PRs (fork PRs do not deploy previews).

## Type of Change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [x] chore (build/tooling/maintenance)
