### PR TITLE
information_schema: hack fix for allowing bad JSON parse result

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScanner.java
@@ -104,6 +104,7 @@ public final class ColumnsScanner implements SystemObjectScanner {
 
   private static final Schema ARROW_SCHEMA = ArrowSchemaUtil.toArrowSchema(SCHEMA);
   private static final int ARROW_BATCH_SIZE = 512;
+  private static final String SCHEMA_ERROR_COLUMN_NAME = "__schema_error__";
 
   @Override
   public Stream<SystemObjectRow> scan(SystemObjectScanContext ctx) {
@@ -234,9 +235,22 @@ public final class ColumnsScanner implements SystemObjectScanner {
 
     String schemaName = namespace.schemaName();
 
-    List<SchemaColumn> columns = ctx.graph().tableSchema(table.id());
-
     if (table instanceof UserTableNode) {
+      List<SchemaColumn> columns;
+      try {
+        columns = ctx.graph().tableSchema(table.id());
+      } catch (RuntimeException e) {
+        return Stream.of(
+            new SystemObjectRow(
+                new Object[] {
+                  catalogName,
+                  schemaName,
+                  table.displayName(),
+                  SCHEMA_ERROR_COLUMN_NAME,
+                  schemaErrorDataType(e),
+                  0
+                }));
+      }
       return columns.stream()
           .sorted(Comparator.comparingInt(SchemaColumn::getFieldId))
           .map(
@@ -253,6 +267,7 @@ public final class ColumnsScanner implements SystemObjectScanner {
     }
 
     // System tables (no field ids) – preserve declared order
+    List<SchemaColumn> columns = ctx.graph().tableSchema(table.id());
     List<SystemObjectRow> rows = new ArrayList<>(columns.size());
     int ordinal = 1;
     for (SchemaColumn col : columns) {
@@ -305,6 +320,14 @@ public final class ColumnsScanner implements SystemObjectScanner {
     return value == null || value.isBlank() ? null : value;
   }
 
+  private static String schemaErrorDataType(RuntimeException e) {
+    String message = e.getMessage();
+    if (message == null || message.isBlank()) {
+      message = e.getClass().getSimpleName();
+    }
+    return "ERROR: " + message;
+  }
+
   private List<ColumnEntry> columnsForRelation(
       SystemObjectScanContext ctx,
       NamespaceEntry namespace,
@@ -316,8 +339,20 @@ public final class ColumnsScanner implements SystemObjectScanner {
     String schemaName = namespace.schemaName();
 
     if (node instanceof TableNode table) {
-      List<SchemaColumn> columns = ctx.graph().tableSchema(table.id());
       if (table instanceof UserTableNode) {
+        List<SchemaColumn> columns;
+        try {
+          columns = ctx.graph().tableSchema(table.id());
+        } catch (RuntimeException e) {
+          return List.of(
+              ColumnEntry.of(
+                  catalogName,
+                  schemaName,
+                  table.displayName(),
+                  SCHEMA_ERROR_COLUMN_NAME,
+                  schemaErrorDataType(e),
+                  0));
+        }
         return columns.stream()
             .sorted(Comparator.comparingInt(SchemaColumn::getFieldId))
             .map(
@@ -331,6 +366,7 @@ public final class ColumnsScanner implements SystemObjectScanner {
                         col.getFieldId()))
             .toList();
       }
+      List<SchemaColumn> columns = ctx.graph().tableSchema(table.id());
       List<ColumnEntry> entries = new ArrayList<>(columns.size());
       int ordinal = 1;
       for (SchemaColumn col : columns) {

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScannerTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScannerTest.java
@@ -25,11 +25,13 @@ import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
+import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanContext;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
 import ai.floedb.floecat.systemcatalog.utilities.TestTableScanContextBuilder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -196,6 +198,24 @@ class ColumnsScannerTest {
   }
 
   @Test
+  void scan_reportsUserTablesWithBrokenSchemas() {
+    SystemObjectScanContext ctx = contextWithBrokenTableBeforeGoodTable();
+
+    var rows = new ColumnsScanner().scan(ctx).map(r -> Arrays.asList(r.values())).toList();
+
+    assertThat(rows)
+        .containsExactly(
+            List.of(
+                "marketing",
+                "finance.sales",
+                "bad_orders",
+                "__schema_error__",
+                "ERROR: Failed to parse Delta schema JSON",
+                0),
+            List.of("marketing", "finance.sales", "good_orders", "id", "long", 1));
+  }
+
+  @Test
   void scanArrow_matchesRowPath() {
     var builder = TestTableScanContextBuilder.builder("marketing");
     var ns = builder.addNamespace("finance.sales");
@@ -251,6 +271,36 @@ class ColumnsScannerTest {
     }
   }
 
+  @Test
+  void scanArrow_reportsUserTablesWithBrokenSchemas() {
+    SystemObjectScanContext ctx = contextWithBrokenTableBeforeGoodTable();
+
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      List<List<String>> arrowRows =
+          new ColumnsScanner()
+              .scanArrow(ctx, null, List.of(), allocator)
+              .map(
+                  batch -> {
+                    try (batch) {
+                      return toRows(batch.root());
+                    }
+                  })
+              .flatMap(List::stream)
+              .toList();
+
+      assertThat(arrowRows)
+          .containsExactly(
+              List.of(
+                  "marketing",
+                  "finance.sales",
+                  "bad_orders",
+                  "__schema_error__",
+                  "ERROR: Failed to parse Delta schema JSON",
+                  "0"),
+              List.of("marketing", "finance.sales", "good_orders", "id", "long", "1"));
+    }
+  }
+
   private static List<List<String>> toRows(VectorSchemaRoot root) {
     int rowCount = root.getRowCount();
     List<FieldVector> vectors = root.getFieldVectors();
@@ -291,10 +341,94 @@ class ColumnsScannerTest {
     return ResourceId.newBuilder().setAccountId("account").setId(id).setKind(kind).build();
   }
 
+  private static SystemObjectScanContext contextWithBrokenTableBeforeGoodTable() {
+    ResourceId catalogId = rid("marketing", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("finance.sales", ResourceKind.RK_NAMESPACE);
+    ResourceId brokenTableId = rid("bad_orders", ResourceKind.RK_TABLE);
+    ResourceId goodTableId = rid("good_orders", ResourceKind.RK_TABLE);
+    var overlay = new BrokenSchemaOverlay(brokenTableId);
+
+    overlay.addNode(
+        new CatalogNode(
+            catalogId,
+            1,
+            Instant.EPOCH,
+            "marketing",
+            Map.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of()));
+    overlay.addNode(
+        new NamespaceNode(
+            namespaceId,
+            1,
+            Instant.EPOCH,
+            catalogId,
+            List.of("finance"),
+            "sales",
+            GraphNodeOrigin.USER,
+            Map.of(),
+            Map.of()));
+    overlay.addRelation(
+        namespaceId, userTable(catalogId, namespaceId, brokenTableId, "bad_orders"));
+    overlay.addRelation(namespaceId, userTable(catalogId, namespaceId, goodTableId, "good_orders"));
+    overlay.setTableSchema(
+        goodTableId,
+        List.of(
+            SchemaColumn.newBuilder()
+                .setName("id")
+                .setLogicalType("long")
+                .setFieldId(1)
+                .setNullable(false)
+                .build()));
+
+    return new SystemObjectScanContext(
+        overlay, NameRef.getDefaultInstance(), catalogId, EngineContext.empty());
+  }
+
+  private static UserTableNode userTable(
+      ResourceId catalogId, ResourceId namespaceId, ResourceId tableId, String name) {
+    return new UserTableNode(
+        tableId,
+        1,
+        Instant.EPOCH,
+        catalogId,
+        namespaceId,
+        name,
+        TableFormat.TF_DELTA,
+        ColumnIdAlgorithm.CID_FIELD_ID,
+        "",
+        Map.of(),
+        List.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        List.of(),
+        Map.of(),
+        Map.of());
+  }
+
   private static final class NamespaceListingFailsOverlay extends TestRefCatalogOverlay {
     @Override
     public List<NamespaceNode> listNamespaces(ResourceId catalogId) {
       throw new AssertionError("ref scan should not materialize namespaces");
+    }
+  }
+
+  private static final class BrokenSchemaOverlay extends TestCatalogOverlay {
+    private final ResourceId brokenTableId;
+
+    private BrokenSchemaOverlay(ResourceId brokenTableId) {
+      this.brokenTableId = brokenTableId;
+    }
+
+    @Override
+    public List<SchemaColumn> tableSchema(ResourceId tableId) {
+      if (brokenTableId.equals(tableId)) {
+        throw new IllegalArgumentException("Failed to parse Delta schema JSON");
+      }
+      return super.tableSchema(tableId);
     }
   }
 }


### PR DESCRIPTION
## Summary

There be demons.  Some of the delta catalog in prod/staging is resulting in JSON parse errors.  Instead of failing whole query for information_schema.columns, instead mark a bad row in result data so we can research/fix by observing results.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Will need a more comprehensive decision on how to handle this.