### PR TITLE
service/context: preserve grpc Context across blocking worker hop

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
@@ -28,16 +28,16 @@ import io.vertx.grpc.BlockingServerInterceptor;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.Optional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 @GlobalInterceptor
 @Priority(0) // Must run before other interceptors
 public class BlockingInboundContextInterceptor implements ServerInterceptor {
+  private static final Logger LOG = Logger.getLogger(BlockingInboundContextInterceptor.class);
+
   private final ServerInterceptor delegate;
 
   @Inject
@@ -60,7 +60,12 @@ public class BlockingInboundContextInterceptor implements ServerInterceptor {
               defaultValue = "account_id")
           String accountClaimName,
       @ConfigProperty(name = "floecat.interceptor.session.role-claim", defaultValue = "roles")
-          String roleClaimName) {
+          String roleClaimName,
+      // Escape hatch: set to true (env: FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP=true) to
+      // revert to the deprecated io.vertx.grpc.BlockingServerInterceptor.wrap. Intended for
+      // before/after validation of the context-preserving fix; leave unset in production.
+      @ConfigProperty(name = "floecat.interceptor.blocking.legacy-wrap", defaultValue = "false")
+          boolean legacyWrap) {
 
     // Plain helper with your logic; does NOT implement ServerInterceptor (avoids Quarkus "unused"
     // warnings).
@@ -76,44 +81,28 @@ public class BlockingInboundContextInterceptor implements ServerInterceptor {
             accountClaimName,
             roleClaimName);
 
-    // Create a ServerInterceptor at runtime that delegates to your helper.
-    ServerInterceptor runtimeInterceptor =
-        (ServerInterceptor)
-            Proxy.newProxyInstance(
-                ServerInterceptor.class.getClassLoader(),
-                new Class<?>[] {ServerInterceptor.class},
-                new InvocationHandler() {
-                  @Override
-                  @SuppressWarnings({"unchecked", "rawtypes"})
-                  public Object invoke(Object proxy, Method method, Object[] args)
-                      throws Throwable {
-                    // Handle Object methods cleanly
-                    switch (method.getName()) {
-                      case "toString":
-                        return "InboundContextInterceptorProxy";
-                      case "hashCode":
-                        return System.identityHashCode(proxy);
-                      case "equals":
-                        return proxy == args[0];
-                      default:
-                        break;
-                    }
-
-                    if ("interceptCall".equals(method.getName())
-                        && args != null
-                        && args.length == 3) {
-                      return inbound.interceptCall(
-                          (ServerCall) args[0], (Metadata) args[1], (ServerCallHandler) args[2]);
-                    }
-
-                    throw new UnsupportedOperationException(
-                        "Unexpected method on ServerInterceptor proxy: " + method);
-                  }
-                });
-
-    // Vert.x pattern: wrap so it runs on a worker thread (off the event-loop).
-    // [oai_citation:2‡GitHub](https://github.com/vert-x3/vertx-grpc/pull/22/changes)
-    this.delegate = BlockingServerInterceptor.wrap(vertx, runtimeInterceptor);
+    // Wrap so the inner interceptor (and the rest of the chain it builds) runs on a Vert.x
+    // worker thread, off the event-loop. Replaces io.vertx.grpc.BlockingServerInterceptor.wrap,
+    // which is deprecated and does not propagate io.grpc.Context across the buffered-event
+    // replay — that gap, combined with Quarkus's GrpcDuplicatedContextGrpcInterceptor hopping
+    // via runOnContext on Vert.x-context mismatch, drops the principal/correlation context on a
+    // subset of inbound calls. The replacement below is modelled on Quarkus's internal
+    // BlockingServerInterceptor + BlockingExecutionHandler pattern (which is only active for
+    // @Blocking-annotated methods); here it applies to every method because the gRPC services
+    // in this module are uniformly blocking.
+    //
+    // ServerInterceptor is a functional interface, so we pass the helper's interceptCall as a
+    // method reference — no JDK Proxy or runtime classloader gymnastics required.
+    if (legacyWrap) {
+      LOG.warnf(
+          "Using deprecated io.vertx.grpc.BlockingServerInterceptor.wrap"
+              + " (floecat.interceptor.blocking.legacy-wrap=true)."
+              + " This reintroduces the gRPC Context drop documented in the fix's commit;"
+              + " expect intermittent empty PrincipalContext on inbound calls.");
+      this.delegate = BlockingServerInterceptor.wrap(vertx, inbound::interceptCall);
+    } else {
+      this.delegate = new CtxPropagatingBlockingWrap(vertx, inbound::interceptCall);
+    }
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrap.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrap.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.context.impl;
+
+import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.ManagedContext;
+import io.vertx.core.Vertx;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
+import org.jboss.logging.Logger;
+
+/**
+ * Worker-thread {@link ServerInterceptor} wrap that preserves both the gRPC {@link Context} and the
+ * CDI request context across the worker hop.
+ *
+ * <p>The pattern mirrors {@code
+ * io.quarkus.grpc.runtime.supports.blocking.BlockingServerInterceptor} + {@code
+ * BlockingExecutionHandler}: the chain build is dispatched via {@code executeBlocking}, and each
+ * subsequent listener event is re-dispatched via {@code executeBlocking} with the gRPC {@link
+ * Context} captured at scheduling time and re-attached on the worker. Unlike Quarkus's class (which
+ * only activates for {@code @Blocking}-annotated methods), this wrap applies to every method.
+ *
+ * <p>Replaces the deprecated {@code io.vertx.grpc.BlockingServerInterceptor.wrap}, which does
+ * <i>not</i> propagate {@code io.grpc.Context} across its buffered-event replay. Combined with
+ * Quarkus's {@code GrpcDuplicatedContextGrpcInterceptor} hopping via {@code runOnContext} on
+ * Vert.x-context mismatch, the deprecated wrap drops the principal/correlation context on a subset
+ * of inbound calls.
+ *
+ * <p>Package-private so the test suite can instantiate it directly without going through the full
+ * Quarkus interceptor chain.
+ */
+final class CtxPropagatingBlockingWrap implements ServerInterceptor {
+  private static final Logger LOG = Logger.getLogger(CtxPropagatingBlockingWrap.class);
+
+  private final Vertx vertx;
+  private final ServerInterceptor inner;
+
+  CtxPropagatingBlockingWrap(Vertx vertx, ServerInterceptor inner) {
+    this.vertx = vertx;
+    this.inner = inner;
+  }
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+
+    // Capture the active CDI request context AND its state on the caller thread (event loop).
+    // The ManagedContext is a global accessor; the ContextState is what's thread-local — we
+    // re-activate the captured state inside the worker.
+    final ManagedContext requestContext = requestContextOrNull();
+    final InjectableContext.ContextState state =
+        requestContext == null ? null : safeGetState(requestContext);
+
+    ReplayListener<ReqT> replay = new ReplayListener<>(vertx, requestContext, state);
+    vertx
+        .<ServerCall.Listener<ReqT>>executeBlocking(
+            () -> {
+              boolean activated = false;
+              if (requestContext != null && state != null) {
+                try {
+                  requestContext.activate(state);
+                  activated = true;
+                } catch (RuntimeException e) {
+                  LOG.debug("Could not re-activate CDI request context on worker", e);
+                }
+              }
+              try {
+                return inner.interceptCall(call, headers, next);
+              } finally {
+                if (activated) {
+                  try {
+                    requestContext.deactivate();
+                  } catch (RuntimeException ignored) {
+                    // ignore
+                  }
+                }
+              }
+            },
+            false)
+        .onComplete(
+            ar -> {
+              if (ar.succeeded()) {
+                replay.setDelegate(ar.result());
+              } else {
+                Metadata md = Status.trailersFromThrowable(ar.cause());
+                if (md == null) {
+                  md = new Metadata();
+                }
+                call.close(Status.fromThrowable(ar.cause()), md);
+              }
+            });
+    return replay;
+  }
+
+  private static ManagedContext requestContextOrNull() {
+    try {
+      return Arc.container() == null ? null : Arc.container().requestContext();
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  private static InjectableContext.ContextState safeGetState(ManagedContext rc) {
+    try {
+      return rc.isActive() ? rc.getState() : null;
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Buffers inbound events until the delegate listener (built on a worker) is available, then
+   * re-dispatches each event to a worker with the gRPC and CDI request contexts re-attached. Events
+   * are processed in order: one worker task at a time, chained via {@code onComplete}.
+   */
+  private static final class ReplayListener<ReqT> extends ServerCall.Listener<ReqT> {
+    private final Vertx vertx;
+    private final ManagedContext requestContext;
+    private final InjectableContext.ContextState requestContextState;
+    private volatile ServerCall.Listener<ReqT> delegate;
+    private final Queue<Consumer<ServerCall.Listener<ReqT>>> incomingEvents =
+        new ConcurrentLinkedQueue<>();
+    private volatile boolean isConsumingFromIncomingEvents;
+
+    ReplayListener(
+        Vertx vertx,
+        ManagedContext requestContext,
+        InjectableContext.ContextState requestContextState) {
+      this.vertx = vertx;
+      this.requestContext = requestContext;
+      this.requestContextState = requestContextState;
+    }
+
+    void setDelegate(ServerCall.Listener<ReqT> delegate) {
+      this.delegate = delegate;
+      if (!isConsumingFromIncomingEvents) {
+        Consumer<ServerCall.Listener<ReqT>> consumer = incomingEvents.poll();
+        if (consumer != null) {
+          executeBlockingWithContext(consumer);
+        }
+      }
+    }
+
+    private void scheduleOrEnqueue(Consumer<ServerCall.Listener<ReqT>> consumer) {
+      // Capture the gRPC Context at event-arrival time (not at execute time) so it survives the
+      // buffer/replay path even when the worker that drains the queue has a different (or no)
+      // io.grpc.Context attached. The wrapper re-attaches `arrivalCtx` around the actual
+      // consumer call on the worker.
+      final Context arrivalCtx = Context.current();
+      Consumer<ServerCall.Listener<ReqT>> withCtx =
+          listener -> {
+            Context prev = arrivalCtx.attach();
+            try {
+              consumer.accept(listener);
+            } finally {
+              arrivalCtx.detach(prev);
+            }
+          };
+      if (delegate != null && !isConsumingFromIncomingEvents) {
+        executeBlockingWithContext(withCtx);
+      } else {
+        incomingEvents.add(withCtx);
+      }
+    }
+
+    /**
+     * Dispatch one event to a worker. The gRPC {@link Context} was already captured in {@link
+     * #scheduleOrEnqueue} so the consumer is responsible for attaching/detaching it; here we only
+     * re-activate the CDI request context state and chain the next queued event via {@code
+     * onComplete}.
+     */
+    private void executeBlockingWithContext(Consumer<ServerCall.Listener<ReqT>> consumer) {
+      final ServerCall.Listener<ReqT> target = delegate;
+      isConsumingFromIncomingEvents = true;
+      vertx
+          .<Void>executeBlocking(
+              () -> {
+                boolean activated = false;
+                if (requestContext != null && requestContextState != null) {
+                  try {
+                    requestContext.activate(requestContextState);
+                    activated = true;
+                  } catch (RuntimeException ignored) {
+                    // ignore
+                  }
+                }
+                try {
+                  consumer.accept(target);
+                } finally {
+                  if (activated) {
+                    try {
+                      requestContext.deactivate();
+                    } catch (RuntimeException ignored) {
+                      // ignore
+                    }
+                  }
+                }
+                return null;
+              },
+              false)
+          .onComplete(
+              p -> {
+                Consumer<ServerCall.Listener<ReqT>> nextEvent = incomingEvents.poll();
+                if (nextEvent != null) {
+                  executeBlockingWithContext(nextEvent);
+                } else {
+                  isConsumingFromIncomingEvents = false;
+                }
+              });
+    }
+
+    @Override
+    public void onMessage(ReqT message) {
+      scheduleOrEnqueue(t -> t.onMessage(message));
+    }
+
+    @Override
+    public void onHalfClose() {
+      scheduleOrEnqueue(ServerCall.Listener::onHalfClose);
+    }
+
+    @Override
+    public void onCancel() {
+      scheduleOrEnqueue(ServerCall.Listener::onCancel);
+    }
+
+    @Override
+    public void onComplete() {
+      scheduleOrEnqueue(ServerCall.Listener::onComplete);
+    }
+
+    @Override
+    public void onReady() {
+      scheduleOrEnqueue(ServerCall.Listener::onReady);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
@@ -1,0 +1,546 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.context.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.Attributes;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.vertx.core.Vertx;
+import io.vertx.grpc.BlockingServerInterceptor;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct coverage of {@link CtxPropagatingBlockingWrap}. Tests build the wrap with a plain Vert.x
+ * instance and a stub inner interceptor; no CDI / Quarkus stack required.
+ *
+ * <p>Each test runs against the wrap from a Vert.x event-loop context (as the real gRPC server
+ * would call {@code interceptCall}), then drives listener events directly.
+ */
+class CtxPropagatingBlockingWrapTest {
+
+  private static final Context.Key<String> KEY = Context.key("test-principal");
+
+  /**
+   * Selects which wrap the tests run against. Honours {@code
+   * floecat.interceptor.blocking.legacy-wrap} (env: {@code
+   * FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP}) so the same env var that flips the production wiring
+   * also flips these tests — with the legacy wrap selected, at least one test below is expected to
+   * fail (see {@link #eventHandlerRunsOffEventLoop}).
+   */
+  private static ServerInterceptor makeWrap(Vertx vertx, ServerInterceptor inner) {
+    if (legacyWrapSelected()) {
+      return BlockingServerInterceptor.wrap(vertx, inner);
+    }
+    return new CtxPropagatingBlockingWrap(vertx, inner);
+  }
+
+  private static boolean legacyWrapSelected() {
+    String env = System.getenv("FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP");
+    String sys = System.getProperty("floecat.interceptor.blocking.legacy-wrap");
+    return "true".equalsIgnoreCase(env) || "true".equalsIgnoreCase(sys);
+  }
+
+  /**
+   * Single-call propagation through the {@code Contexts.interceptCall} CSL chain — the production
+   * shape. The inner attaches a value via {@code Contexts.interceptCall}; the handler reads {@code
+   * KEY.get()} on its {@code onHalfClose}; the wrap must dispatch the event to a worker and the
+   * inner CSL must re-attach the value.
+   */
+  @Test
+  void grpcContextSurvivesSingleCall() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      ServerInterceptor inner =
+          new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call,
+                Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+              Context ctx = Context.current().withValue(KEY, "set-by-inner");
+              return Contexts.interceptCall(ctx, call, headers, next);
+            }
+          };
+      ServerInterceptor wrap = makeWrap(vertx, inner);
+
+      AtomicReference<String> observed = new AtomicReference<>("<unset>");
+      CountDownLatch done = new CountDownLatch(1);
+      ServerCallHandler<Object, Object> handler = capturingHandler(observed, done);
+
+      drive(vertx, wrap, handler);
+      assertTrue(done.await(10, TimeUnit.SECONDS), "handler.onHalfClose never ran");
+      assertEquals("set-by-inner", observed.get());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  /**
+   * Buffer/replay path: events fire on the wrap's listener <i>before</i> the inner has finished
+   * building its listener on the worker. The wrap must buffer the events and deliver them after the
+   * delegate is set.
+   */
+  @Test
+  void bufferedEventsReplayedAfterSetDelegate() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      CountDownLatch holdInner = new CountDownLatch(1);
+      ServerInterceptor inner =
+          new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call,
+                Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+              // Block the chain build until the test fires the event, forcing the buffer path.
+              try {
+                holdInner.await(5, TimeUnit.SECONDS);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              Context ctx = Context.current().withValue(KEY, "set-by-inner");
+              return Contexts.interceptCall(ctx, call, headers, next);
+            }
+          };
+      ServerInterceptor wrap = makeWrap(vertx, inner);
+
+      AtomicReference<String> observed = new AtomicReference<>("<unset>");
+      CountDownLatch done = new CountDownLatch(1);
+      ServerCallHandler<Object, Object> handler = capturingHandler(observed, done);
+
+      CompletableFuture<ServerCall.Listener<Object>> outerListener = new CompletableFuture<>();
+      vertx.runOnContext(
+          ignored ->
+              outerListener.complete(wrap.interceptCall(stubCall(), new Metadata(), handler)));
+      ServerCall.Listener<Object> listener = outerListener.get(5, TimeUnit.SECONDS);
+
+      // Fire BEFORE the inner is allowed to finish — must be buffered.
+      listener.onHalfClose();
+      // Give the wrap a moment to confirm delegate is still null.
+      Thread.sleep(50);
+      assertEquals("<unset>", observed.get(), "handler ran before delegate was set");
+
+      holdInner.countDown();
+      assertTrue(done.await(10, TimeUnit.SECONDS), "buffered event never replayed");
+      assertEquals("set-by-inner", observed.get());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  /**
+   * Concurrent calls: each carries a unique principal in metadata and must observe its own value at
+   * the handler entry. Any mismatch indicates cross-call state bleed.
+   */
+  @Test
+  void concurrentCallsDoNotBleed() throws Exception {
+    int n = 200;
+    Vertx vertx = Vertx.vertx();
+    try {
+      Metadata.Key<String> principalHeader =
+          Metadata.Key.of("x-test-principal", Metadata.ASCII_STRING_MARSHALLER);
+
+      ServerInterceptor inner =
+          new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call,
+                Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+              String value = headers.get(principalHeader);
+              Context ctx = Context.current().withValue(KEY, value);
+              return Contexts.interceptCall(ctx, call, headers, next);
+            }
+          };
+      ServerInterceptor wrap = makeWrap(vertx, inner);
+
+      ConcurrentMap<Integer, String> mismatches = new ConcurrentHashMap<>();
+      CountDownLatch done = new CountDownLatch(n);
+
+      for (int i = 0; i < n; i++) {
+        final int id = i;
+        final String expected = "principal-" + id;
+        ServerCallHandler<Object, Object> handler =
+            (call, headers) ->
+                new ServerCall.Listener<>() {
+                  @Override
+                  public void onHalfClose() {
+                    String v = KEY.get();
+                    if (!expected.equals(v)) {
+                      mismatches.putIfAbsent(id, "expected=" + expected + " observed=" + v);
+                    }
+                    done.countDown();
+                  }
+                };
+        Metadata md = new Metadata();
+        md.put(principalHeader, expected);
+
+        vertx.runOnContext(
+            ignored -> {
+              try {
+                ServerCall.Listener<Object> listener = wrap.interceptCall(stubCall(), md, handler);
+                listener.onHalfClose();
+              } catch (Throwable t) {
+                mismatches.putIfAbsent(id, "dispatch-failed=" + t);
+                done.countDown();
+              }
+            });
+      }
+
+      assertTrue(
+          done.await(30, TimeUnit.SECONDS),
+          () -> "did not complete in 30s; remaining=" + done.getCount());
+      if (!mismatches.isEmpty()) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("cross-call bleed: ").append(mismatches.size()).append(" / ").append(n);
+        int printed = 0;
+        for (Map.Entry<Integer, String> e : mismatches.entrySet()) {
+          if (printed++ >= 5) break;
+          sb.append("\n  id=").append(e.getKey()).append(' ').append(e.getValue());
+        }
+        fail(sb.toString());
+      }
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  /**
+   * All five {@link ServerCall.Listener} callbacks are forwarded to the inner listener in arrival
+   * order, including events fired before the inner chain has finished building (the buffer-replay
+   * path). Matches the surface of the deprecated {@code io.vertx.grpc.BlockingServerInterceptor
+   * .AsyncListener} that this wrap replaces.
+   */
+  @Test
+  void allFiveCallbacksForwardedInOrderThroughBuffer() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      List<String> order = new ArrayList<>();
+      Object lock = new Object();
+      CountDownLatch holdInner = new CountDownLatch(1);
+
+      ServerInterceptor inner =
+          new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call,
+                Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+              try {
+                // Block the chain build so every event below buffers before delegate is set.
+                holdInner.await(5, TimeUnit.SECONDS);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return next.startCall(call, headers);
+            }
+          };
+      ServerInterceptor wrap = makeWrap(vertx, inner);
+
+      CountDownLatch done = new CountDownLatch(5);
+      ServerCallHandler<Object, Object> handler =
+          (call, headers) ->
+              new ServerCall.Listener<>() {
+                @Override
+                public void onReady() {
+                  record("ready");
+                }
+
+                @Override
+                public void onMessage(Object message) {
+                  record("message:" + message);
+                }
+
+                @Override
+                public void onHalfClose() {
+                  record("halfClose");
+                }
+
+                @Override
+                public void onCancel() {
+                  record("cancel");
+                }
+
+                @Override
+                public void onComplete() {
+                  record("complete");
+                }
+
+                private void record(String event) {
+                  synchronized (lock) {
+                    order.add(event);
+                  }
+                  done.countDown();
+                }
+              };
+
+      CompletableFuture<ServerCall.Listener<Object>> outer = new CompletableFuture<>();
+      vertx.runOnContext(
+          ignored -> outer.complete(wrap.interceptCall(stubCall(), new Metadata(), handler)));
+      ServerCall.Listener<Object> listener = outer.get(5, TimeUnit.SECONDS);
+
+      // Fire ALL five events before unblocking the chain build — every one must buffer.
+      listener.onReady();
+      listener.onMessage("m1");
+      listener.onHalfClose();
+      listener.onCancel();
+      listener.onComplete();
+
+      // Brief pause to confirm nothing fired yet.
+      Thread.sleep(50);
+      synchronized (lock) {
+        assertTrue(order.isEmpty(), "events ran before delegate was set: " + order);
+      }
+
+      holdInner.countDown();
+      assertTrue(done.await(10, TimeUnit.SECONDS), "buffered events never fully replayed");
+      synchronized (lock) {
+        assertEquals(List.of("ready", "message:m1", "halfClose", "cancel", "complete"), order);
+      }
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  /**
+   * Error path: inner throws — the wrap must close the {@link ServerCall} with the translated
+   * status rather than swallowing the error or hanging.
+   */
+  @Test
+  void innerFailureClosesCallWithStatus() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      ServerInterceptor failing =
+          new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call,
+                Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+              throw Status.PERMISSION_DENIED.withDescription("nope").asRuntimeException();
+            }
+          };
+      ServerInterceptor wrap = makeWrap(vertx, failing);
+
+      ServerCall<Object, Object> call = stubCall();
+      CountDownLatch closed = new CountDownLatch(1);
+      AtomicReference<Status> capturedStatus = new AtomicReference<>();
+      org.mockito.Mockito.doAnswer(
+              inv -> {
+                capturedStatus.set(inv.getArgument(0));
+                closed.countDown();
+                return null;
+              })
+          .when(call)
+          .close(any(Status.class), any(Metadata.class));
+
+      vertx.runOnContext(ignored -> wrap.interceptCall(call, new Metadata(), noopHandler()));
+
+      assertTrue(closed.await(5, TimeUnit.SECONDS), "call.close never invoked");
+      assertNotNull(capturedStatus.get());
+      assertEquals(Status.Code.PERMISSION_DENIED, capturedStatus.get().getCode());
+      verify(call, atLeastOnce()).close(any(Status.class), any(Metadata.class));
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  /**
+   * Proves the actual production symptom: a gRPC {@link Context} value attached on the caller's
+   * thread when a listener event arrives must still be readable from the handler when the event is
+   * finally delivered. The inner is a plain pass-through (no {@code Contexts.interceptCall} → no
+   * inner CSL to re-attach) so the only thing keeping the {@link Context} alive across the
+   * worker/buffer hop is the wrap itself.
+   *
+   * <p>This is the test that <i>fails</i> against the deprecated {@code BlockingServerInterceptor
+   * .wrap}: that wrap doesn't capture the caller's gRPC {@link Context} when an event is buffered,
+   * so by the time {@code setDelegate} replays the event on the {@code executeBlocking} onComplete
+   * thread (which has no {@link Context} attached), {@code KEY.get()} returns {@code null} — i.e.,
+   * {@link io.grpc.Context.Key#get()} loses the value. The new wrap captures the {@link Context} at
+   * event arrival in {@code scheduleOrEnqueue} and re-attaches it on the worker around the delegate
+   * call.
+   */
+  @Test
+  void grpcContextAttachedAtArrivalSurvivesBufferAndReplay() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      // Block the chain build so onHalfClose hits the BUFFER path.
+      CountDownLatch holdInner = new CountDownLatch(1);
+      ServerInterceptor inner =
+          new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call,
+                Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+              try {
+                holdInner.await(5, TimeUnit.SECONDS);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              // Pass-through: no Contexts.interceptCall, no inner CSL. The wrap is solely
+              // responsible for io.grpc.Context propagation across the buffer.
+              return next.startCall(call, headers);
+            }
+          };
+      ServerInterceptor wrap = makeWrap(vertx, inner);
+
+      AtomicReference<String> observed = new AtomicReference<>("<unset>");
+      CountDownLatch done = new CountDownLatch(1);
+      ServerCallHandler<Object, Object> handler =
+          (call, headers) ->
+              new ServerCall.Listener<>() {
+                @Override
+                public void onHalfClose() {
+                  String v = KEY.get();
+                  observed.set(v == null ? "<null>" : v);
+                  done.countDown();
+                }
+              };
+
+      CompletableFuture<ServerCall.Listener<Object>> outer = new CompletableFuture<>();
+      vertx.runOnContext(
+          ignored -> outer.complete(wrap.interceptCall(stubCall(), new Metadata(), handler)));
+      ServerCall.Listener<Object> listener = outer.get(5, TimeUnit.SECONDS);
+
+      // Fire onHalfClose from a thread that has the gRPC Context attached — this is the only
+      // window where the wrap can capture the value. Detach immediately so the value is gone
+      // from every ThreadLocal by the time the worker runs the replay.
+      Thread driver =
+          new Thread(
+              () -> {
+                Context ctx = Context.current().withValue(KEY, "set-at-arrival");
+                Context prev = ctx.attach();
+                try {
+                  listener.onHalfClose();
+                } finally {
+                  ctx.detach(prev);
+                }
+              },
+              "test-event-driver");
+      driver.start();
+      driver.join(5_000);
+
+      // Let the wrap settle (event sitting in the buffer), then release the chain build so
+      // setDelegate fires and the buffered event gets replayed.
+      Thread.sleep(50);
+      assertEquals("<unset>", observed.get(), "handler ran before delegate was set");
+      holdInner.countDown();
+
+      assertTrue(done.await(10, TimeUnit.SECONDS), "buffered event never replayed");
+      assertEquals(
+          "set-at-arrival",
+          observed.get(),
+          "io.grpc.Context attached at event arrival was lost across the buffer/replay; if"
+              + " legacyWrap was selected via FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP this is the"
+              + " expected failure (Context.Key.get() returns null inside the handler).");
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  // ---------- helpers ----------
+
+  private static void drive(
+      Vertx vertx, ServerInterceptor wrap, ServerCallHandler<Object, Object> handler)
+      throws Exception {
+    CompletableFuture<Void> driven = new CompletableFuture<>();
+    vertx.runOnContext(
+        ignored -> {
+          try {
+            ServerCall.Listener<Object> listener =
+                wrap.interceptCall(stubCall(), new Metadata(), handler);
+            listener.onHalfClose();
+            driven.complete(null);
+          } catch (Throwable t) {
+            driven.completeExceptionally(t);
+          }
+        });
+    driven.get(5, TimeUnit.SECONDS);
+  }
+
+  private static ServerCallHandler<Object, Object> capturingHandler(
+      AtomicReference<String> sink, CountDownLatch done) {
+    return (call, headers) ->
+        new ServerCall.Listener<>() {
+          @Override
+          public void onHalfClose() {
+            String v = KEY.get();
+            sink.set(v == null ? "<null>" : v);
+            done.countDown();
+          }
+        };
+  }
+
+  private static ServerCallHandler<Object, Object> noopHandler() {
+    return (call, headers) -> new ServerCall.Listener<>() {};
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static ServerCall<Object, Object> stubCall() {
+    ServerCall mocked = mock(ServerCall.class);
+    MethodDescriptor<Object, Object> method =
+        MethodDescriptor.newBuilder()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName("test/Method")
+            .setRequestMarshaller(new NoopMarshaller())
+            .setResponseMarshaller(new NoopMarshaller())
+            .build();
+    when(mocked.getMethodDescriptor()).thenReturn(method);
+    when(mocked.getAttributes()).thenReturn(Attributes.EMPTY);
+    return mocked;
+  }
+
+  private static final class NoopMarshaller implements MethodDescriptor.Marshaller<Object> {
+    @Override
+    public InputStream stream(Object value) {
+      return new ByteArrayInputStream(new byte[0]);
+    }
+
+    @Override
+    public Object parse(InputStream stream) {
+      return new Object();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The deprecated io.vertx.grpc.BlockingServerInterceptor.wrap that backed our BlockingInboundContextInterceptor does not carry the io.grpc.Context across its buffered-event replay. Combined with Quarkus's GrpcDuplicatedContextGrpcInterceptor — which hops via duplicated.runOnContext when an inbound event arrives on a Vert.x context that doesn't match the chain's duplicated one — the gRPC Context ThreadLocal is gone by the time the service-method body reads it. That is the production symptom: an empty PrincipalContext at createAccount (and elsewhere) on a subset of inbound calls even though the interceptor resolved a valid principal.

This PR replaces the deprecated wrap with a custom worker-thread wrap modelled on Quarkus's internal BlockingServerInterceptor + BlockingExecutionHandler pattern, tightened in one way: the gRPC Context is captured at
event arrival (inside scheduleOrEnqueue), not at execute time, so it survives the buffer/replay even when no inner ContextualizedServerCallListener is in the chain to re-attach it. The active CDI request-context state is captured on the caller and re-activated on the worker. Per-event dispatch is chained via executeBlocking onComplete so listener callbacks stay ordered.

This supersedes #298, which addressed the same symptom by mirroring each request-scoped value into Vert.x duplicated-context locals via a ContextStore facade. That approach is conceptually similar to vertx-grpc-context-storage (which was verified does not survive the runOnContext hop because duplicated contexts have per-duplicate locals), and it required updating every consumer call site. The fix here addresses the loss at its source — the buffered-event replay running on a thread without the original gRPC Context attached — so existing KEY.get() and principal.get() call sites work unchanged.

## Commit Summary

- Replace deprecated Vert.x BlockingServerInterceptor.wrap, which does not carry the gRPC Context across its buffered-event replay; under the Quarkus duplicated-context interceptor's runOnContext hop this dropped the request principal and correlation context on a subset of inbound calls.
- Introduce a worker-thread wrap that captures the gRPC Context at event arrival, captures the active CDI request context state on the caller, and re-applies both on the worker around each listener callback. Per-event dispatch is chained via executeBlocking onComplete so events stay in order.
- Pass the inner helper to the wrap via a method reference, removing the runtime JDK proxy that previously bridged its non-ServerInterceptor shape.
- Add a floecat.interceptor.blocking.legacy-wrap config flag (env FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP) that reverts to the deprecated wrap for before/after validation, with a startup warning.
- Cover the new wrap with focused tests: single-call propagation, buffered-event replay, concurrent calls without cross-call bleed, all five listener callbacks forwarded in order through the buffer, error propagation closing the call with the right status, and a reproducer that reads Context.Key inside the handler and fails with the deprecated wrap selected.


## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [x] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

- Validation toggle. floecat.interceptor.blocking.legacy-wrap (env: FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP=true) reverts to the deprecated wrap. Off by default; logs a startup warning when on. The same toggle flips the test suite, so mvn test -Dtest=CtxPropagatingBlockingWrapTest is a self-contained before/after harness.
- JDK proxy removed. ServerInterceptor is a functional interface; the inner helper is now passed via inbound::interceptCall rather than a runtime Proxy.newProxyInstance bridge. No behaviour change.
- #298 disposition. If #298 has not merged, close it in favour of this PR. If it has, the follow-up cleanup removes ContextStore, PrincipalContexts, EngineContext.isEmpty(), the ContextStore.clear() call in the interceptor close handler, and every ContextStore.get(KEY) consumer migration.
- Why not the gRPC ContextStorage override path. io.vertx:vertx-grpc-context-storage rebinds gRPC Context storage to Vertx.currentContext().localContextData(). Duplicated Vert.x contexts have per-duplicate locals, so storage written on context A is not visible on context A-dup after runOnContext. Source inspection confirms it; reproducer test (now removed; was retained briefly in the branch history) demonstrated it.
- References. Vert.x deprecated BlockingServerInterceptor (no context propagation); Quarkus internal BlockingServerInterceptor + BlockingExecutionHandler (the model); Quarkus #14665 / PR #14697; Quarkus #26830. 