### PR TITLE
storage/aws: refresh clients after closed pools

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
@@ -67,43 +67,50 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
    */
   public Uni<InitScanResponse> initScan(InitScanRequest request) {
     var L = LogHelper.start(LOG, "InitScan");
-    return run(() -> {
-          String correlationId = principal.get().getCorrelationId();
-          authz.require(principal.get(), "catalog.read");
-          String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-          if (!request.hasTableId()) {
-            throw GrpcErrors.invalidArgument(
-                correlationId, QUERY_TABLE_ID_REQUIRED, Map.of("query_id", queryId));
-          }
-          var ctx =
-              queryStore
-                  .get(queryId)
-                  .orElseThrow(
-                      () ->
-                          GrpcErrors.notFound(
-                              correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId)));
-          ResourceId tableId = request.getTableId();
-          var pin = ctx.requireSnapshotPin(tableId, correlationId);
-          var initData = scanBundles.initScan(correlationId, tableId, pin.getSnapshotId());
-          var session =
-              ScanSession.builder()
-                  .queryId(queryId)
-                  .tableId(tableId)
-                  .snapshotId(initData.snapshotId())
-                  .tableInfo(initData.tableInfo())
-                  .includeColumnStats(request.getIncludeColumnStats())
-                  .excludePartitionDataJson(request.getExcludePartitionDataJson())
-                  .targetBatchItems(capped(request.getTargetBatchItems(), defaultBatchItems))
-                  .targetBatchBytes(capped(request.getTargetBatchBytes(), defaultBatchBytes))
-                  .requiredColumns(request.getRequiredColumnsList())
-                  .predicates(request.getPredicatesList())
-                  .build();
-          ScanHandle handle = queryStore.createScanSession(correlationId, session);
-          return InitScanResponse.newBuilder()
-              .setHandle(handle)
-              .setTableInfo(initData.tableInfo())
-              .build();
-        })
+    var init =
+        runWithRetry(
+                () -> {
+                  String correlationId = principal.get().getCorrelationId();
+                  authz.require(principal.get(), "catalog.read");
+                  String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+                  if (!request.hasTableId()) {
+                    throw GrpcErrors.invalidArgument(
+                        correlationId, QUERY_TABLE_ID_REQUIRED, Map.of("query_id", queryId));
+                  }
+                  var ctx =
+                      queryStore
+                          .get(queryId)
+                          .orElseThrow(
+                              () ->
+                                  GrpcErrors.notFound(
+                                      correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId)));
+                  ResourceId tableId = request.getTableId();
+                  var pin = ctx.requireSnapshotPin(tableId, correlationId);
+                  var initData = scanBundles.initScan(correlationId, tableId, pin.getSnapshotId());
+                  var session =
+                      ScanSession.builder()
+                          .queryId(queryId)
+                          .tableId(tableId)
+                          .snapshotId(initData.snapshotId())
+                          .tableInfo(initData.tableInfo())
+                          .includeColumnStats(request.getIncludeColumnStats())
+                          .excludePartitionDataJson(request.getExcludePartitionDataJson())
+                          .targetBatchItems(
+                              capped(request.getTargetBatchItems(), defaultBatchItems))
+                          .targetBatchBytes(
+                              capped(request.getTargetBatchBytes(), defaultBatchBytes))
+                          .requiredColumns(request.getRequiredColumnsList())
+                          .predicates(request.getPredicatesList())
+                          .build();
+                  ScanHandle handle = queryStore.createScanSession(correlationId, session);
+                  return InitScanResponse.newBuilder()
+                      .setHandle(handle)
+                      .setTableInfo(initData.tableInfo())
+                      .build();
+                })
+            .onFailure()
+            .invoke(t -> logInitScanFailure(request, t));
+    return mapFailures(init, correlationId())
         .onFailure()
         .invoke(L::fail)
         .onItem()
@@ -132,6 +139,8 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
                           .invoke(e -> markPlanningFailed(session, correlationId))
                           .onFailure()
                           .invoke(e -> queryStore.removeScanSession(handle))
+                          .onFailure()
+                          .transform(e -> toStatus(e, correlationId))
                           .onCompletion()
                           .invoke(L::ok);
                     }))
@@ -161,6 +170,8 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
                           .invoke(e -> markPlanningFailed(session, correlationId))
                           .onFailure()
                           .invoke(e -> queryStore.removeScanSession(handle))
