### PR TITLE
service/reconciler: bound lease-scan concurrency to stop ready-scan storm

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -901,14 +901,24 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       if (scanStats.abortedByBudget) {
         // Surfaced, not swallowed: a scan that cannot reach leasable work within its budget
         // signals a ready-queue backlog that needs draining (stuck/failing jobs requeueing).
+        // pruned>0 means it is actively self-draining; pruned stuck at 0 with a backlog points
+        // elsewhere.
         LOG.warnf(
             "leaseNext aborted by scan budget total_ms=%d scan_count=%d candidate_count=%d"
-                + " budget_ms=%d",
-            totalMs, scanStats.scanCount, scanStats.candidateCount, leaseScanBudgetMs);
+                + " pruned=%d budget_ms=%d",
+            totalMs,
+            scanStats.scanCount,
+            scanStats.candidateCount,
+            scanStats.prunedCount,
+            leaseScanBudgetMs);
       } else {
         LOG.debugf(
-            "leaseNext total_ms=%d scan_count=%d candidate_count=%d leased=%s",
-            totalMs, scanStats.scanCount, scanStats.candidateCount, leased.isPresent());
+            "leaseNext total_ms=%d scan_count=%d candidate_count=%d pruned=%d leased=%s",
+            totalMs,
+            scanStats.scanCount,
+            scanStats.candidateCount,
+            scanStats.prunedCount,
+            leased.isPresent());
       }
       return leased;
     } finally {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -81,6 +81,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -111,6 +113,18 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   private static final long DEFAULT_LEASE_RENEW_GRACE_MS = 5_000L;
   private static final long CANCEL_POKE_MAX_DELAY_MS = 1_000L;
   private static final int DEFAULT_READY_SCAN_LIMIT = 128;
+  // Caps how many ready-queue lease scans may run concurrently across all callers (the in-process
+  // poller plus every external executor that funnels through leaseNext). Without this, client-side
+  // lease timeouts + retries amplify into a runaway fan-out of overlapping DynamoDB scans that
+  // saturate the client and collapse throughput. Excess callers shed to an empty ("no work") result
+  // and poll again.
+  private static final int DEFAULT_LEASE_MAX_CONCURRENCY = 8;
+  // How long a caller waits for a scan permit before shedding to an empty result.
+  private static final long DEFAULT_LEASE_ACQUIRE_TIMEOUT_MS = 250L;
+  // Wall-clock budget for a single ready scan. Kept under the worker-control client deadline so a
+  // scan a caller has already abandoned yields its permit instead of running to completion. 0 =
+  // off.
+  private static final long DEFAULT_LEASE_SCAN_BUDGET_MS = 8_000L;
   private static final int CAS_MAX = 16;
   private static final String INLINE_FINALIZED_SNAPSHOT_EVENT_PREFIX =
       "inline:reconcile-finalized-snapshot:";
@@ -149,6 +163,11 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   private long reclaimIntervalMs = DEFAULT_RECLAIM_INTERVAL_MS;
   private long leaseRenewGraceMs = DEFAULT_LEASE_RENEW_GRACE_MS;
   private int readyScanLimit = DEFAULT_READY_SCAN_LIMIT;
+  private int leaseMaxConcurrency = DEFAULT_LEASE_MAX_CONCURRENCY;
+  // Package-private so tests can drive the shed path deterministically.
+  long leaseAcquireTimeoutMs = DEFAULT_LEASE_ACQUIRE_TIMEOUT_MS;
+  private long leaseScanBudgetMs = DEFAULT_LEASE_SCAN_BUDGET_MS;
+  volatile Semaphore leaseScanPermits = new Semaphore(DEFAULT_LEASE_MAX_CONCURRENCY, true);
 
   private ReconcilePayloadStore payloads() {
     if (payloadStore == null) {
@@ -464,6 +483,27 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
             config
                 .getOptionalValue("floecat.reconciler.job-store.ready-scan-limit", Integer.class)
                 .orElse(DEFAULT_READY_SCAN_LIMIT));
+    leaseMaxConcurrency =
+        Math.max(
+            1,
+            config
+                .getOptionalValue(
+                    "floecat.reconciler.job-store.lease-max-concurrency", Integer.class)
+                .orElse(DEFAULT_LEASE_MAX_CONCURRENCY));
+    leaseAcquireTimeoutMs =
+        Math.max(
+            0L,
+            config
+                .getOptionalValue(
+                    "floecat.reconciler.job-store.lease-acquire-timeout-ms", Long.class)
+                .orElse(DEFAULT_LEASE_ACQUIRE_TIMEOUT_MS));
+    leaseScanBudgetMs =
+        Math.max(
+            0L,
+            config
+                .getOptionalValue("floecat.reconciler.job-store.lease-scan-budget-ms", Long.class)
+                .orElse(DEFAULT_LEASE_SCAN_BUDGET_MS));
+    leaseScanPermits = new Semaphore(leaseMaxConcurrency, true);
   }
 
   @Override
@@ -833,17 +873,47 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
 
   @Override
   public Optional<LeasedJob> leaseNext(LeaseRequest request) {
-    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
+    Semaphore permits = leaseScanPermits;
+    boolean acquired;
+    try {
+      acquired = permits.tryAcquire(leaseAcquireTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return Optional.empty();
+    }
+    if (!acquired) {
+      // Shed load: too many lease scans already in flight. Returning empty is a valid
+      // "no work right now" response; the caller polls again. This caps the ready-scan
+      // fan-out so client-side timeouts + retries cannot amplify into congestion collapse.
+      LOG.debugf(
+          "leaseNext shed: lease scan concurrency cap reached (cap=%d)", leaseMaxConcurrency);
+      return Optional.empty();
+    }
     long startedAtMs = System.currentTimeMillis();
+    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
     LeaseScanStats scanStats = new LeaseScanStats();
-    var leased = leaseReadyDue(startedAtMs, effective, scanStats);
-    LOG.debugf(
-        "leaseNext total_ms=%d scan_count=%d candidate_count=%d leased=%s",
-        System.currentTimeMillis() - startedAtMs,
-        scanStats.scanCount,
-        scanStats.candidateCount,
-        leased.isPresent());
-    return leased;
+    if (leaseScanBudgetMs > 0L) {
+      scanStats.deadlineAtMs = startedAtMs + leaseScanBudgetMs;
+    }
+    try {
+      var leased = leaseReadyDue(startedAtMs, effective, scanStats);
+      long totalMs = System.currentTimeMillis() - startedAtMs;
+      if (scanStats.abortedByBudget) {
+        // Surfaced, not swallowed: a scan that cannot reach leasable work within its budget
+        // signals a ready-queue backlog that needs draining (stuck/failing jobs requeueing).
+        LOG.warnf(
+            "leaseNext aborted by scan budget total_ms=%d scan_count=%d candidate_count=%d"
+                + " budget_ms=%d",
+            totalMs, scanStats.scanCount, scanStats.candidateCount, leaseScanBudgetMs);
+      } else {
+        LOG.debugf(
+            "leaseNext total_ms=%d scan_count=%d candidate_count=%d leased=%s",
+            totalMs, scanStats.scanCount, scanStats.candidateCount, leased.isPresent());
+      }
+      return leased;
+    } finally {
+      permits.release();
+    }
   }
 
   void runMaintenanceOnce(long maxMillis) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
@@ -271,8 +271,13 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
       }
     }
     for (String readyPointerKey : batch.readyMutation().deletes()) {
+      // Resolve the delete key from the ready pointer alone: a delete fires when a canonical
+      // mutation (requeue/fail/terminal) supersedes the old ready pointer, and the canonical it
+      // referenced is being rewritten in this same transaction. Passing a blank canonical here made
+      // the row resolve to null, so no delete item was added and the old ready row leaked — the
+      // backlog source the prune path is meant to drain.
       ReadyQueueBackendSupport.ReadyQueueRow row =
-          ReadyQueueBackendSupport.toReadyQueueRow(readyPointerKey, "");
+          ReadyQueueBackendSupport.toReadyQueueRow(readyPointerKey);
       if (row != null) {
         tx.add(buildReadyDelete(row));
       }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
@@ -190,7 +190,8 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
       }
       for (String readyDeleteKey : jobIndexBatch.readyMutation().deletes()) {
         // Resolve the delete key from the ready pointer alone (the canonical it referenced is being
-        // rewritten in this same lease transaction). A blank canonical made the row resolve to null,
+        // rewritten in this same lease transaction). A blank canonical made the row resolve to
+        // null,
         // dropping the delete item so the old ready row leaked.
         ReadyQueueBackendSupport.ReadyQueueRow row =
             ReadyQueueBackendSupport.toReadyQueueRow(readyDeleteKey);

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
@@ -189,8 +189,11 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
                     readyUpsert.readyPointerKey(), readyUpsert.canonicalPointerKey())));
       }
       for (String readyDeleteKey : jobIndexBatch.readyMutation().deletes()) {
+        // Resolve the delete key from the ready pointer alone (the canonical it referenced is being
+        // rewritten in this same lease transaction). A blank canonical made the row resolve to null,
+        // dropping the delete item so the old ready row leaked.
         ReadyQueueBackendSupport.ReadyQueueRow row =
-            ReadyQueueBackendSupport.toReadyQueueRow(readyDeleteKey, "");
+            ReadyQueueBackendSupport.toReadyQueueRow(readyDeleteKey);
         if (row != null) {
           tx.add(buildReadyDelete(row));
         }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackend.java
@@ -164,8 +164,12 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
 
   @Override
   public boolean deleteReadyEntry(String readyPointerKey) {
+    // Resolve the primary key from the ready pointer alone. The canonical pointer key is a stored
+    // attribute, not part of the key, and a stale/leaked entry's canonical pointer is often already
+    // gone; passing a blank canonical here used to make decode reject the key, so this delete was a
+    // silent no-op for every caller (inline prune and ReconcileJobGc alike).
     ReadyQueueBackendSupport.ReadyQueueRow row =
-        ReadyQueueBackendSupport.toReadyQueueRow(readyPointerKey, "");
+        ReadyQueueBackendSupport.toReadyQueueRow(readyPointerKey);
     if (row == null) {
       return false;
     }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
@@ -171,6 +171,9 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
     String token = "";
     int pages = 0;
     while (true) {
+      if (scanBudgetExceeded(scanStats)) {
+        return Optional.empty();
+      }
       if (scanStats != null) {
         scanStats.scanCount++;
       }
@@ -185,6 +188,9 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
           scanStats.candidateCount++;
         }
         if (candidate.dueAtMs() > nowMs) {
+          return Optional.empty();
+        }
+        if (scanBudgetExceeded(scanStats)) {
           return Optional.empty();
         }
         CanonicalPointerSnapshot canonicalSnapshot =
@@ -347,6 +353,17 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
       case PINNED_EXECUTOR -> candidate.filterValue().equals(record.pinnedExecutorId());
       case JOB_KIND -> candidate.filterValue().equals(record.jobKind().name());
     };
+  }
+
+  private static boolean scanBudgetExceeded(LeaseScanStats scanStats) {
+    if (scanStats == null || scanStats.deadlineAtMs <= 0L) {
+      return false;
+    }
+    if (System.currentTimeMillis() < scanStats.deadlineAtMs) {
+      return false;
+    }
+    scanStats.abortedByBudget = true;
+    return true;
   }
 
   private static String blankToEmpty(String value) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
