### PR TITLE
Stabilize engine-version context propagation test capture

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
@@ -74,7 +74,7 @@ public class BlockingInboundContextInterceptor implements ServerInterceptor {
 
     // ServerInterceptor is a functional interface, so we pass the helper's interceptCall as a
     // method reference — no JDK Proxy or runtime classloader gymnastics required.
-    this.delegate = new CtxPropagatingBlockingWrap(vertx, inbound::interceptCall);
+    this.delegate = new CtxPropagatingBlockingWrap(vertx, inbound::interceptCall)::interceptCall;
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrap.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrap.java
@@ -32,8 +32,8 @@ import java.util.function.Consumer;
 import org.jboss.logging.Logger;
 
 /**
- * Worker-thread {@link ServerInterceptor} wrap that preserves both the gRPC {@link Context} and the
- * CDI request context across the worker hop.
+ * Worker-thread wrap that preserves both the gRPC {@link Context} and the CDI request context
+ * across the worker hop.
  *
  * <p>The pattern mirrors {@code
  * io.quarkus.grpc.runtime.supports.blocking.BlockingServerInterceptor} + {@code
@@ -51,7 +51,7 @@ import org.jboss.logging.Logger;
  * <p>Package-private so the test suite can instantiate it directly without going through the full
  * Quarkus interceptor chain.
  */
-final class CtxPropagatingBlockingWrap implements ServerInterceptor {
+final class CtxPropagatingBlockingWrap {
   private static final Logger LOG = Logger.getLogger(CtxPropagatingBlockingWrap.class);
 
   private final Vertx vertx;
@@ -62,7 +62,6 @@ final class CtxPropagatingBlockingWrap implements ServerInterceptor {
     this.inner = inner;
   }
 
-  @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
       ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
 

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
@@ -63,7 +63,7 @@ class CtxPropagatingBlockingWrapTest {
   private static final Context.Key<String> KEY = Context.key("test-principal");
 
   private static ServerInterceptor makeWrap(Vertx vertx, ServerInterceptor inner) {
-    return new CtxPropagatingBlockingWrap(vertx, inner);
+    return new CtxPropagatingBlockingWrap(vertx, inner)::interceptCall;
   }
 
   /**

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/TestEngineVersionCaptureInterceptor.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/TestEngineVersionCaptureInterceptor.java
@@ -35,9 +35,20 @@ import java.util.concurrent.atomic.AtomicReference;
 @GlobalInterceptor
 @Priority(1000)
 public class TestEngineVersionCaptureInterceptor implements ServerInterceptor {
+  private static final Metadata.Key<String> ENGINE_VERSION =
+      Metadata.Key.of("x-engine-version", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> CORR =
+      Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
+  private static final AtomicReference<String> TARGET_CORRELATION_ID = new AtomicReference<>();
   private static final AtomicReference<String> CAPTURED = new AtomicReference<>();
 
   public static void reset() {
+    TARGET_CORRELATION_ID.set(null);
+    CAPTURED.set(null);
+  }
+
+  public static void captureFor(String correlationId) {
+    TARGET_CORRELATION_ID.set(correlationId);
     CAPTURED.set(null);
   }
 
@@ -48,9 +59,10 @@ public class TestEngineVersionCaptureInterceptor implements ServerInterceptor {
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
       ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-    Metadata.Key<String> ENGINE_VERSION =
-        Metadata.Key.of("x-engine-version", Metadata.ASCII_STRING_MARSHALLER);
-    CAPTURED.set(headers.get(ENGINE_VERSION));
+    String targetCorrelationId = TARGET_CORRELATION_ID.get();
+    if (targetCorrelationId == null || targetCorrelationId.equals(headers.get(CORR))) {
+      CAPTURED.set(headers.get(ENGINE_VERSION));
+    }
     return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(
         next.startCall(
             new ForwardingServerCall.SimpleForwardingServerCall<>(call) {

--- a/service/src/test/java/ai/floedb/floecat/service/it/PropagationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/PropagationIT.java
@@ -172,6 +172,8 @@ class PropagationIT {
     engineMeta.put(ENGINE_VERSION, "it-engine");
     engineMeta.put(CORR, corr);
 
+    TestEngineVersionCaptureInterceptor.captureFor(corr);
+
     catalog
         .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(engineMeta))
         .listCatalogs(ListCatalogsRequest.getDefaultInstance());


### PR DESCRIPTION
## Summary

Fixes the propagation test harness so engine-version assertions are scoped to the request under test.

The test interceptor previously stored the last observed `x-engine-version` in one static value. In a shared Quarkus test JVM, any unrelated inbound gRPC call without that header could overwrite the capture with `null`, causing intermittent failures even when the target request carried the expected engine version.

The capture now tracks the test request correlation id and only records engine-version headers for matching calls.

 This also includes cleanup around the blocking context wrapper: it is now a plain internal helper instead of implementing `ServerInterceptor` directly, leaving `BlockingInboundContextInterceptor` as the only Quarkus-discoverable global interceptor while preserving direct test coverage.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

### Test Updates

- Scoped engine-version capture by correlation id in the propagation test harness.
- Updated the propagation test to register the expected correlation id before issuing the request.
- Adjusted blocking-wrapper tests for the helper refactor.

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Unfortunate that test stability wasn't seen until last pr merged.
