### PR TITLE
service/context: preserve request context across Vert.x gRPC handoff

### DIFF
--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/utils/EngineContext.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/utils/EngineContext.java
@@ -138,4 +138,8 @@ public final class EngineContext {
   public boolean hasEngineHeaders() {
     return hasEngineKind;
   }
+
+  public boolean isEmpty() {
+    return !hasEngineKind && engineVersion.isBlank();
+  }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -33,6 +33,7 @@ import ai.floedb.floecat.account.rpc.UpdateAccountRequest;
 import ai.floedb.floecat.account.rpc.UpdateAccountResponse;
 import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.common.AccountIds;
@@ -160,11 +161,13 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
   @Override
   public Uni<CreateAccountResponse> createAccount(CreateAccountRequest request) {
     var L = LogHelper.start(LOG, "CreateAccount");
+    final var requestPrincipal = principal.get();
+    assertCreateAccountPrincipal(requestPrincipal);
 
     return mapFailures(
             runWithRetry(
                 () -> {
-                  final var pc = principal.get();
+                  final var pc = requestPrincipal;
                   final var corr = pc.getCorrelationId();
                   final var accountId = pc.getAccountId();
                   final var idempotencyAccount =
@@ -255,6 +258,16 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
         .invoke(L::fail)
         .onItem()
         .invoke(L::ok);
+  }
+
+  private static void assertCreateAccountPrincipal(PrincipalContext principalContext) {
+    if (principalContext.getSubject().isBlank() || principalContext.getPermissionsCount() == 0) {
+      throw new IllegalStateException(
+          "createAccount principal context missing required fields: subject="
+              + principalContext.getSubject()
+              + " permissions="
+              + principalContext.getPermissionsList());
+    }
   }
 
   private ResourceId resolveAccountId(

--- a/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.context;
 
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.context.impl.ContextStore;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Optional;
@@ -49,13 +50,15 @@ public final class EngineContextProvider {
   }
 
   public EngineContext engineContext() {
-    EngineContext ctx = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
+    EngineContext ctx = ContextStore.get(InboundContextInterceptor.ENGINE_CONTEXT_KEY);
     if (ctx != null) {
       return ctx;
     }
-    String kind = Optional.ofNullable(InboundContextInterceptor.ENGINE_KIND_KEY.get()).orElse("");
+    String kind =
+        Optional.ofNullable(ContextStore.get(InboundContextInterceptor.ENGINE_KIND_KEY)).orElse("");
     String version =
-        Optional.ofNullable(InboundContextInterceptor.ENGINE_VERSION_KEY.get()).orElse("");
+        Optional.ofNullable(ContextStore.get(InboundContextInterceptor.ENGINE_VERSION_KEY))
+            .orElse("");
     return EngineContext.of(kind, version);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/ContextStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/ContextStore.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.context.impl;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.security.impl.PrincipalContexts;
+import io.grpc.Context;
+import io.vertx.core.Vertx;
+import java.util.HashMap;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/** Stores request-scoped gRPC context values in both gRPC and Vert.x local context. */
+public final class ContextStore {
+  private static final Logger LOG = Logger.getLogger(ContextStore.class);
+  private static final Object VERTX_LOCAL_VALUES = new Object();
+  private Context context;
+
+  private ContextStore(Context base) {
+    this.context = base == null ? Context.current() : base;
+  }
+
+  public static <T> Context set(Context base, Context.Key<T> key, T value) {
+    return withValue(base, key, value).context();
+  }
+
+  public static <T> ContextStore withValue(Context base, Context.Key<T> key, T value) {
+    return new ContextStore(base).withValue(key, value);
+  }
+
+  public static <T> T get(Context.Key<T> key) {
+    T grpcValue = get(Context.current(), key);
+    if (isUsable(grpcValue)) {
+      return grpcValue;
+    }
+
+    T vertxValue = getVertxLocal(key);
+    if (isUsable(vertxValue)) {
+      return vertxValue;
+    }
+
+    return grpcValue != null ? grpcValue : vertxValue;
+  }
+
+  public static <T> T get(Context context, Context.Key<T> key) {
+    return context == null ? null : key.get(context);
+  }
+
+  public static void clear() {
+    var context = Vertx.currentContext();
+    if (context == null) {
+      return;
+    }
+    try {
+      context.removeLocal(VERTX_LOCAL_VALUES);
+    } catch (RuntimeException e) {
+      LOG.warn("Failed to clear request context from Vert.x local context", e);
+    }
+  }
+
+  private static boolean isUsable(Object value) {
+    if (value == null) {
+      return false;
+    }
+    if (value instanceof String text) {
+      return !text.isBlank();
+    }
+    if (value instanceof PrincipalContext principalContext) {
+      return !PrincipalContexts.isEmpty(principalContext);
+    }
+    if (value instanceof EngineContext engineContext) {
+      return !engineContext.isEmpty();
+    }
+    return true;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T getVertxLocal(Context.Key<T> key) {
+    var context = Vertx.currentContext();
+    if (context == null) {
+      return null;
+    }
+    Object value = context.getLocal(VERTX_LOCAL_VALUES);
+    if (!(value instanceof Map<?, ?> values)) {
+      return null;
+    }
+    return (T) values.get(key);
+  }
+
+  private static <T> void setVertxLocal(Context.Key<T> key, T value) {
+    var context = Vertx.currentContext();
+    if (context == null) {
+      return;
+    }
+    try {
+      Object current = context.getLocal(VERTX_LOCAL_VALUES);
+      Map<Context.Key<?>, Object> values;
+      if (current instanceof Map<?, ?> existing) {
+        values = new HashMap<>();
+        existing.forEach(
+            (existingKey, existingValue) ->
+                values.put((Context.Key<?>) existingKey, existingValue));
+      } else {
+        values = new HashMap<>();
+      }
+      values.put(key, value);
+      context.putLocal(VERTX_LOCAL_VALUES, values);
+    } catch (RuntimeException e) {
+      LOG.warnf(e, "Failed to store request context value for key %s in Vert.x local context", key);
+    }
+  }
+
+  public <T> ContextStore withValue(Context.Key<T> key, T value) {
+    setVertxLocal(key, value);
+    context = context.withValue(key, value);
+    return this;
+  }
+
+  public Context context() {
+    return context;
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
@@ -134,6 +134,7 @@ public class InboundContextInterceptor {
             try {
               metadata.put(CORR, correlationId);
             } finally {
+              ContextStore.clear();
               clearMdc();
             }
             super.close(status, metadata);
@@ -165,20 +166,21 @@ public class InboundContextInterceptor {
     String sessionHeaderValue = resolved.sessionHeaderValue();
     String authorizationHeaderValue = resolved.authorizationHeaderValue();
 
-    Context context =
-        base.withValue(PC_KEY, principalContext)
+    ContextStore contextStore =
+        ContextStore.withValue(base, PC_KEY, principalContext)
             .withValue(QUERY_KEY, queryId)
             .withValue(ENGINE_VERSION_KEY, engineVersion)
             .withValue(ENGINE_KIND_KEY, engineKind)
             .withValue(ENGINE_CONTEXT_KEY, engineContext)
             .withValue(CORR_KEY, correlationId);
     if (sessionHeaderValue != null) {
-      context = context.withValue(SESSION_HEADER_VALUE_KEY, sessionHeaderValue);
+      contextStore = contextStore.withValue(SESSION_HEADER_VALUE_KEY, sessionHeaderValue);
     }
     if (authorizationHeaderValue != null) {
-      context = context.withValue(AUTHORIZATION_HEADER_VALUE_KEY, authorizationHeaderValue);
+      contextStore =
+          contextStore.withValue(AUTHORIZATION_HEADER_VALUE_KEY, authorizationHeaderValue);
     }
-    return context;
+    return contextStore.context();
   }
 
   public static void populateMdc(ResolvedCallContext resolved) {

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptor.java
@@ -61,21 +61,23 @@ public class OutboundContextClientInterceptor implements io.grpc.ClientIntercept
 
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
-        String sessionHeaderValue = InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
+        String sessionHeaderValue =
+            ContextStore.get(InboundContextInterceptor.SESSION_HEADER_VALUE_KEY);
         String authorizationHeaderValue =
-            InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
+            ContextStore.get(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY);
         var queryId =
-            Optional.ofNullable(InboundContextInterceptor.QUERY_KEY.get())
+            Optional.ofNullable(ContextStore.get(InboundContextInterceptor.QUERY_KEY))
                 .orElseGet(() -> Baggage.current().getEntryValue("query_id"));
 
-        EngineContext engineContext = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
+        EngineContext engineContext =
+            ContextStore.get(InboundContextInterceptor.ENGINE_CONTEXT_KEY);
 
         String engineKind =
             firstNonBlank(
                 engineContext != null && engineContext.hasEngineKind()
                     ? engineContext.engineKind()
                     : null,
-                InboundContextInterceptor.ENGINE_KIND_KEY.get(),
+                ContextStore.get(InboundContextInterceptor.ENGINE_KIND_KEY),
                 Baggage.current().getEntryValue("engine_kind"));
 
         // Only propagate an engine version if we are propagating an engine kind.
@@ -84,11 +86,11 @@ public class OutboundContextClientInterceptor implements io.grpc.ClientIntercept
                 ? null
                 : firstNonBlank(
                     engineContext != null ? engineContext.engineVersion() : null,
-                    InboundContextInterceptor.ENGINE_VERSION_KEY.get(),
+                    ContextStore.get(InboundContextInterceptor.ENGINE_VERSION_KEY),
                     Baggage.current().getEntryValue("engine_version"));
 
         var correlationId =
-            Optional.ofNullable(InboundContextInterceptor.CORR_KEY.get())
+            Optional.ofNullable(ContextStore.get(InboundContextInterceptor.CORR_KEY))
                 .orElseGet(() -> Baggage.current().getEntryValue("correlation_id"));
 
         if (sessionHeaderValue != null && sessionHeader.isPresent()) {

--- a/service/src/main/java/ai/floedb/floecat/service/credentials/AuthResolutionContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/credentials/AuthResolutionContexts.java
@@ -17,14 +17,16 @@
 package ai.floedb.floecat.service.credentials;
 
 import ai.floedb.floecat.connector.spi.AuthResolutionContext;
+import ai.floedb.floecat.service.context.impl.ContextStore;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 
 public final class AuthResolutionContexts {
   private AuthResolutionContexts() {}
 
   public static AuthResolutionContext fromInboundContext() {
-    String sessionToken = InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
-    String authorizationToken = InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
+    String sessionToken = ContextStore.get(InboundContextInterceptor.SESSION_HEADER_VALUE_KEY);
+    String authorizationToken =
+        ContextStore.get(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY);
     return new AuthResolutionContext(
         sessionToken == null ? "" : sessionToken,
         authorizationToken == null ? "" : authorizationToken);

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/LocalizeErrorsInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/LocalizeErrorsInterceptor.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.error.impl;
 
 import ai.floedb.floecat.common.rpc.Error;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.service.context.impl.ContextStore;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import com.google.protobuf.Any;
 import com.google.rpc.Status;
@@ -44,7 +45,7 @@ public class LocalizeErrorsInterceptor implements ServerInterceptor {
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
       ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
 
-    PrincipalContext principal = InboundContextInterceptor.PC_KEY.get();
+    PrincipalContext principal = ContextStore.get(InboundContextInterceptor.PC_KEY);
 
     String tag = pickLocaleTag(headers, principal);
     final Locale locale =

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.error.impl;
 
 import ai.floedb.floecat.common.rpc.Error;
+import ai.floedb.floecat.service.context.impl.ContextStore;
 import ai.floedb.floecat.service.context.impl.InboundCallContextHelper;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import com.google.protobuf.Any;
@@ -57,8 +58,8 @@ public class RpcLoggingInterceptor implements ServerInterceptor {
     final long startNanos = System.nanoTime();
     final String method = call.getMethodDescriptor().getFullMethodName();
 
-    String contextCorrelationId = InboundContextInterceptor.CORR_KEY.get();
-    String contextQueryId = InboundContextInterceptor.QUERY_KEY.get();
+    String contextCorrelationId = ContextStore.get(InboundContextInterceptor.CORR_KEY);
+    String contextQueryId = ContextStore.get(InboundContextInterceptor.QUERY_KEY);
     String headerCorrelationId = headers.get(CORRELATION_ID_KEY);
     String headerQueryId = headers.get(QUERY_ID_KEY);
     final String correlationId =

--- a/service/src/main/java/ai/floedb/floecat/service/query/flight/GrpcResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/flight/GrpcResolvedCallContexts.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.query.flight;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.context.impl.ContextStore;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 
 /** Resolves Floecat Flight call context from the current shared gRPC request context. */
@@ -27,17 +28,18 @@ final class GrpcResolvedCallContexts {
   private GrpcResolvedCallContexts() {}
 
   static ResolvedCallContext currentOrUnauthenticated() {
-    PrincipalContext principal = InboundContextInterceptor.PC_KEY.get();
+    PrincipalContext principal = ContextStore.get(InboundContextInterceptor.PC_KEY);
     if (principal == null) {
       return ResolvedCallContext.unauthenticated();
     }
 
-    String queryId = InboundContextInterceptor.QUERY_KEY.get();
-    String correlationId = InboundContextInterceptor.CORR_KEY.get();
-    EngineContext engineContext = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
-    String sessionHeaderValue = InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
+    String queryId = ContextStore.get(InboundContextInterceptor.QUERY_KEY);
+    String correlationId = ContextStore.get(InboundContextInterceptor.CORR_KEY);
+    EngineContext engineContext = ContextStore.get(InboundContextInterceptor.ENGINE_CONTEXT_KEY);
+    String sessionHeaderValue =
+        ContextStore.get(InboundContextInterceptor.SESSION_HEADER_VALUE_KEY);
     String authorizationHeaderValue =
-        InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
+        ContextStore.get(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY);
 
     return new ResolvedCallContext(
         principal,

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
@@ -24,6 +24,7 @@ import ai.floedb.floecat.query.rpc.UserObjectsService;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
+import ai.floedb.floecat.service.context.impl.ContextStore;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
@@ -75,7 +76,7 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
                   () -> {
                     workStartNs.compareAndSet(0L, System.nanoTime());
                     var principalContext = principal.get();
-                    var contextCorrelationId = InboundContextInterceptor.CORR_KEY.get();
+                    var contextCorrelationId = ContextStore.get(InboundContextInterceptor.CORR_KEY);
                     var principalCorrelationId = principalContext.getCorrelationId();
                     var correlationId =
                         contextCorrelationId != null && !contextCorrelationId.isBlank()

--- a/service/src/main/java/ai/floedb/floecat/service/security/impl/PrincipalContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/impl/PrincipalContexts.java
@@ -17,17 +17,16 @@
 package ai.floedb.floecat.service.security.impl;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
-import ai.floedb.floecat.service.context.impl.ContextStore;
-import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
-import io.grpc.Context;
-import jakarta.enterprise.context.ApplicationScoped;
 
-@ApplicationScoped
-public class PrincipalProvider {
-  public static final Context.Key<PrincipalContext> KEY = Context.key("principal");
+public final class PrincipalContexts {
+  private PrincipalContexts() {}
 
-  public PrincipalContext get() {
-    PrincipalContext principalContext = ContextStore.get(InboundContextInterceptor.PC_KEY);
-    return principalContext != null ? principalContext : PrincipalContext.getDefaultInstance();
+  public static boolean isEmpty(PrincipalContext principalContext) {
+    return principalContext == null
+        || (principalContext.getSubject().isBlank()
+            && principalContext.getAccountId().isBlank()
+            && principalContext.getPermissionsCount() == 0
+            && principalContext.getQueryId().isBlank()
+            && principalContext.getCorrelationId().isBlank());
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryInterceptor.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.telemetry;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.service.context.impl.ContextStore;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.grpc.GrpcTelemetryServerInterceptor;
@@ -48,7 +49,7 @@ public final class ServiceTelemetryInterceptor implements ServerInterceptor {
             Objects.requireNonNull(observability, "observability"),
             "service",
             (__call, __headers) -> {
-              PrincipalContext pc = InboundContextInterceptor.PC_KEY.get();
+              PrincipalContext pc = ContextStore.get(InboundContextInterceptor.PC_KEY);
               return pc == null ? null : pc.getAccountId();
             });
   }
@@ -59,24 +60,24 @@ public final class ServiceTelemetryInterceptor implements ServerInterceptor {
     String operation = GrpcTelemetryServerInterceptor.simplifyOp(call.getMethodDescriptor());
     Span span = Span.current();
     if (span.getSpanContext().isValid()) {
-      String queryId = InboundContextInterceptor.QUERY_KEY.get();
+      String queryId = ContextStore.get(InboundContextInterceptor.QUERY_KEY);
       if (queryId != null && !queryId.isBlank()) {
         span.setAttribute("query_id", queryId);
       }
-      String correlationId = InboundContextInterceptor.CORR_KEY.get();
+      String correlationId = ContextStore.get(InboundContextInterceptor.CORR_KEY);
       if (correlationId != null && !correlationId.isBlank()) {
         span.setAttribute("correlation_id", correlationId);
       }
-      PrincipalContext principalContext = InboundContextInterceptor.PC_KEY.get();
+      PrincipalContext principalContext = ContextStore.get(InboundContextInterceptor.PC_KEY);
       if (principalContext != null) {
         span.setAttribute("floecat_account_id", principalContext.getAccountId());
         span.setAttribute("floecat_subject", principalContext.getSubject());
       }
-      String engineVersion = InboundContextInterceptor.ENGINE_VERSION_KEY.get();
+      String engineVersion = ContextStore.get(InboundContextInterceptor.ENGINE_VERSION_KEY);
       if (engineVersion != null && !engineVersion.isBlank()) {
         span.setAttribute("floecat_engine_version", engineVersion);
       }
-      String engineKind = InboundContextInterceptor.ENGINE_KIND_KEY.get();
+      String engineKind = ContextStore.get(InboundContextInterceptor.ENGINE_KIND_KEY);
       if (engineKind != null && !engineKind.isBlank()) {
         span.setAttribute("floecat_engine_kind", engineKind);
       }

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.account.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.account.rpc.Account;
+import ai.floedb.floecat.account.rpc.AccountSpec;
+import ai.floedb.floecat.account.rpc.CreateAccountRequest;
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.service.repo.impl.AccountRepository;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class AccountServiceImplTest {
+
+  @Test
+  void createAccount_usesCapturedPrincipalAcrossRetry() {
+    var service = new AccountServiceImpl();
+    service.accountRepo = mock(AccountRepository.class);
+    service.principal = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+
+    PrincipalContext requestPrincipal =
+        PrincipalContext.newBuilder()
+            .setAccountId("acct-1")
+            .setSubject("bootstrap-user")
+            .setCorrelationId("corr-1")
+            .addPermissions("account.write")
+            .build();
+    when(service.principal.get())
+        .thenReturn(requestPrincipal)
+        .thenReturn(PrincipalContext.getDefaultInstance());
+    doNothing().when(service.authz).require(any(), eq("account.write"));
+
+    when(service.accountRepo.getByName("Example")).thenReturn(Optional.empty());
+    doThrow(new BaseResourceRepository.AbortRetryableException("retry once"))
+        .doNothing()
+        .when(service.accountRepo)
+        .create(any(Account.class));
+    when(service.accountRepo.metaForSafe(any()))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(1L).build());
+
+    var response =
+        service
+            .createAccount(
+                CreateAccountRequest.newBuilder()
+                    .setSpec(AccountSpec.newBuilder().setDisplayName("Example").build())
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals("Example", response.getAccount().getDisplayName());
+    assertEquals("acct-1", response.getAccount().getResourceId().getAccountId());
+    verify(service.principal, times(1)).get();
+    verify(service.authz, times(2)).require(requestPrincipal, "account.write");
+  }
+
+  @Test
+  void createAccount_rejectsBlankPrincipalContext() {
+    var service = new AccountServiceImpl();
+    service.principal = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+
+    when(service.principal.get()).thenReturn(PrincipalContext.getDefaultInstance());
+
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                service
+                    .createAccount(
+                        CreateAccountRequest.newBuilder()
+                            .setSpec(AccountSpec.newBuilder().setDisplayName("Example").build())
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(
+        "createAccount principal context missing required fields: subject= permissions=[]",
+        ex.getMessage());
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SystemObjectsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SystemObjectsServiceImplTest.java
@@ -27,6 +27,7 @@ import ai.floedb.floecat.query.rpc.TableBackendKind;
 import ai.floedb.floecat.scanner.utils.EngineCatalogNames;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.context.EngineContextProvider;
+import ai.floedb.floecat.service.context.impl.ContextStore;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
@@ -95,9 +96,10 @@ class SystemObjectsServiceImplTest {
             .addPermissions("system-objects.read")
             .build();
     Context context =
-        Context.current()
-            .withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, ctx)
-            .withValue(PrincipalProvider.KEY, principal);
+        ContextStore.set(
+            Context.current().withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, ctx),
+            InboundContextInterceptor.PC_KEY,
+            principal);
     Context previous = context.attach();
     try {
       GetSystemObjectsResponse response =
@@ -132,9 +134,10 @@ class SystemObjectsServiceImplTest {
     PrincipalContext principal =
         PrincipalContext.newBuilder().setAccountId("acct-1").setSubject("tester").build();
     Context context =
-        Context.current()
-            .withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, ctx)
-            .withValue(PrincipalProvider.KEY, principal);
+        ContextStore.set(
+            Context.current().withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, ctx),
+            InboundContextInterceptor.PC_KEY,
+            principal);
     Context previous = context.attach();
     try {
       assertThatThrownBy(

--- a/service/src/test/java/ai/floedb/floecat/service/common/GrpcContextUtilTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/common/GrpcContextUtilTest.java
@@ -19,7 +19,8 @@ package ai.floedb.floecat.service.common;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
-import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.service.context.impl.ContextStore;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import io.grpc.Context;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -38,7 +39,8 @@ class GrpcContextUtilTest {
             .setCorrelationId("cid-123")
             .build();
 
-    Context contextWithPrincipal = Context.current().withValue(PrincipalProvider.KEY, expected);
+    Context contextWithPrincipal =
+        ContextStore.set(Context.current(), InboundContextInterceptor.PC_KEY, expected);
     ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
       CompletableFuture<PrincipalContext> observed = new CompletableFuture<>();
@@ -46,7 +48,10 @@ class GrpcContextUtilTest {
           () -> {
             GrpcContextUtil captured = GrpcContextUtil.capture();
             executor.submit(
-                () -> captured.run(() -> observed.complete(PrincipalProvider.KEY.get())));
+                () ->
+                    captured.run(
+                        () ->
+                            observed.complete(ContextStore.get(InboundContextInterceptor.PC_KEY))));
           });
 
       assertEquals(expected, observed.get(5, TimeUnit.SECONDS));

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/ContextStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/ContextStoreTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.context.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import io.grpc.Context;
+import io.vertx.core.Vertx;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class ContextStoreTest {
+
+  @Test
+  void grpcPrincipalTakesPrecedence() {
+    PrincipalContext expected =
+        PrincipalContext.newBuilder()
+            .setSubject("grpc-user")
+            .addPermissions("account.read")
+            .build();
+    AtomicReference<PrincipalContext> observed = new AtomicReference<>();
+
+    ContextStore.set(Context.current(), InboundContextInterceptor.PC_KEY, expected)
+        .run(() -> observed.set(ContextStore.get(InboundContextInterceptor.PC_KEY)));
+
+    assertSame(expected, observed.get());
+  }
+
+  @Test
+  void fallsBackToVertxPrincipalWhenGrpcPrincipalMissing() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      PrincipalContext expected =
+          PrincipalContext.newBuilder()
+              .setSubject("vertx-user")
+              .setAccountId("account-1")
+              .addPermissions("account.write")
+              .build();
+      AtomicReference<PrincipalContext> observed = new AtomicReference<>();
+
+      CompletableFuture<Void> completion = new CompletableFuture<>();
+      vertx.runOnContext(
+          ignored -> {
+            ContextStore.set(Context.current(), InboundContextInterceptor.PC_KEY, expected);
+            observed.set(ContextStore.get(InboundContextInterceptor.PC_KEY));
+            ContextStore.clear();
+            completion.complete(null);
+          });
+
+      completion.get();
+      assertEquals(expected, observed.get());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void ignoresEmptyGrpcPrincipalAndFallsBackToVertxPrincipal() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      PrincipalContext vertxPrincipal =
+          PrincipalContext.newBuilder()
+              .setSubject("vertx-user")
+              .setAccountId("account-1")
+              .addPermissions("account.write")
+              .build();
+      AtomicReference<PrincipalContext> observed = new AtomicReference<>();
+
+      CompletableFuture<Void> completion = new CompletableFuture<>();
+      vertx.runOnContext(
+          ignored ->
+              ContextStore.set(
+                      Context.current(),
+                      InboundContextInterceptor.PC_KEY,
+                      PrincipalContext.getDefaultInstance())
+                  .run(
+                      () -> {
+                        ContextStore.set(
+                            Context.current(), InboundContextInterceptor.PC_KEY, vertxPrincipal);
+                        observed.set(ContextStore.get(InboundContextInterceptor.PC_KEY));
+                        ContextStore.clear();
+                        completion.complete(null);
+                      }));
+
+      completion.get();
+      assertEquals(vertxPrincipal, observed.get());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void fallsBackToVertxEngineContextWhenGrpcContextMissing() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      EngineContext expected = EngineContext.of("floedb", "16.0");
+      AtomicReference<EngineContext> observed = new AtomicReference<>();
+
+      CompletableFuture<Void> completion = new CompletableFuture<>();
+      vertx.runOnContext(
+          ignored -> {
+            ContextStore.set(
+                Context.current(), InboundContextInterceptor.ENGINE_CONTEXT_KEY, expected);
+            observed.set(ContextStore.get(InboundContextInterceptor.ENGINE_CONTEXT_KEY));
+            ContextStore.clear();
+            completion.complete(null);
+          });
+
+      completion.get();
+      assertEquals(expected, observed.get());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void blankGrpcStringFallsBackToVertxLocalValue() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      AtomicReference<String> observed = new AtomicReference<>();
+
+      CompletableFuture<Void> completion = new CompletableFuture<>();
+      vertx.runOnContext(
+          ignored ->
+              ContextStore.set(Context.current(), InboundContextInterceptor.QUERY_KEY, "")
+                  .run(
+                      () -> {
+                        ContextStore.set(
+                            Context.current(), InboundContextInterceptor.QUERY_KEY, "query-1");
+                        observed.set(ContextStore.get(InboundContextInterceptor.QUERY_KEY));
+                        ContextStore.clear();
+                        completion.complete(null);
+                      }));
+
+      completion.get();
+      assertEquals("query-1", observed.get());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void clearRemovesVertxLocalValues() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      AtomicReference<String> observed = new AtomicReference<>();
+
+      CompletableFuture<Void> completion = new CompletableFuture<>();
+      vertx.runOnContext(
+          ignored -> {
+            ContextStore.set(Context.current(), InboundContextInterceptor.CORR_KEY, "corr-1");
+            ContextStore.clear();
+            observed.set(ContextStore.get(InboundContextInterceptor.CORR_KEY));
+            completion.complete(null);
+          });
+
+      completion.get();
+      assertNull(observed.get());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void clearRemovesStoredPrincipal() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      PrincipalContext vertxPrincipal =
+          PrincipalContext.newBuilder().setSubject("vertx-user").build();
+      AtomicReference<PrincipalContext> observed = new AtomicReference<>();
+
+      CompletableFuture<Void> completion = new CompletableFuture<>();
+      vertx.runOnContext(
+          ignored -> {
+            ContextStore.set(Context.current(), InboundContextInterceptor.PC_KEY, vertxPrincipal);
+            ContextStore.clear();
+            observed.set(ContextStore.get(InboundContextInterceptor.PC_KEY));
+            completion.complete(null);
+          });
+
+      completion.get();
+      assertNull(observed.get());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptorContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptorContextTest.java
@@ -41,7 +41,7 @@ class InboundContextInterceptorContextTest {
 
     Context previous = callContext.attach();
     try {
-      assertEquals("acct-1", InboundContextInterceptor.PC_KEY.get().getAccountId());
+      assertEquals("acct-1", ContextStore.get(InboundContextInterceptor.PC_KEY).getAccountId());
       assertEquals("query-1", InboundContextInterceptor.QUERY_KEY.get());
       assertEquals("corr-1", InboundContextInterceptor.CORR_KEY.get());
       assertEquals("floedb", InboundContextInterceptor.ENGINE_KIND_KEY.get());

--- a/service/src/test/java/ai/floedb/floecat/service/it/AccountCreateContextPropagationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/AccountCreateContextPropagationIT.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.it;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import ai.floedb.floecat.account.rpc.AccountServiceGrpc;
+import ai.floedb.floecat.account.rpc.AccountSpec;
+import ai.floedb.floecat.account.rpc.CreateAccountRequest;
+import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
+import ai.floedb.floecat.service.it.profiles.OidcSessionHeaderProfile;
+import ai.floedb.floecat.service.it.util.TestKeyPair;
+import ai.floedb.floecat.service.repo.impl.AccountRepository;
+import ai.floedb.floecat.service.util.TestDataResetter;
+import ai.floedb.floecat.service.util.TestSupport;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.jwt.build.Jwt;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(OidcSessionHeaderProfile.class)
+class AccountCreateContextPropagationIT {
+
+  private static final Metadata.Key<String> SESSION_HEADER =
+      Metadata.Key.of("x-floe-session", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> CORRELATION_HEADER =
+      Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
+  private static final int DEFAULT_ATTEMPTS = 250;
+
+  @GrpcClient("floecat")
+  AccountServiceGrpc.AccountServiceBlockingStub accounts;
+
+  @Inject AccountRepository accountRepository;
+  @Inject TestDataResetter resetter;
+  @Inject SeedRunner seeder;
+
+  private String accountId;
+
+  @BeforeEach
+  void resetStores() {
+    resetter.wipeAll();
+    seeder.seedData();
+    accountId =
+        accountRepository
+            .getByName(TestSupport.DEFAULT_SEED_ACCOUNT)
+            .orElseThrow()
+            .getResourceId()
+            .getId();
+  }
+
+  @Test
+  void repeatedCreateAccountWithValidSessionJwtDoesNotLosePrincipalContext() throws Exception {
+    int attempts = Integer.getInteger("floecat.test.create-account.max-attempts", DEFAULT_ATTEMPTS);
+    String jwt = initAccountJwt();
+    String runId = "ctx-prop-" + UUID.randomUUID();
+    int successes = 0;
+
+    for (int attempt = 1; attempt <= attempts; attempt++) {
+      String correlationId = runId + "-attempt-" + attempt;
+      Metadata metadata = new Metadata();
+      metadata.put(SESSION_HEADER, jwt);
+      metadata.put(CORRELATION_HEADER, correlationId);
+      var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+
+      String displayName = "ctx-prop-account-" + correlationId;
+      try {
+        stub.createAccount(
+            CreateAccountRequest.newBuilder()
+                .setSpec(
+                    AccountSpec.newBuilder()
+                        .setDisplayName(displayName)
+                        .setDescription("attempt-" + attempt)
+                        .build())
+                .build());
+        successes++;
+      } catch (StatusRuntimeException e) {
+        FailureClassification failure = classifyFailure(e);
+        if (failure.contextPropagationFailure()) {
+          fail(
+              "Context propagation failure on createAccount attempt "
+                  + attempt
+                  + "/"
+                  + attempts
+                  + " after "
+                  + successes
+                  + " successes"
+                  + ": correlationId="
+                  + correlationId
+                  + " code="
+                  + e.getStatus().getCode()
+                  + " description="
+                  + e.getStatus().getDescription()
+                  + " evidence="
+                  + failure.evidence(),
+              e);
+        }
+        throw new AssertionError(
+            "Inconclusive createAccount failure on attempt "
+                + attempt
+                + "/"
+                + attempts
+                + " after "
+                + successes
+                + " successes"
+                + ": correlationId="
+                + correlationId
+                + " code="
+                + e.getStatus().getCode()
+                + " description="
+                + e.getStatus().getDescription()
+                + " evidence="
+                + failure.evidence(),
+            e);
+      }
+    }
+
+    System.out.println(
+        "Completed "
+            + successes
+            + "/"
+            + attempts
+            + " createAccount attempts without reproducing principal-context loss.");
+  }
+
+  private String initAccountJwt() throws Exception {
+    var now = Instant.now();
+    return Jwt.claims()
+        .issuer("https://floecat.test")
+        .subject("it-init-account")
+        .claim("account_id", accountId)
+        .claim("roles", java.util.List.of("init-account"))
+        .issuedAt(now)
+        .expiresAt(now.plusSeconds(7L * 365 * 24 * 3600))
+        .audience("floecat-client")
+        .sign(TestKeyPair.privateKey());
+  }
+
+  private static FailureClassification classifyFailure(StatusRuntimeException exception) {
+    Status.Code code = exception.getStatus().getCode();
+    String description = exception.getStatus().getDescription();
+
+    if (code == Status.Code.PERMISSION_DENIED) {
+      return new FailureClassification(true, "grpc-code=PERMISSION_DENIED");
+    }
+    if (code == Status.Code.UNKNOWN
+        && description != null
+        && description.contains("createAccount principal context missing required fields")) {
+      return new FailureClassification(
+          true, "grpc-description=createAccount principal context missing required fields");
+    }
+
+    return new FailureClassification(false, "no-context-propagation-signature");
+  }
+
+  private record FailureClassification(boolean contextPropagationFailure, String evidence) {}
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/flight/GrpcResolvedCallContextsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/flight/GrpcResolvedCallContextsTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.context.impl.ContextStore;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import io.grpc.Context;
 import org.junit.jupiter.api.Test;
@@ -53,7 +54,8 @@ class GrpcResolvedCallContextsTest {
   void currentOrUnauthenticatedUsesDefaultsForMissingOptionalValues() {
     PrincipalContext principal =
         PrincipalContext.newBuilder().setAccountId("acct-1").setSubject("subject-1").build();
-    Context callContext = Context.ROOT.withValue(InboundContextInterceptor.PC_KEY, principal);
+    Context callContext =
+        ContextStore.set(Context.ROOT, InboundContextInterceptor.PC_KEY, principal);
 
     Context previous = callContext.attach();
     try {
@@ -76,8 +78,7 @@ class GrpcResolvedCallContextsTest {
         PrincipalContext.newBuilder().setAccountId("acct-1").setSubject("subject-1").build();
     EngineContext engineContext = EngineContext.of("floedb", "9.9.9");
     Context callContext =
-        Context.ROOT
-            .withValue(InboundContextInterceptor.PC_KEY, principal)
+        ContextStore.set(Context.ROOT, InboundContextInterceptor.PC_KEY, principal)
             .withValue(InboundContextInterceptor.QUERY_KEY, "query-1")
             .withValue(InboundContextInterceptor.CORR_KEY, "corr-1")
             .withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, engineContext)

--- a/service/src/test/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImplTest.java
@@ -38,6 +38,8 @@ import ai.floedb.floecat.query.rpc.TargetStatsBundleChunk;
 import ai.floedb.floecat.query.rpc.TargetStatsBundleEnd;
 import ai.floedb.floecat.query.rpc.TargetStatsResult;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.service.context.impl.ContextStore;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.query.catalog.PlannerStatsBundleService;
 import ai.floedb.floecat.service.query.catalog.StatsProviderFactory;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
@@ -370,7 +372,7 @@ class PlannerStatsServiceImplTest {
   }
 
   private static <T> T withPrincipal(PrincipalContext principal, Supplier<T> action) {
-    Context ctx = Context.current().withValue(PrincipalProvider.KEY, principal);
+    Context ctx = ContextStore.set(Context.current(), InboundContextInterceptor.PC_KEY, principal);
     Context previous = ctx.attach();
     try {
       return action.get();

--- a/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
@@ -26,6 +26,8 @@ import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.query.rpc.GetUserObjectsRequest;
 import ai.floedb.floecat.query.rpc.TableReferenceCandidate;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
+import ai.floedb.floecat.service.context.impl.ContextStore;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.query.catalog.UserObjectBundleService;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
 import ai.floedb.floecat.service.security.impl.Authorizer;
@@ -130,7 +132,8 @@ class UserObjectsServiceImplTest {
             .setSubject("tester")
             .addPermissions("catalog.read")
             .build();
-    Context grpcCtx = Context.current().withValue(PrincipalProvider.KEY, principal);
+    Context grpcCtx =
+        ContextStore.set(Context.current(), InboundContextInterceptor.PC_KEY, principal);
     Context previous = grpcCtx.attach();
     try {
       List<UserObjectsBundleChunk> chunks =
@@ -218,7 +221,8 @@ class UserObjectsServiceImplTest {
             .setSubject("tester")
             .addPermissions("catalog.read")
             .build();
-    Context grpcCtx = Context.current().withValue(PrincipalProvider.KEY, principal);
+    Context grpcCtx =
+        ContextStore.set(Context.current(), InboundContextInterceptor.PC_KEY, principal);
     Context previous = grpcCtx.attach();
     try {
       AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();


### PR DESCRIPTION
## Summary

There is an intermittent problem with request-context propagation through the
gRPC server call path:

```
vertx -> interceptor -> blocking interceptor wrapper -> service
```

In some requests, inbound call context is resolved correctly in the interceptor,
but by the time the request reaches the service, the gRPC Context no longer
contains that state. This was first observed with principal propagation, where
calls could see an empty/default principal even though the inbound JWT or
session header was valid, but the same gap can also affect other request-scoped
context such as engine information.

This change makes request-context lookup resilient to that propagation gap by
introducing ContextStore, which mirrors request-scoped values into both:

- the gRPC Context
- the current Vert.x local context

Context consumers continue to read the same request context keys, but now fall
back to the Vert.x-local copy when the gRPC Context is missing or empty. The
interceptor also clears the Vert.x-local request state at call close so the
fallback remains request-scoped.

## Why

The failure is not in JWT parsing. The issue is that the gRPC context can be lost across the blocking interceptor handoff, while the Vert.x request context remains available.

## What

```
    - Preserve request-scoped principal, engine, query, correlation, and auth
      values when gRPC context is lost after the blocking interceptor handoff.
    - Route request context reads through a shared context store that falls back
      from gRPC context to Vert.x local request state.
    - Keep the interceptor wiring close to the original gRPC context flow while
      extending the fallback to other request-scoped context consumers.
    - Add regression coverage for the context loss path and the account create
      failure it can trigger.
```

## Tests

- Added ContextStoreTest.
- Added AccountCreateContextPropagationIT, which repeatedly calls CreateAccount with a valid session JWT and fails only on the known propagation signatures.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Include any follow-ups, risks, or reviewer guidance.