@@ -25,6 +25,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -38,6 +39,18 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
   private ReconcileLeaseStore leaseStore;
   private int readyScanLimit;
   private Predicate<StoredReconcileJob> requiresReadyPointer;
+
+  // Delete ready-queue pointers the scan finds to be non-current (canonical/record gone, the job is
+  // waiting, or the pointer was superseded by a requeue) as they are encountered. Requeue/fail
+  // paths
+  // leak these stale pointers; left in place they pile up at the head of the due-ordered scan and a
+  // budget-bounded scan never reaches leasable work behind them. Pruning only ever removes pointers
+  // that are NOT a job's current pointer, so it cannot strand leasable work. Kill-switch for
+  // safety.
+  @ConfigProperty(
+      name = "floecat.reconciler.job-store.lease-scan-prune-stale",
+      defaultValue = "true")
+  boolean pruneStaleReadyEntries = true;
 
   public void bind(
       ReconcileReadyQueueBackend readyQueueBackend,
@@ -196,19 +209,24 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
         CanonicalPointerSnapshot canonicalSnapshot =
             readyQueueBackend.loadCanonicalSnapshot(candidate.canonicalPointerKey()).orElse(null);
         if (canonicalSnapshot == null) {
+          pruneStaleReadyEntry(candidate, scanStats);
           continue;
         }
         var recordOpt = jobIndexStore.readRecord(canonicalSnapshot);
         if (recordOpt.isEmpty()) {
+          pruneStaleReadyEntry(candidate, scanStats);
           continue;
         }
         StoredReconcileJob record = recordOpt.get();
         if ("JS_WAITING".equals(record.state)) {
+          pruneStaleReadyEntry(candidate, scanStats);
           continue;
         }
         if (!readyPointerMatchesRecord(candidate, record)) {
+          pruneStaleReadyEntry(candidate, scanStats);
           continue;
         }
+        // Not stale, just not eligible for this requester: leave the pointer for another lane.
         if (!matchesLeaseRequest(record, request)) {
           continue;
         }
@@ -353,6 +371,24 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
       case PINNED_EXECUTOR -> candidate.filterValue().equals(record.pinnedExecutorId());
       case JOB_KIND -> candidate.filterValue().equals(record.jobKind().name());
     };
