### PR TITLE
Fix: Storage auth scoping for iceberg

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
@@ -118,8 +118,8 @@ abstract class DeltaConnector implements FloecatConnector {
       ResourceId destinationTableId,
       FloecatConnector.SnapshotEnumerationOptions options) {
 
-    final String tableRoot = storageLocation(namespaceFq, tableName);
-    final Table table = loadTable(tableRoot);
+    final String storageLocation = storageLocation(namespaceFq, tableName);
+    final Table table = loadTable(storageLocation);
     boolean fullRescan = options == null || options.fullRescan();
     Set<Long> knownSnapshotIds = options == null ? Set.of() : options.knownSnapshotIds();
     Set<Long> targetSnapshotIds = options == null ? Set.of() : options.targetSnapshotIds();
@@ -150,7 +150,7 @@ abstract class DeltaConnector implements FloecatConnector {
       SnapshotLoadResult snapshotResult =
           version == latestVersion
               ? SnapshotLoadResult.snapshot(latestSnapshot)
-              : loadSnapshotAsOfVersion(table, version, tableRoot, earliestAvailableVersion);
+              : loadSnapshotAsOfVersion(table, version, storageLocation, earliestAvailableVersion);
       if (snapshotResult.earliestAvailableVersion() > earliestAvailableVersion) {
         earliestAvailableVersion = snapshotResult.earliestAvailableVersion();
       }
@@ -158,7 +158,7 @@ abstract class DeltaConnector implements FloecatConnector {
       if (snapshot == null) {
         continue;
       }
-      bundles.add(buildSnapshotBundle(tableRoot, version, snapshot));
+      bundles.add(buildSnapshotBundle(storageLocation, version, snapshot));
     }
     return List.copyOf(bundles);
   }
@@ -213,14 +213,14 @@ abstract class DeltaConnector implements FloecatConnector {
     if (snapshotId < 0) {
       return List.of();
     }
-    final String tableRoot = storageLocation(namespaceFq, tableName);
-    final Table table = loadTable(tableRoot);
+    final String storageLocation = storageLocation(namespaceFq, tableName);
+    final Table table = loadTable(storageLocation);
     Snapshot snapshot = table.getSnapshotAsOfVersion(engine, snapshotId);
     if (snapshot == null) {
       return List.of();
     }
     return buildTargetStats(
-        tableRoot,
+        storageLocation,
         destinationTableId,
         includeColumns,
         columnSelectorPolicy,
@@ -251,8 +251,8 @@ abstract class DeltaConnector implements FloecatConnector {
       return Optional.of(DirectSnapshotStatsCapture.of(List.of(), 0));
     }
 
-    final String tableRoot = storageLocation(namespaceFq, tableName);
-    final Table table = loadTable(tableRoot);
+    final String storageLocation = storageLocation(namespaceFq, tableName);
+    final Table table = loadTable(storageLocation);
     Snapshot snapshot = table.getSnapshotAsOfVersion(engine, snapshotId);
     if (snapshot == null) {
       return Optional.empty();
@@ -268,7 +268,7 @@ abstract class DeltaConnector implements FloecatConnector {
         new DeltaPlanner(
             this.engine,
             this.parquetInput,
-            tableRoot,
+            storageLocation,
             snapshotId,
             includeNames,
             Set.of(),
@@ -327,7 +327,7 @@ abstract class DeltaConnector implements FloecatConnector {
     return Optional.of(
         DirectSnapshotStatsCapture.of(
             buildTargetStats(
-                tableRoot,
+                storageLocation,
                 destinationTableId,
                 includeColumns,
                 columnSelectorPolicy,
@@ -375,15 +375,15 @@ abstract class DeltaConnector implements FloecatConnector {
     if (snapshotId < 0 || plannedFilePaths == null || plannedFilePaths.isEmpty()) {
       return FileGroupCaptureResult.empty();
     }
-    final String tableRoot = storageLocation(namespaceFq, tableName);
-    final Table table = loadTable(tableRoot);
+    final String storageLocation = storageLocation(namespaceFq, tableName);
+    final Table table = loadTable(storageLocation);
     Snapshot snapshot = table.getSnapshotAsOfVersion(engine, snapshotId);
     if (snapshot == null) {
       return FileGroupCaptureResult.empty();
     }
     List<TargetStatsRecord> stats =
         buildTargetStats(
-            tableRoot,
+            storageLocation,
             destinationTableId,
             includeColumns,
             columnSelectorPolicy,
@@ -406,8 +406,8 @@ abstract class DeltaConnector implements FloecatConnector {
     if (snapshotId < 0) {
       return Optional.empty();
     }
-    final String tableRoot = storageLocation(namespaceFq, tableName);
-    final Table table = loadTable(tableRoot);
+    final String storageLocation = storageLocation(namespaceFq, tableName);
+    final Table table = loadTable(storageLocation);
     Snapshot snapshot = table.getSnapshotAsOfVersion(engine, snapshotId);
     if (snapshot == null) {
       return Optional.empty();
@@ -417,7 +417,7 @@ abstract class DeltaConnector implements FloecatConnector {
         new DeltaPlanner(
             engine,
             parquetInput,
-            tableRoot,
+            storageLocation,
             snapshotId,
             Set.of(),
             Set.of(),
@@ -485,8 +485,8 @@ abstract class DeltaConnector implements FloecatConnector {
         planned.sequenceNumber());
   }
 
-  protected Table loadTable(String tableRoot) {
-    return Table.forPath(engine, tableRoot);
+  protected Table loadTable(String storageLocation) {
+    return Table.forPath(engine, storageLocation);
   }
 
   private static Map<String, String> requestedColumnTypes(
@@ -505,27 +505,27 @@ abstract class DeltaConnector implements FloecatConnector {
     return typed;
   }
 
-  protected String describeTableSchemaJson(String tableRoot) {
-    Table table = loadTable(tableRoot);
+  protected String describeTableSchemaJson(String storageLocation) {
+    Table table = loadTable(storageLocation);
     Snapshot snapshot = table.getLatestSnapshot(engine);
     if (snapshot == null) {
-      throw new IllegalStateException("Delta table has no latest snapshot at " + tableRoot);
+      throw new IllegalStateException("Delta table has no latest snapshot at " + storageLocation);
     }
     return snapshotSchemaJson(snapshot);
   }
 
   protected TableDescriptor describeFromDelta(
-      String tableRoot, String namespaceFq, String tableName) {
+      String storageLocation, String namespaceFq, String tableName) {
     try {
       Map<String, String> props = new LinkedHashMap<>();
       props.put("data_source_format", "DELTA");
-      props.put("storage_location", tableRoot);
+      props.put("storage_location", storageLocation);
 
       return new TableDescriptor(
           namespaceFq,
           tableName,
-          tableRoot,
-          describeTableSchemaJson(tableRoot),
+          storageLocation,
+          describeTableSchemaJson(storageLocation),
           List.of(),
           ColumnIdAlgorithm.CID_PATH_ORDINAL,
           props);
@@ -542,7 +542,7 @@ abstract class DeltaConnector implements FloecatConnector {
       List<DeletionVectorDescriptor> deletionVectors) {}
 
   protected EngineOut runEngine(
-      String tableRoot,
+      String storageLocation,
       long version,
       Set<String> includeNames,
       Set<String> plannedFilePaths,
@@ -566,7 +566,7 @@ abstract class DeltaConnector implements FloecatConnector {
         new DeltaPlanner(
             this.engine,
             this.parquetInput,
-            tableRoot,
+            storageLocation,
             version,
             includeNames,
             plannedFilePaths,
@@ -637,7 +637,7 @@ abstract class DeltaConnector implements FloecatConnector {
   }
 
   private SnapshotLoadResult loadSnapshotAsOfVersion(
-      Table table, long version, String tableRoot, long currentEarliestAvailableVersion) {
+      Table table, long version, String storageLocation, long currentEarliestAvailableVersion) {
     try {
       return SnapshotLoadResult.snapshot(table.getSnapshotAsOfVersion(engine, version));
     } catch (KernelException e) {
@@ -645,7 +645,7 @@ abstract class DeltaConnector implements FloecatConnector {
       if (earliest.present() && version < earliest.value()) {
         LOG.debugf(
             "Skipping Delta snapshot version %d for %s because retained history starts at %d",
-            Long.valueOf(version), tableRoot, Long.valueOf(earliest.value()));
+            Long.valueOf(version), storageLocation, Long.valueOf(earliest.value()));
         return SnapshotLoadResult.skipUntil(earliest.value());
       }
       if (version < currentEarliestAvailableVersion) {
@@ -742,7 +742,8 @@ abstract class DeltaConnector implements FloecatConnector {
     return List.copyOf(out);
   }
 
-  private SnapshotBundle buildSnapshotBundle(String tableRoot, long version, Snapshot snapshot) {
+  private SnapshotBundle buildSnapshotBundle(
+      String storageLocation, long version, Snapshot snapshot) {
     final long createdMs = snapshot.getTimestamp(engine);
     final long parent = Math.max(0L, version - 1L);
 
@@ -754,7 +755,7 @@ abstract class DeltaConnector implements FloecatConnector {
   }
 
   private List<TargetStatsRecord> buildTargetStats(
-      String tableRoot,
+      String storageLocation,
       ResourceId destinationTableId,
       Set<String> includeColumns,
       ColumnSelectorPolicy columnSelectorPolicy,
@@ -763,7 +764,7 @@ abstract class DeltaConnector implements FloecatConnector {
       Set<StatsTargetKind> includeTargetKinds,
       Set<String> plannedFilePaths) {
     return buildTargetStats(
-        tableRoot,
+        storageLocation,
         destinationTableId,
         includeColumns,
         columnSelectorPolicy,
@@ -775,7 +776,7 @@ abstract class DeltaConnector implements FloecatConnector {
   }
 
   private List<TargetStatsRecord> buildTargetStats(
-      String tableRoot,
+      String storageLocation,
       ResourceId destinationTableId,
       Set<String> includeColumns,
       ColumnSelectorPolicy columnSelectorPolicy,
@@ -800,7 +801,12 @@ abstract class DeltaConnector implements FloecatConnector {
 
     EngineOut engineOut =
         runEngine(
-            tableRoot, version, includeNames, plannedFilePaths, nameToType, allowFooterFallback);
+            storageLocation,
+            version,
+            includeNames,
+            plannedFilePaths,
+            nameToType,
+            allowFooterFallback);
     if (engineOut.hasInlineDeletionVectors()) {
       throw new UnsupportedOperationException(
           "Delta table uses inline deletion vectors; not supported for snapshot " + version);

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorFactory.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorFactory.java
@@ -61,8 +61,8 @@ final class DeltaConnectorFactory {
     Map<String, String> effectiveAuthProps = authProps == null ? Map.of() : authProps;
 
     DeltaSource source = selectSource(effectiveOptions);
-    String tableRoot = effectiveOptions.getOrDefault("delta.table-root", "");
-    validateOptions(source, tableRoot);
+    String storageLocation = effectiveOptions.getOrDefault("delta.table-root", "");
+    validateOptions(source, storageLocation);
 
     EngineContext engineContext = buildEngine(effectiveOptions);
     boolean ndvEnabled =
@@ -89,7 +89,7 @@ final class DeltaConnectorFactory {
       case FILESYSTEM -> {
         String namespaceFq = effectiveOptions.getOrDefault("external.namespace", "");
         String tableName =
-            effectiveOptions.getOrDefault("external.table-name", deriveTableName(tableRoot));
+            effectiveOptions.getOrDefault("external.table-name", deriveTableName(storageLocation));
         yield new DeltaFilesystemConnector(
             "delta-filesystem",
             engineContext.engine(),
@@ -97,7 +97,7 @@ final class DeltaConnectorFactory {
             ndvEnabled,
             ndvSampleFraction,
             ndvMaxFiles,
-            tableRoot,
+            storageLocation,
             namespaceFq,
             tableName);
       }
@@ -151,8 +151,8 @@ final class DeltaConnectorFactory {
     return DeltaSource.UNITY;
   }
 
-  static void validateOptions(DeltaSource source, String tableRoot) {
-    boolean hasTableRoot = tableRoot != null && !tableRoot.isBlank();
+  static void validateOptions(DeltaSource source, String storageLocation) {
+    boolean hasTableRoot = storageLocation != null && !storageLocation.isBlank();
     if (source == DeltaSource.FILESYSTEM && !hasTableRoot) {
       throw new IllegalArgumentException(
           "delta.table-root is required for delta.source=filesystem");
@@ -243,12 +243,14 @@ final class DeltaConnectorFactory {
     return defaultValue;
   }
 
-  private static String deriveTableName(String tableRoot) {
-    if (tableRoot == null || tableRoot.isBlank()) {
+  private static String deriveTableName(String storageLocation) {
+    if (storageLocation == null || storageLocation.isBlank()) {
       return "";
     }
     String trimmed =
-        tableRoot.endsWith("/") ? tableRoot.substring(0, tableRoot.length() - 1) : tableRoot;
+        storageLocation.endsWith("/")
+            ? storageLocation.substring(0, storageLocation.length() - 1)
+            : storageLocation;
     int slash = trimmed.lastIndexOf('/');
     if (slash < 0 || slash == trimmed.length() - 1) {
       return trimmed;

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaFilesystemConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaFilesystemConnector.java
@@ -26,7 +26,7 @@ final class DeltaFilesystemConnector extends DeltaConnector {
 
   private final String namespaceFq;
   private final String tableName;
-  private final String tableRoot;
+  private final String storageLocation;
 
   DeltaFilesystemConnector(
       String connectorId,
@@ -35,11 +35,11 @@ final class DeltaFilesystemConnector extends DeltaConnector {
       boolean ndvEnabled,
       double ndvSampleFraction,
       long ndvMaxFiles,
-      String tableRoot,
+      String storageLocation,
       String namespaceFq,
       String tableName) {
     super(connectorId, engine, parquetInput, ndvEnabled, ndvSampleFraction, ndvMaxFiles);
-    this.tableRoot = tableRoot;
+    this.storageLocation = storageLocation;
     this.namespaceFq = namespaceFq == null ? "" : namespaceFq;
     this.tableName = tableName == null ? "" : tableName;
   }
@@ -64,12 +64,12 @@ final class DeltaFilesystemConnector extends DeltaConnector {
   public TableDescriptor describe(String namespaceFq, String tableName) {
     String effectiveNs = this.namespaceFq.isBlank() ? namespaceFq : this.namespaceFq;
     String effectiveTable = this.tableName.isBlank() ? tableName : this.tableName;
-    return describeFromDelta(tableRoot, effectiveNs, effectiveTable);
+    return describeFromDelta(storageLocation, effectiveNs, effectiveTable);
   }
 
   @Override
   protected String storageLocation(String namespaceFq, String tableName) {
-    return tableRoot;
+    return storageLocation;
   }
 
   /**

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaPlanner.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaPlanner.java
@@ -96,7 +96,7 @@ final class DeltaPlanner implements Planner<String> {
   private final boolean allowFooterFallback;
   private final Engine engine;
   private final Snapshot snapshot;
-  private final String tableRoot;
+  private final String storageLocation;
   private final List<DeletionVectorDescriptor> diskDeletionVectors = new ArrayList<>();
   private final List<String> missingLogStatsSamplePaths = new ArrayList<>();
   private final List<String> checkpointStructRecoverySamplePaths = new ArrayList<>();
@@ -113,7 +113,7 @@ final class DeltaPlanner implements Planner<String> {
   DeltaPlanner(
       Engine engine,
       Function<String, InputFile> parquetInput,
-      String tableRoot,
+      String storageLocation,
       long version,
       Set<String> includeColumns,
       Set<String> plannedFilePaths,
@@ -124,13 +124,13 @@ final class DeltaPlanner implements Planner<String> {
     this.engine = engine;
     this.ndvProvider = ndvProvider;
     this.allowFooterFallback = allowFooterFallback;
-    this.tableRoot = Objects.requireNonNull(tableRoot);
+    this.storageLocation = Objects.requireNonNull(storageLocation);
     this.plannedFilePaths =
         plannedFilePaths == null || plannedFilePaths.isEmpty()
             ? Collections.emptySet()
             : Collections.unmodifiableSet(new LinkedHashSet<>(plannedFilePaths));
 
-    final Table table = Table.forPath(engine, Objects.requireNonNull(tableRoot));
+    final Table table = Table.forPath(engine, Objects.requireNonNull(storageLocation));
     final Snapshot snapshot = table.getSnapshotAsOfVersion(engine, version);
     this.snapshot = snapshot;
 
@@ -435,7 +435,7 @@ final class DeltaPlanner implements Planner<String> {
             if (pathOrdinal < 0 || addRow.isNullAt(pathOrdinal)) {
               continue;
             }
-            String resolvedPath = absoluteDataPath(tableRoot, addRow.getString(pathOrdinal));
+            String resolvedPath = absoluteDataPath(storageLocation, addRow.getString(pathOrdinal));
             if (!plannedFilePaths.isEmpty() && !plannedFilePaths.contains(resolvedPath)) {
               continue;
             }
@@ -514,7 +514,7 @@ final class DeltaPlanner implements Planner<String> {
     return projected;
   }
 
-  static String absoluteDataPath(String tableRoot, String addPath) {
+  static String absoluteDataPath(String storageLocation, String addPath) {
     if (addPath == null || addPath.isBlank()) {
       return addPath;
     }
@@ -522,7 +522,7 @@ final class DeltaPlanner implements Planner<String> {
     if (candidate.isAbsolute()) {
       return candidate.toString();
     }
-    return new Path(new Path(tableRoot), candidate).toString();
+    return new Path(new Path(storageLocation), candidate).toString();
   }
 
   private static Map<Column, Literal> readLiteralStruct(

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
@@ -429,7 +429,7 @@ class DeltaConnectorTest {
     }
 
     @Override
-    protected Table loadTable(String tableRoot) {
+    protected Table loadTable(String storageLocation) {
       return table;
     }
 
@@ -483,7 +483,7 @@ class DeltaConnectorTest {
     }
 
     @Override
-    protected Table loadTable(String tableRoot) {
+    protected Table loadTable(String storageLocation) {
       return table;
     }
 

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
@@ -549,7 +549,7 @@ public interface FloecatConnector extends Closeable {
   record TableDescriptor(
       String namespaceFq,
       String tableName,
-      String location,
+      String storageLocation,
       String schemaJson,
       List<String> partitionKeys,
       ColumnIdAlgorithm columnIdAlgorithm,

--- a/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcilerBackend.java
+++ b/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcilerBackend.java
@@ -289,6 +289,7 @@ public interface ReconcilerBackend {
   record TableSpecDescriptor(
       String namespaceFq,
       String displayName,
+      String storageLocation,
       String schemaJson,
       Map<String, String> properties,
       List<String> partitionKeys,

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -1436,7 +1436,17 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
   }
 
   private Map<String, String> safeProperties(TableSpecDescriptor descriptor) {
-    return descriptor.properties() != null ? descriptor.properties() : Map.of();
+    Map<String, String> source =
+        descriptor.properties() != null ? descriptor.properties() : Map.of();
+    String storageLocation = descriptor.storageLocation();
+    if (storageLocation == null
+        || storageLocation.isBlank()
+        || source.containsKey("storage_location")) {
+      return source;
+    }
+    LinkedHashMap<String, String> merged = new LinkedHashMap<>(source);
+    merged.put("storage_location", storageLocation);
+    return Map.copyOf(merged);
   }
 
   private UpstreamRef buildUpstream(TableSpecDescriptor descriptor) {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
@@ -1202,6 +1202,7 @@ class QueuedReconcileWorkerSupport {
     return new TableSpecDescriptor(
         landingView.namespaceFq(),
         landingView.tableName(),
+        landingView.storageLocation(),
         landingView.schemaJson(),
         landingView.properties(),
         landingView.partitionKeys(),
@@ -1450,7 +1451,7 @@ class QueuedReconcileWorkerSupport {
     return new FloecatConnector.TableDescriptor(
         destNamespace != null ? destNamespace : upstream.namespaceFq(),
         destTable != null ? destTable : upstream.tableName(),
-        upstream.location(),
+        upstream.storageLocation(),
         upstream.schemaJson(),
         upstream.partitionKeys(),
         upstream.columnIdAlgorithm(),

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackendTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
 import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
 import ai.floedb.floecat.catalog.rpc.ConstraintType;
+import ai.floedb.floecat.catalog.rpc.CreateTableRequest;
 import ai.floedb.floecat.catalog.rpc.CreateTableResponse;
 import ai.floedb.floecat.catalog.rpc.FileContent;
 import ai.floedb.floecat.catalog.rpc.FileStatsTarget;
@@ -84,8 +85,93 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class GrpcReconcilerBackendTest {
+  @Test
+  void ensureTablePersistsStorageLocationFromDescriptorWhenMissingFromProperties() {
+    GrpcReconcilerBackend backend =
+        new GrpcReconcilerBackend(
+            Optional.<String>empty(), Optional.<String>empty(), Optional.<Duration>empty());
+    backend.directory =
+        mock(ai.floedb.floecat.catalog.rpc.DirectoryServiceGrpc.DirectoryServiceBlockingStub.class);
+    backend.namespace =
+        mock(ai.floedb.floecat.catalog.rpc.NamespaceServiceGrpc.NamespaceServiceBlockingStub.class);
+    backend.table =
+        mock(ai.floedb.floecat.catalog.rpc.TableServiceGrpc.TableServiceBlockingStub.class);
+    when(backend.directory.withInterceptors(any())).thenReturn(backend.directory);
+    when(backend.namespace.withInterceptors(any())).thenReturn(backend.namespace);
+    when(backend.table.withInterceptors(any())).thenReturn(backend.table);
+
+    ResourceId catalogId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_CATALOG)
+            .setId("cat")
+            .build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("ns")
+            .build();
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("tbl")
+            .build();
+
+    when(backend.directory.lookupTableByRef(any()))
+        .thenReturn(LookupTableByRefResponse.getDefaultInstance());
+    when(backend.namespace.getNamespace(any()))
+        .thenReturn(
+            GetNamespaceResponse.newBuilder()
+                .setNamespace(
+                    ai.floedb.floecat.catalog.rpc.Namespace.newBuilder()
+                        .setResourceId(namespaceId)
+                        .setCatalogId(catalogId)
+                        .build())
+                .build());
+    when(backend.table.createTable(any()))
+        .thenReturn(
+            CreateTableResponse.newBuilder()
+                .setTable(Table.newBuilder().setResourceId(tableId).build())
+                .build());
+
+    TableSpecDescriptor descriptor =
+        new TableSpecDescriptor(
+            "main.sales",
+            "orders",
+            "s3://warehouse/main.db/orders",
+            "{\"type\":\"struct\",\"fields\":[]}",
+            Map.of("write.parquet.compression-codec", "zstd"),
+            List.of(),
+            ColumnIdAlgorithm.CID_FIELD_ID,
+            ConnectorFormat.CF_ICEBERG,
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setKind(ResourceKind.RK_CONNECTOR)
+                .setId("conn")
+                .build(),
+            "https://glue.us-east-1.amazonaws.com/iceberg/",
+            "main.sales",
+            "orders");
+
+    backend.ensureTable(
+        reconcileContext(),
+        namespaceId,
+        NameRef.newBuilder().setCatalog("main").addPath("sales").setName("orders").build(),
+        descriptor);
+
+    ArgumentCaptor<CreateTableRequest> requestCaptor =
+        ArgumentCaptor.forClass(CreateTableRequest.class);
+    verify(backend.table).createTable(requestCaptor.capture());
+    assertThat(requestCaptor.getValue().getSpec().getPropertiesMap())
+        .containsEntry("storage_location", "s3://warehouse/main.db/orders")
+        .containsEntry("write.parquet.compression-codec", "zstd");
+  }
+
   @Test
   void withBearerPrefixLeavesExistingBearer() {
     String token = GrpcReconcilerBackend.withBearerPrefix("Bearer abc123");
@@ -391,6 +477,7 @@ class GrpcReconcilerBackendTest {
             new ReconcilerBackend.TableSpecDescriptor(
                 "cat.ns",
                 "tbl",
+                "",
                 "{\"type\":\"struct\",\"fields\":[]}",
                 Map.of(),
                 List.of(),
@@ -856,6 +943,7 @@ class GrpcReconcilerBackendTest {
             new TableSpecDescriptor(
                 "main",
                 "orders",
+                "",
                 "{}",
                 Map.of("reconciled", "true"),
                 List.of(),

--- a/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
@@ -415,8 +415,7 @@ public class ScanBundleService {
 
     String metadataLocation = SnapshotRepository.metadataLocation(snapshot);
     Map<String, String> tableProperties =
-        fileIoPropertiesResolver.applyToTableProperties(
-            table, metadataLocation, table.getPropertiesMap());
+        fileIoPropertiesResolver.applyToTableProperties(table, null, table.getPropertiesMap());
     if (deltaTable
         && rawSchemaJson != null
         && !rawSchemaJson.isBlank()

--- a/service/src/test/java/ai/floedb/floecat/service/execution/impl/ScanBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/execution/impl/ScanBundleServiceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.execution.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.catalog.rpc.Table;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
+import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.storage.impl.ServerSideFileIoPropertiesResolver;
+import ai.floedb.floecat.stats.spi.StatsStore;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ScanBundleServiceTest {
+
+  @Test
+  void initScanUsesTableLocationForFileIoPropertiesWhileKeepingMetadataLocation() {
+    var tableRepo = mock(TableRepository.class);
+    var snapshotRepo = mock(SnapshotRepository.class);
+    var statsStore = mock(StatsStore.class);
+    var resolver = mock(ServerSideFileIoPropertiesResolver.class);
+
+    var tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("tbl")
+            .build();
+    var table =
+        Table.newBuilder()
+            .setResourceId(tableId)
+            .setSchemaJson("{\"type\":\"struct\",\"fields\":[]}")
+            .putProperties("storage_location", "s3://bucket/table")
+            .putProperties("current-snapshot-id", "42")
+            .build();
+    var snapshot =
+        Snapshot.newBuilder()
+            .setTableId(tableId)
+            .setSnapshotId(42L)
+            .setSchemaJson("{\"type\":\"struct\",\"fields\":[]}")
+            .setMetadataLocation("s3://bucket/table/metadata/00001.metadata.json")
+            .build();
+
+    when(tableRepo.getById(tableId)).thenReturn(Optional.of(table));
+    when(snapshotRepo.getById(tableId, 42L)).thenReturn(Optional.of(snapshot));
+    when(resolver.applyToTableProperties(table, null, table.getPropertiesMap()))
+        .thenReturn(Map.of("s3.region", "us-east-1"));
+
+    var service = new ScanBundleService(tableRepo, snapshotRepo, statsStore, resolver);
+
+    var init = service.initScan("corr", tableId, 42L);
+
+    verify(resolver).applyToTableProperties(table, null, table.getPropertiesMap());
+    assertEquals(
+        "s3://bucket/table/metadata/00001.metadata.json", init.tableInfo().getMetadataLocation());
+    assertEquals("us-east-1", init.tableInfo().getPropertiesMap().get("s3.region"));
+    assertFalse(init.tableInfo().getPropertiesMap().containsKey("metadata-location"));
+  }
+}


### PR DESCRIPTION
## Summary

Storage authorities for Iceberg constrain vended credentials to only allow access to metadata.json, not the table root.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Include any follow-ups, risks, or reviewer guidance.
