### PR TITLE
scan: add snapshot_id to TableInfo

### DIFF
--- a/core/proto/src/main/proto/floecat/query/user_scan.proto
+++ b/core/proto/src/main/proto/floecat/query/user_scan.proto
@@ -58,6 +58,7 @@ message TableInfo {
   ai.floedb.floecat.catalog.PartitionSpecInfo partition_specs = 3;
   map<string,string> properties = 4;
   string metadata_location = 5;
+  int64 snapshot_id = 6;
 }
 
 message FetchScanBundleResponse {

--- a/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
@@ -83,7 +83,7 @@ public class ScanBundleService {
 
     FloecatConnector.ScanBundle bundle = buildFromStats(table, snapshotId);
 
-    TableInfo info = buildTableInfo(table, snapshot);
+    TableInfo info = buildTableInfo(table, snapshot, snapshotId);
     return new ScanBundleWithInfo(bundle, info);
   }
 
@@ -147,8 +147,9 @@ public class ScanBundleService {
     return new FloecatConnector.ScanBundle(linkedData, deletes);
   }
 
-  private TableInfo buildTableInfo(Table table, Snapshot snapshot) {
-    TableInfo.Builder builder = TableInfo.newBuilder().setTableId(table.getResourceId());
+  private TableInfo buildTableInfo(Table table, Snapshot snapshot, long snapshotId) {
+    TableInfo.Builder builder =
+        TableInfo.newBuilder().setTableId(table.getResourceId()).setSnapshotId(snapshotId);
 
     String schemaJson = snapshot.getSchemaJson();
     if (schemaJson == null || schemaJson.isBlank()) {

--- a/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
@@ -220,6 +220,7 @@ class QueryScanServiceIT {
     assertEquals(tbl.getSchemaJson(), info.getSchemaJson());
     assertEquals(metadataLocation, info.getMetadataLocation());
     assertFalse(info.getPropertiesMap().containsKey("metadata-location"));
+    assertEquals(snap.getSnapshotId(), info.getSnapshotId());
   }
 
   /** Ensures FetchScanBundle rejects unpinned tables. */


### PR DESCRIPTION
Additive int64 snapshot_id = 6 on TableInfo so callers of FetchScanBundle can identify the pinned snapshot without parsing metadata_location. The server-side ScanBundleService.buildTableInfo populates it from the already-resolved pin used to enumerate data_files.

Files:
- core/proto/src/main/proto/floecat/query/user_scan.proto
- service/src/main/java/.../ScanBundleService.java
- service/src/test/java/.../QueryScanServiceIT.java

## Summary

Describe what this PR changes and why.

## Type of Change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [ ] `make fmt`
- [ ] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [ ] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [ ] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Include any follow-ups, risks, or reviewer guidance.
