### PR TITLE
stats: exclude operational timestamps from target-stats content hash

### DIFF
--- a/core/stats/src/main/java/ai/floedb/floecat/stats/identity/TargetStatsRecords.java
+++ b/core/stats/src/main/java/ai/floedb/floecat/stats/identity/TargetStatsRecords.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.catalog.rpc.ScalarStats;
 import ai.floedb.floecat.catalog.rpc.StatsMetadata;
 import ai.floedb.floecat.catalog.rpc.TableValueStats;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
+import ai.floedb.floecat.catalog.rpc.UpstreamStamp;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -172,6 +173,61 @@ public final class TargetStatsRecords {
         record.getSnapshotId(),
         record.getFile(),
         record.hasMetadata() ? record.getMetadata() : null);
+  }
+
+  /**
+   * Returns a copy of {@code record} with volatile operational timestamps cleared, for use as the
+   * content-hash image behind a content-addressed storage key.
+   *
+   * <p>{@link StatsMetadata} {@code captured_at}/{@code refreshed_at} and every {@link
+   * UpstreamStamp} {@code fetched_at} are wall-clock stamps applied at capture time. Folding them
+   * into the content hash makes an otherwise-identical resubmission hash differently, so the stable
+   * target pointer can no longer be re-bound to the same blob and the write fails with a "pointer
+   * bound to different blob" conflict. They are excluded here so records that differ only in these
+   * timestamps share one blob and re-submit idempotently, mirroring the idempotency-fingerprint
+   * contract. The stored record is untouched; only the hash image drops them.
+   */
+  public static TargetStatsRecord contentHashImage(TargetStatsRecord record) {
+    if (record == null) {
+      return null;
+    }
+    TargetStatsRecord.Builder builder = record.toBuilder();
+    if (builder.hasMetadata()) {
+      builder.setMetadata(builder.getMetadata().toBuilder().clearCapturedAt().clearRefreshedAt());
+    }
+    switch (record.getValueCase()) {
+      case TABLE -> {
+        if (record.getTable().hasUpstream()) {
+          builder.setTable(
+              record.getTable().toBuilder()
+                  .setUpstream(record.getTable().getUpstream().toBuilder().clearFetchedAt()));
+        }
+      }
+      case SCALAR -> builder.setScalar(scalarHashImage(record.getScalar()));
+      case FILE -> builder.setFile(fileHashImage(record.getFile()));
+      case VALUE_NOT_SET -> {}
+    }
+    return builder.build();
+  }
+
+  private static ScalarStats scalarHashImage(ScalarStats scalar) {
+    if (!scalar.hasUpstream()) {
+      return scalar;
+    }
+    return scalar.toBuilder()
+        .setUpstream(scalar.getUpstream().toBuilder().clearFetchedAt())
+        .build();
+  }
+
+  private static FileTargetStats fileHashImage(FileTargetStats file) {
+    FileTargetStats.Builder builder = file.toBuilder();
+    for (int i = 0; i < builder.getColumnsCount(); i++) {
+      FileColumnStats column = builder.getColumns(i);
+      if (column.hasScalar() && column.getScalar().hasUpstream()) {
+        builder.setColumns(i, column.toBuilder().setScalar(scalarHashImage(column.getScalar())));
+      }
+    }
+    return builder.build();
   }
 
   private static FileTargetStats canonicalFileStats(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -427,6 +427,13 @@ public class StatsRepository implements StatsStore {
     }
 
     private boolean createIfAbsent(String pointerKey, String blobUri, TargetStatsRecord value) {
+      // The target pointer is bound, so ifAbsent must leave the existing record untouched. Now
+      // that content-hash images can map distinct records to one blobUri (timestamp-only resubmits
+      // share a blob), writing the blob before this check would overwrite the live record's bytes
+      // and still return false on the CAS miss. Check the pointer first and write nothing.
+      if (pointerStore.get(pointerKey).isPresent()) {
+        return false;
+      }
       boolean blobExistedBefore = blobStore.head(blobUri).isPresent();
       putBlob(blobUri, value);
       Pointer reserve = PointerReferences.blobPointer(pointerKey, blobUri, 1L);

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -358,7 +358,7 @@ public class StatsRepository implements StatsStore {
         record.getSnapshotId(),
         generationId,
         StatsTargetIdentity.storageId(record.getTarget()),
-        Hashing.sha256Hex(record.toByteArray()));
+        Hashing.sha256Hex(TargetStatsRecords.contentHashImage(record).toByteArray()));
   }
 
   private void deleteGeneration(

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/impl/StatsCanonicalizer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/impl/StatsCanonicalizer.java
@@ -177,8 +177,8 @@ final class StatsCanonicalizer {
           g.scalar("system", up.getSystem().name());
           g.scalar("table_native_id", up.getTableNativeId());
           g.scalar("commit_ref", up.getCommitRef());
-          g.scalar("fetched_at_seconds", up.hasFetchedAt() ? up.getFetchedAt().getSeconds() : 0L);
-          g.scalar("fetched_at_nanos", up.hasFetchedAt() ? up.getFetchedAt().getNanos() : 0);
+          // fetched_at is an operational timestamp and intentionally excluded from content
+          // identity/fingerprinting, matching captured_at/refreshed_at in canonicalStatsMetadata.
           g.map("properties", up.getPropertiesMap());
         });
   }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -491,6 +491,44 @@ class StatsRepositoryTargetStorageTest {
   }
 
   @Test
