### PR TITLE
Cleanup stale generated proto files automatically

### DIFF
--- a/core/proto/pom.xml
+++ b/core/proto/pom.xml
@@ -72,6 +72,38 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <executions>
+          <!--
+            Wipe stale generated proto sources before each build. The Quarkus
+            generate-code goal rewrites files for messages still present in the
+            .proto sources, but leaves orphans behind when a message is removed
+            or renamed. Orphans then fail to compile against the freshly
+            generated outer class.
+          -->
+          <execution>
+            <id>clean-generated-proto-sources</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <configuration>
+              <excludeDefaultDirectories>true</excludeDefaultDirectories>
+              <filesets>
+                <fileset>
+                  <directory>${project.build.directory}/generated-sources/grpc</directory>
+                </fileset>
+                <fileset>
+                  <directory>${project.build.directory}/generated-test-sources/test-grpc</directory>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
## Summary

Describe what this PR changes and why.

Cleanup stale protos on build

## Type of Change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [x] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [ ] `make fmt`
- [ ] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [ ] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [ ] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Include any follow-ups, risks, or reviewer guidance.
