### PR TITLE
Reconciler: scope worker auth and remote execution to the leased target account

### DIFF
--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/auth/OidcReconcileWorkerAuthProvider.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/auth/OidcReconcileWorkerAuthProvider.java
@@ -28,6 +28,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -45,7 +46,7 @@ public class OidcReconcileWorkerAuthProvider implements ReconcileWorkerAuthProvi
   private final Clock clock;
   private final TokenEndpointClient tokenEndpointClient;
 
-  private volatile CachedToken cachedToken;
+  private final ConcurrentHashMap<String, CachedToken> cachedTokens = new ConcurrentHashMap<>();
 
   @Inject
   public OidcReconcileWorkerAuthProvider(
@@ -87,35 +88,37 @@ public class OidcReconcileWorkerAuthProvider implements ReconcileWorkerAuthProvi
   }
 
   @Override
-  public Optional<String> authorizationHeader() {
+  public Optional<String> authorizationHeader(String accountId) {
     if (issuer.isEmpty() || clientId.isEmpty() || clientSecret.isEmpty()) {
       return Optional.empty();
     }
-    CachedToken current = cachedToken;
+    String normalizedAccountId = normalizeAccountId(accountId);
+    CachedToken current = cachedTokens.get(normalizedAccountId);
     Instant now = clock.instant();
     if (current != null && now.isBefore(current.refreshAt())) {
       return Optional.of(current.authorizationHeader());
     }
     synchronized (this) {
-      current = cachedToken;
+      current = cachedTokens.get(normalizedAccountId);
       now = clock.instant();
       if (current != null && now.isBefore(current.refreshAt())) {
         return Optional.of(current.authorizationHeader());
       }
-      CachedToken refreshed = fetchToken(now);
-      cachedToken = refreshed;
+      CachedToken refreshed = fetchToken(now, normalizedAccountId);
+      cachedTokens.put(normalizedAccountId, refreshed);
       return Optional.of(refreshed.authorizationHeader());
     }
   }
 
-  private CachedToken fetchToken(Instant now) {
+  private CachedToken fetchToken(Instant now, String accountId) {
     URI endpoint = tokenEndpoint();
     String requestBody =
         "client_id="
             + urlEncode(clientId.orElseThrow())
             + "&client_secret="
             + urlEncode(clientSecret.orElseThrow())
-            + "&grant_type=client_credentials";
+            + "&grant_type=client_credentials"
+            + (accountId.isBlank() ? "" : "&account_id=" + urlEncode(accountId));
     TokenResponse response = tokenEndpointClient.fetch(endpoint, requestBody, connectTimeout);
     Instant expiresAt = now.plusSeconds(Math.max(1L, response.expiresInSeconds()));
     Instant refreshAt = expiresAt.minusSeconds(refreshSkewSeconds);
@@ -123,7 +126,8 @@ public class OidcReconcileWorkerAuthProvider implements ReconcileWorkerAuthProvi
       refreshAt = now;
     }
     LOG.debugf(
-        "Acquired reconcile worker OIDC token; refreshAt=%s expiresAt=%s", refreshAt, expiresAt);
+        "Acquired reconcile worker OIDC token; accountId=%s refreshAt=%s expiresAt=%s",
+        accountId, refreshAt, expiresAt);
     return new CachedToken(withBearerPrefix(response.accessToken()), refreshAt);
   }
 