+  void putTargetStatsIfAbsentDoesNotOverwriteWhenOnlyOperationalTimestampsDiffer() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 9191L;
+
+    TargetStatsRecord existing =
+        TargetStatsRecords.tableRecord(
+            TABLE_ID,
+            snapshotId,
+            TableValueStats.newBuilder()
+                .setRowCount(11L)
+                .setUpstream(
+                    UpstreamStamp.newBuilder().setCommitRef("snap").setFetchedAt(ts(1_000L)))
+                .build(),
+            metadataAt(ts(1_000L), ts(1_000L)));
+    // Same payload, only operational timestamps differ -> same content blob address as `existing`.
+    TargetStatsRecord resubmit =
+        TargetStatsRecords.tableRecord(
+            TABLE_ID,
+            snapshotId,
+            TableValueStats.newBuilder()
+                .setRowCount(11L)
+                .setUpstream(
+                    UpstreamStamp.newBuilder().setCommitRef("snap").setFetchedAt(ts(2_000L)))
+                .build(),
+            metadataAt(ts(2_000L), ts(2_000L)));
+
+    repository.putTargetStats(existing);
+
+    // The target is already bound, so ifAbsent must report false AND leave the stored record's
+    // bytes (including its real operational timestamps) untouched -- it must not overwrite the
+    // shared blob before the pointer CAS miss.
+    assertThat(repository.putTargetStatsIfAbsent(resubmit)).isFalse();
+    assertThat(repository.getTargetStats(TABLE_ID, snapshotId, StatsTargetIdentity.tableTarget()))
+        .contains(existing);
+  }
+
+  @Test
   void replaceAllStatsForSnapshotSwapsAndRemovesSnapshotStats() {
     StatsRepository repository =
         new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ai.floedb.floecat.catalog.rpc.EngineExpressionStatsTarget;
+import ai.floedb.floecat.catalog.rpc.FileColumnStats;
 import ai.floedb.floecat.catalog.rpc.FileTargetStats;
 import ai.floedb.floecat.catalog.rpc.ScalarStats;
 import ai.floedb.floecat.catalog.rpc.StatsCaptureMode;
@@ -29,6 +30,7 @@ import ai.floedb.floecat.catalog.rpc.StatsProducer;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.TableValueStats;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
+import ai.floedb.floecat.catalog.rpc.UpstreamStamp;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
@@ -38,6 +40,7 @@ import ai.floedb.floecat.stats.spi.StatsTargetType;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -358,6 +361,107 @@ class StatsRepositoryTargetStorageTest {
                         null)))
         .isInstanceOf(BaseResourceRepository.NameConflictException.class)
         .hasMessageContaining("pointer bound to different blob");