+                          .onFailure()
+                          .transform(e -> toStatus(e, correlationId))
                           .onCompletion()
                           .invoke(
                               () -> {
@@ -182,14 +193,17 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
    */
   public Uni<Empty> closeScan(ScanHandle handle) {
     var L = LogHelper.start(LOG, "CloseScan");
-    return run(() -> {
-          String correlationId = principal.get().getCorrelationId();
-          queryStore
-              .getScanSession(handle)
-              .ifPresent(session -> markPlanningCompleted(session, correlationId));
-          queryStore.removeScanSession(handle);
-          return Empty.newBuilder().build();
-        })
+    return mapFailures(
+            run(
+                () -> {
+                  String correlationId = principal.get().getCorrelationId();
+                  queryStore
+                      .getScanSession(handle)
+                      .ifPresent(session -> markPlanningCompleted(session, correlationId));
+                  queryStore.removeScanSession(handle);
+                  return Empty.newBuilder().build();
+                }),
+            correlationId())
         .onFailure()
         .invoke(L::fail)
         .onItem()
@@ -202,6 +216,31 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
         .orElseThrow(
             () ->
                 GrpcErrors.notFound(correlationId, SCAN_HANDLE, Map.of("handle", handle.getId())));
+  }
+
+  private void logInitScanFailure(InitScanRequest request, Throwable failure) {
+    String tableAccountId = "-";
+    String tableKind = "-";
+    String tableId = "-";
+    if (request != null && request.hasTableId()) {
+      ResourceId resourceId = request.getTableId();
+      tableAccountId = logValue(resourceId.getAccountId());
+      tableKind = logValue(resourceId.getKind().name());
+      tableId = logValue(resourceId.getId());
+    }
+    LOG.errorf(
+        failure,
+        "InitScan failed before gRPC error mapping query_id=%s table_account_id=%s table_kind=%s"
+            + " table_id=%s correlation_id=%s",
+        logValue(request == null ? "" : request.getQueryId()),
+        tableAccountId,
+        tableKind,
+        tableId,
+        logValue(correlationId()));
+  }
+
+  private static String logValue(String value) {
+    return value == null || value.isBlank() ? "-" : value;
   }
 
   private void markPlanningFailed(ScanSession session, String correlationId) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
@@ -69,47 +69,43 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
     var L = LogHelper.start(LOG, "InitScan");
     var init =
         runWithRetry(
-                () -> {
-                  String correlationId = principal.get().getCorrelationId();
-                  authz.require(principal.get(), "catalog.read");
-                  String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-                  if (!request.hasTableId()) {
-                    throw GrpcErrors.invalidArgument(
-                        correlationId, QUERY_TABLE_ID_REQUIRED, Map.of("query_id", queryId));
-                  }
-                  var ctx =
-                      queryStore
-                          .get(queryId)
-                          .orElseThrow(
-                              () ->
-                                  GrpcErrors.notFound(
-                                      correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId)));
-                  ResourceId tableId = request.getTableId();
-                  var pin = ctx.requireSnapshotPin(tableId, correlationId);
-                  var initData = scanBundles.initScan(correlationId, tableId, pin.getSnapshotId());
-                  var session =
-                      ScanSession.builder()
-                          .queryId(queryId)
-                          .tableId(tableId)
-                          .snapshotId(initData.snapshotId())
-                          .tableInfo(initData.tableInfo())
-                          .includeColumnStats(request.getIncludeColumnStats())
-                          .excludePartitionDataJson(request.getExcludePartitionDataJson())
-                          .targetBatchItems(
-                              capped(request.getTargetBatchItems(), defaultBatchItems))
-                          .targetBatchBytes(
-                              capped(request.getTargetBatchBytes(), defaultBatchBytes))
-                          .requiredColumns(request.getRequiredColumnsList())
-                          .predicates(request.getPredicatesList())
-                          .build();
-                  ScanHandle handle = queryStore.createScanSession(correlationId, session);
-                  return InitScanResponse.newBuilder()
-                      .setHandle(handle)
-                      .setTableInfo(initData.tableInfo())
+            () -> {
+              String correlationId = principal.get().getCorrelationId();
+              authz.require(principal.get(), "catalog.read");
+              String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+              if (!request.hasTableId()) {
+                throw GrpcErrors.invalidArgument(
+                    correlationId, QUERY_TABLE_ID_REQUIRED, Map.of("query_id", queryId));
+              }
+              var ctx =
+                  queryStore
+                      .get(queryId)
+                      .orElseThrow(
+                          () ->
+                              GrpcErrors.notFound(
+                                  correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId)));
+              ResourceId tableId = request.getTableId();
+              var pin = ctx.requireSnapshotPin(tableId, correlationId);
+              var initData = scanBundles.initScan(correlationId, tableId, pin.getSnapshotId());
+              var session =
+                  ScanSession.builder()
+                      .queryId(queryId)
+                      .tableId(tableId)
+                      .snapshotId(initData.snapshotId())
+                      .tableInfo(initData.tableInfo())
+                      .includeColumnStats(request.getIncludeColumnStats())
+                      .excludePartitionDataJson(request.getExcludePartitionDataJson())
+                      .targetBatchItems(capped(request.getTargetBatchItems(), defaultBatchItems))
+                      .targetBatchBytes(capped(request.getTargetBatchBytes(), defaultBatchBytes))
+                      .requiredColumns(request.getRequiredColumnsList())
+                      .predicates(request.getPredicatesList())
                       .build();
-                })
-            .onFailure()
-            .invoke(t -> logInitScanFailure(request, t));
+              ScanHandle handle = queryStore.createScanSession(correlationId, session);
+              return InitScanResponse.newBuilder()
+                  .setHandle(handle)
+                  .setTableInfo(initData.tableInfo())
+                  .build();
+            });
     return mapFailures(init, correlationId())
         .onFailure()
         .invoke(L::fail)
@@ -216,31 +212,6 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
         .orElseThrow(
             () ->
                 GrpcErrors.notFound(correlationId, SCAN_HANDLE, Map.of("handle", handle.getId())));
