### PR TITLE
Add --limit to relevant CLI commands

### DIFF
--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/AccountCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/AccountCliSupport.java
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 /** CLI support for the {@code account} command. */
 final class AccountCliSupport {
 
-  private static final int DEFAULT_PAGE_SIZE = 1000;
+  private static final int DEFAULT_PAGE_SIZE = 100;
 
   private AccountCliSupport() {}
 

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/CatalogCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/CatalogCliSupport.java
@@ -43,7 +43,7 @@ import java.util.function.Supplier;
 /** CLI support for the {@code catalogs} and {@code catalog} commands. */
 final class CatalogCliSupport {
 
-  private static final int DEFAULT_PAGE_SIZE = 1000;
+  private static final int DEFAULT_PAGE_SIZE = 100;
 
   private CatalogCliSupport() {}
 

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/CliArgs.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/CliArgs.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.common.rpc.Precondition;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -166,6 +167,29 @@ final class CliArgs {
       Function<R, List<T>> items,
       Function<R, String> next,
       Consumer<List<T>> pageConsumer) {
+    return forEachPageUntil(
+        pageSize,
+        fetch,
+        items,
+        next,
+        (response, pageItems) -> {
+          pageConsumer.accept(pageItems);
+          return true;
+        });
+  }
+
+  /**
+   * Visits each page from a paginated gRPC call until the visitor returns {@code false} or there
+   * are no more pages.
+   *
+   * @return total number of items seen across fetched pages
+   */
+  static <T, R> int forEachPageUntil(
+      int pageSize,
+      Function<PageRequest, R> fetch,
+      Function<R, List<T>> items,
+      Function<R, String> next,
+      BiFunction<R, List<T>, Boolean> pageVisitor) {
 
     int seen = 0;
     String token = "";
@@ -175,7 +199,9 @@ final class CliArgs {
       List<T> pageItems = items.apply(resp);
       if (pageItems != null && !pageItems.isEmpty()) {
         seen += pageItems.size();
-        pageConsumer.accept(pageItems);
+        if (!pageVisitor.apply(resp, pageItems)) {
+          break;
+        }
       }
       token = Optional.ofNullable(next.apply(resp)).orElse("");
     } while (!token.isBlank());

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/ConnectorCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/ConnectorCliSupport.java
@@ -90,7 +90,7 @@ import java.util.stream.Collectors;
 /** CLI support for the {@code connectors} and {@code connector} commands. */
 final class ConnectorCliSupport {
 
-  private static final int DEFAULT_PAGE_SIZE = 1000;
+  private static final int DEFAULT_PAGE_SIZE = 100;
   private static final String TABLE_TARGET_SPEC = "table";
   private static final int CONNECTOR_W_ID = 36;
   private static final int CONNECTOR_W_KIND = 10;
@@ -171,13 +171,12 @@ final class ConnectorCliSupport {
     switch (sub) {
       case "list" -> {
         String kindStr = Quotes.unquote(CliArgs.parseStringFlag(args, "--kind", ""));
-        int pageSize = CliArgs.parseIntFlag(args, "--page-size", DEFAULT_PAGE_SIZE);
         ConnectorKind filter = parseConnectorKind(kindStr);
         filter = (filter == ConnectorKind.CK_UNSPECIFIED && kindStr.isBlank()) ? null : filter;
         final ConnectorKind kindFilter = filter;
         printConnectorsHeader(out);
         CliArgs.forEachPage(
-            pageSize,
+            DEFAULT_PAGE_SIZE,
             pr -> connectors.listConnectors(ListConnectorsRequest.newBuilder().setPage(pr).build()),
             r ->
                 kindFilter == null
@@ -700,7 +699,7 @@ final class ConnectorCliSupport {
         }
       }
       case "jobs" -> {
-        int pageSize = CliArgs.parseIntFlag(args, "--page-size", DEFAULT_PAGE_SIZE);
+        int limit = Math.max(1, CliArgs.parseIntFlag(args, "--limit", Integer.MAX_VALUE));
         String childJobId = Quotes.unquote(CliArgs.parseStringFlag(args, "--child", ""));
         boolean printJson = args.contains("--json");
         String connectorRef = Quotes.unquote(CliArgs.parseStringFlag(args, "--connector", ""));
@@ -708,7 +707,7 @@ final class ConnectorCliSupport {
         if (printJson) {
           if (childJobId.isBlank()) {
             streamJsonJobs(
-                pageSize,
+                limit,
                 connectorRef,
                 stateArg,
                 connectors,
@@ -727,7 +726,7 @@ final class ConnectorCliSupport {
         } else {
           if (childJobId.isBlank()) {
             streamReconcileJobsTable(
-                pageSize,
+                limit,
                 connectorRef,
                 stateArg,
                 connectors,
@@ -904,7 +903,7 @@ final class ConnectorCliSupport {
   }
 
   private static void streamReconcileJobsTable(
-      int pageSize,
+      int limit,
       String connectorRef,
       String stateArg,
       ConnectorsGrpc.ConnectorsBlockingStub connectors,
@@ -913,8 +912,10 @@ final class ConnectorCliSupport {
       PrintStream out) {
     final boolean[] printedAny = {false};
     final boolean[] printedHeader = {false};
-    CliArgs.forEachPage(
-        pageSize,
+    final int[] remaining = {limit};
+    final boolean[] truncated = {false};
+    CliArgs.forEachPageUntil(
+        DEFAULT_PAGE_SIZE,
         pageRequest -> {
           var req = ListReconcileJobsRequest.newBuilder().setPage(pageRequest).setRootsOnly(true);
           if (!connectorRef.isBlank()) {
@@ -931,23 +932,33 @@ final class ConnectorCliSupport {
         },
         response -> response.getJobsList(),
         response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
-        jobs -> {
-          if (!jobs.isEmpty()) {
+        (response, jobs) -> {
+          List<GetReconcileJobResponse> page = jobs.stream().limit(remaining[0]).toList();
+          if (!page.isEmpty()) {
             if (!printedHeader[0]) {
               printReconcileJobsTableHeader(out);
               printedHeader[0] = true;
             }
-            printReconcileJobsTableRows(jobs, out);
+            printReconcileJobsTableRows(page, out);
             printedAny[0] = true;
+            remaining[0] -= page.size();
           }
+          if (remaining[0] <= 0) {
+            truncated[0] = jobs.size() > page.size() || response.hasPage();
+            return false;
+          }
+          return true;
         });
     if (!printedAny[0]) {
       out.println("no reconcile jobs");
+    } else if (truncated[0]) {
+      out.printf(
+          "Showing first %d reconcile jobs. Re-run with --limit <n> to fetch more.%n", limit);
     }
   }
 
   private static void streamJsonJobs(
-      int pageSize,
+      int limit,
       String connectorRef,
       String stateArg,
       ConnectorsGrpc.ConnectorsBlockingStub connectors,
@@ -956,8 +967,9 @@ final class ConnectorCliSupport {
       PrintStream out) {
     try {
       JsonArrayWriter writer = new JsonArrayWriter("jobs", out);
-      CliArgs.forEachPage(
-          pageSize,
+      final int[] remaining = {limit};
+      CliArgs.forEachPageUntil(
+          DEFAULT_PAGE_SIZE,
           pageRequest -> {
             var req = ListReconcileJobsRequest.newBuilder().setPage(pageRequest).setRootsOnly(true);
             if (!connectorRef.isBlank()) {
@@ -974,12 +986,18 @@ final class ConnectorCliSupport {
           },
           response -> response.getJobsList(),
           response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
-          jobs -> {
+          (response, jobs) -> {
+            List<GetReconcileJobResponse> page = jobs.stream().limit(remaining[0]).toList();
+            if (page.isEmpty()) {
+              return remaining[0] > 0;
+            }
             try {
-              writer.write(jobs);
+              writer.write(page);
             } catch (InvalidProtocolBufferException e) {
               throw new JsonStreamRuntimeException(e);
             }
+            remaining[0] -= page.size();
+            return remaining[0] > 0;
           });
       writer.finish();
     } catch (JsonStreamRuntimeException e) {

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/NamespaceCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/NamespaceCliSupport.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 /** CLI support for the {@code namespaces} and {@code namespace} commands. */
 final class NamespaceCliSupport {
 
-  private static final int DEFAULT_PAGE_SIZE = 1000;
+  private static final int DEFAULT_PAGE_SIZE = 100;
 
   private NamespaceCliSupport() {}
 

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -62,11 +62,20 @@ import picocli.CommandLine;
 @TopCommand
 @CommandLine.Command(
     name = "floecat-shell",
-    mixinStandardHelpOptions = true,
     version = "floecat-shell 0.1",
     description = "Interactive CLI to browse and manage catalogs/namespaces/tables/connectors")
 @jakarta.inject.Singleton
 public class Shell implements Runnable {
+
+  @CommandLine.Option(
+      names = {"-h", "--help"},
+      description = "Show this help message and exit")
+  boolean helpRequested;
+
+  @CommandLine.Option(
+      names = {"-V", "--version"},
+      description = "Print version information and exit")
+  boolean versionRequested;
 
   @CommandLine.Option(
       names = {"--host"},
@@ -217,6 +226,14 @@ public class Shell implements Runnable {
 
   @Override
   public void run() {
+    if (versionRequested) {
+      out.println("floecat-shell 0.1");
+      return;
+    }
+    if (helpRequested) {
+      printHelp();
+      return;
+    }
     initAuthConfig();
     out.println("Floecat Shell (type 'help' for commands, 'quit' to exit).");
     try {

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -511,7 +511,7 @@ public class Shell implements Runnable {
          view delete <id|fq>
          resolve table <fq> | resolve view <fq> | resolve catalog <name> | resolve namespace <fq>
          describe table <fq>
-         snapshots <tableFQ>
+         snapshots <tableFQ> [--limit N]
          snapshot get <id|catalog.ns[.ns...].table> <snapshot_id>
          snapshot delete <id|catalog.ns[.ns...].table> <snapshot_id> [--etag <etag>]
          stats table <tableFQ> [--snapshot <id>|--current] [--json] (defaults to --current)
@@ -543,7 +543,7 @@ public class Shell implements Runnable {
          query get <query_id>
          query fetch-scan <query_id> <table_id>
          connectors
-         connector list [--kind <KIND>] [--page-size <N>]
+         connector list [--kind <KIND>]
          connector get <display_name|id>
          connector create <display_name> <source_type (ICEBERG|DELTA|GLUE|UNITY)> <uri> <source_namespace (a[.b[.c]...])> <destination_catalog (name)>
              [--source-table <name>] [--source-cols c1,#id2,...]
@@ -577,13 +577,13 @@ public class Shell implements Runnable {
              [--default-cols first-n|all|explicit-only] [--max-default-cols <n>]
              # Defaults to --default-cols first-n --max-default-cols 32 when --columns is not set.
          connector job <jobId> [--json]
-         connector jobs [--connector <display_name|id>] [--state <queued|running|cancelling|cancelled|succeeded|failed>[,...]] [--page-size <N>] [--json]
-         connector jobs --child <parentJobId> [--connector <display_name|id>] [--state <queued|running|cancelling|cancelled|succeeded|failed>[,...]] [--page-size <N>] [--json]
+         connector jobs [--connector <display_name|id>] [--state <queued|running|cancelling|cancelled|succeeded|failed>[,...]] [--limit N] [--json]
+         connector jobs --child <parentJobId> [--json]
          connector cancel <jobId> [--reason <text>]
          connector settings get
          connector settings update [--auto-enabled true|false] [--default-interval-sec <n>] [--default-mode incremental|full] [--finished-job-retention-sec <n>]
          storage-authorities
-         storage-authority list [--page-size <N>]
+         storage-authority list
          storage-authority get <display_name|id>
          storage-authority create <display_name> --location-prefix <uri-prefix>
              [--desc <text>] [--enabled true|false] [--type <type>]

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/SnapshotCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/SnapshotCliSupport.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
 /** CLI support for {@code snapshots} and {@code snapshot} commands. */
 final class SnapshotCliSupport {
 
-  private static final int DEFAULT_PAGE_SIZE = 1000;
+  private static final int DEFAULT_PAGE_SIZE = 100;
 
   private SnapshotCliSupport() {}
 
@@ -68,19 +68,36 @@ final class SnapshotCliSupport {
       SnapshotServiceGrpc.SnapshotServiceBlockingStub snapshotsService,
       Function<String, ResourceId> resolveTableId) {
     if (args.isEmpty()) {
-      out.println("usage: snapshots <tableFQ>");
+      out.println("usage: snapshots <tableFQ> [--limit N]");
       return;
     }
+    int limit = Math.max(1, CliArgs.parseIntFlag(args, "--limit", Integer.MAX_VALUE));
     ResourceId tableId = resolveTableId.apply(args.get(0));
     printSnapshotsHeader(out);
-    CliArgs.forEachPage(
+    var remaining = new int[] {limit};
+    var truncated = new boolean[] {false};
+    CliArgs.forEachPageUntil(
         DEFAULT_PAGE_SIZE,
         pr ->
             snapshotsService.listSnapshots(
                 ListSnapshotsRequest.newBuilder().setTableId(tableId).setPage(pr).build()),
         r -> r.getSnapshotsList(),
         r -> r.hasPage() ? r.getPage().getNextPageToken() : "",
-        snaps -> printSnapshotsRows(snaps, out));
+        (response, snaps) -> {
+          List<Snapshot> page = snaps.stream().limit(remaining[0]).toList();
+          if (!page.isEmpty()) {
+            printSnapshotsRows(page, out);
+            remaining[0] -= page.size();
+          }
+          if (remaining[0] <= 0) {
+            truncated[0] = snaps.size() > page.size() || response.hasPage();
+            return false;
+          }
+          return true;
+        });
+    if (truncated[0]) {
+      out.printf("Showing first %d snapshots. Re-run with --limit <n> to fetch more.%n", limit);
+    }
   }
 
   private static void snapshotCrud(

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/StatsCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/StatsCliSupport.java
@@ -60,7 +60,7 @@ import java.util.function.Function;
 /** CLI support for {@code stats} and {@code analyze} commands. */
 final class StatsCliSupport {
 
-  private static final int DEFAULT_PAGE_SIZE = 1000;
+  private static final int DEFAULT_PAGE_SIZE = 100;
   private static final int FILE_STATS_PAGE_SIZE = 100;
   private static final String TABLE_TARGET_SPEC = "table";
 
@@ -201,13 +201,15 @@ final class StatsCliSupport {
                 CliUtils.snapshotFromTokenOrCurrent(
                     CliArgs.parseStringFlag(args, "--snapshot", "current")))
             .addTargetKinds(StatsTargetKind.STK_COLUMN);
+    Function<ai.floedb.floecat.catalog.rpc.ListTargetStatsResponse, String> nextToken =
+        r -> r.hasPage() ? r.getPage().getNextPageToken() : "";
 
     if (json) {
       streamJsonRecords(
           out,
           writer -> {
             var remaining = new int[] {limit};
-            CliArgs.forEachPage(
+            CliArgs.forEachPageUntil(
                 pageSize,
                 pr ->
                     statistics.listTargetStats(
@@ -218,10 +220,10 @@ final class StatsCliSupport {
                                     .build())
                             .build()),
                 r -> r.getRecordsList(),
-                r -> r.hasPage() ? r.getPage().getNextPageToken() : "",
-                records -> {
+                nextToken,
+                (response, records) -> {
                   if (remaining[0] <= 0) {
-                    return;
+                    return false;
                   }
                   List<TargetStatsRecord> page =
                       records.stream()
@@ -236,40 +238,44 @@ final class StatsCliSupport {
                     }
                     remaining[0] -= page.size();
                   }
+                  return remaining[0] > 0;
                 });
           });
       return;
     }
     printColumnStatsHeader(out);
     var remaining = new int[] {limit};
-    int seen =
-        CliArgs.forEachPage(
-            pageSize,
-            pr ->
-                statistics.listTargetStats(
-                    rb.setPage(
-                            PageRequest.newBuilder()
-                                .setPageSize(pr.getPageSize())
-                                .setPageToken(pr.getPageToken())
-                                .build())
-                        .build()),
-            r -> r.getRecordsList(),
-            r -> r.hasPage() ? r.getPage().getNextPageToken() : "",
-            records -> {
-              if (remaining[0] <= 0) {
-                return;
-              }
-              List<TargetStatsRecord> page =
-                  records.stream()
-                      .filter(TargetStatsRecord::hasScalar)
-                      .limit(remaining[0])
-                      .toList();
-              if (!page.isEmpty()) {
-                printColumnStatsRows(page, out);
-                remaining[0] -= page.size();
-              }
-            });
-    if (hasLimit && seen > limit) {
+    var truncated = new boolean[] {false};
+    CliArgs.forEachPageUntil(
+        pageSize,
+        pr ->
+            statistics.listTargetStats(
+                rb.setPage(
+                        PageRequest.newBuilder()
+                            .setPageSize(pr.getPageSize())
+                            .setPageToken(pr.getPageToken())
+                            .build())
+                    .build()),
+        r -> r.getRecordsList(),
+        nextToken,
+        (response, records) -> {
+          if (remaining[0] <= 0) {
+            return false;
+          }
+          List<TargetStatsRecord> filtered =
+              records.stream().filter(TargetStatsRecord::hasScalar).toList();
+          List<TargetStatsRecord> page = filtered.stream().limit(remaining[0]).toList();
+          if (!page.isEmpty()) {
+            printColumnStatsRows(page, out);
+            remaining[0] -= page.size();
+          }
+          if (remaining[0] <= 0) {
+            truncated[0] = filtered.size() > page.size() || !nextToken.apply(response).isBlank();
+            return false;
+          }
+          return true;
+        });
+    if (hasLimit && truncated[0]) {
       printLimitNotice("column stats", limit, out);
     }
   }
@@ -299,39 +305,47 @@ final class StatsCliSupport {
                 CliUtils.snapshotFromTokenOrCurrent(
                     CliArgs.parseStringFlag(args, "--snapshot", "current")))
             .addTargetKinds(StatsTargetKind.STK_FILE);
+    Function<ai.floedb.floecat.catalog.rpc.ListTargetStatsResponse, String> nextToken =
+        r -> r.hasPage() ? r.getPage().getNextPageToken() : "";
 
     var remaining = new int[] {limit};
     var printed = new int[] {0};
-    int seen =
-        CliArgs.forEachPage(
-            pageSize,
-            pr ->
-                statistics.listTargetStats(
-                    rb.setPage(
-                            PageRequest.newBuilder()
-                                .setPageSize(pr.getPageSize())
-                                .setPageToken(pr.getPageToken())
-                                .build())
-                        .build()),
-            r -> r.getRecordsList(),
-            r -> r.hasPage() ? r.getPage().getNextPageToken() : "",
-            records -> {
-              if (remaining[0] <= 0) {
-                return;
-              }
-              List<TargetStatsRecord> page =
-                  records.stream().filter(TargetStatsRecord::hasFile).limit(remaining[0]).toList();
-              if (!page.isEmpty()) {
-                printFileColumnStatsPage(page, printed[0], printed[0] == 0, out);
-                printed[0] += page.size();
-                remaining[0] -= page.size();
-              }
-            });
-    if (seen == 0 || printed[0] == 0) {
+    var truncated = new boolean[] {false};
+    CliArgs.forEachPageUntil(
+        pageSize,
+        pr ->
+            statistics.listTargetStats(
+                rb.setPage(
+                        PageRequest.newBuilder()
+                            .setPageSize(pr.getPageSize())
+                            .setPageToken(pr.getPageToken())
+                            .build())
+                    .build()),
+        r -> r.getRecordsList(),
+        nextToken,
+        (response, records) -> {
+          if (remaining[0] <= 0) {
+            return false;
+          }
+          List<TargetStatsRecord> filtered =
+              records.stream().filter(TargetStatsRecord::hasFile).toList();
+          List<TargetStatsRecord> page = filtered.stream().limit(remaining[0]).toList();
+          if (!page.isEmpty()) {
+            printFileColumnStatsPage(page, printed[0], printed[0] == 0, out);
+            printed[0] += page.size();
+            remaining[0] -= page.size();
+          }
+          if (remaining[0] <= 0) {
+            truncated[0] = filtered.size() > page.size() || !nextToken.apply(response).isBlank();
+            return false;
+          }
+          return true;
+        });
+    if (printed[0] == 0) {
       out.println("No file stats found.");
       return;
     }
-    if (hasLimit && seen > limit) {
+    if (hasLimit && truncated[0]) {
       printLimitNotice("file stats", limit, out);
     }
   }
@@ -364,13 +378,15 @@ final class StatsCliSupport {
             .setSnapshot(
                 CliUtils.snapshotFromTokenOrCurrent(
                     CliArgs.parseStringFlag(args, "--snapshot", "current")));
+    Function<ai.floedb.floecat.catalog.rpc.ListIndexArtifactsResponse, String> nextToken =
+        r -> r.hasPage() ? r.getPage().getNextPageToken() : "";
 
     if (json) {
       streamJsonRecords(
           out,
           writer -> {
             var remaining = new int[] {limit};
-            CliArgs.forEachPage(
+            CliArgs.forEachPageUntil(
                 pageSize,
                 pr ->
                     indexes.listIndexArtifacts(
@@ -381,10 +397,10 @@ final class StatsCliSupport {
                                     .build())
                             .build()),
                 r -> r.getRecordsList(),
-                r -> r.hasPage() ? r.getPage().getNextPageToken() : "",
-                records -> {
+                nextToken,
+                (response, records) -> {
                   if (remaining[0] <= 0) {
-                    return;
+                    return false;
                   }
                   List<IndexArtifactRecord> page = records.stream().limit(remaining[0]).toList();
                   if (!page.isEmpty()) {
@@ -395,44 +411,50 @@ final class StatsCliSupport {
                     }
                     remaining[0] -= page.size();
                   }
+                  return remaining[0] > 0;
                 });
           });
       return;
     }
     var remaining = new int[] {limit};
     var printed = new int[] {0};
-    int seen =
-        CliArgs.forEachPage(
-            pageSize,
-            pr ->
-                indexes.listIndexArtifacts(
-                    rb.setPage(
-                            PageRequest.newBuilder()
-                                .setPageSize(pr.getPageSize())
-                                .setPageToken(pr.getPageToken())
-                                .build())
-                        .build()),
-            r -> r.getRecordsList(),
-            r -> r.hasPage() ? r.getPage().getNextPageToken() : "",
-            records -> {
-              if (remaining[0] <= 0) {
-                return;
-              }
-              List<IndexArtifactRecord> page = records.stream().limit(remaining[0]).toList();
-              if (!page.isEmpty()) {
-                if (printed[0] == 0) {
-                  printIndexArtifactsHeader(out);
-                }
-                printIndexArtifactsRows(page, printed[0], out);
-                printed[0] += page.size();
-                remaining[0] -= page.size();
-              }
-            });
-    if (seen == 0 || printed[0] == 0) {
+    var truncated = new boolean[] {false};
+    CliArgs.forEachPageUntil(
+        pageSize,
+        pr ->
+            indexes.listIndexArtifacts(
+                rb.setPage(
+                        PageRequest.newBuilder()
+                            .setPageSize(pr.getPageSize())
+                            .setPageToken(pr.getPageToken())
+                            .build())
+                    .build()),
+        r -> r.getRecordsList(),
+        nextToken,
+        (response, records) -> {
+          if (remaining[0] <= 0) {
+            return false;
+          }
+          List<IndexArtifactRecord> page = records.stream().limit(remaining[0]).toList();
+          if (!page.isEmpty()) {
+            if (printed[0] == 0) {
+              printIndexArtifactsHeader(out);
+            }
+            printIndexArtifactsRows(page, printed[0], out);
+            printed[0] += page.size();
+            remaining[0] -= page.size();
+          }
+          if (remaining[0] <= 0) {
+            truncated[0] = records.size() > page.size() || !nextToken.apply(response).isBlank();
+            return false;
+          }
+          return true;
+        });
+    if (printed[0] == 0) {
       out.println("No index artifacts found.");
       return;
     }
-    if (hasLimit && seen > limit) {
+    if (hasLimit && truncated[0]) {
       printLimitNotice("index artifacts", limit, out);
     }
   }

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/StorageAuthorityCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/StorageAuthorityCliSupport.java
@@ -46,10 +46,9 @@ final class StorageAuthorityCliSupport {
       Supplier<String> getCurrentAccountId) {
     switch (command) {
       case "storage-authorities" -> {
-        int pageSize = CliArgs.parseIntFlag(args, "--page-size", DEFAULT_PAGE_SIZE);
         printAuthoritiesHeader(out);
         CliArgs.forEachPage(
-            pageSize,
+            DEFAULT_PAGE_SIZE,
             pr ->
                 authorities.listStorageAuthorities(
                     ListStorageAuthoritiesRequest.newBuilder().setPage(pr).build()),
@@ -74,10 +73,9 @@ final class StorageAuthorityCliSupport {
     }
     switch (args.get(0)) {
       case "list" -> {
-        int pageSize = CliArgs.parseIntFlag(args, "--page-size", DEFAULT_PAGE_SIZE);
         printAuthoritiesHeader(out);
         CliArgs.forEachPage(
-            pageSize,
+            DEFAULT_PAGE_SIZE,
             pr ->
                 authorities.listStorageAuthorities(
                     ListStorageAuthoritiesRequest.newBuilder().setPage(pr).build()),

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/TableCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/TableCliSupport.java
@@ -55,7 +55,7 @@ import java.util.function.Supplier;
  */
 final class TableCliSupport {
 
-  private static final int DEFAULT_PAGE_SIZE = 1000;
+  private static final int DEFAULT_PAGE_SIZE = 100;
 
   private TableCliSupport() {}
 

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/ViewCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/ViewCliSupport.java
@@ -44,7 +44,7 @@ import java.util.function.Supplier;
 /** CLI support for the {@code views} and {@code view} commands. */
 final class ViewCliSupport {
 
-  private static final int DEFAULT_PAGE_SIZE = 1000;
+  private static final int DEFAULT_PAGE_SIZE = 100;
 
   private ViewCliSupport() {}
 

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/ConnectorCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/ConnectorCliSupportTest.java
@@ -34,6 +34,7 @@ import ai.floedb.floecat.catalog.rpc.ResolveViewRequest;
 import ai.floedb.floecat.catalog.rpc.ResolveViewResponse;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotServiceGrpc;
+import ai.floedb.floecat.common.rpc.PageResponse;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
@@ -833,6 +834,51 @@ class ConnectorCliSupportTest {
   }
 
   @Test
+  void connectorJobsLimitStopsPagingAfterRequestedRows() throws Exception {
+    try (Harness h = new Harness()) {
+      h.reconcileControlService.listJobsPages =
+          List.of(
+              ListReconcileJobsResponse.newBuilder()
+                  .addJobs(
+                      ai.floedb.floecat.reconciler.rpc.GetReconcileJobResponse.newBuilder()
+                          .setJobId("job-plan-2")
+                          .setConnectorId(CONNECTOR_UUID)
+                          .setKind(ReconcileJobKind.RJK_PLAN_CONNECTOR)
+                          .build())
+                  .addJobs(
+                      ai.floedb.floecat.reconciler.rpc.GetReconcileJobResponse.newBuilder()
+                          .setJobId("job-plan-1")
+                          .setConnectorId(CONNECTOR_UUID)
+                          .setKind(ReconcileJobKind.RJK_PLAN_CONNECTOR)
+                          .build())
+                  .setPage(PageResponse.newBuilder().setNextPageToken("page-2").build())
+                  .build(),
+              ListReconcileJobsResponse.newBuilder()
+                  .addJobs(
+                      ai.floedb.floecat.reconciler.rpc.GetReconcileJobResponse.newBuilder()
+                          .setJobId("job-plan-0")
+                          .setConnectorId(CONNECTOR_UUID)
+                          .setKind(ReconcileJobKind.RJK_PLAN_CONNECTOR)
+                          .build())
+                  .build());
+
+      ByteArrayOutputStream buf = new ByteArrayOutputStream();
+      ConnectorCliSupport.handle(
+          "connector",
+          List.of("jobs", "--limit", "2"),
+          new PrintStream(buf),
+          h.connectorsStub,
+          h.reconcileControlStub,
+          h.directoryStub,
+          () -> "acct-1");
+
+      assertEquals(1, h.reconcileControlService.listReconcileJobsCalls.get());
+      assertTrue(buf.toString().contains("Showing first 2 reconcile jobs."));
+      assertFalse(buf.toString().contains("job-plan-0"));
+    }
+  }
+
+  @Test
   void connectorJobsRendersWaitingStateAndSanitizesUuidPrefixedMessage() throws Exception {
     try (Harness h = new Harness()) {
       h.reconcileControlService.listJobsResponse =
@@ -1271,6 +1317,8 @@ class ConnectorCliSupportTest {
     ai.floedb.floecat.reconciler.rpc.GetReconcileJobTreeResponse getJobTreeResponse =
         ai.floedb.floecat.reconciler.rpc.GetReconcileJobTreeResponse.getDefaultInstance();
     ListReconcileJobsResponse listJobsResponse = ListReconcileJobsResponse.getDefaultInstance();
+    List<ListReconcileJobsResponse> listJobsPages = List.of();
+    ListReconcileJobsRequest lastListJobsRequest;
 
     @Override
     public void startCapture(
@@ -1305,7 +1353,13 @@ class ConnectorCliSupportTest {
         ListReconcileJobsRequest request,
         StreamObserver<ListReconcileJobsResponse> responseObserver) {
       listReconcileJobsCalls.incrementAndGet();
-      responseObserver.onNext(listJobsResponse);
+      lastListJobsRequest = request;
+      if (!listJobsPages.isEmpty()) {
+        int index = Math.min(listReconcileJobsCalls.get() - 1, listJobsPages.size() - 1);
+        responseObserver.onNext(listJobsPages.get(index));
+      } else {
+        responseObserver.onNext(listJobsResponse);
+      }
       responseObserver.onCompleted();
     }
 

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellFqQuoteTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellFqQuoteTest.java
@@ -27,6 +27,7 @@ import java.io.PrintStream;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 class ShellFqQuoteTest {
 
@@ -399,6 +400,30 @@ class ShellFqQuoteTest {
             "[--snapshot <id>|--current] [--mode metadata-only|metadata-and-capture|capture-only]"));
     assertTrue(help.contains("[--capture stats|table-stats|file-stats|column-stats|index,...]"));
     assertTrue(help.contains("[--wait-seconds <n>]"));
+  }
+
+  @Test
+  void commandLineHelpIncludesLimitCommands() {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream original = System.out;
+    int exitCode;
+    try {
+      System.setOut(new PrintStream(baos));
+      CommandLine cmd = new CommandLine(shell);
+      exitCode = cmd.execute("--help");
+    } finally {
+      System.setOut(original);
+    }
+
+    assertEquals(0, exitCode);
+    String help = baos.toString();
+    assertTrue(help.contains("snapshots <tableFQ> [--limit N]"));
+    assertTrue(help.contains("stats columns <tableFQ> [--snapshot <id>|--current] [--limit N]"));
+    assertTrue(help.contains("stats files <tableFQ> [--snapshot <id>|--current] [--limit N]"));
+    assertTrue(help.contains("stats index <tableFQ> [--snapshot <id>|--current] [--limit N]"));
+    assertTrue(
+        help.contains(
+            "connector jobs [--connector <display_name|id>] [--state <queued|running|cancelling|cancelled|succeeded|failed>[,...]] [--limit N] [--json]"));
   }
 
   @Test

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/SnapshotCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/SnapshotCliSupportTest.java
@@ -27,6 +27,7 @@ import ai.floedb.floecat.catalog.rpc.ListSnapshotsRequest;
 import ai.floedb.floecat.catalog.rpc.ListSnapshotsResponse;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotServiceGrpc;
+import ai.floedb.floecat.common.rpc.PageResponse;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
@@ -76,6 +77,34 @@ class SnapshotCliSupportTest {
       SnapshotCliSupport.handle(
           "snapshots", List.of(), new PrintStream(buf), h.snapshotsStub, ignored -> tableId());
       assertTrue(buf.toString().contains("usage:"), "expected usage message");
+    }
+  }
+
+  @Test
+  void snapshotsLimitStopsPagingAfterRequestedRows() throws Exception {
+    try (Harness h = new Harness()) {
+      h.snapshotService.listSnapshotsPages =
+          List.of(
+              ListSnapshotsResponse.newBuilder()
+                  .addSnapshots(Snapshot.newBuilder().setSnapshotId(3L).build())
+                  .addSnapshots(Snapshot.newBuilder().setSnapshotId(2L).build())
+                  .setPage(PageResponse.newBuilder().setNextPageToken("page-2").build())
+                  .build(),
+              ListSnapshotsResponse.newBuilder()
+                  .addSnapshots(Snapshot.newBuilder().setSnapshotId(1L).build())
+                  .build());
+
+      ByteArrayOutputStream buf = new ByteArrayOutputStream();
+      SnapshotCliSupport.handle(
+          "snapshots",
+          List.of("catalog.ns.tbl", "--limit", "2"),
+          new PrintStream(buf),
+          h.snapshotsStub,
+          ignored -> tableId());
+
+      assertEquals(1, h.snapshotService.listSnapshotsCalls.get());
+      assertTrue(buf.toString().contains("Showing first 2 snapshots."));
+      assertTrue(!buf.toString().contains("1"));
     }
   }
 
@@ -237,9 +266,12 @@ class SnapshotCliSupportTest {
   private static final class CapturingSnapshotService
       extends SnapshotServiceGrpc.SnapshotServiceImplBase {
 
+    final AtomicInteger listSnapshotsCalls = new AtomicInteger();
     final AtomicInteger getSnapshotCalls = new AtomicInteger();
     final AtomicInteger deleteSnapshotCalls = new AtomicInteger();
     final List<Snapshot> snapshotsToReturn = new ArrayList<>();
+    List<ListSnapshotsResponse> listSnapshotsPages = List.of();
+    ListSnapshotsRequest lastListSnapshotsRequest;
     Snapshot snapshotToReturn = Snapshot.getDefaultInstance();
     GetSnapshotRequest lastGetRequest;
     DeleteSnapshotRequest lastDeleteRequest;
@@ -248,8 +280,15 @@ class SnapshotCliSupportTest {
     @Override
     public void listSnapshots(
         ListSnapshotsRequest request, StreamObserver<ListSnapshotsResponse> responseObserver) {
-      responseObserver.onNext(
-          ListSnapshotsResponse.newBuilder().addAllSnapshots(snapshotsToReturn).build());
+      listSnapshotsCalls.incrementAndGet();
+      lastListSnapshotsRequest = request;
+      if (!listSnapshotsPages.isEmpty()) {
+        int index = Math.min(listSnapshotsCalls.get() - 1, listSnapshotsPages.size() - 1);
+        responseObserver.onNext(listSnapshotsPages.get(index));
+      } else {
+        responseObserver.onNext(
+            ListSnapshotsResponse.newBuilder().addAllSnapshots(snapshotsToReturn).build());
+      }
       responseObserver.onCompleted();
     }
 

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/StatsCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/StatsCliSupportTest.java
@@ -49,6 +49,7 @@ import ai.floedb.floecat.catalog.rpc.TableStatsTarget;
 import ai.floedb.floecat.catalog.rpc.TableValueStats;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
 import ai.floedb.floecat.catalog.rpc.UpstreamRef;
+import ai.floedb.floecat.common.rpc.PageResponse;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.reconciler.rpc.CaptureNowRequest;
@@ -228,6 +229,49 @@ class StatsCliSupportTest {
     }
   }
 
+  @Test
+  void statsColumnsLimitStopsPagingAfterRequestedRows() throws Exception {
+    try (Harness h = new Harness()) {
+      h.statisticsService.listTargetStatsPages =
+          List.of(
+              ListTargetStatsResponse.newBuilder()
+                  .addRecords(
+                      TargetStatsRecord.newBuilder()
+                          .setTableId(tableId())
+                          .setScalar(ai.floedb.floecat.catalog.rpc.ScalarStats.getDefaultInstance())
+                          .build())
+                  .addRecords(
+                      TargetStatsRecord.newBuilder()
+                          .setTableId(tableId())
+                          .setScalar(ai.floedb.floecat.catalog.rpc.ScalarStats.getDefaultInstance())
+                          .build())
+                  .setPage(PageResponse.newBuilder().setNextPageToken("page-2").build())
+                  .build(),
+              ListTargetStatsResponse.newBuilder()
+                  .addRecords(
+                      TargetStatsRecord.newBuilder()
+                          .setTableId(tableId())
+                          .setScalar(ai.floedb.floecat.catalog.rpc.ScalarStats.getDefaultInstance())
+                          .build())
+                  .build());
+
+      ByteArrayOutputStream buf = new ByteArrayOutputStream();
+      StatsCliSupport.handle(
+          "stats",
+          List.of("columns", "catalog.ns.tbl", "--limit", "2"),
+          new PrintStream(buf),
+          h.statisticsStub,
+          h.indexesStub,
+          h.tablesStub,
+          h.namespacesStub,
+          h.reconcileControlStub,
+          ignored -> tableId());
+
+      assertEquals(1, h.statisticsService.listTargetStatsCalls.get());
+      assertTrue(buf.toString().contains("Showing first 2 column stats."));
+    }
+  }
+
   // --- stats files ---
 
   @Test
@@ -269,6 +313,52 @@ class StatsCliSupportTest {
           h.reconcileControlStub,
           ignored -> tableId());
       assertTrue(buf.toString().contains("usage:"));
+    }
+  }
+
+  @Test
+  void statsFilesLimitStopsPagingAfterRequestedRows() throws Exception {
+    try (Harness h = new Harness()) {
+      h.statisticsService.listTargetStatsPages =
+          List.of(
+              ListTargetStatsResponse.newBuilder()
+                  .addRecords(
+                      TargetStatsRecord.newBuilder()
+                          .setTableId(tableId())
+                          .setFile(
+                              ai.floedb.floecat.catalog.rpc.FileTargetStats.getDefaultInstance())
+                          .build())
+                  .addRecords(
+                      TargetStatsRecord.newBuilder()
+                          .setTableId(tableId())
+                          .setFile(
+                              ai.floedb.floecat.catalog.rpc.FileTargetStats.getDefaultInstance())
+                          .build())
+                  .setPage(PageResponse.newBuilder().setNextPageToken("page-2").build())
+                  .build(),
+              ListTargetStatsResponse.newBuilder()
+                  .addRecords(
+                      TargetStatsRecord.newBuilder()
+                          .setTableId(tableId())
+                          .setFile(
+                              ai.floedb.floecat.catalog.rpc.FileTargetStats.getDefaultInstance())
+                          .build())
+                  .build());
+
+      ByteArrayOutputStream buf = new ByteArrayOutputStream();
+      StatsCliSupport.handle(
+          "stats",
+          List.of("files", "catalog.ns.tbl", "--limit", "2"),
+          new PrintStream(buf),
+          h.statisticsStub,
+          h.indexesStub,
+          h.tablesStub,
+          h.namespacesStub,
+          h.reconcileControlStub,
+          ignored -> tableId());
+
+      assertEquals(1, h.statisticsService.listTargetStatsCalls.get());
+      assertTrue(buf.toString().contains("Showing first 2 file stats."));
     }
   }
 
@@ -392,6 +482,73 @@ class StatsCliSupportTest {
           ignored -> tableId());
 
       assertTrue(buf.toString().contains("Showing first 1000 index artifacts."));
+    }
+  }
+
+  @Test
+  void statsIndexLimitStopsPagingAfterRequestedRows() throws Exception {
+    try (Harness h = new Harness()) {
+      h.indexService.listIndexArtifactsPages =
+          List.of(
+              ListIndexArtifactsResponse.newBuilder()
+                  .addRecords(
+                      IndexArtifactRecord.newBuilder()
+                          .setTableId(tableId())
+                          .setSnapshotId(7L)
+                          .setTarget(
+                              IndexTarget.newBuilder()
+                                  .setFile(
+                                      IndexFileTarget.newBuilder()
+                                          .setFilePath("file-2.parquet")
+                                          .build())
+                                  .build())
+                          .setArtifactUri("file-2.idx")
+                          .build())
+                  .addRecords(
+                      IndexArtifactRecord.newBuilder()
+                          .setTableId(tableId())
+                          .setSnapshotId(7L)
+                          .setTarget(
+                              IndexTarget.newBuilder()
+                                  .setFile(
+                                      IndexFileTarget.newBuilder()
+                                          .setFilePath("file-1.parquet")
+                                          .build())
+                                  .build())
+                          .setArtifactUri("file-1.idx")
+                          .build())
+                  .setPage(PageResponse.newBuilder().setNextPageToken("page-2").build())
+                  .build(),
+              ListIndexArtifactsResponse.newBuilder()
+                  .addRecords(
+                      IndexArtifactRecord.newBuilder()
+                          .setTableId(tableId())
+                          .setSnapshotId(7L)
+                          .setTarget(
+                              IndexTarget.newBuilder()
+                                  .setFile(
+                                      IndexFileTarget.newBuilder()
+                                          .setFilePath("file-0.parquet")
+                                          .build())
+                                  .build())
+                          .setArtifactUri("file-0.idx")
+                          .build())
+                  .build());
+
+      ByteArrayOutputStream buf = new ByteArrayOutputStream();
+      StatsCliSupport.handle(
+          "stats",
+          List.of("index", "catalog.ns.tbl", "--limit", "2"),
+          new PrintStream(buf),
+          h.statisticsStub,
+          h.indexesStub,
+          h.tablesStub,
+          h.namespacesStub,
+          h.reconcileControlStub,
+          ignored -> tableId());
+
+      assertEquals(1, h.indexService.listIndexArtifactsCalls.get());
+      assertTrue(buf.toString().contains("Showing first 2 index artifacts."));
     }
   }
 
@@ -695,6 +852,7 @@ class StatsCliSupportTest {
     GetTargetStatsRequest lastTargetStatsRequest;
     ListTargetStatsRequest lastListTargetStatsRequest;
     TargetStatsRecord tableStatsToReturn = TargetStatsRecord.getDefaultInstance();
+    List<ListTargetStatsResponse> listTargetStatsPages = List.of();
 
     @Override
     public void getTargetStats(
@@ -711,7 +869,12 @@ class StatsCliSupportTest {
         ListTargetStatsRequest request, StreamObserver<ListTargetStatsResponse> responseObserver) {
       listTargetStatsCalls.incrementAndGet();
       lastListTargetStatsRequest = request;
-      responseObserver.onNext(ListTargetStatsResponse.getDefaultInstance());
+      if (!listTargetStatsPages.isEmpty()) {
+        int index = Math.min(listTargetStatsCalls.get() - 1, listTargetStatsPages.size() - 1);
+        responseObserver.onNext(listTargetStatsPages.get(index));
+      } else {
+        responseObserver.onNext(ListTargetStatsResponse.getDefaultInstance());
+      }
       responseObserver.onCompleted();
     }
   }
@@ -721,6 +884,7 @@ class StatsCliSupportTest {
     final AtomicInteger listIndexArtifactsCalls = new AtomicInteger();
     ListIndexArtifactsRequest lastListIndexArtifactsRequest;
     List<IndexArtifactRecord> recordsToReturn = List.of();
+    List<ListIndexArtifactsResponse> listIndexArtifactsPages = List.of();
 
     @Override
     public void listIndexArtifacts(
@@ -728,8 +892,13 @@ class StatsCliSupportTest {
         StreamObserver<ListIndexArtifactsResponse> responseObserver) {
       listIndexArtifactsCalls.incrementAndGet();
       lastListIndexArtifactsRequest = request;
-      responseObserver.onNext(
-          ListIndexArtifactsResponse.newBuilder().addAllRecords(recordsToReturn).build());
+      if (!listIndexArtifactsPages.isEmpty()) {
+        int index = Math.min(listIndexArtifactsCalls.get() - 1, listIndexArtifactsPages.size() - 1);
+        responseObserver.onNext(listIndexArtifactsPages.get(index));
+      } else {
+        responseObserver.onNext(
+            ListIndexArtifactsResponse.newBuilder().addAllRecords(recordsToReturn).build());
+      }
       responseObserver.onCompleted();
     }
   }

--- a/core/proto/src/main/proto/floecat/connector/connector.proto
+++ b/core/proto/src/main/proto/floecat/connector/connector.proto
@@ -261,4 +261,16 @@ service Connectors {
   rpc DeleteConnector(DeleteConnectorRequest) returns (DeleteConnectorResponse);
 
   rpc ValidateConnector(ValidateConnectorRequest) returns (ValidateConnectorResponse);
+
+
+  rpc ListCatalogs(ListCatalogsRequest) returns (ListCatalogsResponse);
+  rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
+  rpc ListTables(ListTablesRequest) returns (ListTablesResponse);
+
+  rpc AddTables(AddTablesRequest) returns (AddTablesResponse);
+  rpc RemoveTables(RemoveTablesRequest) returns (RemoveTablesResponse);
+
+  rpc ConnectorStatus(ConnectorStatusRequest) returns (ConnectorStatusResponse);
+  
+
 }

--- a/core/proto/src/main/proto/floecat/connector/connector.proto
+++ b/core/proto/src/main/proto/floecat/connector/connector.proto
@@ -261,16 +261,4 @@ service Connectors {
   rpc DeleteConnector(DeleteConnectorRequest) returns (DeleteConnectorResponse);
 
   rpc ValidateConnector(ValidateConnectorRequest) returns (ValidateConnectorResponse);
-
-
-  rpc ListCatalogs(ListCatalogsRequest) returns (ListCatalogsResponse);
-  rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
-  rpc ListTables(ListTablesRequest) returns (ListTablesResponse);
-
-  rpc AddTables(AddTablesRequest) returns (AddTablesResponse);
-  rpc RemoveTables(RemoveTablesRequest) returns (RemoveTablesResponse);
-
-  rpc ConnectorStatus(ConnectorStatusRequest) returns (ConnectorStatusResponse);
-  
-
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -39,7 +39,7 @@ view get <id|catalog.ns[.ns...].name>
 view update <id|fq> [--display <name>] [--namespace <catalog.ns[.ns...]>] [--sql <text>] [--desc <text>] [--props k=v ...]
 view delete <id|fq>
 
-snapshots <catalog.ns[.ns...].table>
+snapshots <catalog.ns[.ns...].table> [--limit N]
 snapshot get <table> <snapshot_id>
 snapshot delete <table> <snapshot_id> [--etag <etag>]
 
@@ -82,7 +82,7 @@ query get <query_id>
 query fetch-scan <query_id> <table_id>
 
 connectors
-connector list [--kind <KIND>] [--page-size <N>]
+connector list [--kind <KIND>]
 connector get <display_name|id>
 connector create <display_name> <source_type (ICEBERG|DELTA|GLUE|UNITY)> <uri> <source_namespace (a[.b[.c]...])> <destination_catalog (name)>
     [--source-table <name>] [--source-cols c1,#id2,...]
@@ -115,14 +115,14 @@ connector trigger <display_name|id> (--full|--incremental)
     [--dest-ns <a.b[.c]>] [--dest-table <name>] [--dest-view <name>]
     [--snapshot <id[,id...]>|--current|--latest-n <n>|--all] [--columns c1,#id2,...]
 connector job <jobId> [--json]
-connector jobs [--connector <id|name>] [--state queued,running,...] [--page-size <N>] [--json]
-connector jobs --child <parentJobId> [--connector <id|name>] [--state queued,running,...] [--page-size <N>] [--json]
+connector jobs [--connector <display_name|id>] [--state <queued|running|cancelling|cancelled|succeeded|failed>[,...]] [--limit N] [--json]
+connector jobs --child <parentJobId> [--json]
 connector cancel <jobId> [--reason <text>]
 connector settings get
 connector settings update [--auto-enabled true|false] [--default-interval-sec <n>] [--default-mode incremental|full] [--finished-job-retention-sec <n>]
 
 storage-authorities
-storage-authority list [--page-size <N>]
+storage-authority list
 storage-authority get <display_name|id>
 storage-authority create <display_name> --location-prefix <uri-prefix>
     [--desc <text>] [--enabled true|false] [--type <type>]

--- a/docs/client-cli.md
+++ b/docs/client-cli.md
@@ -70,8 +70,9 @@ syntactic sugar such as `catalog.ns.table` references and `--props k=v` repeated
 - **Secret handling** – Secret-bearing connector and storage-authority values must be supplied via
   `--cred-type` / `--cred`, not `--auth k=v`. The service stores those secrets out-of-band and
   only returns redacted or client-safe values.
-- **Pagination defaults** – `DEFAULT_PAGE_SIZE` is 1000; commands paginate internally by default.
-  Commands that expose `--page-size` include connector and storage-authority listing workflows.
+- **Pagination defaults** – Commands paginate internally in batches of 100 rows. User-facing limits
+  are exposed only on ordered result sets such as `snapshots`, `connector jobs`, and ordered stats
+  commands.
 - **Query display** – `query get` prints the `QueryDescriptor` metadata (snapshots, expansions,
   obligations). Use `query fetch-scan <query_id> <table_id>` to print the data/delete `ScanFile`
   entries returned by connectors via the query lifecycle SPI.


### PR DESCRIPTION
## Summary

Add --limit control to commands (principally connector jobs) to limit the number of lines returned to the client to the first N. Other small cleanups (removal of pointless --page-size option) on a few commands too.

## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
