### PR TITLE
Fix Snapshot not found regressions in reconcile/update path

### DIFF
--- a/core/types/src/main/java/ai/floedb/floecat/types/ManagedTableProperties.java
+++ b/core/types/src/main/java/ai/floedb/floecat/types/ManagedTableProperties.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.types;
+
+import java.util.Set;
+
+/** Shared table-property keys managed by the Iceberg-compatible metadata layer. */
+public final class ManagedTableProperties {
+
+  public static final String TABLE_UUID = "table-uuid";
+  public static final String FORMAT_VERSION = "format-version";
+  public static final String CURRENT_SCHEMA_ID = "current-schema-id";
+  public static final String LAST_COLUMN_ID = "last-column-id";
+  public static final String DEFAULT_SPEC_ID = "default-spec-id";
+  public static final String LAST_PARTITION_ID = "last-partition-id";
+  public static final String DEFAULT_SORT_ORDER_ID = "default-sort-order-id";
+  public static final String CURRENT_SNAPSHOT_ID = "current-snapshot-id";
+  public static final String LAST_SEQUENCE_NUMBER = "last-sequence-number";
+  public static final String METADATA_REFS = "metadata.refs";
+
+  private static final Set<String> ENGINE_MANAGED_KEYS =
+      Set.of(
+          TABLE_UUID,
+          FORMAT_VERSION,
+          CURRENT_SCHEMA_ID,
+          LAST_COLUMN_ID,
+          DEFAULT_SPEC_ID,
+          LAST_PARTITION_ID,
+          DEFAULT_SORT_ORDER_ID,
+          CURRENT_SNAPSHOT_ID,
+          LAST_SEQUENCE_NUMBER,
+          METADATA_REFS);
+
+  private static final Set<String> TABLE_DEFINITION_KEYS =
+      Set.of(
+          FORMAT_VERSION,
+          LAST_COLUMN_ID,
+          CURRENT_SCHEMA_ID,
+          DEFAULT_SPEC_ID,
+          LAST_PARTITION_ID,
+          DEFAULT_SORT_ORDER_ID);
+
+  private ManagedTableProperties() {}
+
+  /** Keys owned by metadata commit logic and not by reconcile descriptor payloads. */
+  public static Set<String> engineManagedKeys() {
+    return ENGINE_MANAGED_KEYS;
+  }
+
+  /** Keys that can be mutated by table-definition commit updates. */
+  public static Set<String> tableDefinitionKeys() {
+    return TABLE_DEFINITION_KEYS;
+  }
+}

--- a/protocol-gateway/iceberg-rest/pom.xml
+++ b/protocol-gateway/iceberg-rest/pom.xml
@@ -90,6 +90,11 @@
     </dependency>
     <dependency>
       <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-types</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
       <artifactId>floecat-connectors-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TablePropertyService.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/table/TablePropertyService.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.gateway.iceberg.rest.common.CommitUpdateInspector;
 import ai.floedb.floecat.gateway.iceberg.rest.common.RefPropertyUtil;
 import ai.floedb.floecat.gateway.iceberg.rest.resources.common.IcebergErrorResponses;
 import ai.floedb.floecat.gateway.iceberg.rest.services.table.metadata.TableCommitMetadataMutator;
+import ai.floedb.floecat.types.ManagedTableProperties;
 import com.google.protobuf.FieldMask;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -46,15 +47,10 @@ import org.jboss.logging.Logger;
 @ApplicationScoped
 public class TablePropertyService {
   private static final Logger LOG = Logger.getLogger(TablePropertyService.class);
-  private static final Set<String> RESERVED_REMOVE_PROPERTIES = Set.of("format-version");
+  private static final Set<String> RESERVED_REMOVE_PROPERTIES =
+      Set.of(ManagedTableProperties.FORMAT_VERSION);
   private static final Set<String> TABLE_DEFINITION_PROPERTY_KEYS =
-      Set.of(
-          "format-version",
-          "last-column-id",
-          "current-schema-id",
-          "default-spec-id",
-          "last-partition-id",
-          "default-sort-order-id");
+      ManagedTableProperties.tableDefinitionKeys();
 
   @Inject TableCommitMetadataMutator metadataMutator;
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -97,6 +97,7 @@ import ai.floedb.floecat.reconciler.spi.capture.CaptureEngineRequest;
 import ai.floedb.floecat.reconciler.spi.capture.CaptureEngineResult;
 import ai.floedb.floecat.reconciler.spi.capture.PlannedFileGroupCaptureRequest;
 import ai.floedb.floecat.types.Hashing;
+import ai.floedb.floecat.types.ManagedTableProperties;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import io.grpc.Metadata;
@@ -123,6 +124,8 @@ import org.jboss.logging.Logger;
 @ApplicationScoped
 public class GrpcReconcilerBackend implements ReconcilerBackend {
   private static final Logger LOG = Logger.getLogger(GrpcReconcilerBackend.class);
+  private static final Set<String> PRESERVED_TABLE_PROPERTIES =
+      ManagedTableProperties.engineManagedKeys();
 
   private static final Metadata.Key<String> AUTHORIZATION =
       Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
@@ -340,12 +343,15 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
           "Destination table display name mismatch for id: " + tableId.getId());
     }
 
