### PR TITLE
Feat: Allow finalizer job execution to be disabled

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -110,6 +110,7 @@ floecat.reconciler.executor.remote-planner.enabled
 floecat.reconciler.executor.remote-default.enabled
 floecat.reconciler.executor.remote-snapshot-planner.enabled
 floecat.reconciler.executor.remote-file-group.enabled
+floecat.reconciler.executor.snapshot-finalize.enabled
 floecat.reconciler.authorization.header
 floecat.reconciler.oidc.issuer
 floecat.reconciler.oidc.client-id

--- a/docs/reconciler.md
+++ b/docs/reconciler.md
@@ -251,8 +251,9 @@ perform a post-completion final lease confirmation after that RPC has durably co
   - `floecat.reconciler.executor.remote-planner.enabled`
   - `floecat.reconciler.executor.remote-snapshot-planner.enabled`
   - `floecat.reconciler.executor.remote-file-group.enabled`
+  - `floecat.reconciler.executor.snapshot-finalize.enabled`
   - `FINALIZE_SNAPSHOT_CAPTURE` is handled by the service-local `SnapshotFinalizeReconcileExecutor`
-    and is not behind a separate feature toggle.
+    and can be disabled independently, but it is not a separate remote worker toggle.
 - Swap out `ReconcileJobStore` for additional backends by providing a CDI alternative (job ID
   references must remain stable for `GetReconcileJob`).
 - Extend `FloecatConnector` to add richer snapshot planning or file execution behavior. Query scan

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
@@ -492,8 +492,9 @@ public class RemoteReconcileExecutorPoller {
                     leaseStateUncertain.set(false);
                     cancellationRequested.set(response.cancellationRequested());
                   },
