### PR TITLE
Prevent OTel Spam in tests

### DIFF
--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -44,10 +44,9 @@ floecat.gc.pointer.enabled=false
 floecat.gc.pointer.tick-every=60s
 floecat.gc.pointer.min-age-ms=30000
 ## OpenTelemetry
-quarkus.otel.enabled=true
-quarkus.otel.traces.enabled=true
-quarkus.otel.propagators=tracecontext,baggage
 quarkus.otel.traces.exporter=none
+quarkus.otel.metrics.exporter=none
+quarkus.otel.logs.exporter=none
 ## logging
 quarkus.log.level=ERROR
 quarkus.log.category."ai.floedb.floecat".level=WARN


### PR DESCRIPTION
## Summary

As the observability stack does not "exist" in CI, the exporters produce a lot of spam about being unable to connect to the collector - simply disable the exporters in tests.

## Type of Change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [x] Config/env var changes (describe below)

Config changed to disable the exporters.

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
