### PR TITLE
Improve Delta nested type handling and query schema resolution

### DIFF
--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaMapper.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaMapper.java
@@ -47,6 +47,7 @@ import io.delta.kernel.types.TimestampNTZType;
 import io.delta.kernel.types.TimestampType;
 import io.delta.kernel.types.VariantType;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * DeltaSchemaMapper: Converts Delta Lake schema JSON to logical SchemaDescriptor.
@@ -68,16 +69,17 @@ final class DeltaSchemaMapper {
 
     try {
       Set<String> effectivePartitionKeys = partitionKeys == null ? Set.of() : partitionKeys;
+      AtomicInteger ordinals = new AtomicInteger(0);
       try {
         StructType root = DataTypeJsonSerDe.deserializeStructType(schemaJson);
-        walkDeltaStruct(cid_algo, sb, root, "", effectivePartitionKeys);
+        walkDeltaStruct(cid_algo, sb, root, "", effectivePartitionKeys, ordinals);
       } catch (Exception kernelFailure) {
         JsonNode root = MAPPER.readTree(schemaJson);
         JsonNode fields = root.get("fields");
         if (fields == null || !fields.isArray()) {
           throw new IllegalArgumentException("Delta schema JSON must contain a 'fields' array");
         }
-        walkFallbackStruct(cid_algo, sb, root, "", effectivePartitionKeys);
+        walkFallbackStruct(cid_algo, sb, root, "", effectivePartitionKeys, ordinals);
       }
     } catch (Exception e) {
       throw new IllegalArgumentException("Failed to parse Delta schema JSON", e);
@@ -91,7 +93,8 @@ final class DeltaSchemaMapper {
       SchemaDescriptor.Builder sb,
       StructType structType,
       String prefix,
-      Set<String> partitionKeys) {
+      Set<String> partitionKeys,
+      AtomicInteger ordinals) {
     if (structType == null) {
       return;
     }
@@ -113,18 +116,18 @@ final class DeltaSchemaMapper {
                   .setNullable(field.isNullable())
                   .setPhysicalPath(physical)
                   .setPartitionKey(isPartition)
-                  .setOrdinal(i + 1)
+                  .setOrdinal(ordinals.incrementAndGet())
                   .setLeaf(!isContainerType(dataType))
                   .build()));
 
       if (dataType instanceof StructType nestedStruct) {
-        walkDeltaStruct(cid_algo, sb, nestedStruct, physical, partitionKeys);
+        walkDeltaStruct(cid_algo, sb, nestedStruct, physical, partitionKeys, ordinals);
       } else if (dataType instanceof ArrayType arrayType
           && arrayType.getElementType() instanceof StructType elementStruct) {
-        walkDeltaStruct(cid_algo, sb, elementStruct, physical + "[]", partitionKeys);
+        walkDeltaStruct(cid_algo, sb, elementStruct, physical + "[]", partitionKeys, ordinals);
       } else if (dataType instanceof MapType mapType
           && mapType.getValueType() instanceof StructType valueStruct) {
-        walkDeltaStruct(cid_algo, sb, valueStruct, physical + "{}", partitionKeys);
+        walkDeltaStruct(cid_algo, sb, valueStruct, physical + "{}", partitionKeys, ordinals);
       }
     }
   }
@@ -185,7 +188,8 @@ final class DeltaSchemaMapper {
       SchemaDescriptor.Builder sb,
       JsonNode node,
       String prefix,
-      Set<String> partitionKeys) {
+      Set<String> partitionKeys,
+      AtomicInteger ordinals) {
     if (node == null || !node.has("fields")) {
       return;
     }
@@ -208,7 +212,7 @@ final class DeltaSchemaMapper {
                   .setNullable(field.path("nullable").asBoolean(true))
                   .setPhysicalPath(physical)
                   .setPartitionKey(isPartition)
-                  .setOrdinal(i + 1)
+                  .setOrdinal(ordinals.incrementAndGet())
                   .setLeaf(!fallbackContainerType(typeNode))
                   .build()));
 
@@ -216,16 +220,16 @@ final class DeltaSchemaMapper {
         continue;
       }
       if ("struct".equals(typeNode.path("type").asText(""))) {
-        walkFallbackStruct(cid_algo, sb, typeNode, physical, partitionKeys);
+        walkFallbackStruct(cid_algo, sb, typeNode, physical, partitionKeys, ordinals);
       } else if ("array".equals(typeNode.path("type").asText(""))) {
         JsonNode elem = typeNode.get("elementType");
         if (elem != null && elem.isObject() && "struct".equals(elem.path("type").asText(""))) {
-          walkFallbackStruct(cid_algo, sb, elem, physical + "[]", partitionKeys);
+          walkFallbackStruct(cid_algo, sb, elem, physical + "[]", partitionKeys, ordinals);
         }
       } else if ("map".equals(typeNode.path("type").asText(""))) {
         JsonNode value = typeNode.get("valueType");
         if (value != null && value.isObject() && "struct".equals(value.path("type").asText(""))) {
-          walkFallbackStruct(cid_algo, sb, value, physical + "{}", partitionKeys);
+          walkFallbackStruct(cid_algo, sb, value, physical + "{}", partitionKeys, ordinals);
         }
       }
     }

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaNormalizer.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaNormalizer.java
@@ -31,6 +31,8 @@ import java.util.Set;
 
 public final class DeltaSchemaNormalizer {
   private static final ObjectMapper JSON = new ObjectMapper();
+  public static final String DEFAULT_NAME_MAPPING_PROPERTY = "schema.name-mapping.default";
+  private static final String COLUMN_MAPPING_PHYSICAL_NAME_KEY = "delta.columnMapping.physicalName";
 
   private DeltaSchemaNormalizer() {}
 
@@ -87,6 +89,23 @@ public final class DeltaSchemaNormalizer {
     }
   }
 
