### PR TITLE
arrow: add @ArrowDecimal support for BigDecimal record components

### DIFF
--- a/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowDecimal.java
+++ b/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowDecimal.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.arrow;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Maps a {@link java.math.BigDecimal} record component to an Arrow {@code DECIMAL(precision,
+ * scale)} column. Arrow decimals require an explicit precision and scale, so {@link
+ * ArrowRecordWriters} rejects {@code BigDecimal} components that are not annotated.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.RECORD_COMPONENT)
+public @interface ArrowDecimal {
+  int precision();
+
+  int scale();
+}

--- a/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowDecimal.java
+++ b/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowDecimal.java
@@ -20,6 +20,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.math.RoundingMode;
 
 /**
  * Maps a {@link java.math.BigDecimal} record component to an Arrow {@code DECIMAL(precision,
@@ -32,4 +33,13 @@ public @interface ArrowDecimal {
   int precision();
 
   int scale();
+
+  /**
+   * How to coerce an input value whose scale exceeds {@link #scale()}. Padding to a larger scale is
+   * always lossless and unaffected by this; it only applies when an input carries more fractional
+   * digits than the column. Defaults to {@link RoundingMode#UNNECESSARY}, which throws rather than
+   * silently dropping precision — set an explicit mode such as {@link RoundingMode#HALF_UP} to opt
+   * into rounding.
+   */
+  RoundingMode rounding() default RoundingMode.UNNECESSARY;
 }

--- a/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowRecordWriters.java
+++ b/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowRecordWriters.java
@@ -198,6 +198,7 @@ public final class ArrowRecordWriters {
         }
         int precision = decimal.precision();
         int scale = decimal.scale();
+        RoundingMode rounding = decimal.rounding();
         // Validate precision/scale through floecat's canonical decimal rules before building
         // the Arrow type (ArrowType.Decimal itself does not validate these).
         LogicalType.decimal(precision, scale);