-  }
-
-  private void logInitScanFailure(InitScanRequest request, Throwable failure) {
-    String tableAccountId = "-";
-    String tableKind = "-";
-    String tableId = "-";
-    if (request != null && request.hasTableId()) {
-      ResourceId resourceId = request.getTableId();
-      tableAccountId = logValue(resourceId.getAccountId());
-      tableKind = logValue(resourceId.getKind().name());
-      tableId = logValue(resourceId.getId());
-    }
-    LOG.errorf(
-        failure,
-        "InitScan failed before gRPC error mapping query_id=%s table_account_id=%s table_kind=%s"
-            + " table_id=%s correlation_id=%s",
-        logValue(request == null ? "" : request.getQueryId()),
-        tableAccountId,
-        tableKind,
-        tableId,
-        logValue(correlationId()));
-  }
-
-  private static String logValue(String value) {
-    return value == null || value.isBlank() ? "-" : value;
   }
 
   private void markPlanningFailed(ScanSession session, String correlationId) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/AwsClients.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/AwsClients.java
@@ -86,6 +86,10 @@ public class AwsClients {
   @Produces
   @Singleton
   public DynamoDbAsyncClient dynamoDbAsyncClient() {
+    return newDynamoDbAsyncClient();
+  }
+
+  public DynamoDbAsyncClient newDynamoDbAsyncClient() {
     var builder =
         DynamoDbAsyncClient.builder()
             .region(region)
@@ -98,6 +102,10 @@ public class AwsClients {
   @Produces
   @Singleton
   S3Client s3Client() {
+    return newS3Client();
+  }
+
+  public S3Client newS3Client() {
     var s3Cfg = S3Configuration.builder().pathStyleAccessEnabled(forcePathStyle).build();
     var builder =
         S3Client.builder()

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/ClosedAwsClientDetector.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/ClosedAwsClientDetector.java
@@ -14,14 +14,23 @@
  * limitations under the License.
  */
 
-package ai.floedb.floecat.storage.errors;
+package ai.floedb.floecat.storage.aws;
 
-public final class StorageAbortRetryableException extends StorageException {
-  public StorageAbortRetryableException(String message) {
-    super(message);
-  }
+public final class ClosedAwsClientDetector {
 
-  public StorageAbortRetryableException(String message, Throwable cause) {
-    super(message, cause);
+  static final String CONNECTION_POOL_SHUT_DOWN = "Connection pool shut down";
+
+  private ClosedAwsClientDetector() {}
+
+  public static boolean isConnectionPoolShutdown(Throwable failure) {
+    Throwable current = failure;
+    while (current != null) {
+      String message = current.getMessage();
+      if (message != null && message.contains(CONNECTION_POOL_SHUT_DOWN)) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/DynamoDbAsyncClientManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/DynamoDbAsyncClientManager.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.storage.aws;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jboss.logging.Logger;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+
+@ApplicationScoped
+public class DynamoDbAsyncClientManager {
+
+  private static final Logger LOG = Logger.getLogger(DynamoDbAsyncClientManager.class);
+
+  @Inject AwsClients awsClients;
+
+  private final AtomicReference<DynamoDbAsyncClient> current = new AtomicReference<>();
+
+  public DynamoDbAsyncClient current() {
+    DynamoDbAsyncClient existing = current.get();
+    if (existing != null) {
+      return existing;
+    }
+
+    DynamoDbAsyncClient next = awsClients.newDynamoDbAsyncClient();
+    if (current.compareAndSet(null, next)) {
+      return next;
+    }
+
+    next.close();
+    return current.get();
+  }
+
+  public void refreshAfterFailure(Throwable failure) {
+    if (!ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
+      return;
+    }
+
+    DynamoDbAsyncClient previous = current.get();
+    DynamoDbAsyncClient next = awsClients.newDynamoDbAsyncClient();
+    if (current.compareAndSet(previous, next)) {
+      closeQuietly(previous);
+      LOG.warn("Refreshed DynamoDB async client after closed connection pool");
+    } else {
+      next.close();
+    }
+  }
+
+  @PreDestroy
+  void close() {
+    closeQuietly(current.getAndSet(null));
+  }
+
+  private static void closeQuietly(DynamoDbAsyncClient client) {
+    if (client == null) {
+      return;
+    }
+    try {
+      client.close();
+    } catch (RuntimeException ignored) {
+    }
+  }
+}

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/S3ClientManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/S3ClientManager.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.storage.aws;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jboss.logging.Logger;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@ApplicationScoped
+public class S3ClientManager {
+
+  private static final Logger LOG = Logger.getLogger(S3ClientManager.class);
+
+  @Inject AwsClients awsClients;
+
+  private final AtomicReference<S3Client> current = new AtomicReference<>();
+
+  public S3Client current() {
+    S3Client existing = current.get();
+    if (existing != null) {
+      return existing;
+    }
+
+    S3Client next = awsClients.newS3Client();
+    if (current.compareAndSet(null, next)) {
+      return next;
+    }
+
+    next.close();
+    return current.get();
+  }
+
+  public void refreshAfterFailure(Throwable failure) {
+    if (!ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
+      return;
+    }
+
+    S3Client previous = current.get();
+    S3Client next = awsClients.newS3Client();
+    if (current.compareAndSet(previous, next)) {
+      closeQuietly(previous);
+      LOG.warn("Refreshed S3 client after closed connection pool");
+    } else {
+      next.close();
+    }
+  }
+
+  @PreDestroy
+  void close() {
+    closeQuietly(current.getAndSet(null));
+  }
+
+  private static void closeQuietly(S3Client client) {
+    if (client == null) {
+      return;
+    }
+    try {
+      client.close();
+    } catch (RuntimeException ignored) {
+    }
+  }
+}

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/s3/S3BlobStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/s3/S3BlobStore.java
@@ -17,6 +17,8 @@
 package ai.floedb.floecat.storage.aws.s3;
 
 import ai.floedb.floecat.common.rpc.BlobHeader;
+import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
+import ai.floedb.floecat.storage.aws.S3ClientManager;
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
 import ai.floedb.floecat.storage.errors.StorageConflictException;
 import ai.floedb.floecat.storage.errors.StorageCorruptionException;
@@ -33,6 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -55,13 +59,26 @@ public class S3BlobStore implements BlobStore {
   private static final String META_SHA256 = "floecat-sha256";
   private static final String META_CREATED_AT = "floecat-created-at";
 
-  private final S3Client s3;
+  private final Supplier<S3Client> s3;
+  private final Consumer<Throwable> clientFailureHandler;
   private final String bucket;
 
   @Inject
   public S3BlobStore(
+      S3ClientManager s3ClientManager,
+      @ConfigProperty(name = "floecat.blob.s3.bucket") Optional<String> bucketOpt) {
+    this(s3ClientManager::current, bucketOpt, s3ClientManager::refreshAfterFailure);
+  }
+
+  public S3BlobStore(
       S3Client s3, @ConfigProperty(name = "floecat.blob.s3.bucket") Optional<String> bucketOpt) {
+    this(() -> s3, bucketOpt, failure -> {});
+  }
+
+  S3BlobStore(
+      Supplier<S3Client> s3, Optional<String> bucketOpt, Consumer<Throwable> clientFailureHandler) {
     this.s3 = s3;
+    this.clientFailureHandler = clientFailureHandler;
     this.bucket = bucketOpt.orElseGet(() -> System.getProperty("floecat.blob.s3.bucket", ""));
     if (this.bucket.isBlank()) {
       throw new IllegalStateException("S3 bucket not configured: floecat.blob.s3.bucket");
@@ -73,7 +90,7 @@ public class S3BlobStore implements BlobStore {
     final String k = normalize(key);
     try {
       HeadObjectResponse r =
-          s3.headObject(HeadObjectRequest.builder().bucket(bucket).key(k).build());
+          s3().headObject(HeadObjectRequest.builder().bucket(bucket).key(k).build());
 
       String metaSha = (r.metadata() != null) ? r.metadata().get(META_SHA256) : null;
 
@@ -106,7 +123,10 @@ public class S3BlobStore implements BlobStore {
 
       throw mapAndWrap("HEAD", k, e);
     } catch (SdkClientException e) {
+      clientFailureHandler.accept(e);
       throw new StorageAbortRetryableException(msg("HEAD", k, e.getMessage()));
+    } catch (RuntimeException e) {
+      throw mapClosedPoolOrRethrow("HEAD", k, e);
     }
   }
 
@@ -114,7 +134,7 @@ public class S3BlobStore implements BlobStore {
   public byte[] get(String key) {
     final String k = normalize(key);
     try {
-      return s3.getObject(
+      return s3().getObject(
               GetObjectRequest.builder().bucket(bucket).key(k).build(),
               ResponseTransformer.toBytes())
           .asByteArray();
@@ -124,7 +144,10 @@ public class S3BlobStore implements BlobStore {
       }
       throw mapAndWrap("GET", k, e);
     } catch (SdkClientException e) {
+      clientFailureHandler.accept(e);
       throw new StorageAbortRetryableException(msg("GET", k, e.getMessage()));
+    } catch (RuntimeException e) {
+      throw mapClosedPoolOrRethrow("GET", k, e);
     }
   }
 
@@ -135,7 +158,7 @@ public class S3BlobStore implements BlobStore {
       Long createdAtMs = null;
       try {
         HeadObjectResponse prev =
-            s3.headObject(HeadObjectRequest.builder().bucket(bucket).key(k).build());
+            s3().headObject(HeadObjectRequest.builder().bucket(bucket).key(k).build());
         createdAtMs =
             Optional.ofNullable(prev.metadata().get(META_CREATED_AT))
                 .map(Long::parseLong)
@@ -161,11 +184,14 @@ public class S3BlobStore implements BlobStore {
       PutObjectRequest req =
           PutObjectRequest.builder().bucket(bucket).key(k).contentType(ct).metadata(meta).build();
 
-      s3.putObject(req, RequestBody.fromBytes(bytes));
+      s3().putObject(req, RequestBody.fromBytes(bytes));
     } catch (S3Exception e) {
       throw mapAndWrap("PUT", k, e);
     } catch (SdkClientException e) {
+      clientFailureHandler.accept(e);
       throw new StorageAbortRetryableException(msg("PUT", k, e.getMessage()));
+    } catch (RuntimeException e) {
+      throw mapClosedPoolOrRethrow("PUT", k, e);
     }
   }
 
@@ -202,7 +228,7 @@ public class S3BlobStore implements BlobStore {
         b = b.continuationToken(pageToken);
       }
 
-      ListObjectsV2Response resp = s3.listObjectsV2(b.build());
+      ListObjectsV2Response resp = s3().listObjectsV2(b.build());
 
       var keys = resp.contents().stream().map(o -> o.key()).toList();
 
@@ -216,7 +242,10 @@ public class S3BlobStore implements BlobStore {
       }
       throw mapAndWrap("LIST", p, e);
     } catch (SdkClientException e) {
+      clientFailureHandler.accept(e);
       throw new StorageAbortRetryableException(msg("LIST", p, e.getMessage()));
+    } catch (RuntimeException e) {
+      throw mapClosedPoolOrRethrow("LIST", p, e);
     }
   }
 
@@ -224,7 +253,7 @@ public class S3BlobStore implements BlobStore {
   public boolean delete(String key) {
     final String k = normalize(key);
     try {
-      s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(k).build());
+      s3().deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(k).build());
       return true;
     } catch (S3Exception e) {
       if (e.statusCode() == 404) {
@@ -232,7 +261,10 @@ public class S3BlobStore implements BlobStore {
       }
       throw mapAndWrap("DELETE", k, e);
     } catch (SdkClientException e) {
+      clientFailureHandler.accept(e);
       throw new StorageAbortRetryableException(msg("DELETE", k, e.getMessage()));
+    } catch (RuntimeException e) {
+      throw mapClosedPoolOrRethrow("DELETE", k, e);
     }
   }
 
@@ -251,7 +283,7 @@ public class S3BlobStore implements BlobStore {
                 .continuationToken(ct)
                 .build();
 
-        var resp = s3.listObjectsV2(req);
+        var resp = s3().listObjectsV2(req);
 
         if (!resp.contents().isEmpty()) {
           var objs = resp.contents();
@@ -259,7 +291,7 @@ public class S3BlobStore implements BlobStore {
             var slice = objs.subList(i, Math.min(i + 1000, objs.size()));
             var dels =
                 slice.stream().map(o -> ObjectIdentifier.builder().key(o.key()).build()).toList();
-            s3.deleteObjects(b -> b.bucket(bucket).delete(d -> d.objects(dels)));
+            s3().deleteObjects(b -> b.bucket(bucket).delete(d -> d.objects(dels)));
           }
         }
 
@@ -269,7 +301,7 @@ public class S3BlobStore implements BlobStore {
 
       if (p.endsWith("/")) {
         try {
-          s3.deleteObject(b -> b.bucket(bucket).key(p));
+          s3().deleteObject(b -> b.bucket(bucket).key(p));
         } catch (Throwable ignore) {
         }
       }
@@ -277,8 +309,24 @@ public class S3BlobStore implements BlobStore {
     } catch (S3Exception e) {
       throw mapAndWrap("DELETE_PREFIX", p, e);
     } catch (SdkClientException e) {
+      clientFailureHandler.accept(e);
       throw new StorageAbortRetryableException(msg("DELETE_PREFIX", p, e.getMessage()));
+    } catch (RuntimeException e) {
+      throw mapClosedPoolOrRethrow("DELETE_PREFIX", p, e);
     }
+  }
+
+  private S3Client s3() {
+    return s3.get();
+  }
+
+  private StorageAbortRetryableException mapClosedPoolOrRethrow(
+      String operation, String key, RuntimeException failure) {
+    if (!ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
+      throw failure;
+    }
+    clientFailureHandler.accept(failure);
+    return new StorageAbortRetryableException(msg(operation, key, failure.getMessage()), failure);
   }
 
   private static String normalize(String key) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -29,18 +29,27 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
 public final class DynamoDbKvStore implements KvStore, KvAttributes {
   static final int DELETE_BATCH_LIMIT = Integer.getInteger("floedb.floecat.delete.batch.size", 25);
-  private final DynamoDbAsyncClient ddb;
+  private final Supplier<DynamoDbAsyncClient> ddb;
+  private final Consumer<Throwable> clientFailureHandler;
   private final String table;
 
   public DynamoDbKvStore(DynamoDbAsyncClient ddb, String table) {
+    this(() -> ddb, table, failure -> {});
+  }
+
+  public DynamoDbKvStore(
+      Supplier<DynamoDbAsyncClient> ddb, String table, Consumer<Throwable> clientFailureHandler) {
     this.ddb = ddb;
     this.table = table;
+    this.clientFailureHandler = clientFailureHandler;
   }
 
   String getTable() {
@@ -174,6 +183,28 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     return current;
   }
 
+  private DynamoDbAsyncClient ddb() {
+    return ddb.get();
+  }
+
+  private <T> Uni<T> dynamo(Supplier<CompletionStage<T>> operation) {
+    try {
+      return fromStage(operation.get()).onFailure().invoke(clientFailureHandler::accept);
+    } catch (Throwable failure) {
+      clientFailureHandler.accept(failure);
+      throw failure;
+    }
+  }
+
+  private <T> T dynamoBlocking(Supplier<T> operation) {
+    try {
+      return operation.get();
+    } catch (Throwable failure) {
+      clientFailureHandler.accept(failure);
+      throw failure;
+    }
+  }
+
   // ---- KvStore (reads)
 
   @Override
@@ -181,7 +212,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     var req =
         GetItemRequest.builder().tableName(table).key(keyMap(key)).consistentRead(true).build();
 
-    return fromStage(ddb.getItem(req))
+    return dynamo(() -> ddb().getItem(req))
         .map(resp -> resp.hasItem() ? Optional.of(avToRecord(resp.item())) : Optional.empty());
   }
 
@@ -208,7 +239,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
           .expressionAttributeValues(Map.of(":ev", N(expectedVersion)));
     }
 
-    return fromStage(ddb.putItem(b.build()))
+    return dynamo(() -> ddb().putItem(b.build()))
         .replaceWith(true)
         .onFailure(ConditionalCheckFailedException.class)
         .recoverWithItem(false);
@@ -229,7 +260,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
             .expressionAttributeValues(Map.of(":ev", N(expectedVersion)))
             .build();
 
-    return fromStage(ddb.deleteItem(req))
+    return dynamo(() -> ddb().deleteItem(req))
         .replaceWith(true)
         .onFailure(ConditionalCheckFailedException.class)
         .recoverWithItem(false);
@@ -261,7 +292,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
     decodeToken(pageToken).ifPresent(qb::exclusiveStartKey);
 
-    return fromStage(ddb.query(qb.build()))
+    return dynamo(() -> ddb().query(qb.build()))
         .map(
             resp -> {
               var items = new ArrayList<Record>(resp.items().size());
@@ -305,7 +336,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
                             ":skp", S(sortKeyPrefix)));
               }
 
-              return fromStage(ddb.query(qb.build()));
+              return dynamo(() -> ddb().query(qb.build()));
             })
         .whilst(resp -> resp.lastEvaluatedKey() != null && !resp.lastEvaluatedKey().isEmpty())
         .onItem()
@@ -343,9 +374,11 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     }
 
     // Attempt to delete this batch.
-    return fromStage(
-            ddb.batchWriteItem(
-                BatchWriteItemRequest.builder().requestItems(Map.of(table, batch)).build()))
+    return dynamo(
+            () ->
+                ddb()
+                    .batchWriteItem(
+                        BatchWriteItemRequest.builder().requestItems(Map.of(table, batch)).build()))
         .onItem()
         .transformToUni(
             resp -> {
@@ -419,7 +452,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
     var req = TransactWriteItemsRequest.builder().transactItems(tx).build();
 
-    return fromStage(ddb.transactWriteItems(req))
+    return dynamo(() -> ddb().transactWriteItems(req))
         .replaceWith(true)
         .onFailure(TransactionCanceledException.class)
         .recoverWithItem(
@@ -463,7 +496,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
             .limit(1) // only need to find one item
             .build();
 
-    return fromStage(ddb.scan(req).thenApply(r -> r.items().isEmpty()));
+    return dynamo(() -> ddb().scan(req).thenApply(r -> r.items().isEmpty()));
   }
 
   @Override
@@ -485,7 +518,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
               .limit(100) // keep logs sane
               .build();
 
-      var resp = ddb.scan(req).get();
+      var resp = ddb().scan(req).get();
 
       System.out.println("\n=== DUMP TABLE: " + this.table + " " + header + " ===");
 
@@ -502,10 +535,12 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
       System.out.println("=== END TABLE DUMP ===\n");
 
     } catch (ExecutionException e) {
+      clientFailureHandler.accept(e);
       // Table probably does not exist — safe to ignore in tests
       System.out.println("Table not found: " + this.table);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      clientFailureHandler.accept(e);
       throw new RuntimeException(e);
     }
   }
@@ -539,7 +574,9 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
   private void dropTableIfExists(String tableName) {
     try {
-      ddb.deleteTable(DeleteTableRequest.builder().tableName(tableName).build()).join();
+      dynamoBlocking(
+          () ->
+              ddb().deleteTable(DeleteTableRequest.builder().tableName(tableName).build()).join());
       // Wait until it's really gone (Local is fast, AWS would be slower)
       for (int i = 0; i < 50; i++) {
         if (!tableExists(tableName)) return;
@@ -575,12 +612,16 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
                     .build())
             .build();
 
-    ddb.createTable(req).join();
+    dynamoBlocking(() -> ddb().createTable(req).join());
   }
 
   private boolean tableExists(String tableName) {
     try {
-      ddb.describeTable(DescribeTableRequest.builder().tableName(tableName).build()).join();
+      dynamoBlocking(
+          () ->
+              ddb()
+                  .describeTable(DescribeTableRequest.builder().tableName(tableName).build())
+                  .join());
       return true;
     } catch (Throwable t) {
       return false;
@@ -592,7 +633,11 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     while (System.currentTimeMillis() < deadline) {
       try {
         var resp =
-            ddb.describeTable(DescribeTableRequest.builder().tableName(tableName).build()).join();
+            dynamoBlocking(
+                () ->
+                    ddb()
+                        .describeTable(DescribeTableRequest.builder().tableName(tableName).build())
+                        .join());
         if (resp.table().tableStatus() == TableStatus.ACTIVE) return;
       } catch (Throwable ignored) {
       }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreProducer.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreProducer.java
@@ -61,10 +61,14 @@ public class KvStoreProducer {
   @KvTable("floecat")
   KvStore coreKvStore(
       DynamoDbAsyncClient ddb, @ConfigProperty(name = "floecat.kv.table") String table) {
-    var manager = Arc.container().select(DynamoDbAsyncClientManager.class);
-    if (manager.isResolvable()) {
-      DynamoDbAsyncClientManager clientManager = manager.get();
-      return new DynamoDbKvStore(clientManager::current, table, clientManager::refreshAfterFailure);
+    var container = Arc.container();
+    if (container != null) {
+      var manager = container.select(DynamoDbAsyncClientManager.class);
+      if (manager.isResolvable()) {
+        DynamoDbAsyncClientManager clientManager = manager.get();
+        return new DynamoDbKvStore(
+            clientManager::current, table, clientManager::refreshAfterFailure);
+      }
     }
     return new DynamoDbKvStore(ddb, table);
   }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreProducer.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreProducer.java
@@ -15,8 +15,10 @@
  */
 package ai.floedb.floecat.storage.kv.dynamodb;
 
+import ai.floedb.floecat.storage.aws.DynamoDbAsyncClientManager;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.cdi.KvTable;
+import io.quarkus.arc.Arc;
 import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.annotation.Priority;
@@ -59,6 +61,11 @@ public class KvStoreProducer {
   @KvTable("floecat")
   KvStore coreKvStore(
       DynamoDbAsyncClient ddb, @ConfigProperty(name = "floecat.kv.table") String table) {
+    var manager = Arc.container().select(DynamoDbAsyncClientManager.class);
+    if (manager.isResolvable()) {
+      DynamoDbAsyncClientManager clientManager = manager.get();
+      return new DynamoDbKvStore(clientManager::current, table, clientManager::refreshAfterFailure);
+    }
     return new DynamoDbKvStore(ddb, table);
   }
 }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
@@ -16,9 +16,11 @@
 package ai.floedb.floecat.storage.kv.dynamodb.ps;
 
 import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * Synchronous adapter that preserves the existing {@link PointerStore} contract while delegating
@@ -34,27 +36,27 @@ public abstract class KvPointerStore implements PointerStore {
 
   @Override
   public Optional<Pointer> get(String key) {
-    return pointers.get(key).await().indefinitely();
+    return await(() -> pointers.get(key).await().indefinitely());
   }
 
   @Override
   public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
-    return pointers.compareAndSet(key, expectedVersion, next).await().indefinitely();
+    return await(() -> pointers.compareAndSet(key, expectedVersion, next).await().indefinitely());
   }
 
   @Override
   public boolean delete(String key) {
-    return pointers.delete(key).await().indefinitely();
+    return await(() -> pointers.delete(key).await().indefinitely());
   }
 
   @Override
   public boolean compareAndDelete(String key, long expectedVersion) {
-    return pointers.compareAndDelete(key, expectedVersion).await().indefinitely();
+    return await(() -> pointers.compareAndDelete(key, expectedVersion).await().indefinitely());
   }
 
   @Override
   public boolean compareAndSetBatch(List<CasOp> ops) {
-    return pointers.compareAndSetBatch(ops).await().indefinitely();
+    return await(() -> pointers.compareAndSetBatch(ops).await().indefinitely());
   }
 
   @Override
@@ -63,7 +65,7 @@ public abstract class KvPointerStore implements PointerStore {
     Optional<String> token =
         (pageToken == null || pageToken.isBlank()) ? Optional.empty() : Optional.of(pageToken);
 
-    var page = pointers.listByPrefix(prefix, limit, token).await().indefinitely();
+    var page = await(() -> pointers.listByPrefix(prefix, limit, token).await().indefinitely());
 
     if (nextTokenOut != null) {
       nextTokenOut.setLength(0);
@@ -75,7 +77,7 @@ public abstract class KvPointerStore implements PointerStore {
 
   @Override
   public int deleteByPrefix(String prefix) {
-    return pointers.deleteByPrefix(prefix).await().indefinitely();
+    return await(() -> pointers.deleteByPrefix(prefix).await().indefinitely());
   }
 
   @Override
@@ -84,7 +86,9 @@ public abstract class KvPointerStore implements PointerStore {
 
     Optional<String> token = Optional.empty();
     do {
-      var page = pointers.listKeysByPrefix(prefix, 500, token).await().indefinitely();
+      Optional<String> pageToken = token;
+      var page =
+          await(() -> pointers.listKeysByPrefix(prefix, 500, pageToken).await().indefinitely());
 
       count += page.items().size();
       token = page.nextToken();
@@ -100,6 +104,20 @@ public abstract class KvPointerStore implements PointerStore {
 
   @Override
   public void dump(String header) {
-    pointers.getKvStore().dump(header).await().indefinitely();
+    await(
+        () -> {
+          pointers.getKvStore().dump(header).await().indefinitely();
+          return null;
+        });
+  }
+
+  private static <T> T await(Supplier<T> operation) {
+    try {
+      return operation.get();
+    } catch (StorageAbortRetryableException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new StorageAbortRetryableException("DynamoDB pointer store operation failed", e);
+    }
   }
 }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
@@ -16,6 +16,7 @@
 package ai.floedb.floecat.storage.kv.dynamodb.ps;
 
 import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.List;
@@ -117,6 +118,9 @@ public abstract class KvPointerStore implements PointerStore {
     } catch (StorageAbortRetryableException e) {
       throw e;
     } catch (RuntimeException e) {
+      if (!ClosedAwsClientDetector.isConnectionPoolShutdown(e)) {
+        throw e;
+      }
       throw new StorageAbortRetryableException("DynamoDB pointer store operation failed", e);
     }
   }

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/DynamoDbAsyncClientManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/DynamoDbAsyncClientManagerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.storage.aws;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+
+class DynamoDbAsyncClientManagerTest {
+
+  @Test
+  void refreshAfterFailure_replaces_client_on_connection_pool_shutdown() {
+    FakeAwsClients clients = new FakeAwsClients();
+    DynamoDbAsyncClientManager manager = new DynamoDbAsyncClientManager();
+    manager.awsClients = clients;
+
+    DynamoDbAsyncClient first = manager.current();
+
+    manager.refreshAfterFailure(new IllegalStateException("Connection pool shut down"));
+
+    DynamoDbAsyncClient second = manager.current();
+    assertNotSame(first, second);
+    assertEquals(2, clients.handles.size());
+    assertTrue(clients.handles.get(0).closed);
+    assertFalse(clients.handles.get(1).closed);
+  }
+
+  @Test
+  void refreshAfterFailure_ignores_unrelated_failure() {
+    FakeAwsClients clients = new FakeAwsClients();
+    DynamoDbAsyncClientManager manager = new DynamoDbAsyncClientManager();
+    manager.awsClients = clients;
+
+    DynamoDbAsyncClient first = manager.current();
+
+    manager.refreshAfterFailure(new IllegalStateException("throttled"));
+
+    assertSame(first, manager.current());
+    assertEquals(1, clients.handles.size());
+    assertFalse(clients.handles.get(0).closed);
+  }
+
+  private static final class FakeAwsClients extends AwsClients {
+    private final List<ClientHandle> handles = new ArrayList<>();
+
+    @Override
+    public DynamoDbAsyncClient newDynamoDbAsyncClient() {
+      ClientHandle handle = new ClientHandle();
+      handles.add(handle);
+      return handle.client;
+    }
+  }
+
+  private static final class ClientHandle implements InvocationHandler {
+    private final DynamoDbAsyncClient client =
+        (DynamoDbAsyncClient)
+            Proxy.newProxyInstance(
+                DynamoDbAsyncClient.class.getClassLoader(),
+                new Class<?>[] {DynamoDbAsyncClient.class},
+                this);
+
+    private boolean closed;
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) {
+      return switch (method.getName()) {
+        case "close" -> {
+          closed = true;
+          yield null;
+        }
+        case "toString" -> "fake-dynamodb-client";
+        case "hashCode" -> System.identityHashCode(proxy);
+        case "equals" -> proxy == args[0];
+        default -> null;
+      };
+    }
+  }
+}

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStoreTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv.dynamodb.ps;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
+import ai.floedb.floecat.storage.kv.KvStore;
+import io.smallrye.mutiny.Uni;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class KvPointerStoreTest {
+
+  @Test
+  void getRethrowsNonClosedPoolRuntimeException() {
+    RuntimeException failure = new RuntimeException("validation failed");
+    KvPointerStore store = pointerStoreFailingReadsWith(failure);
+
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> store.get("/accounts/acct-1/catalog/cat-1"));
+
+    assertSame(failure, thrown);
+  }
+
+  @Test
+  void getWrapsClosedPoolRuntimeExceptionAsRetryableAbort() {
+    RuntimeException failure = new RuntimeException("Connection pool shut down");
+    KvPointerStore store = pointerStoreFailingReadsWith(failure);
+
+    StorageAbortRetryableException thrown =
+        assertThrows(
+            StorageAbortRetryableException.class,
+            () -> store.get("/accounts/acct-1/catalog/cat-1"));
+
+    assertSame(failure, thrown.getCause());
+  }
+
+  private static KvPointerStore pointerStoreFailingReadsWith(RuntimeException failure) {
+    return new KvPointerStore(new PointerStoreEntity(new FailingReadKvStore(failure))) {};
+  }
+
+  private static final class FailingReadKvStore implements KvStore {
+    private final RuntimeException failure;
+
+    private FailingReadKvStore(RuntimeException failure) {
+      this.failure = failure;
+    }
+
+    @Override
+    public Uni<Optional<Record>> get(Key key) {
+      return Uni.createFrom().failure(failure);
+    }
+
+    @Override
+    public Uni<Boolean> putCas(Record record, long expectedVersion) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uni<Boolean> deleteCas(Key key, long expectedVersion) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uni<Page> queryByPartitionKeyPrefix(
+        String partitionKey, String sortKeyPrefix, int limit, Optional<String> pageToken) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uni<Void> reset() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uni<Boolean> isEmpty() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uni<Void> dump(String header) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uni<Boolean> txnWriteCas(List<TxnOp> ops) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Recreate S3 and DynamoDB clients when AWS reports a closed connection pool.
- Convert closed-pool storage failures into retryable service errors.
- Add InitScan failure logging before gRPC error mapping drops the stack.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

I've only observed the pool closed problem after floecat is left running 30+ minutes.  I believe the root cause is in the s3 library, but there was also "use-after-error" pattern in dynamodb client, so I made them match.  Further, the non-conversion of errors and retry on the query path seemed wrong in light of other code.