### PR TITLE
Fix PR changed-file detection for scoped CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   detect-core-changes:
-    name: detect-core-changes
+    name: Route core checks by changed files
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BEFORE_SHA: ${{ github.event.before }}
-          HEAD_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: ./tools/ci/detect-core-changes.sh
 
   gitleaks:
@@ -327,4 +328,3 @@ jobs:
             CONTAINER_TAG=${{ steps.vars.outputs.primary_tag }} \
             CONTAINER_EXTRA_TAGS=${{ steps.vars.outputs.sha_tag }} \
             JIB_IMAGE_PLATFORMS=linux/amd64,linux/arm64
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BEFORE_SHA: ${{ github.event.before }}
-          HEAD_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: ./tools/ci/detect-core-changes.sh
 
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   detect-core-changes:
-    name: detect-core-changes
+    name: Route core checks by changed files
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,7 @@ on:
       - ".markdownlint-cli2.yaml"
       - ".github/workflows/pages.yml"
       - "lighthouserc.json"
+      - "tools/ci/list-changed-files.sh"
       - "tools/site/**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, closed]
@@ -20,6 +21,7 @@ on:
       - ".markdownlint-cli2.yaml"
       - ".github/workflows/pages.yml"
       - "lighthouserc.json"
+      - "tools/ci/list-changed-files.sh"
       - "tools/site/**"
   workflow_dispatch:
 
@@ -83,7 +85,9 @@ jobs:
         id: detect
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_ACTION: ${{ github.event.action }}
         run: |
           set -euo pipefail
@@ -98,15 +102,13 @@ jobs:
             exit 0
           fi
 
-          git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
-          if ! git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
+          changed="$(./tools/ci/list-changed-files.sh)"
+          if [[ -z "${changed}" ]]; then
             site=true
             docs=true
           else
-            changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)"
-
             # Shared website/docs infrastructure -> run both area checks.
-            if echo "${changed}" | grep -qE '^(tools/site/|lighthouserc\.json$|\.github/workflows/pages\.yml$|\.markdownlint-cli2\.yaml$)'; then
+            if echo "${changed}" | grep -qE '^(tools/site/|tools/ci/list-changed-files\.sh$|lighthouserc\.json$|\.github/workflows/pages\.yml$|\.markdownlint-cli2\.yaml$)'; then
               site=true
               docs=true
             fi
@@ -195,7 +197,9 @@ jobs:
       - name: Resolve Site Validation Paths
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
@@ -204,10 +208,9 @@ jobs:
             echo "/floecat/blog/"
           } > /tmp/site-validation-paths.txt
 