@@ -205,7 +206,10 @@ public final class ArrowRecordWriters {
         writer =
             (root, i, row) -> {
               BigDecimal val = get(getter, row, BigDecimal.class);
-              BigDecimal scaled = (val == null) ? null : val.setScale(scale, RoundingMode.HALF_UP);
+              // Padding to a larger scale is lossless; excess scale uses the annotation's rounding
+              // mode (UNNECESSARY by default, which throws rather than silently dropping
+              // precision).
+              BigDecimal scaled = (val == null) ? null : val.setScale(scale, rounding);
               // ArrowDecimalTypes uses a 256-bit vector for precision > 38, a 128-bit one
               // otherwise.
               FieldVector v = root.getVector(name);

--- a/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowRecordWriters.java
+++ b/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowRecordWriters.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.arrow;
 
+import ai.floedb.floecat.types.LogicalType;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -33,6 +34,7 @@ import java.util.UUID;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.Decimal256Vector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
@@ -194,16 +196,32 @@ public final class ArrowRecordWriters {
           throw new IllegalArgumentException(
               "BigDecimal component " + name + " must be annotated with @ArrowDecimal");
         }
+        int precision = decimal.precision();
         int scale = decimal.scale();
-        field = field(name, ArrowDecimalTypes.decimalType(decimal.precision(), scale));
+        // Validate precision/scale through floecat's canonical decimal rules before building
+        // the Arrow type (ArrowType.Decimal itself does not validate these).
+        LogicalType.decimal(precision, scale);
+        field = field(name, ArrowDecimalTypes.decimalType(precision, scale));
         writer =
             (root, i, row) -> {
-              DecimalVector v = (DecimalVector) root.getVector(name);
               BigDecimal val = get(getter, row, BigDecimal.class);
-              if (val == null) {
-                v.setNull(i);
+              BigDecimal scaled = (val == null) ? null : val.setScale(scale, RoundingMode.HALF_UP);
+              // ArrowDecimalTypes uses a 256-bit vector for precision > 38, a 128-bit one
+              // otherwise.
+              FieldVector v = root.getVector(name);
+              if (v instanceof Decimal256Vector decimal256) {
+                if (scaled == null) {
+                  decimal256.setNull(i);
+                } else {
+                  decimal256.setSafe(i, scaled);
+                }
               } else {
-                v.setSafe(i, val.setScale(scale, RoundingMode.HALF_UP));
+                DecimalVector decimal128 = (DecimalVector) v;
+                if (scaled == null) {
+                  decimal128.setNull(i);
+                } else {
+                  decimal128.setSafe(i, scaled);
+                }
               }
             };
       } else if (jt == Instant.class) {

--- a/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowRecordWriters.java
+++ b/core/arrow/src/main/java/ai/floedb/floecat/arrow/ArrowRecordWriters.java
@@ -20,6 +20,8 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.RecordComponent;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -31,6 +33,7 @@ import java.util.UUID;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float8Vector;
@@ -183,6 +186,24 @@ public final class ArrowRecordWriters {
                 v.setNull(i);
               } else {
                 v.setSafe(i, val);
+              }
+            };
+      } else if (jt == BigDecimal.class) {
+        ArrowDecimal decimal = comp.getAnnotation(ArrowDecimal.class);
+        if (decimal == null) {
+          throw new IllegalArgumentException(
+              "BigDecimal component " + name + " must be annotated with @ArrowDecimal");
+        }
+        int scale = decimal.scale();
+        field = field(name, ArrowDecimalTypes.decimalType(decimal.precision(), scale));
+        writer =
+            (root, i, row) -> {
+              DecimalVector v = (DecimalVector) root.getVector(name);
+              BigDecimal val = get(getter, row, BigDecimal.class);
+              if (val == null) {
+                v.setNull(i);
+              } else {
+                v.setSafe(i, val.setScale(scale, RoundingMode.HALF_UP));
               }
             };
       } else if (jt == Instant.class) {

--- a/core/arrow/src/test/java/ai/floedb/floecat/arrow/ArrowRecordWritersTest.java
+++ b/core/arrow/src/test/java/ai/floedb/floecat/arrow/ArrowRecordWritersTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -164,6 +165,33 @@ class ArrowRecordWritersTest {
   }
 
   @Test
+  void defaultRounding_padsLosslessly() {
+    ArrowRecordWriter<DefaultRoundingDecimalRow> writer =
+        ArrowRecordWriters.fromRecordClass(DefaultRoundingDecimalRow.class);
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(writer.schema(), allocator)) {
+      writer.write(root, List.of(new DefaultRoundingDecimalRow(new BigDecimal("5"))));
+
+      DecimalVector amount = (DecimalVector) root.getVector("amount");
+      assertThat(amount.getObject(0)).isEqualByComparingTo(new BigDecimal("5.000"));
+    }
+  }
+
+  @Test
+  void defaultRounding_rejectsExcessScaleAtWriteTime() {
+    ArrowRecordWriter<DefaultRoundingDecimalRow> writer =
+        ArrowRecordWriters.fromRecordClass(DefaultRoundingDecimalRow.class);
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(writer.schema(), allocator)) {
+      assertThatThrownBy(
+              () ->
+                  writer.write(
+                      root, List.of(new DefaultRoundingDecimalRow(new BigDecimal("1.2345")))))
+          .isInstanceOf(ArithmeticException.class);
+    }
+  }
+
+  @Test
   void fromRecordClass_rejectsUnannotatedDecimal() {
     assertThatThrownBy(() -> ArrowRecordWriters.fromRecordClass(UnannotatedDecimalRow.class))
         .isInstanceOf(IllegalArgumentException.class)
@@ -199,7 +227,12 @@ class ArrowRecordWritersTest {
       UUID uuidValue,
       byte[] bytesValue) {}
 
-  private record DecimalRow(@ArrowDecimal(precision = 18, scale = 3) BigDecimal amount) {}
+  private record DecimalRow(
+      @ArrowDecimal(precision = 18, scale = 3, rounding = RoundingMode.HALF_UP)
+          BigDecimal amount) {}
+
+  private record DefaultRoundingDecimalRow(
+      @ArrowDecimal(precision = 18, scale = 3) BigDecimal amount) {}
 
   private record Decimal256Row(@ArrowDecimal(precision = 50, scale = 2) BigDecimal amount) {}
 

--- a/core/arrow/src/test/java/ai/floedb/floecat/arrow/ArrowRecordWritersTest.java
+++ b/core/arrow/src/test/java/ai/floedb/floecat/arrow/ArrowRecordWritersTest.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.arrow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -27,12 +28,15 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.jupiter.api.Test;
 
 class ArrowRecordWritersTest {
@@ -109,6 +113,41 @@ class ArrowRecordWritersTest {
   }
 
   @Test
+  void fromRecordClass_writesAnnotatedDecimalColumns() {
+    ArrowRecordWriter<DecimalRow> writer = ArrowRecordWriters.fromRecordClass(DecimalRow.class);
+
+    Field field = writer.schema().findField("amount");
+    assertThat(field.getType()).isInstanceOf(ArrowType.Decimal.class);
+    ArrowType.Decimal type = (ArrowType.Decimal) field.getType();
+    assertThat(type.getPrecision()).isEqualTo(18);
+    assertThat(type.getScale()).isEqualTo(3);
+
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(writer.schema(), allocator)) {
+      writer.write(
+          root,
+          List.of(
+              new DecimalRow(new BigDecimal("12.5")),
+              new DecimalRow(new BigDecimal("1.2345")),
+              new DecimalRow(null)));
+
+      DecimalVector amount = (DecimalVector) root.getVector("amount");
+      assertThat(amount.getObject(0)).isEqualByComparingTo(new BigDecimal("12.500"));
+      // Excess scale is rounded HALF_UP to the column scale.
+      assertThat(amount.getObject(1)).isEqualByComparingTo(new BigDecimal("1.235"));
+      assertThat(amount.isNull(2)).isTrue();
+      assertThat(root.getRowCount()).isEqualTo(3);
+    }
+  }
+
+  @Test
+  void fromRecordClass_rejectsUnannotatedDecimal() {
+    assertThatThrownBy(() -> ArrowRecordWriters.fromRecordClass(UnannotatedDecimalRow.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("@ArrowDecimal");
+  }
+
+  @Test
   void fromRecordClass_rejectsUnsupportedTypes() {
     assertThatThrownBy(() -> ArrowRecordWriters.fromRecordClass(UnsupportedRow.class))
         .isInstanceOf(IllegalArgumentException.class)
@@ -130,5 +169,9 @@ class ArrowRecordWritersTest {
       UUID uuidValue,
       byte[] bytesValue) {}
 
-  private record UnsupportedRow(java.math.BigDecimal unsupported) {}
+  private record DecimalRow(@ArrowDecimal(precision = 18, scale = 3) BigDecimal amount) {}
+
+  private record UnannotatedDecimalRow(BigDecimal amount) {}
+
+  private record UnsupportedRow(Object unsupported) {}
 }

--- a/core/arrow/src/test/java/ai/floedb/floecat/arrow/ArrowRecordWritersTest.java
+++ b/core/arrow/src/test/java/ai/floedb/floecat/arrow/ArrowRecordWritersTest.java
@@ -28,6 +28,7 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.Decimal256Vector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
@@ -141,10 +142,39 @@ class ArrowRecordWritersTest {
   }
 
   @Test
+  void fromRecordClass_writesDecimal256ForHighPrecision() {
+    ArrowRecordWriter<Decimal256Row> writer =
+        ArrowRecordWriters.fromRecordClass(Decimal256Row.class);
+
+    ArrowType.Decimal type = (ArrowType.Decimal) writer.schema().findField("amount").getType();
+    assertThat(type.getPrecision()).isEqualTo(50);
+    assertThat(type.getBitWidth()).isEqualTo(256);
+
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(writer.schema(), allocator)) {
+      // 40 significant digits — does not fit in a 128-bit decimal, so the writer must use the
+      // Decimal256Vector path rather than casting to DecimalVector.
+      BigDecimal big = new BigDecimal("12345678901234567890123456789012345678.99");
+      writer.write(root, List.of(new Decimal256Row(big), new Decimal256Row(null)));
+
+      Decimal256Vector amount = (Decimal256Vector) root.getVector("amount");
+      assertThat(amount.getObject(0)).isEqualByComparingTo(big);
+      assertThat(amount.isNull(1)).isTrue();
+    }
+  }
+
+  @Test
   void fromRecordClass_rejectsUnannotatedDecimal() {
     assertThatThrownBy(() -> ArrowRecordWriters.fromRecordClass(UnannotatedDecimalRow.class))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("@ArrowDecimal");
+  }
+
+  @Test
+  void fromRecordClass_rejectsInvalidDecimalPrecisionScale() {
+    assertThatThrownBy(() -> ArrowRecordWriters.fromRecordClass(InvalidDecimalRow.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("DECIMAL");
   }
 
   @Test
@@ -170,6 +200,10 @@ class ArrowRecordWritersTest {
       byte[] bytesValue) {}
 
   private record DecimalRow(@ArrowDecimal(precision = 18, scale = 3) BigDecimal amount) {}
+
+  private record Decimal256Row(@ArrowDecimal(precision = 50, scale = 2) BigDecimal amount) {}
+
+  private record InvalidDecimalRow(@ArrowDecimal(precision = 5, scale = 7) BigDecimal amount) {}
 
   private record UnannotatedDecimalRow(BigDecimal amount) {}
 

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -21,6 +21,21 @@
   --md-accent-fg-color: #0b5f80;
 }
 
+/*
+ * Accessibility (WCAG AA contrast). Material's default
+ * --md-default-fg-color--light (black @ 54%) is the muted color behind code
+ * comment/variable/punctuation syntax tokens and blockquote text. Over the
+ * light docs backgrounds (#f5f5f5 code, #f0ecec content) it composites to
+ * ~#717171 / #6e6d6d — a 4.4:1 ratio that fails Lighthouse's color-contrast
+ * audit (AA needs 4.5:1). Darken it so every dependent token clears AA with
+ * margin (~5.9:1) while staying visibly muted. The selector must match the
+ * body-level [data-md-color-scheme] that the bundled palette uses, otherwise a
+ * :root override is shadowed for everything inside <body>.
+ */
+[data-md-color-scheme="default"] {
+  --md-default-fg-color--light: rgba(0, 0, 0, 0.62);
+}
+
 /* Keep docs palette close to Floecat site tones. */
 .md-header,
 .md-tabs {
@@ -131,4 +146,17 @@
 .md-footer-meta a,
 .md-footer-meta a:visited {
   color: #f8f2ef;
+}
+
+/*
+ * Accessibility (touch targets). Material's desktop sidebar nav links render
+ * ~18px tall with ~22px of safe clickable spacing, below the 24x24 minimum
+ * Lighthouse's target-size audit expects. Add vertical padding so each link is
+ * a >=24px target without changing the nav's visual rhythm noticeably.
+ */
+@media screen and (min-width: 76.25em) {
+  .md-sidebar--primary .md-nav__link {
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+  }
 }

--- a/docs/types.md
+++ b/docs/types.md
@@ -168,6 +168,21 @@ arbitrary engine-native type systems.
 If external Flight providers want to reuse `core/arrow`, they should first map their source type
 surface into Floecat logical types.
 
+### Record reflection writer (`ArrowRecordWriters`)
+
+`ArrowRecordWriters.fromRecordClass(...)` builds an Arrow schema + writer directly from a Java
+`record` (used by Flight system-table producers). Component types map to Arrow as above, with one
+extra rule for decimals: a `BigDecimal` carries no precision/scale, so a `BigDecimal` component
+**must** be annotated `@ArrowDecimal(precision, scale)` — an unannotated one is rejected. Precision
+and scale are validated through `LogicalType.decimal(...)` (`precision ≥ 1`, `0 ≤ scale ≤ precision`),
+and the column uses `Decimal128` for precision ≤ 38 and `Decimal256` for 39..76.
+
+Rounding is explicit. `@ArrowDecimal(rounding = ...)` controls how an input whose scale exceeds the
+column scale is coerced; it defaults to `RoundingMode.UNNECESSARY`, so excess scale throws rather
+than silently dropping precision. Padding a value to a larger scale is always lossless. Callers that
+intend lossy rounding opt in explicitly, e.g.
+`@ArrowDecimal(precision = 18, scale = 3, rounding = RoundingMode.HALF_UP)`.
+
 ## Source-Format Alias Lookup
 
 `LogicalKind.fromName(String candidate)` resolves source-format type names to canonical kinds:


### PR DESCRIPTION
## What

Adds Arrow `DECIMAL` support to the reflection-backed `ArrowRecordWriters.fromRecordClass`, via a new `@ArrowDecimal(precision, scale)` record-component annotation.

Until now the writer's type switch covered `String`/`byte[]`/`boolean`/`int`/`long`/`double`/`Instant`/`LocalDate`/`UUID` and threw `"Unsupported component type"` for anything else — including `BigDecimal`. There was no way to emit an Arrow decimal column from a record class, even though the rest of the arrow module (`ArrowDecimalTypes` / `ArrowSchemaUtil`, the scanner path) already knows how to build one. `BigDecimal` carries no precision/scale, so the annotation supplies that metadata; everything else routes through the existing decimal machinery.

## Changes

- **`ArrowDecimal`** (new annotation) — `@ArrowDecimal(precision, scale)`, `@Target(RECORD_COMPONENT)`, mirroring the existing `@ArrowFieldName`.
- **`ArrowRecordWriters`** — a `BigDecimal` branch that:
  - validates precision/scale through floecat's canonical `LogicalType.decimal(precision, scale)` (rejects `precision < 1`, `scale < 0`, `scale > precision`);
  - builds the field type via the shared `ArrowDecimalTypes.decimalType(precision, scale)` helper (the same one `ArrowSchemaUtil` uses);
  - writes through `DecimalVector` (128-bit) **or** `Decimal256Vector` (precision > 38), matching what `ArrowDecimalTypes` produces and how the scanner's `ArrowConversion` handles decimals;
  - coerces an input whose scale exceeds the column via the annotation's `rounding()` mode, which **defaults to `RoundingMode.UNNECESSARY`** (throws rather than silently dropping precision) — lossy rounding is an explicit caller opt-in (e.g. `rounding = HALF_UP`); padding to a larger scale is always lossless;
  - rejects an **unannotated** `BigDecimal` with a specific `"must be annotated with @ArrowDecimal"` error (Arrow decimals need explicit precision/scale, so reject-unless-told is preserved).
- **`docs/types.md`** — new `Record reflection writer` subsection documenting the `@ArrowDecimal` precision/scale mapping (Decimal128 ≤ 38, Decimal256 39..76) and the rounding contract.
- **`ArrowRecordWritersTest`** — annotated-decimal round-trip (schema precision/scale, value, `HALF_UP` rounding, null), a 256-bit / high-precision round-trip exercising the `Decimal256Vector` path, unannotated-rejection, and invalid-precision/scale rejection; the unsupported-type test now uses `Object` since `BigDecimal` is conditionally supported.

Backward-compatible: behavior is identical for every non-`BigDecimal` record, and `fromRecordClass` has no other callers in floecat.

## Why

`sys.query` exposes duration columns as `DECIMAL(18,3)`. The consumer-side wire schema is built from a record (`QueryRow`) through this writer, so it needs a decimal branch. core PR eng-floe/core#1541 currently works around this with a forked copy of the writer in core; this lets that PR annotate `QueryRow` and delete the fork.

## Verification

`mvn -pl core/arrow test` — all `core/arrow` tests pass (`ArrowRecordWritersTest` = 10, covering the 128-bit and 256-bit paths, HALF_UP rounding, default-UNNECESSARY padding/excess-scale rejection, nulls, and unannotated/invalid rejection). `fmt:check` clean.