+  }
+
+  @Test
+  void resubmitDifferingOnlyInOperationalTimestampsIsIdempotent() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 9091L;
+
+    TargetStatsRecord first =
+        TargetStatsRecords.tableRecord(
+            TABLE_ID,
+            snapshotId,
+            TableValueStats.newBuilder()
+                .setRowCount(11L)
+                .setUpstream(
+                    UpstreamStamp.newBuilder().setCommitRef("snap").setFetchedAt(ts(1_000L)))
+                .build(),
+            metadataAt(ts(1_000L), ts(1_000L)));
+    TargetStatsRecord second =
+        TargetStatsRecords.tableRecord(
+            TABLE_ID,
+            snapshotId,
+            TableValueStats.newBuilder()
+                .setRowCount(11L)
+                .setUpstream(
+                    UpstreamStamp.newBuilder().setCommitRef("snap").setFetchedAt(ts(2_000L)))
+                .build(),
+            metadataAt(ts(2_000L), ts(2_000L)));
+
+    repository.putTargetStats(first);
+    // Identical payload, only operational timestamps differ: both records hash to the same content
+    // blob, so the stable target pointer re-binds to that same blob (last write wins on content)
+    // instead of failing with a "pointer bound to different blob" conflict. Regression for the
+    // MC_CONFLICT resubmit bug.
+    repository.putTargetStats(second);
+
+    assertThat(repository.getTargetStats(TABLE_ID, snapshotId, StatsTargetIdentity.tableTarget()))
+        .contains(second);
+  }
+
+  @Test
+  void resubmitFileTargetDifferingOnlyInColumnUpstreamIsIdempotent() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 9092L;
+
+    TargetStatsRecord first =
+        TargetStatsRecords.fileRecord(
+            TABLE_ID,
+            snapshotId,
+            fileStatsWithColumnFetchedAt(ts(1_000L)),
+            metadataAt(ts(1_000L), ts(1_000L)));
+    TargetStatsRecord second =
+        TargetStatsRecords.fileRecord(
+            TABLE_ID,
+            snapshotId,
+            fileStatsWithColumnFetchedAt(ts(2_000L)),
+            metadataAt(ts(2_000L), ts(2_000L)));
+
+    repository.putTargetStats(first);
+    // Mirrors the ingest case: per-column scalar upstream fetched_at is wall-clock and differs on
+    // every capture; it must not change the content blob address, so the resubmit re-binds the same
+    // pointer instead of conflicting (last write wins on content).
+    repository.putTargetStats(second);
+
+    assertThat(
+            repository.getTargetStats(
+                TABLE_ID, snapshotId, StatsTargetIdentity.fileTarget("s3://bucket/f.parquet")))
+        .contains(second);
+  }
+
+  private static FileTargetStats fileStatsWithColumnFetchedAt(Timestamp fetchedAt) {
+    return FileTargetStats.newBuilder()
+        .setFilePath("s3://bucket/f.parquet")
+        .setRowCount(7L)
+        .addColumns(
+            FileColumnStats.newBuilder()
+                .setColumnId(1L)
+                .setScalar(
+                    ScalarStats.newBuilder()
+                        .setLogicalType("BIGINT")
+                        .setRowCount(7L)
+                        .setUpstream(
+                            UpstreamStamp.newBuilder()
+                                .setCommitRef("snap")
+                                .setFetchedAt(fetchedAt))))
+        .build();
+  }
+
+  private static StatsMetadata metadataAt(Timestamp capturedAt, Timestamp refreshedAt) {
+    return StatsMetadata.newBuilder()
+        .setProducer(StatsProducer.SPROD_SOURCE_NATIVE)
+        .setCompleteness(StatsCompleteness.SC_COMPLETE)
+        .setCaptureMode(StatsCaptureMode.SCM_ASYNC)
+        .setCapturedAt(capturedAt)
+        .setRefreshedAt(refreshedAt)
+        .build();
+  }
+
+  private static Timestamp ts(long seconds) {
+    return Timestamp.newBuilder().setSeconds(seconds).build();
   }
 
   @Test


### PR DESCRIPTION
## Problem

`SubmitLeasedFileGroupExecutionResult` resubmits fail `ABORTED MC_CONFLICT` →
`NameConflictException: pointer bound to different blob: .../target-generations/<gen>/targets/file-<sha>`,
so jobs burn attempts to permanent `FAILED`.

`StatsRepository.blobUri` content-addresses each target blob by `sha256(record.toByteArray())`,
but records carry wall-clock timestamps (`StatsMetadata.captured_at`/`refreshed_at`, every
`UpstreamStamp.fetched_at`). An otherwise-identical re-capture therefore hashes to a different
blob, and rebinding the stable target pointer to it throws. The idempotency fingerprint already
excludes operational timestamps by contract — the blob hash just never used it.

## Fix

- **`TargetStatsRecords.contentHashImage()`** — returns a copy with operational timestamps cleared
  (`captured_at`/`refreshed_at` + every `fetched_at`, including per-column scalars in file records).
  `blobUri` now hashes that image instead of raw bytes, so timestamp-only resubmits re-bind the
  stable pointer to the same blob (last-writer-wins on content) instead of conflicting. **Stored
  records keep their real timestamps** — this is hash-only, provenance/CLI unaffected.
- **`StatsCanonicalizer.canonicalUpstream`** — stop folding `fetched_at` into the idempotency
  fingerprint, honoring its own "operational timestamps intentionally excluded" docstring, so the
  fingerprint and blob identity now agree.
- Side effect: a crash between pointer bind and idempotency-record write is no longer fatal — a
  lost idempotency record causes a harmless re-bind, not a conflict.

## Tests

- New regression tests (table + file/per-column upstream) in `StatsRepositoryTargetStorageTest`.
- `StatsRepositoryTargetStorageTest`, `TableStatisticsServiceImplFingerprintTest`, `StatsIT` (9/9)
  all green; `fmt:check` clean. Existing `conflictingPutTargetStatsForSameTargetIsRejected` still
  passes — real content differences still conflict, only operational timestamps are excluded.

## Deploy note

Governs **new** writes only. Targets already bound under the old full-bytes hash will conflict
once on the first post-deploy resubmit into the existing active generation (new stripped-hash blob
≠ stale pointer's old blob). Clear `targets-active`/generation pointers (or delete/recreate) for
affected snapshots after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