-          git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
-          if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
-            git diff --name-status --find-renames --diff-filter=ACMR "${BASE_SHA}...${HEAD_SHA}" -- site-src \
-              | awk 'NF {print $NF}' > /tmp/site-changed-paths.txt
+          ./tools/ci/list-changed-files.sh \
+            | awk '/^site-src\// {print}' > /tmp/site-changed-paths.txt
+          if [[ -s /tmp/site-changed-paths.txt ]]; then
             {
               sed -nE 's#^site-src/_posts/([0-9]{4})-([0-9]{2})-([0-9]{2})-(.+)\.md$#/floecat/\1/\2/\3/\4.html#p' /tmp/site-changed-paths.txt
               sed -nE \
@@ -294,16 +297,17 @@ jobs:
       - name: Resolve Docs Validation Paths
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
           echo "/floecat/documentation/" > /tmp/docs-validation-paths.txt
 
-          git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
-          if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
-            git diff --name-status --find-renames --diff-filter=ACMR "${BASE_SHA}...${HEAD_SHA}" -- docs mkdocs.yml \
-              | awk 'NF {print $NF}' > /tmp/docs-changed-paths.txt
+          ./tools/ci/list-changed-files.sh \
+            | awk '/^(docs\/|mkdocs\.yml$)/ {print}' > /tmp/docs-changed-paths.txt
+          if [[ -s /tmp/docs-changed-paths.txt ]]; then
             {
               sed -nE 's#^docs/index\.md$#/floecat/documentation/#p' /tmp/docs-changed-paths.txt
               sed -nE 's#^docs/(.+)/index\.md$#/floecat/documentation/\1/#p' /tmp/docs-changed-paths.txt

--- a/tools/ci/detect-core-changes.sh
+++ b/tools/ci/detect-core-changes.sh
@@ -19,11 +19,12 @@ set -euo pipefail
 #
 # Required env:
 #   EVENT_NAME  (github.event_name)
-#   HEAD_SHA    (github.sha)
+#   HEAD_SHA    (github.event.pull_request.head.sha for PRs, github.sha otherwise)
 #
 # Optional env:
 #   BASE_SHA    (github.event.pull_request.base.sha)
 #   BEFORE_SHA  (github.event.before)
+#   PR_NUMBER   (github.event.pull_request.number)
 #   CORE_NON_CORE_REGEX (override default non-core matcher)
 #
 # Output:
@@ -33,22 +34,13 @@ EVENT_NAME="${EVENT_NAME:-}"
 BASE_SHA="${BASE_SHA:-}"
 BEFORE_SHA="${BEFORE_SHA:-}"
 HEAD_SHA="${HEAD_SHA:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NON_CORE_RE="${CORE_NON_CORE_REGEX:-^(site-src/|docs/|mkdocs\.yml$|\.markdownlint-cli2\.yaml$|lighthouserc\.json$|tools/site/|\.github/workflows/pages\.yml$)}"
 
 core_changed=true
 changed_files=""
 
-if [[ "${EVENT_NAME}" == "pull_request" && -n "${BASE_SHA}" ]]; then
-  git fetch --no-tags --depth=1 origin "${BASE_SHA}" || true
-  if git cat-file -e "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
-    changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)"
-  fi
-elif [[ "${EVENT_NAME}" == "push" && -n "${BEFORE_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
-  git fetch --no-tags --depth=1 origin "${BEFORE_SHA}" || true
-  if git cat-file -e "${BEFORE_SHA}^{commit}" >/dev/null 2>&1; then
-    changed_files="$(git diff --name-only "${BEFORE_SHA}...${HEAD_SHA}" || true)"
-  fi
-fi
+changed_files="$("${SCRIPT_DIR}/list-changed-files.sh")"
 
 if [[ -n "${changed_files}" ]]; then
   if echo "${changed_files}" | grep -qEv "${NON_CORE_RE}"; then

--- a/tools/ci/list-changed-files.sh
+++ b/tools/ci/list-changed-files.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2026 Yellowbrick Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+# Print changed files for CI routing. PR runs compare the PR base commit to the
+# actual PR head commit, not GitHub's synthetic merge commit, so shallow clones
+# do not need a merge base.
+#
+# Required env:
+#   EVENT_NAME
+#   HEAD_SHA
+#
+# Optional env:
+#   BASE_SHA    (pull_request base sha)
+#   BEFORE_SHA  (push before sha)
+#   PR_NUMBER   (pull_request number; used as fallback for fetching PR heads)
+
+EVENT_NAME="${EVENT_NAME:-}"
+BASE_SHA="${BASE_SHA:-}"
+BEFORE_SHA="${BEFORE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-}"
+PR_NUMBER="${PR_NUMBER:-}"
+
+fetch_commit() {
+  local sha="$1"
+  [[ -n "${sha}" ]] || return 1
+  git fetch --no-tags --depth=1 origin "${sha}" >/dev/null 2>&1 || true
+  git cat-file -e "${sha}^{commit}" >/dev/null 2>&1
+}
+
+if [[ "${EVENT_NAME}" == "pull_request" && -n "${BASE_SHA}" && -n "${HEAD_SHA}" ]]; then
+  if ! fetch_commit "${HEAD_SHA}" && [[ -n "${PR_NUMBER}" ]]; then
+    git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head" >/dev/null 2>&1 || true
+  fi
+  if fetch_commit "${BASE_SHA}" && fetch_commit "${HEAD_SHA}"; then
+    git diff --name-only "${BASE_SHA}" "${HEAD_SHA}"
+  fi
+elif [[ "${EVENT_NAME}" == "push" && -n "${BEFORE_SHA}" && -n "${HEAD_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+  if fetch_commit "${BEFORE_SHA}" && fetch_commit "${HEAD_SHA}"; then
+    git diff --name-only "${BEFORE_SHA}" "${HEAD_SHA}"
+  fi
+fi

--- a/tools/ci/list-changed-files.sh
+++ b/tools/ci/list-changed-files.sh
@@ -41,14 +41,31 @@ fetch_commit() {
 }
 
 if [[ "${EVENT_NAME}" == "pull_request" && -n "${BASE_SHA}" && -n "${HEAD_SHA}" ]]; then
+  if ! fetch_commit "${BASE_SHA}"; then
+    echo "ERROR: unable to fetch PR base commit ${BASE_SHA}" >&2
+    exit 1
+  fi
+
   if ! fetch_commit "${HEAD_SHA}" && [[ -n "${PR_NUMBER}" ]]; then
     git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head" >/dev/null 2>&1 || true
   fi
-  if fetch_commit "${BASE_SHA}" && fetch_commit "${HEAD_SHA}"; then
-    git diff --name-only "${BASE_SHA}" "${HEAD_SHA}"
+
+  if ! fetch_commit "${HEAD_SHA}"; then
+    echo "ERROR: unable to fetch PR head commit ${HEAD_SHA}" >&2
+    exit 1
   fi
+
+  git diff --name-only "${BASE_SHA}" "${HEAD_SHA}"
 elif [[ "${EVENT_NAME}" == "push" && -n "${BEFORE_SHA}" && -n "${HEAD_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
-  if fetch_commit "${BEFORE_SHA}" && fetch_commit "${HEAD_SHA}"; then
-    git diff --name-only "${BEFORE_SHA}" "${HEAD_SHA}"
+  if ! fetch_commit "${BEFORE_SHA}"; then
+    echo "ERROR: unable to fetch push base commit ${BEFORE_SHA}" >&2
+    exit 1
   fi
+
+  if ! fetch_commit "${HEAD_SHA}"; then
+    echo "ERROR: unable to fetch push head commit ${HEAD_SHA}" >&2
+    exit 1
+  fi
+
+  git diff --name-only "${BEFORE_SHA}" "${HEAD_SHA}"
 fi


### PR DESCRIPTION
## Summary

Fixes CI changed-file detection for pull requests so docs/site checks are not skipped when GitHub Actions runs on a synthetic PR merge commit.

## Problem

The scoped CI workflows used `github.sha` and `BASE...HEAD` diffs for PR routing. On `pull_request` events, `github.sha` points to GitHub's synthetic merge commit, not the actual PR head commit. In shallow checkouts, that can fail with `no merge base`.

When that happened, the Pages workflow could detect:

```text
site=false docs=false
```
even if the PR changed files under docs/**, causing docs checks to be skipped.

## Changes
- Add tools/ci/list-changed-files.sh as the shared changed-file detector.
- Compare PR base SHA directly against the actual PR head SHA.
- Avoid merge-base-dependent triple-dot diffs in shallow clones.
- Fail loudly if required commits cannot be fetched.
- Reuse the helper for:
    - core CI routing
    - CodeQL routing
    - Pages site/docs area detection
    - Pages changed page selection for Playwright/Lighthouse
- Rename the core routing check to Route core checks by changed files.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [ ] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

