### PR TITLE
Fix: Prevent switching to a non-existent account

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/security/impl/PrincipalProvider.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/impl/PrincipalProvider.java
@@ -17,10 +17,16 @@
 package ai.floedb.floecat.service.security.impl;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import io.grpc.Context;
+import io.grpc.Status;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Resolves the principal for the current call. The principal is carried on two channels:
@@ -49,6 +55,18 @@ public class PrincipalProvider {
   /** Vert.x duplicated-context local key under which the resolved principal is mirrored. */
   private static final String PRINCIPAL_LOCAL = "floecat.principal";
 
+  @Inject AccountRepository accountRepository;
+
+  @ConfigProperty(name = "floecat.interceptor.validate.account", defaultValue = "true")
+  boolean validateAccount;
+
+  public PrincipalProvider() {}
+
+  PrincipalProvider(AccountRepository accountRepository, boolean validateAccount) {
+    this.accountRepository = accountRepository;
+    this.validateAccount = validateAccount;
+  }
+
   /**
    * Returns the principal for the current call.
    *
@@ -63,11 +81,11 @@ public class PrincipalProvider {
   public PrincipalContext get() {
     PrincipalContext fromContextLocal = fromDuplicatedContext();
     if (fromContextLocal != null) {
-      return fromContextLocal;
+      return requireKnownAccount(fromContextLocal);
     }
     PrincipalContext fromGrpc = KEY.get();
     if (fromGrpc != null) {
-      return fromGrpc;
+      return requireKnownAccount(fromGrpc);
     }
     return PrincipalContext.getDefaultInstance();
   }
@@ -96,5 +114,23 @@ public class PrincipalProvider {
       }
     }
     return null;
+  }
+
+  private PrincipalContext requireKnownAccount(PrincipalContext principalContext) {
+    if (!validateAccount || principalContext == null) {
+      return principalContext;
+    }
+    String accountId = principalContext.getAccountId();
+    if (accountId == null || accountId.isBlank() || accountRepository == null) {
+      return principalContext;
+    }
+    ResourceId accountRid =
+        ResourceId.newBuilder().setId(accountId).setKind(ResourceKind.RK_ACCOUNT).build();
+    if (accountRepository.getById(accountRid).isEmpty()) {
+      throw Status.UNAUTHENTICATED
+          .withDescription("invalid or unknown account: " + accountId)
+          .asRuntimeException();
+    }
+    return principalContext;
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/it/AuthModeDevIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/AuthModeDevIT.java
@@ -16,14 +16,22 @@
 
 package ai.floedb.floecat.service.it;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import ai.floedb.floecat.account.rpc.AccountServiceGrpc;
 import ai.floedb.floecat.account.rpc.ListAccountsRequest;
+import ai.floedb.floecat.catalog.rpc.CatalogServiceGrpc;
+import ai.floedb.floecat.catalog.rpc.ListCatalogsRequest;
 import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
 import ai.floedb.floecat.service.it.profiles.AuthModeDevProfile;
 import ai.floedb.floecat.service.util.TestDataResetter;
 import ai.floedb.floecat.service.util.TestSupport;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -35,8 +43,14 @@ import org.junit.jupiter.api.Test;
 @TestProfile(AuthModeDevProfile.class)
 class AuthModeDevIT {
 
+  private static final Metadata.Key<String> DEV_ACCOUNT_HEADER =
+      Metadata.Key.of("x-floe-account", Metadata.ASCII_STRING_MARSHALLER);
+
   @GrpcClient("floecat")
   AccountServiceGrpc.AccountServiceBlockingStub accounts;
+
+  @GrpcClient("floecat")
+  CatalogServiceGrpc.CatalogServiceBlockingStub catalogs;
 
   @Inject TestDataResetter resetter;
   @Inject SeedRunner seeder;
@@ -53,5 +67,33 @@ class AuthModeDevIT {
         TestSupport.callWhenGrpcReady(
             () -> accounts.listAccounts(ListAccountsRequest.getDefaultInstance()));
     assertFalse(response.getAccountsList().isEmpty());
+  }
+
+  @Test
+  void listAccountsRejectsUnknownDevAccountHeader() {
+    Metadata metadata = new Metadata();
+    metadata.put(DEV_ACCOUNT_HEADER, "00000000-0000-0000-0000-000000000001");
+
+    var stub = accounts.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listAccounts(ListAccountsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void listCatalogsRejectsUnknownDevAccountHeader() {
+    Metadata metadata = new Metadata();
+    metadata.put(DEV_ACCOUNT_HEADER, "00000000-0000-0000-0000-000000000001");
+
+    var stub = catalogs.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> stub.listCatalogs(ListCatalogsRequest.getDefaultInstance()));
+
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/security/impl/PrincipalProviderTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/impl/PrincipalProviderTest.java
@@ -17,15 +17,23 @@
 package ai.floedb.floecat.service.security.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import io.grpc.Context;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 /**
  * Unit coverage for the dual-channel principal carrier in {@link PrincipalProvider}.
@@ -119,6 +127,27 @@ class PrincipalProviderTest {
   void returnsDefaultWhenNoPrincipalAnywhere() throws Exception {
     PrincipalContext got = Context.ROOT.call(() -> new PrincipalProvider().get());
     assertEquals(PrincipalContext.getDefaultInstance(), got);
+  }
+
+  @Test
+  void rejectsUnknownAccountWhenServiceSideValidationEnabled() {
+    AccountRepository accounts = Mockito.mock(AccountRepository.class);
+    ResourceId accountId =
+        ResourceId.newBuilder()
+            .setId(PRINCIPAL.getAccountId())
+            .setKind(ResourceKind.RK_ACCOUNT)
+            .build();
+    Mockito.when(accounts.getById(accountId)).thenReturn(Optional.empty());
+
+    PrincipalProvider provider = new PrincipalProvider(accounts, true);
+    Context grpc = Context.current().withValue(PrincipalProvider.KEY, PRINCIPAL);
+    Context prev = grpc.attach();
+    try {
+      StatusRuntimeException error = assertThrows(StatusRuntimeException.class, provider::get);
+      assertEquals(Status.Code.UNAUTHENTICATED, error.getStatus().getCode());
+    } finally {
+      grpc.detach(prev);
+    }
   }
 
   /** Storing off a duplicated context is a safe no-op, not an exception. */


### PR DESCRIPTION
## Summary

It is possible to switch to a non-existent account, if the account ID specified is a valid UUID

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

