### PR TITLE
Atomically replace stats on full rescan

### DIFF
--- a/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsStore.java
+++ b/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsStore.java
@@ -74,6 +74,21 @@ public interface StatsStore {
   boolean deleteAllStatsForSnapshot(ResourceId tableId, long snapshotId);
 
   /**
+   * Replaces all target stats for a table snapshot.
+   *
+   * <p>Implementations should publish the replacement set atomically when the backing store
+   * supports multi-pointer CAS. The default implementation preserves correctness for simple test
+   * stores.
+   */
+  default void replaceAllStatsForSnapshot(
+      ResourceId tableId, long snapshotId, List<TargetStatsRecord> records) {
+    deleteAllStatsForSnapshot(tableId, snapshotId);
+    for (TargetStatsRecord record : records == null ? List.<TargetStatsRecord>of() : records) {
+      putTargetStats(record);
+    }
+  }
+
+  /**
    * Returns mutation metadata for an exact table/snapshot/target key.
    *
    * <p>{@code nowTs} is used to stamp metadata when no record exists yet.

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizeReconcileExecutor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizeReconcileExecutor.java
@@ -118,11 +118,17 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
     }
     boolean requestsStatsOutputs = requestsStatsOutputs(lease);
     Set<FloecatConnector.StatsTargetKind> aggregateKinds = requestedAggregateKinds(lease);
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId(lease.accountId)
+            .setKind(ResourceKind.RK_TABLE)
+            .setId(snapshotTask.tableId())
+            .build();
     if (coverage.state() == PlannedCoverageState.DIRECT_STATS) {
       try {
         long statsProcessed =
             requestsStatsOutputs
-                ? ingestDirectStats(snapshotTask)
+                ? ingestDirectStats(snapshotTask, tableId, lease.fullRescan)
                 : snapshotTask.directStatsRecordCount();
         return ExecutionResult.success(
             0,
@@ -168,7 +174,9 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
             new IllegalStateException("snapshot file-group child jobs unexpected for empty plan"));
       }
       long statsProcessed =
-          requestsStatsOutputs ? persistEmptySnapshotCompletionMarker(lease, snapshotTask) : 0L;
+          requestsStatsOutputs
+              ? persistEmptySnapshotCompletionMarker(lease, snapshotTask, tableId)
+              : 0L;
       return ExecutionResult.success(
           0,
           0,
@@ -285,8 +293,9 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
           0,
           "Skipped snapshot finalization " + snapshotTask.snapshotId() + " (no stats outputs)");
     }
+    List<TargetStatsRecord> loadedFileStats;
     try {
-      ingestFileGroupStatsBlobs(childState.completedGroupTasks());
+      loadedFileStats = loadFileGroupStatsBlobs(childState.completedGroupTasks());
     } catch (RuntimeException e) {
       return ExecutionResult.failure(
           0,
@@ -302,14 +311,31 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
               + e.getMessage(),
           e);
     }
-
-    ResourceId tableId =
-        ResourceId.newBuilder()
-            .setAccountId(lease.accountId)
-            .setKind(ResourceKind.RK_TABLE)
-            .setId(snapshotTask.tableId())
-            .build();
-    List<TargetStatsRecord> fileStats = listFileStats(tableId, snapshotTask.snapshotId());
+    if (lease.fullRescan) {
+      CoverageValidation coverageValidation =
+          validateCoverage(coverage.expectedFiles(), loadedFileStats);
+      if (!coverageValidation.valid()) {
+        return ExecutionResult.terminalFailure(
+            0,
+            0,
+            0,
+            0,
+            coverageValidation.missingFiles().size()
+                + coverageValidation.unexpectedFiles().size()
+                + coverageValidation.duplicateFiles().size(),
+            0,
+            0,
+            coverageValidation.message(),
+            new IllegalStateException(coverageValidation.message()));
+      }
+      statsStore.replaceAllStatsForSnapshot(tableId, snapshotTask.snapshotId(), loadedFileStats);
+    } else {
+      persistLoadedFileStats(loadedFileStats);
+    }
+    List<TargetStatsRecord> fileStats =
+        lease.fullRescan
+            ? List.copyOf(loadedFileStats)
+            : listFileStats(tableId, snapshotTask.snapshotId());
     CoverageValidation coverageValidation = validateCoverage(coverage.expectedFiles(), fileStats);
     if (!coverageValidation.valid()) {
       return ExecutionResult.terminalFailure(
@@ -357,24 +383,14 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
   }
 
   private long persistEmptySnapshotCompletionMarker(
-      ReconcileJobStore.LeasedJob lease, ReconcileSnapshotTask snapshotTask) {
+      ReconcileJobStore.LeasedJob lease, ReconcileSnapshotTask snapshotTask, ResourceId tableId) {
     if (lease == null
         || snapshotTask == null
+        || tableId == null
         || lease.accountId == null
         || lease.accountId.isBlank()
         || snapshotTask.tableId().isBlank()
         || snapshotTask.snapshotId() < 0L) {
-      return 0L;
-    }
-    ResourceId tableId =
-        ResourceId.newBuilder()
-            .setAccountId(lease.accountId)
-            .setKind(ResourceKind.RK_TABLE)
-            .setId(snapshotTask.tableId())
-            .build();
-    if (statsStore
-        .getTargetStats(tableId, snapshotTask.snapshotId(), StatsTargetIdentity.tableTarget())
-        .isPresent()) {
       return 0L;
     }
     TargetStatsRecord zeroMarker =
@@ -387,6 +403,16 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
                 .setTotalSizeBytes(0L)
                 .build(),
             null);
+    if (lease.fullRescan) {
+      statsStore.replaceAllStatsForSnapshot(
+          tableId, snapshotTask.snapshotId(), List.of(TargetStatsRecords.canonicalize(zeroMarker)));
+      return 1L;
+    }
+    if (statsStore
+        .getTargetStats(tableId, snapshotTask.snapshotId(), StatsTargetIdentity.tableTarget())
+        .isPresent()) {
+      return 0L;
+    }
     if (statsStore.putTargetStatsIfAbsent(zeroMarker)) {
       return 1L;
     }
@@ -570,7 +596,8 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
         "");
   }
 
-  private long ingestDirectStats(ReconcileSnapshotTask snapshotTask) {
+  private long ingestDirectStats(
+      ReconcileSnapshotTask snapshotTask, ResourceId tableId, boolean fullRescan) {
     List<TargetStatsRecord> records = snapshotPlanBlobStore.loadDirectStats(snapshotTask);
     if (snapshotTask.directStatsRecordCount() > 0
         && records.size() != snapshotTask.directStatsRecordCount()) {
@@ -580,6 +607,10 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
               + " actual="
               + records.size());
     }
+    if (fullRescan) {
+      statsStore.replaceAllStatsForSnapshot(tableId, snapshotTask.snapshotId(), records);
+      return records.size();
+    }
     long processed = 0L;
     for (TargetStatsRecord record : records) {
       statsStore.putTargetStats(TargetStatsRecords.canonicalize(record));
@@ -588,8 +619,9 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
     return processed;
   }
 
-  private long ingestFileGroupStatsBlobs(List<ReconcileFileGroupTask> completedGroups) {
-    long processed = 0L;
+  private List<TargetStatsRecord> loadFileGroupStatsBlobs(
+      List<ReconcileFileGroupTask> completedGroups) {
+    List<TargetStatsRecord> allRecords = new ArrayList<>();
     List<ReconcileFileGroupTask> groups =
         completedGroups == null ? List.<ReconcileFileGroupTask>of() : completedGroups;
     for (ReconcileFileGroupTask group : groups) {
@@ -608,9 +640,17 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
                 + describeGroup(group));
       }
       for (TargetStatsRecord record : records) {
-        statsStore.putTargetStats(TargetStatsRecords.canonicalize(record));
-        processed++;
+        allRecords.add(TargetStatsRecords.canonicalize(record));
       }
+    }
+    return List.copyOf(allRecords);
+  }
+
+  private long persistLoadedFileStats(List<TargetStatsRecord> records) {
+    long processed = 0L;
+    for (TargetStatsRecord record : records == null ? List.<TargetStatsRecord>of() : records) {
+      statsStore.putTargetStats(TargetStatsRecords.canonicalize(record));
+      processed++;
     }
     return processed;
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -19,108 +19,80 @@ package ai.floedb.floecat.service.repo.impl;
 import ai.floedb.floecat.catalog.rpc.StatsTarget;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
 import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.Schemas;
-import ai.floedb.floecat.service.repo.model.TargetStatsKey;
-import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
+import ai.floedb.floecat.stats.identity.TargetStatsRecords;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsTargetType;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
+import ai.floedb.floecat.types.Hashing;
+import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @ApplicationScoped
 public class StatsRepository implements StatsStore {
 
-  private final GenericResourceRepository<TargetStatsRecord, TargetStatsKey> targetStatsRepo;
+  private final PointerStore pointerStore;
+  private final BlobStore blobStore;
+  private final TargetStatsStorage targetStatsStorage;
 
   @Inject
   public StatsRepository(PointerStore pointerStore, BlobStore blobStore) {
-    this.targetStatsRepo =
-        new GenericResourceRepository<>(
-            pointerStore,
-            blobStore,
-            Schemas.TARGET_STATS,
-            TargetStatsRecord::parseFrom,
-            TargetStatsRecord::toByteArray,
-            "application/x-protobuf");
-  }
-
-  private static String targetStatsPrefix(ResourceId tableId, long snapshotId) {
-    return Keys.snapshotTargetStatsPrefix(tableId.getAccountId(), tableId.getId(), snapshotId);
-  }
-
-  private static String targetStatsPrefixWithStorageIdPrefix(
-      ResourceId tableId, long snapshotId, String targetStorageIdPrefix) {
-    return Keys.snapshotTargetColumnStatsPrefix(
-        tableId.getAccountId(), tableId.getId(), snapshotId, targetStorageIdPrefix);
-  }
-
-  private static TargetStatsKey targetStatsLookupKey(
-      ResourceId tableId, long snapshotId, StatsTarget target) {
-    return new TargetStatsKey(
-        tableId.getAccountId(),
-        tableId.getId(),
-        snapshotId,
-        StatsTargetIdentity.storageId(target),
-        "");
+    this.pointerStore = pointerStore;
+    this.blobStore = blobStore;
+    this.targetStatsStorage = new TargetStatsStorage(pointerStore, blobStore);
   }
 
   @Override
   public void putTargetStats(TargetStatsRecord value) {
-    targetStatsRepo.create(value);
+    TargetStatsRecord canonicalRecord = canonicalRecord(value);
+    ActiveSnapshotStats active =
+        ensureActiveGeneration(canonicalRecord.getTableId(), canonicalRecord.getSnapshotId());
+    targetStatsStorage.create(
+        pointerKey(canonicalRecord, active.generationId()),
+        blobUri(canonicalRecord, active.generationId()),
+        canonicalRecord);
   }
 
   @Override
   public boolean putTargetStatsIfAbsent(TargetStatsRecord value) {
-    return targetStatsRepo.createIfAbsent(value);
+    TargetStatsRecord canonicalRecord = canonicalRecord(value);
+    ActiveSnapshotStats active =
+        ensureActiveGeneration(canonicalRecord.getTableId(), canonicalRecord.getSnapshotId());
+    return targetStatsStorage.createIfAbsent(
+        pointerKey(canonicalRecord, active.generationId()),
+        blobUri(canonicalRecord, active.generationId()),
+        canonicalRecord);
   }
 
   @Override
   public Optional<TargetStatsRecord> getTargetStats(
       ResourceId tableId, long snapshotId, StatsTarget target) {
-    return targetStatsRepo.getByKey(targetStatsLookupKey(tableId, snapshotId, target));
+    return activeGeneration(tableId, snapshotId)
+        .flatMap(
+            active ->
+                targetStatsStorage.getByPointer(
+                    targetPointerKey(tableId, snapshotId, active.generationId(), target)));
   }
 
   @Override
   public boolean deleteTargetStats(ResourceId tableId, long snapshotId, StatsTarget target) {
-    return targetStatsRepo.delete(targetStatsLookupKey(tableId, snapshotId, target));
-  }
-
-  private List<TargetStatsRecord> listTargetStats(
-      ResourceId tableId, long snapshotId, int limit, String token, StringBuilder nextOut) {
-    String prefix = targetStatsPrefix(tableId, snapshotId);
-    return targetStatsRepo.listByPrefix(prefix, limit, token, nextOut);
-  }
-
-  private int countTargetStats(ResourceId tableId, long snapshotId) {
-    String prefix = targetStatsPrefix(tableId, snapshotId);
-    return targetStatsRepo.countByPrefix(prefix);
-  }
-
-  private List<TargetStatsRecord> listTargetStatsByStoragePrefix(
-      ResourceId tableId,
-      long snapshotId,
-      String targetStorageIdPrefix,
-      int limit,
-      String token,
-      StringBuilder nextOut) {
-    String prefix =
-        targetStatsPrefixWithStorageIdPrefix(tableId, snapshotId, targetStorageIdPrefix);
-    return targetStatsRepo.listByPrefix(prefix, limit, token, nextOut);
-  }
-
-  private int countTargetStatsByStoragePrefix(
-      ResourceId tableId, long snapshotId, String targetStorageIdPrefix) {
-    String prefix =
-        targetStatsPrefixWithStorageIdPrefix(tableId, snapshotId, targetStorageIdPrefix);
-    return targetStatsRepo.countByPrefix(prefix);
+    return activeGeneration(tableId, snapshotId)
+        .map(
+            active ->
+                pointerStore.delete(
+                    targetPointerKey(tableId, snapshotId, active.generationId(), target)))
+        .orElse(false);
   }
 
   @Override
@@ -130,54 +102,291 @@ public class StatsRepository implements StatsStore {
       Optional<StatsTargetType> targetType,
       int limit,
       String pageToken) {
+    Optional<ActiveSnapshotStats> active = activeGeneration(tableId, snapshotId);
+    if (active.isEmpty()) {
+      return new StatsStorePage(List.of(), "");
+    }
     StringBuilder next = new StringBuilder();
     List<TargetStatsRecord> rows =
-        targetType
-            .map(
-                type ->
-                    listTargetStatsByStoragePrefix(
-                        tableId,
-                        snapshotId,
-                        storagePrefixFor(type),
-                        Math.max(1, limit),
-                        pageToken,
-                        next))
-            .orElseGet(
-                () -> listTargetStats(tableId, snapshotId, Math.max(1, limit), pageToken, next));
+        targetStatsStorage.listByPrefix(
+            listPrefix(tableId, snapshotId, active.get().generationId(), targetType),
+            Math.max(1, limit),
+            pageToken,
+            next);
     return new StatsStorePage(rows, next.toString());
   }
 
   @Override
   public int countTargetStats(
       ResourceId tableId, long snapshotId, Optional<StatsTargetType> targetType) {
-    return targetType
-        .map(type -> countTargetStatsByStoragePrefix(tableId, snapshotId, storagePrefixFor(type)))
-        .orElseGet(() -> countTargetStats(tableId, snapshotId));
+    return activeGeneration(tableId, snapshotId)
+        .map(
+            active ->
+                targetStatsStorage.countByPrefix(
+                    listPrefix(tableId, snapshotId, active.generationId(), targetType)))
+        .orElse(0);
   }
 
   @Override
   public boolean deleteAllStatsForSnapshot(ResourceId tableId, long snapshotId) {
-    String colPrefix = targetStatsPrefix(tableId, snapshotId);
-    String token = "";
-    StringBuilder next = new StringBuilder();
-
-    do {
-      List<TargetStatsRecord> page = targetStatsRepo.listByPrefix(colPrefix, 200, token, next);
-      for (TargetStatsRecord record : page) {
-        TargetStatsKey key = Schemas.TARGET_STATS.keyFromValue.apply(record);
-        targetStatsRepo.delete(key);
-      }
-      token = next.toString();
-      next.setLength(0);
-    } while (!token.isEmpty());
-
+    activeGeneration(tableId, snapshotId)
+        .ifPresent(
+            active -> {
+              deleteGeneration(
+                  active.accountId(), active.tableId(), snapshotId, active.generationId());
+              deleteQuietly(() -> blobStore.delete(active.manifestBlobUri()));
+              deleteQuietly(
+                  () ->
+                      pointerStore.compareAndDelete(
+                          active.manifestPointerKey(), active.manifestVersion()));
+            });
+    String generationRoot =
+        Keys.snapshotTargetStatsGenerationRootPointer(
+            tableId.getAccountId(), tableId.getId(), snapshotId);
+    deleteQuietly(() -> pointerStore.deleteByPrefix(generationRoot));
+    deleteQuietly(
+        () ->
+            blobStore.deletePrefix(
+                Keys.snapshotTargetStatsBlobPrefix(
+                    tableId.getAccountId(), tableId.getId(), snapshotId)));
+    deleteQuietly(
+        () ->
+            pointerStore.delete(
+                Keys.snapshotTargetStatsManifestPointer(
+                    tableId.getAccountId(), tableId.getId(), snapshotId)));
     return true;
+  }
+
+  @Override
+  public void replaceAllStatsForSnapshot(
+      ResourceId tableId, long snapshotId, List<TargetStatsRecord> records) {
+    List<TargetStatsRecord> canonicalRecords =
+        (records == null ? List.<TargetStatsRecord>of() : records)
+            .stream()
+                .map(this::canonicalRecord)
+                .peek(record -> requireRecordForSnapshot(tableId, snapshotId, record))
+                .toList();
+    Optional<ActiveSnapshotStats> current = activeGeneration(tableId, snapshotId);
+    String generationId = newGenerationId();
+
+    try {
+      for (TargetStatsRecord record : canonicalRecords) {
+        targetStatsStorage.create(
+            pointerKey(record, generationId), blobUri(record, generationId), record);
+      }
+      publishActiveGeneration(tableId, snapshotId, generationId, current);
+    } catch (RuntimeException e) {
+      deleteGeneration(tableId.getAccountId(), tableId.getId(), snapshotId, generationId);
+      deleteQuietly(
+          () ->
+              blobStore.delete(
+                  Keys.snapshotTargetStatsManifestBlobUri(
+                      tableId.getAccountId(), tableId.getId(), snapshotId, generationId)));
+      throw e;
+    }
+
+    current.ifPresent(
+        active -> {
+          deleteGeneration(active.accountId(), active.tableId(), snapshotId, active.generationId());
+          deleteQuietly(() -> blobStore.delete(active.manifestBlobUri()));
+        });
   }
 
   @Override
   public MutationMeta metaForTargetStats(
       ResourceId tableId, long snapshotId, StatsTarget target, Timestamp nowTs) {
-    return targetStatsRepo.metaFor(targetStatsLookupKey(tableId, snapshotId, target), nowTs);
+    ActiveSnapshotStats active =
+        activeGeneration(tableId, snapshotId)
+            .orElseThrow(
+                () ->
+                    new BaseResourceRepository.NotFoundException(
+                        "No active target stats generation for snapshot " + snapshotId));
+    String pointerKey = targetPointerKey(tableId, snapshotId, active.generationId(), target);
+    Pointer pointer =
+        pointerStore
+            .get(pointerKey)
+            .orElseThrow(
+                () ->
+                    new BaseResourceRepository.NotFoundException(
+                        "Pointer missing for target-stats: " + pointerKey));
+    return targetStatsStorage.metaForPointer(pointerKey, pointer.getBlobUri(), nowTs);
+  }
+
+  private TargetStatsRecord canonicalRecord(TargetStatsRecord value) {
+    TargetStatsRecord canonical = TargetStatsRecords.canonicalize(value);
+    Schemas.TARGET_STATS.keyFromValue.apply(canonical);
+    return canonical;
+  }
+
+  private void publishActiveGeneration(
+      ResourceId tableId,
+      long snapshotId,
+      String generationId,
+      Optional<ActiveSnapshotStats> current) {
+    String manifestPointer =
+        Keys.snapshotTargetStatsManifestPointer(
+            tableId.getAccountId(), tableId.getId(), snapshotId);
+    String manifestBlobUri =
+        Keys.snapshotTargetStatsManifestBlobUri(
+            tableId.getAccountId(), tableId.getId(), snapshotId, generationId);
+    StringValue manifest = StringValue.of(generationId);
+    targetStatsStorage.putManifestBlob(manifestBlobUri, manifest);
+
+    long expectedVersion = current.map(ActiveSnapshotStats::manifestVersion).orElse(0L);
+    Pointer next =
+        Pointer.newBuilder()
+            .setKey(manifestPointer)
+            .setBlobUri(manifestBlobUri)
+            .setVersion(expectedVersion + 1L)
+            .build();
+    if (!pointerStore.compareAndSet(manifestPointer, expectedVersion, next)) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "active target stats generation update conflicted for snapshot " + snapshotId);
+    }
+  }
+
+  private Optional<ActiveSnapshotStats> activeGeneration(ResourceId tableId, long snapshotId) {
+    String manifestPointer =
+        Keys.snapshotTargetStatsManifestPointer(
+            tableId.getAccountId(), tableId.getId(), snapshotId);
+    return pointerStore
+        .get(manifestPointer)
+        .map(pointer -> readActiveGeneration(tableId, snapshotId, manifestPointer, pointer));
+  }
+
+  private ActiveSnapshotStats ensureActiveGeneration(ResourceId tableId, long snapshotId) {
+    Optional<ActiveSnapshotStats> existing = activeGeneration(tableId, snapshotId);
+    if (existing.isPresent()) {
+      return existing.get();
+    }
+
+    String generationId = newGenerationId();
+    String manifestPointer =
+        Keys.snapshotTargetStatsManifestPointer(
+            tableId.getAccountId(), tableId.getId(), snapshotId);
+    String manifestBlobUri =
+        Keys.snapshotTargetStatsManifestBlobUri(
+            tableId.getAccountId(), tableId.getId(), snapshotId, generationId);
+    targetStatsStorage.putManifestBlob(manifestBlobUri, StringValue.of(generationId));
+    Pointer created =
+        Pointer.newBuilder()
+            .setKey(manifestPointer)
+            .setBlobUri(manifestBlobUri)
+            .setVersion(1L)
+            .build();
+    if (pointerStore.compareAndSet(manifestPointer, 0L, created)) {
+      return new ActiveSnapshotStats(
+          tableId.getAccountId(),
+          tableId.getId(),
+          generationId,
+          manifestPointer,
+          1L,
+          manifestBlobUri);
+    }
+    deleteQuietly(() -> blobStore.delete(manifestBlobUri));
+    return activeGeneration(tableId, snapshotId)
+        .orElseThrow(
+            () ->
+                new BaseResourceRepository.AbortRetryableException(
+                    "active target stats generation vanished during create"));
+  }
+
+  private ActiveSnapshotStats readActiveGeneration(
+      ResourceId tableId, long snapshotId, String manifestPointerKey, Pointer manifestPointer) {
+    byte[] bytes = blobStore.get(manifestPointer.getBlobUri());
+    try {
+      String generationId = StringValue.parseFrom(bytes).getValue();
+      if (generationId == null || generationId.isBlank()) {
+        throw new BaseResourceRepository.CorruptionException(
+            "empty target stats generation manifest for snapshot " + snapshotId, null);
+      }
+      return new ActiveSnapshotStats(
+          tableId.getAccountId(),
+          tableId.getId(),
+          generationId,
+          manifestPointerKey,
+          manifestPointer.getVersion(),
+          manifestPointer.getBlobUri());
+    } catch (Exception e) {
+      throw new BaseResourceRepository.CorruptionException(
+          "parse failed: " + manifestPointer.getBlobUri(), e);
+    }
+  }
+
+  private static void requireRecordForSnapshot(
+      ResourceId tableId, long snapshotId, TargetStatsRecord record) {
+    if (!record.hasTableId()
+        || !tableId.getAccountId().equals(record.getTableId().getAccountId())
+        || !tableId.getId().equals(record.getTableId().getId())
+        || snapshotId != record.getSnapshotId()) {
+      throw new IllegalArgumentException(
+          "target stats replacement record belongs to a different table snapshot");
+    }
+  }
+
+  private String listPrefix(
+      ResourceId tableId,
+      long snapshotId,
+      String generationId,
+      Optional<StatsTargetType> targetType) {
+    return targetType
+        .map(
+            type ->
+                Keys.snapshotTargetColumnStatsGenerationPrefix(
+                    tableId.getAccountId(),
+                    tableId.getId(),
+                    snapshotId,
+                    generationId,
+                    storagePrefixFor(type)))
+        .orElseGet(
+            () ->
+                Keys.snapshotTargetStatsGenerationPrefix(
+                    tableId.getAccountId(), tableId.getId(), snapshotId, generationId));
+  }
+
+  private String pointerKey(TargetStatsRecord record, String generationId) {
+    return targetPointerKey(
+        record.getTableId(), record.getSnapshotId(), generationId, record.getTarget());
+  }
+
+  private static String targetPointerKey(
+      ResourceId tableId, long snapshotId, String generationId, StatsTarget target) {
+    return Keys.snapshotTargetStatsGenerationPointer(
+        tableId.getAccountId(),
+        tableId.getId(),
+        snapshotId,
+        generationId,
+        StatsTargetIdentity.storageId(target));
+  }
+
+  private String blobUri(TargetStatsRecord record, String generationId) {
+    return Keys.snapshotTargetStatsBlobUri(
+        record.getTableId().getAccountId(),
+        record.getTableId().getId(),
+        record.getSnapshotId(),
+        generationId,
+        StatsTargetIdentity.storageId(record.getTarget()),
+        Hashing.sha256Hex(record.toByteArray()));
+  }
+
+  private void deleteGeneration(
+      String accountId, String tableId, long snapshotId, String generationId) {
+    deleteQuietly(
+        () ->
+            pointerStore.deleteByPrefix(
+                Keys.snapshotTargetStatsGenerationPrefix(
+                    accountId, tableId, snapshotId, generationId)));
+    deleteQuietly(
+        () ->
+            blobStore.deletePrefix(
+                Keys.snapshotTargetStatsBlobPrefix(accountId, tableId, snapshotId)
+                    + "generations/"
+                    + Keys.encodeSegment(generationId)
+                    + "/"));
+  }
+
+  private static String newGenerationId() {
+    return UUID.randomUUID().toString();
   }
 
   private static String storagePrefixFor(StatsTargetType type) {
@@ -187,5 +396,78 @@ public class StatsRepository implements StatsStore {
       case EXPRESSION -> StatsTargetIdentity.expressionStorageIdPrefix();
       case FILE -> StatsTargetIdentity.fileStorageIdPrefix();
     };
+  }
+
+  private static void deleteQuietly(Runnable runnable) {
+    try {
+      runnable.run();
+    } catch (Throwable ignore) {
+      // ignore
+    }
+  }
+
+  private record ActiveSnapshotStats(
+      String accountId,
+      String tableId,
+      String generationId,
+      String manifestPointerKey,
+      long manifestVersion,
+      String manifestBlobUri) {}
+
+  private static final class TargetStatsStorage extends BaseResourceRepository<TargetStatsRecord> {
+
+    private TargetStatsStorage(PointerStore pointerStore, BlobStore blobStore) {
+      super(
+          pointerStore,
+          blobStore,
+          TargetStatsRecord::parseFrom,
+          TargetStatsRecord::toByteArray,
+          "application/x-protobuf");
+    }
+
+    private Optional<TargetStatsRecord> getByPointer(String pointerKey) {
+      return get(pointerKey);
+    }
+
+    private void create(String pointerKey, String blobUri, TargetStatsRecord value) {
+      putBlob(blobUri, value);
+      reserveAllOrRollback(pointerKey, blobUri);
+    }
+
+    private boolean createIfAbsent(String pointerKey, String blobUri, TargetStatsRecord value) {
+      boolean blobExistedBefore = blobStore.head(blobUri).isPresent();
+      putBlob(blobUri, value);
+      Pointer reserve =
+          Pointer.newBuilder().setKey(pointerKey).setBlobUri(blobUri).setVersion(1L).build();
+      if (!pointerStore.compareAndSet(pointerKey, 0L, reserve)) {
+        cleanupCreateIfAbsentBlobOnCasMiss(pointerKey, blobUri, blobExistedBefore);
+        return false;
+      }
+      return true;
+    }
+
+    private void putManifestBlob(String blobUri, StringValue manifest) {
+      putBlobStrictBytes(blobUri, manifest.toByteArray());
+    }
+
+    private MutationMeta metaForPointer(String pointerKey, String blobUri, Timestamp nowTs) {
+      return safeMetaOrDefault(pointerKey, blobUri, nowTs);
+    }
+
+    private void cleanupCreateIfAbsentBlobOnCasMiss(
+        String pointerKey, String blobUri, boolean blobExistedBefore) {
+      if (blobExistedBefore || blobUri.isBlank()) {
+        return;
+      }
+      Pointer pointer = pointerStore.get(pointerKey).orElse(null);
+      if (pointer != null && blobUri.equals(pointer.getBlobUri())) {
+        return;
+      }
+      try {
+        blobStore.delete(blobUri);
+      } catch (Throwable ignore) {
+        // ignore
+      }
+    }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -502,6 +502,88 @@ public final class Keys {
     return String.format("/accounts/%s/tables/%s/target-stats/", encode(tid), encode(tbid));
   }
 
+  public static String snapshotTargetStatsManifestPointer(
+      String accountId, String tableId, long snapshotId) {
+    return snapshotStatsRootPointer(accountId, tableId, snapshotId) + "targets-active";
+  }
+
+  public static String snapshotTargetStatsGenerationRootPointer(
+      String accountId, String tableId, long snapshotId) {
+    return snapshotStatsRootPointer(accountId, tableId, snapshotId) + "target-generations/";
+  }
+
+  public static String snapshotTargetStatsGenerationDirectoryPointer(
+      String accountId, String tableId, long snapshotId, String generationId) {
+    String generation = req("generation_id", generationId);
+    return snapshotTargetStatsGenerationRootPointer(accountId, tableId, snapshotId)
+        + encode(generation)
+        + "/targets/";
+  }
+
+  public static String snapshotTargetStatsGenerationPointer(
+      String accountId, String tableId, long snapshotId, String generationId, String targetId) {
+    String target = req("target_id", targetId);
+    return snapshotTargetStatsGenerationDirectoryPointer(
+            accountId, tableId, snapshotId, generationId)
+        + encode(target);
+  }
+
+  public static String snapshotTargetStatsGenerationPrefix(
+      String accountId, String tableId, long snapshotId, String generationId) {
+    return snapshotTargetStatsGenerationDirectoryPointer(
+        accountId, tableId, snapshotId, generationId);
+  }
+
+  public static String snapshotTargetColumnStatsGenerationPrefix(
+      String accountId,
+      String tableId,
+      long snapshotId,
+      String generationId,
+      String columnTargetIdPrefix) {
+    String prefix = req("column_target_id_prefix", columnTargetIdPrefix);
+    return snapshotTargetStatsGenerationDirectoryPointer(
+            accountId, tableId, snapshotId, generationId)
+        + encode(prefix);
+  }
+
+  public static String snapshotTargetStatsManifestBlobUri(
+      String accountId, String tableId, long snapshotId, String generationId) {
+    String tid = req("account_id", accountId);
+    String tbid = req("table_id", tableId);
+    long sid = reqNonNegative("snapshot_id", snapshotId);
+    String generation = req("generation_id", generationId);
+    return String.format(
+        "/accounts/%s/tables/%s/target-stats/%019d/manifests/%s.pb",
+        encode(tid), encode(tbid), sid, encode(generation));
+  }
+
+  public static String snapshotTargetStatsBlobUri(
+      String accountId,
+      String tableId,
+      long snapshotId,
+      String generationId,
+      String targetId,
+      String sha256) {
+    String tid = req("account_id", accountId);
+    String tbid = req("table_id", tableId);
+    long sid = reqNonNegative("snapshot_id", snapshotId);
+    String generation = req("generation_id", generationId);
+    String target = req("target_id", targetId);
+    String sha = req("sha256", sha256);
+    return String.format(
+        "/accounts/%s/tables/%s/target-stats/%019d/generations/%s/%s/%s.pb",
+        encode(tid), encode(tbid), sid, encode(generation), encode(target), encode(sha));
+  }
+
+  public static String snapshotTargetStatsBlobPrefix(
+      String accountId, String tableId, long snapshotId) {
+    String tid = req("account_id", accountId);
+    String tbid = req("table_id", tableId);
+    long sid = reqNonNegative("snapshot_id", snapshotId);
+    return String.format(
+        "/accounts/%s/tables/%s/target-stats/%019d/", encode(tid), encode(tbid), sid);
+  }
+
   public static String snapshotTargetStatsPrefix(
       String accountId, String tableId, long snapshotId) {
     return snapshotTargetStatsDirectoryPointer(accountId, tableId, snapshotId);

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizeReconcileExecutorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizeReconcileExecutorTest.java
@@ -820,7 +820,7 @@ class SnapshotFinalizeReconcileExecutorTest {
   }
 
   @Test
-  void executeIngestsFileGroupStatsBlobsBeforeCoverageValidation() {
+  void executeRollsUpAggregatesFromLoadedFileGroupStats() {
     var store = new InMemoryReconcileJobStore();
     var statsStore = new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
     var snapshotPlanBlobStore = snapshotPlanBlobStore();
@@ -964,6 +964,248 @@ class SnapshotFinalizeReconcileExecutorTest {
             .orElseThrow()
             .getTable()
             .getRowCount());
+  }
+
+  @Test
+  void executeFullRescanReplacesExistingFileStatsAfterValidation() {
+    var store = new InMemoryReconcileJobStore();
+    var statsStore = new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    var snapshotPlanBlobStore = snapshotPlanBlobStore();
+    var executor = new SnapshotFinalizeReconcileExecutor();
+    executor.jobs = store;
+    executor.statsStore = statsStore;
+    executor.snapshotPlanBlobStore = snapshotPlanBlobStore;
+
+    String filePath = "s3://bucket/data/file-1.parquet";
+    ReconcileFileGroupTask group =
+        ReconcileFileGroupTask.of("plan-1", "group-1", TABLE_ID, SNAPSHOT_ID, List.of(filePath));
+    ReconcileScope scope = captureScope();
+    ReconcileSnapshotTask snapshotTask = persistedSnapshotPlan(snapshotPlanBlobStore, scope, group);
+    String parentJobId =
+        store.enqueueSnapshotPlan(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            true,
+            CaptureMode.METADATA_AND_CAPTURE,
+            scope,
+            snapshotTask,
+            ReconcileExecutionPolicy.defaults(),
+            "",
+            "");
+    String childJobId =
+        store.enqueueFileGroupExecution(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            true,
+            CaptureMode.METADATA_AND_CAPTURE,
+            scope,
+            group,
+            ReconcileExecutionPolicy.defaults(),
+            parentJobId,
+            "");
+    store.enqueueSnapshotFinalization(
+        ACCOUNT_ID,
+        CONNECTOR_ID,
+        true,
+        CaptureMode.METADATA_AND_CAPTURE,
+        scope,
+        snapshotTask,
+        ReconcileExecutionPolicy.defaults(),
+        parentJobId,
+        "");
+
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId(ACCOUNT_ID)
+            .setKind(ResourceKind.RK_TABLE)
+            .setId(TABLE_ID)
+            .build();
+    statsStore.putTargetStats(
+        TargetStatsRecords.fileRecord(
+            tableId,
+            SNAPSHOT_ID,
+            FileTargetStats.newBuilder()
+                .setFilePath(filePath)
+                .setRowCount(1L)
+                .setSizeBytes(32L)
+                .build(),
+            null));
+
+    String fileStatsBlobUri = "/accounts/acct/reconcile/jobs/job-child-1/file-group-stats/1.json";
+    FILE_GROUP_STATS_RECORDS
+        .get(snapshotPlanBlobStore)
+        .put(
+            fileStatsBlobUri,
+            List.of(
+                TargetStatsRecords.fileRecord(
+                    tableId,
+                    SNAPSHOT_ID,
+                    FileTargetStats.newBuilder()
+                        .setFilePath(filePath)
+                        .setRowCount(10L)
+                        .setSizeBytes(128L)
+                        .build(),
+                    null)));
+    store.persistFileGroupResult(
+        childJobId,
+        group
+            .withFileStatsBlob(fileStatsBlobUri, 1)
+            .withFileResults(List.of(ReconcileFileResult.succeeded(filePath, 0L))));
+    ReconcileJobStore.LeasedJob childLease =
+        store
+            .leaseNext(
+                new ReconcileJobStore.LeaseRequest(
+                    null, null, null, EnumSet.of(ReconcileJobKind.EXEC_FILE_GROUP)))
+            .orElseThrow();
+    store.markSucceeded(
+        childLease.jobId, childLease.leaseEpoch, System.currentTimeMillis(), 0, 0, 0, 0);
+
+    ReconcileJobStore.LeasedJob finalizerLease =
+        store
+            .leaseNext(
+                new ReconcileJobStore.LeaseRequest(
+                    null, null, null, EnumSet.of(ReconcileJobKind.FINALIZE_SNAPSHOT_CAPTURE)))
+            .orElseThrow();
+
+    ExecutionResult result = executor.execute(context(finalizerLease));
+
+    assertTrue(result.ok());
+    assertEquals(
+        10L,
+        statsStore
+            .getTargetStats(tableId, SNAPSHOT_ID, StatsTargetIdentity.fileTarget(filePath))
+            .orElseThrow()
+            .getFile()
+            .getRowCount());
+  }
+
+  @Test
+  void executeFullRescanCoverageFailurePreservesExistingFileStats() {
+    var store = new InMemoryReconcileJobStore();
+    var statsStore = new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    var snapshotPlanBlobStore = snapshotPlanBlobStore();
+    var executor = new SnapshotFinalizeReconcileExecutor();
+    executor.jobs = store;
+    executor.statsStore = statsStore;
+    executor.snapshotPlanBlobStore = snapshotPlanBlobStore;
+
+    ReconcileFileGroupTask group =
+        ReconcileFileGroupTask.of(
+            "plan-1",
+            "group-1",
+            TABLE_ID,
+            SNAPSHOT_ID,
+            List.of("s3://bucket/data/file-1.parquet", "s3://bucket/data/file-2.parquet"));
+    ReconcileScope scope = captureScope();
+    ReconcileSnapshotTask snapshotTask = persistedSnapshotPlan(snapshotPlanBlobStore, scope, group);
+    String parentJobId =
+        store.enqueueSnapshotPlan(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            true,
+            CaptureMode.METADATA_AND_CAPTURE,
+            scope,
+            snapshotTask,
+            ReconcileExecutionPolicy.defaults(),
+            "",
+            "");
+    String childJobId =
+        store.enqueueFileGroupExecution(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            true,
+            CaptureMode.METADATA_AND_CAPTURE,
+            scope,
+            group,
+            ReconcileExecutionPolicy.defaults(),
+            parentJobId,
+            "");
+    store.enqueueSnapshotFinalization(
+        ACCOUNT_ID,
+        CONNECTOR_ID,
+        true,
+        CaptureMode.METADATA_AND_CAPTURE,
+        scope,
+        snapshotTask,
+        ReconcileExecutionPolicy.defaults(),
+        parentJobId,
+        "");
+
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId(ACCOUNT_ID)
+            .setKind(ResourceKind.RK_TABLE)
+            .setId(TABLE_ID)
+            .build();
+    String existingFilePath = "s3://bucket/data/file-1.parquet";
+    statsStore.putTargetStats(
+        TargetStatsRecords.fileRecord(
+            tableId,
+            SNAPSHOT_ID,
+            FileTargetStats.newBuilder()
+                .setFilePath(existingFilePath)
+                .setRowCount(5L)
+                .setSizeBytes(64L)
+                .build(),
+            null));
+
+    String fileStatsBlobUri = "/accounts/acct/reconcile/jobs/job-child-1/file-group-stats/1.json";
+    FILE_GROUP_STATS_RECORDS
+        .get(snapshotPlanBlobStore)
+        .put(
+            fileStatsBlobUri,
+            List.of(
+                TargetStatsRecords.fileRecord(
+                    tableId,
+                    SNAPSHOT_ID,
+                    FileTargetStats.newBuilder()
+                        .setFilePath(existingFilePath)
+                        .setRowCount(10L)
+                        .setSizeBytes(128L)
+                        .build(),
+                    null)));
+    store.persistFileGroupResult(
+        childJobId,
+        group
+            .withFileStatsBlob(fileStatsBlobUri, 1)
+            .withFileResults(
+                List.of(
+                    ReconcileFileResult.succeeded(existingFilePath, 0L),
+                    ReconcileFileResult.succeeded("s3://bucket/data/file-2.parquet", 0L))));
+    ReconcileJobStore.LeasedJob childLease =
+        store
+            .leaseNext(
+                new ReconcileJobStore.LeaseRequest(
+                    null, null, null, EnumSet.of(ReconcileJobKind.EXEC_FILE_GROUP)))
+            .orElseThrow();
+    store.markSucceeded(
+        childLease.jobId, childLease.leaseEpoch, System.currentTimeMillis(), 0, 0, 0, 0);
+
+    ReconcileJobStore.LeasedJob finalizerLease =
+        store
+            .leaseNext(
+                new ReconcileJobStore.LeaseRequest(
+                    null, null, null, EnumSet.of(ReconcileJobKind.FINALIZE_SNAPSHOT_CAPTURE)))
+            .orElseThrow();
+
+    ExecutionResult result = executor.execute(context(finalizerLease));
+
+    assertFalse(result.ok());
+    assertTrue(result.message.contains("coverage mismatch"));
+    assertEquals(
+        5L,
+        statsStore
+            .getTargetStats(tableId, SNAPSHOT_ID, StatsTargetIdentity.fileTarget(existingFilePath))
+            .orElseThrow()
+            .getFile()
+            .getRowCount());
+    assertTrue(
+        statsStore
+            .getTargetStats(
+                tableId,
+                SNAPSHOT_ID,
+                StatsTargetIdentity.fileTarget("s3://bucket/data/file-2.parquet"))
+            .isEmpty());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -387,6 +387,48 @@ class StatsRepositoryTargetStorageTest {
   }
 
   @Test
+  void replaceAllStatsForSnapshotSwapsAndRemovesSnapshotStats() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 9192L;
+    String oldFilePath = "s3://bucket/path/old.parquet";
+
+    repository.putTargetStats(
+        TargetStatsRecords.tableRecord(
+            TABLE_ID,
+            snapshotId,
+            TableValueStats.newBuilder().setRowCount(11L).setDataFileCount(1L).build(),
+            null));
+    repository.putTargetStats(
+        TargetStatsRecords.fileRecord(
+            TABLE_ID,
+            snapshotId,
+            FileTargetStats.newBuilder().setFilePath(oldFilePath).setRowCount(11L).build(),
+            null));
+
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        List.of(
+            TargetStatsRecords.tableRecord(
+                TABLE_ID,
+                snapshotId,
+                TableValueStats.newBuilder().setRowCount(27L).setDataFileCount(0L).build(),
+                null)));
+
+    assertThat(repository.countTargetStats(TABLE_ID, snapshotId, Optional.empty())).isEqualTo(1);
+    assertThat(repository.getTargetStats(TABLE_ID, snapshotId, StatsTargetIdentity.tableTarget()))
+        .isPresent()
+        .get()
+        .extracting(record -> record.getTable().getRowCount())
+        .isEqualTo(27L);
+    assertThat(
+            repository.getTargetStats(
+                TABLE_ID, snapshotId, StatsTargetIdentity.fileTarget(oldFilePath)))
+        .isEmpty();
+  }
+
+  @Test
   void puttingStatsDoesNotAdvanceTablePointerVersion() {
     InMemoryPointerStore pointerStore = new InMemoryPointerStore();
     InMemoryBlobStore blobStore = new InMemoryBlobStore();


### PR DESCRIPTION
## Summary

Implement proper full rescan semantics, which is to actually regenerate and replace existing stats.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

