### PR TITLE
reconcile: surface connector and table planning failure causes

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnector.java
@@ -191,7 +191,11 @@ public final class UnityDeltaConnector extends DeltaConnector {
       out.sort((a, b) -> a.name().compareTo(b.name()));
       return out;
     } catch (Exception e) {
-      throw new RuntimeException("listViewDescriptors failed", e);
+      // Include the namespace and underlying cause; a bare "listViewDescriptors
+      // failed" hides the real error (e.g. a UC API auth/HTTP failure) and makes
+      // connector-planning failures undiagnosable.
+      throw new RuntimeException(
+          "listViewDescriptors failed for namespace=" + namespaceFq + ": " + e, e);
     }
   }
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutor.java
@@ -30,9 +30,14 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class RemoteDefaultReconcileExecutor implements ReconcileExecutor {
+  // Surfaces table-planning execution failures, which were previously not logged
+  // anywhere (a failing job would silently requeue and retry).
+  private static final Logger LOG = Logger.getLogger(RemoteDefaultReconcileExecutor.class);
+
   private final ReconcilerService reconcilerService;
   private final QueuedReconcileWorkerSupport queuedWorkerSupport;
   private final RemotePlannerWorkerClient workerClient;
@@ -122,6 +127,14 @@ public class RemoteDefaultReconcileExecutor implements ReconcileExecutor {
       return result;
     }
     if (result.error != null) {
+      LOG.warnf(
+          result.error,
+          "PLAN_TABLE execution failed jobId=%s connectorId=%s failureKind=%s retryDisposition=%s message=%s",
+          lease.jobId,
+          connectorId,
+          result.failureKind,
+          result.retryDisposition,
+          result.message);
       workerClient.submitPlanTableFailure(
           remoteLease,
           result.failureKind,


### PR DESCRIPTION
## Summary

- Log table planning execution failures at the source; a failing plan job previously requeued and retried with no recorded reason.
- Include the namespace and underlying cause when listing a connector's views fails, so connector planning errors such as an upstream catalog auth or HTTP failure are diagnosable instead of opaque.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Could not see why reconcilers were failing in floe prod.  They stalled out for days and these debug patches indicated why (stale credential).
