### PR TITLE
Fix propagation of connector job cancellation

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
@@ -1093,6 +1093,10 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
       var cancelled = jobs.cancel(accountId, effectiveChild.jobId, reason);
       if (cancelled.isPresent() && "JS_CANCELLING".equals(cancelled.get().state)) {
         cancellations.requestCancel(cancelled.get().jobId);
+      }
+      var recursiveTarget = cancelled.orElse(storedChild);
+      if (recursiveTarget != null && supportsChildAggregation(recursiveTarget.jobKind)) {
+        cancelChildJobs(accountId, recursiveTarget, reason);
       } else if (cancelled.isEmpty() && canCancelViaActiveChildren(storedChild, effectiveChild)) {
         cancelChildJobs(accountId, storedChild, reason);
       }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
@@ -279,6 +279,10 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
       var cancelled = jobs.cancel(accountId, child.jobId, message);
       if (cancelled.isPresent() && "JS_CANCELLING".equals(cancelled.get().state)) {
         cancellations.requestCancel(cancelled.get().jobId);
+      }
+      var recursiveTarget = cancelled.orElse(storedChild);
+      if (recursiveTarget != null && supportsChildCancellation(recursiveTarget.jobKind)) {
+        cancelChildJobs(accountId, recursiveTarget, message);
       } else if (cancelled.isEmpty()
           && storedChild != null
           && supportsChildCancellation(storedChild.jobKind)

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
@@ -1002,6 +1002,66 @@ class ReconcileControlImplTest {
   }
 
   @Test
+  void cancelReconcileJobCancelsQueuedGrandchildrenOfCancelledPlanChildren() {
+    var connector = job("plan-1", "JS_CANCELLED", 0, 0, 0, "");
+    var table = childJob("table-1", "JS_CANCELLED", 0, 0, 0, "", "plan-1");
+    var snapshot = snapshotChildJob("snapshot-1", "JS_CANCELLED", 0, 0, 0, "", "table-1");
+    var fileGroup =
+        new ReconcileJobStore.ReconcileJob(
+            "file-1",
+            "acct",
+            "connector-1",
+            "JS_CANCELLED",
+            "",
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            false,
+            ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode.METADATA_AND_CAPTURE,
+            0L,
+            0L,
+            null,
+            null,
+            "",
+            "executor-1",
+            ReconcileJobKind.EXEC_FILE_GROUP,
+            null,
+            null,
+            null,
+            ReconcileFileGroupTask.empty(),
+            "snapshot-1");
+    when(service.jobs.cancel("acct", "plan-1", "stop")).thenReturn(Optional.of(connector));
+    when(service.jobs.cancel("acct", "table-1", "stop")).thenReturn(Optional.of(table));
+    when(service.jobs.cancel("acct", "snapshot-1", "stop")).thenReturn(Optional.of(snapshot));
+    when(service.jobs.cancel("acct", "file-1", "stop")).thenReturn(Optional.of(fileGroup));
+    when(service.jobs.get("acct", "plan-1")).thenReturn(Optional.of(connector));
+    when(service.jobs.get("acct", "table-1")).thenReturn(Optional.of(table));
+    when(service.jobs.get("acct", "snapshot-1")).thenReturn(Optional.of(snapshot));
+    when(service.jobs.childJobsPage("acct", "plan-1", 200, ""))
+        .thenReturn(new ReconcileJobStore.ReconcileJobPage(java.util.List.of(table), ""));
+    when(service.jobs.childJobsPage("acct", "table-1", 200, ""))
+        .thenReturn(new ReconcileJobStore.ReconcileJobPage(java.util.List.of(snapshot), ""));
+    when(service.jobs.childJobsPage("acct", "snapshot-1", 200, ""))
+        .thenReturn(new ReconcileJobStore.ReconcileJobPage(java.util.List.of(fileGroup), ""));
+
+    var response =
+        service
+            .cancelReconcileJob(
+                CancelReconcileJobRequest.newBuilder().setJobId("plan-1").setReason("stop").build())
+            .await()
+            .indefinitely();
+
+    assertEquals(true, response.getCancelled());
+    verify(service.jobs).cancel("acct", "table-1", "stop");
+    verify(service.jobs).cancel("acct", "snapshot-1", "stop");
+    verify(service.jobs).cancel("acct", "file-1", "stop");
+  }
+
+  @Test
   void getReconcileJobUsesPreAggregatedSummaryWithoutChildTraversal() {
     var aggregateJob =
         new ReconcileJobStore.ReconcileJob(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
@@ -707,6 +707,59 @@ class ReconcileExecutorControlImplTest {
             eq(0L));
   }
 
+  @Test
+  void completeLeasedReconcileJobCancelsQueuedGrandchildrenOfCancelledPlanChildren() {
+    when(service.jobs.applyLeaseOutcome(
+            eq("job-1"),
+            eq("lease-1"),
+            eq(ReconcileJobStore.CompletionKind.CANCELLED),
+            anyLong(),
+            eq("stop"),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L)))
+        .thenReturn(true);
+    var connector = job("job-1", "acct", ReconcileJobKind.PLAN_CONNECTOR, "", "JS_CANCELLED");
+    var table = job("table-1", "acct", ReconcileJobKind.PLAN_TABLE, "job-1", "JS_CANCELLED");
+    var snapshot =
+        job("snapshot-1", "acct", ReconcileJobKind.PLAN_SNAPSHOT, "table-1", "JS_CANCELLED");
+    var fileGroup =
+        job("file-1", "acct", ReconcileJobKind.EXEC_FILE_GROUP, "snapshot-1", "JS_CANCELLED");
+    when(service.jobs.get(null, "job-1")).thenReturn(Optional.of(connector));
+    when(service.jobs.get("acct", "table-1")).thenReturn(Optional.of(table));
+    when(service.jobs.get("acct", "snapshot-1")).thenReturn(Optional.of(snapshot));
+    when(service.jobs.cancel("acct", "table-1", "stop")).thenReturn(Optional.of(table));
+    when(service.jobs.cancel("acct", "snapshot-1", "stop")).thenReturn(Optional.of(snapshot));
+    when(service.jobs.cancel("acct", "file-1", "stop")).thenReturn(Optional.of(fileGroup));
+    when(service.jobs.childJobsPage("acct", "job-1", 200, ""))
+        .thenReturn(new ReconcileJobStore.ReconcileJobPage(List.of(table), ""));
+    when(service.jobs.childJobsPage("acct", "table-1", 200, ""))
+        .thenReturn(new ReconcileJobStore.ReconcileJobPage(List.of(snapshot), ""));
+    when(service.jobs.childJobsPage("acct", "snapshot-1", 200, ""))
+        .thenReturn(new ReconcileJobStore.ReconcileJobPage(List.of(fileGroup), ""));
+
+    var response =
+        service
+            .completeLeasedReconcileJob(
+                CompleteLeasedReconcileJobRequest.newBuilder()
+                    .setJobId("job-1")
+                    .setLeaseEpoch("lease-1")
+                    .setState(ReconcileCompletionState.RCS_CANCELLED)
+                    .setMessage("stop")
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertTrue(response.getAccepted());
+    verify(service.jobs).cancel("acct", "table-1", "stop");
+    verify(service.jobs).cancel("acct", "snapshot-1", "stop");
+    verify(service.jobs).cancel("acct", "file-1", "stop");
+  }
+
   private static ReconcileJobStore.ReconcileJob job(
       String jobId, String accountId, ReconcileJobKind jobKind, String parentJobId) {
     return job(jobId, accountId, jobKind, parentJobId, "JS_QUEUED");


### PR DESCRIPTION
## Summary

Cancellation requests are not propagated to file_group jobs. This PR fixes this.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

