### PR TITLE
Speed up information_schema enumeration with topology refs

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/CheckConstraintsScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/CheckConstraintsScanner.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -41,7 +42,16 @@ public final class CheckConstraintsScanner implements SystemObjectScanner {
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
-    return ConstraintScanIndex.build(ctx).entries().stream()
+    return rows(ConstraintScanIndex.build(ctx));
+  }
+
+  @Override
+  public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
+    return rows(ConstraintScanIndex.build(ctx, request, "constraint_schema", null));
+  }
+
+  private static Stream<SystemObjectRow> rows(ConstraintScanIndex index) {
+    return index.entries().stream()
         .filter(e -> e.type() == ConstraintType.CT_CHECK)
         .map(
             e ->

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScanner.java
@@ -21,7 +21,6 @@ import ai.floedb.floecat.arrow.ArrowValueWriters;
 import ai.floedb.floecat.arrow.ColumnarBatch;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
-import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.RelationNode;
 import ai.floedb.floecat.metagraph.model.TableNode;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
@@ -33,7 +32,8 @@ import ai.floedb.floecat.scanner.spi.ScanOutputFormat;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
-import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
+import ai.floedb.floecat.systemcatalog.informationschema.NamespaceScanSupport.NamespaceEntry;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -107,12 +107,19 @@ public final class ColumnsScanner implements SystemObjectScanner {
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
+    return scan(ctx, SystemScanRequest.empty());
+  }
+
+  @Override
+  public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
     // Small per-scan caches (cheap, bounded)
     Map<ResourceId, String> catalogNames = new HashMap<>();
 
-    return ctx.listNamespaces().stream()
-        .flatMap(ns -> ctx.listRelations(ns.id()).stream())
-        .flatMap(node -> scanRelation(ctx, node, catalogNames));
+    return NamespaceScanSupport.entries(ctx, request, "table_schema").stream()
+        .flatMap(
+            ns ->
+                NamespaceScanSupport.relations(ctx, ns.id(), request, "table_name").stream()
+                    .flatMap(node -> scanRelation(ctx, ns, node, catalogNames)));
   }
 
   @Override
@@ -126,19 +133,25 @@ public final class ColumnsScanner implements SystemObjectScanner {
       Expr predicate,
       List<String> requiredColumns,
       BufferAllocator allocator) {
+    return scanArrow(ctx, SystemScanRequest.of(predicate, requiredColumns), allocator);
+  }
+
+  @Override
+  public Stream<ColumnarBatch> scanArrow(
+      SystemObjectScanContext ctx, SystemScanRequest request, BufferAllocator allocator) {
     Objects.requireNonNull(ctx, "ctx");
     Objects.requireNonNull(allocator, "allocator");
-    Objects.requireNonNull(requiredColumns, "requiredColumns");
-    Set<String> requiredSet = ArrowSchemaUtil.normalizeRequiredColumns(requiredColumns);
-    List<NamespaceNode> namespaces = ctx.listNamespaces();
-    Iterator<NamespaceNode> namespaceIterator = namespaces.iterator();
+    Objects.requireNonNull(request, "request");
+    Set<String> requiredSet = ArrowSchemaUtil.normalizeRequiredColumns(request.requiredColumns());
+    Iterator<NamespaceEntry> namespaceIterator =
+        NamespaceScanSupport.entries(ctx, request, "table_schema").iterator();
     Spliterator<ColumnarBatch> spliterator =
         new Spliterators.AbstractSpliterator<ColumnarBatch>(
             Long.MAX_VALUE, Spliterator.ORDERED | Spliterator.NONNULL) {
-          private final Iterator<NamespaceNode> nsIter = namespaceIterator;
+          private final Iterator<NamespaceEntry> nsIter = namespaceIterator;
           private Iterator<RelationNode> relationIter = Collections.emptyIterator();
           private Iterator<ColumnEntry> columnIter = Collections.emptyIterator();
-          private NamespaceNode currentNamespace;
+          private NamespaceEntry currentNamespace;
           private final Map<ResourceId, String> catalogNames = new HashMap<>();
 
           @Override
@@ -181,7 +194,9 @@ public final class ColumnsScanner implements SystemObjectScanner {
                 return null;
               }
               currentNamespace = nsIter.next();
-              relationIter = ctx.listRelations(currentNamespace.id()).iterator();
+              relationIter =
+                  NamespaceScanSupport.relations(ctx, currentNamespace.id(), request, "table_name")
+                      .iterator();
             }
             return relationIter.next();
           }
@@ -190,34 +205,38 @@ public final class ColumnsScanner implements SystemObjectScanner {
   }
 
   private Stream<SystemObjectRow> scanRelation(
-      SystemObjectScanContext ctx, RelationNode node, Map<ResourceId, String> catalogNames) {
+      SystemObjectScanContext ctx,
+      NamespaceEntry namespace,
+      RelationNode node,
+      Map<ResourceId, String> catalogNames) {
 
     if (node instanceof TableNode table) {
-      return scanTable(ctx, table, catalogNames);
+      return scanTable(ctx, namespace, table, catalogNames);
     }
 
     if (node instanceof ViewNode view) {
-      return scanView(ctx, view, catalogNames);
+      return scanView(ctx, namespace, view, catalogNames);
     }
 
     return Stream.empty();
   }
 
   private Stream<SystemObjectRow> scanTable(
-      SystemObjectScanContext ctx, TableNode table, Map<ResourceId, String> catalogNames) {
-
-    NamespaceNode namespace = (NamespaceNode) ctx.resolve(table.namespaceId());
+      SystemObjectScanContext ctx,
+      NamespaceEntry namespace,
+      TableNode table,
+      Map<ResourceId, String> catalogNames) {
     ResourceId catalogId = namespace.catalogId();
 
     String catalogName =
         catalogNames.computeIfAbsent(
             catalogId, id -> ((CatalogNode) ctx.resolve(id)).displayName());
 
-    String schemaName = schemaName(namespace);
+    String schemaName = namespace.schemaName();
 
     List<SchemaColumn> columns = ctx.graph().tableSchema(table.id());
 
-    if (table instanceof UserTableNode ut) {
+    if (table instanceof UserTableNode) {
       return columns.stream()
           .sorted(Comparator.comparingInt(SchemaColumn::getFieldId))
           .map(
@@ -252,16 +271,17 @@ public final class ColumnsScanner implements SystemObjectScanner {
   }
 
   private Stream<SystemObjectRow> scanView(
-      SystemObjectScanContext ctx, ViewNode view, Map<ResourceId, String> catalogNames) {
-
-    NamespaceNode namespace = (NamespaceNode) ctx.resolve(view.namespaceId());
+      SystemObjectScanContext ctx,
+      NamespaceEntry namespace,
+      ViewNode view,
+      Map<ResourceId, String> catalogNames) {
     ResourceId catalogId = namespace.catalogId();
 
     String catalogName =
         catalogNames.computeIfAbsent(
             catalogId, id -> ((CatalogNode) ctx.resolve(id)).displayName());
 
-    String schemaName = schemaName(namespace);
+    String schemaName = namespace.schemaName();
     List<SchemaColumn> cols = view.outputColumns();
 
     List<SystemObjectRow> rows = new ArrayList<>(cols.size());
@@ -281,23 +301,19 @@ public final class ColumnsScanner implements SystemObjectScanner {
     return rows.stream();
   }
 
-  private static String schemaName(NamespaceNode namespace) {
-    return NameRefUtil.namespaceName(namespace.pathSegments(), namespace.displayName());
-  }
-
   private static String blankToNull(String value) {
     return value == null || value.isBlank() ? null : value;
   }
 
   private List<ColumnEntry> columnsForRelation(
       SystemObjectScanContext ctx,
-      NamespaceNode namespace,
+      NamespaceEntry namespace,
       RelationNode node,
       Map<ResourceId, String> catalogNames) {
     String catalogName =
         catalogNames.computeIfAbsent(
             namespace.catalogId(), id -> ((CatalogNode) ctx.resolve(id)).displayName());
-    String schemaName = schemaName(namespace);
+    String schemaName = namespace.schemaName();
 
     if (node instanceof TableNode table) {
       List<SchemaColumn> columns = ctx.graph().tableSchema(table.id());

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ConstraintColumnUsageScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ConstraintColumnUsageScanner.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -44,7 +45,16 @@ public final class ConstraintColumnUsageScanner implements SystemObjectScanner {
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
-    return ConstraintScanIndex.build(ctx).entries().stream()
+    return rows(ConstraintScanIndex.build(ctx));
+  }
+
+  @Override
+  public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
+    return rows(ConstraintScanIndex.build(ctx, request, "constraint_schema", null));
+  }
+
+  private static Stream<SystemObjectRow> rows(ConstraintScanIndex index) {
+    return index.entries().stream()
         .flatMap(
             entry -> {
               if (entry.type() == ConstraintType.CT_FOREIGN_KEY) {

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ConstraintScanIndex.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ConstraintScanIndex.java
@@ -25,11 +25,12 @@ import ai.floedb.floecat.catalog.rpc.ForeignKeyMatchOption;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
-import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.RelationNode;
 import ai.floedb.floecat.metagraph.model.TableNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
+import ai.floedb.floecat.systemcatalog.informationschema.NamespaceScanSupport.NamespaceEntry;
 import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -61,6 +62,22 @@ public final class ConstraintScanIndex {
   }
 
   private static ConstraintScanIndex buildUncached(SystemObjectScanContext ctx) {
+    return buildUncached(ctx, SystemScanRequest.empty(), null, null);
+  }
+
+  public static ConstraintScanIndex build(
+      SystemObjectScanContext ctx,
+      SystemScanRequest request,
+      String schemaColumnName,
+      String tableNameColumn) {
+    return buildUncached(ctx, request, schemaColumnName, tableNameColumn);
+  }
+
+  private static ConstraintScanIndex buildUncached(
+      SystemObjectScanContext ctx,
+      SystemScanRequest request,
+      String schemaColumnName,
+      String tableNameColumn) {
     Map<ResourceId, TableRef> tableRefs = new LinkedHashMap<>();
     Map<ResourceId, TableRef> tablesWithConstraints = new LinkedHashMap<>();
     Map<ResourceId, String> catalogNames = new HashMap<>();
@@ -70,12 +87,13 @@ public final class ConstraintScanIndex {
         new HashMap<>();
     Map<String, Optional<TableRef>> referencedTablesByName = new HashMap<>();
 
-    for (NamespaceNode namespace : ctx.listNamespaces()) {
+    for (NamespaceEntry namespace : NamespaceScanSupport.entries(ctx, request, schemaColumnName)) {
       String catalogName =
           catalogNames.computeIfAbsent(
               namespace.catalogId(), id -> ((CatalogNode) ctx.resolve(id)).displayName());
-      String schemaName = schemaName(namespace);
-      for (RelationNode relation : ctx.listRelations(namespace.id())) {
+      String schemaName = namespace.schemaName();
+      for (RelationNode relation :
+          NamespaceScanSupport.relations(ctx, namespace.id(), request, tableNameColumn)) {
         if (!(relation instanceof TableNode table)) {
           continue;
         }
@@ -321,10 +339,6 @@ public final class ConstraintScanIndex {
       case FK_ACTION_RULE_NO_ACTION, FK_ACTION_RULE_UNSPECIFIED -> "NO ACTION";
       case UNRECOGNIZED -> "NO ACTION";
     };
-  }
-
-  private static String schemaName(NamespaceNode namespace) {
-    return NameRefUtil.namespaceName(namespace.pathSegments(), namespace.displayName());
   }
 
   public record TableRef(ResourceId tableId, String catalog, String schema, String name) {}

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ConstraintTableUsageScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ConstraintTableUsageScanner.java
@@ -20,6 +20,7 @@ import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -42,7 +43,16 @@ public final class ConstraintTableUsageScanner implements SystemObjectScanner {
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
-    return ConstraintScanIndex.build(ctx).entries().stream()
+    return rows(ConstraintScanIndex.build(ctx));
+  }
+
+  @Override
+  public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
+    return rows(ConstraintScanIndex.build(ctx, request, "constraint_schema", null));
+  }
+
+  private static Stream<SystemObjectRow> rows(ConstraintScanIndex index) {
+    return index.entries().stream()
         .flatMap(
             entry -> {
               ConstraintScanIndex.TableRef local = entry.table();

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/KeyColumnUsageScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/KeyColumnUsageScanner.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -47,7 +48,16 @@ public final class KeyColumnUsageScanner implements SystemObjectScanner {
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
-    return ConstraintScanIndex.build(ctx).entries().stream()
+    return rows(ConstraintScanIndex.build(ctx));
+  }
+
+  @Override
+  public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
+    return rows(ConstraintScanIndex.build(ctx, request, "table_schema", "table_name"));
+  }
+
+  private static Stream<SystemObjectRow> rows(ConstraintScanIndex index) {
+    return index.entries().stream()
         .filter(entry -> isKeyConstraint(entry.type()))
         .flatMap(
             entry ->

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/NamespaceScanSupport.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/NamespaceScanSupport.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.systemcatalog.informationschema;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.metagraph.model.NamespaceNode;
+import ai.floedb.floecat.metagraph.model.RelationNode;
+import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
+import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+final class NamespaceScanSupport {
+  private NamespaceScanSupport() {}
+
+  static List<NamespaceEntry> entries(SystemObjectScanContext ctx) {
+    return entries(ctx, SystemScanRequest.empty(), null);
+  }
+
+  static List<NamespaceEntry> entries(
+      SystemObjectScanContext ctx, SystemScanRequest request, String schemaColumnName) {
+    if (request.constraints().isAlwaysFalse()) {
+      return List.of();
+    }
+    Set<String> schemaNames =
+        schemaColumnName == null
+            ? null
+            : request.constraints().values(schemaColumnName).orElse(null);
+    if (ctx.supportsLightweightRefs()) {
+      List<TopologyGraph.NamespaceRef> refs;
+      if (schemaNames == null) {
+        refs = ctx.listNamespaceRefs();
+      } else if (canUseDirectNamespaceLookup(schemaNames)) {
+        refs = ctx.listNamespaceRefsByName(schemaNames);
+      } else {
+        refs =
+            ctx.listNamespaceRefs().stream()
+                .filter(ns -> schemaNames.contains(schemaName(ns)))
+                .toList();
+      }
+      return refs.stream()
+          .map(ns -> new NamespaceEntry(ns.id(), catalogIdFor(ctx, ns), schemaName(ns)))
+          .toList();
+    }
+    Stream<NamespaceNode> namespaces = ctx.listNamespaces().stream();
+    if (schemaNames != null) {
+      namespaces = namespaces.filter(ns -> schemaNames.contains(schemaName(ns)));
+    }
+    return namespaces
+        .map(ns -> new NamespaceEntry(ns.id(), ns.catalogId(), schemaName(ns)))
+        .toList();
+  }
+
+  static List<TopologyGraph.RelationRef> relationRefs(
+      SystemObjectScanContext ctx,
+      ResourceId namespaceId,
+      SystemScanRequest request,
+      String relationNameColumn) {
+    if (request.constraints().isAlwaysFalse()) {
+      return List.of();
+    }
+    Set<String> relationNames =
+        relationNameColumn == null
+            ? null
+            : request.constraints().values(relationNameColumn).orElse(null);
+    if (relationNames == null) {
+      return ctx.listRelationRefs(namespaceId);
+    }
+    return ctx.listRelationRefsByName(namespaceId, relationNames);
+  }
+
+  static List<RelationNode> relations(
+      SystemObjectScanContext ctx,
+      ResourceId namespaceId,
+      SystemScanRequest request,
+      String relationNameColumn) {
+    if (request.constraints().isAlwaysFalse()) {
+      return List.of();
+    }
+    Set<String> relationNames =
+        relationNameColumn == null
+            ? null
+            : request.constraints().values(relationNameColumn).orElse(null);
+    if (ctx.supportsLightweightRefs() && relationNames != null) {
+      return ctx.listRelationRefsByName(namespaceId, relationNames).stream()
+          .map(ref -> ctx.tryResolve(ref.id()))
+          .flatMap(Optional::stream)
+          .filter(RelationNode.class::isInstance)
+          .map(RelationNode.class::cast)
+          .toList();
+    }
+    Stream<RelationNode> relations = ctx.listRelations(namespaceId).stream();
+    if (relationNames != null) {
+      relations = relations.filter(rel -> relationNames.contains(rel.displayName()));
+    }
+    return relations.toList();
+  }
+
+  private static ResourceId catalogIdFor(
+      SystemObjectScanContext ctx, TopologyGraph.NamespaceRef namespace) {
+    ResourceId catalogId = namespace.catalogId();
+    if (catalogId == null || catalogId.getId().isBlank()) {
+      return ctx.queryDefaultCatalogId();
+    }
+    return catalogId;
+  }
+
+  private static String schemaName(NamespaceNode namespace) {
+    return NameRefUtil.namespaceName(namespace.pathSegments(), namespace.displayName());
+  }
+
+  private static String schemaName(TopologyGraph.NamespaceRef namespace) {
+    return NameRefUtil.namespaceName(namespace.pathSegments(), namespace.name());
+  }
+
+  private static boolean canUseDirectNamespaceLookup(Set<String> schemaNames) {
+    return schemaNames.stream().noneMatch(name -> name != null && name.contains("."));
+  }
+
+  record NamespaceEntry(ResourceId id, ResourceId catalogId, String schemaName) {}
+}

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ReferentialConstraintsScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ReferentialConstraintsScanner.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -46,7 +47,16 @@ public final class ReferentialConstraintsScanner implements SystemObjectScanner 
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
-    return ConstraintScanIndex.build(ctx).entries().stream()
+    return rows(ConstraintScanIndex.build(ctx));
+  }
+
+  @Override
+  public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
+    return rows(ConstraintScanIndex.build(ctx, request, "constraint_schema", null));
+  }
+
+  private static Stream<SystemObjectRow> rows(ConstraintScanIndex index) {
+    return index.entries().stream()
         .filter(e -> e.type() == ConstraintType.CT_FOREIGN_KEY)
         .map(
             e -> {

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/SchemataScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/SchemataScanner.java
@@ -21,7 +21,6 @@ import ai.floedb.floecat.arrow.ArrowValueWriters;
 import ai.floedb.floecat.arrow.ColumnarBatch;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
-import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.columnar.AbstractArrowBatchBuilder;
 import ai.floedb.floecat.scanner.expr.Expr;
@@ -29,7 +28,8 @@ import ai.floedb.floecat.scanner.spi.ScanOutputFormat;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
-import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
+import ai.floedb.floecat.systemcatalog.informationschema.NamespaceScanSupport.NamespaceEntry;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -75,21 +75,22 @@ public final class SchemataScanner implements SystemObjectScanner {
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
+    return scan(ctx, SystemScanRequest.empty());
+  }
+
+  @Override
+  public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
     Map<ResourceId, String> catalogById = new HashMap<>();
 
-    return ctx.listNamespaces().stream()
+    return NamespaceScanSupport.entries(ctx, request, "schema_name").stream()
         .map(
             ns ->
                 new SystemObjectRow(
                     new Object[] {
                       catalogById.computeIfAbsent(
                           ns.catalogId(), id -> ((CatalogNode) ctx.resolve(id)).displayName()),
-                      schemaName(ns)
+                      ns.schemaName()
                     }));
-  }
-
-  private static String schemaName(NamespaceNode namespace) {
-    return NameRefUtil.namespaceName(namespace.pathSegments(), namespace.displayName());
   }
 
   @Override
@@ -103,16 +104,22 @@ public final class SchemataScanner implements SystemObjectScanner {
       Expr predicate,
       List<String> requiredColumns,
       BufferAllocator allocator) {
+    return scanArrow(ctx, SystemScanRequest.of(predicate, requiredColumns), allocator);
+  }
+
+  @Override
+  public Stream<ColumnarBatch> scanArrow(
+      SystemObjectScanContext ctx, SystemScanRequest request, BufferAllocator allocator) {
     Objects.requireNonNull(ctx, "ctx");
     Objects.requireNonNull(allocator, "allocator");
-    Objects.requireNonNull(requiredColumns, "requiredColumns");
-    Set<String> requiredSet = ArrowSchemaUtil.normalizeRequiredColumns(requiredColumns);
-    List<NamespaceNode> namespaces = ctx.listNamespaces();
-    Iterator<NamespaceNode> namespaceIterator = namespaces.iterator();
+    Objects.requireNonNull(request, "request");
+    Set<String> requiredSet = ArrowSchemaUtil.normalizeRequiredColumns(request.requiredColumns());
+    Iterator<NamespaceEntry> namespaceIterator =
+        NamespaceScanSupport.entries(ctx, request, "schema_name").iterator();
     Spliterator<ColumnarBatch> spliterator =
         new Spliterators.AbstractSpliterator<ColumnarBatch>(
             Long.MAX_VALUE, Spliterator.ORDERED | Spliterator.NONNULL) {
-          private final Iterator<NamespaceNode> nsIter = namespaceIterator;
+          private final Iterator<NamespaceEntry> nsIter = namespaceIterator;
           private final Map<ResourceId, String> catalogNames = new HashMap<>();
 
           @Override
@@ -130,12 +137,12 @@ public final class SchemataScanner implements SystemObjectScanner {
                 if (builder == null) {
                   builder = new SchemataBatchBuilder(allocator, requiredSet);
                 }
-                NamespaceNode namespace = nsIter.next();
+                NamespaceEntry namespace = nsIter.next();
                 ResourceId catalogId = namespace.catalogId();
                 String catalogName =
                     catalogNames.computeIfAbsent(
                         catalogId, id -> ((CatalogNode) ctx.resolve(id)).displayName());
-                builder.append(catalogName, schemaName(namespace));
+                builder.append(catalogName, namespace.schemaName());
                 if (builder.isFull()) {
                   action.accept(builder.build());
                   return true;

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/TableConstraintsScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/TableConstraintsScanner.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -47,7 +48,16 @@ public final class TableConstraintsScanner implements SystemObjectScanner {
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
-    return ConstraintScanIndex.build(ctx).entries().stream()
+    return rows(ConstraintScanIndex.build(ctx));
+  }
+
+  @Override
+  public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
+    return rows(ConstraintScanIndex.build(ctx, request, "table_schema", "table_name"));
+  }
+
+  private static Stream<SystemObjectRow> rows(ConstraintScanIndex index) {
+    return index.entries().stream()
         .filter(e -> e.type() != ConstraintType.CT_NOT_NULL)
         .map(
             e ->

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/TablesScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/TablesScanner.java
@@ -20,8 +20,8 @@ import ai.floedb.floecat.arrow.ArrowSchemaUtil;
 import ai.floedb.floecat.arrow.ArrowValueWriters;
 import ai.floedb.floecat.arrow.ColumnarBatch;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
-import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.RelationNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.columnar.AbstractArrowBatchBuilder;
@@ -30,7 +30,9 @@ import ai.floedb.floecat.scanner.spi.ScanOutputFormat;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
-import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
+import ai.floedb.floecat.systemcatalog.informationschema.NamespaceScanSupport.NamespaceEntry;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -42,7 +44,6 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.arrow.memory.BufferAllocator;
@@ -90,17 +91,33 @@ public final class TablesScanner implements SystemObjectScanner {
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
-    Map<ResourceId, String> schemaByNamespace =
-        ctx.listNamespaces().stream()
-            .collect(Collectors.toMap(NamespaceNode::id, TablesScanner::schemaName));
+    return scan(ctx, SystemScanRequest.empty());
+  }
 
+  @Override
+  public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
+    boolean supportsLightweightRefs = ctx.supportsLightweightRefs();
+    List<NamespaceEntry> namespaces = NamespaceScanSupport.entries(ctx, request, "table_schema");
     Map<ResourceId, String> catalogNames = new HashMap<>();
 
-    return ctx.listNamespaces().stream()
+    return namespaces.stream()
         .flatMap(
-            ns ->
-                ctx.listRelations(ns.id()).stream()
-                    .map(rel -> rowForRelation(ctx, ns, rel, schemaByNamespace, catalogNames)));
+            ns -> {
+              String catalogName =
+                  catalogNames.computeIfAbsent(
+                      ns.catalogId(), id -> ((CatalogNode) ctx.resolve(id)).displayName());
+              if (supportsLightweightRefs) {
+                List<TopologyGraph.RelationRef> refs =
+                    NamespaceScanSupport.relationRefs(ctx, ns.id(), request, "table_name");
+                return refs.stream()
+                    .filter(ref -> matchesTableType(request, ref))
+                    .map(ref -> rowForRef(catalogName, ns.schemaName(), ref));
+              }
+              // Fall back to full relation load when the overlay has no lightweight ref source.
+              return NamespaceScanSupport.relations(ctx, ns.id(), request, "table_name").stream()
+                  .filter(rel -> matchesTableType(request, rel))
+                  .map(rel -> rowForRelation(catalogName, ns.schemaName(), rel));
+            });
   }
 
   @Override
@@ -114,23 +131,27 @@ public final class TablesScanner implements SystemObjectScanner {
       Expr predicate,
       List<String> requiredColumns,
       BufferAllocator allocator) {
+    return scanArrow(ctx, SystemScanRequest.of(predicate, requiredColumns), allocator);
+  }
+
+  @Override
+  public Stream<ColumnarBatch> scanArrow(
+      SystemObjectScanContext ctx, SystemScanRequest request, BufferAllocator allocator) {
     Objects.requireNonNull(ctx, "ctx");
     Objects.requireNonNull(allocator, "allocator");
-    Objects.requireNonNull(requiredColumns, "requiredColumns");
-    Set<String> requiredSet = ArrowSchemaUtil.normalizeRequiredColumns(requiredColumns);
-    if (predicate != null) {
-      // TODO: predicate handling is delegated to the arrow filter operator downstream
-    }
-    List<NamespaceNode> namespaces = ctx.listNamespaces();
-    Map<ResourceId, String> schemaByNamespace =
-        namespaces.stream().collect(Collectors.toMap(NamespaceNode::id, TablesScanner::schemaName));
-    Iterator<NamespaceNode> namespaceIterator = namespaces.iterator();
+    Objects.requireNonNull(request, "request");
+    Set<String> requiredSet = ArrowSchemaUtil.normalizeRequiredColumns(request.requiredColumns());
+    boolean supportsLightweightRefs = ctx.supportsLightweightRefs();
+    Iterator<NamespaceEntry> namespaceIterator =
+        NamespaceScanSupport.entries(ctx, request, "table_schema").iterator();
+    // Each entry is {name, kind_string} -- populated from lightweight refs (fast, no S3)
+    // or full RelationNode objects when the overlay has no lightweight ref source.
     Spliterator<ColumnarBatch> spliterator =
         new Spliterators.AbstractSpliterator<ColumnarBatch>(
             Long.MAX_VALUE, Spliterator.ORDERED | Spliterator.NONNULL) {
-          private final Iterator<NamespaceNode> namespaceIter = namespaceIterator;
-          private Iterator<RelationNode> relationIterator = Collections.emptyIterator();
-          private NamespaceNode currentNamespace;
+          private final Iterator<NamespaceEntry> namespaceIter = namespaceIterator;
+          private Iterator<String[]> entryIterator = Collections.emptyIterator();
+          private NamespaceEntry currentNamespace;
           private final Map<ResourceId, String> catalogNames = new HashMap<>();
 
           @Override
@@ -138,8 +159,8 @@ public final class TablesScanner implements SystemObjectScanner {
             TablesBatchBuilder builder = null;
             try {
               while (true) {
-                RelationNode relation = nextRelation(ctx);
-                if (relation != null) {
+                String[] entry = nextEntry(ctx);
+                if (entry != null) {
                   if (builder == null) {
                     builder = new TablesBatchBuilder(allocator, requiredSet);
                   }
@@ -147,9 +168,7 @@ public final class TablesScanner implements SystemObjectScanner {
                   String catalogName =
                       catalogNames.computeIfAbsent(
                           catalogId, id -> ((CatalogNode) ctx.resolve(id)).displayName());
-                  String schemaName = schemaByNamespace.getOrDefault(currentNamespace.id(), "");
-                  builder.append(
-                      catalogName, schemaName, relation.displayName(), relationKind(relation));
+                  builder.append(catalogName, currentNamespace.schemaName(), entry[0], entry[1]);
                   if (builder.isFull()) {
                     action.accept(builder.build());
                     return true;
@@ -169,40 +188,72 @@ public final class TablesScanner implements SystemObjectScanner {
             }
           }
 
-          private RelationNode nextRelation(SystemObjectScanContext ctx) {
-            while (!relationIterator.hasNext()) {
+          private String[] nextEntry(SystemObjectScanContext ctx) {
+            while (!entryIterator.hasNext()) {
               if (!namespaceIter.hasNext()) {
                 return null;
               }
               currentNamespace = namespaceIter.next();
-              relationIterator = ctx.listRelations(currentNamespace.id()).iterator();
+              if (supportsLightweightRefs) {
+                List<TopologyGraph.RelationRef> refs =
+                    NamespaceScanSupport.relationRefs(
+                        ctx, currentNamespace.id(), request, "table_name");
+                entryIterator =
+                    refs.stream()
+                        .filter(ref -> matchesTableType(request, ref))
+                        .map(ref -> new String[] {ref.name(), refKindString(ref.kind())})
+                        .iterator();
+              } else {
+                entryIterator =
+                    NamespaceScanSupport.relations(
+                            ctx, currentNamespace.id(), request, "table_name")
+                        .stream()
+                        .filter(rel -> matchesTableType(request, rel))
+                        .map(rel -> new String[] {rel.displayName(), relationKind(rel)})
+                        .iterator();
+              }
             }
-            return relationIterator.next();
+            return entryIterator.next();
           }
         };
     return StreamSupport.stream(spliterator, false);
   }
 
+  private static boolean matchesTableType(
+      SystemScanRequest request, TopologyGraph.RelationRef ref) {
+    return request
+        .constraints()
+        .values("table_type")
+        .map(types -> types.contains(refKindString(ref.kind())))
+        .orElse(true);
+  }
+
+  private static boolean matchesTableType(SystemScanRequest request, RelationNode node) {
+    return request
+        .constraints()
+        .values("table_type")
+        .map(types -> types.contains(relationKind(node)))
+        .orElse(true);
+  }
+
   private static SystemObjectRow rowForRelation(
-      SystemObjectScanContext ctx,
-      NamespaceNode namespace,
-      RelationNode node,
-      Map<ResourceId, String> schemaByNamespace,
-      Map<ResourceId, String> catalogNames) {
-
-    ResourceId catalogId = namespace.catalogId();
-
-    String catalogName =
-        catalogNames.computeIfAbsent(
-            catalogId, id -> ((CatalogNode) ctx.resolve(id)).displayName());
-
+      String catalogName, String schemaName, RelationNode node) {
     return new SystemObjectRow(
-        new Object[] {
-          catalogName,
-          schemaByNamespace.getOrDefault(namespace.id(), ""),
-          node.displayName(),
-          relationKind(node)
-        });
+        new Object[] {catalogName, schemaName, node.displayName(), relationKind(node)});
+  }
+
+  private static SystemObjectRow rowForRef(
+      String catalogName, String schemaName, TopologyGraph.RelationRef ref) {
+    return new SystemObjectRow(
+        new Object[] {catalogName, schemaName, ref.name(), refKindString(ref.kind())});
+  }
+
+  private static String refKindString(ResourceKind kind) {
+    return switch (kind) {
+      case RK_TABLE -> "BASE TABLE";
+      case RK_VIEW -> "VIEW";
+      default -> "UNKNOWN";
+    };
   }
 
   private static String relationKind(RelationNode node) {
@@ -211,10 +262,6 @@ public final class TablesScanner implements SystemObjectScanner {
       case VIEW -> "VIEW";
       default -> "UNKNOWN";
     };
-  }
-
-  private static String schemaName(NamespaceNode namespace) {
-    return NameRefUtil.namespaceName(namespace.pathSegments(), namespace.displayName());
   }
 
   private static final class TablesBatchBuilder extends AbstractArrowBatchBuilder {

--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/NameRefUtil.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/NameRefUtil.java
@@ -158,12 +158,6 @@ public final class NameRefUtil {
    * <p>The leaf is appended only when not already present as the last path segment.
    */
   public static String namespaceName(List<String> pathSegments, String displayName) {
-    List<String> segments = new ArrayList<>(pathSegments);
-    if (displayName != null
-        && !displayName.isBlank()
-        && (segments.isEmpty() || !displayName.equals(segments.get(segments.size() - 1)))) {
-      segments.add(displayName);
-    }
-    return String.join(".", segments);
+    return ai.floedb.floecat.scanner.spi.TopologyNames.namespaceName(pathSegments, displayName);
   }
 }

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScannerTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScannerTest.java
@@ -19,14 +19,25 @@ package ai.floedb.floecat.systemcatalog.informationschema;
 import static org.assertj.core.api.Assertions.*;
 
 import ai.floedb.floecat.arrow.ColumnarBatch;
+import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
+import ai.floedb.floecat.catalog.rpc.TableFormat;
+import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.metagraph.model.CatalogNode;
+import ai.floedb.floecat.metagraph.model.NamespaceNode;
+import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.systemcatalog.utilities.TestTableScanContextBuilder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -83,6 +94,63 @@ class ColumnsScannerTest {
     var rows = new ColumnsScanner().scan(ctx).map(r -> Arrays.asList(r.values())).toList();
 
     assertThat(rows).containsExactly(List.of("marketing", "org.sales", "orders", "id", "long", 1));
+  }
+
+  @Test
+  void scan_usesTopologyNamespaceRefsWithoutMaterializingNamespaces() {
+    ResourceId catalogId = rid("marketing", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("namespace", ResourceKind.RK_NAMESPACE);
+    ResourceId tableId = rid("orders-id", ResourceKind.RK_TABLE);
+    var overlay = new NamespaceListingFailsOverlay();
+    overlay.addNode(
+        new CatalogNode(
+            catalogId,
+            1,
+            Instant.EPOCH,
+            "marketing",
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of()));
+    overlay.addRelation(
+        namespaceId,
+        new UserTableNode(
+            tableId,
+            1,
+            Instant.EPOCH,
+            catalogId,
+            namespaceId,
+            "orders",
+            TableFormat.TF_ICEBERG,
+            ColumnIdAlgorithm.CID_FIELD_ID,
+            "",
+            Map.of(),
+            List.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            List.of(),
+            Map.of(),
+            Map.of()));
+    overlay.setTableSchema(
+        tableId,
+        List.of(
+            SchemaColumn.newBuilder()
+                .setName("id")
+                .setLogicalType("long")
+                .setFieldId(1)
+                .setNullable(false)
+                .build()));
+    overlay.withNamespaceRef(namespaceId, "sales", catalogId, List.of("finance", "sales"));
+    SystemObjectScanContext ctx =
+        new SystemObjectScanContext(
+            overlay, NameRef.getDefaultInstance(), catalogId, EngineContext.empty());
+
+    var rows = new ColumnsScanner().scan(ctx).map(r -> Arrays.asList(r.values())).toList();
+
+    assertThat(rows)
+        .containsExactly(List.of("marketing", "finance.sales", "orders", "id", "long", 1));
   }
 
   @Test
@@ -217,5 +285,16 @@ class ColumnsScannerTest {
       result.add(value == null ? null : value.toString());
     }
     return result;
+  }
+
+  private static ResourceId rid(String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("account").setId(id).setKind(kind).build();
+  }
+
+  private static final class NamespaceListingFailsOverlay extends TestRefCatalogOverlay {
+    @Override
+    public List<NamespaceNode> listNamespaces(ResourceId catalogId) {
+      throw new AssertionError("ref scan should not materialize namespaces");
+    }
   }
 }

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/SchemataScannerTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/SchemataScannerTest.java
@@ -19,12 +19,23 @@ package ai.floedb.floecat.systemcatalog.informationschema;
 import static org.assertj.core.api.Assertions.*;
 
 import ai.floedb.floecat.arrow.ColumnarBatch;
+import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.metagraph.model.CatalogNode;
+import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
+import ai.floedb.floecat.scanner.expr.Expr;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.systemcatalog.utilities.TestTableScanContextBuilder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -77,6 +88,63 @@ class SchemataScannerTest {
     var rows = new SchemataScanner().scan(ctx).map(r -> List.of(r.values())).toList();
 
     assertThat(rows).containsExactly(List.of("main_catalog", "org.sales"));
+  }
+
+  @Test
+  void scan_usesTopologyNamespaceRefsWithoutMaterializingNamespaces() {
+    ResourceId catalogId = rid("main_catalog", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("namespace", ResourceKind.RK_NAMESPACE);
+    var overlay = new NamespaceListingFailsOverlay();
+    overlay.addNode(
+        new CatalogNode(
+            catalogId,
+            1,
+            Instant.EPOCH,
+            "main_catalog",
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of()));
+    overlay.withNamespaceRef(namespaceId, "sales", catalogId, List.of("finance", "sales"));
+    SystemObjectScanContext ctx =
+        new SystemObjectScanContext(
+            overlay, NameRef.getDefaultInstance(), catalogId, EngineContext.empty());
+
+    var rows = new SchemataScanner().scan(ctx).map(r -> List.of(r.values())).toList();
+
+    assertThat(rows).containsExactly(List.of("main_catalog", "finance.sales"));
+  }
+
+  @Test
+  void scan_doesNotPushDottedSchemaConstraintIntoNamespaceLookupByName() {
+    ResourceId catalogId = rid("main_catalog", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("foo.bar", ResourceKind.RK_NAMESPACE);
+    var overlay = new NamespaceListingFailsOverlay();
+    overlay.addNode(
+        new CatalogNode(
+            catalogId,
+            1,
+            Instant.EPOCH,
+            "main_catalog",
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of()));
+    overlay
+        .withNamespaceRef(namespaceId, "foo.bar", catalogId, List.of())
+        .failNamespaceRefsByName("dotted schema names must not use direct namespace lookup");
+    SystemObjectScanContext ctx =
+        new SystemObjectScanContext(
+            overlay, NameRef.getDefaultInstance(), catalogId, EngineContext.empty());
+    SystemScanRequest request =
+        SystemScanRequest.of(
+            new Expr.Eq(new Expr.ColumnRef("schema_name"), new Expr.Literal("foo.bar")), List.of());
+
+    var rows = new SchemataScanner().scan(ctx, request).map(r -> List.of(r.values())).toList();
+
+    assertThat(rows).containsExactly(List.of("main_catalog", "foo.bar"));
   }
 
   @Test
@@ -158,5 +226,16 @@ class SchemataScannerTest {
       list.add(value == null ? null : value.toString());
     }
     return list;
+  }
+
+  private static ResourceId rid(String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("account").setId(id).setKind(kind).build();
+  }
+
+  private static final class NamespaceListingFailsOverlay extends TestRefCatalogOverlay {
+    @Override
+    public List<NamespaceNode> listNamespaces(ResourceId catalogId) {
+      throw new AssertionError("ref scan should not materialize namespaces");
+    }
   }
 }

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/TablesScannerTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/TablesScannerTest.java
@@ -19,13 +19,23 @@ package ai.floedb.floecat.systemcatalog.informationschema;
 import static org.assertj.core.api.Assertions.*;
 
 import ai.floedb.floecat.arrow.ColumnarBatch;
+import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.metagraph.model.CatalogNode;
+import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
+import ai.floedb.floecat.scanner.expr.Expr;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.systemcatalog.utilities.TestTableScanContextBuilder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -84,6 +94,111 @@ class TablesScannerTest {
 
     assertThat(rows).hasSize(1);
     assertThat(rows.get(0)).containsExactly("catalog", "org.sales", "orders", "BASE TABLE");
+  }
+
+  @Test
+  void scan_usesTopologyNamespaceRefsWithoutMaterializingNamespaces() {
+    ResourceId catalogId = rid("catalog", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("namespace", ResourceKind.RK_NAMESPACE);
+    ResourceId tableId = rid("table", ResourceKind.RK_TABLE);
+    var overlay = new NamespaceListingFailsOverlay();
+    overlay.addNode(
+        new CatalogNode(
+            catalogId,
+            1,
+            Instant.EPOCH,
+            "catalog",
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of()));
+    overlay
+        .withNamespaceRef(namespaceId, "sales", catalogId, List.of("finance", "sales"))
+        .withRelationRef(namespaceId, tableId, "orders", ResourceKind.RK_TABLE);
+    SystemObjectScanContext ctx =
+        new SystemObjectScanContext(
+            overlay, NameRef.getDefaultInstance(), catalogId, EngineContext.empty());
+
+    var rows = new TablesScanner().scan(ctx).map(r -> r.values()).toList();
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0)).containsExactly("catalog", "finance.sales", "orders", "BASE TABLE");
+  }
+
+  @Test
+  void scan_pushesSchemaAndNameConstraintsIntoTopologyRefs() {
+    ResourceId catalogId = rid("catalog", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("sales", ResourceKind.RK_NAMESPACE);
+    ResourceId tableId = rid("orders", ResourceKind.RK_TABLE);
+    var overlay = new NamespaceListingFailsOverlay();
+    overlay.addNode(
+        new CatalogNode(
+            catalogId,
+            1,
+            Instant.EPOCH,
+            "catalog",
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of()));
+    overlay
+        .withNamespaceRef(namespaceId, "sales", catalogId, List.of("sales"))
+        .withRelationRef(namespaceId, tableId, "orders", ResourceKind.RK_TABLE)
+        .failNamespaceRefs("schema predicate should use namespace lookup by name")
+        .failRelationRefs("table_name predicate should use relation lookup by name");
+    SystemObjectScanContext ctx =
+        new SystemObjectScanContext(
+            overlay, NameRef.getDefaultInstance(), catalogId, EngineContext.empty());
+    SystemScanRequest request =
+        SystemScanRequest.of(
+            new Expr.And(
+                eq("table_schema", "sales"),
+                new Expr.Or(eq("table_name", "orders"), eq("table_name", "customers"))),
+            List.of());
+
+    var rows = new TablesScanner().scan(ctx, request).map(r -> r.values()).toList();
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0)).containsExactly("catalog", "sales", "orders", "BASE TABLE");
+    assertThat(overlay.namespaceNames()).containsExactly("sales");
+    assertThat(overlay.relationNames(namespaceId)).containsExactlyInAnyOrder("orders", "customers");
+  }
+
+  @Test
+  void scan_doesNotPushDottedSchemaConstraintIntoNamespaceLookupByName() {
+    ResourceId catalogId = rid("catalog", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("foo.bar", ResourceKind.RK_NAMESPACE);
+    ResourceId tableId = rid("orders", ResourceKind.RK_TABLE);
+    var overlay = new NamespaceListingFailsOverlay();
+    overlay.addNode(
+        new CatalogNode(
+            catalogId,
+            1,
+            Instant.EPOCH,
+            "catalog",
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of()));
+    overlay
+        .withNamespaceRef(namespaceId, "foo.bar", catalogId, List.of())
+        .withRelationRef(namespaceId, tableId, "orders", ResourceKind.RK_TABLE)
+        .failNamespaceRefsByName("dotted schema names must not use direct namespace lookup");
+    SystemObjectScanContext ctx =
+        new SystemObjectScanContext(
+            overlay, NameRef.getDefaultInstance(), catalogId, EngineContext.empty());
+    SystemScanRequest request =
+        SystemScanRequest.of(
+            new Expr.And(eq("table_schema", "foo.bar"), eq("table_name", "orders")), List.of());
+
+    var rows = new TablesScanner().scan(ctx, request).map(r -> r.values()).toList();
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0)).containsExactly("catalog", "foo.bar", "orders", "BASE TABLE");
+    assertThat(overlay.relationNames(namespaceId)).containsExactly("orders");
   }
 
   @Test
@@ -167,5 +282,20 @@ class TablesScannerTest {
       list.add(value == null ? null : value.toString());
     }
     return list;
+  }
+
+  private static ResourceId rid(String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("account").setId(id).setKind(kind).build();
+  }
+
+  private static Expr eq(String column, String value) {
+    return new Expr.Eq(new Expr.ColumnRef(column), new Expr.Literal(value));
+  }
+
+  private static final class NamespaceListingFailsOverlay extends TestRefCatalogOverlay {
+    @Override
+    public List<NamespaceNode> listNamespaces(ResourceId catalogId) {
+      throw new AssertionError("ref scan should not materialize namespaces");
+    }
   }
 }

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/TestRefCatalogOverlay.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/TestRefCatalogOverlay.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.systemcatalog.informationschema;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
+import ai.floedb.floecat.scanner.spi.TopologyNames;
+import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class TestRefCatalogOverlay extends TestCatalogOverlay {
+
+  private final List<TopologyGraph.NamespaceRef> namespaceRefs = new ArrayList<>();
+  private final Map<ResourceId, List<TopologyGraph.RelationRef>> relationRefsByNamespace =
+      new HashMap<>();
+  private final Map<ResourceId, Set<String>> relationNamesByNamespace = new HashMap<>();
+
+  private String namespaceRefsFailure;
+  private String namespaceRefsByNameFailure;
+  private String relationRefsFailure;
+  private String relationRefsByNameFailure;
+  private Set<String> namespaceNames = Set.of();
+
+  TestRefCatalogOverlay withNamespaceRef(
+      ResourceId namespaceId, String name, ResourceId catalogId, List<String> pathSegments) {
+    namespaceRefs.add(new TopologyGraph.NamespaceRef(namespaceId, name, catalogId, pathSegments));
+    return this;
+  }
+
+  TestRefCatalogOverlay withRelationRef(
+      ResourceId namespaceId, ResourceId relationId, String name, ResourceKind kind) {
+    relationRefsByNamespace
+        .computeIfAbsent(namespaceId, ignored -> new ArrayList<>())
+        .add(new TopologyGraph.RelationRef(relationId, name, kind));
+    return this;
+  }
+
+  TestRefCatalogOverlay failNamespaceRefs(String message) {
+    namespaceRefsFailure = message;
+    return this;
+  }
+
+  TestRefCatalogOverlay failNamespaceRefsByName(String message) {
+    namespaceRefsByNameFailure = message;
+    return this;
+  }
+
+  TestRefCatalogOverlay failRelationRefs(String message) {
+    relationRefsFailure = message;
+    return this;
+  }
+
+  TestRefCatalogOverlay failRelationRefsByName(String message) {
+    relationRefsByNameFailure = message;
+    return this;
+  }
+
+  Set<String> namespaceNames() {
+    return namespaceNames;
+  }
+
+  Set<String> relationNames(ResourceId namespaceId) {
+    return relationNamesByNamespace.getOrDefault(namespaceId, Set.of());
+  }
+
+  @Override
+  public boolean supportsLightweightRefs() {
+    return true;
+  }
+
+  @Override
+  public List<TopologyGraph.NamespaceRef> listNamespaceRefs(ResourceId catalogId) {
+    if (namespaceRefsFailure != null) {
+      throw new AssertionError(namespaceRefsFailure);
+    }
+    return List.copyOf(namespaceRefs);
+  }
+
+  @Override
+  public List<TopologyGraph.NamespaceRef> listNamespaceRefsByName(
+      ResourceId catalogId, Set<String> names) {
+    if (namespaceRefsByNameFailure != null) {
+      throw new AssertionError(namespaceRefsByNameFailure);
+    }
+    namespaceNames = Set.copyOf(names);
+    return namespaceRefs.stream()
+        .filter(ns -> names.contains(TopologyNames.namespaceName(ns.pathSegments(), ns.name())))
+        .toList();
+  }
+
+  @Override
+  public List<TopologyGraph.RelationRef> listRelationRefs(
+      ResourceId catalogId, ResourceId namespaceId) {
+    if (relationRefsFailure != null) {
+      throw new AssertionError(relationRefsFailure);
+    }
+    return List.copyOf(relationRefsByNamespace.getOrDefault(namespaceId, List.of()));
+  }
+
+  @Override
+  public List<TopologyGraph.RelationRef> listRelationRefsByName(
+      ResourceId catalogId, ResourceId namespaceId, Set<String> names) {
+    if (relationRefsByNameFailure != null) {
+      throw new AssertionError(relationRefsByNameFailure);
+    }
+    relationNamesByNamespace.put(namespaceId, Set.copyOf(names));
+    return relationRefsByNamespace.getOrDefault(namespaceId, List.of()).stream()
+        .filter(ref -> names.contains(ref.name()))
+        .toList();
+  }
+}

--- a/core/proto/src/main/proto/floecat/common/common.proto
+++ b/core/proto/src/main/proto/floecat/common/common.proto
@@ -101,6 +101,10 @@ message Pointer {
   int64 version = 3;
   google.protobuf.Timestamp expires_at = 4;
   PointerReferenceKind reference_kind = 5;
+  // Stable resource identity — populated at write time for topology-capable resources
+  // (TABLE, VIEW, NAMESPACE). Empty on legacy pointers; fall back to key/blob-uri parsing.
+  ResourceId resource_id = 6;
+  string display_name = 7;
 }
 
 message BlobHeader {

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/columnar/ArrowFilterOperator.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/columnar/ArrowFilterOperator.java
@@ -149,6 +149,7 @@ public final class ArrowFilterOperator {
         case Expr.Eq eq -> equalityMask(eq);
         case Expr.Gt gt -> greaterThanMask(gt);
         case Expr.IsNull isNull -> isNullMask(isNull.expression());
+        case Expr.BooleanLiteral bool -> constantMask(bool.value());
         default -> throw new UnsupportedOperationException("Expr not supported: " + expr);
       };
     }
@@ -468,9 +469,14 @@ public final class ArrowFilterOperator {
     }
 
     private BitVector falseMask() {
+      return constantMask(false);
+    }
+
+    private BitVector constantMask(boolean value) {
       BitVector mask = newMask();
+      int bit = value ? 1 : 0;
       for (int i = 0; i < rowCount; i++) {
-        mask.setSafe(i, 0);
+        mask.setSafe(i, bit);
       }
       mask.setValueCount(rowCount);
       return mask;

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/expr/Expr.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/expr/Expr.java
@@ -20,6 +20,7 @@ package ai.floedb.floecat.scanner.expr;
 public sealed interface Expr
     permits Expr.ColumnRef,
         Expr.Literal,
+        Expr.BooleanLiteral,
         Expr.Eq,
         Expr.And,
         Expr.Or,
@@ -32,6 +33,9 @@ public sealed interface Expr
 
   /** Constant literal (string or null). */
   record Literal(String value) implements Expr {}
+
+  /** Constant boolean literal. */
+  record BooleanLiteral(boolean value) implements Expr {}
 
   /** Equality comparison. */
   record Eq(Expr left, Expr right) implements Expr {}

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/expr/PredicateConstraints.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/expr/PredicateConstraints.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.scanner.expr;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Conservative finite-domain constraints extracted from a predicate expression.
+ *
+ * <p>These constraints are an optimization input only. The original predicate must still be
+ * evaluated downstream for correctness.
+ */
+public final class PredicateConstraints {
+
+  private static final PredicateConstraints EMPTY = new PredicateConstraints(false, Map.of());
+  private static final PredicateConstraints ALWAYS_FALSE = new PredicateConstraints(true, Map.of());
+
+  private final boolean alwaysFalse;
+  private final Map<String, Set<String>> valuesByColumn;
+
+  private PredicateConstraints(boolean alwaysFalse, Map<String, Set<String>> valuesByColumn) {
+    this.alwaysFalse = alwaysFalse;
+    Map<String, Set<String>> copy = new HashMap<>();
+    valuesByColumn.forEach((k, v) -> copy.put(canonical(k), Set.copyOf(v)));
+    this.valuesByColumn = Map.copyOf(copy);
+  }
+
+  public static PredicateConstraints empty() {
+    return EMPTY;
+  }
+
+  public static PredicateConstraints alwaysFalse() {
+    return ALWAYS_FALSE;
+  }
+
+  public static PredicateConstraints from(Expr expr) {
+    if (expr == null) {
+      return empty();
+    }
+    return extract(expr);
+  }
+
+  public boolean isAlwaysFalse() {
+    return alwaysFalse;
+  }
+
+  public Optional<Set<String>> values(String columnName) {
+    Set<String> values = valuesByColumn.get(canonical(columnName));
+    return values == null ? Optional.empty() : Optional.of(values);
+  }
+
+  public boolean hasConstraint(String columnName) {
+    return values(columnName).isPresent();
+  }
+
+  private static PredicateConstraints extract(Expr expr) {
+    return switch (expr) {
+      case Expr.And and -> intersect(extract(and.left()), extract(and.right()));
+      case Expr.Or or -> union(extract(or.left()), extract(or.right()));
+      case Expr.Eq eq -> equality(eq);
+      case Expr.BooleanLiteral bool -> bool.value() ? empty() : alwaysFalse();
+      default -> empty();
+    };
+  }
+
+  private static PredicateConstraints equality(Expr.Eq eq) {
+    ColumnLiteral pair = columnLiteral(eq.left(), eq.right());
+    if (pair == null || pair.literal() == null) {
+      return empty();
+    }
+    return new PredicateConstraints(false, Map.of(pair.column(), Set.of(pair.literal())));
+  }
+
+  private static ColumnLiteral columnLiteral(Expr left, Expr right) {
+    if (left instanceof Expr.ColumnRef column && right instanceof Expr.Literal literal) {
+      return new ColumnLiteral(column.name(), literal.value());
+    }
+    if (right instanceof Expr.ColumnRef column && left instanceof Expr.Literal literal) {
+      return new ColumnLiteral(column.name(), literal.value());
+    }
+    return null;
+  }
+
+  private static PredicateConstraints intersect(
+      PredicateConstraints left, PredicateConstraints right) {
+    if (left.alwaysFalse || right.alwaysFalse) {
+      return alwaysFalse();
+    }
+    Map<String, Set<String>> out = new HashMap<>();
+    left.valuesByColumn.forEach((k, v) -> out.put(k, new HashSet<>(v)));
+    for (Map.Entry<String, Set<String>> entry : right.valuesByColumn.entrySet()) {
+      out.merge(
+          entry.getKey(),
+          new HashSet<>(entry.getValue()),
+          (a, b) -> {
+            a.retainAll(b);
+            return a;
+          });
+      if (out.get(entry.getKey()).isEmpty()) {
+        return alwaysFalse();
+      }
+    }
+    return out.isEmpty() ? empty() : new PredicateConstraints(false, out);
+  }
+
+  private static PredicateConstraints union(PredicateConstraints left, PredicateConstraints right) {
+    if (left.alwaysFalse) {
+      return right;
+    }
+    if (right.alwaysFalse) {
+      return left;
+    }
+    Map<String, Set<String>> out = new HashMap<>();
+    for (Map.Entry<String, Set<String>> entry : left.valuesByColumn.entrySet()) {
+      Set<String> rightValues = right.valuesByColumn.get(entry.getKey());
+      if (rightValues == null) {
+        continue;
+      }
+      Set<String> values = new HashSet<>(entry.getValue());
+      values.addAll(rightValues);
+      out.put(entry.getKey(), values);
+    }
+    return out.isEmpty() ? empty() : new PredicateConstraints(false, out);
+  }
+
+  private static String canonical(String columnName) {
+    return columnName == null ? "" : columnName.toLowerCase(Locale.ROOT);
+  }
+
+  private record ColumnLiteral(String column, String literal) {}
+}

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -18,10 +18,12 @@ package ai.floedb.floecat.scanner.spi;
 
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
 import ai.floedb.floecat.metagraph.model.FunctionNode;
 import ai.floedb.floecat.metagraph.model.GraphNode;
+import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.RelationNode;
 import ai.floedb.floecat.metagraph.model.TypeNode;
@@ -31,6 +33,7 @@ import ai.floedb.floecat.query.rpc.SnapshotPin;
 import com.google.protobuf.Timestamp;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Shared overlay between metadata/system objects that exposes the graph operations needed by
@@ -59,6 +62,90 @@ public interface CatalogOverlay {
    * Lists relations that live inside the given namespace. Engine context is resolved implicitly.
    */
   List<RelationNode> listRelationsInNamespace(ResourceId catalogId, ResourceId namespaceId);
+
+  /**
+   * Lists only system (built-in) relations in a namespace. Default falls back to a full list and
+   * filters; MetaGraph overrides this to skip the expensive user-object DynamoDB+S3 scan.
+   */
+  default List<RelationNode> listSystemRelationsInNamespace(
+      ResourceId catalogId, ResourceId namespaceId) {
+    return listRelationsInNamespace(catalogId, namespaceId).stream()
+        .filter(n -> n.origin() == GraphNodeOrigin.SYSTEM)
+        .toList();
+  }
+
+  /**
+   * Lists only system namespaces in a catalog. Default falls back to a full list and filters;
+   * MetaGraph overrides to skip the user-namespace storage scan.
+   */
+  default List<NamespaceNode> listSystemNamespaces(ResourceId catalogId) {
+    return listNamespaces(catalogId).stream()
+        .filter(n -> n.origin() == GraphNodeOrigin.SYSTEM)
+        .toList();
+  }
+
+  /**
+   * Whether this overlay can enumerate lightweight refs without materializing full graph nodes.
+   *
+   * <p>Default implementations below are correct but derive refs from full objects, so callers that
+   * need a true no-hydration path should check this before relying on refs for performance.
+   */
+  default boolean supportsLightweightRefs() {
+    return false;
+  }
+
+  /**
+   * Lists namespace refs for callers that only need topology metadata. Default derives refs from
+   * full namespace nodes; production overlays should override this with cache-backed pointer refs.
+   */
+  default List<TopologyGraph.NamespaceRef> listNamespaceRefs(ResourceId catalogId) {
+    return listNamespaces(catalogId).stream()
+        .map(
+            ns ->
+                new TopologyGraph.NamespaceRef(
+                    ns.id(), ns.displayName(), ns.catalogId(), ns.pathSegments()))
+        .toList();
+  }
+
+  /** Lists namespace refs whose rendered information_schema names match the supplied set. */
+  default List<TopologyGraph.NamespaceRef> listNamespaceRefsByName(
+      ResourceId catalogId, Set<String> names) {
+    if (names == null || names.isEmpty()) {
+      return List.of();
+    }
+    return listNamespaceRefs(catalogId).stream()
+        .filter(ref -> names.contains(TopologyNames.namespaceName(ref.pathSegments(), ref.name())))
+        .toList();
+  }
+
+  /**
+   * Lists relation refs for callers that only need relation name/id/kind. Default derives refs from
+   * full relation nodes; production overlays should override this with cache-backed pointer refs.
+   */
+  default List<TopologyGraph.RelationRef> listRelationRefs(
+      ResourceId catalogId, ResourceId namespaceId) {
+    return listRelationsInNamespace(catalogId, namespaceId).stream()
+        .map(
+            rel -> {
+              ResourceKind kind =
+                  rel.id().getKind() == ResourceKind.RK_VIEW
+                      ? ResourceKind.RK_VIEW
+                      : ResourceKind.RK_TABLE;
+              return new TopologyGraph.RelationRef(rel.id(), rel.displayName(), kind);
+            })
+        .toList();
+  }
+
+  /** Lists relation refs whose names match the supplied set. */
+  default List<TopologyGraph.RelationRef> listRelationRefsByName(
+      ResourceId catalogId, ResourceId namespaceId, Set<String> names) {
+    if (names == null || names.isEmpty()) {
+      return List.of();
+    }
+    return listRelationRefs(catalogId, namespaceId).stream()
+        .filter(ref -> names.contains(ref.name()))
+        .toList();
+  }
 
   List<FunctionNode> listFunctions(ResourceId catalogId, ResourceId namespaceId);
 

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/SystemObjectScanContext.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/SystemObjectScanContext.java
@@ -124,6 +124,32 @@ public record SystemObjectScanContext(
     return graph.resolve(id);
   }
 
+  /** Lightweight namespace refs from the overlay; production avoids full node hydration. */
+  public List<TopologyGraph.NamespaceRef> listNamespaceRefs() {
+    return graph.listNamespaceRefs(queryDefaultCatalogId);
+  }
+
+  /** Lightweight namespace refs matching the supplied information_schema names. */
+  public List<TopologyGraph.NamespaceRef> listNamespaceRefsByName(java.util.Set<String> names) {
+    return graph.listNamespaceRefsByName(queryDefaultCatalogId, names);
+  }
+
+  /** Whether the overlay has a true lightweight ref implementation. */
+  public boolean supportsLightweightRefs() {
+    return graph.supportsLightweightRefs();
+  }
+
+  /** Lightweight relation refs for a namespace; production avoids full node hydration. */
+  public List<TopologyGraph.RelationRef> listRelationRefs(ResourceId namespaceId) {
+    return graph.listRelationRefs(queryDefaultCatalogId, namespaceId);
+  }
+
+  /** Lightweight relation refs matching the supplied names. */
+  public List<TopologyGraph.RelationRef> listRelationRefsByName(
+      ResourceId namespaceId, java.util.Set<String> names) {
+    return graph.listRelationRefsByName(queryDefaultCatalogId, namespaceId, names);
+  }
+
   /** Tables + views */
   public List<RelationNode> listRelations(ResourceId namespaceId) {
     return graph.listRelationsInNamespace(queryDefaultCatalogId, namespaceId);

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/SystemObjectScanner.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/SystemObjectScanner.java
@@ -39,6 +39,14 @@ public interface SystemObjectScanner {
   Stream<SystemObjectRow> scan(SystemObjectScanContext ctx);
 
   /**
+   * Lazily streams rows with optional request metadata. Implementations may use the request for
+   * safe access-path pruning; callers still apply the original predicate downstream.
+   */
+  default Stream<SystemObjectRow> scan(SystemObjectScanContext ctx, SystemScanRequest request) {
+    return scan(ctx);
+  }
+
+  /**
    * Arrow-native scan.
    *
    * <p>The {@code predicate} argument represents the expression that will be evaluated downstream
@@ -52,6 +60,15 @@ public interface SystemObjectScanner {
       List<String> requiredColumns,
       BufferAllocator allocator) {
     return Stream.empty();
+  }
+
+  /**
+   * Arrow-native scan with optional request metadata. Implementations may use the request for safe
+   * access-path pruning; callers still apply the original predicate downstream.
+   */
+  default Stream<ColumnarBatch> scanArrow(
+      SystemObjectScanContext ctx, SystemScanRequest request, BufferAllocator allocator) {
+    return scanArrow(ctx, request.predicate(), request.requiredColumns(), allocator);
   }
 
   /** Declares supported execution formats. */

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/SystemScanRequest.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/SystemScanRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.scanner.spi;
+
+import ai.floedb.floecat.scanner.expr.Expr;
+import ai.floedb.floecat.scanner.expr.PredicateConstraints;
+import java.util.List;
+
+/** Shared row/Arrow scan request metadata for system-object scanners. */
+public record SystemScanRequest(
+    Expr predicate, PredicateConstraints constraints, List<String> requiredColumns) {
+
+  public SystemScanRequest {
+    constraints = constraints == null ? PredicateConstraints.empty() : constraints;
+    requiredColumns = requiredColumns == null ? List.of() : List.copyOf(requiredColumns);
+  }
+
+  public static SystemScanRequest of(Expr predicate, List<String> requiredColumns) {
+    return new SystemScanRequest(predicate, PredicateConstraints.from(predicate), requiredColumns);
+  }
+
+  public static SystemScanRequest empty() {
+    return of(null, List.of());
+  }
+}

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/TopologyGraph.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/TopologyGraph.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.scanner.spi;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Lightweight topology view of a catalog: names, IDs, and kinds -- available entirely from pointer
+ * metadata (no blob fetch, no S3). {@link CatalogOverlay} exposes these ref-listing methods to
+ * scanners and traversal callers; this interface remains the shared ref shape and cache
+ * invalidation hook.
+ *
+ * <p>Scanners that only need to enumerate objects should prefer {@link
+ * CatalogOverlay#listRelationRefs} / {@link CatalogOverlay#listNamespaceRefs} over full object
+ * listing methods that force object materialization.
+ */
+public interface TopologyGraph {
+
+  /** Returns all namespace refs visible in the given catalog. */
+  default List<NamespaceRef> listNamespaceRefs(ResourceId catalogId) {
+    return java.util.List.of();
+  }
+
+  /** Returns namespace refs whose information_schema name matches the given set. */
+  default List<NamespaceRef> listNamespaceRefsByName(ResourceId catalogId, Set<String> names) {
+    return listNamespaceRefs(catalogId).stream()
+        .filter(r -> names.contains(TopologyNames.namespaceName(r.pathSegments(), r.name())))
+        .collect(java.util.stream.Collectors.toList());
+  }
+
+  /** Returns all relation refs (tables + views) in the given namespace. */
+  default List<RelationRef> listRelationRefs(ResourceId catalogId, ResourceId namespaceId) {
+    return java.util.List.of();
+  }
+
+  /**
+   * Returns relation refs whose names match the given set. Allows predicate pushdown for {@code
+   * WHERE table_name IN (...)} filters.
+   */
+  default List<RelationRef> listRelationRefsByName(
+      ResourceId catalogId, ResourceId namespaceId, Set<String> names) {
+    return listRelationRefs(catalogId, namespaceId).stream()
+        .filter(r -> names.contains(r.name()))
+        .collect(java.util.stream.Collectors.toList());
+  }
+
+  /**
+   * Evicts a table or view from the topology cache using the reverse map to locate its namespace.
+   * Call BEFORE the storage delete so the reverse-map lookup still works.
+   */
+  default void evict(ResourceId resourceId) {}
+
+  /**
+   * Evicts the cached relation list for a specific namespace. Call after a table/view create/delete
+   * when the namespace ID is known directly.
+   */
+  default void evictRelationRefs(ResourceId namespaceId) {}
+
+  /**
+   * Evicts the cached namespace list for a specific catalog. Call after a namespace create/delete.
+   */
+  default void evictNamespaceRefs(ResourceId catalogId) {}
+
+  record NamespaceRef(ResourceId id, String name, ResourceId catalogId, List<String> pathSegments) {
+    public NamespaceRef(ResourceId id, String name) {
+      this(id, name, null, List.of());
+    }
+
+    public NamespaceRef {
+      pathSegments = pathSegments == null ? List.of() : List.copyOf(pathSegments);
+    }
+  }
+
+  record RelationRef(ResourceId id, String name, ResourceKind kind) {}
+}

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/TopologyNames.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/TopologyNames.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.scanner.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Shared name rendering for lightweight topology refs. */
+public final class TopologyNames {
+
+  private TopologyNames() {}
+
+  /**
+   * Builds the information_schema namespace name from path segments and the leaf display name.
+   *
+   * <p>The leaf is appended only when not already present as the last path segment.
+   */
+  public static String namespaceName(List<String> pathSegments, String displayName) {
+    List<String> segments = new ArrayList<>(pathSegments == null ? List.of() : pathSegments);
+    if (displayName != null
+        && !displayName.isBlank()
+        && (segments.isEmpty() || !displayName.equals(segments.get(segments.size() - 1)))) {
+      segments.add(displayName);
+    }
+    return String.join(".", segments);
+  }
+}

--- a/core/scanner/src/test/java/ai/floedb/floecat/scanner/expr/PredicateConstraintsTest.java
+++ b/core/scanner/src/test/java/ai/floedb/floecat/scanner/expr/PredicateConstraintsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.scanner.expr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class PredicateConstraintsTest {
+
+  @Test
+  void extractsEqualityDomain() {
+    PredicateConstraints constraints = PredicateConstraints.from(eq("table_name", "orders"));
+
+    assertThat(constraints.values("TABLE_NAME")).contains(Set.of("orders"));
+  }
+
+  @Test
+  void intersectsEqualitiesUnderAnd() {
+    PredicateConstraints constraints =
+        PredicateConstraints.from(
+            new Expr.And(
+                new Expr.Or(eq("table_name", "orders"), eq("table_name", "customers")),
+                eq("table_name", "orders")));
+
+    assertThat(constraints.values("table_name")).contains(Set.of("orders"));
+  }
+
+  @Test
+  void detectsContradictoryAnd() {
+    PredicateConstraints constraints =
+        PredicateConstraints.from(new Expr.And(eq("table_name", "orders"), eq("table_name", "x")));
+
+    assertThat(constraints.isAlwaysFalse()).isTrue();
+    assertThat(constraints.values("table_name")).isEmpty();
+    assertThat(constraints.hasConstraint("table_name")).isFalse();
+  }
+
+  @Test
+  void unionsCommonConstraintsUnderOr() {
+    PredicateConstraints constraints =
+        PredicateConstraints.from(new Expr.Or(eq("table_name", "orders"), eq("table_name", "x")));
+
+    assertThat(constraints.values("table_name")).contains(Set.of("orders", "x"));
+  }
+
+  @Test
+  void doesNotConstrainColumnMissingFromOneOrBranch() {
+    PredicateConstraints constraints =
+        PredicateConstraints.from(new Expr.Or(eq("table_name", "orders"), eq("table_schema", "s")));
+
+    assertThat(constraints.values("table_name")).isEmpty();
+    assertThat(constraints.values("table_schema")).isEmpty();
+  }
+
+  @Test
+  void unsupportedExpressionProducesNoConstraints() {
+    PredicateConstraints constraints =
+        PredicateConstraints.from(
+            new Expr.Gt(new Expr.ColumnRef("ordinal_position"), new Expr.Literal("1")));
+
+    assertThat(constraints.values("ordinal_position")).isEmpty();
+    assertThat(constraints.isAlwaysFalse()).isFalse();
+  }
+
+  @Test
+  void falseLiteralProducesAlwaysFalseConstraint() {
+    PredicateConstraints constraints = PredicateConstraints.from(new Expr.BooleanLiteral(false));
+
+    assertThat(constraints.isAlwaysFalse()).isTrue();
+    assertThat(constraints.values("table_name")).isEmpty();
+  }
+
+  private static Expr eq(String column, String value) {
+    return new Expr.Eq(new Expr.ColumnRef(column), new Expr.Literal(value));
+  }
+}

--- a/core/scanner/src/test/java/ai/floedb/floecat/scanner/spi/TopologyGraphTest.java
+++ b/core/scanner/src/test/java/ai/floedb/floecat/scanner/spi/TopologyGraphTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.scanner.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class TopologyGraphTest {
+
+  @Test
+  void defaultNamespaceLookupMatchesInformationSchemaName() {
+    ResourceId catalogId = rid("cat", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("ns", ResourceKind.RK_NAMESPACE);
+    TopologyGraph graph =
+        new TopologyGraph() {
+          @Override
+          public List<NamespaceRef> listNamespaceRefs(ResourceId catalogId) {
+            return List.of(
+                new NamespaceRef(namespaceId, "sales", catalogId, List.of("finance", "sales")));
+          }
+        };
+
+    List<TopologyGraph.NamespaceRef> refs =
+        graph.listNamespaceRefsByName(catalogId, Set.of("finance.sales"));
+
+    assertThat(refs).extracting(TopologyGraph.NamespaceRef::id).containsExactly(namespaceId);
+  }
+
+  private static ResourceId rid(String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("acct").setId(id).setKind(kind).build();
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
@@ -32,9 +32,9 @@ import ai.floedb.floecat.catalog.rpc.UpdateNamespaceRequest;
 import ai.floedb.floecat.catalog.rpc.UpdateNamespaceResponse;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
-import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.Canonicalizer;
 import ai.floedb.floecat.service.common.IdempotencyGuard;
@@ -75,6 +75,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
   @Inject Authorizer authz;
   @Inject IdempotencyRepository idempotencyStore;
   @Inject UserGraph metadataGraph;
+  @Inject TopologyGraph topology;
   @Inject MarkerStore markerStore;
 
   // Overlay gives access to system namespaces (and other system objects)
@@ -90,9 +91,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
     if (catalogId == null) {
       return List.of();
     }
-    return overlay.listNamespaces(catalogId).stream()
-        .filter(ns -> ns != null && ns.origin() == GraphNodeOrigin.SYSTEM)
-        .toList();
+    return overlay.listSystemNamespaces(catalogId);
   }
 
   private static final String PATH_DELIM = "\u001F";
@@ -702,6 +701,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                                               existing.getCatalogId(),
                                               existing.getParentsList());
                                           metadataGraph.invalidate(existing.getResourceId());
+                                          topology.evictNamespaceRefs(existing.getCatalogId());
                                           return new IdempotencyGuard.CreateResult<>(
                                               existing, existing.getResourceId());
                                         }
@@ -720,6 +720,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                                     bumpParentNamespaceMarker(
                                         accountId, spec.getCatalogId(), parents);
                                     metadataGraph.invalidate(namespaceId);
+                                    topology.evictNamespaceRefs(spec.getCatalogId());
                                     return new IdempotencyGuard.CreateResult<>(built, namespaceId);
                                   },
                                   (ns) -> namespaceRepo.metaForSafe(ns.getResourceId()),
@@ -781,6 +782,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
         markerStore.bumpCatalogMarker(catalogId);
         bumpParentNamespaceMarker(accountId, catalogId, parentList);
         metadataGraph.invalidate(rid);
+        topology.evictNamespaceRefs(catalogId);
       } catch (BaseResourceRepository.NameConflictException nce) {
         if (namespaceRepo.getByPath(accountId, catalogId.getId(), chain).isPresent()) {
           continue;
@@ -883,6 +885,8 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                             "expected", Long.toString(meta.getPointerVersion()),
                             "actual", Long.toString(nowMeta.getPointerVersion())));
                   }
+                  topology.evictNamespaceRefs(current.getCatalogId());
+                  topology.evictNamespaceRefs(desired.getCatalogId());
                   metadataGraph.invalidate(nsId);
 
                   var outMeta = namespaceRepo.metaForSafe(nsId);
@@ -935,6 +939,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                     }
                     MutationOps.BaseServiceChecks.enforcePreconditions(
                         correlationId, safe, request.getPrecondition());
+                    topology.evictRelationRefs(namespaceId);
                     metadataGraph.invalidate(namespaceId);
                     return DeleteNamespaceResponse.newBuilder().setMeta(safe).build();
                   }
@@ -1006,6 +1011,8 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                           "namespace",
                           Map.of("id", namespaceId.getId()));
 
+                  topology.evictRelationRefs(namespaceId);
+                  topology.evictNamespaceRefs(catalogId);
                   metadataGraph.invalidate(namespaceId);
                   markerStore.bumpCatalogMarker(catalogId);
                   bumpParentNamespaceMarker(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
@@ -42,6 +42,7 @@ import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.TableNode;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
 import ai.floedb.floecat.service.catalog.hint.EngineHintSchemaCleaner;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.Canonicalizer;
@@ -85,6 +86,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
   @Inject Authorizer authz;
   @Inject IdempotencyRepository idempotencyStore;
   @Inject UserGraph metadataGraph;
+  @Inject TopologyGraph topology;
   @Inject MarkerStore markerStore;
   @Inject PointerStore pointerStore;
   @Inject EngineHintSchemaCleaner hintCleaner;
@@ -279,10 +281,9 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                     // Always need sysCount for totalSize.
                     // Only need to materialize + sort if we're going to emit.
                     var rels =
-                        overlay.listRelationsInNamespace(catalogId, namespaceId).stream()
+                        overlay.listSystemRelationsInNamespace(catalogId, namespaceId).stream()
                             .filter(TableNode.class::isInstance)
                             .map(TableNode.class::cast)
-                            .filter(tn -> tn.origin() == GraphNodeOrigin.SYSTEM)
                             .toList();
 
                     sysCount = rels.size();
@@ -314,10 +315,8 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                     // Repo not exhausted: still need sysCount for totalSize, but avoid sorting.
                     sysCount =
                         (int)
-                            overlay.listRelationsInNamespace(catalogId, namespaceId).stream()
+                            overlay.listSystemRelationsInNamespace(catalogId, namespaceId).stream()
                                 .filter(TableNode.class::isInstance)
-                                .map(TableNode.class::cast)
-                                .filter(tn -> tn.origin() == GraphNodeOrigin.SYSTEM)
                                 .count();
                   }
 
@@ -487,6 +486,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                     }
                     markerStore.bumpNamespaceMarker(table.getNamespaceId());
                     metadataGraph.invalidate(tableResourceId);
+                    topology.evictRelationRefs(table.getNamespaceId());
                     var meta = tableRepo.metaForSafe(tableResourceId);
                     return CreateTableResponse.newBuilder().setTable(table).setMeta(meta).build();
                   }
@@ -517,6 +517,8 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                                               existingOpt.get().getNamespaceId());
                                           metadataGraph.invalidate(
                                               existingOpt.get().getResourceId());
+                                          topology.evictRelationRefs(
+                                              existingOpt.get().getNamespaceId());
                                           return new IdempotencyGuard.CreateResult<>(
                                               existingOpt.get(), existingOpt.get().getResourceId());
                                         }
@@ -531,6 +533,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                                     }
                                     markerStore.bumpNamespaceMarker(table.getNamespaceId());
                                     metadataGraph.invalidate(tableResourceId);
+                                    topology.evictRelationRefs(table.getNamespaceId());
                                     return new IdempotencyGuard.CreateResult<>(
                                         table, tableResourceId);
                                   },
@@ -650,9 +653,11 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                             "expected", Long.toString(meta.getPointerVersion()),
                             "actual", Long.toString(nowMeta.getPointerVersion())));
                   }
+                  topology.evict(tableId);
                   metadataGraph.invalidate(tableId);
 
                   if (!current.getNamespaceId().getId().equals(desired.getNamespaceId().getId())) {
+                    topology.evictRelationRefs(desired.getNamespaceId());
                     markerStore.bumpNamespaceMarker(current.getNamespaceId());
                     markerStore.bumpNamespaceMarker(desired.getNamespaceId());
                   }
@@ -702,6 +707,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                     }
                     MutationOps.BaseServiceChecks.enforcePreconditions(
                         correlationId, safe, request.getPrecondition());
+                    topology.evict(tableId);
                     metadataGraph.invalidate(tableId);
                     if (existing != null) {
                       markerStore.bumpNamespaceMarker(existing.getNamespaceId());
@@ -720,6 +726,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                           "table",
                           Map.of("id", tableId.getId()));
 
+                  topology.evict(tableId);
                   metadataGraph.invalidate(tableId);
                   if (existing != null) {
                     markerStore.bumpNamespaceMarker(existing.getNamespaceId());

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
@@ -40,6 +40,7 @@ import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
 import ai.floedb.floecat.service.catalog.hint.EngineHintSchemaCleaner;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.Canonicalizer;
@@ -81,6 +82,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
   @Inject Authorizer authz;
   @Inject IdempotencyRepository idempotencyStore;
   @Inject UserGraph metadataGraph;
+  @Inject TopologyGraph topology;
   @Inject CatalogOverlay overlay;
   @Inject EngineHintSchemaCleaner hintCleaner;
 
@@ -154,10 +156,9 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                   final boolean repoExhausted = repoNext.isBlank();
                   if (repoExhausted) {
                     var sysNodes =
-                        overlay.listRelationsInNamespace(catalogId, namespaceId).stream()
+                        overlay.listSystemRelationsInNamespace(catalogId, namespaceId).stream()
                             .filter(ViewNode.class::isInstance)
                             .map(ViewNode.class::cast)
-                            .filter(this::isSystemViewNode)
                             .toList();
                     sysCount = sysNodes.size();
 
@@ -185,10 +186,8 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                   } else {
                     sysCount =
                         (int)
-                            overlay.listRelationsInNamespace(catalogId, namespaceId).stream()
+                            overlay.listSystemRelationsInNamespace(catalogId, namespaceId).stream()
                                 .filter(ViewNode.class::isInstance)
-                                .map(ViewNode.class::cast)
-                                .filter(this::isSystemViewNode)
                                 .count();
                   }
 
@@ -337,6 +336,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                     }
                     viewRepo.create(view);
                     metadataGraph.invalidate(viewResourceId);
+                    topology.evictRelationRefs(view.getNamespaceId());
                     var meta = viewRepo.metaForSafe(viewResourceId);
                     return CreateViewResponse.newBuilder().setView(view).setMeta(meta).build();
                   }
@@ -365,6 +365,8 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                                             fingerprint, canonicalFingerprint(existingSpec))) {
                                           metadataGraph.invalidate(
                                               existingOpt.get().getResourceId());
+                                          topology.evictRelationRefs(
+                                              existingOpt.get().getNamespaceId());
                                           return new IdempotencyGuard.CreateResult<>(
                                               existingOpt.get(), existingOpt.get().getResourceId());
                                         }
@@ -378,6 +380,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                                               "namespace_id", spec.getNamespaceId().getId()));
                                     }
                                     metadataGraph.invalidate(viewResourceId);
+                                    topology.evictRelationRefs(view.getNamespaceId());
                                     return new IdempotencyGuard.CreateResult<>(
                                         view, viewResourceId);
                                   },
@@ -490,6 +493,10 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                             "expected", Long.toString(meta.getPointerVersion()),
                             "actual", Long.toString(nowMeta.getPointerVersion())));
                   }
+                  topology.evict(viewId);
+                  if (!current.getNamespaceId().getId().equals(desired.getNamespaceId().getId())) {
+                    topology.evictRelationRefs(desired.getNamespaceId());
+                  }
                   metadataGraph.invalidate(viewId);
 
                   var outMeta = viewRepo.metaForSafe(viewId);
@@ -529,6 +536,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                     }
                     MutationOps.BaseServiceChecks.enforcePreconditions(
                         correlationId, safe, request.getPrecondition());
+                    topology.evict(viewId);
                     metadataGraph.invalidate(viewId);
                     return DeleteViewResponse.newBuilder().setMeta(safe).build();
                   }
@@ -543,6 +551,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                           "view",
                           Map.of("id", viewId.getId()));
 
