### PR TITLE
service/security: propagate principal across grpc worker thread-hop

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
@@ -120,6 +120,10 @@ public class InboundContextInterceptor {
     Context context = contextWithResolvedCallContext(Context.current(), resolved);
 
     populateMdc(resolved);
+    // Mirror the principal onto the Vert.x duplicated context (same channel as MDC) so it survives
+    // Quarkus's gRPC dispatch worker thread-hop into the service body, where the io.grpc.Context
+    // key alone is unreliable. See PrincipalProvider for the full rationale.
+    PrincipalProvider.storeOnDuplicatedContext(resolved.principalContext());
 
     var forwarding =
         new SimpleForwardingServerCall<ReqT, RespT>(call) {

--- a/service/src/main/java/ai/floedb/floecat/service/security/impl/PrincipalProvider.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/impl/PrincipalProvider.java
@@ -18,13 +18,83 @@ package ai.floedb.floecat.service.security.impl;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import io.grpc.Context;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Vertx;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/**
+ * Resolves the principal for the current call. The principal is carried on two channels:
+ *
+ * <ul>
+ *   <li>an {@link io.grpc.Context} key ({@link #KEY}), read by gRPC server interceptors that run
+ *       <i>before</i> the call is dispatched to the service method; and
+ *   <li>a Vert.x duplicated-context local ({@link #PRINCIPAL_LOCAL}), read by the service-method
+ *       body, which runs <i>after</i> Quarkus's gRPC dispatch has hopped the call onto a Vert.x
+ *       worker.
+ * </ul>
+ *
+ * <p>The second channel exists because {@link io.grpc.Context} is not reliable across that worker
+ * thread-hop: {@code io.grpc.override.ContextStorageOverride} stores the context as a
+ * duplicated-context local only while it is attached on a duplicated context, and otherwise falls
+ * back to a plain {@link ThreadLocal}. When the principal is attached on one context and read on a
+ * different worker without a re-attach, the thread-local fallback diverges and {@link #KEY} reads
+ * back empty — surfacing as a misleading {@code PERMISSION_DENIED}. A duplicated-context local, on
+ * the other hand, is keyed off the (per-call) duplicated context itself, so it survives the hop for
+ * exactly the same reason MDC does, and cannot bleed between concurrent calls.
+ */
 @ApplicationScoped
 public class PrincipalProvider {
   public static final Context.Key<PrincipalContext> KEY = Context.key("principal");
 
+  /** Vert.x duplicated-context local key under which the resolved principal is mirrored. */
+  private static final String PRINCIPAL_LOCAL = "floecat.principal";
+
+  /**
+   * Returns the principal for the current call.
+   *
+   * <p>The duplicated-context local is preferred over {@link #KEY}: every read through this method
+   * happens in the service-method body (the interceptors read {@link #KEY} directly), where the
+   * local is the per-call value that survived the worker hop, while {@link #KEY} may be empty or —
+   * via its thread-local fallback on a reused worker — carry a stale value. Falls back to {@link
+   * #KEY} for callers that resolve the principal without a Vert.x duplicated context (e.g. unit
+   * tests that drive {@link io.grpc.Context} directly), and to the empty default when neither
+   * channel carries a principal.
+   */
   public PrincipalContext get() {
-    return KEY.get() != null ? KEY.get() : PrincipalContext.getDefaultInstance();
+    PrincipalContext fromContextLocal = fromDuplicatedContext();
+    if (fromContextLocal != null) {
+      return fromContextLocal;
+    }
+    PrincipalContext fromGrpc = KEY.get();
+    if (fromGrpc != null) {
+      return fromGrpc;
+    }
+    return PrincipalContext.getDefaultInstance();
+  }
+
+  /**
+   * Mirrors the resolved principal onto the current Vert.x duplicated context so it survives the
+   * gRPC dispatch worker thread-hop into the service-method body. Called from the inbound
+   * interceptor alongside MDC population, on the same context MDC is written to.
+   *
+   * <p>No-op when the current call is not on a Vert.x duplicated context (the {@link
+   * io.grpc.Context} key remains the carrier in that case), so it is safe to call unconditionally.
+   */
+  public static void storeOnDuplicatedContext(PrincipalContext principalContext) {
+    io.vertx.core.Context ctx = Vertx.currentContext();
+    if (ctx != null && VertxContext.isDuplicatedContext(ctx)) {
+      ctx.putLocal(PRINCIPAL_LOCAL, principalContext);
+    }
+  }
+
+  private static PrincipalContext fromDuplicatedContext() {
+    io.vertx.core.Context ctx = Vertx.currentContext();
+    if (ctx != null && VertxContext.isDuplicatedContext(ctx)) {
+      Object value = ctx.getLocal(PRINCIPAL_LOCAL);
+      if (value instanceof PrincipalContext principalContext) {
+        return principalContext;
+      }
+    }
+    return null;
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/security/impl/PrincipalProviderTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/impl/PrincipalProviderTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.security.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import io.grpc.Context;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Vertx;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for the dual-channel principal carrier in {@link PrincipalProvider}.
+ *
+ * <p>These tests model the production failure deterministically: the resolved principal is mirrored
+ * onto a Vert.x duplicated context by the inbound interceptor, then read back from the
+ * service-method body, which runs on a worker after Quarkus's gRPC dispatch thread-hop — a point
+ * where the {@code io.grpc.Context} key is absent (or, on a reused worker, stale). The
+ * duplicated-context local must carry the principal across that hop the same way MDC does.
+ */
+class PrincipalProviderTest {
+
+  private static final PrincipalContext PRINCIPAL =
+      PrincipalContext.newBuilder()
+          .setSubject("dev-user")
+          .setAccountId("5eaa9cd5")
+          .addPermissions("catalog.read")
+          .build();
+
+  @FunctionalInterface
+  private interface Body {
+    PrincipalContext run();
+  }
+
+  /**
+   * The core fix: a principal stored on the duplicated context survives the worker thread-hop into
+   * the service body and is read back even though {@code io.grpc.Context} carries no principal
+   * there. Before the fix this returned {@link PrincipalContext#getDefaultInstance()} → missing
+   * {@code catalog.read}.
+   */
+  @Test
+  void principalSurvivesWorkerHopWhenGrpcKeyAbsent() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      PrincipalContext observed = storeThenRunOnWorker(vertx, () -> new PrincipalProvider().get());
+      assertEquals("dev-user", observed.getSubject());
+      assertEquals(List.of("catalog.read"), observed.getPermissionsList());
+    } finally {
+      close(vertx);
+    }
+  }
+
+  /**
+   * The duplicated-context local (per-call, correct) is preferred over a non-null {@code
+   * io.grpc.Context} key — which on a reused worker can hold a previous call's principal via the
+   * thread-local fallback. Guards against cross-call principal bleed.
+   */
+  @Test
+  void duplicatedContextLocalPreferredOverStaleGrpcKey() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      PrincipalContext stale =
+          PrincipalContext.newBuilder().setSubject("other-tenant").setAccountId("deadbeef").build();
+      PrincipalContext observed =
+          storeThenRunOnWorker(
+              vertx,
+              () -> {
+                // A stale principal lingering on io.grpc.Context, as on a reused worker thread.
+                Context grpc = Context.current().withValue(PrincipalProvider.KEY, stale);
+                Context prev = grpc.attach();
+                try {
+                  return new PrincipalProvider().get();
+                } finally {
+                  grpc.detach(prev);
+                }
+              });
+      assertEquals("dev-user", observed.getSubject(), "should prefer the per-call context local");
+    } finally {
+      close(vertx);
+    }
+  }
+
+  /** Off any Vert.x duplicated context, the {@code io.grpc.Context} key remains the carrier. */
+  @Test
+  void fallsBackToGrpcKeyOffDuplicatedContext() {
+    Context grpc = Context.current().withValue(PrincipalProvider.KEY, PRINCIPAL);
+    Context prev = grpc.attach();
+    try {
+      assertEquals("dev-user", new PrincipalProvider().get().getSubject());
+    } finally {
+      grpc.detach(prev);
+    }
+  }
+
+  /** With no principal on either channel, the empty default is returned (contract preserved). */
+  @Test
+  void returnsDefaultWhenNoPrincipalAnywhere() {
+    assertEquals(PrincipalContext.getDefaultInstance(), new PrincipalProvider().get());
+  }
+
+  /** Storing off a duplicated context is a safe no-op, not an exception. */
+  @Test
+  void storeIsNoOpOffDuplicatedContext() {
+    PrincipalProvider.storeOnDuplicatedContext(PRINCIPAL);
+    assertEquals(PrincipalContext.getDefaultInstance(), new PrincipalProvider().get());
+  }
+
+  // ---------- helpers ----------
+
+  /**
+   * Models the real call shape: store the principal on a fresh per-call duplicated context (the
+   * inbound interceptor), then run {@code body} on a worker hop that stays on that same duplicated
+   * context (the service body, dispatched off the event loop). The completion is chained back
+   * asynchronously so the event loop is never blocked.
+   */
+  private static PrincipalContext storeThenRunOnWorker(Vertx vertx, Body body) throws Exception {
+    CompletableFuture<PrincipalContext> result = new CompletableFuture<>();
+    io.vertx.core.Context dup = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+    dup.runOnContext(
+        ignored -> {
+          try {
+            PrincipalProvider.storeOnDuplicatedContext(PRINCIPAL);
+            Vertx.currentContext()
+                .<PrincipalContext>executeBlocking(body::run, false)
+                .onComplete(
+                    ar -> {
+                      if (ar.succeeded()) {
+                        result.complete(ar.result());
+                      } else {
+                        result.completeExceptionally(ar.cause());
+                      }
+                    });
+          } catch (Throwable t) {
+            result.completeExceptionally(t);
+          }
+        });
+    return result.get(10, TimeUnit.SECONDS);
+  }
+
+  private static void close(Vertx vertx) throws Exception {
+    vertx.close().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/security/impl/PrincipalProviderTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/impl/PrincipalProviderTest.java
@@ -110,17 +110,27 @@ class PrincipalProviderTest {
     }
   }
 
-  /** With no principal on either channel, the empty default is returned (contract preserved). */
+  /**
+   * With no principal on either channel, the empty default is returned (contract preserved). Runs
+   * under a clean root gRPC context: the shared surefire JVM can leave an unrelated principal
+   * attached on this thread's {@code io.grpc.Context}, which must not mask the default.
+   */
   @Test
-  void returnsDefaultWhenNoPrincipalAnywhere() {
-    assertEquals(PrincipalContext.getDefaultInstance(), new PrincipalProvider().get());
+  void returnsDefaultWhenNoPrincipalAnywhere() throws Exception {
+    PrincipalContext got = Context.ROOT.call(() -> new PrincipalProvider().get());
+    assertEquals(PrincipalContext.getDefaultInstance(), got);
   }
 
   /** Storing off a duplicated context is a safe no-op, not an exception. */
   @Test
-  void storeIsNoOpOffDuplicatedContext() {
-    PrincipalProvider.storeOnDuplicatedContext(PRINCIPAL);
-    assertEquals(PrincipalContext.getDefaultInstance(), new PrincipalProvider().get());
+  void storeIsNoOpOffDuplicatedContext() throws Exception {
+    PrincipalContext got =
+        Context.ROOT.call(
+            () -> {
+              PrincipalProvider.storeOnDuplicatedContext(PRINCIPAL);
+              return new PrincipalProvider().get();
+            });
+    assertEquals(PrincipalContext.getDefaultInstance(), got);
   }
 
   // ---------- helpers ----------


### PR DESCRIPTION
## Problem

The principal rode only an `io.grpc.Context` key. Quarkus hops the gRPC call onto a Vert.x worker between the inbound interceptors and the service-method body. `io.grpc.Context` only tracks a duplicated-context local while it is attached on a duplicated context; otherwise it falls back to a plain `ThreadLocal`. After the hop the key reads back empty. `authz.require` then throws `missing permission: catalog.read` (also seen on `GetUserObjects`, `ListTargetStats`, and `GetConnector`/`connector.manage`). It is intermittent, ~1 in thousands, load-dependent.

AUTHDIAG repro confirmed the principal at `authz.require` is fully empty (accountId, subject, permissions all blank) while MDC stays correct. So it is a propagation race, not a reduced-role token and not the blank-account downgrade. MDC survives because it rides the Vert.x duplicated context. The principal did not.

## Fix

Mirror the resolved principal onto the Vert.x duplicated context (MDC's channel) in the inbound interceptor. Read it first in `PrincipalProvider.get()`, before the gRPC key. The local is per-call, so it survives the hop and cannot bleed between concurrent calls. Interceptor-phase readers keep using the gRPC key unchanged.

## Tests

- `PrincipalProviderTest` (new): principal survives the worker hop with the gRPC key absent; per-call local wins over a stale key; off-context fallback and default preserved.
- `CtxPropagatingBlockingWrapTest`: unchanged, 7/7.
- `QueryContextPropagationIT`: 1600 calls per method, OTel on, 0 `PERMISSION_DENIED`.

## Note

`BlockingInboundContextInterceptor`'s `@Priority(0)` is ignored by Quarkus's interceptor comparator, which only honors `Prioritized`. So it runs innermost, not "before other interceptors" as its comment claims. Not changed here — this fix is order-independent. Worth a follow-up.

Closes #335
