### PR TITLE
Truncate oversized downstream-exception detail in gRPC status mapping

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
@@ -353,6 +353,8 @@ public final class GrpcErrors {
 
   private static final int DEFAULT_MAX_DETAIL_CHARS = 512;
   private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+  private static final String ELISION_PREFIX = " ...[";
+  private static final String ELISION_SUFFIX = " chars elided]... ";
 
   private static boolean fetchDebugDetailsFlag() {
     try {
@@ -392,7 +394,8 @@ public final class GrpcErrors {
    *
    * <p>Whitespace is collapsed and, when the text exceeds the cap, the middle is elided while head
    * and tail are preserved — AWS messages place the actionable constraint <em>after</em> the
-   * embedded dump, so a head-only truncation would discard it.
+   * embedded dump, so a head-only truncation would discard it. The elision marker is counted
+   * against the cap, so the returned string never exceeds {@code max}.
    */
   static String clampDetail(String raw) {
     if (raw == null) {
@@ -403,10 +406,21 @@ public final class GrpcErrors {
     if (collapsed.length() <= max) {
       return collapsed;
     }
-    int dropped = collapsed.length() - max;
-    int head = (max + 1) / 2;
-    int tail = max - head;
-    String elision = " ...[" + dropped + " chars elided]... ";
+    // Reserve room for the marker inside the cap so head + tail + marker <= max. The dropped count
+    // is strictly less than collapsed.length(), so its decimal width is bounded by that length's.
+    int markerWidth =
+        ELISION_PREFIX.length()
+            + Integer.toString(collapsed.length()).length()
+            + ELISION_SUFFIX.length();
+    if (max <= markerWidth) {
+      // Cap too small to fit head/tail around a marker; hard-truncate the head.
+      return collapsed.substring(0, max);
+    }
+    int budget = max - markerWidth;
+    int head = (budget + 1) / 2;
+    int tail = budget - head;
+    int dropped = collapsed.length() - budget;
+    String elision = ELISION_PREFIX + dropped + ELISION_SUFFIX;
     return collapsed.substring(0, head) + elision + collapsed.substring(collapsed.length() - tail);
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 public final class GrpcErrors {
@@ -325,7 +326,7 @@ public final class GrpcErrors {
       eb.setMessageKey(messageKey);
     }
 
-    String resolvedMessage = resolveStatusMessage(eb, canonical, t, correlationId);
+    String resolvedMessage = clampDetail(resolveStatusMessage(eb, canonical, t, correlationId));
     eb.setMessage(resolvedMessage);
 
     Status.Builder statusBuilder =
@@ -350,6 +351,9 @@ public final class GrpcErrors {
   private static final MessageCatalog DEFAULT_MESSAGE_CATALOG = new MessageCatalog(DEFAULT_LOCALE);
   private static final String ERROR_DOMAIN = "ai.floedb.floecat";
 
+  private static final int DEFAULT_MAX_DETAIL_CHARS = 512;
+  private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+
   private static boolean fetchDebugDetailsFlag() {
     try {
       return ConfigProvider.getConfig()
@@ -364,6 +368,48 @@ public final class GrpcErrors {
     return fetchDebugDetailsFlag();
   }
 
+  private static int maxDetailChars() {
+    try {
+      return ConfigProvider.getConfig()
+          .getOptionalValue("floecat.errors.max-detail-chars", Integer.class)
+          .filter(n -> n > 0)
+          .orElse(DEFAULT_MAX_DETAIL_CHARS);
+    } catch (Throwable e) {
+      return DEFAULT_MAX_DETAIL_CHARS;
+    }
+  }
+
+  /**
+   * Bounds free-text exception detail before it is packed into a gRPC status.
+   *
+   * <p>Downstream exception messages — notably AWS SDK validation errors, which echo the entire
+   * offending request (e.g. DynamoDB {@code TransactWriteItems} dumps tens of KB) — are otherwise
+   * copied verbatim into the {@code Error} detail params, the {@code grpc-message} description, and
+   * (via the {@code MC_INTERNAL} catalog template's {@code {root_message}} placeholder, re-rendered
+   * in {@code LocalizeErrorsInterceptor}) the {@code grpc-status-details-bin} trailer. Left
+   * unbounded the trailer exceeds the HTTP/2 max-header-list-size and the peer (Netty/Envoy
+   * waypoint) resets the stream with {@code RST_STREAM PROTOCOL_ERROR}, masking the real cause.
+   *
+   * <p>Whitespace is collapsed and, when the text exceeds the cap, the middle is elided while head
+   * and tail are preserved — AWS messages place the actionable constraint <em>after</em> the
+   * embedded dump, so a head-only truncation would discard it.
+   */
+  static String clampDetail(String raw) {
+    if (raw == null) {
+      return "";
+    }
+    String collapsed = WHITESPACE.matcher(raw).replaceAll(" ").trim();
+    int max = maxDetailChars();
+    if (collapsed.length() <= max) {
+      return collapsed;
+    }
+    int dropped = collapsed.length() - max;
+    int head = (max + 1) / 2;
+    int tail = max - head;
+    String elision = " ...[" + dropped + " chars elided]... ";
+    return collapsed.substring(0, head) + elision + collapsed.substring(collapsed.length() - tail);
+  }
+
   private static void annotateCause(Map<String, String> params, Throwable t) {
     if (t != null) {
       Throwable root = rootCause(t);
@@ -372,7 +418,7 @@ public final class GrpcErrors {
       params.put("cause", root.getClass().getSimpleName());
       String m = root.getMessage();
       if (m != null && !m.isBlank()) {
-        params.putIfAbsent("root_message", m);
+        params.putIfAbsent("root_message", clampDetail(m));
       }
       return;
     }
@@ -511,7 +557,8 @@ public final class GrpcErrors {
   private static DebugInfo buildDebugInfo(Throwable t) {
     Throwable root = rootCause(t);
     DebugInfo.Builder builder =
-        DebugInfo.newBuilder().setDetail(root.getClass().getName() + ": " + safeRootMessage(root));
+        DebugInfo.newBuilder()
+            .setDetail(clampDetail(root.getClass().getName() + ": " + safeRootMessage(root)));
     StackTraceElement[] stackTrace = root.getStackTrace();
     int limit = Math.min(stackTrace.length, 5);
     for (int i = 0; i < limit; i++) {

--- a/service/src/test/java/ai/floedb/floecat/service/error/impl/GrpcErrorsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/error/impl/GrpcErrorsTest.java
@@ -26,6 +26,7 @@ import com.google.rpc.DebugInfo;
 import com.google.rpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -122,6 +123,64 @@ class GrpcErrorsTest {
     assertEquals(ErrorCode.MC_UNAVAILABLE, floecatStatus.errorCode());
     assertEquals("stats.engine.not.implemented", floecatStatus.messageKey());
     assertEquals("list_target_stats", floecatStatus.params().get("operation"));
+  }
+
+  @Test
+  void clampDetailKeepsHeadAndTailAndElidesMiddle() {
+    // Shape mirrors an AWS SDK validation message: the actionable constraint trails the
+    // embedded request/value dump, so the truncation must preserve both ends.
+    String head = "1 validation error detected: Value '";
+    String tail =
+        "' at 'transactItems' failed to satisfy constraint: "
+            + "Member must have length less than or equal to 100";
+    String oversized = head + "A".repeat(40_000) + tail;
+
+    String clamped = GrpcErrors.clampDetail(oversized);
+
+    assertTrue(clamped.length() < 700, "clamped detail should be bounded, was " + clamped.length());
+    assertTrue(clamped.startsWith("1 validation error detected"), clamped);
+    assertTrue(
+        clamped.endsWith("Member must have length less than or equal to 100"),
+        "tail constraint must survive: " + clamped);
+    assertTrue(clamped.contains("elided"), clamped);
+  }
+
+  @Test
+  void clampDetailLeavesShortMessagesIntact() {
+    assertEquals("boom", GrpcErrors.clampDetail("boom"));
+    assertEquals("", GrpcErrors.clampDetail(null));
+    // Whitespace runs (multi-line SDK dumps) are collapsed so they stay header-safe.
+    assertEquals("a b c", GrpcErrors.clampDetail("a\n\t b   c"));
+  }
+
+  @Test
+  void internalErrorBoundsRootMessageAndRenderedMessageForOversizedCause() {
+    String dump = "X".repeat(40_000);
+    StatusRuntimeException ex =
+        GrpcErrors.internal("corr-id", null, null, new RuntimeException(dump));
+
+    Status statusProto = StatusProto.fromThrowable(ex);
+    Error error = detailOfType(statusProto, Error.class);
+    assertNotNull(error, "Error detail should be present");
+
+    String rootMessage = error.getParamsMap().get("root_message");
+    assertNotNull(rootMessage, "root_message param should be set");
+    assertTrue(
+        rootMessage.length() < 700, "root_message must be clamped, was " + rootMessage.length());
+
+    // The MC_INTERNAL catalog template interpolates {root_message}; LocalizeErrorsInterceptor
+    // re-renders it into grpc-message + grpc-status-details-bin. With the source clamped, the
+    // rendered message stays well under the HTTP/2 header-list-size limit.
+    String rendered = new MessageCatalog(Locale.ENGLISH).render(error);
+    assertTrue(rendered.contains("root="), "template should still render the cause: " + rendered);
+    assertTrue(
+        rendered.length() < 2048,
+        "rendered message must stay header-safe, was " + rendered.length());
+
+    // The whole serialized status (what becomes grpc-status-details-bin) must be bounded too.
+    assertTrue(
+        statusProto.toByteArray().length < 4096,
+        "serialized status trailer must be bounded, was " + statusProto.toByteArray().length);
   }
 
   private static <T extends com.google.protobuf.Message> T detailOfType(

--- a/service/src/test/java/ai/floedb/floecat/service/error/impl/GrpcErrorsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/error/impl/GrpcErrorsTest.java
@@ -137,7 +137,10 @@ class GrpcErrorsTest {
 
     String clamped = GrpcErrors.clampDetail(oversized);
 
-    assertTrue(clamped.length() < 700, "clamped detail should be bounded, was " + clamped.length());
+    // The elision marker is counted against the cap, so the whole string stays within the
+    // default 512-char budget (not budget + marker).
+    assertTrue(
+        clamped.length() <= 512, "clamped detail must respect the cap, was " + clamped.length());
     assertTrue(clamped.startsWith("1 validation error detected"), clamped);
     assertTrue(
         clamped.endsWith("Member must have length less than or equal to 100"),


### PR DESCRIPTION
## Problem

A downstream `DynamoDbException` (e.g. the `TransactWriteItems` 100-item breach) carries the **entire offending request** — tens of KB — in its message. `GrpcErrors` mapped it to `INTERNAL` and copied that text verbatim into the `Error` detail's `root_message` param. The `MC_INTERNAL` catalog template (`errors_en.properties`) contains `{root_message}`, so `LocalizeErrorsInterceptor` **re-rendered** the full dump into both the `grpc-message` description and the re-packed `grpc-status-details-bin` trailer.

That trailer then exceeded the HTTP/2 `max-header-list-size`, so Netty / the Envoy waypoint reset the stream with `RST_STREAM PROTOCOL_ERROR`. The reconcile worker reported a transport error instead of the real cause — the actual DynamoDB reason was only recoverable from floecat's own server-side `RpcLoggingInterceptor` log. This masks *any* large downstream error, not just the DynamoDB one.

Note `GrpcErrors.build`'s message-hiding for `INTERNAL` was **not** sufficient: the interceptor's locale re-render re-expands `{root_message}`, so the fix has to bound the text at its source param.

## Fix

A `clampDetail(String)` helper in `GrpcErrors` that:
- collapses whitespace (multi-line SDK dumps → header-safe single line), and
- when over the cap, **keeps head + tail and elides the middle** — AWS places the actionable constraint *after* the embedded value dump, so a head-only truncation would discard it.

Cap is `floecat.errors.max-detail-chars` (default **512**), read the same way as the existing `floecat.errors.debug-details` flag. Applied to the `root_message` param, the resolved status message, and the `DebugInfo` detail — bounding every copy that reaches the status/trailer.

## Tests

`GrpcErrorsTest` (+3 new): head/tail-elide preservation, short/whitespace passthrough, and an end-to-end check that a 40 KB cause yields a header-safe rendered `MC_INTERNAL` message and bounded serialized status. Full targeted run green: `GrpcErrorsTest` 7/7, `GrpcErrorsContractArchTest` 5/5, `MessageCatalogTest` 2/2, `BaseServiceImplTest` 1/1. `mvn fmt:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)