@@ -138,6 +142,10 @@ public class OidcReconcileWorkerAuthProvider implements ReconcileWorkerAuthProvi
 
   private static Optional<String> normalize(Optional<String> value) {
     return value.map(String::trim).filter(v -> !v.isBlank());
+  }
+
+  private static String normalizeAccountId(String accountId) {
+    return accountId == null ? "" : accountId.trim();
   }
 
   private static String withBearerPrefix(String token) {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/auth/ReconcileWorkerAuthProvider.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/auth/ReconcileWorkerAuthProvider.java
@@ -19,5 +19,5 @@ package ai.floedb.floecat.reconciler.auth;
 import java.util.Optional;
 
 public interface ReconcileWorkerAuthProvider {
-  Optional<String> authorizationHeader();
+  Optional<String> authorizationHeader(String accountId);
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -138,6 +138,8 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
 
   private static final Metadata.Key<String> AUTHORIZATION =
       Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> ACCOUNT =
+      Metadata.Key.of("x-floe-account", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> CORRELATION_ID =
       Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
   private static final Duration DEFAULT_STATS_TIMEOUT = Duration.ofMinutes(1);
@@ -1325,6 +1327,10 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
   Metadata metadataForContext(ReconcileContext ctx) {
     Metadata metadata = new Metadata();
     metadata.put(CORRELATION_ID, ctx.correlationId());
+    String accountId = ctx.principal().getAccountId();
+    if (accountId != null && !accountId.isBlank()) {
+      metadata.put(ACCOUNT, accountId);
+    }
     ctx.authorizationToken()
         .ifPresent(value -> metadata.put(authHeaderKey(), withBearerPrefix(value)));
     return metadata;

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClient.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClient.java
@@ -81,6 +81,8 @@ class GrpcRemoteReconcileExecutorClient
 
   private static final Metadata.Key<String> AUTHORIZATION =
       Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> ACCOUNT =
+      Metadata.Key.of("x-floe-account", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> CORRELATION_ID =
       Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
 
@@ -199,6 +201,7 @@ class GrpcRemoteReconcileExecutorClient
             "leaseReconcileJob",
             "reconcile-lease-"
                 + (leaseClientId == null || leaseClientId.isBlank() ? "aggregate" : leaseClientId),
+            null,
             stub ->
                 stub.leaseReconcileJob(
                     LeaseReconcileJobRequest.newBuilder()
@@ -228,6 +231,7 @@ class GrpcRemoteReconcileExecutorClient
     invokeWorkerControlOnce(
         "startLeasedReconcileJob",
         correlationId(lease),
+        lease.lease().accountId,
         stub ->
             stub.startLeasedReconcileJob(
                 StartLeasedReconcileJobRequest.newBuilder()
@@ -243,6 +247,7 @@ class GrpcRemoteReconcileExecutorClient
         invokeWorkerControlRetryable(
             "renewReconcileLease",
             correlationId(lease),
+            lease.lease().accountId,
             stub ->
                 stub.renewReconcileLease(
                     RenewReconcileLeaseRequest.newBuilder()
@@ -267,6 +272,7 @@ class GrpcRemoteReconcileExecutorClient
         invokeWorkerControlRetryable(
             "reportReconcileProgress",
             correlationId(lease),
+            lease.lease().accountId,
             stub ->
                 stub.reportReconcileProgress(
                     ReportReconcileProgressRequest.newBuilder()
@@ -302,6 +308,7 @@ class GrpcRemoteReconcileExecutorClient
         invokeWorkerControlOnce(
             "completeLeasedReconcileJob",
             correlationId(lease),
+            lease.lease().accountId,
             stub ->
                 stub.completeLeasedReconcileJob(
                     CompleteLeasedReconcileJobRequest.newBuilder()
@@ -327,6 +334,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControlRetryable(
         "getReconcileCancellation",
         correlationId(lease),
+        lease.lease().accountId,
         stub ->
             stub.getReconcileCancellation(
                     GetReconcileCancellationRequest.newBuilder()
@@ -340,6 +348,7 @@ class GrpcRemoteReconcileExecutorClient
         invokeWorkerControlRetryable(
             "getLeasedPlanConnectorInput",
             correlationId(lease),
+            lease.lease().accountId,
             stub ->
                 stub.getLeasedPlanConnectorInput(
                     GetLeasedPlanConnectorInputRequest.newBuilder()
@@ -385,6 +394,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControlOnce(
         "submitLeasedPlanConnectorResult",
         correlationId(lease),
+        lease.lease().accountId,
         stub ->
             stub.submitLeasedPlanConnectorResult(
                     SubmitLeasedPlanConnectorResultRequest.newBuilder()
@@ -404,6 +414,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControlOnce(
         "submitLeasedPlanConnectorResult",
         correlationId(lease),
+        lease.lease().accountId,
         stub ->
             stub.submitLeasedPlanConnectorResult(
                     SubmitLeasedPlanConnectorResultRequest.newBuilder()
@@ -425,6 +436,7 @@ class GrpcRemoteReconcileExecutorClient
         invokeWorkerControlRetryable(
             "getLeasedPlanTableInput",
             correlationId(lease),
+            lease.lease().accountId,
             stub ->
                 stub.getLeasedPlanTableInput(
                     GetLeasedPlanTableInputRequest.newBuilder()
@@ -472,6 +484,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControlOnce(
         "submitLeasedPlanTableResult",
         correlationId(lease),
+        lease.lease().accountId,
         stub ->
             stub.submitLeasedPlanTableResult(
                     SubmitLeasedPlanTableResultRequest.newBuilder()
@@ -491,6 +504,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControlOnce(
         "submitLeasedPlanTableResult",
         correlationId(lease),
+        lease.lease().accountId,
         stub ->
             stub.submitLeasedPlanTableResult(
                     SubmitLeasedPlanTableResultRequest.newBuilder()
@@ -512,6 +526,7 @@ class GrpcRemoteReconcileExecutorClient
         invokeWorkerControlRetryable(
             "getLeasedPlanViewInput",
             correlationId(lease),
+            lease.lease().accountId,
             stub ->
                 stub.getLeasedPlanViewInput(
                     GetLeasedPlanViewInputRequest.newBuilder()
@@ -550,6 +565,7 @@ class GrpcRemoteReconcileExecutorClient
         invokeWorkerControlOnce(
             "submitLeasedPlanViewResult",
             correlationId(lease),
+            lease.lease().accountId,
             stub ->
                 stub.submitLeasedPlanViewResult(
                     SubmitLeasedPlanViewResultRequest.newBuilder()
@@ -570,6 +586,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControlOnce(
         "submitLeasedPlanViewResult",
         correlationId(lease),
+        lease.lease().accountId,
         stub ->
             stub.submitLeasedPlanViewResult(
                     SubmitLeasedPlanViewResultRequest.newBuilder()
@@ -591,6 +608,7 @@ class GrpcRemoteReconcileExecutorClient
         invokeWorkerControlRetryable(
             "getLeasedPlanSnapshotInput",
             correlationId(lease),
+            lease.lease().accountId,
             stub ->
                 stub.getLeasedPlanSnapshotInput(
                     GetLeasedPlanSnapshotInputRequest.newBuilder()
@@ -628,6 +646,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControlOnce(
         "submitLeasedPlanSnapshotResult",
         correlationId(lease),
+        lease.lease().accountId,
         stub ->
             stub.submitLeasedPlanSnapshotResult(
                     SubmitLeasedPlanSnapshotResultRequest.newBuilder()
@@ -647,6 +666,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControlOnce(
         "submitLeasedPlanSnapshotResult",
         correlationId(lease),
+        lease.lease().accountId,
         stub ->
             stub.submitLeasedPlanSnapshotResult(
                     SubmitLeasedPlanSnapshotResultRequest.newBuilder()
@@ -668,6 +688,7 @@ class GrpcRemoteReconcileExecutorClient
         invokeWorkerControlRetryable(
             "getLeasedFileGroupExecution",
             correlationId(lease),
+            lease.lease().accountId,
             stub ->
                 stub.getLeasedFileGroupExecution(
                     GetLeasedFileGroupExecutionRequest.newBuilder()
@@ -753,6 +774,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControl(
         "submitLeasedFileGroupExecutionResult",
         correlationId(lease),
+        lease.lease().accountId,
         !resultId.isBlank(),
         stub ->
             stub.submitLeasedFileGroupExecutionResult(
@@ -769,6 +791,7 @@ class GrpcRemoteReconcileExecutorClient
     return invokeWorkerControl(
         "submitLeasedFileGroupExecutionResult",
         correlationId(lease),
+        lease.lease().accountId,
         !stableResultId.isBlank(),
         stub ->
             stub.submitLeasedFileGroupExecutionResult(
@@ -1392,27 +1415,30 @@ class GrpcRemoteReconcileExecutorClient
   private <T> T invokeWorkerControlRetryable(
       String operation,
       String correlationId,
+      String accountId,
       Function<ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub, T> invocation) {
-    return invokeWorkerControl(operation, correlationId, true, invocation);
+    return invokeWorkerControl(operation, correlationId, accountId, true, invocation);
   }
 
   private <T> T invokeWorkerControlOnce(
       String operation,
       String correlationId,
+      String accountId,
       Function<ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub, T> invocation) {
-    return invokeWorkerControl(operation, correlationId, false, invocation);
+    return invokeWorkerControl(operation, correlationId, accountId, false, invocation);
   }
 
   private <T> T invokeWorkerControl(
       String operation,
       String correlationId,
+      String accountId,
       boolean retryOnTransportFailure,
       Function<ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub, T> invocation) {
     RuntimeException lastError = null;
     int maxAttempts = retryOnTransportFailure ? 2 : 1;
     for (int attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        return invocation.apply(withHeaders(controlStub(), correlationId));
+        return invocation.apply(withHeaders(controlStub(), correlationId, accountId));
       } catch (RuntimeException error) {
         lastError = error;
         boolean transportFailure = isTransportFailure(error);
@@ -1451,23 +1477,27 @@ class GrpcRemoteReconcileExecutorClient
     return false;
   }
 
-  private <T extends AbstractStub<T>> T withHeaders(T stub, String correlationId) {
+  private <T extends AbstractStub<T>> T withHeaders(
+      T stub, String correlationId, String accountId) {
     return stub.withInterceptors(
-        MetadataUtils.newAttachHeadersInterceptor(metadata(correlationId)));
+        MetadataUtils.newAttachHeadersInterceptor(metadata(correlationId, accountId)));
   }
 
-  Metadata metadata(String correlationId) {
+  Metadata metadata(String correlationId, String accountId) {
     Metadata metadata = new Metadata();
     metadata.put(CORRELATION_ID, correlationId == null ? "" : correlationId);
-    attachWorkerAuthorization(metadata);
+    if (accountId != null && !accountId.isBlank()) {
+      metadata.put(ACCOUNT, accountId);
+    }
+    attachWorkerAuthorization(metadata, accountId);
     return metadata;
   }
 
-  private void attachWorkerAuthorization(Metadata metadata) {
+  private void attachWorkerAuthorization(Metadata metadata, String accountId) {
     if (workerAuthHeaderName.isEmpty()) {
       return;
     }
-    Optional<String> authorization = reconcileWorkerAuthProvider.authorizationHeader();
+    Optional<String> authorization = reconcileWorkerAuthProvider.authorizationHeader(accountId);
     if (authorization.isEmpty()) {
       if (!workerAuthRequired) {
         return;

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutor.java
@@ -113,7 +113,7 @@ public class RemoteDefaultReconcileExecutor implements ReconcileExecutor {
             payload.scope(),
             payload.tableTask(),
             payload.captureMode(),
-            workerAuthorizationHeader(),
+            workerAuthorizationHeader(lease.accountId),
             context.shouldStop(),
             progressListener);
     ExecutionResult result = tableExecution.result();
@@ -213,7 +213,7 @@ public class RemoteDefaultReconcileExecutor implements ReconcileExecutor {
             connectorId,
             payload.scope(),
             payload.viewTask(),
-            workerAuthorizationHeader(),
+            workerAuthorizationHeader(remoteLease.lease().accountId),
             context.shouldStop(),
             progressListener);
     ExecutionResult result = planned.result();
@@ -286,11 +286,11 @@ public class RemoteDefaultReconcileExecutor implements ReconcileExecutor {
         scope,
         task,
         payload.captureMode(),
-        workerAuthorizationHeader());
+        workerAuthorizationHeader(principal.getAccountId()));
   }
 
-  private String workerAuthorizationHeader() {
-    return reconcileWorkerAuthProvider.authorizationHeader().orElse(null);
+  private String workerAuthorizationHeader(String accountId) {
+    return reconcileWorkerAuthProvider.authorizationHeader(accountId).orElse(null);
   }
 
   private static ReconcileTableTask resolvedTableTaskForSnapshotPlanning(

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemotePlannerReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemotePlannerReconcileExecutor.java
@@ -136,7 +136,7 @@ public class RemotePlannerReconcileExecutor implements ReconcileExecutor {
       if (scope.hasTableFilter()) {
         var tableTasks =
             reconcilerService.planTableTasks(
-                principal, connectorId, scope, workerAuthorizationHeader());
+                principal, connectorId, scope, workerAuthorizationHeader(lease.accountId));
         if (tableTasks.isEmpty()) {
           return ExecutionResult.terminalFailure(
               0,
@@ -180,7 +180,7 @@ public class RemotePlannerReconcileExecutor implements ReconcileExecutor {
       } else if (scope.hasViewFilter()) {
         List<ReconcileViewTask> plannedViews =
             reconcilerService.planViewTasks(
-                principal, connectorId, scope, workerAuthorizationHeader());
+                principal, connectorId, scope, workerAuthorizationHeader(lease.accountId));
         if (plannedViews.isEmpty()) {
           return ExecutionResult.terminalFailure(
               0,
@@ -217,11 +217,11 @@ public class RemotePlannerReconcileExecutor implements ReconcileExecutor {
             !includesMetadata(payload.captureMode()) && scope.hasCaptureRequestFilter()
                 ? planCaptureOnlyScopedTableTasks(principal, connectorId, scope)
                 : reconcilerService.planTableTasks(
-                    principal, connectorId, scope, workerAuthorizationHeader());
+                    principal, connectorId, scope, workerAuthorizationHeader(lease.accountId));
         List<ReconcileViewTask> plannedViews =
             includesMetadata(payload.captureMode())
                 ? reconcilerService.planViewTasks(
-                    principal, connectorId, scope, workerAuthorizationHeader())
+                    principal, connectorId, scope, workerAuthorizationHeader(lease.accountId))
                 : List.of();
         validateScopedCaptureRequestsMatched(payload.captureMode(), scope, tableTasks);
         if (includesMetadata(payload.captureMode())) {
@@ -400,7 +400,10 @@ public class RemotePlannerReconcileExecutor implements ReconcileExecutor {
           ReconcileScope.of(List.of(), entry.getKey(), entry.getValue(), scope.capturePolicy());
       plannedTasks.addAll(
           reconcilerService.planTableTasks(
-              principal, connectorId, strictScope, workerAuthorizationHeader()));
+              principal,
+              connectorId,
+              strictScope,
+              workerAuthorizationHeader(principal.getAccountId())));
     }
     return plannedTasks;
   }
@@ -457,7 +460,7 @@ public class RemotePlannerReconcileExecutor implements ReconcileExecutor {
     return ExecutionResult.cancelled(tablesPlanned, 0, viewsPlanned, 0, 0, 0, 0, "Cancelled");
   }
 
-  private String workerAuthorizationHeader() {
-    return reconcileWorkerAuthProvider.authorizationHeader().orElse(null);
+  private String workerAuthorizationHeader(String accountId) {
+    return reconcileWorkerAuthProvider.authorizationHeader(accountId).orElse(null);
   }
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutor.java
@@ -495,11 +495,11 @@ public class RemoteSnapshotPlanningReconcileExecutor implements ReconcileExecuto
         principal,
         id(),
         Instant.now(),
-        Optional.ofNullable(workerAuthorizationHeader()));
+        Optional.ofNullable(workerAuthorizationHeader(lease.accountId)));
   }
 
-  private String workerAuthorizationHeader() {
-    return reconcileWorkerAuthProvider.authorizationHeader().orElse(null);
+  private String workerAuthorizationHeader(String accountId) {
+    return reconcileWorkerAuthProvider.authorizationHeader(accountId).orElse(null);
   }
 
   private static ReconcileScope effectiveFileGroupScope(

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/StandaloneJavaFileGroupExecutionRunner.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/StandaloneJavaFileGroupExecutionRunner.java
@@ -55,7 +55,8 @@ public class StandaloneJavaFileGroupExecutionRunner {
                 FileGroupExecutionSupport.columnSelectorPolicy(payload.capturePolicy()),
                 FileGroupExecutionSupport.requestedStatsTargetKinds(payload.capturePolicy()),
                 payload.capturePageIndex(),
-                reconcileWorkerAuthProvider.authorizationHeader()));
+                reconcileWorkerAuthProvider.authorizationHeader(
+                    payload.tableId() == null ? "" : payload.tableId().getAccountId())));
     if (!payload.capturePageIndex() || !capture.stagedIndexArtifacts().isEmpty()) {
       return capture;
     }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/auth/OidcReconcileWorkerAuthProviderTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/auth/OidcReconcileWorkerAuthProviderTest.java
@@ -22,6 +22,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
@@ -29,9 +31,10 @@ import org.junit.jupiter.api.Test;
 class OidcReconcileWorkerAuthProviderTest {
 
   @Test
-  void cachesTokenUntilRefreshWindow() {
+  void cachesTokenUntilRefreshWindowForSameAccount() {
     MutableClock clock = new MutableClock(Instant.parse("2026-05-07T12:00:00Z"));
     AtomicInteger calls = new AtomicInteger();
+    List<String> requestBodies = new ArrayList<>();
     OidcReconcileWorkerAuthProvider provider =
         new OidcReconcileWorkerAuthProvider(
             Optional.of("http://issuer"),
@@ -40,14 +43,49 @@ class OidcReconcileWorkerAuthProviderTest {
             30,
             Duration.ofSeconds(10),
             clock,
-            (endpoint, requestBody, connectTimeout) ->
-                new OidcReconcileWorkerAuthProvider.TokenResponse(
-                    "token-" + calls.incrementAndGet(), 120));
+            (endpoint, requestBody, connectTimeout) -> {
+              requestBodies.add(requestBody);
+              return new OidcReconcileWorkerAuthProvider.TokenResponse(
+                  "token-" + calls.incrementAndGet(), 120);
+            });
 
-    assertThat(provider.authorizationHeader()).contains("Bearer token-1");
+    assertThat(provider.authorizationHeader("account-a")).contains("Bearer token-1");
     clock.advanceSeconds(60);
-    assertThat(provider.authorizationHeader()).contains("Bearer token-1");
+    assertThat(provider.authorizationHeader("account-a")).contains("Bearer token-1");
     assertThat(calls.get()).isEqualTo(1);
+    assertThat(requestBodies)
+        .containsExactly(
+            "client_id=worker-client&client_secret=worker-secret&grant_type=client_credentials&account_id=account-a");
+  }
+
+  @Test
+  void cachesTokensSeparatelyPerAccount() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-05-07T12:00:00Z"));
+    AtomicInteger calls = new AtomicInteger();
+    List<String> requestBodies = new ArrayList<>();
+    OidcReconcileWorkerAuthProvider provider =
+        new OidcReconcileWorkerAuthProvider(
+            Optional.of("http://issuer"),
+            Optional.of("worker-client"),
+            Optional.of("worker-secret"),
+            30,
+            Duration.ofSeconds(10),
+            clock,
+            (endpoint, requestBody, connectTimeout) -> {
+              requestBodies.add(requestBody);
+              return new OidcReconcileWorkerAuthProvider.TokenResponse(
+                  "token-" + calls.incrementAndGet(), 120);
+            });
+
+    assertThat(provider.authorizationHeader("account-a")).contains("Bearer token-1");
+    assertThat(provider.authorizationHeader("account-b")).contains("Bearer token-2");
+    assertThat(provider.authorizationHeader("account-a")).contains("Bearer token-1");
+    assertThat(provider.authorizationHeader("account-b")).contains("Bearer token-2");
+    assertThat(calls.get()).isEqualTo(2);
+    assertThat(requestBodies)
+        .containsExactly(
+            "client_id=worker-client&client_secret=worker-secret&grant_type=client_credentials&account_id=account-a",
+            "client_id=worker-client&client_secret=worker-secret&grant_type=client_credentials&account_id=account-b");
   }
 
   @Test
@@ -66,9 +104,9 @@ class OidcReconcileWorkerAuthProviderTest {
                 new OidcReconcileWorkerAuthProvider.TokenResponse(
                     "token-" + calls.incrementAndGet(), 120));
 
-    assertThat(provider.authorizationHeader()).contains("Bearer token-1");
+    assertThat(provider.authorizationHeader("account-a")).contains("Bearer token-1");
     clock.advanceSeconds(91);
-    assertThat(provider.authorizationHeader()).contains("Bearer token-2");
+    assertThat(provider.authorizationHeader("account-a")).contains("Bearer token-2");
     assertThat(calls.get()).isEqualTo(2);
   }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendMetadataTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendMetadataTest.java
@@ -41,10 +41,13 @@ class GrpcReconcilerBackendMetadataTest {
 
     Metadata.Key<String> correlationKey =
         Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
+    Metadata.Key<String> accountKey =
+        Metadata.Key.of("x-floe-account", Metadata.ASCII_STRING_MARSHALLER);
     Metadata.Key<String> authorizationKey =
         Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
 
     assertThat(metadata.get(correlationKey)).isEqualTo("corr");
+    assertThat(metadata.get(accountKey)).isEqualTo("acct");
     assertThat(metadata.get(authorizationKey)).isEqualTo("Bearer secret-token");
   }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClientTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClientTest.java
@@ -60,12 +60,14 @@ class GrpcRemoteReconcileExecutorClientTest {
   void metadataIncludesExplicitWorkerAuthorizationHeader() {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
 
-    Metadata metadata = client.metadata("corr-1");
+    Metadata metadata = client.metadata("corr-1", "acct-1");
 
     assertThat(metadata.get(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)))
         .isEqualTo("Bearer worker-token");
+    assertThat(metadata.get(Metadata.Key.of("x-floe-account", Metadata.ASCII_STRING_MARSHALLER)))
+        .isEqualTo("acct-1");
     assertThat(metadata.get(Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER)))
         .isEqualTo("corr-1");
   }
@@ -73,10 +75,11 @@ class GrpcRemoteReconcileExecutorClientTest {
   @Test
   void oidcModeRequiresWorkerAuthorizationHeader() {
     GrpcRemoteReconcileExecutorClient client =
-        new GrpcRemoteReconcileExecutorClient("authorization", java.util.Optional::empty);
+        new GrpcRemoteReconcileExecutorClient(
+            "authorization", ignored -> java.util.Optional.empty());
 
     IllegalStateException ex =
-        assertThrows(IllegalStateException.class, () -> client.metadata("corr-2"));
+        assertThrows(IllegalStateException.class, () -> client.metadata("corr-2", null));
 
     assertThat(ex).hasMessageContaining("Reconcile worker authorization header is required");
   }
@@ -84,9 +87,10 @@ class GrpcRemoteReconcileExecutorClientTest {
   @Test
   void workerAuthCanBeExplicitlyDisabled() {
     GrpcRemoteReconcileExecutorClient client =
-        new GrpcRemoteReconcileExecutorClient("authorization", false, java.util.Optional::empty);
+        new GrpcRemoteReconcileExecutorClient(
+            "authorization", false, ignored -> java.util.Optional.empty());
 
-    Metadata metadata = client.metadata("corr-disabled");
+    Metadata metadata = client.metadata("corr-disabled", null);
 
     assertThat(metadata.get(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)))
         .isNull();
@@ -98,9 +102,9 @@ class GrpcRemoteReconcileExecutorClientTest {
   void workerCallsUseSessionHeaderWhenConfigured() {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "x-floe-session", () -> java.util.Optional.of("Bearer worker-token"));
+            "x-floe-session", ignored -> java.util.Optional.of("Bearer worker-token"));
 
-    Metadata metadata = client.metadata("corr-3");
+    Metadata metadata = client.metadata("corr-3", null);
 
     assertThat(metadata.keys()).contains("x-correlation-id");
     assertThat(metadata.get(Metadata.Key.of("x-floe-session", Metadata.ASCII_STRING_MARSHALLER)))
@@ -108,10 +112,30 @@ class GrpcRemoteReconcileExecutorClientTest {
   }
 
   @Test
+  void metadataUsesAccountScopedWorkerAuthorizationWithoutLeakage() {
+    GrpcRemoteReconcileExecutorClient client =
+        new GrpcRemoteReconcileExecutorClient(
+            "authorization",
+            accountId -> java.util.Optional.of("Bearer worker-token-" + accountId));
+
+    Metadata accountOne = client.metadata("corr-1", "acct-1");
+    Metadata accountTwo = client.metadata("corr-2", "acct-2");
+
+    assertThat(accountOne.get(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)))
+        .isEqualTo("Bearer worker-token-acct-1");
+    assertThat(accountTwo.get(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)))
+        .isEqualTo("Bearer worker-token-acct-2");
+    assertThat(accountOne.get(Metadata.Key.of("x-floe-account", Metadata.ASCII_STRING_MARSHALLER)))
+        .isEqualTo("acct-1");
+    assertThat(accountTwo.get(Metadata.Key.of("x-floe-account", Metadata.ASCII_STRING_MARSHALLER)))
+        .isEqualTo("acct-2");
+  }
+
+  @Test
   void planConnectorInputPreservesSnapshotSelection() {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     client.executorControl =
         mock(ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub.class);
     when(client.executorControl.withInterceptors(any())).thenReturn(client.executorControl);
@@ -145,7 +169,7 @@ class GrpcRemoteReconcileExecutorClientTest {
   void planTableInputPreservesSnapshotSelection() {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     client.executorControl =
         mock(ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub.class);
     when(client.executorControl.withInterceptors(any())).thenReturn(client.executorControl);
@@ -181,7 +205,7 @@ class GrpcRemoteReconcileExecutorClientTest {
   void submitPlanSnapshotSuccessOmitsDuplicateSnapshotFileGroupsWhenFileGroupJobsArePresent() {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     client.executorControl =
         mock(ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub.class);
     client.snapshotPlanBlobStore = mock(SnapshotPlanBlobStore.class);
@@ -242,7 +266,7 @@ class GrpcRemoteReconcileExecutorClientTest {
   void renewRetriesOnceOnTransportFailure() {
     TransportLoggingClient client =
         new TransportLoggingClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     client.executorControl =
         mock(ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub.class);
     when(client.executorControl.withInterceptors(any())).thenReturn(client.executorControl);
@@ -266,7 +290,7 @@ class GrpcRemoteReconcileExecutorClientTest {
   void closeWorkerControlChannelUsesGracefulShutdownForReset() throws Exception {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     ManagedChannel channel = mock(ManagedChannel.class);
 
     client.closeWorkerControlChannel(channel, false);
@@ -281,7 +305,7 @@ class GrpcRemoteReconcileExecutorClientTest {
   void closeWorkerControlChannelUsesForcedShutdownForDestroy() throws Exception {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     ManagedChannel channel = mock(ManagedChannel.class);
     when(channel.awaitTermination(5, TimeUnit.SECONDS)).thenReturn(true);
 
@@ -296,7 +320,7 @@ class GrpcRemoteReconcileExecutorClientTest {
   void submitFileGroupSuccessRetriesWhenResultIdIsStable() {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     client.executorControl =
         mock(ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub.class);
     when(client.executorControl.withInterceptors(any())).thenReturn(client.executorControl);
@@ -318,7 +342,7 @@ class GrpcRemoteReconcileExecutorClientTest {
   void submitFileGroupSuccessDoesNotRetryWhenResultIdIsBlank() {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     client.executorControl =
         mock(ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub.class);
     when(client.executorControl.withInterceptors(any())).thenReturn(client.executorControl);
@@ -338,7 +362,7 @@ class GrpcRemoteReconcileExecutorClientTest {
   void submitFileGroupSuccessSendsUploadedArtifactManifestWithoutInlineContent() {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     client.executorControl =
         mock(ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub.class);
     when(client.executorControl.withInterceptors(any())).thenReturn(client.executorControl);
@@ -375,7 +399,7 @@ class GrpcRemoteReconcileExecutorClientTest {
   void submitFileGroupSuccessSendsFileStatsBlobManifestWithoutInlineStats() {
     GrpcRemoteReconcileExecutorClient client =
         new GrpcRemoteReconcileExecutorClient(
-            "authorization", () -> java.util.Optional.of("Bearer worker-token"));
+            "authorization", ignored -> java.util.Optional.of("Bearer worker-token"));
     client.executorControl =
         mock(ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub.class);
     when(client.executorControl.withInterceptors(any())).thenReturn(client.executorControl);

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutorTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutorTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.reconciler.auth.ReconcileWorkerAuthProvider;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RemoteDefaultReconcileExecutorTest {
+
+  @Test
+  void executeTableDoesNotLeakWorkerAuthorizationAcrossAccounts() {
+    ReconcilerService reconcilerService = mock(ReconcilerService.class);
+    QueuedReconcileWorkerSupport queuedWorkerSupport = mock(QueuedReconcileWorkerSupport.class);
+    RemotePlannerWorkerClient workerClient = mock(RemotePlannerWorkerClient.class);
+    ReconcileWorkerAuthProvider authProvider =
+        accountId -> java.util.Optional.of("Bearer worker-token-" + accountId);
+    var executor =
+        new RemoteDefaultReconcileExecutor(
+            reconcilerService, queuedWorkerSupport, workerClient, authProvider, true);
+
+    ReconcileJobStore.LeasedJob leaseOne = tableLease("job-1", "acct-a");
+    ReconcileJobStore.LeasedJob leaseTwo = tableLease("job-2", "acct-b");
+    RemoteLeasedJob remoteLeaseOne = new RemoteLeasedJob(leaseOne);
+    RemoteLeasedJob remoteLeaseTwo = new RemoteLeasedJob(leaseTwo);
+
+    when(workerClient.getPlanTableInput(remoteLeaseOne))
+        .thenReturn(planTablePayload(leaseOne, connectorId("acct-a")));
+    when(workerClient.getPlanTableInput(remoteLeaseTwo))
+        .thenReturn(planTablePayload(leaseTwo, connectorId("acct-b")));
+    when(queuedWorkerSupport.executePlannedTable(
+            any(),
+            eq(connectorId("acct-a")),
+            eq(false),
+            any(),
+            any(),
+            eq(ReconcilerService.CaptureMode.METADATA_ONLY),
+            eq("Bearer worker-token-acct-a"),
+            any(),
+            any()))
+        .thenReturn(
+            new QueuedReconcileWorkerSupport.TableExecutionResult(
+                ReconcileExecutor.ExecutionResult.successHandled(1, 0, 0, 0, 0, 0, 0, "ok"),
+                List.of()));
+    when(queuedWorkerSupport.executePlannedTable(
+            any(),
+            eq(connectorId("acct-b")),
+            eq(false),
+            any(),
+            any(),
+            eq(ReconcilerService.CaptureMode.METADATA_ONLY),
+            eq("Bearer worker-token-acct-b"),
+            any(),
+            any()))
+        .thenReturn(
+            new QueuedReconcileWorkerSupport.TableExecutionResult(
+                ReconcileExecutor.ExecutionResult.successHandled(1, 0, 0, 0, 0, 0, 0, "ok"),
+                List.of()));
+    when(workerClient.submitPlanTableSuccess(
+            any(), any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong()))
+        .thenReturn(true);
+
+    assertTrue(
+        executor
+            .execute(
+                new ReconcileExecutor.ExecutionContext(
+                    leaseOne, () -> false, (a, b, c, d, e, f, g, h) -> {}))
+            .ok());
+    assertTrue(
+        executor
+            .execute(
+                new ReconcileExecutor.ExecutionContext(
+                    leaseTwo, () -> false, (a, b, c, d, e, f, g, h) -> {}))
+            .ok());
+
+    verify(queuedWorkerSupport)
+        .executePlannedTable(
+            any(),
+            eq(connectorId("acct-a")),
+            eq(false),
+            any(),
+            any(),
+            eq(ReconcilerService.CaptureMode.METADATA_ONLY),
+            eq("Bearer worker-token-acct-a"),
+            any(),
+            any());
+    verify(queuedWorkerSupport)
+        .executePlannedTable(
+            any(),
+            eq(connectorId("acct-b")),
+            eq(false),
+            any(),
+            any(),
+            eq(ReconcilerService.CaptureMode.METADATA_ONLY),
+            eq("Bearer worker-token-acct-b"),
+            any(),
+            any());
+  }
+
+  private static ReconcileJobStore.LeasedJob tableLease(String jobId, String accountId) {
+    return new ReconcileJobStore.LeasedJob(
+        jobId,
+        accountId,
+        "connector-1",
+        false,
+        ReconcilerService.CaptureMode.METADATA_ONLY,
+        ReconcileScope.empty(),
+        ReconcileExecutionPolicy.defaults(),
+        "lease-" + jobId,
+        "",
+        "",
+        ReconcileJobKind.PLAN_TABLE,
+        ReconcileTableTask.of("src", "table", "ns", "table-1", "table-1"),
+        ReconcileViewTask.empty(),
+        ReconcileSnapshotTask.empty(),
+        ai.floedb.floecat.reconciler.jobs.ReconcileFileGroupTask.empty(),
+        "");
+  }
+
+  private static StandalonePlanTablePayload planTablePayload(
+      ReconcileJobStore.LeasedJob lease, ResourceId connectorId) {
+    return new StandalonePlanTablePayload(
+        lease.jobId,
+        lease.leaseEpoch,
+        "",
+        connectorId,
+        lease.captureMode,
+        false,
+        ReconcileScope.empty(),
+        lease.tableTask);
+  }
+
+  private static ResourceId connectorId(String accountId) {
+    return ResourceId.newBuilder()
+        .setAccountId(accountId)
+        .setKind(ResourceKind.RK_CONNECTOR)
+        .setId("connector-1")
+        .build();
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemotePlannerReconcileExecutorTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemotePlannerReconcileExecutorTest.java
@@ -47,7 +47,8 @@ class RemotePlannerReconcileExecutorTest {
   void executeMarksMissingPinnedDestinationTableIdTerminal() {
     ReconcilerService reconcilerService = mock(ReconcilerService.class);
     RemotePlannerWorkerClient workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = () -> java.util.Optional.of("Bearer worker-token");
+    ReconcileWorkerAuthProvider authProvider =
+        ignored -> java.util.Optional.of("Bearer worker-token");
     var executor =
         new RemotePlannerReconcileExecutor(reconcilerService, workerClient, authProvider, true);
 
@@ -124,7 +125,8 @@ class RemotePlannerReconcileExecutorTest {
   void executeMarksMissingAwsCredentialsTerminal() {
     ReconcilerService reconcilerService = mock(ReconcilerService.class);
     RemotePlannerWorkerClient workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = () -> java.util.Optional.of("Bearer worker-token");
+    ReconcileWorkerAuthProvider authProvider =
+        ignored -> java.util.Optional.of("Bearer worker-token");
     var executor =
         new RemotePlannerReconcileExecutor(reconcilerService, workerClient, authProvider, true);
 
@@ -198,7 +200,8 @@ class RemotePlannerReconcileExecutorTest {
   void executeUsesWorkerAuthorizationForScopedViewPlanning() {
     ReconcilerService reconcilerService = mock(ReconcilerService.class);
     RemotePlannerWorkerClient workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = () -> java.util.Optional.of("Bearer worker-token");
+    ReconcileWorkerAuthProvider authProvider =
+        ignored -> java.util.Optional.of("Bearer worker-token");
     var executor =
         new RemotePlannerReconcileExecutor(reconcilerService, workerClient, authProvider, true);
 
@@ -258,7 +261,8 @@ class RemotePlannerReconcileExecutorTest {
   void executeUsesWorkerAuthorizationForScopedCaptureOnlyTablePlanning() {
     ReconcilerService reconcilerService = mock(ReconcilerService.class);
     RemotePlannerWorkerClient workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = () -> java.util.Optional.of("Bearer worker-token");
+    ReconcileWorkerAuthProvider authProvider =
+        ignored -> java.util.Optional.of("Bearer worker-token");
     var executor =
         new RemotePlannerReconcileExecutor(reconcilerService, workerClient, authProvider, true);
 
@@ -339,7 +343,8 @@ class RemotePlannerReconcileExecutorTest {
   void executePreservesSnapshotSelectionForScopedSingleTablePlanning() {
     ReconcilerService reconcilerService = mock(ReconcilerService.class);
     RemotePlannerWorkerClient workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = () -> java.util.Optional.of("Bearer worker-token");
+    ReconcileWorkerAuthProvider authProvider =
+        ignored -> java.util.Optional.of("Bearer worker-token");
     var executor =
         new RemotePlannerReconcileExecutor(reconcilerService, workerClient, authProvider, true);
 
@@ -417,5 +422,95 @@ class RemotePlannerReconcileExecutorTest {
                         && tableJobs.getFirst().scope().snapshotSelection().kind()
                             == ReconcileSnapshotSelection.Kind.CURRENT),
             any());
+  }
+
+  @Test
+  void executeDoesNotLeakWorkerAuthorizationAcrossAccounts() {
+    ReconcilerService reconcilerService = mock(ReconcilerService.class);
+    RemotePlannerWorkerClient workerClient = mock(RemotePlannerWorkerClient.class);
+    ReconcileWorkerAuthProvider authProvider =
+        accountId -> java.util.Optional.of("Bearer worker-token-" + accountId);
+    var executor =
+        new RemotePlannerReconcileExecutor(reconcilerService, workerClient, authProvider, true);
+
+    ReconcileScope scope = ReconcileScope.ofView(List.of(), "view-1");
+    ReconcileJobStore.LeasedJob leaseOne = lease("job-1", "acct-a", scope);
+    ReconcileJobStore.LeasedJob leaseTwo = lease("job-2", "acct-b", scope);
+    RemoteLeasedJob remoteLeaseOne = new RemoteLeasedJob(leaseOne);
+    RemoteLeasedJob remoteLeaseTwo = new RemoteLeasedJob(leaseTwo);
+
+    when(workerClient.getPlanConnectorInput(remoteLeaseOne))
+        .thenReturn(planConnectorPayload(leaseOne, connectorId("acct-a"), scope));
+    when(workerClient.getPlanConnectorInput(remoteLeaseTwo))
+        .thenReturn(planConnectorPayload(leaseTwo, connectorId("acct-b"), scope));
+    when(reconcilerService.planViewTasks(
+            any(), eq(connectorId("acct-a")), eq(scope), eq("Bearer worker-token-acct-a")))
+        .thenReturn(List.of(ReconcileViewTask.of("src", "view", "ns", "view-1")));
+    when(reconcilerService.planViewTasks(
+            any(), eq(connectorId("acct-b")), eq(scope), eq("Bearer worker-token-acct-b")))
+        .thenReturn(List.of(ReconcileViewTask.of("src", "view", "ns", "view-1")));
+    when(workerClient.submitPlanConnectorSuccess(any(), any(), any())).thenReturn(true);
+
+    assertTrue(
+        executor
+            .execute(
+                new ReconcileExecutor.ExecutionContext(
+                    leaseOne, () -> false, (a, b, c, d, e, f, g, h) -> {}))
+            .ok());
+    assertTrue(
+        executor
+            .execute(
+                new ReconcileExecutor.ExecutionContext(
+                    leaseTwo, () -> false, (a, b, c, d, e, f, g, h) -> {}))
+            .ok());
+
+    verify(reconcilerService)
+        .planViewTasks(
+            any(), eq(connectorId("acct-a")), eq(scope), eq("Bearer worker-token-acct-a"));
+    verify(reconcilerService)
+        .planViewTasks(
+            any(), eq(connectorId("acct-b")), eq(scope), eq("Bearer worker-token-acct-b"));
+  }
+
+  private static ReconcileJobStore.LeasedJob lease(
+      String jobId, String accountId, ReconcileScope scope) {
+    return new ReconcileJobStore.LeasedJob(
+        jobId,
+        accountId,
+        "connector-1",
+        false,
+        ReconcilerService.CaptureMode.METADATA_AND_CAPTURE,
+        scope,
+        ReconcileExecutionPolicy.defaults(),
+        "lease-" + jobId,
+        "",
+        "",
+        ReconcileJobKind.PLAN_CONNECTOR,
+        ReconcileTableTask.empty(),
+        ReconcileViewTask.empty(),
+        ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask.empty(),
+        ai.floedb.floecat.reconciler.jobs.ReconcileFileGroupTask.empty(),
+        "");
+  }
+
+  private static StandalonePlanConnectorPayload planConnectorPayload(
+      ReconcileJobStore.LeasedJob lease, ResourceId connectorId, ReconcileScope scope) {
+    return new StandalonePlanConnectorPayload(
+        lease.jobId,
+        lease.leaseEpoch,
+        connectorId,
+        lease.captureMode,
+        false,
+        scope,
+        ReconcileExecutionPolicy.defaults(),
+        "");
+  }
+
+  private static ResourceId connectorId(String accountId) {
+    return ResourceId.newBuilder()
+        .setAccountId(accountId)
+        .setKind(ResourceKind.RK_CONNECTOR)
+        .setId("connector-1")
+        .build();
   }
 }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutorTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutorTest.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -44,6 +45,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class RemoteSnapshotPlanningReconcileExecutorTest {
 
@@ -51,7 +53,7 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
   void executeUsesDirectStatsFastPathForStatsOnlySnapshot() {
     var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
     var workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = java.util.Optional::<String>empty;
+    ReconcileWorkerAuthProvider authProvider = ignored -> java.util.Optional.empty();
     var executor =
         new RemoteSnapshotPlanningReconcileExecutor(backend, workerClient, authProvider, 2, true);
 
@@ -107,7 +109,7 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
   void executeFallsBackToFileGroupsWhenPageIndexesAreRequested() {
     var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
     var workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = java.util.Optional::<String>empty;
+    ReconcileWorkerAuthProvider authProvider = ignored -> java.util.Optional.empty();
     var executor =
         new RemoteSnapshotPlanningReconcileExecutor(backend, workerClient, authProvider, 2, true);
 
@@ -168,7 +170,7 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
   void executeFallsBackToFileGroupsWhenDirectStatsAreUnavailable() {
     var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
     var workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = java.util.Optional::<String>empty;
+    ReconcileWorkerAuthProvider authProvider = ignored -> java.util.Optional.empty();
     var executor =
         new RemoteSnapshotPlanningReconcileExecutor(backend, workerClient, authProvider, 2, true);
 
@@ -218,7 +220,7 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
   void executePersistsGrpcFailureDetailsForSnapshotPlanningErrors() {
     var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
     var workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = java.util.Optional::<String>empty;
+    ReconcileWorkerAuthProvider authProvider = ignored -> java.util.Optional.empty();
     var executor =
         new RemoteSnapshotPlanningReconcileExecutor(backend, workerClient, authProvider, 2, true);
 
@@ -259,7 +261,7 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
   void executeDoesNotRequirePersistedSnapshotMetadataForCaptureOnlyPlanning() {
     var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
     var workerClient = mock(RemotePlannerWorkerClient.class);
-    ReconcileWorkerAuthProvider authProvider = java.util.Optional::<String>empty;
+    ReconcileWorkerAuthProvider authProvider = ignored -> java.util.Optional.empty();
     var executor =
         new RemoteSnapshotPlanningReconcileExecutor(backend, workerClient, authProvider, 2, true);
 
@@ -288,16 +290,77 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
     verify(backend, never()).fetchSnapshot(any(), any(), anyLong());
   }
 
+  @Test
+  void executeDoesNotLeakWorkerAuthorizationAcrossAccounts() {
+    var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
+    var workerClient = mock(RemotePlannerWorkerClient.class);
+    ReconcileWorkerAuthProvider authProvider =
+        accountId -> java.util.Optional.of("Bearer worker-token-" + accountId);
+    var executor =
+        new RemoteSnapshotPlanningReconcileExecutor(backend, workerClient, authProvider, 2, true);
+
+    ReconcileJobStore.LeasedJob leaseOne = lease("job-1", "acct-a", statsOnlyScope());
+    ReconcileJobStore.LeasedJob leaseTwo = lease("job-2", "acct-b", statsOnlyScope());
+
+    when(workerClient.getPlanSnapshotInput(any()))
+        .thenAnswer(
+            invocation -> {
+              RemoteLeasedJob remoteLease = invocation.getArgument(0);
+              ReconcileJobStore.LeasedJob lease = remoteLease.lease();
+              return new StandalonePlanSnapshotPayload(
+                  lease.jobId,
+                  lease.leaseEpoch,
+                  "",
+                  connectorId(lease.accountId),
+                  ReconcilerService.CaptureMode.CAPTURE_ONLY,
+                  false,
+                  statsOnlyScope(),
+                  snapshotTask());
+            });
+    when(backend.captureSnapshotTargetStatsDirect(any(), any(), eq(55L), any(), any(), any()))
+        .thenReturn(Optional.of(List.of()));
+    when(workerClient.submitPlanSnapshotSuccess(any(), any(), any(), any())).thenReturn(true);
+
+    assertTrue(
+        executor
+            .execute(
+                new ReconcileExecutor.ExecutionContext(
+                    leaseOne, () -> false, (a, b, c, d, e, f, g, h) -> {}))
+            .ok());
+    assertTrue(
+        executor
+            .execute(
+                new ReconcileExecutor.ExecutionContext(
+                    leaseTwo, () -> false, (a, b, c, d, e, f, g, h) -> {}))
+            .ok());
+
+    ArgumentCaptor<ai.floedb.floecat.reconciler.spi.ReconcileContext> contextCaptor =
+        ArgumentCaptor.forClass(ai.floedb.floecat.reconciler.spi.ReconcileContext.class);
+    verify(backend, org.mockito.Mockito.times(2))
+        .captureSnapshotTargetStatsDirect(
+            contextCaptor.capture(), any(), eq(55L), any(), any(), any());
+    assertThat(contextCaptor.getAllValues())
+        .extracting(
+            ctx ->
+                ctx.principal().getAccountId() + "|" + ctx.authorizationToken().orElse("<missing>"))
+        .containsExactly("acct-a|Bearer worker-token-acct-a", "acct-b|Bearer worker-token-acct-b");
+  }
+
   private static ReconcileJobStore.LeasedJob lease(ReconcileScope scope) {
+    return lease("job-1", "acct", scope);
+  }
+
+  private static ReconcileJobStore.LeasedJob lease(
+      String jobId, String accountId, ReconcileScope scope) {
     return new ReconcileJobStore.LeasedJob(
-        "job-1",
-        "acct",
+        jobId,
+        accountId,
         "connector-1",
         false,
         ReconcilerService.CaptureMode.CAPTURE_ONLY,
         scope,
         ReconcileExecutionPolicy.defaults(),
-        "lease-1",
+        "lease-" + jobId,
         "",
         "",
         ReconcileJobKind.PLAN_SNAPSHOT,
@@ -334,8 +397,12 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
   }
 
   private static ResourceId connectorId() {
+    return connectorId("acct");
+  }
+
+  private static ResourceId connectorId(String accountId) {
     return ResourceId.newBuilder()
-        .setAccountId("acct")
+        .setAccountId(accountId)
         .setKind(ResourceKind.RK_CONNECTOR)
         .setId("connector-1")
         .build();

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/StandaloneJavaFileGroupExecutionRunnerTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/StandaloneJavaFileGroupExecutionRunnerTest.java
@@ -41,7 +41,7 @@ class StandaloneJavaFileGroupExecutionRunnerTest {
   void executePassesWorkerAuthorizationToCaptureEngine() {
     var runner = new StandaloneJavaFileGroupExecutionRunner();
     runner.captureEngineRegistry = mock(CaptureEngineRegistry.class);
-    runner.reconcileWorkerAuthProvider = () -> Optional.of("Bearer worker-token");
+    runner.reconcileWorkerAuthProvider = ignored -> Optional.of("Bearer worker-token");
     when(runner.captureEngineRegistry.capture(any())).thenReturn(CaptureEngineResult.empty());
 
     runner.execute(payload());
@@ -56,7 +56,7 @@ class StandaloneJavaFileGroupExecutionRunnerTest {
   void executeAllowsMissingWorkerAuthorization() {
     var runner = new StandaloneJavaFileGroupExecutionRunner();
     runner.captureEngineRegistry = mock(CaptureEngineRegistry.class);
-    runner.reconcileWorkerAuthProvider = Optional::<String>empty;
+    runner.reconcileWorkerAuthProvider = ignored -> Optional.empty();
     when(runner.captureEngineRegistry.capture(any())).thenReturn(CaptureEngineResult.empty());
 
     runner.execute(payload());
@@ -67,7 +67,32 @@ class StandaloneJavaFileGroupExecutionRunnerTest {
     assertThat(request.getValue().authorizationToken()).isEmpty();
   }
 
+  @Test
+  void executeDoesNotLeakWorkerAuthorizationAcrossAccounts() {
+    var runner = new StandaloneJavaFileGroupExecutionRunner();
+    runner.captureEngineRegistry = mock(CaptureEngineRegistry.class);
+    runner.reconcileWorkerAuthProvider =
+        accountId -> Optional.of("Bearer worker-token-" + accountId);
+    when(runner.captureEngineRegistry.capture(any())).thenReturn(CaptureEngineResult.empty());
+
+    runner.execute(payload("acct-a"));
+    runner.execute(payload("acct-b"));
+
+    ArgumentCaptor<CaptureEngineRequest> request =
+        ArgumentCaptor.forClass(CaptureEngineRequest.class);
+    org.mockito.Mockito.verify(runner.captureEngineRegistry, org.mockito.Mockito.times(2))
+        .capture(request.capture());
+    assertThat(request.getAllValues())
+        .extracting(CaptureEngineRequest::authorizationToken)
+        .containsExactly(
+            Optional.of("Bearer worker-token-acct-a"), Optional.of("Bearer worker-token-acct-b"));
+  }
+
   private static StandaloneFileGroupExecutionPayload payload() {
+    return payload("acct");
+  }
+
+  private static StandaloneFileGroupExecutionPayload payload(String accountId) {
     return new StandaloneFileGroupExecutionPayload(
         "job-1",
         "lease-1",
@@ -76,7 +101,7 @@ class StandaloneJavaFileGroupExecutionRunnerTest {
         "ns",
         "table",
         ResourceId.newBuilder()
-            .setAccountId("acct")
+            .setAccountId(accountId)
             .setKind(ResourceKind.RK_TABLE)
             .setId("table-id")
             .build(),


### PR DESCRIPTION
## Summary

This branch tightens reconciler account routing for remote workers by carrying the leased job’s target account through planner, table, snapshot, and file-group execution paths. It adds explicit account metadata on worker-control and backend gRPC calls, passes account-aware worker auth through all remote execution entry points, and fixes the OIDC worker auth provider so tokens are cached per account instead of leaking across accounts.

Test coverage was expanded across the reconciler remote-worker stack to prove account-specific auth propagation and to catch cross-account token reuse.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [ ] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