+  public static String defaultNameMappingJson(String rawSchemaJson) {
+    if (rawSchemaJson == null || rawSchemaJson.isBlank()) {
+      return null;
+    }
+    try {
+      Map<String, Object> root =
+          JSON.readValue(rawSchemaJson, new TypeReference<Map<String, Object>>() {});
+      List<Map<String, Object>> fields = buildNameMappingFields(root.get("fields"));
+      if (fields.isEmpty()) {
+        return null;
+      }
+      return JSON.writeValueAsString(fields);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Failed to build Delta name mapping JSON", e);
+    }
+  }
+
   private static Map<String, Object> normalizeSchemaMap(
       Map<String, Object> root, int desiredSchemaId, boolean rewriteVariantAsStruct) {
     if (root == null) {
@@ -105,6 +124,143 @@ public final class DeltaSchemaNormalizer {
     normalized.put("fields", fields);
     normalized.put("last-column-id", lastColumnId);
     return normalized;
+  }
+
+  private static List<Map<String, Object>> buildNameMappingFields(Object rawFields) {
+    if (!(rawFields instanceof List<?> list)) {
+      return List.of();
+    }
+    List<Map<String, Object>> out = new ArrayList<>(list.size());
+    for (Object entry : list) {
+      if (!(entry instanceof Map<?, ?> rawField)) {
+        continue;
+      }
+      Map<String, Object> field = asStringObjectMap(rawField);
+      Map<String, Object> mapped = buildNameMappingField(field);
+      if (mapped != null) {
+        out.add(mapped);
+      }
+    }
+    return out;
+  }
+
+  private static Map<String, Object> buildNameMappingField(Map<String, Object> field) {
+    int fieldId = fieldId(field);
+    String logicalName = stringValue(field.get("name"));
+    if (fieldId <= 0 || logicalName == null || logicalName.isBlank()) {
+      return null;
+    }
+
+    List<String> names = new ArrayList<>(2);
+    names.add(logicalName);
+    Object metadataObj = field.get("metadata");
+    if (metadataObj instanceof Map<?, ?> metadataMap) {
+      String physicalName = stringValue(metadataMap.get(COLUMN_MAPPING_PHYSICAL_NAME_KEY));
+      if (physicalName != null && !physicalName.isBlank() && !physicalName.equals(logicalName)) {
+        names.add(physicalName);
+      }
+    }
+
+    Map<String, Object> mapped = new LinkedHashMap<>();
+    mapped.put("field-id", fieldId);
+    mapped.put("names", names);
+
+    Object rawType = field.get("type");
+    if (rawType instanceof Map<?, ?> rawTypeMap) {
+      Map<String, Object> typeMap = asStringObjectMap(rawTypeMap);
+      String typeName = stringValue(typeMap.get("type"));
+      if (typeName != null) {
+        String normalized = typeName.trim().toLowerCase(Locale.ROOT);
+        switch (normalized) {
+          case "struct" -> {
+            List<Map<String, Object>> children = buildNameMappingFields(typeMap.get("fields"));
+            if (!children.isEmpty()) {
+              mapped.put("fields", children);
+            }
+          }
+          case "array", "list" -> {
+            Map<String, Object> elementField = buildListElementNameMapping(typeMap);
+            if (elementField != null) {
+              mapped.put("fields", List.of(elementField));
+            }
+          }
+          case "map" -> {
+            List<Map<String, Object>> children = buildMapFieldNameMappings(typeMap);
+            if (!children.isEmpty()) {
+              mapped.put("fields", children);
+            }
+          }
+          default -> {}
+        }
+      }
+    }
+    return mapped;
+  }
+
+  private static Map<String, Object> buildListElementNameMapping(Map<String, Object> typeMap) {
+    Object element = firstNonNull(typeMap.get("element"), typeMap.get("elementType"));
+    if (!(element instanceof Map<?, ?> rawElementMap)) {
+      return null;
+    }
+    int elementId = nonNegativeInt(typeMap.get("element-id"), 0);
+    if (elementId <= 0) {
+      return null;
+    }
+    Map<String, Object> mapped = new LinkedHashMap<>();
+    mapped.put("field-id", elementId);
+    mapped.put("names", List.of("element"));
+
+    Map<String, Object> elementType = asStringObjectMap(rawElementMap);
+    String typeName = stringValue(elementType.get("type"));
+    if (typeName != null && "struct".equalsIgnoreCase(typeName)) {
+      List<Map<String, Object>> nested = buildNameMappingFields(elementType.get("fields"));
+      if (!nested.isEmpty()) {
+        mapped.put("fields", nested);
+      }
+    }
+    return mapped;
+  }
+
+  private static List<Map<String, Object>> buildMapFieldNameMappings(Map<String, Object> typeMap) {
+    List<Map<String, Object>> mapped = new ArrayList<>(2);
+    Map<String, Object> keyField =
+        buildMapChildNameMapping(
+            typeMap.get("key"), typeMap.get("keyType"), typeMap.get("key-id"), "key");
+    if (keyField != null) {
+      mapped.add(keyField);
+    }
+    Map<String, Object> valueField =
+        buildMapChildNameMapping(
+            typeMap.get("value"), typeMap.get("valueType"), typeMap.get("value-id"), "value");
+    if (valueField != null) {
+      mapped.add(valueField);
+    }
+    return mapped;
+  }
+
+  private static Map<String, Object> buildMapChildNameMapping(
+      Object childTypeObj, Object fallbackTypeObj, Object childIdObj, String name) {
+    Object child = firstNonNull(childTypeObj, fallbackTypeObj);
+    if (!(child instanceof Map<?, ?> rawChildMap)) {
+      return null;
+    }
+    int childId = nonNegativeInt(childIdObj, 0);
+    if (childId <= 0) {
+      return null;
+    }
+    Map<String, Object> mapped = new LinkedHashMap<>();
+    mapped.put("field-id", childId);
+    mapped.put("names", List.of(name));
+
+    Map<String, Object> childType = asStringObjectMap(rawChildMap);
+    String typeName = stringValue(childType.get("type"));
+    if (typeName != null && "struct".equalsIgnoreCase(typeName)) {
+      List<Map<String, Object>> nested = buildNameMappingFields(childType.get("fields"));
+      if (!nested.isEmpty()) {
+        mapped.put("fields", nested);
+      }
+    }
+    return mapped;
   }
 
   private static List<Map<String, Object>> normalizeFields(

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/LogicalSchemaMapper.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/LogicalSchemaMapper.java
@@ -120,7 +120,11 @@ public class LogicalSchemaMapper {
         // Iterate through all columns (top-level and nested) and extract ordinals.
         for (var col : schemaDesc.getColumnsList()) {
           if (col.getOrdinal() > 0) {
-            ordinals.put(col.getName(), col.getOrdinal());
+            String key = col.getPhysicalPath();
+            if (key == null || key.isBlank()) {
+              key = col.getName();
+            }
+            ordinals.put(key, col.getOrdinal());
           }
         }
       }

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaMapperTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaMapperTest.java
@@ -313,7 +313,7 @@ class DeltaSchemaMapperTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Ordinals are 1-based within each struct
+  // Ordinals are 1-based across the flattened schema
   // ---------------------------------------------------------------------------
 
   @Test
@@ -331,6 +331,97 @@ class DeltaSchemaMapperTest {
     assertThat(desc.getColumns(0).getOrdinal()).isEqualTo(1);
     assertThat(desc.getColumns(1).getOrdinal()).isEqualTo(2);
     assertThat(desc.getColumns(2).getOrdinal()).isEqualTo(3);
+  }
+
+  @Test
+  void nestedOrdinalsAdvanceAcrossFlattenedSchema() {
+    String json =
+        """
+        {"fields":[
+          {"name":"id","type":"long","nullable":false},
+          {"name":"location","type":{
+            "type":"struct",
+            "fields":[
+              {"name":"lat","type":"double","nullable":true},
+              {"name":"lon","type":"double","nullable":true}
+            ]
+          },"nullable":true},
+          {"name":"name","type":"string","nullable":true}
+        ]}
+        """;
+
+    SchemaDescriptor desc = DeltaSchemaMapper.map(CID, json, Set.of());
+
+    assertThat(desc.getColumnsList().stream().map(SchemaColumn::getOrdinal))
+        .containsExactly(1, 2, 3, 4, 5);
+    assertThat(desc.getColumnsList().stream().map(SchemaColumn::getPhysicalPath))
+        .containsExactly("id", "location", "location.lat", "location.lon", "name");
+  }
+
+  @Test
+  void otelSchemaKeepsTopLevelColumnAfterNestedChildren() {
+    String json =
+        """
+        {"type":"struct","fields":[
+          {"name":"record_id","type":"string","nullable":true,"metadata":{}},
+          {"name":"time","type":"timestamp","nullable":true,"metadata":{}},
+          {"name":"date","type":"date","nullable":true,"metadata":{}},
+          {"name":"service_name","type":"string","nullable":true,"metadata":{}},
+          {"name":"trace_id","type":"string","nullable":true,"metadata":{}},
+          {"name":"span_id","type":"string","nullable":true,"metadata":{}},
+          {"name":"trace_state","type":"string","nullable":true,"metadata":{}},
+          {"name":"parent_span_id","type":"string","nullable":true,"metadata":{}},
+          {"name":"flags","type":"integer","nullable":true,"metadata":{}},
+          {"name":"name","type":"string","nullable":true,"metadata":{}},
+          {"name":"kind","type":"string","nullable":true,"metadata":{}},
+          {"name":"start_time_unix_nano","type":"long","nullable":true,"metadata":{}},
+          {"name":"end_time_unix_nano","type":"long","nullable":true,"metadata":{}},
+          {"name":"attributes","type":"variant","nullable":true,"metadata":{}},
+          {"name":"dropped_attributes_count","type":"integer","nullable":true,"metadata":{}},
+          {"name":"events","type":{"type":"array","elementType":{"type":"struct","fields":[
+            {"name":"time_unix_nano","type":"long","nullable":true,"metadata":{}},
+            {"name":"name","type":"string","nullable":true,"metadata":{}},
+            {"name":"attributes","type":"variant","nullable":true,"metadata":{}},
+            {"name":"dropped_attributes_count","type":"integer","nullable":true,"metadata":{}}
+          ]},"containsNull":true},"nullable":true,"metadata":{}},
+          {"name":"dropped_events_count","type":"integer","nullable":true,"metadata":{}},
+          {"name":"links","type":{"type":"array","elementType":{"type":"struct","fields":[
+            {"name":"trace_id","type":"string","nullable":true,"metadata":{}},
+            {"name":"span_id","type":"string","nullable":true,"metadata":{}},
+            {"name":"trace_state","type":"string","nullable":true,"metadata":{}},
+            {"name":"attributes","type":"variant","nullable":true,"metadata":{}},
+            {"name":"dropped_attributes_count","type":"integer","nullable":true,"metadata":{}},
+            {"name":"flags","type":"integer","nullable":true,"metadata":{}}
+          ]},"containsNull":true},"nullable":true,"metadata":{}},
+          {"name":"dropped_links_count","type":"integer","nullable":true,"metadata":{}},
+          {"name":"status","type":{"type":"struct","fields":[
+            {"name":"message","type":"string","nullable":true,"metadata":{}},
+            {"name":"code","type":"string","nullable":true,"metadata":{}}
+          ]},"nullable":true,"metadata":{}},
+          {"name":"resource","type":{"type":"struct","fields":[
+            {"name":"attributes","type":"variant","nullable":true,"metadata":{}},
+            {"name":"dropped_attributes_count","type":"integer","nullable":true,"metadata":{}}
+          ]},"nullable":true,"metadata":{}},
+          {"name":"resource_schema_url","type":"string","nullable":true,"metadata":{}},
+          {"name":"instrumentation_scope","type":{"type":"struct","fields":[
+            {"name":"name","type":"string","nullable":true,"metadata":{}},
+            {"name":"version","type":"string","nullable":true,"metadata":{}},
+            {"name":"attributes","type":"variant","nullable":true,"metadata":{}},
+            {"name":"dropped_attributes_count","type":"integer","nullable":true,"metadata":{}}
+          ]},"nullable":true,"metadata":{}},
+          {"name":"span_schema_url","type":"string","nullable":true,"metadata":{}}
+        ]}
+        """;
+
+    SchemaDescriptor desc = DeltaSchemaMapper.map(CID, json, Set.of());
+
+    SchemaColumn spanSchemaUrl =
+        desc.getColumnsList().stream()
+            .filter(col -> "span_schema_url".equals(col.getName()))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(spanSchemaUrl.getOrdinal()).isEqualTo(desc.getColumnsCount());
   }
 
   @Test

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaNormalizerTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaNormalizerTest.java
@@ -112,4 +112,27 @@ class DeltaSchemaNormalizerTest {
     Map<String, Object> elementType = (Map<String, Object>) itemsType.get("element");
     assertEquals("struct", elementType.get("type"));
   }
+
+  @Test
+  void defaultNameMappingJsonIncludesLogicalAndPhysicalNames() throws Exception {
+    String deltaSchemaJson =
+        "{\"type\":\"struct\",\"fields\":["
+            + "{\"name\":\"flags\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{\"delta.columnMapping.id\":9,\"delta.columnMapping.physicalName\":\"col-111\"}},"
+            + "{\"name\":\"status\",\"type\":{\"type\":\"struct\",\"fields\":["
+            + "{\"name\":\"message\",\"type\":\"string\",\"nullable\":true,\"metadata\":{\"delta.columnMapping.id\":21,\"delta.columnMapping.physicalName\":\"col-211\"}}"
+            + "]},\"nullable\":true,\"metadata\":{\"delta.columnMapping.id\":20,\"delta.columnMapping.physicalName\":\"col-200\"}}]}";
+
+    String mappingJson = DeltaSchemaNormalizer.defaultNameMappingJson(deltaSchemaJson);
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> mapping = JSON.readValue(mappingJson, List.class);
+    assertEquals(List.of("flags", "col-111"), mapping.get(0).get("names"));
+    assertEquals(9, mapping.get(0).get("field-id"));
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> nested = (List<Map<String, Object>>) mapping.get(1).get("fields");
+    assertEquals(List.of("status", "col-200"), mapping.get(1).get("names"));
+    assertEquals(List.of("message", "col-211"), nested.get(0).get("names"));
+    assertEquals(21, nested.get(0).get("field-id"));
+  }
 }

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/LogicalSchemaMapperTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/LogicalSchemaMapperTest.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.query.rpc.SchemaDescriptor;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class LogicalSchemaMapperTest {
@@ -212,14 +213,14 @@ class LogicalSchemaMapperTest {
     assertEquals("lat", lat.getName());
     assertEquals("location.lat", lat.getPhysicalPath());
     assertEquals(0, lat.getFieldId());
-    assertEquals(1, lat.getOrdinal());
+    assertEquals(3, lat.getOrdinal());
     assertTrue(lat.getLeaf());
 
     SchemaColumn lon = desc.getColumns(3);
     assertEquals("lon", lon.getName());
     assertEquals("location.lon", lon.getPhysicalPath());
     assertEquals(0, lon.getFieldId());
-    assertEquals(2, lon.getOrdinal());
+    assertEquals(4, lon.getOrdinal());
     assertTrue(lon.getLeaf());
 
     assertNotEquals(lat.getId(), lon.getId());
@@ -359,6 +360,32 @@ class LogicalSchemaMapperTest {
       assertEquals(a.getOrdinal(), b.getOrdinal());
       assertEquals(a.getId(), b.getId(), "id must be deterministic");
     }
+  }
+
+  @Test
+  void buildColumnOrdinalsUsesPhysicalPathsForNestedFields() {
+    String deltaJson =
+        """
+        {"fields":[
+          {"name":"id","type":"long","nullable":false},
+          {"name":"location","type":{
+            "type":"struct",
+            "fields":[
+              {"name":"lat","type":"double","nullable":true},
+              {"name":"lon","type":"double","nullable":true}
+            ]
+          },"nullable":true}
+        ]}
+        """;
+
+    Map<String, Integer> ordinals =
+        LogicalSchemaMapper.buildColumnOrdinals(
+            ColumnIdAlgorithm.CID_PATH_ORDINAL, TableFormat.TF_DELTA, deltaJson);
+
+    assertEquals(1, ordinals.get("id"));
+    assertEquals(2, ordinals.get("location"));
+    assertEquals(3, ordinals.get("location.lat"));
+    assertEquals(4, ordinals.get("location.lon"));
   }
 
   @Test

--- a/core/proto/src/main/proto/floecat/query/user_scan.proto
+++ b/core/proto/src/main/proto/floecat/query/user_scan.proto
@@ -50,6 +50,9 @@ message FetchScanBundleRequest {
 
   // Logical predicates used for file-level pruning.
   repeated ai.floedb.floecat.common.Predicate predicates = 4;
+
+  // When true, return only table_info and omit scan bundle materialization.
+  bool metadata_only = 5;
 }
 
 message TableInfo {

--- a/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
@@ -33,11 +33,13 @@ import ai.floedb.floecat.query.rpc.TableInfo;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.storage.impl.ServerSideFileIoPropertiesResolver;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsTargetType;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,26 +51,46 @@ public class ScanBundleService {
   private final TableRepository tables;
   private final SnapshotRepository snapshots;
   private final StatsStore statsStore;
+  private final ServerSideFileIoPropertiesResolver fileIoPropertiesResolver;
 
   @Inject
   public ScanBundleService(
-      TableRepository tables, SnapshotRepository snapshots, StatsStore statsStore) {
+      TableRepository tables,
+      SnapshotRepository snapshots,
+      StatsStore statsStore,
+      ServerSideFileIoPropertiesResolver fileIoPropertiesResolver) {
     this.tables = tables;
     this.snapshots = snapshots;
     this.statsStore = statsStore;
+    this.fileIoPropertiesResolver = fileIoPropertiesResolver;
   }
 
   public ScanBundleWithInfo fetch(
       String correlationId, ResourceId tableId, SnapshotPin snapshotPin) {
+    Table table = requireTable(correlationId, tableId);
+    Snapshot snapshot = requireSnapshot(correlationId, tableId, snapshotPin.getSnapshotId());
+    FloecatConnector.ScanBundle bundle = buildFromStats(table, snapshotPin.getSnapshotId());
+    TableInfo info = buildTableInfo(table, snapshot, snapshotPin.getSnapshotId());
+    return new ScanBundleWithInfo(bundle, info);
+  }
 
+  public TableInfo fetchTableInfo(
+      String correlationId, ResourceId tableId, SnapshotPin snapshotPin) {
+    Table table = requireTable(correlationId, tableId);
+    Snapshot snapshot = requireSnapshot(correlationId, tableId, snapshotPin.getSnapshotId());
+    return buildTableInfo(table, snapshot, snapshotPin.getSnapshotId());
+  }
+
+  private Table requireTable(String correlationId, ResourceId tableId) {
     Table table =
         tables
             .getById(tableId)
             .orElseThrow(
                 () -> GrpcErrors.notFound(correlationId, TABLE, Map.of("id", tableId.getId())));
+    return table;
+  }
 
-    long snapshotId = snapshotPin.getSnapshotId();
-
+  private Snapshot requireSnapshot(String correlationId, ResourceId tableId, long snapshotId) {
     Snapshot snapshot =
         snapshots
             .getById(tableId, snapshotId)
@@ -82,11 +104,7 @@ public class ScanBundleService {
                             tableId.getId(),
                             "snapshot_id",
                             Long.toString(snapshotId))));
-
-    FloecatConnector.ScanBundle bundle = buildFromStats(table, snapshotId);
-
-    TableInfo info = buildTableInfo(table, snapshot, snapshotId);
-    return new ScanBundleWithInfo(bundle, info);
+    return snapshot;
   }
 
   private FloecatConnector.ScanBundle buildFromStats(Table table, long snapshotId) {
@@ -157,12 +175,14 @@ public class ScanBundleService {
     if (schemaJson == null || schemaJson.isBlank()) {
       schemaJson = table.getSchemaJson();
     }
+    String rawSchemaJson = schemaJson;
+    boolean deltaTable = DeltaSchemaNormalizer.isDeltaTable(table, table.getPropertiesMap());
     if (schemaJson != null && !schemaJson.isBlank()) {
       // Delta/Unity tables store the raw Delta schema JSON (name/type/nullable), but the scan
       // engine parses TableInfo.schema_json as an Iceberg schema (id/required). Convert it here,
       // mirroring what the Iceberg REST gateway does for the same tables. Variant is left as a
       // scalar type for the engine to rewrite into a struct.
-      if (DeltaSchemaNormalizer.isDeltaTable(table, table.getPropertiesMap())) {
+      if (deltaTable) {
         schemaJson = DeltaSchemaNormalizer.normalizeSchemaJson(schemaJson, snapshot.getSchemaId());
       }
       builder.setSchemaJson(schemaJson);
@@ -177,11 +197,23 @@ public class ScanBundleService {
       builder.setPartitionSpecs(PartitionSpecInfo.newBuilder().setSpecId(0).build());
     }
 
-    if (table.getPropertiesCount() > 0) {
-      builder.putAllProperties(table.getPropertiesMap());
-    }
-
     String metadataLocation = SnapshotRepository.metadataLocation(snapshot);
+    Map<String, String> tableProperties =
+        fileIoPropertiesResolver.applyToTableProperties(
+            table, metadataLocation, table.getPropertiesMap());
+    if (deltaTable
+        && rawSchemaJson != null
+        && !rawSchemaJson.isBlank()
+        && !tableProperties.containsKey(DeltaSchemaNormalizer.DEFAULT_NAME_MAPPING_PROPERTY)) {
+      String nameMappingJson = DeltaSchemaNormalizer.defaultNameMappingJson(rawSchemaJson);
+      if (nameMappingJson != null && !nameMappingJson.isBlank()) {
+        tableProperties = new LinkedHashMap<>(tableProperties);
+        tableProperties.put(DeltaSchemaNormalizer.DEFAULT_NAME_MAPPING_PROPERTY, nameMappingJson);
+      }
+    }
+    if (!tableProperties.isEmpty()) {
+      builder.putAllProperties(tableProperties);
+    }
     if (metadataLocation != null && !metadataLocation.isBlank()) {
       builder.setMetadataLocation(metadataLocation);
     }

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -477,7 +477,14 @@ public class UserObjectBundleService {
         relation.node() instanceof ViewNode view
             ? view.outputColumns()
             : relation.node() instanceof UserTableNode userTable
-                ? logicalSchemaMapper.map(userTable).getColumnsList()
+                ? UserObjectBundleUtils.qualifyNestedColumnNames(
+                    logicalSchemaForRelation(
+                            correlationId,
+                            relation.relationId(),
+                            userTable,
+                            relation.selectedInput(),
+                            queryContext)
+                        .getColumnsList())
                 : overlay.tableSchema(relation.node().id());
 
     List<SchemaColumn> pruned =
@@ -1075,6 +1082,48 @@ public class UserObjectBundleService {
       builder.setSnapshot(relation.selectedInput().getSnapshot());
     }
     return builder.build();
+  }
+
+  private ai.floedb.floecat.query.rpc.SchemaDescriptor logicalSchemaForRelation(
+      String correlationId,
+      ResourceId relationId,
+      UserTableNode userTable,
+      QueryInput selectedInput,
+      QueryContext queryContext) {
+    SnapshotRef snapshotRef = explicitSnapshotOverride(selectedInput);
+    if (snapshotRef == null) {
+      snapshotRef = snapshotRefFromPin(queryContext.findSnapshotPin(relationId, correlationId));
+    }
+    if (snapshotRef == null) {
+      return logicalSchemaMapper.map(userTable);
+    }
+    CatalogOverlay.SchemaResolution resolved =
+        overlay.schemaFor(correlationId, relationId, snapshotRef);
+    return logicalSchemaMapper.map(resolved.table(), resolved.schemaJson());
+  }
+
+  private SnapshotRef explicitSnapshotOverride(QueryInput selectedInput) {
+    if (selectedInput == null || !selectedInput.hasSnapshot()) {
+      return null;
+    }
+    SnapshotRef snapshot = selectedInput.getSnapshot();
+    return switch (snapshot.getWhichCase()) {
+      case SNAPSHOT_ID, AS_OF -> snapshot;
+      default -> null;
+    };
+  }
+
+  private SnapshotRef snapshotRefFromPin(Optional<SnapshotPin> pin) {
+    if (pin.isEmpty()) {
+      return null;
+    }
+    if (pin.get().hasSnapshotId()) {
+      return SnapshotRef.newBuilder().setSnapshotId(pin.get().getSnapshotId()).build();
+    }
+    if (pin.get().hasAsOf()) {
+      return SnapshotRef.newBuilder().setAsOf(pin.get().getAsOf()).build();
+    }
+    return null;
   }
 
   private NameRef canonicalName(ResourceId id, GraphNode node) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleUtils.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleUtils.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.query.rpc.ColumnInfo;
 import ai.floedb.floecat.query.rpc.Origin;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
+import ai.floedb.floecat.query.rpc.SchemaDescriptor;
 import ai.floedb.floecat.query.rpc.TableReferenceCandidate;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
@@ -67,6 +68,44 @@ public final class UserObjectBundleUtils {
       columns.add(column);
     }
     return columns;
+  }
+
+  public static List<SchemaColumn> qualifyNestedColumnNames(List<SchemaColumn> schema) {
+    if (schema == null || schema.isEmpty()) {
+      return List.of();
+    }
+    return schema.stream().map(UserObjectBundleUtils::withQualifiedNestedName).toList();
+  }
+
+  public static SchemaDescriptor qualifyNestedColumnNames(SchemaDescriptor schema) {
+    if (schema == null || schema.getColumnsCount() == 0) {
+      return SchemaDescriptor.getDefaultInstance();
+    }
+    return schema.toBuilder()
+        .clearColumns()
+        .addAllColumns(qualifyNestedColumnNames(schema.getColumnsList()))
+        .build();
+  }
+
+  static SchemaColumn withQualifiedNestedName(SchemaColumn column) {
+    if (column == null) {
+      return null;
+    }
+    String path = column.getPhysicalPath();
+    if (path == null || path.isBlank()) {
+      path = column.getName();
+    }
+    if (!path.contains(".")) {
+      return column;
+    }
+    return column.toBuilder().setName(toCatalystPath(path)).build();
+  }
+
+  static String toCatalystPath(String path) {
+    if (path == null || path.isBlank()) {
+      return path;
+    }
+    return path.replace("[]", ".element").replace("{}", ".value");
   }
 
   public static ColumnInfo columnInfo(SchemaColumn column, Origin origin) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
@@ -98,19 +98,28 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
                   var pin = ctx.requireSnapshotPin(tableId, correlationId);
 
                   try {
-                    var raw = scanBundles.fetch(correlationId, request.getTableId(), pin);
-
-                    ScanBundle pruned =
-                        ScanPruningUtils.pruneBundle(
-                            raw.bundle(),
-                            request.getRequiredColumnsList(),
-                            request.getPredicatesList());
+                    ScanBundle pruned;
+                    var tableInfo =
+                        request.getMetadataOnly()
+                            ? scanBundles.fetchTableInfo(correlationId, request.getTableId(), pin)
+                            : null;
+                    if (request.getMetadataOnly()) {
+                      pruned = ScanBundle.getDefaultInstance();
+                    } else {
+                      var raw = scanBundles.fetch(correlationId, request.getTableId(), pin);
+                      pruned =
+                          ScanPruningUtils.pruneBundle(
+                              raw.bundle(),
+                              request.getRequiredColumnsList(),
+                              request.getPredicatesList());
+                      tableInfo = raw.tableInfo();
+                    }
 
                     ctx.markPlanningCompleted();
 
                     return FetchScanBundleResponse.newBuilder()
                         .setBundle(pruned)
-                        .setTableInfo(raw.tableInfo())
+                        .setTableInfo(tableInfo)
                         .build();
 
                   } catch (RuntimeException e) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
@@ -33,6 +33,7 @@ import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.LogHelper;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
+import ai.floedb.floecat.service.query.catalog.UserObjectBundleUtils;
 import ai.floedb.floecat.service.query.resolver.ObligationsResolver;
 import ai.floedb.floecat.service.query.resolver.QueryInputResolver;
 import ai.floedb.floecat.service.query.resolver.ViewExpansionResolver;
@@ -171,7 +172,8 @@ public class QuerySchemaServiceImpl extends BaseServiceImpl implements QuerySche
     SnapshotRef snapshotRef = snapshotRefFrom(pin);
     CatalogOverlay.SchemaResolution resolved =
         catalogOverlay.schemaFor(correlationId, rid, snapshotRef);
-    return schemaMapper.map(resolved.table(), resolved.schemaJson());
+    return UserObjectBundleUtils.qualifyNestedColumnNames(
+        schemaMapper.map(resolved.table(), resolved.schemaJson()));
   }
 
   private SchemaDescriptor describeView(String correlationId, ResourceId rid) {

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.storage.impl;
+
+import ai.floedb.floecat.catalog.rpc.Table;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.impl.StorageAuthorityRepository;
+import ai.floedb.floecat.storage.rpc.ResolveStorageAuthorityResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class ServerSideFileIoPropertiesResolver {
+  private static final List<String> FILE_IO_PROPERTY_KEYS =
+      List.of(
+          "s3.region",
+          "s3.endpoint",
+          "s3.path-style-access",
+          "s3.access-key-id",
+          "s3.secret-access-key",
+          "s3.session-token");
+
+  @Inject StorageAuthorityRepository repo;
+  @Inject StorageAuthorityResolver resolver;
+
+  public Map<String, String> resolve(Table table, String location) {
+    String locationPrefix = resolveLocationPrefix(table, location);
+    ResourceId tableId = resolvePersistedTableId(table);
+    if (locationPrefix == null || tableId == null) {
+      return Map.of();
+    }
+
+    var authorities = repo.list(tableId.getAccountId(), Integer.MAX_VALUE, "", new StringBuilder());
+    var authority = StorageAuthorityResolver.resolveBest(authorities, locationPrefix).orElse(null);
+    ResolveStorageAuthorityResponse response =
+        resolver.buildResponse(
+            authority, locationPrefix, tableId.getAccountId(), true, false, true);
+    return mergeStorageAuthorityFileIoConfig(response);
+  }
+
+  public Map<String, String> applyToTableProperties(
+      Table table, String location, Map<String, String> properties) {
+    Map<String, String> resolved = resolve(table, location);
+    if (resolved.isEmpty()) {
+      return properties == null || properties.isEmpty() ? Map.of() : Map.copyOf(properties);
+    }
+
+    LinkedHashMap<String, String> merged = new LinkedHashMap<>();
+    if (properties != null && !properties.isEmpty()) {
+      merged.putAll(properties);
+      FILE_IO_PROPERTY_KEYS.forEach(merged::remove);
+    }
+    merged.putAll(resolved);
+    return merged.isEmpty() ? Map.of() : Map.copyOf(merged);
+  }
+
+  private static Map<String, String> mergeStorageAuthorityFileIoConfig(
+      ResolveStorageAuthorityResponse response) {
+    if (response == null) {
+      return Map.of();
+    }
+    LinkedHashMap<String, String> merged = new LinkedHashMap<>();
+    if (response.getClientSafeConfigCount() > 0) {
+      merged.putAll(response.getClientSafeConfigMap());
+    }
+    if (response.getStorageCredentialsCount() > 0) {
+      merged.putAll(response.getStorageCredentials(0).getConfigMap());
+    }
+    return merged.isEmpty() ? Map.of() : Map.copyOf(merged);
+  }
+
+  private static ResourceId resolvePersistedTableId(Table table) {
+    if (table != null
+        && table.hasResourceId()
+        && table.getResourceId().getKind() == ResourceKind.RK_TABLE) {
+      return table.getResourceId();
+    }
+    return null;
+  }
+
+  private static String resolveLocationPrefix(Table table, String location) {
+    String requestedLocation = resolveStorageUri(location);
+    if (requestedLocation != null) {
+      return requestedLocation;
+    }
+    if (table == null) {
+      return null;
+    }
+    String propertyLocation = resolveStorageUri(table.getPropertiesMap().get("location"));
+    if (propertyLocation != null) {
+      return propertyLocation;
+    }
+    String storageLocation = resolveStorageUri(table.getPropertiesMap().get("storage_location"));
+    if (storageLocation != null) {
+      return storageLocation;
+    }
+    String deltaTableRoot = resolveStorageUri(table.getPropertiesMap().get("delta.table-root"));
+    if (deltaTableRoot != null) {
+      return deltaTableRoot;
+    }
+    String externalLocation = resolveStorageUri(table.getPropertiesMap().get("external.location"));
+    if (externalLocation != null) {
+      return externalLocation;
+    }
+    String upstreamUri = table.hasUpstream() ? table.getUpstream().getUri() : null;
+    return resolveStorageUri(upstreamUri);
+  }
+
+  private static String resolveStorageUri(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    String trimmed = value.trim();
+    String lower = trimmed.toLowerCase(java.util.Locale.ROOT);
+    if (lower.startsWith("s3://")
+        || lower.startsWith("s3a://")
+        || lower.startsWith("s3n://")
+        || lower.startsWith("abfs://")
+        || lower.startsWith("abfss://")
+        || lower.startsWith("gs://")
+        || lower.startsWith("gcs://")
+        || lower.startsWith("wasb://")
+        || lower.startsWith("wasbs://")
+        || lower.startsWith("adl://")
+        || lower.startsWith("oss://")
+        || lower.startsWith("cos://")
+        || lower.startsWith("file://")) {
+      return trimmed;
+    }
+    return null;
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleUtilsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleUtilsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import ai.floedb.floecat.query.rpc.Origin;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class UserObjectBundleUtilsTest {
@@ -41,5 +42,33 @@ class UserObjectBundleUtilsTest {
     assertThat(info.getName()).isEqualTo("ts");
     assertThat(info.getNullable()).isTrue();
     assertThat(info.getOrdinal()).isEqualTo(1);
+  }
+
+  @Test
+  void qualifyNestedColumnNamesUsesPhysicalPathForNestedLeaves() {
+    List<SchemaColumn> schema =
+        List.of(
+            SchemaColumn.newBuilder().setName("flags").setPhysicalPath("flags").build(),
+            SchemaColumn.newBuilder().setName("links").setPhysicalPath("links").build(),
+            SchemaColumn.newBuilder().setName("flags").setPhysicalPath("links[].flags").build(),
+            SchemaColumn.newBuilder()
+                .setName("span_schema_url")
+                .setPhysicalPath("span_schema_url")
+                .build(),
+            SchemaColumn.newBuilder().setName("message").setPhysicalPath("status.message").build());
+
+    assertThat(UserObjectBundleUtils.qualifyNestedColumnNames(schema))
+        .extracting(SchemaColumn::getName)
+        .containsExactly(
+            "flags", "links", "links.element.flags", "span_schema_url", "status.message");
+  }
+
+  @Test
+  void toCatalystPathRewritesCollectionSegments() {
+    assertThat(UserObjectBundleUtils.toCatalystPath("tags[]")).isEqualTo("tags.element");
+    assertThat(UserObjectBundleUtils.toCatalystPath("links[].flags"))
+        .isEqualTo("links.element.flags");
+    assertThat(UserObjectBundleUtils.toCatalystPath("props{}.value"))
+        .isEqualTo("props.value.value");
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolverTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.storage.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.rpc.Table;
+import ai.floedb.floecat.catalog.rpc.UpstreamRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.AuthCredentials;
+import ai.floedb.floecat.service.repo.impl.StorageAuthorityRepository;
+import ai.floedb.floecat.storage.rpc.StorageAuthority;
+import ai.floedb.floecat.storage.secrets.SecretsManager;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ServerSideFileIoPropertiesResolverTest {
+  private ServerSideFileIoPropertiesResolver service;
+  private StorageAuthorityRepository repo;
+
+  @BeforeEach
+  void setUp() {
+    service = new ServerSideFileIoPropertiesResolver();
+    repo = mock(StorageAuthorityRepository.class);
+
+    StorageAuthorityResolver resolver = new StorageAuthorityResolver();
+    resolver.secretsManager = new StaticSecretsManager();
+
+    service.repo = repo;
+    service.resolver = resolver;
+  }
+
+  @Test
+  void applyToTablePropertiesReplacesLocalstackIoSettingsForResolvedAwsAuthority() {
+    when(repo.list(eq("acct"), anyInt(), eq(""), any())).thenReturn(List.of(databricksAuthority()));
+
+    Map<String, String> props =
+        service.applyToTableProperties(
+            table(),
+            "s3://floedb-databricks-metastore-367509577365/metastore/table/metadata/00001.json",
+            Map.of(
+                "s3.endpoint", "http://localhost:19110",
+                "s3.path-style-access", "true",
+                "owner", "analytics"));
+
+    assertEquals("analytics", props.get("owner"));
+    assertEquals("us-east-1", props.get("s3.region"));
+    assertEquals("akid", props.get("s3.access-key-id"));
+    assertEquals("secret", props.get("s3.secret-access-key"));
+    assertFalse(props.containsKey("s3.endpoint"));
+    assertFalse(props.containsKey("s3.path-style-access"));
+  }
+
+  private static Table table() {
+    return Table.newBuilder()
+        .setResourceId(
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setKind(ResourceKind.RK_TABLE)
+                .setId("tbl-1")
+                .build())
+        .putProperties("location", "s3://localstack-output/warehouse/orders")
+        .setUpstream(
+            UpstreamRef.newBuilder()
+                .setUri("s3://floedb-databricks-metastore-367509577365/metastore/table")
+                .build())
+        .build();
+  }
+
+  private static StorageAuthority databricksAuthority() {
+    return StorageAuthority.newBuilder()
+        .setResourceId(
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setKind(ResourceKind.RK_STORAGE_AUTHORITY)
+                .setId("sa-db")
+                .build())
+        .setDisplayName("databricks")
+        .setEnabled(true)
+        .setType("s3")
+        .setLocationPrefix("s3://floedb-databricks-metastore-367509577365")
+        .setRegion("us-east-1")
+        .build();
+  }
+
+  private static final class StaticSecretsManager implements SecretsManager {
+    @Override
+    public void put(String accountId, String secretType, String secretId, byte[] payload) {}
+
+    @Override
+    public Optional<byte[]> get(String accountId, String secretType, String secretId) {
+      return Optional.of(
+          AuthCredentials.newBuilder()
+              .setAws(
+                  AuthCredentials.AwsCredentials.newBuilder()
+                      .setAccessKeyId("akid")
+                      .setSecretAccessKey("secret"))
+              .build()
+              .toByteArray());
+    }
+
+    @Override
+    public void update(String accountId, String secretType, String secretId, byte[] payload) {}
+
+    @Override
+    public void delete(String accountId, String secretType, String secretId) {}
+  }
+}


### PR DESCRIPTION
## Summary

Improve Delta logical schema mapping for nested and complex types.

Normalize nested column names across query schema surfaces so
DescribeInputs and GetUserObjects agree on projected paths.

Refine relation schema resolution to honor explicit relation-level
snapshot overrides while preserving existing SS_CURRENT and effective
query-pin behavior for working query paths.

Include supporting updates to scan bundle and resolver code plus
coverage for the new schema behaviors.

## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