+                  topology.evict(viewId);
                   metadataGraph.invalidate(viewId);
                   return DeleteViewResponse.newBuilder().setMeta(out).build();
                 }),

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/cache/CatalogTopologyCache.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/cache/CatalogTopologyCache.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.metagraph.cache;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.scanner.spi.TopologyGraph.NamespaceRef;
+import ai.floedb.floecat.scanner.spi.TopologyGraph.RelationRef;
+import ai.floedb.floecat.scanner.spi.TopologyNames;
+import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.repo.impl.ViewRepository;
+import ai.floedb.floecat.telemetry.Observability;
+import ai.floedb.floecat.telemetry.helpers.CacheMetrics;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * Application-scoped cache for catalog topology: namespace and relation (table/view) refs without
+ * full proto materialization.
+ *
+ * <p>Cache population goes to DynamoDB only (pointer prefix scan) — no S3. Warm hits are
+ * sub-millisecond; cold population of 200K tables across 10 namespaces is ~50ms (parallelism added
+ * in Layer 5).
+ *
+ * <p>Two Caffeine caches:
+ *
+ * <ul>
+ *   <li>{@code nsRefs}: keyed by {@code (accountId, catalogId)} — 15-min access TTL, 10K entries
+ *   <li>{@code relRefs}: keyed by {@code (accountId, namespaceId)} — 15-min access TTL, 5K entries
+ * </ul>
+ *
+ * <p>A {@code reverseMap} stores {@code relId → nsId} so that {@link #evict} can find the parent
+ * namespace for a relation being deleted, even after the relation's own pointer is gone.
+ */
+@ApplicationScoped
+public class CatalogTopologyCache {
+
+  private final Cache<NsCacheKey, List<NamespaceRef>> nsRefs;
+  private final Cache<RelCacheKey, List<RelationRef>> relRefs;
+  private final ConcurrentMap<ResourceId, ResourceId> reverseMap;
+
+  private final NamespaceRepository nsRepo;
+  private final TableRepository tableRepo;
+  private final ViewRepository viewRepo;
+
+  private final CacheMetrics nsCacheMetrics;
+  private final CacheMetrics relCacheMetrics;
+
+  @Inject
+  public CatalogTopologyCache(
+      NamespaceRepository nsRepo,
+      TableRepository tableRepo,
+      ViewRepository viewRepo,
+      Observability observability,
+      @ConfigProperty(name = "floecat.topology.ns-cache-size", defaultValue = "10000")
+          long nsCacheSize,
+      @ConfigProperty(name = "floecat.topology.rel-cache-size", defaultValue = "5000")
+          long relCacheSize,
+      @ConfigProperty(name = "floecat.topology.cache-ttl-minutes", defaultValue = "15")
+          long cacheTtlMinutes) {
+    this.nsRepo = Objects.requireNonNull(nsRepo, "nsRepo");
+    this.tableRepo = Objects.requireNonNull(tableRepo, "tableRepo");
+    this.viewRepo = Objects.requireNonNull(viewRepo, "viewRepo");
+
+    Duration ttl = Duration.ofMinutes(cacheTtlMinutes);
+    this.nsRefs =
+        Caffeine.newBuilder().maximumSize(Math.max(1L, nsCacheSize)).expireAfterAccess(ttl).build();
+    this.reverseMap = new ConcurrentHashMap<>();
+    this.relRefs =
+        Caffeine.newBuilder()
+            .maximumSize(Math.max(1L, relCacheSize))
+            .expireAfterAccess(ttl)
+            .<RelCacheKey, List<RelationRef>>removalListener(
+                (RelCacheKey key, List<RelationRef> value, RemovalCause cause) -> {
+                  if (value != null) {
+                    for (RelationRef ref : value) {
+                      reverseMap.remove(ref.id());
+                    }
+                  }
+                })
+            .build();
+
+    this.nsCacheMetrics =
+        new CacheMetrics(observability, "service", "topology-cache", "topology-ns");
+    this.relCacheMetrics =
+        new CacheMetrics(observability, "service", "topology-cache", "topology-rel");
+
+    nsCacheMetrics.trackSize(nsRefs::estimatedSize, "ns-refs cache size");
+    relCacheMetrics.trackSize(relRefs::estimatedSize, "rel-refs cache size");
+  }
+
+  public List<NamespaceRef> listNamespaceRefs(ResourceId catalogId) {
+    var key = new NsCacheKey(catalogId.getAccountId(), catalogId.getId());
+    var cached = nsRefs.getIfPresent(key);
+    if (cached != null) {
+      nsCacheMetrics.recordHit();
+      return cached;
+    }
+    nsCacheMetrics.recordMiss();
+    var loaded = nsRepo.listRefs(catalogId.getAccountId(), catalogId.getId());
+    nsRefs.put(key, loaded);
+    return loaded;
+  }
+
+  public List<NamespaceRef> listNamespaceRefsByName(ResourceId catalogId, Set<String> names) {
+    if (names == null || names.isEmpty()) {
+      return List.of();
+    }
+    var key = new NsCacheKey(catalogId.getAccountId(), catalogId.getId());
+    var cached = nsRefs.getIfPresent(key);
+    if (cached != null) {
+      nsCacheMetrics.recordHit();
+      return cached.stream()
+          .filter(
+              ref -> names.contains(TopologyNames.namespaceName(ref.pathSegments(), ref.name())))
+          .toList();
+    }
+    nsCacheMetrics.recordMiss();
+    return nsRepo.listRefsByName(catalogId.getAccountId(), catalogId.getId(), names);
+  }
+
+  public List<RelationRef> listRelationRefs(ResourceId catalogId, ResourceId namespaceId) {
+    var key = new RelCacheKey(namespaceId.getAccountId(), namespaceId.getId());
+    var cached = relRefs.getIfPresent(key);
+    if (cached != null) {
+      relCacheMetrics.recordHit();
+      return cached;
+    }
+    relCacheMetrics.recordMiss();
+    var loaded = loadRelationRefs(catalogId, namespaceId);
+    relRefs.put(key, loaded);
+    for (var ref : loaded) {
+      reverseMap.put(ref.id(), namespaceId);
+    }
+    return loaded;
+  }
+
+  public List<RelationRef> listRelationRefsByName(
+      ResourceId catalogId, ResourceId namespaceId, Set<String> names) {
+    if (names == null || names.isEmpty()) {
+      return List.of();
+    }
+    var key = new RelCacheKey(namespaceId.getAccountId(), namespaceId.getId());
+    var cached = relRefs.getIfPresent(key);
+    if (cached != null) {
+      relCacheMetrics.recordHit();
+      return cached.stream().filter(r -> names.contains(r.name())).collect(Collectors.toList());
+    }
+    relCacheMetrics.recordMiss();
+    List<RelationRef> refs = new ArrayList<>();
+    refs.addAll(
+        tableRepo.listRefsByName(
+            catalogId.getAccountId(), catalogId.getId(), namespaceId.getId(), names));
+    refs.addAll(
+        viewRepo.listRefsByName(
+            catalogId.getAccountId(), catalogId.getId(), namespaceId.getId(), names));
+    for (var ref : refs) {
+      reverseMap.put(ref.id(), namespaceId);
+    }
+    return refs;
+  }
+
+  public void evict(ResourceId resourceId) {
+    if (resourceId == null) {
+      return;
+    }
+    ResourceId nsId = reverseMap.remove(resourceId);
+    if (nsId != null) {
+      relRefs.invalidate(new RelCacheKey(nsId.getAccountId(), nsId.getId()));
+    }
+  }
+
+  public void evictRelationRefs(ResourceId namespaceId) {
+    if (namespaceId != null) {
+      relRefs.invalidate(new RelCacheKey(namespaceId.getAccountId(), namespaceId.getId()));
+    }
+  }
+
+  public void evictNamespaceRefs(ResourceId catalogId) {
+    if (catalogId != null) {
+      nsRefs.invalidate(new NsCacheKey(catalogId.getAccountId(), catalogId.getId()));
+    }
+  }
+
+  private List<RelationRef> loadRelationRefs(ResourceId catalogId, ResourceId namespaceId) {
+    String accountId = catalogId.getAccountId();
+    String catId = catalogId.getId();
+    String nsId = namespaceId.getId();
+
+    List<RelationRef> refs = new ArrayList<>();
+    refs.addAll(tableRepo.listRefs(accountId, catId, nsId));
+    refs.addAll(viewRepo.listRefs(accountId, catId, nsId));
+    return refs;
+  }
+
+  private record NsCacheKey(String accountId, String catalogId) {}
+
+  private record RelCacheKey(String accountId, String namespaceId) {}
+}

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.metagraph.overlay;
 
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.connector.common.resolver.LogicalSchemaMapper;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
@@ -32,10 +33,13 @@ import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
+import ai.floedb.floecat.scanner.spi.TopologyNames;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.context.EngineContextProvider;
 import ai.floedb.floecat.service.error.impl.GeneratedErrorMessages;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import ai.floedb.floecat.service.metagraph.cache.CatalogTopologyCache;
 import ai.floedb.floecat.service.metagraph.overlay.systemobjects.SystemGraph;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.systemcatalog.graph.SystemCatalogTranslator;
@@ -55,31 +59,26 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 @ApplicationScoped
-public final class MetaGraph implements CatalogOverlay {
+public final class MetaGraph implements CatalogOverlay, TopologyGraph {
 
   private final UserGraph userGraph;
   private final LogicalSchemaMapper schemaMapper;
   private final SystemGraph systemGraph;
   private final EngineContextProvider engine;
+  private final CatalogTopologyCache topologyCache;
 
-  /**
-   * Constructs a MetaGraph that merges system and user graph overlays.
-   *
-   * @param userGraph the user-defined graph overlay for mutable catalog objects
-   * @param schemaMapper mapper for converting between logical and physical schemas
-   * @param systemGraph the system graph overlay for immutable built-in catalog objects
-   * @param engine provider for current engine context (kind and version)
-   */
   @Inject
   public MetaGraph(
       UserGraph userGraph,
       LogicalSchemaMapper schemaMapper,
       SystemGraph systemGraph,
-      EngineContextProvider engine) {
+      EngineContextProvider engine,
+      CatalogTopologyCache topologyCache) {
     this.userGraph = userGraph;
     this.schemaMapper = schemaMapper;
     this.systemGraph = systemGraph;
     this.engine = engine;
+    this.topologyCache = topologyCache;
   }
 
   private EngineContext engineContext() {
@@ -118,7 +117,8 @@ public final class MetaGraph implements CatalogOverlay {
   public List<RelationNode> listRelations(ResourceId catalogId) {
     EngineContext ctx = engineContext();
     return mergeLists(
-        () -> systemGraph.listRelations(catalogId, ctx), () -> userGraph.listRelations(catalogId));
+        () -> systemGraph.listRelations(catalogId, ctx),
+        () -> listUserRelationsFromTopology(catalogId));
   }
 
   /**
@@ -136,7 +136,7 @@ public final class MetaGraph implements CatalogOverlay {
     EngineContext ctx = engineContext();
     return mergeLists(
         () -> systemGraph.listRelationsInNamespace(catalogId, namespaceId, ctx),
-        () -> userGraph.listRelationsInNamespace(catalogId, namespaceId));
+        () -> listUserRelationsFromTopology(catalogId, namespaceId));
   }
 
   /**
@@ -176,7 +176,24 @@ public final class MetaGraph implements CatalogOverlay {
     EngineContext ctx = engineContext();
     return mergeLists(
         () -> systemGraph.listNamespaces(catalogId, ctx),
-        () -> userGraph.listNamespaces(catalogId));
+        () -> listUserNamespacesFromTopology(catalogId));
+  }
+
+  @Override
+  public List<RelationNode> listSystemRelationsInNamespace(
+      ResourceId catalogId, ResourceId namespaceId) {
+    EngineContext ctx = engineContext();
+    return systemGraph.listRelationsInNamespace(catalogId, namespaceId, ctx).stream()
+        .map(RelationNode.class::cast)
+        .toList();
+  }
+
+  @Override
+  public List<NamespaceNode> listSystemNamespaces(ResourceId catalogId) {
+    EngineContext ctx = engineContext();
+    return systemGraph.listNamespaces(catalogId, ctx).stream()
+        .map(NamespaceNode.class::cast)
+        .toList();
   }
 
   /**
@@ -586,6 +603,37 @@ public final class MetaGraph implements CatalogOverlay {
     return result;
   }
 
+  private List<NamespaceNode> listUserNamespacesFromTopology(ResourceId catalogId) {
+    return topologyCache.listNamespaceRefs(catalogId).stream()
+        .map(TopologyGraph.NamespaceRef::id)
+        .map(userGraph::namespace)
+        .flatMap(Optional::stream)
+        .toList();
+  }
+
+  private List<RelationNode> listUserRelationsFromTopology(ResourceId catalogId) {
+    List<RelationNode> result = new ArrayList<>();
+    for (TopologyGraph.NamespaceRef namespace : topologyCache.listNamespaceRefs(catalogId)) {
+      result.addAll(listUserRelationsFromTopology(catalogId, namespace.id()));
+    }
+    return result;
+  }
+
+  private List<RelationNode> listUserRelationsFromTopology(
+      ResourceId catalogId, ResourceId namespaceId) {
+    return topologyCache.listRelationRefs(catalogId, namespaceId).stream()
+        .map(this::resolveUserRelation)
+        .flatMap(Optional::stream)
+        .toList();
+  }
+
+  private Optional<RelationNode> resolveUserRelation(TopologyGraph.RelationRef ref) {
+    if (ref.kind() == ResourceKind.RK_VIEW) {
+      return userGraph.view(ref.id()).map(RelationNode.class::cast);
+    }
+    return userGraph.table(ref.id()).map(RelationNode.class::cast);
+  }
+
   /**
    * Resolves a name reference with system-first precedence and ambiguity checking.
    *
@@ -780,5 +828,118 @@ public final class MetaGraph implements CatalogOverlay {
         correlationId,
         GeneratedErrorMessages.MessageKey.QUERY_INPUT_AMBIGUOUS,
         Map.of("name", name.toString()));
+  }
+
+  // ---- Lightweight ref listing and topology-cache invalidation ----
+
+  @Override
+  public boolean supportsLightweightRefs() {
+    return true;
+  }
+
+  @Override
+  public List<TopologyGraph.NamespaceRef> listNamespaceRefs(ResourceId catalogId) {
+    EngineContext ctx = engineContext();
+    List<NamespaceNode> sysNs = systemGraph.listNamespaces(catalogId, ctx);
+    List<TopologyGraph.NamespaceRef> userNs = topologyCache.listNamespaceRefs(catalogId);
+    if (sysNs.isEmpty()) {
+      return userNs;
+    }
+    List<TopologyGraph.NamespaceRef> result = new ArrayList<>(sysNs.size() + userNs.size());
+    for (NamespaceNode ns : sysNs) {
+      result.add(
+          new TopologyGraph.NamespaceRef(
+              ns.id(), ns.displayName(), ns.catalogId(), ns.pathSegments()));
+    }
+    result.addAll(userNs);
+    return result;
+  }
+
+  @Override
+  public List<TopologyGraph.NamespaceRef> listNamespaceRefsByName(
+      ResourceId catalogId, Set<String> names) {
+    if (names == null || names.isEmpty()) {
+      return List.of();
+    }
+    EngineContext ctx = engineContext();
+    List<NamespaceNode> sysNs =
+        systemGraph.listNamespaces(catalogId, ctx).stream()
+            .filter(
+                ns ->
+                    names.contains(
+                        TopologyNames.namespaceName(ns.pathSegments(), ns.displayName())))
+            .toList();
+    List<TopologyGraph.NamespaceRef> userNs =
+        topologyCache.listNamespaceRefsByName(catalogId, names);
+    if (sysNs.isEmpty()) {
+      return userNs;
+    }
+    List<TopologyGraph.NamespaceRef> result = new ArrayList<>(sysNs.size() + userNs.size());
+    for (NamespaceNode ns : sysNs) {
+      result.add(
+          new TopologyGraph.NamespaceRef(
+              ns.id(), ns.displayName(), ns.catalogId(), ns.pathSegments()));
+    }
+    result.addAll(userNs);
+    return result;
+  }
+
+  @Override
+  public List<TopologyGraph.RelationRef> listRelationRefs(
+      ResourceId catalogId, ResourceId namespaceId) {
+    EngineContext ctx = engineContext();
+    List<RelationNode> sysRels = systemGraph.listRelationsInNamespace(catalogId, namespaceId, ctx);
+    List<TopologyGraph.RelationRef> userRels =
+        topologyCache.listRelationRefs(catalogId, namespaceId);
+    if (sysRels.isEmpty()) {
+      return userRels;
+    }
+    List<TopologyGraph.RelationRef> result = new ArrayList<>(sysRels.size() + userRels.size());
+    for (RelationNode rel : sysRels) {
+      ResourceKind kind = rel instanceof ViewNode ? ResourceKind.RK_VIEW : ResourceKind.RK_TABLE;
+      result.add(new TopologyGraph.RelationRef(rel.id(), rel.displayName(), kind));
+    }
+    result.addAll(userRels);
+    return result;
+  }
+
+  @Override
+  public List<TopologyGraph.RelationRef> listRelationRefsByName(
+      ResourceId catalogId, ResourceId namespaceId, Set<String> names) {
+    if (names == null || names.isEmpty()) {
+      return List.of();
+    }
+    EngineContext ctx = engineContext();
+    List<RelationNode> sysRels =
+        systemGraph.listRelationsInNamespace(catalogId, namespaceId, ctx).stream()
+            .filter(r -> names.contains(r.displayName()))
+            .toList();
+    List<TopologyGraph.RelationRef> userRels =
+        topologyCache.listRelationRefsByName(catalogId, namespaceId, names);
+    if (sysRels.isEmpty()) {
+      return userRels;
+    }
+    List<TopologyGraph.RelationRef> result = new ArrayList<>(sysRels.size() + userRels.size());
+    for (RelationNode rel : sysRels) {
+      ResourceKind kind = rel instanceof ViewNode ? ResourceKind.RK_VIEW : ResourceKind.RK_TABLE;
+      result.add(new TopologyGraph.RelationRef(rel.id(), rel.displayName(), kind));
+    }
+    result.addAll(userRels);
+    return result;
+  }
+
+  @Override
+  public void evict(ResourceId resourceId) {
+    topologyCache.evict(resourceId);
+  }
+
+  @Override
+  public void evictRelationRefs(ResourceId namespaceId) {
+    topologyCache.evictRelationRefs(namespaceId);
+  }
+
+  @Override
+  public void evictNamespaceRefs(ResourceId catalogId) {
+    topologyCache.evictNamespaceRefs(catalogId);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -30,10 +30,16 @@ import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Semaphore;
+import org.eclipse.microprofile.context.ManagedExecutor;
 
 /**
  * Repository-backed name resolution helpers.
@@ -59,10 +65,14 @@ public final class NameResolver {
   // Dependencies
   // ----------------------------------------------------------------------
 
+  /** Max concurrent DynamoDB namespace scans per top-level listing call. */
+  static final int MAX_PARALLEL_NS_SCANS = 8;
+
   private final CatalogRepository catalogRepository;
   private final NamespaceRepository namespaceRepository;
   private final TableRepository tableRepository;
   private final ViewRepository viewRepository;
+  private volatile Executor blockingExecutor = ForkJoinPool.commonPool();
 
   @Inject
   public NameResolver(
@@ -75,6 +85,13 @@ public final class NameResolver {
     this.namespaceRepository = namespaceRepository;
     this.tableRepository = tableRepository;
     this.viewRepository = viewRepository;
+  }
+
+  @Inject
+  void init(Instance<ManagedExecutor> managedExecutors) {
+    if (managedExecutors != null) {
+      managedExecutors.stream().findFirst().ifPresent(e -> blockingExecutor = e);
+    }
   }
 
   // ----------------------------------------------------------------------
@@ -238,16 +255,12 @@ public final class NameResolver {
   }
 
   public List<ResourceId> listTableIds(String accountId, String catalogId) {
-    List<ResourceId> out = new ArrayList<>();
     List<ResourceId> nsIds = namespaceRepository.listIds(accountId, catalogId);
-
-    for (ResourceId ns : nsIds) {
-      List<Table> tables =
-          tableRepository.list(
-              accountId, catalogId, ns.getId(), Integer.MAX_VALUE, "", new StringBuilder());
-      for (Table t : tables) out.add(requireCanonicalTableId(t.getResourceId()));
+    if (nsIds.isEmpty()) return List.of();
+    if (nsIds.size() == 1) {
+      return listTableIdsInNamespace(accountId, catalogId, nsIds.get(0).getId());
     }
-    return out;
+    return parallelScan(nsIds, ns -> listTableIdsInNamespace(accountId, catalogId, ns.getId()));
   }
 
   public List<ResourceId> listTableIdsInNamespace(
@@ -256,6 +269,43 @@ public final class NameResolver {
         tableRepository.list(
             accountId, catalogId, namespaceId, Integer.MAX_VALUE, "", new StringBuilder());
     return tables.stream().map(Table::getResourceId).map(this::requireCanonicalTableId).toList();
+  }
+
+  /**
+   * Fans out per-namespace work across up to {@value #MAX_PARALLEL_NS_SCANS} concurrent tasks on
+   * the injected blocking executor. Each namespace is an independent DynamoDB scan; parallel
+   * execution reduces wall-clock time from O(N) to O(1) for warm DynamoDB connections.
+   */
+  private <T> List<T> parallelScan(
+      List<ResourceId> nsIds, java.util.function.Function<ResourceId, List<T>> task) {
+    Semaphore gate = new Semaphore(MAX_PARALLEL_NS_SCANS);
+    List<CompletableFuture<List<T>>> futures =
+        nsIds.stream()
+            .<CompletableFuture<List<T>>>map(
+                ns ->
+                    CompletableFuture.<List<T>>supplyAsync(
+                        () -> {
+                          gate.acquireUninterruptibly();
+                          try {
+                            return task.apply(ns);
+                          } finally {
+                            gate.release();
+                          }
+                        },
+                        blockingExecutor))
+            .toList();
+    List<T> out = new ArrayList<>();
+    for (CompletableFuture<List<T>> f : futures) {
+      try {
+        out.addAll(f.join());
+      } catch (java.util.concurrent.CompletionException ce) {
+        Throwable cause = ce.getCause();
+        if (cause instanceof RuntimeException re) throw re;
+        if (cause instanceof Error e) throw e;
+        throw new IllegalStateException("unexpected checked exception from async task", cause);
+      }
+    }
+    return out;
   }
 
   private ResourceId requireCanonicalTableId(ResourceId tableId) {
@@ -269,16 +319,12 @@ public final class NameResolver {
   }
 
   public List<ResourceId> listViewIds(String accountId, String catalogId) {
-    List<ResourceId> out = new ArrayList<>();
     List<ResourceId> nsIds = namespaceRepository.listIds(accountId, catalogId);
-
-    for (ResourceId ns : nsIds) {
-      List<View> views =
-          viewRepository.list(
-              accountId, catalogId, ns.getId(), Integer.MAX_VALUE, "", new StringBuilder());
-      for (View t : views) out.add(t.getResourceId());
+    if (nsIds.isEmpty()) return List.of();
+    if (nsIds.size() == 1) {
+      return listViewIdsInNamespace(accountId, catalogId, nsIds.get(0).getId());
     }
-    return out;
+    return parallelScan(nsIds, ns -> listViewIdsInNamespace(accountId, catalogId, ns.getId()));
   }
 
   public List<ResourceId> listViewIdsInNamespace(

--- a/service/src/main/java/ai/floedb/floecat/service/query/flight/SystemTableFlightProducer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/flight/SystemTableFlightProducer.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
@@ -184,6 +185,7 @@ public final class SystemTableFlightProducer extends SystemTableFlightProducerBa
     List<String> requiredColumns = command.getRequiredColumnsList();
     List<Predicate> predicates = command.getPredicatesList();
     Expr arrowExpr = SystemRowFilter.EXPRESSION_PROVIDER.toExpr(predicates);
+    SystemScanRequest scanRequest = SystemScanRequest.of(arrowExpr, requiredColumns);
     SystemObjectScanContext scanContext =
         new SystemObjectScanContext(
             graph,
@@ -194,7 +196,13 @@ public final class SystemTableFlightProducer extends SystemTableFlightProducerBa
             constraintFactory.provider());
 
     return arrowPlanner.plan(
-        scanner, scanContext, scanner.schema(), predicates, requiredColumns, arrowExpr, allocator);
+        scanner,
+        scanContext,
+        scanner.schema(),
+        predicates,
+        requiredColumns,
+        scanRequest,
+        allocator);
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySystemScanServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySystemScanServiceImpl.java
@@ -28,6 +28,7 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.GrpcContextUtil;
@@ -144,14 +145,14 @@ public class QuerySystemScanServiceImpl extends BaseServiceImpl implements Query
             Map.of("output_format", format.toString()));
       }
       boolean arrowRequested = format != OutputFormat.ROWS;
-      Expr arrowExpr =
-          arrowRequested ? SystemRowFilter.EXPRESSION_PROVIDER.toExpr(predicates) : null;
+      Expr predicateExpr = SystemRowFilter.EXPRESSION_PROVIDER.toExpr(predicates);
+      SystemScanRequest scanRequest = SystemScanRequest.of(predicateExpr, requiredColumns);
 
       if (arrowRequested) {
         BufferAllocator allocator = new RootAllocator(arrowMaxBytes);
         ArrowScanPlan plan =
             arrowPlanner.plan(
-                scanner, ctx, schema, predicates, requiredColumns, arrowExpr, allocator);
+                scanner, ctx, schema, predicates, requiredColumns, scanRequest, allocator);
         arrowSink.sink(
             emitter,
             plan,
@@ -160,7 +161,7 @@ public class QuerySystemScanServiceImpl extends BaseServiceImpl implements Query
         return;
       }
 
-      try (Stream<SystemObjectRow> rows = scanner.scan(ctx);
+      try (Stream<SystemObjectRow> rows = scanner.scan(ctx, scanRequest);
           Stream<SystemObjectRow> filtered = SystemRowFilter.filter(rows, schema, predicates);
           Stream<SystemObjectRow> projected =
               SystemRowProjector.project(filtered, schema, requiredColumns)) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/arrow/ArrowScanPlanner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/arrow/ArrowScanPlanner.java
@@ -27,6 +27,7 @@ import ai.floedb.floecat.scanner.spi.ScanOutputFormat;
 import ai.floedb.floecat.scanner.spi.SystemObjectRow;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
+import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import ai.floedb.floecat.scanner.utils.RowStreamToArrowBatchAdapter;
 import ai.floedb.floecat.service.query.system.SystemRowFilter;
 import ai.floedb.floecat.service.query.system.SystemRowProjector;
@@ -52,19 +53,20 @@ public final class ArrowScanPlanner {
       List<SchemaColumn> schemaColumns,
       List<Predicate> predicates,
       List<String> requiredColumns,
-      Expr arrowExpr,
+      SystemScanRequest request,
       BufferAllocator allocator) {
     // Use the projected schema so plan.schema() matches the projected batch stream.
     Schema schema = ArrowBatchSerializer.schemaForColumns(schemaColumns, requiredColumns);
+    Expr arrowExpr = request.predicate();
     Stream<ColumnarBatch> batches;
     if (scanner.supportedFormats().contains(ScanOutputFormat.ARROW_IPC)) {
       batches =
           scanner
-              .scanArrow(ctx, arrowExpr, requiredColumns, allocator)
+              .scanArrow(ctx, request, allocator)
               .map(batch -> ArrowFilterOperator.filter(batch, arrowExpr, allocator))
               .map(batch -> ArrowProjectOperator.project(batch, requiredColumns, allocator));
     } else {
-      Stream<SystemObjectRow> rows = scanner.scan(ctx);
+      Stream<SystemObjectRow> rows = scanner.scan(ctx, request);
       Stream<SystemObjectRow> filtered = SystemRowFilter.filter(rows, schemaColumns, predicates);
       Stream<SystemObjectRow> projected =
           SystemRowProjector.project(filtered, schemaColumns, requiredColumns);

--- a/service/src/main/java/ai/floedb/floecat/service/query/system/SystemRowFilter.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/system/SystemRowFilter.java
@@ -62,6 +62,7 @@ public final class SystemRowFilter {
 
     return switch (p.getOp()) {
       case OP_EQ -> value != null && value.toString().equals(p.getValues(0));
+      case OP_IN -> value != null && p.getValuesList().contains(value.toString());
       case OP_IS_NULL -> value == null;
       case OP_IS_NOT_NULL -> value != null;
       default ->
@@ -99,6 +100,7 @@ public final class SystemRowFilter {
 
     return switch (predicate.getOp()) {
       case OP_EQ -> new Expr.Eq(column, new Expr.Literal(firstValue(predicate)));
+      case OP_IN -> inExpr(column, predicate.getValuesList());
       case OP_IS_NULL -> new Expr.IsNull(column);
       case OP_IS_NOT_NULL -> new Expr.Not(new Expr.IsNull(column));
       default ->
@@ -109,5 +111,17 @@ public final class SystemRowFilter {
 
   private static String firstValue(Predicate predicate) {
     return predicate.getValuesCount() > 0 ? predicate.getValues(0) : null;
+  }
+
+  private static Expr inExpr(Expr column, List<String> values) {
+    if (values.isEmpty()) {
+      return new Expr.BooleanLiteral(false);
+    }
+    Expr expr = null;
+    for (String value : values) {
+      Expr eq = new Expr.Eq(column, new Expr.Literal(value));
+      expr = expr == null ? eq : new Expr.Or(expr, eq);
+    }
+    return expr;
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -19,6 +19,8 @@ package ai.floedb.floecat.service.repo.impl;
 import ai.floedb.floecat.catalog.rpc.Namespace;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.scanner.spi.TopologyGraph.NamespaceRef;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.NamespaceKey;
 import ai.floedb.floecat.service.repo.model.Schemas;
@@ -28,8 +30,10 @@ import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @ApplicationScoped
 public class NamespaceRepository {
@@ -104,6 +108,76 @@ public class NamespaceRepository {
       ids.add(ns.getResourceId());
     }
     return ids;
+  }
+
+  /**
+   * Scans the by-path pointer prefix for a catalog and returns lightweight refs without loading
+   * blobs from S3. Falls back to key/blobUri parsing for legacy pointers.
+   */
+  public List<NamespaceRef> listRefs(String accountId, String catalogId) {
+    String prefix = Keys.namespacePointerByPathPrefix(accountId, catalogId, List.of());
+    var pointers = repo.listRefsByPrefix(prefix);
+    var refs = new ArrayList<NamespaceRef>(pointers.size());
+    ResourceId catalogResourceId = catalogResourceId(accountId, catalogId);
+    for (var p : pointers) {
+      toNamespaceRef(accountId, catalogId, catalogResourceId, p).ifPresent(refs::add);
+    }
+    return refs;
+  }
+
+  /** Reads exact by-path namespace pointers and returns refs without fetching blobs from S3. */
+  public List<NamespaceRef> listRefsByName(String accountId, String catalogId, Set<String> names) {
+    if (names == null || names.isEmpty()) {
+      return List.of();
+    }
+    ResourceId catalogResourceId = catalogResourceId(accountId, catalogId);
+    List<NamespaceRef> refs = new ArrayList<>(names.size());
+    for (String name : names) {
+      if (name == null || name.isBlank()) {
+        continue;
+      }
+      repo.refByPointer(
+              Keys.namespacePointerByPath(accountId, catalogId, List.of(name.split("\\.", -1))))
+          .flatMap(p -> toNamespaceRef(accountId, catalogId, catalogResourceId, p))
+          .ifPresent(refs::add);
+    }
+    return refs;
+  }
+
+  private static ResourceId catalogResourceId(String accountId, String catalogId) {
+    return ResourceId.newBuilder()
+        .setAccountId(accountId)
+        .setId(catalogId)
+        .setKind(ResourceKind.RK_CATALOG)
+        .build();
+  }
+
+  private static Optional<NamespaceRef> toNamespaceRef(
+      String accountId,
+      String catalogId,
+      ResourceId catalogResourceId,
+      ai.floedb.floecat.common.rpc.Pointer p) {
+    List<String> pathSegments = Keys.extractNamespacePathSegments(accountId, catalogId, p.getKey());
+    String name =
+        !p.getDisplayName().isEmpty()
+            ? p.getDisplayName()
+            : pathSegments.isEmpty()
+                ? Keys.extractLastSegment(p.getKey())
+                : pathSegments.get(pathSegments.size() - 1);
+    ResourceId rid = p.getResourceId();
+    if (rid.getId().isEmpty()) {
+      String rawId = Keys.extractResourceIdFromBlobUri(p.getBlobUri());
+      if (rawId.isEmpty()) {
+        return Optional.empty();
+      }
+      rid =
+          ResourceId.newBuilder()
+              .setAccountId(accountId)
+              .setId(rawId)
+              .setKind(ResourceKind.RK_NAMESPACE)
+              .build();
+    }
+    return Optional.of(new NamespaceRef(rid, name, catalogResourceId, pathSegments));
   }
 
   public MutationMeta metaFor(ResourceId namespaceResourceId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
@@ -19,6 +19,8 @@ package ai.floedb.floecat.service.repo.impl;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.scanner.spi.TopologyGraph.RelationRef;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.model.TableKey;
@@ -28,8 +30,10 @@ import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @ApplicationScoped
 public class TableRepository {
@@ -88,6 +92,54 @@ public class TableRepository {
 
   public int count(String accountId, String catalogId, String namespaceId) {
     return repo.countByPrefix(Keys.tablePointerByNamePrefix(accountId, catalogId, namespaceId));
+  }
+
+  /**
+   * Scans the by-name pointer prefix for a namespace and returns lightweight refs without loading
+   * blobs from S3. Falls back to key/blobUri parsing for legacy pointers that predate
+   * Pointer.resource_id / display_name.
+   */
+  public List<RelationRef> listRefs(String accountId, String catalogId, String namespaceId) {
+    String prefix = Keys.tablePointerByNamePrefix(accountId, catalogId, namespaceId);
+    var pointers = repo.listRefsByPrefix(prefix);
+    var refs = new ArrayList<RelationRef>(pointers.size());
+    for (var p : pointers) {
+      toRelationRef(accountId, ResourceKind.RK_TABLE, p).ifPresent(refs::add);
+    }
+    return refs;
+  }
+
+  /** Reads exact by-name table pointers and returns refs without fetching blobs from S3. */
+  public List<RelationRef> listRefsByName(
+      String accountId, String catalogId, String namespaceId, Set<String> names) {
+    if (names == null || names.isEmpty()) {
+      return List.of();
+    }
+    List<RelationRef> refs = new ArrayList<>(names.size());
+    for (String name : names) {
+      if (name == null || name.isBlank()) {
+        continue;
+      }
+      repo.refByPointer(Keys.tablePointerByName(accountId, catalogId, namespaceId, name))
+          .flatMap(p -> toRelationRef(accountId, ResourceKind.RK_TABLE, p))
+          .ifPresent(refs::add);
+    }
+    return refs;
+  }
+
+  static Optional<RelationRef> toRelationRef(
+      String accountId, ResourceKind kind, ai.floedb.floecat.common.rpc.Pointer p) {
+    String name =
+        !p.getDisplayName().isEmpty() ? p.getDisplayName() : Keys.extractLastSegment(p.getKey());
+    ResourceId rid = p.getResourceId();
+    if (rid.getId().isEmpty()) {
+      String rawId = Keys.extractResourceIdFromBlobUri(p.getBlobUri());
+      if (rawId.isEmpty()) {
+        return Optional.empty();
+      }
+      rid = ResourceId.newBuilder().setAccountId(accountId).setId(rawId).setKind(kind).build();
+    }
+    return Optional.of(new RelationRef(rid, name, kind));
   }
 
   public MutationMeta metaFor(ResourceId tableResourceId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
@@ -19,6 +19,8 @@ package ai.floedb.floecat.service.repo.impl;
 import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.scanner.spi.TopologyGraph.RelationRef;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.model.ViewKey;
@@ -28,8 +30,10 @@ import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @ApplicationScoped
 public class ViewRepository {
@@ -87,6 +91,38 @@ public class ViewRepository {
 
   public int count(String accountId, String catalogId, String namespaceId) {
     return repo.countByPrefix(Keys.viewPointerByNamePrefix(accountId, catalogId, namespaceId));
+  }
+
+  /**
+   * Scans the by-name pointer prefix for a namespace and returns lightweight refs without loading
+   * blobs from S3. Falls back to key/blobUri parsing for legacy pointers.
+   */
+  public List<RelationRef> listRefs(String accountId, String catalogId, String namespaceId) {
+    String prefix = Keys.viewPointerByNamePrefix(accountId, catalogId, namespaceId);
+    var pointers = repo.listRefsByPrefix(prefix);
+    var refs = new ArrayList<RelationRef>(pointers.size());
+    for (var p : pointers) {
+      TableRepository.toRelationRef(accountId, ResourceKind.RK_VIEW, p).ifPresent(refs::add);
+    }
+    return refs;
+  }
+
+  /** Reads exact by-name view pointers and returns refs without fetching blobs from S3. */
+  public List<RelationRef> listRefsByName(
+      String accountId, String catalogId, String namespaceId, Set<String> names) {
+    if (names == null || names.isEmpty()) {
+      return List.of();
+    }
+    List<RelationRef> refs = new ArrayList<>(names.size());
+    for (String name : names) {
+      if (name == null || name.isBlank()) {
+        continue;
+      }
+      repo.refByPointer(Keys.viewPointerByName(accountId, catalogId, namespaceId, name))
+          .flatMap(p -> TableRepository.toRelationRef(accountId, ResourceKind.RK_VIEW, p))
+          .ifPresent(refs::add);
+    }
+    return refs;
   }
 
   public MutationMeta metaFor(ResourceId viewResourceId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.repo.model;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 
@@ -1255,5 +1256,103 @@ public final class Keys {
     String tid = req("account_id", accountId);
     String nid = req("namespace_id", namespaceId);
     return "/accounts/" + encode(tid) + "/namespaces/" + encode(nid) + "/markers/children";
+  }
+
+  /**
+   * Extracts the resource ID string from a blob URI following the standard pattern {@code
+   * /accounts/{accountId}/{type-plural}/{resourceId}/...}. Returns empty string if the URI does not
+   * match. Used as a fallback for legacy pointers that predate the {@code Pointer.resource_id}
+   * field.
+   *
+   * <p>Example: {@code /accounts/x/tables/my-table-id/table/sha.pb} → {@code my-table-id}
+   */
+  public static String extractResourceIdFromBlobUri(String blobUri) {
+    if (blobUri == null || blobUri.isEmpty()) {
+      return "";
+    }
+    // Pattern: /accounts/{accountId}/{type}/{resourceId}/...
+    int start = 0;
+    int slashCount = 0;
+    for (int i = 0; i < blobUri.length(); i++) {
+      if (blobUri.charAt(i) == '/') {
+        slashCount++;
+        if (slashCount == 4) {
+          start = i + 1;
+        } else if (slashCount == 5) {
+          return percentDecode(blobUri.substring(start, i));
+        }
+      }
+    }
+    return "";
+  }
+
+  /**
+   * Returns the last path segment of a pointer key, percent-decoded. Used as a fallback to extract
+   * display_name from a by-name pointer key when the Pointer.display_name field is not set (e.g.
+   * for pointers written before the topology fields were added).
+   *
+   * <p>Example: {@code /accounts/x/catalogs/c/namespaces/n/tables/by-name/my%20table} → {@code my
+   * table}
+   */
+  public static String extractLastSegment(String key) {
+    if (key == null || key.isEmpty()) {
+      return key;
+    }
+    int lastSlash = key.lastIndexOf('/');
+    String encoded = lastSlash >= 0 ? key.substring(lastSlash + 1) : key;
+    return percentDecode(encoded);
+  }
+
+  /**
+   * Returns the full namespace path encoded in a by-path namespace pointer key.
+   *
+   * <p>The by-path key is reversible because each namespace path segment is percent-encoded before
+   * the segments are joined with {@code /}. Literal slashes in namespace names are encoded as
+   * {@code %2F}, so splitting the suffix on {@code /} is delimiter-safe.
+   */
+  public static List<String> extractNamespacePathSegments(
+      String accountId, String catalogId, String key) {
+    if (key == null || key.isEmpty()) {
+      return List.of();
+    }
+    String prefix = namespacePointerByPathPrefix(accountId, catalogId, List.of());
+    if (!key.startsWith(prefix)) {
+      return List.of();
+    }
+    String suffix = key.substring(prefix.length());
+    if (suffix.isEmpty()) {
+      return List.of();
+    }
+    String[] encodedSegments = suffix.split("/");
+    java.util.ArrayList<String> segments = new java.util.ArrayList<>(encodedSegments.length);
+    for (String encoded : encodedSegments) {
+      if (!encoded.isEmpty()) {
+        segments.add(percentDecode(encoded));
+      }
+    }
+    return List.copyOf(segments);
+  }
+
+  private static String percentDecode(String encoded) {
+    if (encoded.indexOf('%') < 0) {
+      return encoded;
+    }
+    byte[] bytes = new byte[encoded.length()];
+    int out = 0;
+    for (int i = 0; i < encoded.length(); ) {
+      char ch = encoded.charAt(i);
+      if (ch == '%' && i + 2 < encoded.length()) {
+        int hi = Character.digit(encoded.charAt(i + 1), 16);
+        int lo = Character.digit(encoded.charAt(i + 2), 16);
+        if (hi >= 0 && lo >= 0) {
+          bytes[out++] = (byte) ((hi << 4) | lo);
+          i += 3;
+          continue;
+        }
+      }
+      bytes[out++] = (byte) ch;
+      i++;
+    }
+    return new String(bytes, 0, out, StandardCharsets.UTF_8);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/PointerReferences.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/PointerReferences.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.repo.model;
 
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.PointerReferenceKind;
+import ai.floedb.floecat.common.rpc.ResourceId;
 
 public final class PointerReferences {
   private PointerReferences() {}
@@ -49,6 +50,18 @@ public final class PointerReferences {
   public static Pointer blobPointer(String key, String blobUri, long version) {
     return asBlobPointer(
             Pointer.newBuilder().setKey(blankToEmpty(key)).setVersion(version), blobUri)
+        .build();
+  }
+
+  public static Pointer blobPointer(
+      String key, String blobUri, long version, ResourceId resourceId, String displayName) {
+    return asBlobPointer(
+            Pointer.newBuilder()
+                .setKey(blankToEmpty(key))
+                .setVersion(version)
+                .setResourceId(resourceId)
+                .setDisplayName(blankToEmpty(displayName)),
+            blobUri)
         .build();
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/ResourceSchema.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/ResourceSchema.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.repo.model;
 
+import ai.floedb.floecat.common.rpc.ResourceId;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -34,13 +35,19 @@ public final class ResourceSchema<T, K extends ResourceKey> {
 
   public final boolean casBlobs;
 
+  // Null for resources that don't participate in topology caching (snapshots, stats, …).
+  public final Function<T, ResourceId> resourceIdFromValue;
+  public final Function<T, String> displayNameFromValue;
+
   private ResourceSchema(
       String resourceName,
       Function<K, String> canonicalPointerForKey,
       Function<K, String> blobUriForKey,
       Function<T, Map<String, String>> secondaryPointersFromValue,
       Function<T, K> keyFromValue,
-      boolean casBlobs) {
+      boolean casBlobs,
+      Function<T, ResourceId> resourceIdFromValue,
+      Function<T, String> displayNameFromValue) {
     this.resourceName = Objects.requireNonNull(resourceName, "resourceName");
     this.canonicalPointerForKey =
         Objects.requireNonNull(canonicalPointerForKey, "canonicalPointerForKey");
@@ -49,6 +56,8 @@ public final class ResourceSchema<T, K extends ResourceKey> {
         Objects.requireNonNull(secondaryPointersFromValue, "secondaryPointersFromValue");
     this.keyFromValue = Objects.requireNonNull(keyFromValue, "keyFromValue");
     this.casBlobs = casBlobs;
+    this.resourceIdFromValue = resourceIdFromValue;
+    this.displayNameFromValue = displayNameFromValue;
   }
 
   public static <T, K extends ResourceKey> ResourceSchema<T, K> of(
@@ -63,7 +72,9 @@ public final class ResourceSchema<T, K extends ResourceKey> {
         blobUriForKey,
         secondaryPointersFromValue,
         keyFromValue,
-        false);
+        false,
+        null,
+        null);
   }
 
   public ResourceSchema<T, K> withCasBlobs() {
@@ -73,6 +84,21 @@ public final class ResourceSchema<T, K extends ResourceKey> {
         blobUriForKey,
         secondaryPointersFromValue,
         keyFromValue,
-        true);
+        true,
+        resourceIdFromValue,
+        displayNameFromValue);
+  }
+
+  public ResourceSchema<T, K> withPointerMeta(
+      Function<T, ResourceId> resourceId, Function<T, String> displayName) {
+    return new ResourceSchema<>(
+        resourceName,
+        canonicalPointerForKey,
+        blobUriForKey,
+        secondaryPointersFromValue,
+        keyFromValue,
+        casBlobs,
+        Objects.requireNonNull(resourceId, "resourceId"),
+        Objects.requireNonNull(displayName, "displayName"));
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Schemas.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Schemas.java
@@ -105,7 +105,8 @@ public final class Schemas {
                 return new NamespaceKey(
                     v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
               })
-          .withCasBlobs();
+          .withCasBlobs()
+          .withPointerMeta(Namespace::getResourceId, Namespace::getDisplayName);
 
   public static final ResourceSchema<Table, TableKey> TABLE =
       ResourceSchema.<Table, TableKey>of(
@@ -125,7 +126,8 @@ public final class Schemas {
                 return new TableKey(
                     v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
               })
-          .withCasBlobs();
+          .withCasBlobs()
+          .withPointerMeta(Table::getResourceId, Table::getDisplayName);
 
   public static final ResourceSchema<Snapshot, SnapshotKey> SNAPSHOT =
       ResourceSchema.<Snapshot, SnapshotKey>of(
@@ -301,7 +303,8 @@ public final class Schemas {
                 return new ViewKey(
                     v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
               })
-          .withCasBlobs();
+          .withCasBlobs()
+          .withPointerMeta(View::getResourceId, View::getDisplayName);
 
   public static final ResourceSchema<Connector, ConnectorKey> CONNECTOR =
       ResourceSchema.<Connector, ConnectorKey>of(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -280,6 +280,29 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
             + after.getVersion());
   }
 
+  /**
+   * Scans the pointer store by prefix and returns pointers without fetching blobs from S3. Used by
+   * topology-ref operations that only need (id, name, kind) — available from pointer metadata.
+   *
+   * <p>Loops through all DynamoDB pages; a single query returns at most ~1MB.
+   */
+  private static final int REFS_PAGE_SIZE = 1_000;
+
+  public List<Pointer> listRefsByPrefix(String prefix) {
+    List<Pointer> out = new ArrayList<>();
+    String token = "";
+    do {
+      var next = new StringBuilder();
+      out.addAll(pointerStore.listPointersByPrefix(prefix, REFS_PAGE_SIZE, token, next));
+      token = next.toString();
+    } while (!token.isBlank());
+    return out;
+  }
+
+  public Optional<Pointer> refByPointer(String key) {
+    return pointerStore.get(key);
+  }
+
   @Override
   public List<T> listByPrefix(String prefix, int limit, String token, StringBuilder nextOut) {
     var rows = pointerStore.listPointersByPrefix(prefix, Math.max(1, limit), token, nextOut);

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -102,7 +102,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
     List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size());
     for (String pointerKey : pointerKeys) {
-      ops.add(new PointerStore.CasUpsert(pointerKey, 0L, reserve(pointerKey, blobUri)));
+      ops.add(new PointerStore.CasUpsert(pointerKey, 0L, reserve(pointerKey, blobUri, value)));
     }
 
     if (pointerStore.compareAndSetBatch(ops)) {
@@ -194,7 +194,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
     List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size());
     for (String pointerKey : pointerKeys) {
-      ops.add(new PointerStore.CasUpsert(pointerKey, 0L, reserve(pointerKey, blobUri)));
+      ops.add(new PointerStore.CasUpsert(pointerKey, 0L, reserve(pointerKey, blobUri, value)));
     }
 
     if (pointerStore.compareAndSetBatch(ops)) {
@@ -248,7 +248,14 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
         "createIfAbsent conflict, no pointer present: " + canonicalPointer);
   }
 
-  private static Pointer reserve(String key, String blobUri) {
+  private Pointer reserve(String key, String blobUri, T value) {
+    if (schema.resourceIdFromValue != null && value != null) {
+      var rid = schema.resourceIdFromValue.apply(value);
+      var dn = schema.displayNameFromValue.apply(value);
+      if (rid != null && !rid.getId().isEmpty()) {
+        return PointerReferences.blobPointer(key, blobUri, 1L, rid, dn != null ? dn : "");
+      }
+    }
     return PointerReferences.blobPointer(key, blobUri, 1L);
   }
 
@@ -359,7 +366,9 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     batchedKeys.add(canonicalPointer);
     ops.add(
         new PointerStore.CasUpsert(
-            canonicalPointer, expectedCanonicalVersion, reserve(canonicalPointer, blobUri)));
+            canonicalPointer,
+            expectedCanonicalVersion,
+            reserve(canonicalPointer, blobUri, updatedValue)));
 
     for (String p : toAdd) {
       if (!batchedKeys.add(p)) {
@@ -367,7 +376,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       }
       Pointer existing = pointerStore.get(p).orElse(null);
       if (existing == null) {
-        ops.add(new PointerStore.CasUpsert(p, 0L, reserve(p, blobUri)));
+        ops.add(new PointerStore.CasUpsert(p, 0L, reserve(p, blobUri, updatedValue)));
       } else if (!blobUri.equals(existing.getBlobUri())) {
         // The new name already belongs to a different blob. Nothing has been committed, so failing
         // fast here leaves no partial state.
@@ -385,9 +394,11 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
         }
         Pointer existing = pointerStore.get(p).orElse(null);
         if (existing == null) {
-          ops.add(new PointerStore.CasUpsert(p, 0L, reserve(p, blobUri)));
+          ops.add(new PointerStore.CasUpsert(p, 0L, reserve(p, blobUri, updatedValue)));
         } else if (!blobUri.equals(existing.getBlobUri())) {
-          ops.add(new PointerStore.CasUpsert(p, existing.getVersion(), reserve(p, blobUri)));
+          ops.add(
+              new PointerStore.CasUpsert(
+                  p, existing.getVersion(), reserve(p, blobUri, updatedValue)));
         }
         // else: already on the new blob — no op needed.
       }

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/cache/CatalogTopologyCacheTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/cache/CatalogTopologyCacheTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.metagraph.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.scanner.spi.TopologyGraph.NamespaceRef;
+import ai.floedb.floecat.scanner.spi.TopologyGraph.RelationRef;
+import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.repo.impl.ViewRepository;
+import ai.floedb.floecat.telemetry.TestObservability;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CatalogTopologyCacheTest {
+
+  private NamespaceRepository namespaceRepository;
+  private TableRepository tableRepository;
+  private ViewRepository viewRepository;
+  private CatalogTopologyCache cache;
+
+  @BeforeEach
+  void setUp() {
+    namespaceRepository = mock(NamespaceRepository.class);
+    tableRepository = mock(TableRepository.class);
+    viewRepository = mock(ViewRepository.class);
+    cache =
+        new CatalogTopologyCache(
+            namespaceRepository,
+            tableRepository,
+            viewRepository,
+            new TestObservability(),
+            100,
+            100,
+            15);
+  }
+
+  @Test
+  void listNamespaceRefsByName_usesExactRepositoryLookupOnColdCache() {
+    ResourceId catalogId = rid("acct", "cat", ResourceKind.RK_CATALOG);
+    Set<String> names = Set.of("sales");
+    NamespaceRef ref = new NamespaceRef(rid("acct", "ns", ResourceKind.RK_NAMESPACE), "sales");
+    when(namespaceRepository.listRefsByName("acct", "cat", names)).thenReturn(List.of(ref));
+
+    List<NamespaceRef> refs = cache.listNamespaceRefsByName(catalogId, names);
+
+    assertThat(refs).containsExactly(ref);
+    verify(namespaceRepository).listRefsByName("acct", "cat", names);
+    verify(namespaceRepository, never()).listRefs("acct", "cat");
+  }
+
+  @Test
+  void listRelationRefsByName_usesExactRepositoryLookupOnColdCache() {
+    ResourceId catalogId = rid("acct", "cat", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("acct", "ns", ResourceKind.RK_NAMESPACE);
+    Set<String> names = Set.of("orders");
+    RelationRef ref =
+        new RelationRef(rid("acct", "tbl", ResourceKind.RK_TABLE), "orders", ResourceKind.RK_TABLE);
+    when(tableRepository.listRefsByName("acct", "cat", "ns", names)).thenReturn(List.of(ref));
+    when(viewRepository.listRefsByName("acct", "cat", "ns", names)).thenReturn(List.of());
+
+    List<RelationRef> refs = cache.listRelationRefsByName(catalogId, namespaceId, names);
+
+    assertThat(refs).containsExactly(ref);
+    verify(tableRepository).listRefsByName("acct", "cat", "ns", names);
+    verify(viewRepository).listRefsByName("acct", "cat", "ns", names);
+    verify(tableRepository, never()).listRefs("acct", "cat", "ns");
+    verify(viewRepository, never()).listRefs("acct", "cat", "ns");
+  }
+
+  private static ResourceId rid(String accountId, String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId(accountId).setId(id).setKind(kind).build();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -33,17 +33,21 @@ import ai.floedb.floecat.metagraph.model.EngineHint;
 import ai.floedb.floecat.metagraph.model.EngineHintKey;
 import ai.floedb.floecat.metagraph.model.GraphNodeKind;
 import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
+import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.RelationNode;
 import ai.floedb.floecat.metagraph.model.TableNode;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.query.rpc.SchemaDescriptor;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.context.EngineContextProvider;
+import ai.floedb.floecat.service.metagraph.cache.CatalogTopologyCache;
 import ai.floedb.floecat.service.metagraph.overlay.systemobjects.SystemGraph;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.metagraph.resolver.FullyQualifiedResolver;
+import ai.floedb.floecat.service.testsupport.TestNodes;
 import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
@@ -52,6 +56,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,6 +67,7 @@ class MetaGraphTest {
   UserGraph user;
   SystemGraph system;
   MetaGraph meta;
+  CatalogTopologyCache topologyCache;
   LogicalSchemaMapper schemaMapper;
   EngineContext context;
 
@@ -83,6 +89,7 @@ class MetaGraphTest {
   void setup() {
     user = mock(UserGraph.class);
     system = mock(SystemGraph.class);
+    topologyCache = mock(CatalogTopologyCache.class);
 
     schemaMapper =
         new LogicalSchemaMapper() {
@@ -97,7 +104,7 @@ class MetaGraphTest {
     when(engine.engineContext()).thenReturn(context);
     when(engine.isPresent()).thenReturn(true);
 
-    meta = new MetaGraph(user, schemaMapper, system, engine);
+    meta = new MetaGraph(user, schemaMapper, system, engine, topologyCache);
   }
 
   @AfterEach
@@ -180,55 +187,32 @@ class MetaGraphTest {
             return Map.of();
           }
         };
-    RelationNode u =
-        new RelationNode() {
-          @Override
-          public ResourceId id() {
-            return usrTable;
-          }
-
-          @Override
-          public ResourceId namespaceId() {
-            return ResourceId.getDefaultInstance();
-          }
-
-          @Override
-          public long version() {
-            return 1;
-          }
-
-          @Override
-          public String displayName() {
-            return "usr";
-          }
-
-          @Override
-          public Instant metadataUpdatedAt() {
-            return Instant.now();
-          }
-
-          @Override
-          public GraphNodeKind kind() {
-            return GraphNodeKind.TABLE;
-          }
-
-          @Override
-          public GraphNodeOrigin origin() {
-            return GraphNodeOrigin.USER;
-          }
-
-          @Override
-          public Map<EngineHintKey, EngineHint> engineHints() {
-            return Map.of();
-          }
-        };
+    UserTableNode u = TestNodes.tableNode(usrTable, "{}");
+    ResourceId catalogId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_CATALOG)
+            .setId("cat")
+            .build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("ns")
+            .build();
 
     when(system.listRelations(any(), same(context))).thenReturn(List.of(s));
-    when(user.listRelations(any())).thenReturn(List.of(u));
+    when(topologyCache.listNamespaceRefs(catalogId))
+        .thenReturn(
+            List.of(new TopologyGraph.NamespaceRef(namespaceId, "ns", catalogId, List.of())));
+    when(topologyCache.listRelationRefs(catalogId, namespaceId))
+        .thenReturn(List.of(new TopologyGraph.RelationRef(usrTable, "usr", ResourceKind.RK_TABLE)));
+    when(user.table(usrTable)).thenReturn(Optional.of(u));
 
-    List<RelationNode> out = meta.listRelations(ResourceId.newBuilder().setId("cat").build());
+    List<RelationNode> out = meta.listRelations(catalogId);
 
     assertThat(out).containsExactly(s, u);
+    verify(user, never()).listRelations(catalogId);
   }
 
   @Test
@@ -547,11 +531,84 @@ class MetaGraphTest {
   }
 
   @Test
+  void listNamespaceRefsByName_usesCacheByNameForUserNamespaces() {
+    ResourceId catalogId = ResourceId.newBuilder().setAccountId("acct").setId("cat").build();
+    ResourceId userNamespaceId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("user-ns")
+            .build();
+    ResourceId systemNamespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    NamespaceNode systemNamespace =
+        new NamespaceNode(
+            systemNamespaceId,
+            1,
+            Instant.EPOCH,
+            catalogId,
+            List.of("information_schema"),
+            "tables",
+            GraphNodeOrigin.SYSTEM,
+            Map.of(),
+            Map.of());
+    Set<String> names = Set.of("sales", "information_schema.tables");
+    when(system.listNamespaces(catalogId, context)).thenReturn(List.of(systemNamespace));
+    when(topologyCache.listNamespaceRefsByName(catalogId, names))
+        .thenReturn(
+            List.of(
+                new TopologyGraph.NamespaceRef(
+                    userNamespaceId, "sales", catalogId, List.of("sales"))));
+
+    List<TopologyGraph.NamespaceRef> refs = meta.listNamespaceRefsByName(catalogId, names);
+
+    assertThat(refs)
+        .extracting(TopologyGraph.NamespaceRef::id)
+        .containsExactly(systemNamespaceId, userNamespaceId);
+    verify(topologyCache).listNamespaceRefsByName(catalogId, names);
+    verify(topologyCache, never()).listNamespaceRefs(catalogId);
+  }
+
+  @Test
+  void listRelationRefsByName_usesCacheByNameForUserRelations() {
+    ResourceId catalogId = ResourceId.newBuilder().setAccountId("acct").setId("cat").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("ns")
+            .build();
+    ResourceId userRelationId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("orders")
+            .build();
+    Set<String> names = Set.of("orders");
+    when(system.listRelationsInNamespace(catalogId, namespaceId, context)).thenReturn(List.of());
+    when(topologyCache.listRelationRefsByName(catalogId, namespaceId, names))
+        .thenReturn(
+            List.of(
+                new TopologyGraph.RelationRef(userRelationId, "orders", ResourceKind.RK_TABLE)));
+
+    List<TopologyGraph.RelationRef> refs =
+        meta.listRelationRefsByName(catalogId, namespaceId, names);
+
+    assertThat(refs).extracting(TopologyGraph.RelationRef::id).containsExactly(userRelationId);
+    verify(topologyCache).listRelationRefsByName(catalogId, namespaceId, names);
+    verify(topologyCache, never()).listRelationRefs(catalogId, namespaceId);
+  }
+
+  @Test
   void engineAbsent_showsEmptySystemGraph() {
     EngineContextProvider engine = mock(EngineContextProvider.class);
     when(engine.isPresent()).thenReturn(false);
 
-    MetaGraph metaNoEngine = new MetaGraph(user, schemaMapper, system, engine);
+    MetaGraph metaNoEngine = new MetaGraph(user, schemaMapper, system, engine, topologyCache);
 
     NameRef ref = NameRef.newBuilder().setName("t").build();
     when(system.resolveTable(ref, EngineContext.empty())).thenReturn(Optional.empty());

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/resolver/NameResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/resolver/NameResolverTest.java
@@ -30,6 +30,9 @@ import ai.floedb.floecat.service.testsupport.UserRepositoryTestSupport.FakeCatal
 import ai.floedb.floecat.service.testsupport.UserRepositoryTestSupport.FakeNamespaceRepository;
 import ai.floedb.floecat.service.testsupport.UserRepositoryTestSupport.FakeTableRepository;
 import ai.floedb.floecat.service.testsupport.UserRepositoryTestSupport.FakeViewRepository;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -111,6 +114,76 @@ class NameResolverTest {
     NameRef ref = NameRef.newBuilder().setCatalog("cat").addPath("ns").setName("orders_v").build();
     assertThat(resolver.resolveViewId("corr", "account", ref))
         .hasValueSatisfying(r -> assertThat(r.getId()).isEqualTo("view"));
+  }
+
+  @Test
+  void listTableIdsCollectsAcrossNamespaces() {
+    ResourceId catalogId = rid("account", "cat", ResourceKind.RK_CATALOG);
+
+    ResourceId ns2Id = rid("account", "ns2", ResourceKind.RK_NAMESPACE);
+    namespaceRepository.put(
+        Namespace.newBuilder()
+            .setResourceId(ns2Id)
+            .setCatalogId(catalogId)
+            .setDisplayName("ns2")
+            .build());
+
+    ResourceId tbl2Id = rid("account", "tbl2", ResourceKind.RK_TABLE);
+    tableRepository.put(
+        Table.newBuilder()
+            .setResourceId(tbl2Id)
+            .setCatalogId(catalogId)
+            .setNamespaceId(ns2Id)
+            .setDisplayName("products")
+            .setSchemaJson("{}")
+            .build());
+
+    List<ResourceId> ids = resolver.listTableIds("account", "cat");
+    Set<String> idSet = ids.stream().map(ResourceId::getId).collect(Collectors.toSet());
+    assertThat(idSet).containsExactlyInAnyOrder("tbl", "tbl2");
+  }
+
+  @Test
+  void listViewIdsCollectsAcrossNamespaces() {
+    ResourceId catalogId = rid("account", "cat", ResourceKind.RK_CATALOG);
+
+    ResourceId ns2Id = rid("account", "ns2", ResourceKind.RK_NAMESPACE);
+    namespaceRepository.put(
+        Namespace.newBuilder()
+            .setResourceId(ns2Id)
+            .setCatalogId(catalogId)
+            .setDisplayName("ns2")
+            .build());
+
+    ResourceId view2Id = rid("account", "view2", ResourceKind.RK_VIEW);
+    viewRepository.put(
+        View.newBuilder()
+            .setResourceId(view2Id)
+            .setCatalogId(catalogId)
+            .setNamespaceId(ns2Id)
+            .setDisplayName("orders_v2")
+            .addSqlDefinitions(
+                ai.floedb.floecat.catalog.rpc.ViewSqlDefinition.newBuilder()
+                    .setSql("select 2")
+                    .build())
+            .build());
+
+    List<ResourceId> ids = resolver.listViewIds("account", "cat");
+    Set<String> idSet = ids.stream().map(ResourceId::getId).collect(Collectors.toSet());
+    assertThat(idSet).containsExactlyInAnyOrder("view", "view2");
+  }
+
+  @Test
+  void listTableIdsEmptyForUnknownCatalog() {
+    assertThat(resolver.listTableIds("account", "no-such-catalog")).isEmpty();
+  }
+
+  @Test
+  void listTableIdsSingleNamespaceSkipsParallelPath() {
+    // Verifies the single-namespace fast path returns the same result.
+    List<ResourceId> ids = resolver.listTableIds("account", "cat");
+    assertThat(ids).hasSize(1);
+    assertThat(ids.get(0).getId()).isEqualTo("tbl");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/query/system/SystemRowFilterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/system/SystemRowFilterTest.java
@@ -77,6 +77,28 @@ class SystemRowFilterTest {
   }
 
   @Test
+  void inPredicateMatchesAnyListedValue() {
+    var rows =
+        List.of(
+            new SystemObjectRow(new Object[] {"a", "b"}),
+            new SystemObjectRow(new Object[] {"c", "d"}),
+            new SystemObjectRow(new Object[] {"x", "y"}));
+
+    Predicate predicate =
+        Predicate.newBuilder()
+            .setColumn("col_a")
+            .setOp(Operator.OP_IN)
+            .addValues("a")
+            .addValues("c")
+            .build();
+
+    var result = SystemRowFilter.applyPredicates(rows, SCHEMA, List.of(predicate));
+
+    assertThat(result).hasSize(2);
+    assertThat(result).extracting(row -> row.values()[0]).containsExactly("a", "c");
+  }
+
+  @Test
   void isNullPredicateMatchesNullValue() {
     var rows =
         List.of(

--- a/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.repo.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class KeysTest {
@@ -45,6 +46,17 @@ class KeysTest {
     assertEquals("a%2Bb", Keys.encodeSegment("a+b"));
     assertEquals("a%2Fb", Keys.encodeSegment("a/b"));
     assertEquals("a%25b", Keys.encodeSegment("a%b"));
+  }
+
+  @Test
+  void namespaceByPathKeyRoundTripsFullPathSegments() {
+    String key =
+        Keys.namespacePointerByPath(
+            "acct id", "cat/id", List.of("finance", "sales/emea", "a+b", "a%b"));
+
+    assertEquals(
+        List.of("finance", "sales/emea", "a+b", "a%b"),
+        Keys.extractNamespacePathSegments("acct id", "cat/id", key));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/UserRepositoryTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/UserRepositoryTestSupport.java
@@ -108,6 +108,17 @@ public final class UserRepositoryTestSupport {
     }
 
     @Override
+    public List<ResourceId> listIds(String accountId, String catalogId) {
+      return entries.values().stream()
+          .filter(
+              ns ->
+                  accountId.equals(ns.getResourceId().getAccountId())
+                      && catalogId.equals(ns.getCatalogId().getId()))
+          .map(Namespace::getResourceId)
+          .toList();
+    }
+
+    @Override
     public MutationMeta metaForSafe(ResourceId id) {
       throw new StorageNotFoundException("unused");
     }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -17,6 +17,8 @@ package ai.floedb.floecat.storage.kv.dynamodb.ps;
 
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.PointerReferenceKind;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.storage.kv.AbstractEntity;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.KvStore.Key;
@@ -58,6 +60,9 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
   static final String GLOBAL_PK = "_ACCOUNT_DIR";
   static final String ATTR_BLOB_URI = "blob_uri";
   static final String ATTR_REFERENCE_KIND = "reference_kind";
+  static final String ATTR_RESOURCE_ID = "rid";
+  static final String ATTR_RESOURCE_KIND = "rk";
+  static final String ATTR_DISPLAY_NAME = "dn";
 
   @Inject
   public PointerStoreEntity(@KvTable("floecat") KvStore kv) {
@@ -147,6 +152,27 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
     if (expiresAtStr != null) {
       long ts = Long.parseLong(expiresAtStr);
       builder.setExpiresAt(Timestamps.fromMillis(ts * 1000L));
+    }
+    String rid = r.attrs().get(ATTR_RESOURCE_ID);
+    String rkStr = r.attrs().get(ATTR_RESOURCE_KIND);
+    if (rid != null && rkStr != null) {
+      try {
+        String pk = r.key().partitionKey();
+        String accountId = pk.startsWith("accounts/") ? pk.substring("accounts/".length()) : "";
+        if (!accountId.isEmpty()) {
+          builder.setResourceId(
+              ResourceId.newBuilder()
+                  .setAccountId(accountId)
+                  .setId(rid)
+                  .setKind(ResourceKind.valueOf(rkStr))
+                  .build());
+        }
+      } catch (IllegalArgumentException ignored) {
+      }
+    }
+    String dn = r.attrs().get(ATTR_DISPLAY_NAME);
+    if (dn != null && !dn.isEmpty()) {
+      builder.setDisplayName(dn);
     }
 
     return builder.buildPartial();
@@ -247,6 +273,13 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
         && pointer.getReferenceKind() != null
         && pointer.getReferenceKind() != PointerReferenceKind.PRK_UNSPECIFIED) {
       attrs.put(ATTR_REFERENCE_KIND, pointer.getReferenceKind().name());
+    }
+    if (pointer.hasResourceId() && !pointer.getResourceId().getId().isEmpty()) {
+      attrs.put(ATTR_RESOURCE_ID, pointer.getResourceId().getId());
+      attrs.put(ATTR_RESOURCE_KIND, pointer.getResourceId().getKind().name());
+    }
+    if (!pointer.getDisplayName().isEmpty()) {
+      attrs.put(ATTR_DISPLAY_NAME, pointer.getDisplayName());
     }
     return attrs;
   }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -269,9 +269,7 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
   private static HashMap<String, String> attrsFor(Pointer pointer) {
     var attrs = new HashMap<String, String>();
     attrs.put(ATTR_BLOB_URI, pointer.getBlobUri());
-    if (pointer != null
-        && pointer.getReferenceKind() != null
-        && pointer.getReferenceKind() != PointerReferenceKind.PRK_UNSPECIFIED) {
+    if (pointer.getReferenceKind() != PointerReferenceKind.PRK_UNSPECIFIED) {
       attrs.put(ATTR_REFERENCE_KIND, pointer.getReferenceKind().name());
     }
     if (pointer.hasResourceId() && !pointer.getResourceId().getId().isEmpty()) {


### PR DESCRIPTION
## Summary

- add lightweight catalog namespace/relation ref APIs to Floescan’s `CatalogOverlay`
- expose pointer-backed namespace/table/view ref listings and cache them in `MetaGraph`
- use scan predicate constraints to prune `information_schema` namespace/table enumeration for row and Arrow scans

## Details
- avoids full table/view object materialization for enum-heavy `information_schema.tables` paths
- makes existing `MetaGraph.listNamespaces`, `listRelations`, and `listRelationsInNamespace` enumerate via cached refs before hydrating
- supports direct by-name ref lookups for `table_schema` / `schema_name` and `table_name` predicates
- keeps dotted schema-name handling conservative by falling back to rendered-ref filtering for correctness

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

