### PR TITLE
Propagate cancellation and bound admission for reconcile lease scans

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
@@ -78,6 +78,7 @@ import ai.floedb.floecat.reconciler.rpc.SubmitLeasedSnapshotFinalizeResultReques
 import ai.floedb.floecat.reconciler.rpc.SubmitLeasedSnapshotFinalizeResultResponse;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import ai.floedb.floecat.service.reconciler.jobs.LeaseScanCapacityExceededException;
 import ai.floedb.floecat.service.security.RolePermissions;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
@@ -87,7 +88,9 @@ import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 
 @GrpcService
 public class ReconcileExecutorControlImpl extends BaseServiceImpl
@@ -134,7 +137,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
                       lanesFrom(request),
                       executorIds,
                       jobKindsFrom(request));
-              var lease = jobs.leaseNext(leaseRequest);
+              var lease = leaseNextOrThrowRateLimited(corr, leaseRequest);
               if (lease.isEmpty()) {
                 return LeaseReconcileJobResponse.newBuilder().setFound(false).build();
               }
@@ -144,6 +147,17 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
                   .build();
             }),
         correlationId());
+  }
+
+  private Optional<ReconcileJobStore.LeasedJob> leaseNextOrThrowRateLimited(
+      String corr, ReconcileJobStore.LeaseRequest leaseRequest) {
+    try {
+      return jobs.leaseNext(leaseRequest);
+    } catch (CancellationException cancelled) {
+      throw GrpcErrors.cancelled(corr, null, null, cancelled);
+    } catch (LeaseScanCapacityExceededException overloaded) {
+      throw GrpcErrors.rateLimited(corr, null, null, overloaded);
+    }
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -50,6 +50,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.storage.ReconcilePayloa
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileJobIndexBackend;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileLeaseBackend;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileReadyQueueBackend;
+import ai.floedb.floecat.service.reconciler.jobs.durable.store.LeaseScanAbortedException;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.MemoryReconcileJobIndexBackend;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.MemoryReconcileLeaseBackend;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.MemoryReconcileReadyQueueBackend;
@@ -68,6 +69,8 @@ import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.Context;
+import io.grpc.Deadline;
 import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -81,6 +84,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -116,10 +120,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   // Caps how many ready-queue lease scans may run concurrently across all callers (the in-process
   // poller plus every external executor that funnels through leaseNext). Without this, client-side
   // lease timeouts + retries amplify into a runaway fan-out of overlapping DynamoDB scans that
-  // saturate the client and collapse throughput. Excess callers shed to an empty ("no work") result
-  // and poll again.
+  // saturate the client and collapse throughput.
   private static final int DEFAULT_LEASE_MAX_CONCURRENCY = 8;
-  // How long a caller waits for a scan permit before shedding to an empty result.
+  // How long a caller waits for a scan permit before rejecting the attempt.
   private static final long DEFAULT_LEASE_ACQUIRE_TIMEOUT_MS = 250L;
   // Wall-clock budget for a single ready scan. Kept under the worker-control client deadline so a
   // scan a caller has already abandoned yields its permit instead of running to completion. 0 =
@@ -164,7 +167,6 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   private long leaseRenewGraceMs = DEFAULT_LEASE_RENEW_GRACE_MS;
   private int readyScanLimit = DEFAULT_READY_SCAN_LIMIT;
   private int leaseMaxConcurrency = DEFAULT_LEASE_MAX_CONCURRENCY;
-  // Package-private so tests can drive the shed path deterministically.
   long leaseAcquireTimeoutMs = DEFAULT_LEASE_ACQUIRE_TIMEOUT_MS;
   private long leaseScanBudgetMs = DEFAULT_LEASE_SCAN_BUDGET_MS;
   volatile Semaphore leaseScanPermits = new Semaphore(DEFAULT_LEASE_MAX_CONCURRENCY, true);
@@ -879,32 +881,37 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       acquired = permits.tryAcquire(leaseAcquireTimeoutMs, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      return Optional.empty();
+      throw new CancellationException("reconcile lease scan admission interrupted");
     }
     if (!acquired) {
-      // Shed load: too many lease scans already in flight. Returning empty is a valid
-      // "no work right now" response; the caller polls again. This caps the ready-scan
-      // fan-out so client-side timeouts + retries cannot amplify into congestion collapse.
-      LOG.debugf(
-          "leaseNext shed: lease scan concurrency cap reached (cap=%d)", leaseMaxConcurrency);
-      return Optional.empty();
+      throw new LeaseScanCapacityExceededException(
+          "reconcile lease scan capacity exhausted cap=" + leaseMaxConcurrency);
     }
     long startedAtMs = System.currentTimeMillis();
     LeaseRequest effective = request == null ? LeaseRequest.all() : request;
     LeaseScanStats scanStats = new LeaseScanStats();
-    if (leaseScanBudgetMs > 0L) {
-      scanStats.deadlineAtMs = startedAtMs + leaseScanBudgetMs;
-    }
+    configureLeaseScanStats(scanStats, startedAtMs);
     try {
-      var leased = leaseReadyDue(startedAtMs, effective, scanStats);
+      Optional<LeasedJob> leased;
+      try {
+        leased = leaseReadyDue(startedAtMs, effective, scanStats);
+      } catch (LeaseScanAbortedException aborted) {
+        if (aborted.callerCancelled()) {
+          scanStats.abortedByCaller = true;
+        } else {
+          scanStats.abortedByDeadline = true;
+        }
+        leased = Optional.empty();
+      }
       long totalMs = System.currentTimeMillis() - startedAtMs;
-      if (scanStats.abortedByBudget) {
-        // Surfaced, not swallowed: a scan that cannot reach leasable work within its budget
-        // signals a ready-queue backlog that needs draining (stuck/failing jobs requeueing).
-        // pruned>0 means it is actively self-draining; pruned stuck at 0 with a backlog points
-        // elsewhere.
+      if (scanStats.abortedByCaller) {
         LOG.warnf(
-            "leaseNext aborted by scan budget total_ms=%d scan_count=%d candidate_count=%d"
+            "leaseNext cancelled by caller total_ms=%d scan_count=%d candidate_count=%d"
+                + " pruned=%d",
+            totalMs, scanStats.scanCount, scanStats.candidateCount, scanStats.prunedCount);
+      } else if (scanStats.abortedByDeadline) {
+        LOG.warnf(
+            "leaseNext aborted by scan deadline total_ms=%d scan_count=%d candidate_count=%d"
                 + " pruned=%d budget_ms=%d",
             totalMs,
             scanStats.scanCount,
@@ -924,6 +931,20 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     } finally {
       permits.release();
     }
+  }
+
+  private void configureLeaseScanStats(LeaseScanStats scanStats, long startedAtMs) {
+    Context grpcContext = Context.current();
+    scanStats.cancelled = grpcContext::isCancelled;
+    long deadlineAtMs = leaseScanBudgetMs <= 0L ? 0L : startedAtMs + leaseScanBudgetMs;
+    Deadline grpcDeadline = grpcContext.getDeadline();
+    if (grpcDeadline != null) {
+      long remainingMs = grpcDeadline.timeRemaining(TimeUnit.MILLISECONDS);
+      long grpcDeadlineAtMs = startedAtMs + Math.max(0L, remainingMs);
+      deadlineAtMs =
+          deadlineAtMs <= 0L ? grpcDeadlineAtMs : Math.min(deadlineAtMs, grpcDeadlineAtMs);
+    }
+    scanStats.deadlineAtMs = deadlineAtMs;
   }
 
   void runMaintenanceOnce(long maxMillis) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/LeaseScanCapacityExceededException.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/LeaseScanCapacityExceededException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.jobs;
+
+/** Indicates the service refused to start another lease scan because local capacity was full. */
+public final class LeaseScanCapacityExceededException extends RuntimeException {
+  public LeaseScanCapacityExceededException(String message) {
+    super(message);
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackend.java
@@ -23,11 +23,16 @@ import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_VERSION;
 import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
@@ -68,7 +73,11 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
 
   @Override
   public ReconcileReadyQueueStore.ReadyQueueScanPage scanReadySlice(
-      ReadyQueueSlice slice, int pageSize, String pageToken) {
+      ReadyQueueSlice slice,
+      int pageSize,
+      String pageToken,
+      ReconcileReadyQueueStore.LeaseScanStats scanStats) {
+    assertLeaseScanActive(scanStats);
     QueryRequest.Builder query =
         QueryRequest.builder()
             .tableName(table)
@@ -88,7 +97,8 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
               ATTR_SORT_KEY, AttributeValue.fromS(token)));
     }
 
-    var response = dynamoDb.query(query.build());
+    applyLeaseScanTimeout(query, scanStats);
+    var response = runLeaseScanCall(scanStats, () -> dynamoDb.query(query.build()));
     List<ReconcileReadyQueueStore.ReadyQueueEntry> entries =
         new ArrayList<>(response.items().size());
     for (var item : response.items()) {
@@ -185,23 +195,25 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
   }
 
   @Override
-  public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(String canonicalPointerKey) {
+  public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(
+      String canonicalPointerKey, ReconcileReadyQueueStore.LeaseScanStats scanStats) {
+    assertLeaseScanActive(scanStats);
     var canonicalJobKey = JobIndexBackendSupport.parseCanonicalJobKey(canonicalPointerKey);
     if (canonicalJobKey != null) {
-      var response =
-          dynamoDb.getItem(
-              GetItemRequest.builder()
-                  .tableName(table)
-                  .consistentRead(true)
-                  .key(
-                      Map.of(
-                          ATTR_PARTITION_KEY,
-                          AttributeValue.fromS(
-                              JobIndexBackendSupport.canonicalPartitionKey(canonicalJobKey)),
-                          ATTR_SORT_KEY,
-                          AttributeValue.fromS(
-                              JobIndexBackendSupport.canonicalSortKey(canonicalJobKey))))
-                  .build());
+      GetItemRequest.Builder request =
+          GetItemRequest.builder()
+              .tableName(table)
+              .consistentRead(true)
+              .key(
+                  Map.of(
+                      ATTR_PARTITION_KEY,
+                      AttributeValue.fromS(
+                          JobIndexBackendSupport.canonicalPartitionKey(canonicalJobKey)),
+                      ATTR_SORT_KEY,
+                      AttributeValue.fromS(
+                          JobIndexBackendSupport.canonicalSortKey(canonicalJobKey))));
+      applyLeaseScanTimeout(request, scanStats);
+      var response = runLeaseScanCall(scanStats, () -> dynamoDb.getItem(request.build()));
       if (!response.hasItem() || response.item().isEmpty()) {
         return Optional.empty();
       }
@@ -216,16 +228,16 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
     if (key == null) {
       return Optional.empty();
     }
-    var response =
-        dynamoDb.getItem(
-            GetItemRequest.builder()
-                .tableName(table)
-                .consistentRead(true)
-                .key(
-                    Map.of(
-                        ATTR_PARTITION_KEY, AttributeValue.fromS(key.partitionKey()),
-                        ATTR_SORT_KEY, AttributeValue.fromS(key.sortKey())))
-                .build());
+    GetItemRequest.Builder request =
+        GetItemRequest.builder()
+            .tableName(table)
+            .consistentRead(true)
+            .key(
+                Map.of(
+                    ATTR_PARTITION_KEY, AttributeValue.fromS(key.partitionKey()),
+                    ATTR_SORT_KEY, AttributeValue.fromS(key.sortKey())));
+    applyLeaseScanTimeout(request, scanStats);
+    var response = runLeaseScanCall(scanStats, () -> dynamoDb.getItem(request.build()));
     if (!response.hasItem() || response.item().isEmpty()) {
       return Optional.empty();
     }
@@ -275,6 +287,68 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
   }
 
   private record DynamoPointerKey(String partitionKey, String sortKey) {}
+
+  private static void assertLeaseScanActive(ReconcileReadyQueueStore.LeaseScanStats scanStats) {
+    if (scanStats != null && scanStats.shouldStop()) {
+      throw new LeaseScanAbortedException(scanStats.abortedByCaller);
+    }
+  }
+
+  private static void applyLeaseScanTimeout(
+      QueryRequest.Builder request, ReconcileReadyQueueStore.LeaseScanStats scanStats) {
+    leaseScanTimeout(scanStats).ifPresent(request::overrideConfiguration);
+  }
+
+  private static void applyLeaseScanTimeout(
+      GetItemRequest.Builder request, ReconcileReadyQueueStore.LeaseScanStats scanStats) {
+    leaseScanTimeout(scanStats).ifPresent(request::overrideConfiguration);
+  }
+
+  private static Optional<AwsRequestOverrideConfiguration> leaseScanTimeout(
+      ReconcileReadyQueueStore.LeaseScanStats scanStats) {
+    if (scanStats == null || scanStats.deadlineAtMs <= 0L) {
+      return Optional.empty();
+    }
+    long remainingMs = scanStats.deadlineAtMs - System.currentTimeMillis();
+    if (remainingMs <= 0L) {
+      scanStats.abortedByDeadline = true;
+      throw new LeaseScanAbortedException(false);
+    }
+    return Optional.of(
+        AwsRequestOverrideConfiguration.builder()
+            .apiCallAttemptTimeout(Duration.ofMillis(Math.max(1L, remainingMs)))
+            .apiCallTimeout(Duration.ofMillis(Math.max(1L, remainingMs)))
+            .build());
+  }
+
+  private static <T> T runLeaseScanCall(
+      ReconcileReadyQueueStore.LeaseScanStats scanStats, java.util.function.Supplier<T> call) {
+    try {
+      return call.get();
+    } catch (ApiCallTimeoutException | ApiCallAttemptTimeoutException timeout) {
+      throw leaseScanAborted(scanStats, false, timeout);
+    } catch (AbortedException aborted) {
+      throw leaseScanAborted(scanStats, callerCancelled(scanStats), aborted);
+    }
+  }
+
+  private static LeaseScanAbortedException leaseScanAborted(
+      ReconcileReadyQueueStore.LeaseScanStats scanStats,
+      boolean callerCancelled,
+      RuntimeException cause) {
+    if (scanStats != null) {
+      if (callerCancelled) {
+        scanStats.abortedByCaller = true;
+      } else {
+        scanStats.abortedByDeadline = true;
+      }
+    }
+    return new LeaseScanAbortedException(callerCancelled, cause);
+  }
+
+  private static boolean callerCancelled(ReconcileReadyQueueStore.LeaseScanStats scanStats) {
+    return scanStats != null && scanStats.cancelled != null && scanStats.cancelled.getAsBoolean();
+  }
 
   private static String blankToEmpty(String value) {
     return value == null ? "" : value;

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/LeaseScanAbortedException.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/LeaseScanAbortedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.jobs.durable.store;
+
+/** Indicates a lease scan stopped because the caller cancelled it or its budget expired. */
+public final class LeaseScanAbortedException extends RuntimeException {
+  private final boolean callerCancelled;
+
+  public LeaseScanAbortedException(boolean callerCancelled) {
+    this(callerCancelled, null);
+  }
+
+  public LeaseScanAbortedException(boolean callerCancelled, Throwable cause) {
+    super(callerCancelled ? "lease scan cancelled by caller" : "lease scan budget expired", cause);
+    this.callerCancelled = callerCancelled;
+  }
+
+  public boolean callerCancelled() {
+    return callerCancelled;
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileReadyQueueBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileReadyQueueBackend.java
@@ -45,7 +45,10 @@ public class MemoryReconcileReadyQueueBackend implements ReconcileReadyQueueBack
 
   @Override
   public ReconcileReadyQueueStore.ReadyQueueScanPage scanReadySlice(
-      ReadyQueueSlice slice, int pageSize, String pageToken) {
+      ReadyQueueSlice slice,
+      int pageSize,
+      String pageToken,
+      ReconcileReadyQueueStore.LeaseScanStats scanStats) {
     String prefix = ReadyQueueBackendSupport.readyIndexPrefix(slice);
     if (prefix.isBlank()) {
       return new ReconcileReadyQueueStore.ReadyQueueScanPage(List.of(), "");
@@ -104,7 +107,8 @@ public class MemoryReconcileReadyQueueBackend implements ReconcileReadyQueueBack
   }
 
   @Override
-  public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(String canonicalPointerKey) {
+  public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(
+      String canonicalPointerKey, ReconcileReadyQueueStore.LeaseScanStats scanStats) {
     return pointerStore
         .get(canonicalPointerKey)
         .map(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
@@ -71,7 +71,7 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
 
   public ReadyQueueScanPage scanReadySlice(
       ReconcileReadyQueueBackend.ReadyQueueSlice slice, int pageSize, String pageToken) {
-    return readyQueueBackend.scanReadySlice(slice, pageSize, pageToken);
+    return readyQueueBackend.scanReadySlice(slice, pageSize, pageToken, null);
   }
 
   public Optional<LeasedJob> leaseReadyDue(
@@ -184,35 +184,43 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
     String token = "";
     int pages = 0;
     while (true) {
-      if (scanBudgetExceeded(scanStats)) {
+      if (shouldStop(scanStats)) {
         return Optional.empty();
       }
       if (scanStats != null) {
         scanStats.scanCount++;
       }
       ReadyQueueScanPage page =
-          readyQueueBackend.scanReadySlice(selection.slice(), readyScanLimit, token);
+          readyQueueBackend.scanReadySlice(selection.slice(), readyScanLimit, token, scanStats);
       if (page.entries().isEmpty()) {
         return Optional.empty();
       }
 
       for (ReadyQueueEntry candidate : page.entries()) {
+        if (shouldStop(scanStats)) {
+          return Optional.empty();
+        }
         if (scanStats != null) {
           scanStats.candidateCount++;
         }
         if (candidate.dueAtMs() > nowMs) {
           return Optional.empty();
         }
-        if (scanBudgetExceeded(scanStats)) {
+        CanonicalPointerSnapshot canonicalSnapshot =
+            readyQueueBackend
+                .loadCanonicalSnapshot(candidate.canonicalPointerKey(), scanStats)
+                .orElse(null);
+        if (shouldStop(scanStats)) {
           return Optional.empty();
         }
-        CanonicalPointerSnapshot canonicalSnapshot =
-            readyQueueBackend.loadCanonicalSnapshot(candidate.canonicalPointerKey()).orElse(null);
         if (canonicalSnapshot == null) {
           pruneStaleReadyEntry(candidate, scanStats);
           continue;
         }
         var recordOpt = jobIndexStore.readRecord(canonicalSnapshot);
+        if (shouldStop(scanStats)) {
+          return Optional.empty();
+        }
         if (recordOpt.isEmpty()) {
           pruneStaleReadyEntry(candidate, scanStats);
           continue;
@@ -229,6 +237,9 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
         // Not stale, just not eligible for this requester: leave the pointer for another lane.
         if (!matchesLeaseRequest(record, request)) {
           continue;
+        }
+        if (shouldStop(scanStats)) {
+          return Optional.empty();
         }
         var leased =
             leaseStore.leaseCanonical(
@@ -391,15 +402,8 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
     }
   }
 
-  private static boolean scanBudgetExceeded(LeaseScanStats scanStats) {
-    if (scanStats == null || scanStats.deadlineAtMs <= 0L) {
-      return false;
-    }
-    if (System.currentTimeMillis() < scanStats.deadlineAtMs) {
-      return false;
-    }
-    scanStats.abortedByBudget = true;
-    return true;
+  private static boolean shouldStop(LeaseScanStats scanStats) {
+    return scanStats != null && scanStats.shouldStop();
   }
 
   private static String blankToEmpty(String value) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileReadyQueueBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileReadyQueueBackend.java
@@ -26,11 +26,15 @@ public interface ReconcileReadyQueueBackend {
       List<ReconcileReadyQueueStore.ReadyQueueEntry> entries, String nextPageToken) {}
 
   ReconcileReadyQueueStore.ReadyQueueScanPage scanReadySlice(
-      ReadyQueueSlice slice, int pageSize, String pageToken);
+      ReadyQueueSlice slice,
+      int pageSize,
+      String pageToken,
+      ReconcileReadyQueueStore.LeaseScanStats scanStats);
 
   ReadyQueueScanPage scanAllReadyEntries(int pageSize, String pageToken);
 
   boolean deleteReadyEntry(String readyPointerKey);
 
-  Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(String canonicalPointerKey);
+  Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(
+      String canonicalPointerKey, ReconcileReadyQueueStore.LeaseScanStats scanStats);
 }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileReadyQueueStore.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeasedJob;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 public interface ReconcileReadyQueueStore {
@@ -35,15 +36,23 @@ public interface ReconcileReadyQueueStore {
   final class LeaseScanStats {
     public int scanCount;
     public int candidateCount;
-    // Absolute wall-clock time (ms) past which the ready scan should stop and yield. 0 = no budget.
     public long deadlineAtMs;
-    // Set when the scan stopped early because it exceeded deadlineAtMs (rather than exhausting the
-    // queue or leasing a job). Lets the caller surface a backlog signal instead of failing
-    // silently.
-    public boolean abortedByBudget;
-    // Number of stale (non-current) ready pointers deleted while scanning. A persistently non-zero
-    // value means the ready queue is leaking pointers faster than scans drain them.
+    public BooleanSupplier cancelled = () -> false;
+    public boolean abortedByDeadline;
+    public boolean abortedByCaller;
     public int prunedCount;
+
+    public boolean shouldStop() {
+      if (cancelled != null && cancelled.getAsBoolean()) {
+        abortedByCaller = true;
+        return true;
+      }
+      if (deadlineAtMs > 0L && System.currentTimeMillis() >= deadlineAtMs) {
+        abortedByDeadline = true;
+        return true;
+      }
+      return false;
+    }
   }
 
   record ReadyQueueEntry(

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -109,10 +109,10 @@ floecat.reconciler.job-store.max-backoff-ms=${FLOECAT_RECONCILER_JOB_STORE_MAX_B
 floecat.reconciler.job-store.lease-ms=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MS:120000}
 floecat.reconciler.job-store.reclaim-interval-ms=${FLOECAT_RECONCILER_JOB_STORE_RECLAIM_INTERVAL_MS:5000}
 floecat.reconciler.job-store.ready-scan-limit=${FLOECAT_RECONCILER_JOB_STORE_READY_SCAN_LIMIT:128}
-# Caps concurrent ready-queue lease scans across all callers; excess callers shed to "no work" and
-# re-poll. Bounds the DynamoDB scan fan-out so lease-RPC timeouts + retries cannot amplify into a
-# self-sustaining scan storm. Scan-budget-ms keeps a single scan under the worker-control client
-# deadline so an abandoned scan yields its slot instead of running to completion.
+# Caps concurrent ready-queue lease scans across all callers. Bounds the DynamoDB scan fan-out so
+# lease-RPC timeouts + retries cannot amplify into a self-sustaining scan storm. Scan-budget-ms
+# keeps a single scan under the worker-control client deadline so an abandoned scan yields its slot
+# instead of running to completion.
 floecat.reconciler.job-store.lease-max-concurrency=${FLOECAT_RECONCILER_JOB_STORE_LEASE_MAX_CONCURRENCY:8}
 floecat.reconciler.job-store.lease-acquire-timeout-ms=${FLOECAT_RECONCILER_JOB_STORE_LEASE_ACQUIRE_TIMEOUT_MS:250}
 floecat.reconciler.job-store.lease-scan-budget-ms=${FLOECAT_RECONCILER_JOB_STORE_LEASE_SCAN_BUDGET_MS:8000}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
@@ -53,6 +53,7 @@ import ai.floedb.floecat.reconciler.rpc.RenewReconcileLeaseRequest;
 import ai.floedb.floecat.reconciler.rpc.ReportReconcileProgressRequest;
 import ai.floedb.floecat.reconciler.rpc.SubmitLeasedFileGroupExecutionResultRequest;
 import ai.floedb.floecat.reconciler.rpc.SubmitLeasedSnapshotFinalizeResultRequest;
+import ai.floedb.floecat.service.reconciler.jobs.LeaseScanCapacityExceededException;
 import ai.floedb.floecat.service.security.RolePermissions;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
@@ -60,6 +61,7 @@ import io.grpc.StatusRuntimeException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -167,6 +169,40 @@ class ReconcileExecutorControlImplTest {
                     .indefinitely());
 
     assertEquals("INTERNAL", error.getStatus().getCode().name());
+  }
+
+  @Test
+  void leaseReconcileJobMapsLeaseScanCapacityToResourceExhausted() {
+    when(service.jobs.leaseNext(any()))
+        .thenThrow(new LeaseScanCapacityExceededException("capacity exhausted"));
+
+    StatusRuntimeException error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .leaseReconcileJob(LeaseReconcileJobRequest.getDefaultInstance())
+                    .await()
+                    .indefinitely());
+
+    assertEquals("RESOURCE_EXHAUSTED", error.getStatus().getCode().name());
+  }
+
+  @Test
+  void leaseReconcileJobMapsAdmissionCancellationToCancelled() {
+    when(service.jobs.leaseNext(any()))
+        .thenThrow(new CancellationException("reconcile lease scan admission interrupted"));
+
+    StatusRuntimeException error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .leaseReconcileJob(LeaseReconcileJobRequest.getDefaultInstance())
+                    .await()
+                    .indefinitely());
+
+    assertEquals("CANCELLED", error.getStatus().getCode().name());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -66,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
@@ -905,59 +906,34 @@ class DurableReconcileJobStoreTest {
   }
 
   @Test
-  void leaseNextShedsWhenScanConcurrencyCapReached() {
-    String execJobId =
-        store.enqueue(
-            ACCOUNT_ID,
-            CONNECTOR_ID,
-            false,
-            CaptureMode.METADATA_AND_CAPTURE,
-            ReconcileScope.of(List.of(), "table-1"),
-            ReconcileJobKind.EXEC_FILE_GROUP,
-            ReconcileTableTask.empty(),
-            ReconcileViewTask.empty(),
-            ReconcileSnapshotTask.empty(),
-            ReconcileFileGroupTask.of(
-                "plan-1", "group-1", "table-1", 55L, List.of("s3://bucket/data/file-1.parquet")),
-            ReconcileExecutionPolicy.defaults(),
-            "",
-            "");
-
-    ReconcileJobStore.LeaseRequest req =
-        ReconcileJobStore.LeaseRequest.of(
-            java.util.EnumSet.of(ReconcileExecutionClass.DEFAULT),
-            Set.of(ReconcileJobStore.LeaseRequest.anyLaneToken()),
-            Set.of("floescan_ingest"),
-            java.util.EnumSet.of(ReconcileJobKind.EXEC_FILE_GROUP));
-
-    // No permit available and no wait: the scan must shed to an empty ("no work") result instead of
-    // touching the ready queue, even though a job is ready. This is the guard that caps the scan
-    // fan-out so lease-RPC timeouts + retries cannot amplify into a self-sustaining scan storm.
+  void leaseNextRejectsWhenLeaseScanCapacityIsExhausted() {
     store.leaseAcquireTimeoutMs = 0L;
     store.leaseScanPermits = new java.util.concurrent.Semaphore(0);
-    assertTrue(
-        store.leaseNext(req).isEmpty(),
-        "expected leaseNext to shed (return no work) when no scan permit is available");
 
-    // Restore capacity: the same ready job now leases normally, proving the shed above was the
-    // concurrency cap and not job unavailability.
-    store.leaseScanPermits = new java.util.concurrent.Semaphore(8, true);
-    long deadlineMs = System.currentTimeMillis() + 2_000L;
-    java.util.Optional<ReconcileJobStore.LeasedJob> leased = java.util.Optional.empty();
-    while (System.currentTimeMillis() < deadlineMs && leased.isEmpty()) {
-      leased = store.leaseNext(req);
-      if (leased.isEmpty()) {
-        try {
-          Thread.sleep(10L);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          break;
-        }
-      }
+    LeaseScanCapacityExceededException error =
+        assertThrows(
+            LeaseScanCapacityExceededException.class,
+            () -> store.leaseNext(ReconcileJobStore.LeaseRequest.all()));
+
+    assertTrue(error.getMessage().contains("capacity exhausted"));
+  }
+
+  @Test
+  void leaseNextPropagatesInterruptedAdmissionAsCancellation() {
+    store.leaseAcquireTimeoutMs = 5_000L;
+    store.leaseScanPermits = new java.util.concurrent.Semaphore(0);
+    Thread.currentThread().interrupt();
+    try {
+      CancellationException error =
+          assertThrows(
+              CancellationException.class,
+              () -> store.leaseNext(ReconcileJobStore.LeaseRequest.all()));
+
+      assertTrue(error.getMessage().contains("admission interrupted"));
+      assertTrue(Thread.currentThread().isInterrupted());
+    } finally {
+      Thread.interrupted();
     }
-    assertTrue(
-        leased.isPresent(), "expected leaseNext to lease the ready job once a permit exists");
-    assertEquals(execJobId, leased.orElseThrow().jobId);
   }
 
   @Test
@@ -2769,7 +2745,7 @@ class DurableReconcileJobStoreTest {
 
   private boolean readyEntryExists(String readyPointerKey) {
     assertDoesNotThrow(() -> invokePrivateMethod(store, "readyQueue", new Class<?>[] {}));
-    return store.readyQueueBackend.loadCanonicalSnapshot(readyPointerKey).isPresent();
+    return store.readyQueueBackend.loadCanonicalSnapshot(readyPointerKey, null).isPresent();
   }
 
   private ReconcileLeaseStore leaseManager() {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackendTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.jobs.durable.store;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueBackend.ReadyQueueSlice;
+import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore.LeaseScanStats;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+
+class DynamoReconcileReadyQueueBackendTest {
+
+  @Test
+  void scanReadySliceNormalizesApiCallTimeoutAsLeaseScanAbort() {
+    DynamoDbClient dynamoDb = mock(DynamoDbClient.class);
+    when(dynamoDb.query(any(QueryRequest.class))).thenThrow(ApiCallTimeoutException.create(25L));
+    DynamoReconcileReadyQueueBackend backend =
+        new DynamoReconcileReadyQueueBackend(dynamoDb, "floecat_pointers");
+    LeaseScanStats stats = new LeaseScanStats();
+    stats.deadlineAtMs = System.currentTimeMillis() + 5_000L;
+
+    LeaseScanAbortedException error =
+        assertThrows(
+            LeaseScanAbortedException.class,
+            () ->
+                backend.scanReadySlice(
+                    new ReadyQueueSlice(ReconcileReadyQueueStore.ReadyIndexType.GLOBAL, ""),
+                    16,
+                    "",
+                    stats));
+
+    assertFalse(error.callerCancelled());
+    assertTrue(stats.abortedByDeadline);
+  }
+
+  @Test
+  void loadCanonicalSnapshotNormalizesAttemptTimeoutAsLeaseScanAbort() {
+    DynamoDbClient dynamoDb = mock(DynamoDbClient.class);
+    when(dynamoDb.getItem(any(GetItemRequest.class)))
+        .thenThrow(ApiCallAttemptTimeoutException.create(25L));
+    DynamoReconcileReadyQueueBackend backend =
+        new DynamoReconcileReadyQueueBackend(dynamoDb, "floecat_pointers");
+    LeaseScanStats stats = new LeaseScanStats();
+    stats.deadlineAtMs = System.currentTimeMillis() + 5_000L;
+
+    LeaseScanAbortedException error =
+        assertThrows(
+            LeaseScanAbortedException.class,
+            () -> backend.loadCanonicalSnapshot("/accounts/acct-1/reconcile/jobs/job-1", stats));
+
+    assertFalse(error.callerCancelled());
+    assertTrue(stats.abortedByDeadline);
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
@@ -19,55 +19,56 @@ package ai.floedb.floecat.service.reconciler.jobs.durable.store;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeaseRequest;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeasedJob;
+import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore.LeaseScanStats;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
-/**
- * Unit coverage for the lease-scan guards: the wall-clock budget (so a scan a caller has already
- * abandoned yields its concurrency slot instead of running to completion) and inline pruning of
- * stale ready pointers (so leaked pointers drain instead of starving leasable work behind them).
- */
 class NativeReconcileReadyQueueStoreBudgetTest {
 
   @Test
-  void scanAbortsImmediatelyWhenBudgetAlreadyExpired() {
+  void scanAbortsBeforeBackendCallsWhenDeadlineAlreadyExpired() {
     CountingBackend backend = new CountingBackend();
     NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
     store.bind(backend, null, null, 128, record -> true);
 
     LeaseScanStats stats = new LeaseScanStats();
-    stats.deadlineAtMs = System.currentTimeMillis() - 1; // already past
-
-    long now = System.currentTimeMillis();
-    Optional<LeasedJob> leased = store.leaseReadyDue(now, LeaseRequest.all(), stats);
-
-    assertTrue(leased.isEmpty(), "expired-budget scan must yield no work");
-    assertTrue(stats.abortedByBudget, "scan must record that it aborted on the budget");
-    assertEquals(
-        0, backend.scanReadySliceCalls, "scan must short-circuit before issuing any DynamoDB scan");
-  }
-
-  @Test
-  void scanProceedsWhenNoBudgetSet() {
-    CountingBackend backend = new CountingBackend();
-    NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
-    store.bind(backend, null, null, 128, record -> true);
-
-    LeaseScanStats stats = new LeaseScanStats(); // deadlineAtMs == 0 -> no budget
+    stats.deadlineAtMs = System.currentTimeMillis() - 1L;
 
     Optional<LeasedJob> leased =
         store.leaseReadyDue(System.currentTimeMillis(), LeaseRequest.all(), stats);
 
-    assertTrue(leased.isEmpty(), "empty ready queue yields no work");
-    assertFalse(stats.abortedByBudget, "no budget means no budget-abort");
-    assertTrue(
-        backend.scanReadySliceCalls >= 1, "scan must reach the backend when not budget-gated");
+    assertTrue(leased.isEmpty());
+    assertTrue(stats.abortedByDeadline);
+    assertEquals(0, backend.scanReadySliceCalls);
+    assertEquals(0, backend.loadCanonicalSnapshotCalls);
+  }
+
+  @Test
+  void scanReachesBackendWhenNoDeadlineIsConfigured() {
+    CountingBackend backend = new CountingBackend();
+    NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
+    store.bind(backend, null, null, 128, record -> true);
+
+    LeaseScanStats stats = new LeaseScanStats();
+    Optional<LeasedJob> leased =
+        store.leaseReadyDue(System.currentTimeMillis(), LeaseRequest.all(), stats);
+
+    assertTrue(leased.isEmpty());
+    assertFalse(stats.abortedByDeadline);
+    assertTrue(backend.scanReadySliceCalls >= 1);
   }
 
   @Test
@@ -80,48 +81,104 @@ class NativeReconcileReadyQueueStoreBudgetTest {
     Optional<LeasedJob> leased =
         store.leaseReadyDue(System.currentTimeMillis(), LeaseRequest.all(), stats);
 
-    assertTrue(leased.isEmpty(), "an orphaned pointer cannot be leased");
-    assertEquals(1, stats.prunedCount, "the orphaned (canonical-missing) pointer must be pruned");
-    assertEquals(
-        List.of("rp-orphan"),
-        backend.deleted,
-        "deleteReadyEntry called with the stale pointer key");
+    assertTrue(leased.isEmpty());
+    assertEquals(1, stats.prunedCount);
+    assertEquals(List.of("rp-orphan"), backend.deleted);
   }
 
-  /** Records ready-scan calls and returns an empty page so the scan terminates cleanly. */
+  @Test
+  void scanStopsBeforeLeaseWriteWhenCallerCancelsAfterRecordDecode() {
+    NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
+    ReconcileReadyQueueBackend backend = mock(ReconcileReadyQueueBackend.class);
+    ReconcileJobIndexStore jobIndexStore = mock(ReconcileJobIndexStore.class);
+    ReconcileLeaseStore leaseStore = mock(ReconcileLeaseStore.class);
+    AtomicBoolean cancelled = new AtomicBoolean(false);
+    store.bind(backend, jobIndexStore, leaseStore, 128, record -> true);
+    long dueAtMs = System.currentTimeMillis();
+    StoredReconcileJob record = new StoredReconcileJob();
+    record.jobId = "job-1";
+    record.accountId = "acct-1";
+    record.jobKind = ReconcileJobKind.PLAN_CONNECTOR.name();
+    record.state = "JS_QUEUED";
+    record.executionClass = "DEFAULT";
+    record.executionLane = "default";
+    record.laneKey = "default";
+    record.nextAttemptAtMs = dueAtMs;
+    record.readyPointerKey = store.readyPointerKeyFor(record, dueAtMs);
+
+    ReconcileReadyQueueStore.ReadyQueueEntry candidate =
+        new ReconcileReadyQueueStore.ReadyQueueEntry(
+            record.readyPointerKey,
+            "/canonical",
+            "acct-1",
+            "job-1",
+            dueAtMs,
+            ReconcileReadyQueueStore.ReadyIndexType.GLOBAL,
+            "");
+    when(backend.scanReadySlice(any(), eq(128), eq(""), any()))
+        .thenReturn(new ReconcileReadyQueueStore.ReadyQueueScanPage(List.of(candidate), ""));
+    CanonicalPointerSnapshot snapshot =
+        new CanonicalPointerSnapshot("/canonical", "blob://job", 7L);
+    when(backend.loadCanonicalSnapshot(eq("/canonical"), any())).thenReturn(Optional.of(snapshot));
+    when(jobIndexStore.readRecord(snapshot))
+        .thenAnswer(
+            ignored -> {
+              cancelled.set(true);
+              return Optional.of(record);
+            });
+
+    LeaseScanStats stats = new LeaseScanStats();
+    stats.cancelled = cancelled::get;
+
+    Optional<LeasedJob> leased =
+        store.leaseReadyDue(System.currentTimeMillis(), LeaseRequest.all(), stats);
+
+    assertTrue(leased.isEmpty());
+    assertTrue(stats.abortedByCaller);
+    verifyNoInteractions(leaseStore);
+  }
+
   private static final class CountingBackend implements ReconcileReadyQueueBackend {
     int scanReadySliceCalls;
+    int loadCanonicalSnapshotCalls;
 
     @Override
     public ReconcileReadyQueueStore.ReadyQueueScanPage scanReadySlice(
-        ReadyQueueSlice slice, int pageSize, String pageToken) {
+        ReadyQueueSlice slice,
+        int pageSize,
+        String pageToken,
+        ReconcileReadyQueueStore.LeaseScanStats scanStats) {
       scanReadySliceCalls++;
       return new ReconcileReadyQueueStore.ReadyQueueScanPage(List.of(), "");
     }
 
     @Override
     public ReadyQueueScanPage scanAllReadyEntries(int pageSize, String pageToken) {
-      throw new UnsupportedOperationException("not used in this test");
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean deleteReadyEntry(String readyPointerKey) {
-      throw new UnsupportedOperationException("not used in this test");
+      throw new UnsupportedOperationException();
     }
 
     @Override
-    public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(String canonicalPointerKey) {
-      throw new UnsupportedOperationException("not used in this test");
+    public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(
+        String canonicalPointerKey, ReconcileReadyQueueStore.LeaseScanStats scanStats) {
+      loadCanonicalSnapshotCalls++;
+      return Optional.empty();
     }
   }
 
-  /** Serves one due candidate whose canonical snapshot is missing, and records prune deletes. */
   private static final class PruningBackend implements ReconcileReadyQueueBackend {
     final List<String> deleted = new ArrayList<>();
 
     @Override
     public ReconcileReadyQueueStore.ReadyQueueScanPage scanReadySlice(
-        ReadyQueueSlice slice, int pageSize, String pageToken) {
+        ReadyQueueSlice slice,
+        int pageSize,
+        String pageToken,
+        ReconcileReadyQueueStore.LeaseScanStats scanStats) {
       ReconcileReadyQueueStore.ReadyQueueEntry orphan =
           new ReconcileReadyQueueStore.ReadyQueueEntry(
               "rp-orphan",
@@ -136,7 +193,7 @@ class NativeReconcileReadyQueueStoreBudgetTest {
 
     @Override
     public ReadyQueueScanPage scanAllReadyEntries(int pageSize, String pageToken) {
-      throw new UnsupportedOperationException("not used in this test");
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -146,7 +203,8 @@ class NativeReconcileReadyQueueStoreBudgetTest {
     }
 
     @Override
-    public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(String canonicalPointerKey) {
+    public Optional<CanonicalPointerSnapshot> loadCanonicalSnapshot(
+        String canonicalPointerKey, ReconcileReadyQueueStore.LeaseScanStats scanStats) {
       return Optional.empty();
     }
   }

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
@@ -65,7 +65,7 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
   @Override
   public ReadyQueueScanPage scanReadySlice(
       ReconcileReadyQueueBackend.ReadyQueueSlice slice, int pageSize, String pageToken) {
-    return readyQueueBackend.scanReadySlice(slice, pageSize, pageToken);
+    return readyQueueBackend.scanReadySlice(slice, pageSize, pageToken, null);
   }
 
   @Override
@@ -185,16 +185,22 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
     String token = "";
     int pages = 0;
     while (true) {
+      if (shouldStop(scanStats)) {
+        return Optional.empty();
+      }
       if (scanStats != null) {
         scanStats.scanCount++;
       }
       ReadyQueueScanPage page =
-          readyQueueBackend.scanReadySlice(selection.slice(), readyScanLimit, token);
+          readyQueueBackend.scanReadySlice(selection.slice(), readyScanLimit, token, scanStats);
       if (page.entries().isEmpty()) {
         return Optional.empty();
       }
 
       for (ReadyQueueEntry candidate : page.entries()) {
+        if (shouldStop(scanStats)) {
+          return Optional.empty();
+        }
         if (scanStats != null) {
           scanStats.candidateCount++;
         }
@@ -202,11 +208,19 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
           return Optional.empty();
         }
         CanonicalPointerSnapshot canonicalSnapshot =
-            readyQueueBackend.loadCanonicalSnapshot(candidate.canonicalPointerKey()).orElse(null);
+            readyQueueBackend
+                .loadCanonicalSnapshot(candidate.canonicalPointerKey(), scanStats)
+                .orElse(null);
+        if (shouldStop(scanStats)) {
+          return Optional.empty();
+        }
         if (canonicalSnapshot == null) {
           continue;
         }
         var recordOpt = jobIndexStore.readRecord(canonicalSnapshot);
+        if (shouldStop(scanStats)) {
+          return Optional.empty();
+        }
         if (recordOpt.isEmpty()) {
           continue;
         }
@@ -357,6 +371,10 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
       case PINNED_EXECUTOR -> candidate.filterValue().equals(record.pinnedExecutorId());
       case JOB_KIND -> candidate.filterValue().equals(record.jobKind().name());
     };
+  }
+
+  private static boolean shouldStop(LeaseScanStats scanStats) {
+    return scanStats != null && scanStats.shouldStop();
   }
 
   private static String blankToEmpty(String value) {


### PR DESCRIPTION
## Summary

This PR adds server-side containment for reconcile lease scans used by LeaseReconcileJob. It bounds concurrent scan admission, propagates caller cancellation/deadlines into the scan path, applies request-scoped Dynamo timeouts, and maps saturation/cancellation to explicit gRPC outcomes (RESOURCE_EXHAUSTED, CANCELLED) so client retries do not amplify abandoned server-side work into queue-scan collapse.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

