### PR TITLE
Harden gRPC context propagation and remove legacy blocking wrapper

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
@@ -24,20 +24,16 @@ import io.grpc.ServerInterceptor;
 import io.quarkus.grpc.GlobalInterceptor;
 import io.quarkus.oidc.TenantIdentityProvider;
 import io.vertx.core.Vertx;
-import io.vertx.grpc.BlockingServerInterceptor;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Optional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 @ApplicationScoped
 @GlobalInterceptor
 @Priority(0) // Must run before other interceptors
 public class BlockingInboundContextInterceptor implements ServerInterceptor {
-  private static final Logger LOG = Logger.getLogger(BlockingInboundContextInterceptor.class);
-
   private final ServerInterceptor delegate;
 
   @Inject
@@ -60,12 +56,7 @@ public class BlockingInboundContextInterceptor implements ServerInterceptor {
               defaultValue = "account_id")
           String accountClaimName,
       @ConfigProperty(name = "floecat.interceptor.session.role-claim", defaultValue = "roles")
-          String roleClaimName,
-      // Escape hatch: set to true (env: FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP=true) to
-      // revert to the deprecated io.vertx.grpc.BlockingServerInterceptor.wrap. Intended for
-      // before/after validation of the context-preserving fix; leave unset in production.
-      @ConfigProperty(name = "floecat.interceptor.blocking.legacy-wrap", defaultValue = "false")
-          boolean legacyWrap) {
+          String roleClaimName) {
 
     // Plain helper with your logic; does NOT implement ServerInterceptor (avoids Quarkus "unused"
     // warnings).
@@ -81,28 +72,9 @@ public class BlockingInboundContextInterceptor implements ServerInterceptor {
             accountClaimName,
             roleClaimName);
 
-    // Wrap so the inner interceptor (and the rest of the chain it builds) runs on a Vert.x
-    // worker thread, off the event-loop. Replaces io.vertx.grpc.BlockingServerInterceptor.wrap,
-    // which is deprecated and does not propagate io.grpc.Context across the buffered-event
-    // replay — that gap, combined with Quarkus's GrpcDuplicatedContextGrpcInterceptor hopping
-    // via runOnContext on Vert.x-context mismatch, drops the principal/correlation context on a
-    // subset of inbound calls. The replacement below is modelled on Quarkus's internal
-    // BlockingServerInterceptor + BlockingExecutionHandler pattern (which is only active for
-    // @Blocking-annotated methods); here it applies to every method because the gRPC services
-    // in this module are uniformly blocking.
-    //
     // ServerInterceptor is a functional interface, so we pass the helper's interceptCall as a
     // method reference — no JDK Proxy or runtime classloader gymnastics required.
-    if (legacyWrap) {
-      LOG.warnf(
-          "Using deprecated io.vertx.grpc.BlockingServerInterceptor.wrap"
-              + " (floecat.interceptor.blocking.legacy-wrap=true)."
-              + " This reintroduces the gRPC Context drop documented in the fix's commit;"
-              + " expect intermittent empty PrincipalContext on inbound calls.");
-      this.delegate = BlockingServerInterceptor.wrap(vertx, inbound::interceptCall);
-    } else {
-      this.delegate = new CtxPropagatingBlockingWrap(vertx, inbound::interceptCall);
-    }
+    this.delegate = new CtxPropagatingBlockingWrap(vertx, inbound::interceptCall);
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrap.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrap.java
@@ -142,7 +142,8 @@ final class CtxPropagatingBlockingWrap implements ServerInterceptor {
     private volatile ServerCall.Listener<ReqT> delegate;
     private final Queue<Consumer<ServerCall.Listener<ReqT>>> incomingEvents =
         new ConcurrentLinkedQueue<>();
-    private volatile boolean isConsumingFromIncomingEvents;
+    private final Object drainLock = new Object();
+    private boolean isConsumingFromIncomingEvents;
 
     ReplayListener(
         Vertx vertx,
@@ -154,13 +155,10 @@ final class CtxPropagatingBlockingWrap implements ServerInterceptor {
     }
 
     void setDelegate(ServerCall.Listener<ReqT> delegate) {
-      this.delegate = delegate;
-      if (!isConsumingFromIncomingEvents) {
-        Consumer<ServerCall.Listener<ReqT>> consumer = incomingEvents.poll();
-        if (consumer != null) {
-          executeBlockingWithContext(consumer);
-        }
+      synchronized (drainLock) {
+        this.delegate = delegate;
       }
+      startDrainIfPossible();
     }
 
     private void scheduleOrEnqueue(Consumer<ServerCall.Listener<ReqT>> consumer) {
@@ -178,11 +176,25 @@ final class CtxPropagatingBlockingWrap implements ServerInterceptor {
               arrivalCtx.detach(prev);
             }
           };
-      if (delegate != null && !isConsumingFromIncomingEvents) {
-        executeBlockingWithContext(withCtx);
-      } else {
+      synchronized (drainLock) {
         incomingEvents.add(withCtx);
       }
+      startDrainIfPossible();
+    }
+
+    private void startDrainIfPossible() {
+      Consumer<ServerCall.Listener<ReqT>> next;
+      synchronized (drainLock) {
+        if (delegate == null || isConsumingFromIncomingEvents) {
+          return;
+        }
+        next = incomingEvents.poll();
+        if (next == null) {
+          return;
+        }
+        isConsumingFromIncomingEvents = true;
+      }
+      executeBlockingWithContext(next);
     }
 
     /**
@@ -193,7 +205,6 @@ final class CtxPropagatingBlockingWrap implements ServerInterceptor {
      */
     private void executeBlockingWithContext(Consumer<ServerCall.Listener<ReqT>> consumer) {
       final ServerCall.Listener<ReqT> target = delegate;
-      isConsumingFromIncomingEvents = true;
       vertx
           .<Void>executeBlocking(
               () -> {
@@ -222,12 +233,15 @@ final class CtxPropagatingBlockingWrap implements ServerInterceptor {
               false)
           .onComplete(
               p -> {
-                Consumer<ServerCall.Listener<ReqT>> nextEvent = incomingEvents.poll();
-                if (nextEvent != null) {
-                  executeBlockingWithContext(nextEvent);
-                } else {
-                  isConsumingFromIncomingEvents = false;
+                Consumer<ServerCall.Listener<ReqT>> nextEvent;
+                synchronized (drainLock) {
+                  nextEvent = incomingEvents.poll();
+                  if (nextEvent == null) {
+                    isConsumingFromIncomingEvents = false;
+                    return;
+                  }
                 }
+                executeBlockingWithContext(nextEvent);
               });
     }
 

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
@@ -46,6 +46,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
@@ -476,6 +478,67 @@ class CtxPropagatingBlockingWrapTest {
               + " legacyWrap was selected via FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP this is the"
               + " expected failure (Context.Key.get() returns null inside the handler).");
     } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  /**
+   * Models the gRPC service implementation shape: the listener callback observes the request
+   * context, captures it, returns, and only then runs the actual service work on another executor.
+   * This covers the extra async hop used by Mutiny service methods.
+   */
+  @Test
+  void capturedGrpcContextSurvivesAsyncWorkAfterListenerCallbackReturns() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      ServerInterceptor inner =
+          new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call,
+                Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+              Context ctx = Context.current().withValue(KEY, "set-by-inner");
+              return Contexts.interceptCall(ctx, call, headers, next);
+            }
+          };
+      ServerInterceptor wrap = makeWrap(vertx, inner);
+
+      CountDownLatch callbackReturned = new CountDownLatch(1);
+      CountDownLatch releaseAsyncWork = new CountDownLatch(1);
+      CountDownLatch asyncDone = new CountDownLatch(1);
+      AtomicReference<String> observed = new AtomicReference<>("<unset>");
+
+      ServerCallHandler<Object, Object> handler =
+          (call, headers) ->
+              new ServerCall.Listener<>() {
+                @Override
+                public void onHalfClose() {
+                  Context captured = Context.current();
+                  executor.execute(
+                      () -> {
+                        try {
+                          releaseAsyncWork.await(10, TimeUnit.SECONDS);
+                          observed.set(captured.call(KEY::get));
+                        } catch (Exception e) {
+                          observed.set("error=" + e.getClass().getSimpleName());
+                        } finally {
+                          asyncDone.countDown();
+                        }
+                      });
+                  callbackReturned.countDown();
+                }
+              };
+
+      drive(vertx, wrap, handler);
+      assertTrue(callbackReturned.await(10, TimeUnit.SECONDS), "listener callback never returned");
+      releaseAsyncWork.countDown();
+
+      assertTrue(asyncDone.await(10, TimeUnit.SECONDS), "async service work never ran");
+      assertEquals("set-by-inner", observed.get());
+    } finally {
+      executor.shutdownNow();
       vertx.close().toCompletionStage().toCompletableFuture().get();
     }
   }

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
@@ -36,7 +36,6 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.vertx.core.Vertx;
-import io.vertx.grpc.BlockingServerInterceptor;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -63,24 +62,8 @@ class CtxPropagatingBlockingWrapTest {
 
   private static final Context.Key<String> KEY = Context.key("test-principal");
 
-  /**
-   * Selects which wrap the tests run against. Honours {@code
-   * floecat.interceptor.blocking.legacy-wrap} (env: {@code
-   * FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP}) so the same env var that flips the production wiring
-   * also flips these tests — with the legacy wrap selected, at least one test below is expected to
-   * fail (see {@link #eventHandlerRunsOffEventLoop}).
-   */
   private static ServerInterceptor makeWrap(Vertx vertx, ServerInterceptor inner) {
-    if (legacyWrapSelected()) {
-      return BlockingServerInterceptor.wrap(vertx, inner);
-    }
     return new CtxPropagatingBlockingWrap(vertx, inner);
-  }
-
-  private static boolean legacyWrapSelected() {
-    String env = System.getenv("FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP");
-    String sys = System.getProperty("floecat.interceptor.blocking.legacy-wrap");
-    return "true".equalsIgnoreCase(env) || "true".equalsIgnoreCase(sys);
   }
 
   /**
@@ -474,9 +457,7 @@ class CtxPropagatingBlockingWrapTest {
       assertEquals(
           "set-at-arrival",
           observed.get(),
-          "io.grpc.Context attached at event arrival was lost across the buffer/replay; if"
-              + " legacyWrap was selected via FLOECAT_INTERCEPTOR_BLOCKING_LEGACY_WRAP this is the"
-              + " expected failure (Context.Key.get() returns null inside the handler).");
+          "io.grpc.Context attached at event arrival was lost across the buffer/replay");
     } finally {
       vertx.close().toCompletionStage().toCompletableFuture().get();
     }

--- a/service/src/test/java/ai/floedb/floecat/service/it/QueryContextPropagationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QueryContextPropagationIT.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.it;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import ai.floedb.floecat.catalog.rpc.CatalogServiceGrpc;
+import ai.floedb.floecat.catalog.rpc.CatalogSpec;
+import ai.floedb.floecat.catalog.rpc.CreateCatalogRequest;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.query.rpc.BeginQueryRequest;
+import ai.floedb.floecat.query.rpc.GetUserObjectsRequest;
+import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
+import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
+import ai.floedb.floecat.query.rpc.UserObjectsServiceGrpc;
+import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
+import ai.floedb.floecat.service.it.profiles.OidcSessionHeaderProfile;
+import ai.floedb.floecat.service.it.util.TestKeyPair;
+import ai.floedb.floecat.service.repo.impl.AccountRepository;
+import ai.floedb.floecat.service.util.TestDataResetter;
+import ai.floedb.floecat.service.util.TestSupport;
+import io.grpc.Channel;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.jwt.build.Jwt;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Stress reproducer for the prod intermittent {@code PERMISSION_DENIED: missing permission:
+ * catalog.read} on {@code QueryService.BeginQuery} and {@code UserObjectsService.GetUserObjects}.
+ *
+ * <p>Both methods run their authorization check ({@code authz.require(pc, "catalog.read")}) inside
+ * a Mutiny {@code Uni}/{@code Multi} body subscribed on {@code
+ * Infrastructure.getDefaultExecutor()}. The principal they read is whatever {@code
+ * GrpcContextUtil.capture()} grabbed at service-method entry. The reported failure is that some
+ * fraction of calls land on the worker with an empty principal — {@code authz.require} then throws
+ * {@code PERMISSION_DENIED}. This test fires many concurrent calls through the real OIDC
+ * session-JWT path and fails the moment any inbound call gets that response.
+ *
+ * <p>Two scenarios exercised:
+ *
+ * <ul>
+ *   <li>{@code beginQuery} on its own — the {@link
+ *       ai.floedb.floecat.service.common.BaseServiceImpl#run BaseServiceImpl.run} path with a
+ *       {@code Uni}.
+ *   <li>{@code beginQuery + getUserObjects} per attempt — the {@code Multi.createFrom().emitter(
+ *       ...).runSubscriptionOn(...)} path, with the in-body {@code grpcCtx.run(...)} that the
+ *       handler uses for streaming.
+ * </ul>
+ *
+ * <p>Tunable via {@code -Dfloecat.test.query-ctx.threads} / {@code .iterations}. Defaults are sized
+ * to saturate the default Vert.x worker pool without making the test miserable to run on a laptop.
+ */
+@QuarkusTest
+@TestProfile(OidcSessionHeaderProfile.class)
+class QueryContextPropagationIT {
+
+  private static final Metadata.Key<String> SESSION_HEADER =
+      Metadata.Key.of("x-floe-session", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> CORRELATION_HEADER =
+      Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
+
+  private static final int DEFAULT_THREADS = 16;
+  private static final int DEFAULT_ITERATIONS_PER_THREAD = 25;
+  private static final long TIMEOUT_SECONDS = 180;
+
+  @GrpcClient("floecat")
+  CatalogServiceGrpc.CatalogServiceBlockingStub catalogs;
+
+  @GrpcClient("floecat")
+  QueryServiceGrpc.QueryServiceBlockingStub queries;
+
+  // UserObjectsService is server-streaming; the Quarkus @GrpcClient injection of the blocking stub
+  // for streaming RPCs is awkward, so build it from the raw Channel per call.
+  @GrpcClient("floecat")
+  Channel channel;
+
+  @Inject AccountRepository accountRepository;
+  @Inject TestDataResetter resetter;
+  @Inject SeedRunner seeder;
+
+  private String accountId;
+  private String jwt;
+  private ResourceId catalogId;
+
+  @BeforeEach
+  void resetStores() throws Exception {
+    resetter.wipeAll();
+    seeder.seedData();
+    accountId =
+        accountRepository
+            .getByName(TestSupport.DEFAULT_SEED_ACCOUNT)
+            .orElseThrow()
+            .getResourceId()
+            .getId();
+    jwt = initAccountJwt();
+
+    // Pre-create a single catalog for all the BeginQuery calls to reference. Uses the same JWT
+    // path so the setup itself exercises the same chain we're testing — if context propagation is
+    // broken in setup, the test will fail loudly here rather than masking the problem.
+    Metadata setupMetadata = metadataFor("ctx-prop-setup");
+    var stub = catalogs.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(setupMetadata));
+    catalogId =
+        stub.createCatalog(
+                CreateCatalogRequest.newBuilder()
+                    .setSpec(
+                        CatalogSpec.newBuilder().setDisplayName("ctxprop_setup_catalog").build())
+                    .build())
+            .getCatalog()
+            .getResourceId();
+  }
+
+  @Test
+  void concurrentBeginQueryDoesNotLosePrincipalContext() throws Exception {
+    runStress(
+        "beginQuery",
+        (threadIdx, iteration) -> {
+          String correlationId = "ctx-prop-bq-t" + threadIdx + "-i" + iteration;
+          Metadata md = metadataFor(correlationId);
+          var stub = queries.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(md));
+          stub.beginQuery(BeginQueryRequest.newBuilder().setDefaultCatalogId(catalogId).build());
+        });
+  }
+
+  @Test
+  void concurrentGetUserObjectsDoesNotLosePrincipalContext() throws Exception {
+    runStress(
+        "getUserObjects",
+        (threadIdx, iteration) -> {
+          String correlationId = "ctx-prop-guo-t" + threadIdx + "-i" + iteration;
+          Metadata md = metadataFor(correlationId);
+
+          var queryStub = queries.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(md));
+          var begin =
+              queryStub.beginQuery(
+                  BeginQueryRequest.newBuilder().setDefaultCatalogId(catalogId).build());
+          String queryId = begin.getQuery().getQueryId();
+
+          var userObjectsStub =
+              UserObjectsServiceGrpc.newBlockingStub(channel)
+                  .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(md));
+
+          Iterator<UserObjectsBundleChunk> it =
+              userObjectsStub.getUserObjects(
+                  GetUserObjectsRequest.newBuilder().setQueryId(queryId).build());
+
+          // Drain the stream so any PERMISSION_DENIED emitted by the server surfaces here.
+          while (it.hasNext()) {
+            it.next();
+          }
+        });
+  }
+
+  // ---------- stress harness ----------
+
+  @FunctionalInterface
+  private interface Attempt {
+    void run(int threadIdx, int iteration);
+  }
+
+  private void runStress(String label, Attempt attempt) throws Exception {
+    int threads = Integer.getInteger("floecat.test.query-ctx.threads", DEFAULT_THREADS);
+    int iterations =
+        Integer.getInteger("floecat.test.query-ctx.iterations", DEFAULT_ITERATIONS_PER_THREAD);
+    int total = threads * iterations;
+
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch start = new CountDownLatch(1);
+    AtomicInteger successes = new AtomicInteger();
+    ConcurrentMap<Status.Code, AtomicInteger> failuresByCode = new ConcurrentHashMap<>();
+    ConcurrentMap<Status.Code, String> firstFailureSample = new ConcurrentHashMap<>();
+
+    for (int t = 0; t < threads; t++) {
+      final int threadIdx = t;
+      pool.submit(
+          () -> {
+            try {
+              start.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              return;
+            }
+            for (int i = 0; i < iterations; i++) {
+              try {
+                attempt.run(threadIdx, i);
+                successes.incrementAndGet();
+              } catch (StatusRuntimeException e) {
+                Status.Code code = e.getStatus().getCode();
+                failuresByCode.computeIfAbsent(code, k -> new AtomicInteger()).incrementAndGet();
+                firstFailureSample.putIfAbsent(
+                    code, "t=" + threadIdx + " i=" + i + " desc=" + e.getStatus().getDescription());
+              } catch (Throwable t2) {
+                failuresByCode
+                    .computeIfAbsent(Status.Code.UNKNOWN, k -> new AtomicInteger())
+                    .incrementAndGet();
+                firstFailureSample.putIfAbsent(
+                    Status.Code.UNKNOWN,
+                    "t="
+                        + threadIdx
+                        + " i="
+                        + i
+                        + " ex="
+                        + t2.getClass().getName()
+                        + ": "
+                        + t2.getMessage());
+              }
+            }
+          });
+    }
+
+    start.countDown();
+    pool.shutdown();
+    boolean done = pool.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    if (!done) {
+      pool.shutdownNow();
+      fail(label + " stress did not complete within " + TIMEOUT_SECONDS + "s");
+    }
+
+    int permissionDenied =
+        failuresByCode.getOrDefault(Status.Code.PERMISSION_DENIED, new AtomicInteger()).get();
+
+    StringBuilder summary = new StringBuilder();
+    summary
+        .append(label)
+        .append(": total=")
+        .append(total)
+        .append(" successes=")
+        .append(successes.get());
+    failuresByCode.forEach(
+        (code, count) -> {
+          summary
+              .append(' ')
+              .append(code)
+              .append('=')
+              .append(count.get())
+              .append('(')
+              .append(firstFailureSample.get(code))
+              .append(')');
+        });
+    System.out.println(summary);
+
+    if (permissionDenied > 0) {
+      fail(
+          "Context propagation failure: "
+              + permissionDenied
+              + "/"
+              + total
+              + " "
+              + label
+              + " calls returned PERMISSION_DENIED — the principal context was lost between the"
+              + " inbound interceptor and the service body running on a Mutiny worker. "
+              + summary);
+    }
+
+    assertTrue(
+        successes.get() > 0, "no " + label + " calls succeeded; test setup broken: " + summary);
+  }
+
+  private Metadata metadataFor(String correlationId) {
+    Metadata md = new Metadata();
+    md.put(SESSION_HEADER, jwt);
+    md.put(CORRELATION_HEADER, correlationId + "-" + UUID.randomUUID());
+    return md;
+  }
+
+  private String initAccountJwt() throws Exception {
+    var now = Instant.now();
+    return Jwt.claims()
+        .issuer("https://floecat.test")
+        .subject("ctx-prop-it")
+        .claim("account_id", accountId)
+        .claim("roles", List.of("init-account"))
+        .issuedAt(now)
+        .expiresAt(now.plusSeconds(7L * 365 * 24 * 3600))
+        .audience("floecat-client")
+        .sign(TestKeyPair.privateKey());
+  }
+}


### PR DESCRIPTION
## Summary

This follow-up tightens the context propagation work from the original PR.

The first adjustment serializes buffered listener-event replay inside the custom blocking wrapper. Delegate installation and queued event draining now coordinate through a lock so inbound events are replayed in order, without overlapping drains, while preserving the captured gRPC Context through the worker execution path.

The second adjustment removes the temporary legacy-wrapper escape hatch. BlockingInboundContextInterceptor now always uses the context-preserving wrapper, and the tests no longer support switching back to the deprecated Vert.x
BlockingServerInterceptor.wrap(...) path.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Hardening the grpc context drain based on analysis and thought it would be best to include fix for race condition introduced by original work, and cleanup test support for A:B testing.