-                  () -> stopHeartbeatsForHandledCompletion(completionStarted, heartbeatExecutor)));
+                  () -> {}));
       if (result.completionHandled) {
+        stopHeartbeatsForHandledCompletion(completionStarted, heartbeatExecutor);
         LOG.infof(
             "Remote reconcile job outcome account=%s connector=%s executor=%s result=succeeded duration_ms=%d",
             lease.accountId,

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPollerTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPollerTest.java
@@ -867,7 +867,7 @@ class RemoteReconcileExecutorPollerTest {
   }
 
   @Test
-  void runLeaseStopsHeartbeatsBeforeHandledCompletionReturns() throws Exception {
+  void runLeaseKeepsHeartbeatsRunningUntilHandledCompletionReturns() throws Exception {
     RemoteReconcileExecutorClient client = mock(RemoteReconcileExecutorClient.class);
     AtomicReference<Throwable> failure = new AtomicReference<>();
     AtomicInteger renewCalls = new AtomicInteger();
@@ -933,8 +933,11 @@ class RemoteReconcileExecutorPollerTest {
     assertTrue(sawHeartbeat.await(5, TimeUnit.SECONDS));
     assertTrue(handledCompletionStarted.await(5, TimeUnit.SECONDS));
     int renewCountAtHandledCompletion = renewCalls.get();
-    Thread.sleep(500L);
-    assertTrue(renewCalls.get() == renewCountAtHandledCompletion);
+    long renewDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+    while (renewCalls.get() <= renewCountAtHandledCompletion && System.nanoTime() < renewDeadline) {
+      Thread.sleep(25L);
+    }
+    assertTrue(renewCalls.get() > renewCountAtHandledCompletion);
     allowHandledCompletion.countDown();
     worker.join(5_000L);
 
@@ -949,13 +952,23 @@ class RemoteReconcileExecutorPollerTest {
   }
 
   @Test
-  void runLeaseDoesNotPerformFinalLeaseConfirmationForHandledCompletion() {
+  void runLeaseCanRenewDuringHandledCompletionWithoutExplicitProgress() throws Exception {
     RemoteReconcileExecutorClient client = mock(RemoteReconcileExecutorClient.class);
+    AtomicInteger renewCalls = new AtomicInteger();
+    CountDownLatch handledCompletionStarted = new CountDownLatch(1);
+    CountDownLatch allowHandledCompletion = new CountDownLatch(1);
     ReconcileExecutor executor =
         remoteExecutor(
             "planner",
             context -> {
               context.beforeHandledCompletion().run();
+              handledCompletionStarted.countDown();
+              try {
+                assertTrue(allowHandledCompletion.await(5, TimeUnit.SECONDS));
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+              }
               return ReconcileExecutor.ExecutionResult.successHandled(0, 0, 0, 0, 0, 0, 0, "done");
             });
 
@@ -968,18 +981,36 @@ class RemoteReconcileExecutorPollerTest {
     when(heartbeatConfig.getOptionalValue("floecat.reconciler.job-store.lease-ms", Long.class))
         .thenReturn(java.util.Optional.of(10_000L));
     when(heartbeatConfig.getOptionalValue("reconciler.lease-heartbeat-ms", Long.class))
-        .thenReturn(java.util.Optional.of(10_000L));
+        .thenReturn(java.util.Optional.of(200L));
     poller.config = heartbeatConfig;
     poller.workerModeValue = "local";
     poller.init();
 
     RemoteLeasedJob lease = leasedJob("job-no-final-confirm", ReconcileJobKind.PLAN_TABLE);
+    when(client.renew(lease))
+        .thenAnswer(
+            invocation -> {
+              renewCalls.incrementAndGet();
+              return new RemoteReconcileExecutorClient.LeaseHeartbeat(true, false);
+            });
     when(client.cancellationRequested(lease)).thenReturn(false);
+    Thread worker =
+        new Thread(
+            () ->
+                poller.runLease(
+                    new RemoteReconcileExecutorPoller.LeaseAssignment(executor, lease)));
+    worker.start();
 
-    poller.runLease(new RemoteReconcileExecutorPoller.LeaseAssignment(executor, lease));
+    assertTrue(handledCompletionStarted.await(5, TimeUnit.SECONDS));
+    long renewDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+    while (renewCalls.get() == 0 && System.nanoTime() < renewDeadline) {
+      Thread.sleep(25L);
+    }
+    assertTrue(renewCalls.get() > 0);
+    allowHandledCompletion.countDown();
+    worker.join(5_000L);
 
     verify(client).start(lease, "planner");
-    verify(client, never()).renew(lease);
     verify(client, never())
         .complete(
             any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(),

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizeReconcileExecutor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizeReconcileExecutor.java
@@ -44,6 +44,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -54,9 +55,19 @@ public class SnapshotFinalizeReconcileExecutor implements ReconcileExecutor {
   @Inject StatsStore statsStore;
   @Inject SnapshotPlanBlobStore snapshotPlanBlobStore;
 
+  @ConfigProperty(
+      name = "floecat.reconciler.executor.snapshot-finalize.enabled",
+      defaultValue = "true")
+  boolean enabled;
+
   @Override
   public String id() {
     return "snapshot_finalize";
+  }
+
+  @Override
+  public boolean enabled() {
+    return enabled;
   }
 
   @Override

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -124,6 +124,7 @@ floecat.reconciler.executor.remote-default.enabled=${FLOECAT_RECONCILER_REMOTE_D
 floecat.reconciler.executor.remote-planner.enabled=${FLOECAT_RECONCILER_REMOTE_PLANNER_EXECUTOR_ENABLED:true}
 floecat.reconciler.executor.remote-snapshot-planner.enabled=${FLOECAT_RECONCILER_REMOTE_SNAPSHOT_PLANNER_EXECUTOR_ENABLED:true}
 floecat.reconciler.executor.remote-file-group.enabled=${FLOECAT_RECONCILER_REMOTE_FILE_GROUP_EXECUTOR_ENABLED:true}
+floecat.reconciler.executor.snapshot-finalize.enabled=${FLOECAT_RECONCILER_SNAPSHOT_FINALIZE_EXECUTOR_ENABLED:true}
 # Reconciler workers always use the gRPC control plane.
 # `local` runs worker loops in this JVM for single-node dev/test.
 # `remote` runs remote-style workers; set `reconciler.max-parallelism=0` on control-plane-only nodes.

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizeReconcileExecutorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizeReconcileExecutorTest.java
@@ -75,6 +75,16 @@ class SnapshotFinalizeReconcileExecutorTest {
   private static final Map<SnapshotPlanBlobStore, Map<String, List<TargetStatsRecord>>>
       FILE_GROUP_STATS_RECORDS = new IdentityHashMap<>();
 
+  @Test
+  void enabledDefaultsTrueAndCanBeDisabled() {
+    var executor = new SnapshotFinalizeReconcileExecutor();
+    executor.enabled = true;
+    assertTrue(executor.enabled());
+
+    executor.enabled = false;
+    assertFalse(executor.enabled());
+  }
+
   private static SnapshotPlanBlobStore snapshotPlanBlobStore() {
     SnapshotPlanBlobStore store = mock(SnapshotPlanBlobStore.class);
     Map<String, List<ReconcileFileGroupTask>> groupsByUri = new HashMap<>();


### PR DESCRIPTION
## Summary

This PR enables the default java snapshot finalizer to be switched off, so that an external finalizer implementation can be used instead.

## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