+  }
+
+  private void pruneStaleReadyEntry(ReadyQueueEntry candidate, LeaseScanStats scanStats) {
+    if (!pruneStaleReadyEntries || candidate == null) {
+      return;
+    }
+    String readyPointerKey = candidate.readyPointerKey();
+    if (readyPointerKey == null || readyPointerKey.isBlank()) {
+      return;
+    }
+    try {
+      if (readyQueueBackend.deleteReadyEntry(readyPointerKey) && scanStats != null) {
+        scanStats.prunedCount++;
+      }
+    } catch (RuntimeException e) {
+      // Best-effort cleanup: a failed delete must never abort the lease scan.
+      LOG.debugf("failed to prune stale ready pointer %s: %s", readyPointerKey, e.getMessage());
+    }
   }
 
   private static boolean scanBudgetExceeded(LeaseScanStats scanStats) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueBackendSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueBackendSupport.java
@@ -65,6 +65,76 @@ final class ReadyQueueBackendSupport {
     if (blankToEmpty(readyPointerKey).isBlank() || blankToEmpty(canonicalPointerKey).isBlank()) {
       return null;
     }
+    ReadyPointerKeyParts parts = parseReadyPointerKeyParts(readyPointerKey, slice);
+    if (parts == null) {
+      return null;
+    }
+    return new ReconcileReadyQueueStore.ReadyQueueEntry(
+        readyPointerKey,
+        canonicalPointerKey,
+        parts.accountId(),
+        parts.jobId(),
+        parts.dueAtMs(),
+        slice.indexType(),
+        blankToEmpty(slice.filterValue()));
+  }
+
+  static ReadyQueueRow toReadyQueueRow(String readyPointerKey, String canonicalPointerKey) {
+    ReconcileReadyQueueBackend.ReadyQueueSlice slice = sliceForReadyPointerKey(readyPointerKey);
+    if (slice == null) {
+      return null;
+    }
+    ReconcileReadyQueueStore.ReadyQueueEntry entry =
+        decodeReadyQueueEntry(readyPointerKey, canonicalPointerKey, slice);
+    if (entry == null) {
+      return null;
+    }
+    return new ReadyQueueRow(partitionKey(slice), sortKeyForEntry(entry), entry);
+  }
+
+  /**
+   * Resolve the storage row (partition + sort key) for a ready pointer from the pointer key alone.
+   *
+   * <p>The canonical pointer key is a stored attribute, never part of the ready entry's primary
+   * key, so locating an entry for deletion must not depend on it. Prune/GC callers cleaning up a
+   * leaked pointer often no longer have the canonical pointer it referenced, and {@link
+   * #decodeReadyQueueEntry} deliberately rejects a blank canonical, so deletes resolve their key
+   * through this path instead. Returns {@code null} only when the pointer key itself is
+   * unrecognized or unparseable. The returned entry carries a blank canonical pointer key.
+   */
+  static ReadyQueueRow toReadyQueueRow(String readyPointerKey) {
+    ReconcileReadyQueueBackend.ReadyQueueSlice slice = sliceForReadyPointerKey(readyPointerKey);
+    if (slice == null) {
+      return null;
+    }
+    ReadyPointerKeyParts parts = parseReadyPointerKeyParts(readyPointerKey, slice);
+    if (parts == null) {
+      return null;
+    }
+    ReconcileReadyQueueStore.ReadyQueueEntry entry =
+        new ReconcileReadyQueueStore.ReadyQueueEntry(
+            readyPointerKey,
+            "",
+            parts.accountId(),
+            parts.jobId(),
+            parts.dueAtMs(),
+            slice.indexType(),
+            blankToEmpty(slice.filterValue()));
+    return new ReadyQueueRow(partitionKey(slice), sortKeyForEntry(entry), entry);
+  }
+
+  private static String sortKeyForEntry(ReconcileReadyQueueStore.ReadyQueueEntry entry) {
+    return String.format(
+        "%019d/%s/%s",
+        entry.dueAtMs(),
+        Keys.encodeSegment(entry.accountId()),
+        Keys.encodeSegment(entry.jobId()));
+  }
+
+  private record ReadyPointerKeyParts(String accountId, String jobId, long dueAtMs) {}
+
+  private static ReadyPointerKeyParts parseReadyPointerKeyParts(
+      String readyPointerKey, ReconcileReadyQueueBackend.ReadyQueueSlice slice) {
     long dueAt = parseTimestampFromOrderedPointer(readyPointerKey, readyIndexPrefix(slice));
     if (dueAt == INVALID_ORDERED_POINTER_MS) {
       return null;
@@ -91,36 +161,10 @@ final class ReadyQueueBackendSupport {
         accountId = URLDecoder.decode(parts[1], StandardCharsets.UTF_8);
         jobId = URLDecoder.decode(parts[2], StandardCharsets.UTF_8);
       }
-      return new ReconcileReadyQueueStore.ReadyQueueEntry(
-          readyPointerKey,
-          canonicalPointerKey,
-          accountId,
-          jobId,
-          dueAt,
-          slice.indexType(),
-          blankToEmpty(slice.filterValue()));
+      return new ReadyPointerKeyParts(accountId, jobId, dueAt);
     } catch (Exception e) {
       return null;
     }
-  }
-
-  static ReadyQueueRow toReadyQueueRow(String readyPointerKey, String canonicalPointerKey) {
-    ReconcileReadyQueueBackend.ReadyQueueSlice slice = sliceForReadyPointerKey(readyPointerKey);
-    if (slice == null) {
-      return null;
-    }
-    ReconcileReadyQueueStore.ReadyQueueEntry entry =
-        decodeReadyQueueEntry(readyPointerKey, canonicalPointerKey, slice);
-    if (entry == null) {
-      return null;
-    }
-    String sortKey =
-        String.format(
-            "%019d/%s/%s",
-            entry.dueAtMs(),
-            Keys.encodeSegment(entry.accountId()),
-            Keys.encodeSegment(entry.jobId()));
-    return new ReadyQueueRow(partitionKey(slice), sortKey, entry);
   }
 
   static ReadyQueueRow rowFromNativeReadyItem(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueBackendSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueBackendSupport.java
@@ -126,9 +126,7 @@ final class ReadyQueueBackendSupport {
   private static String sortKeyForEntry(ReconcileReadyQueueStore.ReadyQueueEntry entry) {
     return String.format(
         "%019d/%s/%s",
-        entry.dueAtMs(),
-        Keys.encodeSegment(entry.accountId()),
-        Keys.encodeSegment(entry.jobId()));
+        entry.dueAtMs(), Keys.encodeSegment(entry.accountId()), Keys.encodeSegment(entry.jobId()));
   }
 
   private record ReadyPointerKeyParts(String accountId, String jobId, long dueAtMs) {}

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileReadyQueueStore.java
@@ -41,6 +41,9 @@ public interface ReconcileReadyQueueStore {
     // queue or leasing a job). Lets the caller surface a backlog signal instead of failing
     // silently.
     public boolean abortedByBudget;
+    // Number of stale (non-current) ready pointers deleted while scanning. A persistently non-zero
+    // value means the ready queue is leaking pointers faster than scans drain them.
+    public int prunedCount;
   }
 
   record ReadyQueueEntry(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileReadyQueueStore.java
@@ -35,6 +35,12 @@ public interface ReconcileReadyQueueStore {
   final class LeaseScanStats {
     public int scanCount;
     public int candidateCount;
+    // Absolute wall-clock time (ms) past which the ready scan should stop and yield. 0 = no budget.
+    public long deadlineAtMs;
+    // Set when the scan stopped early because it exceeded deadlineAtMs (rather than exhausting the
+    // queue or leasing a job). Lets the caller surface a backlog signal instead of failing
+    // silently.
+    public boolean abortedByBudget;
   }
 
   record ReadyQueueEntry(

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -116,6 +116,10 @@ floecat.reconciler.job-store.ready-scan-limit=${FLOECAT_RECONCILER_JOB_STORE_REA
 floecat.reconciler.job-store.lease-max-concurrency=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MAX_CONCURRENCY:8}
 floecat.reconciler.job-store.lease-acquire-timeout-ms=${FLOECAT_RECONCILER_JOB_STORE_LEASE_ACQUIRE_TIMEOUT_MS:250}
 floecat.reconciler.job-store.lease-scan-budget-ms=${FLOECAT_RECONCILER_JOB_STORE_LEASE_SCAN_BUDGET_MS:8000}
+# Delete non-current ready pointers (canonical/record gone, job waiting, or pointer superseded) as
+# the lease scan encounters them. Drains leaked pointers that would otherwise pile up at the head of
+# the due-ordered scan and starve leasable work behind them. Kill-switch; on by default.
+floecat.reconciler.job-store.lease-scan-prune-stale=${FLOECAT_RECONCILER_JOB_STORE_LEASE_SCAN_PRUNE_STALE:true}
 floecat.reconciler.job-store.lease-maintenance.enabled=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MAINTENANCE_ENABLED:true}
 floecat.reconciler.job-store.lease-maintenance.tick-every=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MAINTENANCE_TICK_EVERY:1s}
 floecat.reconciler.job-store.lease-maintenance.max-tick-millis=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MAINTENANCE_MAX_TICK_MILLIS:250}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -109,6 +109,13 @@ floecat.reconciler.job-store.max-backoff-ms=${FLOECAT_RECONCILER_JOB_STORE_MAX_B
 floecat.reconciler.job-store.lease-ms=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MS:120000}
 floecat.reconciler.job-store.reclaim-interval-ms=${FLOECAT_RECONCILER_JOB_STORE_RECLAIM_INTERVAL_MS:5000}
 floecat.reconciler.job-store.ready-scan-limit=${FLOECAT_RECONCILER_JOB_STORE_READY_SCAN_LIMIT:128}
+# Caps concurrent ready-queue lease scans across all callers; excess callers shed to "no work" and
+# re-poll. Bounds the DynamoDB scan fan-out so lease-RPC timeouts + retries cannot amplify into a
+# self-sustaining scan storm. Scan-budget-ms keeps a single scan under the worker-control client
+# deadline so an abandoned scan yields its slot instead of running to completion.
+floecat.reconciler.job-store.lease-max-concurrency=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MAX_CONCURRENCY:8}
+floecat.reconciler.job-store.lease-acquire-timeout-ms=${FLOECAT_RECONCILER_JOB_STORE_LEASE_ACQUIRE_TIMEOUT_MS:250}
+floecat.reconciler.job-store.lease-scan-budget-ms=${FLOECAT_RECONCILER_JOB_STORE_LEASE_SCAN_BUDGET_MS:8000}
 floecat.reconciler.job-store.lease-maintenance.enabled=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MAINTENANCE_ENABLED:true}
 floecat.reconciler.job-store.lease-maintenance.tick-every=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MAINTENANCE_TICK_EVERY:1s}
 floecat.reconciler.job-store.lease-maintenance.max-tick-millis=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MAINTENANCE_MAX_TICK_MILLIS:250}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -905,6 +905,62 @@ class DurableReconcileJobStoreTest {
   }
 
   @Test
