### PR TITLE
Make sure storage create() is atomic

### DIFF
--- a/docs/telemetry/contract.json
+++ b/docs/telemetry/contract.json
@@ -778,5 +778,15 @@
     "description": "Per-account pointer count stored in the service.",
     "requiredTags": ["account"],
     "allowedTags": ["account"]
+  },
+  {
+    "name": "floecat.service.storage.partial_state.total",
+    "type": "COUNTER",
+    "unit": "",
+    "since": "v1",
+    "origin": "service",
+    "description": "Stored partial-pointer-state anomalies surfaced (non-retryably) by the repository layer: a canonical/secondary pointer mismatch that an atomic create/createIfAbsent can never itself produce and that must be reconciled out of band.",
+    "requiredTags": ["operation", "resource"],
+    "allowedTags": ["operation", "resource"]
   }
 ]

--- a/docs/telemetry/contract.md
+++ b/docs/telemetry/contract.md
@@ -100,6 +100,7 @@ This lists all metrics currently available in the repository:
 | floecat.service.stats.sync_outcomes.total | COUNTER |  | v1 | Sync-first resolution outcomes by result (HIT, CAPTURED, PARTIAL, TIMEOUT, FAILED, SKIPPED). | component, operation | component, mode, operation, reason, resource, result, scope, trigger |
 | floecat.service.storage.account.bytes | GAUGE | bytes | v1 | Estimated per-account storage byte consumption (sampled, not exact). | account | account |
 | floecat.service.storage.account.pointers | GAUGE |  | v1 | Per-account pointer count stored in the service. | account | account |