+    Map<String, String> mergedProperties =
+        mergedTableProperties(before.getPropertiesMap(), safeProperties(descriptor));
+
     TableSpec spec =
         TableSpec.newBuilder()
             .setDisplayName(descriptor.displayName())
             .setSchemaJson(descriptor.schemaJson())
             .setUpstream(buildUpstream(descriptor))
-            .putAllProperties(safeProperties(descriptor))
+            .putAllProperties(mergedProperties)
             .build();
     var response =
         table(ctx)
@@ -1330,6 +1336,24 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
 
   private Map<String, String> safeProperties(TableSpecDescriptor descriptor) {
     return descriptor.properties() != null ? descriptor.properties() : Map.of();
+  }
+
+  private Map<String, String> mergedTableProperties(
+      Map<String, String> existingProperties, Map<String, String> incomingProperties) {
+    Map<String, String> merged = new LinkedHashMap<>();
+    if (incomingProperties != null && !incomingProperties.isEmpty()) {
+      merged.putAll(incomingProperties);
+    }
+    if (existingProperties == null || existingProperties.isEmpty()) {
+      return merged;
+    }
+    for (String key : PRESERVED_TABLE_PROPERTIES) {
+      String value = existingProperties.get(key);
+      if (value != null && !value.isBlank()) {
+        merged.put(key, value);
+      }
+    }
+    return merged;
   }
 
   private UpstreamRef buildUpstream(TableSpecDescriptor descriptor) {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendTest.java
@@ -44,6 +44,8 @@ import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.TableStatisticsServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
+import ai.floedb.floecat.catalog.rpc.UpdateTableRequest;
+import ai.floedb.floecat.catalog.rpc.UpdateTableResponse;
 import ai.floedb.floecat.catalog.rpc.UpdateViewRequest;
 import ai.floedb.floecat.catalog.rpc.UpdateViewResponse;
 import ai.floedb.floecat.catalog.rpc.UpstreamRef;
@@ -61,15 +63,18 @@ import ai.floedb.floecat.connector.spi.ConnectorFormat;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
+import ai.floedb.floecat.reconciler.spi.ReconcilerBackend.TableSpecDescriptor;
 import ai.floedb.floecat.reconciler.spi.capture.CaptureEngine;
 import ai.floedb.floecat.reconciler.spi.capture.CaptureEngineCapabilities;
 import ai.floedb.floecat.reconciler.spi.capture.CaptureEngineRegistry;
 import ai.floedb.floecat.reconciler.spi.capture.CaptureEngineRequest;
 import ai.floedb.floecat.reconciler.spi.capture.CaptureEngineResult;
 import ai.floedb.floecat.reconciler.spi.capture.PlannedFileGroupCaptureRequest;
+import ai.floedb.floecat.types.ManagedTableProperties;
 import io.grpc.Status;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -678,6 +683,91 @@ class GrpcReconcilerBackendTest {
             "base_relations",
             "creation_search_path",
             "output_columns");
+  }
+
+  @Test
+  void updateTableByIdPreservesManagedIcebergProperties() {
+    GrpcReconcilerBackend backend =
+        new GrpcReconcilerBackend(
+            Optional.<String>empty(), Optional.<String>empty(), Optional.<Duration>empty());
+    backend.table =
+        mock(ai.floedb.floecat.catalog.rpc.TableServiceGrpc.TableServiceBlockingStub.class);
+    when(backend.table.withInterceptors(any())).thenReturn(backend.table);
+
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("table-1")
+            .build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("ns-1")
+            .build();
+
+    Map<String, String> existingManaged = new LinkedHashMap<>();
+    int index = 0;
+    for (String key : ManagedTableProperties.engineManagedKeys()) {
+      existingManaged.put(key, "existing-" + index++);
+    }
+    Map<String, String> incoming = new LinkedHashMap<>();
+    index = 0;
+    for (String key : ManagedTableProperties.engineManagedKeys()) {
+      incoming.put(key, "incoming-" + index++);
+    }
+    incoming.put("write.parquet.compression-codec", "zstd");
+
+    Table.Builder beforeBuilder =
+        Table.newBuilder()
+            .setResourceId(tableId)
+            .setNamespaceId(namespaceId)
+            .setDisplayName("lineitem");
+    beforeBuilder.putAllProperties(existingManaged);
+    Table before = beforeBuilder.build();
+    Table after =
+        before.toBuilder().putProperties("write.parquet.compression-codec", "zstd").build();
+
+    when(backend.table.getTable(any()))
+        .thenReturn(GetTableResponse.newBuilder().setTable(before).build());
+    when(backend.table.updateTable(any()))
+        .thenReturn(UpdateTableResponse.newBuilder().setTable(after).build());
+
+    TableSpecDescriptor descriptor =
+        new TableSpecDescriptor(
+            "tpch_1",
+            "lineitem",
+            "{}",
+            incoming,
+            List.of(),
+            ColumnIdAlgorithm.CID_FIELD_ID,
+            ConnectorFormat.CF_ICEBERG,
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setKind(ResourceKind.RK_CONNECTOR)
+                .setId("connector-1")
+                .build(),
+            "http://localhost:1234",
+            "tpch_1",
+            "lineitem");
+
+    boolean changed =
+        backend.updateTableById(
+            reconcileContext(),
+            tableId,
+            namespaceId,
+            NameRef.newBuilder().setName("lineitem").build(),
+            descriptor);
+
+    assertThat(changed).isTrue();
+    var updateCaptor = org.mockito.ArgumentCaptor.forClass(UpdateTableRequest.class);
+    verify(backend.table).updateTable(updateCaptor.capture());
+    Map<String, String> props = updateCaptor.getValue().getSpec().getPropertiesMap();
+    for (Map.Entry<String, String> managed : existingManaged.entrySet()) {
+      assertThat(props.get(managed.getKey())).isEqualTo(managed.getValue());
+    }
+    assertThat(props.get("write.parquet.compression-codec")).isEqualTo("zstd");
   }
 
   private static ReconcileContext reconcileContext() {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
@@ -94,18 +94,19 @@ public class SnapshotRepository {
     }
     String currentSnapshotId = table.get().getPropertiesMap().get("current-snapshot-id");
     if (currentSnapshotId == null || currentSnapshotId.isBlank()) {
-      return Optional.empty();
+      return latestSnapshotByTime(tableId);
     }
     long snapshotId;
     try {
       snapshotId = Long.parseLong(currentSnapshotId);
     } catch (NumberFormatException e) {
-      return Optional.empty();
+      return latestSnapshotByTime(tableId);
     }
     if (snapshotId < 0) {
-      return Optional.empty();
+      return latestSnapshotByTime(tableId);
     }
-    return getById(tableId, snapshotId);
+    Optional<Snapshot> current = getById(tableId, snapshotId);
+    return current.isPresent() ? current : latestSnapshotByTime(tableId);
   }
 
   public Optional<Snapshot> getAsOf(ResourceId tableId, Timestamp asOf) {
@@ -157,5 +158,35 @@ public class SnapshotRepository {
 
   public MutationMeta metaForSafe(ResourceId tableId, long snapshotId) {
     return repo.metaForSafe(new SnapshotKey(tableId.getAccountId(), tableId.getId(), snapshotId));
+  }
+
+  private Optional<Snapshot> latestSnapshotByTime(ResourceId tableId) {
+    String prefix = Keys.snapshotPointerByTimePrefix(tableId.getAccountId(), tableId.getId());
+    String token = "";
+    StringBuilder next = new StringBuilder();
+    Snapshot best = null;
+    long bestCreatedMs = Long.MIN_VALUE;
+
+    do {
+      List<Snapshot> batch = repo.listByPrefix(prefix, 200, token, next);
+      for (Snapshot snapshot : batch) {
+        long createdMs = Timestamps.toMillis(snapshot.getUpstreamCreatedAt());
+        if (best == null) {
+          best = snapshot;
+          bestCreatedMs = createdMs;
+          continue;
+        }
+        if (createdMs != bestCreatedMs) {
+          return Optional.of(best);
+        }
+        if (snapshot.getSnapshotId() > best.getSnapshotId()) {
+          best = snapshot;
+        }
+      }
+      token = next.toString();
+      next.setLength(0);
+    } while (!token.isEmpty());
+
+    return Optional.ofNullable(best);
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotRepositoryTest.java
@@ -197,7 +197,7 @@ class SnapshotRepositoryTest {
   }
 
   @Test
-  void getCurrentSnapshotReturnsEmptyWithoutTableCurrentSnapshotId() {
+  void getCurrentSnapshotFallsBackToLatestSnapshotWhenTableCurrentSnapshotIdMissing() {
     String account = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT).getId();
     var tableRid =
         ResourceId.newBuilder()
@@ -208,7 +208,25 @@ class SnapshotRepositoryTest {
     tableRepo.create(tableWithCurrentSnapshot(account, tableRid, null));
     seedSnapshot(snapshotRepo, account, tableRid, 204, clock.millis(), clock.millis() - 10_000);
 
-    assertTrue(snapshotRepo.getCurrentSnapshot(tableRid).isEmpty());
+    Snapshot fallback = snapshotRepo.getCurrentSnapshot(tableRid).orElseThrow();
+    assertEquals(204L, fallback.getSnapshotId());
+  }
+
+  @Test
+  void getCurrentSnapshotFallsBackToLatestSnapshotWhenCurrentPointerIsDangling() {
+    String account = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT).getId();
+    var tableRid =
+        ResourceId.newBuilder()
+            .setAccountId(account)
+            .setId(UUID.randomUUID().toString())
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    tableRepo.create(tableWithCurrentSnapshot(account, tableRid, 999_999L));
+    seedSnapshot(snapshotRepo, account, tableRid, 101, clock.millis(), clock.millis() - 20_000);
+    seedSnapshot(snapshotRepo, account, tableRid, 204, clock.millis(), clock.millis() - 10_000);
+
+    Snapshot fallback = snapshotRepo.getCurrentSnapshot(tableRid).orElseThrow();
+    assertEquals(204L, fallback.getSnapshotId());
   }
 
   private void seedSnapshot(
@@ -333,7 +351,10 @@ class SnapshotRepositoryTest {
     assertTrue(unexpected.isEmpty(), "unexpected exceptions: " + unexpected.size());
     assertTrue(conflicts.sum() >= 0, "should have some conflicts");
 
-    assertTrue(snapshotRepo.getCurrentSnapshot(tblId).isEmpty());
+    Snapshot current = snapshotRepo.getCurrentSnapshot(tblId).orElse(null);
+    if (current != null) {
+      assertTrue(current.getSnapshotId() >= 160 && current.getSnapshotId() <= 209);
+    }
 
     var next = new StringBuilder();
     var first = snapshotRepo.list(tblId, 5, "", next);


### PR DESCRIPTION
Fix snapshot-not-found regressions by preserving managed table properties and hardening current snapshot resolution

## Summary

Regression introduced by https://github.com/eng-floe/floecat/pull/295

Root cause:
- Reconcile `updateTableById` replaced table properties from descriptor payload and could overwrite engine-managed metadata fields (notably `current-snapshot-id`).
- Some tables then had missing/dangling current snapshot pointers, causing `GetUserObjects` / TPCH failures with `Snapshot not found`.

What changed:
- Made `SnapshotRepository.getCurrentSnapshot()` resilient:
  - falls back to latest snapshot when `current-snapshot-id` is missing, invalid, or dangling.
- Prevented reconciler from clobbering engine-managed properties during table updates.
- Introduced a shared managed-property contract (`ManagedTableProperties`) and reused it in both reconciler and protocol gateway to avoid future drift.
- Strengthened tests:
  - snapshot fallback behavior (missing + dangling pointer),
  - managed-property preservation on reconcile updates (dynamic coverage from shared key set).

Why this is safe:
- Reconciler still updates user/upstream properties.
- Engine-owned metadata fields remain authoritative from existing table state.
- Behavior is format-safe under the current Iceberg-compatible metadata model (including Delta paths in this architecture).

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Include any follow-ups, risks, or reviewer guidance.