+  void leaseNextShedsWhenScanConcurrencyCapReached() {
+    String execJobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.of(List.of(), "table-1"),
+            ReconcileJobKind.EXEC_FILE_GROUP,
+            ReconcileTableTask.empty(),
+            ReconcileViewTask.empty(),
+            ReconcileSnapshotTask.empty(),
+            ReconcileFileGroupTask.of(
+                "plan-1", "group-1", "table-1", 55L, List.of("s3://bucket/data/file-1.parquet")),
+            ReconcileExecutionPolicy.defaults(),
+            "",
+            "");
+
+    ReconcileJobStore.LeaseRequest req =
+        ReconcileJobStore.LeaseRequest.of(
+            java.util.EnumSet.of(ReconcileExecutionClass.DEFAULT),
+            Set.of(ReconcileJobStore.LeaseRequest.anyLaneToken()),
+            Set.of("floescan_ingest"),
+            java.util.EnumSet.of(ReconcileJobKind.EXEC_FILE_GROUP));
+
+    // No permit available and no wait: the scan must shed to an empty ("no work") result instead of
+    // touching the ready queue, even though a job is ready. This is the guard that caps the scan
+    // fan-out so lease-RPC timeouts + retries cannot amplify into a self-sustaining scan storm.
+    store.leaseAcquireTimeoutMs = 0L;
+    store.leaseScanPermits = new java.util.concurrent.Semaphore(0);
+    assertTrue(
+        store.leaseNext(req).isEmpty(),
+        "expected leaseNext to shed (return no work) when no scan permit is available");
+
+    // Restore capacity: the same ready job now leases normally, proving the shed above was the
+    // concurrency cap and not job unavailability.
+    store.leaseScanPermits = new java.util.concurrent.Semaphore(8, true);
+    long deadlineMs = System.currentTimeMillis() + 2_000L;
+    java.util.Optional<ReconcileJobStore.LeasedJob> leased = java.util.Optional.empty();
+    while (System.currentTimeMillis() < deadlineMs && leased.isEmpty()) {
+      leased = store.leaseNext(req);
+      if (leased.isEmpty()) {
+        try {
+          Thread.sleep(10L);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+    }
+    assertTrue(
+        leased.isPresent(), "expected leaseNext to lease the ready job once a permit exists");
+    assertEquals(execJobId, leased.orElseThrow().jobId);
+  }
+
+  @Test
   void enqueueUpsertsStoredRootSummaryImmediately() {
     String connectorJobId =
         store.enqueue(ACCOUNT_ID, CONNECTOR_ID, false, CaptureMode.METADATA_AND_CAPTURE, null);

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.jobs.durable.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeaseRequest;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeasedJob;
+import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore.LeaseScanStats;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for the ready-scan wall-clock budget. The budget lets a lease scan a caller has
+ * already abandoned (past the worker-control client deadline) stop and yield its concurrency slot
+ * instead of running to completion, which is what prevents abandoned scans from piling up.
+ */
+class NativeReconcileReadyQueueStoreBudgetTest {
+
+  @Test
+  void scanAbortsImmediatelyWhenBudgetAlreadyExpired() {
+    CountingBackend backend = new CountingBackend();
+    NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
+    store.bind(backend, null, null, 128, record -> true);
+
+    LeaseScanStats stats = new LeaseScanStats();
+    stats.deadlineAtMs = System.currentTimeMillis() - 1; // already past
+
+    long now = System.currentTimeMillis();
+    Optional<LeasedJob> leased = store.leaseReadyDue(now, LeaseRequest.all(), stats);
+
+    assertTrue(leased.isEmpty(), "expired-budget scan must yield no work");
+    assertTrue(stats.abortedByBudget, "scan must record that it aborted on the budget");
+    assertEquals(
+        0, backend.scanReadySliceCalls, "scan must short-circuit before issuing any DynamoDB scan");
+  }
+
+  @Test
+  void scanProceedsWhenNoBudgetSet() {
+    CountingBackend backend = new CountingBackend();
+    NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
+    store.bind(backend, null, null, 128, record -> true);
+
+    LeaseScanStats stats = new LeaseScanStats(); // deadlineAtMs == 0 -> no budget
+
+    Optional<LeasedJob> leased =
+        store.leaseReadyDue(System.currentTimeMillis(), LeaseRequest.all(), stats);
+
+    assertTrue(leased.isEmpty(), "empty ready queue yields no work");
+    assertFalse(stats.abortedByBudget, "no budget means no budget-abort");
+    assertTrue(
+        backend.scanReadySliceCalls >= 1, "scan must reach the backend when not budget-gated");
+  }
+
+  /** Records ready-scan calls and returns an empty page so the scan terminates cleanly. */
+  private static final class CountingBackend implements ReconcileReadyQueueBackend {
+    int scanReadySliceCalls;
+
+    @Override
+    public ReconcileReadyQueueStore.ReadyQueueScanPage scanReadySlice(
+        ReadyQueueSlice slice, int pageSize, String pageToken) {
+      scanReadySliceCalls++;
+      return new ReconcileReadyQueueStore.ReadyQueueScanPage(List.of(), "");
+    }
+
+    @Override
+    public ReadyQueueScanPage scanAllReadyEntries(int pageSize, String pageToken) {
+      throw new UnsupportedOperationException("not used in this test");
+    }
+
+    @Override
+    public boolean deleteReadyEntry(String readyPointerKey) {
+      throw new UnsupportedOperationException("not used in this test");
+    }
+
+    @Override
+    public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(String canonicalPointerKey) {
+      throw new UnsupportedOperationException("not used in this test");
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
@@ -23,14 +23,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeaseRequest;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeasedJob;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore.LeaseScanStats;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit coverage for the ready-scan wall-clock budget. The budget lets a lease scan a caller has
- * already abandoned (past the worker-control client deadline) stop and yield its concurrency slot
- * instead of running to completion, which is what prevents abandoned scans from piling up.
+ * Unit coverage for the lease-scan guards: the wall-clock budget (so a scan a caller has already
+ * abandoned yields its concurrency slot instead of running to completion) and inline pruning of
+ * stale ready pointers (so leaked pointers drain instead of starving leasable work behind them).
  */
 class NativeReconcileReadyQueueStoreBudgetTest {
 
@@ -69,6 +70,24 @@ class NativeReconcileReadyQueueStoreBudgetTest {
         backend.scanReadySliceCalls >= 1, "scan must reach the backend when not budget-gated");
   }
 
+  @Test
+  void scanPrunesOrphanedReadyPointer() {
+    PruningBackend backend = new PruningBackend();
+    NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
+    store.bind(backend, null, null, 128, record -> true);
+
+    LeaseScanStats stats = new LeaseScanStats();
+    Optional<LeasedJob> leased =
+        store.leaseReadyDue(System.currentTimeMillis(), LeaseRequest.all(), stats);
+
+    assertTrue(leased.isEmpty(), "an orphaned pointer cannot be leased");
+    assertEquals(1, stats.prunedCount, "the orphaned (canonical-missing) pointer must be pruned");
+    assertEquals(
+        List.of("rp-orphan"),
+        backend.deleted,
+        "deleteReadyEntry called with the stale pointer key");
+  }
+
   /** Records ready-scan calls and returns an empty page so the scan terminates cleanly. */
   private static final class CountingBackend implements ReconcileReadyQueueBackend {
     int scanReadySliceCalls;
@@ -93,6 +112,42 @@ class NativeReconcileReadyQueueStoreBudgetTest {
     @Override
     public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(String canonicalPointerKey) {
       throw new UnsupportedOperationException("not used in this test");
+    }
+  }
+
+  /** Serves one due candidate whose canonical snapshot is missing, and records prune deletes. */
+  private static final class PruningBackend implements ReconcileReadyQueueBackend {
+    final List<String> deleted = new ArrayList<>();
+
+    @Override
+    public ReconcileReadyQueueStore.ReadyQueueScanPage scanReadySlice(
+        ReadyQueueSlice slice, int pageSize, String pageToken) {
+      ReconcileReadyQueueStore.ReadyQueueEntry orphan =
+          new ReconcileReadyQueueStore.ReadyQueueEntry(
+              "rp-orphan",
+              "cp-orphan",
+              "acct",
+              "job",
+              1L,
+              ReconcileReadyQueueStore.ReadyIndexType.GLOBAL,
+              "");
+      return new ReconcileReadyQueueStore.ReadyQueueScanPage(List.of(orphan), "");
+    }
+
+    @Override
+    public ReadyQueueScanPage scanAllReadyEntries(int pageSize, String pageToken) {
+      throw new UnsupportedOperationException("not used in this test");
+    }
+
+    @Override
+    public boolean deleteReadyEntry(String readyPointerKey) {
+      deleted.add(readyPointerKey);
+      return true;
+    }
+
+    @Override
+    public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(String canonicalPointerKey) {
+      return Optional.empty();
     }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueBackendSupportTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueBackendSupportTest.java
@@ -40,4 +40,26 @@ class ReadyQueueBackendSupportTest {
     assertEquals("acct-1", row.entry().accountId());
     assertEquals("job-1", row.entry().jobId());
   }
+
+  @Test
+  void toReadyQueueRowResolvesDeleteKeyWithoutCanonicalPointer() {
+    String readyPointerKey = Keys.reconcileReadyPointerByDue(1234L, "acct-1", "lane-1", "job-1");
+
+    // The write path knows the canonical pointer; deletes pruning a leaked pointer do not. The
+    // key-only resolver must still land on the exact primary key the entry was written under,
+    // otherwise the delete silently targets nothing (the original starvation bug).
+    ReadyQueueBackendSupport.ReadyQueueRow withCanonical =
+        ReadyQueueBackendSupport.toReadyQueueRow(
+            readyPointerKey, "/accounts/acct-1/reconcile/jobs/by-id/job-1");
+    ReadyQueueBackendSupport.ReadyQueueRow keyOnly =
+        ReadyQueueBackendSupport.toReadyQueueRow(readyPointerKey);
+
+    assertNotNull(keyOnly);
+    assertEquals(withCanonical.partitionKey(), keyOnly.partitionKey());
+    assertEquals(withCanonical.sortKey(), keyOnly.sortKey());
+    assertEquals("reconcile-ready#global", keyOnly.partitionKey());
+    assertEquals(ReadyIndexType.GLOBAL, keyOnly.entry().indexType());
+    assertEquals("acct-1", keyOnly.entry().accountId());
+    assertEquals("job-1", keyOnly.entry().jobId());
+  }
 }


### PR DESCRIPTION
leaseReconcileJob -> leaseNext scans the ready queue with one consistent DynamoDB read per candidate (loadCanonicalSnapshot), and did not honor the caller deadline. After #334 added the worker-control client deadline, timed-out callers retry while the abandoned server scan keeps running. Under a ready-queue backlog these accumulate. A staging thread dump showed ~145 concurrent leaseNext, 141 stuck in loadCanonicalSnapshot, behind 4 DynamoDB Netty threads. The client saturates and lease throughput drops to zero.

Fix:
- lease-max-concurrency (default 8): a semaphore caps concurrent scans across all callers. Excess callers shed to an empty result and re-poll.
- lease-scan-budget-ms (default 8000, under the client deadline): a scan that cannot reach work in time yields its permit instead of running to completion, and logs a WARN.

Both are config-driven. Tests cover the shed path and the budget.