+| floecat.service.storage.partial_state.total | COUNTER |  | v1 | Stored partial-pointer-state anomalies surfaced (non-retryably) by the repository layer: a canonical/secondary pointer mismatch that an atomic create/createIfAbsent can never itself produce and that must be reconciled out of band. | operation, resource | operation, resource |
 
 <!-- METRICS:END -->
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -87,6 +87,10 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
   }
 
   public static class CorruptionException extends RepoException {
+    public CorruptionException(String msg) {
+      super(msg);
+    }
+
     public CorruptionException(String msg, Throwable cause) {
       super(msg, cause);
     }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -24,6 +24,7 @@ import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
+import io.micrometer.core.instrument.Metrics;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -33,8 +34,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import org.jboss.logging.Logger;
 
 public class GenericResourceRepository<T, K extends ResourceKey> extends BaseResourceRepository<T> {
+
+  private static final Logger log = Logger.getLogger(GenericResourceRepository.class);
 
   private final ResourceSchema<T, K> schema;
 
@@ -63,9 +67,14 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
    * <p>The blob is written first; it is content-addressed (SHA-256), so a dangling blob after a
    * failed batch is harmless and deduped on retry.
    *
-   * <p><b>Idempotency contract</b> (unchanged from the previous sequential implementation):
-   * re-creating a byte-identical resource is a no-op, and a collision against a pointer bound to a
-   * different blob throws {@link NameConflictException} with the same message as before.
+   * <p><b>Idempotency &amp; conflict contract:</b> re-creating a byte-identical resource (every
+   * pointer already resolves to our blob) is a no-op; a collision against a pointer bound to a
+   * different blob throws {@link NameConflictException}. A pre-existing <em>partial</em> state —
+   * some of this resource's pointers present (bound to our blob) and some absent, which an atomic
+   * create can never itself produce — is a stored inconsistency left by a legacy or non-atomic
+   * writer; it is surfaced as a (non-retryable) {@link CorruptionException} rather than silently
+   * repaired or spun on. A batch that conflicts but whose read-back finds <em>no</em> pointer at
+   * all is a transient transaction conflict and is signalled as retryable.
    */
   public void create(T value) {
     K key = schema.keyFromValue.apply(value);
@@ -86,58 +95,79 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
     List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size());
     for (String pointerKey : pointerKeys) {
-      Pointer reserve =
-          Pointer.newBuilder().setKey(pointerKey).setBlobUri(blobUri).setVersion(1L).build();
-      ops.add(new PointerStore.CasUpsert(pointerKey, 0L, reserve));
+      ops.add(new PointerStore.CasUpsert(pointerKey, 0L, reserve(pointerKey, blobUri)));
     }
 
     if (pointerStore.compareAndSetBatch(ops)) {
       return;
     }
 
-    // The batch committed nothing (atomic) because at least one pointer already existed. Reproduce
-    // the old per-key idempotency classification with a single read-back, walking
-    // canonical-then-secondary order so a conflict reports the same key/message as before.
+    // The batch committed nothing (atomic) because at least one pointer already existed. Read back
+    // and classify, walking canonical-then-secondary order so a conflict reports the same
+    // key/message as before.
     classifyCreateConflict(blobUri, pointerKeys);
   }
 
   private void classifyCreateConflict(String blobUri, List<String> pointerKeys) {
-    boolean allBoundToOurBlob = true;
+    int present = 0;
+    int absent = 0;
     for (String pointerKey : pointerKeys) {
       Pointer pointer = pointerStore.get(pointerKey).orElse(null);
       if (pointer == null) {
-        allBoundToOurBlob = false;
+        absent++;
         continue;
       }
       if (!blobUri.equals(pointer.getBlobUri())) {
         throw new NameConflictException("pointer bound to different blob: " + pointerKey);
       }
+      present++;
     }
-    if (allBoundToOurBlob) {
+    if (absent == 0) {
       // Every pointer already resolves to our blob: a byte-identical re-create is a no-op.
       return;
     }
-    // Some pointers exist and some are absent: a genuinely concurrent or partially-applied state
-    // (e.g. a legacy orphan). Signal the caller to retry rather than papering over it.
-    throw new AbortRetryableException("partial create state for: " + pointerKeys.get(0));
+    if (present == 0) {
+      // The batch reported a conflict yet read-back finds no pointer at all: a transient batch
+      // conflict (e.g. a DynamoDB TransactionConflict) or a concurrent delete, not a stable state.
+      // Re-running the atomic batch can still make progress, so signal a retry.
+      throw new AbortRetryableException(
+          "create conflict, no pointer present: " + pointerKeys.get(0));
+    }
+    // Mixed: some pointers present (bound to our blob), some absent. An atomic create cannot
+    // produce this, so it is a stored inconsistency (a legacy orphan, or a non-atomic
+    // createIfAbsent / update that died mid-flight). Strict no-repair semantics: surface it
+    // terminally instead of healing it or spinning on a retry that can never converge.
+    throw partialStateAnomaly(
+        "create",
+        "partial create state ("
+            + present
+            + " present, "
+            + absent
+            + " absent) for: "
+            + pointerKeys);
   }
 
   /**
-   * Creates a resource only when the canonical pointer is currently absent.
+   * Creates a resource only when it does not already exist, <b>atomically</b>.
    *
-   * <p>Returns {@code true} only when this call won the canonical pointer CAS from version 0 to 1.
-   * This provides distributed create-if-absent semantics across repository instances.
+   * <p>The canonical (by-id) pointer and every secondary pointer are reserved in a single {@link
+   * PointerStore#compareAndSetBatch} transaction, so — exactly like {@link #create} — a failure
+   * leaves zero partial pointer state and there is no intermediate window in which the resource is
+   * visible by id but not yet by name.
    *
-   * <p><b>Visibility ordering:</b> the canonical pointer is published atomically via CAS before
-   * secondary pointers are created. During secondary creation a concurrent reader may find the
-   * resource via the canonical key but not yet via secondary keys. This is an inherent trade-off of
-   * the non-transactional storage model; the canonical pointer is the authoritative source of
-   * truth.
+   * <p>Returns {@code true} only when this call committed the batch (it won the create). Returns
+   * {@code false} when the canonical pointer already exists — some other writer owns the resource —
+   * <em>regardless</em> of which blob that pointer is bound to; the canonical pointer is the
+   * authoritative "already created" marker. A new secondary name owned by a different blob throws
+   * {@link NameConflictException}. A stored inconsistency (canonical absent but a secondary
+   * present, which an atomic path can never produce) is surfaced as a non-retryable {@link
+   * CorruptionException}; a transient batch conflict with nothing present is signalled as
+   * retryable.
    *
-   * <p><b>Blob cleanup:</b> the blob is written before the canonical CAS attempt. On any failure
-   * (CAS miss or secondary creation error), a best-effort cleanup is attempted. For {@code
-   * casBlobs} schemas the blob URI is content-addressed (SHA256), so a cleanup failure only wastes
-   * space; it has no correctness impact.
+   * <p><b>Blob cleanup:</b> the blob is written before the batch. When the batch does not commit, a
+   * best-effort cleanup is attempted. For {@code casBlobs} schemas the blob URI is
+   * content-addressed (SHA256), so a cleanup failure only wastes space; it has no correctness
+   * impact.
    */
   public boolean createIfAbsent(T value) {
     K key = schema.keyFromValue.apply(value);
@@ -147,41 +177,91 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
     putBlob(blobUri, value);
 
-    Pointer reserveCanonical =
-        Pointer.newBuilder().setKey(canonicalPointer).setBlobUri(blobUri).setVersion(1L).build();
-    if (!pointerStore.compareAndSet(canonicalPointer, 0L, reserveCanonical)) {
-      cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
+    Map<String, String> secondaries = schema.secondaryPointersFromValue.apply(value);
+    // Canonical first, then secondaries, de-duplicated (a schema may expose the canonical pointer
+    // as a secondary too, and a transactional batch must not repeat a key). See create().
+    LinkedHashSet<String> uniqueKeys = new LinkedHashSet<>(1 + secondaries.size());
+    uniqueKeys.add(canonicalPointer);
+    uniqueKeys.addAll(secondaries.values());
+    List<String> pointerKeys = new ArrayList<>(uniqueKeys);
+
+    List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size());
+    for (String pointerKey : pointerKeys) {
+      ops.add(new PointerStore.CasUpsert(pointerKey, 0L, reserve(pointerKey, blobUri)));
+    }
+
+    if (pointerStore.compareAndSetBatch(ops)) {
+      return true;
+    }
+    return classifyCreateIfAbsentConflict(
+        canonicalPointer, blobUri, pointerKeys, blobExistedBefore);
+  }
+
+  private boolean classifyCreateIfAbsentConflict(
+      String canonicalPointer,
+      String blobUri,
+      List<String> pointerKeys,
+      boolean blobExistedBefore) {
+    // The batch committed nothing, so this call did not create the resource. Reclaim the blob we
+    // optimistically wrote (best-effort, content-addressed) before classifying the outcome.
+    cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
+
+    Pointer canonical = pointerStore.get(canonicalPointer).orElse(null);
+    if (canonical != null) {
+      // Canonical already taken — another writer owns the create; report a lost race regardless of
+      // which blob it points to.
       return false;
     }
 
-    Map<String, String> secondaries = schema.secondaryPointersFromValue.apply(value);
-    final var createdSecondary = new ArrayList<String>(secondaries.size());
-    try {
-      for (String secondaryPtr : secondaries.values()) {
-        var reserve =
-            Pointer.newBuilder().setKey(secondaryPtr).setBlobUri(blobUri).setVersion(1L).build();
-        if (pointerStore.compareAndSet(secondaryPtr, 0L, reserve)) {
-          createdSecondary.add(secondaryPtr);
-          continue;
-        }
-        var pointer = pointerStore.get(secondaryPtr).orElse(null);
-        if (pointer == null) {
-          throw new AbortRetryableException("pointer suddenly vanished: " + secondaryPtr);
-        }
-        if (!blobUri.equals(pointer.getBlobUri())) {
-          throw new NameConflictException("pointer bound to different blob: " + secondaryPtr);
-        }
+    // Canonical is absent. If a secondary nonetheless exists, classify by what it is bound to.
+    boolean anySecondaryPresent = false;
+    for (String pointerKey : pointerKeys) {
+      if (pointerKey.equals(canonicalPointer)) {
+        continue;
       }
-      return true;
-    } catch (Throwable e) {
-      for (int i = createdSecondary.size() - 1; i >= 0; i--) {
-        compareAndDeleteOrFalse(createdSecondary.get(i), 1L);
+      Pointer secondary = pointerStore.get(pointerKey).orElse(null);
+      if (secondary == null) {
+        continue;
       }
-      compareAndDeleteOrFalse(canonicalPointer, 1L);
-      // Blob was written before the try block; attempt cleanup now that all pointers are gone.
-      cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
-      throw e;
+      anySecondaryPresent = true;
+      if (!blobUri.equals(secondary.getBlobUri())) {
+        throw new NameConflictException("pointer bound to different blob: " + pointerKey);
+      }
     }
+    if (anySecondaryPresent) {
+      // Canonical absent but a secondary (bound to our blob) exists: a stored partial-create
+      // inconsistency an atomic path can never produce. Surface it terminally, do not repair.
+      throw partialStateAnomaly(
+          "createIfAbsent",
+          "partial create state (canonical absent, secondary present) for: " + canonicalPointer);
+    }
+    // Nothing present: a transient batch conflict (or a concurrent delete). A retry re-attempts
+    // the atomic batch.
+    throw new AbortRetryableException(
+        "createIfAbsent conflict, no pointer present: " + canonicalPointer);
+  }
+
+  private static Pointer reserve(String key, String blobUri) {
+    return Pointer.newBuilder().setKey(key).setBlobUri(blobUri).setVersion(1L).build();
+  }
+
+  /**
+   * A stable partial-pointer state that an atomic create/createIfAbsent can never itself produce (a
+   * legacy orphan, or a non-atomic writer that died mid-flight). Under the strict no-repair
+   * contract we surface it as a non-retryable {@link CorruptionException}. Log it and bump a
+   * counter so the (rare) anomaly is visible and can be reconciled out of band rather than
+   * vanishing into a generic 500.
+   */
+  private CorruptionException partialStateAnomaly(String operation, String message) {
+    log.errorf("partial pointer state in %s.%s: %s", schema.resourceName, operation, message);
+    Metrics.counter(
+            "floecat_repo_partial_state_anomalies",
+            "floecat_resource",
+            schema.resourceName,
+            "floecat_operation",
+            operation)
+        .increment();
+    return new CorruptionException(message);
   }
 
   private void cleanupCreateIfAbsentBlobOnCasMiss(
@@ -200,6 +280,19 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     deleteQuietly(() -> blobStore.delete(blobUri));
   }
 
+  /**
+   * Atomically updates a resource: the canonical pointer is advanced, new secondary pointers are
+   * reserved, kept secondaries are moved onto the new (content-addressed) blob when it changed, and
+   * removed secondaries are deleted — all in a single {@link PointerStore#compareAndSetBatch}
+   * transaction. Because the batch is all-or-nothing, a mid-update storage error (or process death)
+   * commits nothing and leaves <b>zero</b> partial pointer state.
+   *
+   * <p>Returns {@code true} on commit. Returns {@code false} when the canonical pointer is not at
+   * {@code expectedCanonicalVersion} (an optimistic-concurrency miss — it moved or was deleted
+   * under us). A new secondary name already owned by a different blob throws {@link
+   * NameConflictException}. A conflict the read-back cannot attribute to either case (a concurrent
+   * version shift) is signalled as retryable.
+   */
   public boolean update(T updatedValue, long expectedCanonicalVersion) {
     K key = schema.keyFromValue.apply(updatedValue);
     String canonicalPointer = schema.canonicalPointerForKey.apply(key);
@@ -222,61 +315,92 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     toAdd.removeAll(currentSecondary);
     Set<String> toDelete = new HashSet<>(currentSecondary);
     toDelete.removeAll(nextSecondary);
+    Set<String> kept = new HashSet<>(nextSecondary);
+    kept.removeAll(toAdd);
 
     putBlob(blobUri, updatedValue);
 
-    if (!toAdd.isEmpty()) {
-      List<String> kvPairs = new ArrayList<>(2 * toAdd.size());
-      for (String p : toAdd) {
-        kvPairs.add(p);
-        kvPairs.add(blobUri);
+    boolean blobChanged = schema.casBlobs && !Objects.equals(currentBlobUri, blobUri);
+
+    // Build a single all-or-nothing batch covering every pointer mutation this update implies. Ops
+    // are de-duplicated by key (a schema may expose the canonical pointer as a secondary too) with
+    // the canonical advance taking precedence. Because the batch is atomic the update can never
+    // leave partial pointer state; a conflict commits nothing and is classified below.
+    Set<String> batchedKeys = new HashSet<>();
+    List<PointerStore.CasOp> ops = new ArrayList<>();
+
+    batchedKeys.add(canonicalPointer);
+    ops.add(
+        new PointerStore.CasUpsert(
+            canonicalPointer, expectedCanonicalVersion, reserve(canonicalPointer, blobUri)));
+
+    for (String p : toAdd) {
+      if (!batchedKeys.add(p)) {
+        continue;
       }
-      reserveAllOrRollback(kvPairs.toArray(String[]::new));
+      Pointer existing = pointerStore.get(p).orElse(null);
+      if (existing == null) {
+        ops.add(new PointerStore.CasUpsert(p, 0L, reserve(p, blobUri)));
+      } else if (!blobUri.equals(existing.getBlobUri())) {
+        // The new name already belongs to a different blob. Nothing has been committed, so failing
+        // fast here leaves no partial state.
+        throw new NameConflictException("pointer bound to different blob: " + p);
+      }
+      // else: already reserved to our blob — idempotent, no op needed.
     }
 
-    try {
-      advancePointer(canonicalPointer, blobUri, expectedCanonicalVersion);
-    } catch (PreconditionFailedException e) {
-      for (String p : toAdd) {
-        pointerStore.get(p).ifPresent(ptr -> compareAndDeleteOrFalse(p, ptr.getVersion()));
-      }
-      return false;
-    }
-
-    if (schema.casBlobs && !Objects.equals(currentBlobUri, blobUri)) {
-      for (String p : nextSecondary) {
-        refreshSecondaryPointer(p, blobUri);
+    if (blobChanged) {
+      // Kept secondaries still point at the old content-addressed blob; advance each onto the new
+      // one (or reserve it if a legacy gap left it absent).
+      for (String p : kept) {
+        if (!batchedKeys.add(p)) {
+          continue;
+        }
+        Pointer existing = pointerStore.get(p).orElse(null);
+        if (existing == null) {
+          ops.add(new PointerStore.CasUpsert(p, 0L, reserve(p, blobUri)));
+        } else if (!blobUri.equals(existing.getBlobUri())) {
+          ops.add(new PointerStore.CasUpsert(p, existing.getVersion(), reserve(p, blobUri)));
+        }
+        // else: already on the new blob — no op needed.
       }
     }
 
     for (String p : toDelete) {
-      pointerStore.get(p).ifPresent(ptr -> compareAndDeleteOrFalse(p, ptr.getVersion()));
-    }
-
-    return true;
-  }
-
-  private void refreshSecondaryPointer(String key, String blobUri) {
-    for (int i = 0; i < CAS_MAX; i++) {
-      var ptr = pointerStore.get(key).orElse(null);
-      if (ptr == null) {
-        Pointer reserve =
-            Pointer.newBuilder().setKey(key).setBlobUri(blobUri).setVersion(1L).build();
-        if (pointerStore.compareAndSet(key, 0L, reserve)) {
-          return;
-        }
+      if (!batchedKeys.add(p)) {
         continue;
       }
-      if (Objects.equals(ptr.getBlobUri(), blobUri)) {
-        return;
-      }
-      try {
-        advancePointer(key, blobUri, ptr.getVersion());
-        return;
-      } catch (PreconditionFailedException ignore) {
-        // retry on concurrent update
+      Pointer existing = pointerStore.get(p).orElse(null);
+      if (existing != null) {
+        ops.add(new PointerStore.CasDelete(p, existing.getVersion()));
       }
     }
+
+    if (pointerStore.compareAndSetBatch(ops)) {
+      return true;
+    }
+    return classifyUpdateConflict(canonicalPointer, expectedCanonicalVersion, blobUri, toAdd);
+  }
+
+  private boolean classifyUpdateConflict(
+      String canonicalPointer, long expectedCanonicalVersion, String blobUri, Set<String> toAdd) {
+    Pointer canonical = pointerStore.get(canonicalPointer).orElse(null);
+    if (canonical == null || canonical.getVersion() != expectedCanonicalVersion) {
+      // Optimistic-concurrency miss: the canonical pointer moved or vanished under us. Same
+      // observable result as the previous advancePointer -> PreconditionFailed path — the caller
+      // retries with a fresh expected version.
+      return false;
+    }
+    // Canonical is exactly where we expected, so a secondary op lost the race. A new name now owned
+    // by a different blob is a terminal collision; otherwise a concurrent writer shifted a
+    // secondary's version between our read and the commit and a retry re-reads fresh versions.
+    for (String p : toAdd) {
+      Pointer secondary = pointerStore.get(p).orElse(null);
+      if (secondary != null && !blobUri.equals(secondary.getBlobUri())) {
+        throw new NameConflictException("pointer bound to different blob: " + p);
+      }
+    }
+    throw new AbortRetryableException("update conflict for: " + canonicalPointer);
   }
 
   public boolean delete(K key) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -20,11 +20,16 @@ import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.service.repo.model.ResourceKey;
 import ai.floedb.floecat.service.repo.model.ResourceSchema;
+import ai.floedb.floecat.service.telemetry.ServiceMetrics;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
+import ai.floedb.floecat.telemetry.NoopObservability;
+import ai.floedb.floecat.telemetry.Observability;
+import ai.floedb.floecat.telemetry.Tag;
+import ai.floedb.floecat.telemetry.Telemetry.TagKey;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
-import io.micrometer.core.instrument.Metrics;
+import io.quarkus.arc.Arc;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -39,6 +44,7 @@ import org.jboss.logging.Logger;
 public class GenericResourceRepository<T, K extends ResourceKey> extends BaseResourceRepository<T> {
 
   private static final Logger log = Logger.getLogger(GenericResourceRepository.class);
+  private static final Observability NOOP_OBSERVABILITY = new NoopObservability();
 
   private final ResourceSchema<T, K> schema;
 
@@ -254,14 +260,34 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
    */
   private CorruptionException partialStateAnomaly(String operation, String message) {
     log.errorf("partial pointer state in %s.%s: %s", schema.resourceName, operation, message);
-    Metrics.counter(
-            "floecat_repo_partial_state_anomalies",
-            "floecat_resource",
-            schema.resourceName,
-            "floecat_operation",
-            operation)
-        .increment();
+    observability()
+        .counter(
+            ServiceMetrics.Storage.PARTIAL_STATE,
+            1.0,
+            Tag.of(TagKey.OPERATION, operation),
+            Tag.of(TagKey.RESOURCE, schema.resourceName));
     return new CorruptionException(message);
+  }
+
+  /**
+   * Resolves the application {@link Observability} via Arc. The repositories are plain helpers, not
+   * CDI beans, so rather than threading an {@code Observability} through every repository
+   * constructor we look the bean up lazily on this rare anomaly path. Outside a running Arc
+   * container (e.g. unit tests) it falls back to a no-op.
+   */
+  private static Observability observability() {
+    try {
+      var container = Arc.container();
+      if (container != null) {
+        var handle = container.instance(Observability.class);
+        if (handle.isAvailable()) {
+          return handle.get();
+        }
+      }
+    } catch (RuntimeException ignore) {
+      // Arc not initialised — fall back to the no-op below.
+    }
+    return NOOP_OBSERVABILITY;
   }
 
   private void cleanupCreateIfAbsentBlobOnCasMiss(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -26,6 +26,7 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -52,6 +53,20 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     return get(schema.canonicalPointerForKey.apply(key));
   }
 
+  /**
+   * Atomically creates a resource: the canonical (by-id) pointer and every secondary (by-name, …)
+   * pointer are reserved in a single {@link PointerStore#compareAndSetBatch} transaction. Because
+   * the batch is all-or-nothing on both backends, a mid-create storage error (or process death)
+   * leaves <b>zero</b> partial pointer state — there is nothing to roll back and no orphan can be
+   * stranded to poison later creates.
+   *
+   * <p>The blob is written first; it is content-addressed (SHA-256), so a dangling blob after a
+   * failed batch is harmless and deduped on retry.
+   *
+   * <p><b>Idempotency contract</b> (unchanged from the previous sequential implementation):
+   * re-creating a byte-identical resource is a no-op, and a collision against a pointer bound to a
+   * different blob throws {@link NameConflictException} with the same message as before.
+   */
   public void create(T value) {
     K key = schema.keyFromValue.apply(value);
     String canonicalPointer = schema.canonicalPointerForKey.apply(key);
@@ -60,14 +75,51 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     putBlob(blobUri, value);
 
     Map<String, String> secondaries = schema.secondaryPointersFromValue.apply(value);
-    List<String> kvPairs = new ArrayList<>(2 + 2 * secondaries.size());
-    kvPairs.add(canonicalPointer);
-    kvPairs.add(blobUri);
-    for (String secondaryPtr : secondaries.values()) {
-      kvPairs.add(secondaryPtr);
-      kvPairs.add(blobUri);
+    // Canonical first, then secondaries, de-duplicated: some schemas (e.g. snapshots) expose the
+    // canonical by-id pointer as a secondary too, and a transactional batch must not contain two
+    // operations on the same key (DynamoDB rejects duplicate items within a transaction). All ops
+    // for a given key target the same blob, so dropping the duplicate is loss-free.
+    LinkedHashSet<String> uniqueKeys = new LinkedHashSet<>(1 + secondaries.size());
+    uniqueKeys.add(canonicalPointer);
+    uniqueKeys.addAll(secondaries.values());
+    List<String> pointerKeys = new ArrayList<>(uniqueKeys);
+
+    List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size());
+    for (String pointerKey : pointerKeys) {
+      Pointer reserve =
+          Pointer.newBuilder().setKey(pointerKey).setBlobUri(blobUri).setVersion(1L).build();
+      ops.add(new PointerStore.CasUpsert(pointerKey, 0L, reserve));
     }
-    reserveAllOrRollback(kvPairs.toArray(String[]::new));
+
+    if (pointerStore.compareAndSetBatch(ops)) {
+      return;
+    }
+
+    // The batch committed nothing (atomic) because at least one pointer already existed. Reproduce
+    // the old per-key idempotency classification with a single read-back, walking
+    // canonical-then-secondary order so a conflict reports the same key/message as before.
+    classifyCreateConflict(blobUri, pointerKeys);
+  }
+
+  private void classifyCreateConflict(String blobUri, List<String> pointerKeys) {
+    boolean allBoundToOurBlob = true;
+    for (String pointerKey : pointerKeys) {
+      Pointer pointer = pointerStore.get(pointerKey).orElse(null);
+      if (pointer == null) {
+        allBoundToOurBlob = false;
+        continue;
+      }
+      if (!blobUri.equals(pointer.getBlobUri())) {
+        throw new NameConflictException("pointer bound to different blob: " + pointerKey);
+      }
+    }
+    if (allBoundToOurBlob) {
+      // Every pointer already resolves to our blob: a byte-identical re-create is a no-op.
+      return;
+    }
+    // Some pointers exist and some are absent: a genuinely concurrent or partially-applied state
+    // (e.g. a legacy orphan). Signal the caller to retry rather than papering over it.
+    throw new AbortRetryableException("partial create state for: " + pointerKeys.get(0));
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
@@ -35,6 +35,13 @@ public final class ServiceMetrics {
             "bytes",
             CONTRACT,
             "service");
+    public static final MetricId PARTIAL_STATE =
+        new MetricId(
+            "floecat.service.storage.partial_state.total",
+            MetricType.COUNTER,
+            "",
+            CONTRACT,
+            "service");
   }
 
   public static final class Flight {

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributor.java
@@ -75,6 +75,15 @@ public final class ServiceTelemetryContributor implements TelemetryContributor {
         accountTag,
         accountTag,
         "Estimated per-account storage byte consumption (sampled, not exact).");
+    Set<String> partialStateTags = Set.of(TagKey.OPERATION, TagKey.RESOURCE);
+    add(
+        defs,
+        Storage.PARTIAL_STATE,
+        partialStateTags,
+        partialStateTags,
+        "Stored partial-pointer-state anomalies surfaced (non-retryably) by the repository layer: a"
+            + " canonical/secondary pointer mismatch that an atomic create/createIfAbsent can never"
+            + " itself produce and that must be reconciled out of band.");
     add(
         defs,
         ServiceMetrics.Flight.REQUESTS,

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateIfAbsentTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateIfAbsentTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.floedb.floecat.account.rpc.Account;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.ConflictingBatchPointerStore;
+import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.FailingBatchPointerStore;
+import ai.floedb.floecat.service.repo.model.AccountKey;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.Schemas;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for {@link GenericResourceRepository#createIfAbsent}. Like {@code create()} it
+ * now reserves the canonical and every secondary pointer in a single atomic {@code
+ * compareAndSetBatch}, so it can never leave partial pointer state; the classification of a
+ * non-committing batch is what these tests pin down.
+ */
+class GenericResourceRepositoryCreateIfAbsentTest {
+
+  private InMemoryPointerStore ptr;
+  private InMemoryBlobStore blobs;
+
+  @BeforeEach
+  void setUp() {
+    ptr = new InMemoryPointerStore();
+    blobs = new InMemoryBlobStore();
+  }
+
+  private GenericResourceRepository<Account, AccountKey> repo() {
+    return repoWith(ptr);
+  }
+
+  private GenericResourceRepository<Account, AccountKey> repoWith(PointerStore pointerStore) {
+    return new GenericResourceRepository<>(
+        pointerStore,
+        blobs,
+        Schemas.ACCOUNT,
+        Account::parseFrom,
+        Account::toByteArray,
+        "application/x-protobuf");
+  }
+
+  private static Account account(String id, String name, String description) {
+    return Account.newBuilder()
+        .setResourceId(ResourceId.newBuilder().setId(id).setKind(ResourceKind.RK_ACCOUNT).build())
+        .setDisplayName(name)
+        .setDescription(description)
+        .build();
+  }
+
+  @Test
+  void createIfAbsent_happyPath_returnsTrue_resolvesByIdAndName() {
+    var repo = repo();
+
+    assertThat(repo.createIfAbsent(account("acct-1", "alpha", ""))).isTrue();
+
+    assertThat(repo.getByKey(new AccountKey("acct-1"))).isPresent();
+    assertThat(repo.get(Keys.accountPointerByName("alpha"))).isPresent();
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
+    assertThat(ptr.get(Keys.accountPointerByName("alpha")).orElseThrow().getVersion())
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void createIfAbsent_whenAlreadyPresent_returnsFalse_withoutAdvancingVersions() {
+    var repo = repo();
+    repo.createIfAbsent(account("acct-1", "alpha", ""));
+
+    assertThat(repo.createIfAbsent(account("acct-1", "alpha", ""))).isFalse();
+
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
+    assertThat(ptr.get(Keys.accountPointerByName("alpha")).orElseThrow().getVersion())
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void createIfAbsent_whenCanonicalExistsBoundToDifferentBlob_returnsFalse() {
+    // createIfAbsent reports a lost race (false) whenever the canonical pointer already exists,
+    // regardless of which blob it is bound to — unlike create(), which would throw NameConflict.
+    var repo = repo();
+    repo.createIfAbsent(account("acct-1", "alpha", "v1"));
+
+    assertThat(repo.createIfAbsent(account("acct-1", "alpha", "v2"))).isFalse();
+
+    // The incumbent pointer is untouched.
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
+    assertThat(repo.getByKey(new AccountKey("acct-1")).orElseThrow().getDescription())
+        .isEqualTo("v1");
+  }
+
+  @Test
+  void createIfAbsent_sameNameDifferentId_throwsNameConflict_andLeavesNoCanonicalOrphan() {
+    var repo = repo();
+    repo.createIfAbsent(account("acct-1", "shared", "v1"));
+
+    assertThatThrownBy(() -> repo.createIfAbsent(account("acct-2", "shared", "v2")))
+        .isInstanceOf(BaseResourceRepository.NameConflictException.class)
+        .hasMessageContaining(Keys.accountPointerByName("shared"));
+
+    assertThat(ptr.get(Keys.accountPointerById("acct-2"))).isEmpty();
+  }
+
+  @Test
+  void createIfAbsent_withCanonicalAbsentButSecondaryPresent_throwsCorruption() {
+    var repo = repo();
+    repo.createIfAbsent(account("acct-1", "alpha", ""));
+
+    // Legacy / partially-applied state an atomic path can never produce: the canonical by-id
+    // pointer is gone but the by-name secondary survives (bound to our blob). Strict no-repair:
+    // surface it terminally.
+    assertThat(ptr.delete(Keys.accountPointerById("acct-1"))).isTrue();
+
+    assertThatThrownBy(() -> repo.createIfAbsent(account("acct-1", "alpha", "")))
+        .isInstanceOf(BaseResourceRepository.CorruptionException.class)
+        .hasMessageContaining("partial create state");
+  }
+
+  @Test
+  void createIfAbsent_whenBatchConflictsButNothingPresent_signalsRetryable() {
+    var repo = repoWith(new ConflictingBatchPointerStore(ptr));
+
+    assertThatThrownBy(() -> repo.createIfAbsent(account("acct-1", "alpha", "")))
+        .isInstanceOf(BaseResourceRepository.AbortRetryableException.class);
+  }
+
+  @Test
+  void createIfAbsent_whenBatchThrows_leavesNoPointerState() {
+    var repo = repoWith(new FailingBatchPointerStore(ptr));
+
+    assertThatThrownBy(() -> repo.createIfAbsent(account("acct-1", "alpha", "")))
+        .isInstanceOf(FailingBatchPointerStore.InjectedBatchFailure.class);
+
+    assertThat(ptr.isEmpty()).isTrue();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
@@ -22,18 +22,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ai.floedb.floecat.account.rpc.Account;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
-import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.ConflictingBatchPointerStore;
+import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.DuplicateKeyRejectingPointerStore;
+import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.FailingBatchPointerStore;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -134,16 +132,30 @@ class GenericResourceRepositoryCreateTest {
   }
 
   @Test
-  void create_withMissingSecondaryPointer_signalsRetryable() {
+  void create_withPartialState_throwsCorruption() {
     var repo = new AccountRepository(ptr, blobs);
     var account = account("acct-1", "alpha", "");
     repo.create(account);
 
     // Mimic a legacy / partially-applied state: the canonical pointer survives (bound to our
-    // blob) but the secondary is gone.
+    // blob) but the secondary is gone. An atomic create can never produce this, so under the
+    // strict no-repair contract it is surfaced terminally rather than healed or retried forever.
     assertThat(ptr.delete(Keys.accountPointerByName("alpha"))).isTrue();
 
     assertThatThrownBy(() -> repo.create(account))
+        .isInstanceOf(BaseResourceRepository.CorruptionException.class)
+        .hasMessageContaining("partial create state");
+  }
+
+  @Test
+  void create_whenBatchConflictsButNothingPresent_signalsRetryable() {
+    // The batch reports a conflict (as a DynamoDB TransactionConflict would) but commits nothing,
+    // and the read-back finds no pointer at all. That is transient, not a stable inconsistency, so
+    // create() asks the caller to retry rather than surfacing a (terminal) corruption.
+    var conflicting = new ConflictingBatchPointerStore(ptr);
+    var repo = new AccountRepository(conflicting, blobs);
+
+    assertThatThrownBy(() -> repo.create(account("acct-1", "alpha", "")))
         .isInstanceOf(BaseResourceRepository.AbortRetryableException.class);
   }
 
@@ -166,97 +178,5 @@ class GenericResourceRepositoryCreateTest {
 
     assertThatCode(() -> snapshotRepo.create(snapshot)).doesNotThrowAnyException();
     assertThat(snapshotRepo.getById(tableId, 42L)).isPresent();
-  }
-
-  /** Forwards every {@link PointerStore} call to a delegate; subclasses override one behavior. */
-  private abstract static class DelegatingPointerStore implements PointerStore {
-    final PointerStore delegate;
-
-    DelegatingPointerStore(PointerStore delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public boolean compareAndSetBatch(List<CasOp> ops) {
-      return delegate.compareAndSetBatch(ops);
-    }
-
-    @Override
-    public Optional<Pointer> get(String key) {
-      return delegate.get(key);
-    }
-
-    @Override
-    public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
-      return delegate.compareAndSet(key, expectedVersion, next);
-    }
-
-    @Override
-    public boolean delete(String key) {
-      return delegate.delete(key);
-    }
-
-    @Override
-    public boolean compareAndDelete(String key, long expectedVersion) {
-      return delegate.compareAndDelete(key, expectedVersion);
-    }
-
-    @Override
-    public List<Pointer> listPointersByPrefix(
-        String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
-      return delegate.listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
-    }
-
-    @Override
-    public int deleteByPrefix(String prefix) {
-      return delegate.deleteByPrefix(prefix);
-    }
-
-    @Override
-    public int countByPrefix(String prefix) {
-      return delegate.countByPrefix(prefix);
-    }
-
-    @Override
-    public boolean isEmpty() {
-      return delegate.isEmpty();
-    }
-  }
-
-  /** PointerStore decorator that fails every batch CAS, simulating a transient storage error. */
-  private static final class FailingBatchPointerStore extends DelegatingPointerStore {
-    private FailingBatchPointerStore(PointerStore delegate) {
-      super(delegate);
-    }
-
-    static final class InjectedBatchFailure extends RuntimeException {
-      InjectedBatchFailure(String message) {
-        super(message);
-      }
-    }
-
-    @Override
-    public boolean compareAndSetBatch(List<CasOp> ops) {
-      throw new InjectedBatchFailure("injected batch storage failure");
-    }
-  }
-
-  /** Mimics DynamoDB: a transaction with two operations on the same key is rejected. */
-  private static final class DuplicateKeyRejectingPointerStore extends DelegatingPointerStore {
-    private DuplicateKeyRejectingPointerStore(PointerStore delegate) {
-      super(delegate);
-    }
-
-    @Override
-    public boolean compareAndSetBatch(List<CasOp> ops) {
-      Set<String> seen = new HashSet<>();
-      for (CasOp op : ops) {
-        String key = op instanceof CasUpsert u ? u.key() : ((CasDelete) op).key();
-        if (!seen.add(key)) {
-          throw new IllegalArgumentException("duplicate key in transactional batch: " + key);
-        }
-      }
-      return delegate.compareAndSetBatch(ops);
-    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.floedb.floecat.account.rpc.Account;
+import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for {@link ai.floedb.floecat.service.repo.util.GenericResourceRepository#create}
+ * exercised through {@link AccountRepository} (canonical by-id pointer + secondary by-name
+ * pointer). The contract is verified at the repository level because {@code create()} only relies
+ * on the backend-agnostic {@link PointerStore#compareAndSetBatch} primitive; backend atomicity
+ * parity is covered separately at the SPI level (in-memory and DynamoDB-local).
+ */
+class GenericResourceRepositoryCreateTest {
+
+  private InMemoryPointerStore ptr;
+  private InMemoryBlobStore blobs;
+
+  @BeforeEach
+  void setUp() {
+    ptr = new InMemoryPointerStore();
+    blobs = new InMemoryBlobStore();
+  }
+
+  private static Account account(String id, String name, String description) {
+    return Account.newBuilder()
+        .setResourceId(ResourceId.newBuilder().setId(id).setKind(ResourceKind.RK_ACCOUNT).build())
+        .setDisplayName(name)
+        .setDescription(description)
+        .build();
+  }
+
+  @Test
+  void create_happyPath_resolvesByIdAndByName_atVersionOne() {
+    var repo = new AccountRepository(ptr, blobs);
+    var account = account("acct-1", "alpha", "");
+
+    repo.create(account);
+
+    assertThat(repo.getById(account.getResourceId())).isPresent();
+    assertThat(repo.getByName("alpha")).isPresent();
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
+    assertThat(ptr.get(Keys.accountPointerByName("alpha")).orElseThrow().getVersion())
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void create_isIdempotent_forByteIdenticalValue() {
+    var repo = new AccountRepository(ptr, blobs);
+    var account = account("acct-1", "alpha", "");
+
+    repo.create(account);
+    assertThatCode(() -> repo.create(account)).doesNotThrowAnyException();
+
+    // The idempotent re-create is a no-op: it does not advance either pointer's version.
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
+    assertThat(ptr.get(Keys.accountPointerByName("alpha")).orElseThrow().getVersion())
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void create_sameIdDifferentBytes_throwsNameConflictOnCanonicalPointer() {
+    var repo = new AccountRepository(ptr, blobs);
+    repo.create(account("acct-1", "alpha", "v1"));
+
+    assertThatThrownBy(() -> repo.create(account("acct-1", "alpha", "v2")))
+        .isInstanceOf(BaseResourceRepository.NameConflictException.class)
+        .hasMessageContaining("pointer bound to different blob")
+        .hasMessageContaining(Keys.accountPointerById("acct-1"));
+  }
+
+  @Test
+  void create_sameNameDifferentId_throwsNameConflict_andLeavesNoCanonicalOrphan() {
+    var repo = new AccountRepository(ptr, blobs);
+    repo.create(account("acct-1", "shared", "v1"));
+
+    assertThatThrownBy(() -> repo.create(account("acct-2", "shared", "v2")))
+        .isInstanceOf(BaseResourceRepository.NameConflictException.class)
+        .hasMessageContaining("pointer bound to different blob")
+        .hasMessageContaining(Keys.accountPointerByName("shared"));
+
+    // Atomicity: acct-2's canonical CAS (expectedVersion 0 against an absent key) would have
+    // individually succeeded, but the whole batch failed on the by-name conflict, so no by-id
+    // orphan is left behind.
+    assertThat(ptr.get(Keys.accountPointerById("acct-2"))).isEmpty();
+  }
+
+  @Test
+  void create_whenBatchThrows_leavesNoPointerState() {
+    var failing = new FailingBatchPointerStore(ptr);
+    var repo = new AccountRepository(failing, blobs);
+
+    assertThatThrownBy(() -> repo.create(account("acct-1", "alpha", "")))
+        .isInstanceOf(FailingBatchPointerStore.InjectedBatchFailure.class);
+
+    // This is the regression guard: a mid-create storage failure leaves the pointer store
+    // byte-for-byte unchanged, so a later create cannot collide with a stranded orphan.
+    assertThat(ptr.isEmpty()).isTrue();
+    assertThat(ptr.get(Keys.accountPointerById("acct-1"))).isEmpty();
+    assertThat(ptr.get(Keys.accountPointerByName("alpha"))).isEmpty();
+  }
+
+  @Test
+  void create_withMissingSecondaryPointer_signalsRetryable() {
+    var repo = new AccountRepository(ptr, blobs);
+    var account = account("acct-1", "alpha", "");
+    repo.create(account);
+
+    // Mimic a legacy / partially-applied state: the canonical pointer survives (bound to our
+    // blob) but the secondary is gone.
+    assertThat(ptr.delete(Keys.accountPointerByName("alpha"))).isTrue();
+
+    assertThatThrownBy(() -> repo.create(account))
+        .isInstanceOf(BaseResourceRepository.AbortRetryableException.class);
+  }
+
+  @Test
+  void create_doesNotEmitDuplicateBatchKeys_whenCanonicalIsAlsoASecondary() {
+    // The snapshot schema exposes the canonical by-id pointer as a secondary too, so the batch
+    // would contain two ops on the same key unless create() de-duplicates. DynamoDB rejects such
+    // transactions outright; reproduce that rejection in-memory so the dedupe is locked in.
+    var rejecting = new DuplicateKeyRejectingPointerStore(ptr);
+    var tableRepo = new TableRepository(rejecting, blobs);
+    var snapshotRepo = new SnapshotRepository(rejecting, blobs, tableRepo);
+
+    var tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct-1")
+            .setId("tbl-1")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    var snapshot = Snapshot.newBuilder().setTableId(tableId).setSnapshotId(42L).build();
+
+    assertThatCode(() -> snapshotRepo.create(snapshot)).doesNotThrowAnyException();
+    assertThat(snapshotRepo.getById(tableId, 42L)).isPresent();
+  }
+
+  /** Forwards every {@link PointerStore} call to a delegate; subclasses override one behavior. */
+  private abstract static class DelegatingPointerStore implements PointerStore {
+    final PointerStore delegate;
+
+    DelegatingPointerStore(PointerStore delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<CasOp> ops) {
+      return delegate.compareAndSetBatch(ops);
+    }
+
+    @Override
+    public Optional<Pointer> get(String key) {
+      return delegate.get(key);
+    }
+
+    @Override
+    public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
+      return delegate.compareAndSet(key, expectedVersion, next);
+    }
+
+    @Override
+    public boolean delete(String key) {
+      return delegate.delete(key);
+    }
+
+    @Override
+    public boolean compareAndDelete(String key, long expectedVersion) {
+      return delegate.compareAndDelete(key, expectedVersion);
+    }
+
+    @Override
+    public List<Pointer> listPointersByPrefix(
+        String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+      return delegate.listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
+    }
+
+    @Override
+    public int deleteByPrefix(String prefix) {
+      return delegate.deleteByPrefix(prefix);
+    }
+
+    @Override
+    public int countByPrefix(String prefix) {
+      return delegate.countByPrefix(prefix);
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return delegate.isEmpty();
+    }
+  }
+
+  /** PointerStore decorator that fails every batch CAS, simulating a transient storage error. */
+  private static final class FailingBatchPointerStore extends DelegatingPointerStore {
+    private FailingBatchPointerStore(PointerStore delegate) {
+      super(delegate);
+    }
+
+    static final class InjectedBatchFailure extends RuntimeException {
+      InjectedBatchFailure(String message) {
+        super(message);
+      }
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<CasOp> ops) {
+      throw new InjectedBatchFailure("injected batch storage failure");
+    }
+  }
+
+  /** Mimics DynamoDB: a transaction with two operations on the same key is rejected. */
+  private static final class DuplicateKeyRejectingPointerStore extends DelegatingPointerStore {
+    private DuplicateKeyRejectingPointerStore(PointerStore delegate) {
+      super(delegate);
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<CasOp> ops) {
+      Set<String> seen = new HashSet<>();
+      for (CasOp op : ops) {
+        String key = op instanceof CasUpsert u ? u.key() : ((CasDelete) op).key();
+        if (!seen.add(key)) {
+          throw new IllegalArgumentException("duplicate key in transactional batch: " + key);
+        }
+      }
+      return delegate.compareAndSetBatch(ops);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryUpdateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryUpdateTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.floedb.floecat.account.rpc.Account;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.FailingBatchPointerStore;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for {@link ai.floedb.floecat.service.repo.util.GenericResourceRepository#update}
+ * exercised through {@link AccountRepository}. The update now applies the canonical advance, new
+ * secondary reservations, kept-secondary blob refreshes and removed-secondary deletes in a single
+ * atomic {@code compareAndSetBatch}, so it can never leave partial pointer state.
+ */
+class GenericResourceRepositoryUpdateTest {
+
+  private InMemoryPointerStore ptr;
+  private InMemoryBlobStore blobs;
+
+  @BeforeEach
+  void setUp() {
+    ptr = new InMemoryPointerStore();
+    blobs = new InMemoryBlobStore();
+  }
+
+  private static ResourceId id(String accountId) {
+    return ResourceId.newBuilder().setId(accountId).setKind(ResourceKind.RK_ACCOUNT).build();
+  }
+
+  private static Account account(String accountId, String name, String description) {
+    return Account.newBuilder()
+        .setResourceId(id(accountId))
+        .setDisplayName(name)
+        .setDescription(description)
+        .build();
+  }
+
+  @Test
+  void update_rename_movesSecondaryAtomically() {
+    var repo = new AccountRepository(ptr, blobs);
+    repo.create(account("acct-1", "alpha", ""));
+
+    assertThat(repo.update(account("acct-1", "beta", ""), 1L)).isTrue();
+
+    assertThat(repo.getByName("beta")).isPresent();
+    assertThat(repo.getByName("alpha")).isEmpty();
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(2L);
+    assertThat(ptr.get(Keys.accountPointerByName("beta")).orElseThrow().getVersion()).isEqualTo(1L);
+  }
+
+  @Test
+  void update_keepsName_refreshesKeptSecondaryOntoNewBlob() {
+    // Account uses content-addressed (casBlobs) blobs, so changing the description moves the blob
+    // URI. The kept by-name secondary must be advanced onto the new blob in the same batch.
+    var repo = new AccountRepository(ptr, blobs);
+    repo.create(account("acct-1", "alpha", "v1"));
+
+    assertThat(repo.update(account("acct-1", "alpha", "v2"), 1L)).isTrue();
+
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(2L);
+    assertThat(ptr.get(Keys.accountPointerByName("alpha")).orElseThrow().getVersion())
+        .isEqualTo(2L);
+    // The by-name secondary still resolves, and to the updated content.
+    assertThat(repo.getByName("alpha").orElseThrow().getDescription()).isEqualTo("v2");
+  }
+
+  @Test
+  void update_wrongExpectedVersion_returnsFalse_andLeavesPointersUnchanged() {
+    var repo = new AccountRepository(ptr, blobs);
+    repo.create(account("acct-1", "alpha", ""));
+
+    assertThat(repo.update(account("acct-1", "beta", ""), 5L)).isFalse();
+
+    // Nothing moved: the rename neither created the new name nor dropped the old one.
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
+    assertThat(repo.getByName("alpha")).isPresent();
+    assertThat(ptr.get(Keys.accountPointerByName("beta"))).isEmpty();
+  }
+
+  @Test
+  void update_newNameOwnedByAnotherResource_throwsNameConflict_andLeavesNoPartialState() {
+    var repo = new AccountRepository(ptr, blobs);
+    repo.create(account("acct-1", "alpha", ""));
+    repo.create(account("acct-2", "beta", ""));
+
+    assertThatThrownBy(() -> repo.update(account("acct-1", "beta", ""), 1L))
+        .isInstanceOf(BaseResourceRepository.NameConflictException.class)
+        .hasMessageContaining(Keys.accountPointerByName("beta"));
+
+    // acct-1 is untouched and "beta" still belongs to acct-2.
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
+    assertThat(repo.getByName("alpha")).isPresent();
+    assertThat(repo.getByName("beta").orElseThrow().getResourceId().getId()).isEqualTo("acct-2");
+  }
+
+  @Test
+  void update_whenBatchThrows_leavesNoPartialState() {
+    var realRepo = new AccountRepository(ptr, blobs);
+    realRepo.create(account("acct-1", "alpha", ""));
+
+    var failingRepo = new AccountRepository(new FailingBatchPointerStore(ptr), blobs);
+
+    assertThatThrownBy(() -> failingRepo.update(account("acct-1", "beta", ""), 1L))
+        .isInstanceOf(FailingBatchPointerStore.InjectedBatchFailure.class);
+
+    // The rename committed nothing: old name kept, new name absent, canonical version unchanged.
+    assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
+    assertThat(realRepo.getByName("alpha")).isPresent();
+    assertThat(ptr.get(Keys.accountPointerByName("beta"))).isEmpty();
+  }
+
+  @Test
+  void update_missingResource_throwsNotFound() {
+    var repo = new AccountRepository(ptr, blobs);
+
+    assertThatThrownBy(() -> repo.update(account("acct-missing", "alpha", ""), 1L))
+        .isInstanceOf(BaseResourceRepository.NotFoundException.class);
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/** Shared {@link PointerStore} decorators used by repository behavioral tests. */
+final class RepoTestPointerStores {
+
+  private RepoTestPointerStores() {}
+
+  /** Forwards every {@link PointerStore} call to a delegate; subclasses override one behavior. */
+  abstract static class DelegatingPointerStore implements PointerStore {
+    final PointerStore delegate;
+
+    DelegatingPointerStore(PointerStore delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<CasOp> ops) {
+      return delegate.compareAndSetBatch(ops);
+    }
+
+    @Override
+    public Optional<Pointer> get(String key) {
+      return delegate.get(key);
+    }
+
+    @Override
+    public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
+      return delegate.compareAndSet(key, expectedVersion, next);
+    }
+
+    @Override
+    public boolean delete(String key) {
+      return delegate.delete(key);
+    }
+
+    @Override
+    public boolean compareAndDelete(String key, long expectedVersion) {
+      return delegate.compareAndDelete(key, expectedVersion);
+    }
+
+    @Override
+    public List<Pointer> listPointersByPrefix(
+        String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+      return delegate.listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
+    }
+
+    @Override
+    public int deleteByPrefix(String prefix) {
+      return delegate.deleteByPrefix(prefix);
+    }
+
+    @Override
+    public int countByPrefix(String prefix) {
+      return delegate.countByPrefix(prefix);
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return delegate.isEmpty();
+    }
+  }
+
+  /** Fails every batch CAS, simulating a transient storage error that aborts the transaction. */
+  static final class FailingBatchPointerStore extends DelegatingPointerStore {
+    FailingBatchPointerStore(PointerStore delegate) {
+      super(delegate);
+    }
+
+    static final class InjectedBatchFailure extends RuntimeException {
+      InjectedBatchFailure(String message) {
+        super(message);
+      }
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<CasOp> ops) {
+      throw new InjectedBatchFailure("injected batch storage failure");
+    }
+  }
+
+  /**
+   * Reports every batch CAS as a non-committing conflict, mimicking a DynamoDB {@code
+   * TransactionConflict} / {@code ConditionalCheckFailed} cancellation: nothing is mutated and
+   * {@code false} is returned. Lets a test drive the "batch said no, but read-back finds nothing"
+   * transient path without a real concurrent writer.
+   */
+  static final class ConflictingBatchPointerStore extends DelegatingPointerStore {
+    ConflictingBatchPointerStore(PointerStore delegate) {
+      super(delegate);
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<CasOp> ops) {
+      return false;
+    }
+  }
+
+  /** Mimics DynamoDB: a transaction with two operations on the same key is rejected. */
+  static final class DuplicateKeyRejectingPointerStore extends DelegatingPointerStore {
+    DuplicateKeyRejectingPointerStore(PointerStore delegate) {
+      super(delegate);
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<CasOp> ops) {
+      Set<String> seen = new HashSet<>();
+      for (CasOp op : ops) {
+        String key = op instanceof CasUpsert u ? u.key() : ((CasDelete) op).key();
+        if (!seen.add(key)) {
+          throw new IllegalArgumentException("duplicate key in transactional batch: " + key);
+        }
+      }
+      return delegate.compareAndSetBatch(ops);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributorTest.java
@@ -161,4 +161,18 @@ class ServiceTelemetryContributorTest {
                 ServiceMetrics.Reconcile.PLANNER_TICK_LATENCY.name(),
                 ServiceMetrics.Reconcile.PLANNER_ENQUEUE.name()));
   }
+
+  @Test
+  void registersPartialStateAnomalyMetricWithExpectedTags() {
+    TelemetryRegistry registry = new TelemetryRegistry();
+    registry.register(new ServiceTelemetryContributor());
+
+    MetricDef partialState = registry.metric(ServiceMetrics.Storage.PARTIAL_STATE.name());
+
+    assertThat(partialState).isNotNull();
+    assertThat(partialState.requiredTags())
+        .containsExactlyInAnyOrder(TagKey.OPERATION, TagKey.RESOURCE);
+    assertThat(partialState.allowedTags())
+        .containsExactlyInAnyOrder(TagKey.OPERATION, TagKey.RESOURCE);
+  }
 }

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.storage.kv.AbstractEntity;
 import ai.floedb.floecat.storage.kv.AbstractEntityTest;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.util.Timestamps;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.mutiny.Uni;
@@ -194,6 +195,69 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
 
     assertTrue(pointers.compareAndDelete(key, 1L).await().indefinitely());
     assertTrue(pointers.get(key).await().indefinitely().isEmpty());
+  }
+
+  // ---- Batch CAS (atomic, all-or-nothing)
+
+  @Test
+  void compareAndSetBatch_allClear_commits_all_at_version_one() {
+    String k1 = "/accounts/by-id/500/catalog/a";
+    String k2 = "/accounts/by-id/500/catalog/b";
+
+    boolean ok =
+        pointers
+            .compareAndSetBatch(
+                List.of(
+                    new PointerStore.CasUpsert(
+                        k1, 0L, Pointer.newBuilder().setKey(k1).setBlobUri("s3://b/a").build()),
+                    new PointerStore.CasUpsert(
+                        k2, 0L, Pointer.newBuilder().setKey(k2).setBlobUri("s3://b/b").build())))
+            .await()
+            .indefinitely();
+
+    assertTrue(ok);
+    assertEquals(1L, pointers.get(k1).await().indefinitely().orElseThrow().getVersion());
+    assertEquals(1L, pointers.get(k2).await().indefinitely().orElseThrow().getVersion());
+  }
+
+  @Test
+  void compareAndSetBatch_partialConflict_is_atomic_and_commits_nothing() {
+    String existing = "/accounts/by-id/501/catalog/existing";
+    String fresh = "/accounts/by-id/501/catalog/fresh";
+    assertTrue(
+        pointers
+            .compareAndSet(
+                existing,
+                0L,
+                Pointer.newBuilder().setKey(existing).setBlobUri("s3://b/existing").build())
+            .await()
+            .indefinitely());
+
+    boolean ok =
+        pointers
+            .compareAndSetBatch(
+                List.of(
+                    new PointerStore.CasUpsert(
+                        fresh,
+                        0L,
+                        Pointer.newBuilder().setKey(fresh).setBlobUri("s3://b/fresh").build()),
+                    new PointerStore.CasUpsert(
+                        existing,
+                        0L,
+                        Pointer.newBuilder()
+                            .setKey(existing)
+                            .setBlobUri("s3://b/conflict")
+                            .build())))
+            .await()
+            .indefinitely();
+
+    assertFalse(ok);
+    // The fresh key's upsert would have individually succeeded; atomic rollback leaves it absent.
+    assertTrue(pointers.get(fresh).await().indefinitely().isEmpty());
+    // The existing key is untouched: still bound to its original blob at version 1.
+    Pointer got = pointers.get(existing).await().indefinitely().orElseThrow();
+    assertEquals("s3://b/existing", got.getBlobUri());
+    assertEquals(1L, got.getVersion());
   }
 
   // ---- TTL mapping

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
@@ -147,8 +147,51 @@ public class PointerStoreContractTest {
         () -> store.listPointersByPrefix(prefix(), 10, "bad-token", next));
   }
 
+  @Test
+  void compareAndSetBatch_emptyOps_returns_true() {
+    assertTrue(store.compareAndSetBatch(List.of()));
+  }
+
+  @Test
+  void compareAndSetBatch_allClear_commits_all_at_version_one() {
+    boolean ok =
+        store.compareAndSetBatch(
+            List.of(
+                new PointerStore.CasUpsert(key(1), 0L, pointerWithBlob(key(1), "blob/1")),
+                new PointerStore.CasUpsert(key(2), 0L, pointerWithBlob(key(2), "blob/2"))));
+
+    assertTrue(ok);
+    assertEquals("blob/1", store.get(key(1)).orElseThrow().getBlobUri());
+    assertEquals(1L, store.get(key(1)).orElseThrow().getVersion());
+    assertEquals("blob/2", store.get(key(2)).orElseThrow().getBlobUri());
+    assertEquals(1L, store.get(key(2)).orElseThrow().getVersion());
+  }
+
+  @Test
+  void compareAndSetBatch_partialConflict_is_atomic_and_commits_nothing() {
+    // Pre-commit key(1); a create-if-absent (expectedVersion 0) batch touching it must now fail.
+    assertTrue(store.compareAndSet(key(1), 0L, pointerWithBlob(key(1), "blob/existing")));
+
+    boolean ok =
+        store.compareAndSetBatch(
+            List.of(
+                new PointerStore.CasUpsert(key(2), 0L, pointerWithBlob(key(2), "blob/2")),
+                new PointerStore.CasUpsert(key(1), 0L, pointerWithBlob(key(1), "blob/conflict"))));
+
+    assertFalse(ok);
+    // key(2)'s upsert would have individually succeeded; the atomic batch rolled it back.
+    assertTrue(store.get(key(2)).isEmpty());
+    // key(1) is untouched: still bound to its original blob at version 1.
+    assertEquals("blob/existing", store.get(key(1)).orElseThrow().getBlobUri());
+    assertEquals(1L, store.get(key(1)).orElseThrow().getVersion());
+  }
+
   private static Pointer pointer(String key, long version) {
     return Pointer.newBuilder().setKey(key).setVersion(version).build();
+  }
+
+  private static Pointer pointerWithBlob(String key, String blobUri) {
+    return Pointer.newBuilder().setKey(key).setBlobUri(blobUri).build();
   }
 
   private static String prefix() {


### PR DESCRIPTION
Otherwise we could have half-created resources and not always clean-up.