### PR TITLE
Add refresh on connector pools for sync clients

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -95,7 +95,6 @@ import java.util.function.UnaryOperator;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 @ApplicationScoped
 @IfBuildProperty(name = "floecat.reconciler.job-store", stringValue = "durable")
@@ -146,7 +145,6 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   @Inject BlobStore blobStore;
   @Inject ObjectMapper mapper;
   @Inject Config config;
-  @Inject Instance<DynamoDbClient> dynamoDb;
   @Inject Instance<DynamoDbClientManager> dynamoDbClientManager;
 
   @ConfigProperty(name = "floecat.kv.table", defaultValue = "floecat_pointers")
@@ -246,10 +244,6 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         && dynamoDbClientManager.isResolvable()) {
       DynamoDbClientManager manager = dynamoDbClientManager.get();
       dynamoBackend.bind(manager::current, kvTable, manager::refreshAfterFailure);
-    } else if (jobIndexBackend instanceof DynamoReconcileJobIndexBackend dynamoBackend
-        && dynamoDb != null
-        && dynamoDb.isResolvable()) {
-      dynamoBackend.bind(dynamoDb.get(), kvTable);
     }
     jobIndexStore.bind(
         jobIndexBackend,
@@ -321,10 +315,6 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         && dynamoDbClientManager.isResolvable()) {
       DynamoDbClientManager manager = dynamoDbClientManager.get();
       dynamoBackend.bind(manager::current, kvTable, manager::refreshAfterFailure);
-    } else if (leaseBackend instanceof DynamoReconcileLeaseBackend dynamoBackend
-        && dynamoDb != null
-        && dynamoDb.isResolvable()) {
-      dynamoBackend.bind(dynamoDb.get(), kvTable);
     }
     leaseStore.bind(
         leaseBackend,
@@ -375,10 +365,6 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         && dynamoDbClientManager.isResolvable()) {
       DynamoDbClientManager manager = dynamoDbClientManager.get();
       dynamoBackend.bind(manager::current, kvTable, manager::refreshAfterFailure);
-    } else if (readyQueueBackend instanceof DynamoReconcileReadyQueueBackend dynamoBackend
-        && dynamoDb != null
-        && dynamoDb.isResolvable()) {
-      dynamoBackend.bind(dynamoDb.get(), kvTable);
     }
     readyQueueStore.bind(
         readyQueueBackend,

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -67,6 +67,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQue
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -146,6 +147,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   @Inject ObjectMapper mapper;
   @Inject Config config;
   @Inject Instance<DynamoDbClient> dynamoDb;
+  @Inject Instance<DynamoDbClientManager> dynamoDbClientManager;
 
   @ConfigProperty(name = "floecat.kv.table", defaultValue = "floecat_pointers")
   String kvTable = "floecat_pointers";
@@ -240,6 +242,11 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     if (jobIndexBackend instanceof MemoryReconcileJobIndexBackend memoryBackend) {
       memoryBackend.bind(pointerStore);
     } else if (jobIndexBackend instanceof DynamoReconcileJobIndexBackend dynamoBackend
+        && dynamoDbClientManager != null
+        && dynamoDbClientManager.isResolvable()) {
+      DynamoDbClientManager manager = dynamoDbClientManager.get();
+      dynamoBackend.bind(manager::current, kvTable, manager::refreshAfterFailure);
+    } else if (jobIndexBackend instanceof DynamoReconcileJobIndexBackend dynamoBackend
         && dynamoDb != null
         && dynamoDb.isResolvable()) {
       dynamoBackend.bind(dynamoDb.get(), kvTable);
@@ -310,6 +317,11 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     if (leaseBackend instanceof MemoryReconcileLeaseBackend memoryBackend) {
       memoryBackend.bind(pointerStore);
     } else if (leaseBackend instanceof DynamoReconcileLeaseBackend dynamoBackend
+        && dynamoDbClientManager != null
+        && dynamoDbClientManager.isResolvable()) {
+      DynamoDbClientManager manager = dynamoDbClientManager.get();
+      dynamoBackend.bind(manager::current, kvTable, manager::refreshAfterFailure);
+    } else if (leaseBackend instanceof DynamoReconcileLeaseBackend dynamoBackend
         && dynamoDb != null
         && dynamoDb.isResolvable()) {
       dynamoBackend.bind(dynamoDb.get(), kvTable);
@@ -358,6 +370,11 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     }
     if (readyQueueBackend instanceof MemoryReconcileReadyQueueBackend memoryBackend) {
       memoryBackend.bind(pointerStore);
+    } else if (readyQueueBackend instanceof DynamoReconcileReadyQueueBackend dynamoBackend
+        && dynamoDbClientManager != null
+        && dynamoDbClientManager.isResolvable()) {
+      DynamoDbClientManager manager = dynamoDbClientManager.get();
+      dynamoBackend.bind(manager::current, kvTable, manager::refreshAfterFailure);
     } else if (readyQueueBackend instanceof DynamoReconcileReadyQueueBackend dynamoBackend
         && dynamoDb != null
         && dynamoDb.isResolvable()) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
@@ -21,8 +21,11 @@ import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_PARTITION_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_SORT_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_VERSION;
 
+import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
+import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
@@ -30,6 +33,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -46,6 +52,10 @@ import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledExcepti
 @IfBuildProperty(name = "floecat.kv", stringValue = "dynamodb")
 public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend {
   @Inject DynamoDbClient dynamoDb;
+  @Inject Instance<DynamoDbClientManager> dynamoDbClientManager;
+  private volatile Supplier<DynamoDbClient> dynamoDbSupplier;
+  private volatile BiConsumer<DynamoDbClient, Throwable> clientFailureHandler =
+      (client, failure) -> {};
 
   @ConfigProperty(name = "floecat.kv.table", defaultValue = "floecat_pointers")
   String table = "floecat_pointers";
@@ -55,7 +65,71 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
 
   public void bind(DynamoDbClient dynamoDb, String table) {
     this.dynamoDb = dynamoDb;
+    this.dynamoDbSupplier = () -> dynamoDb;
+    this.clientFailureHandler = (client, failure) -> {};
     this.table = table;
+  }
+
+  public void bind(
+      Supplier<DynamoDbClient> dynamoDbSupplier,
+      String table,
+      BiConsumer<DynamoDbClient, Throwable> clientFailureHandler) {
+    this.dynamoDbSupplier = dynamoDbSupplier;
+    this.clientFailureHandler =
+        clientFailureHandler == null ? (client, failure) -> {} : clientFailureHandler;
+    this.table = table;
+  }
+
+  private DynamoDbClient dynamoDb() {
+    if (dynamoDbSupplier != null) {
+      return dynamoDbSupplier.get();
+    }
+    if (dynamoDbClientManager != null && dynamoDbClientManager.isResolvable()) {
+      DynamoDbClientManager manager = dynamoDbClientManager.get();
+      dynamoDbSupplier = manager::current;
+      clientFailureHandler = manager::refreshAfterFailure;
+      return dynamoDbSupplier.get();
+    }
+    return dynamoDb;
+  }
+
+  private boolean refreshAfterFailure(DynamoDbClient client, Throwable failure) {
+    if (ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
+      clientFailureHandler.accept(client, failure);
+      return true;
+    }
+    return false;
+  }
+
+  private <T> T callDynamo(Function<DynamoDbClient, T> operation) {
+    for (int attempt = 0; ; attempt++) {
+      DynamoDbClient client = dynamoDb();
+      try {
+        return operation.apply(client);
+      } catch (RuntimeException e) {
+        boolean refreshed = refreshAfterFailure(client, e);
+        if (refreshed && attempt == 0) {
+          continue;
+        }
+        throw e;
+      }
+    }
+  }
+
+  private void callDynamoVoid(java.util.function.Consumer<DynamoDbClient> operation) {
+    for (int attempt = 0; ; attempt++) {
+      DynamoDbClient client = dynamoDb();
+      try {
+        operation.accept(client);
+        return;
+      } catch (RuntimeException e) {
+        boolean refreshed = refreshAfterFailure(client, e);
+        if (refreshed && attempt == 0) {
+          continue;
+        }
+        throw e;
+      }
+    }
   }
 
   @Override
@@ -233,19 +307,21 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
       if (exclusiveStartKey != null && !exclusiveStartKey.isEmpty()) {
         request.exclusiveStartKey(exclusiveStartKey);
       }
-      var response = dynamoDb.scan(request.build());
+      var response = callDynamo(client -> client.scan(request.build()));
       for (var item : response.items()) {
         if (item == null || item.isEmpty()) {
           continue;
         }
-        dynamoDb.deleteItem(
-            software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest.builder()
-                .tableName(table)
-                .key(
-                    Map.of(
-                        ATTR_PARTITION_KEY, item.get(ATTR_PARTITION_KEY),
-                        ATTR_SORT_KEY, item.get(ATTR_SORT_KEY)))
-                .build());
+        callDynamoVoid(
+            client ->
+                client.deleteItem(
+                    software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest.builder()
+                        .tableName(table)
+                        .key(
+                            Map.of(
+                                ATTR_PARTITION_KEY, item.get(ATTR_PARTITION_KEY),
+                                ATTR_SORT_KEY, item.get(ATTR_SORT_KEY)))
+                        .build()));
         deleted = true;
       }
       exclusiveStartKey = response.lastEvaluatedKey();
@@ -283,7 +359,10 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
       }
     }
     try {
-      dynamoDb.transactWriteItems(TransactWriteItemsRequest.builder().transactItems(tx).build());
+      callDynamoVoid(
+          client ->
+              client.transactWriteItems(
+                  TransactWriteItemsRequest.builder().transactItems(tx).build()));
       return true;
     } catch (TransactionCanceledException e) {
       return false;
@@ -338,17 +417,20 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
   private Optional<JobIndexEntrySnapshot> loadCanonicalPointer(
       JobIndexBackendSupport.CanonicalJobKey key) {
     var response =
-        dynamoDb.getItem(
-            GetItemRequest.builder()
-                .tableName(table)
-                .consistentRead(true)
-                .key(
-                    Map.of(
-                        ATTR_PARTITION_KEY,
-                        AttributeValue.fromS(JobIndexBackendSupport.canonicalPartitionKey(key)),
-                        ATTR_SORT_KEY,
-                        AttributeValue.fromS(JobIndexBackendSupport.canonicalSortKey(key))))
-                .build());
+        callDynamo(
+            client ->
+                client.getItem(
+                    GetItemRequest.builder()
+                        .tableName(table)
+                        .consistentRead(true)
+                        .key(
+                            Map.of(
+                                ATTR_PARTITION_KEY,
+                                AttributeValue.fromS(
+                                    JobIndexBackendSupport.canonicalPartitionKey(key)),
+                                ATTR_SORT_KEY,
+                                AttributeValue.fromS(JobIndexBackendSupport.canonicalSortKey(key))))
+                        .build()));
     if (!response.hasItem() || response.item().isEmpty()) {
       return Optional.empty();
     }
@@ -362,15 +444,17 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
   private Optional<JobIndexEntrySnapshot> loadIndexPointer(
       String partitionKey, String sortKey, String referenceAttributeName) {
     var response =
-        dynamoDb.getItem(
-            GetItemRequest.builder()
-                .tableName(table)
-                .consistentRead(true)
-                .key(
-                    Map.of(
-                        ATTR_PARTITION_KEY, AttributeValue.fromS(partitionKey),
-                        ATTR_SORT_KEY, AttributeValue.fromS(sortKey)))
-                .build());
+        callDynamo(
+            client ->
+                client.getItem(
+                    GetItemRequest.builder()
+                        .tableName(table)
+                        .consistentRead(true)
+                        .key(
+                            Map.of(
+                                ATTR_PARTITION_KEY, AttributeValue.fromS(partitionKey),
+                                ATTR_SORT_KEY, AttributeValue.fromS(sortKey)))
+                        .build()));
     if (!response.hasItem() || response.item().isEmpty()) {
       return Optional.empty();
     }
@@ -398,7 +482,7 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
               ATTR_PARTITION_KEY, AttributeValue.fromS(partitionKey),
               ATTR_SORT_KEY, AttributeValue.fromS(resumeSortKey)));
     }
-    var response = dynamoDb.query(query.build());
+    var response = callDynamo(client -> client.query(query.build()));
     List<JobIndexEntrySnapshot> pointers = new ArrayList<>(response.items().size());
     for (var item : response.items()) {
       pointers.add(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
@@ -21,7 +21,6 @@ import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_PARTITION_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_SORT_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_VERSION;
 
-import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
 import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import io.quarkus.arc.properties.IfBuildProperty;
@@ -34,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -51,85 +49,20 @@ import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledExcepti
 @Singleton
 @IfBuildProperty(name = "floecat.kv", stringValue = "dynamodb")
 public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend {
-  @Inject DynamoDbClient dynamoDb;
   @Inject Instance<DynamoDbClientManager> dynamoDbClientManager;
-  private volatile Supplier<DynamoDbClient> dynamoDbSupplier;
-  private volatile BiConsumer<DynamoDbClient, Throwable> clientFailureHandler =
-      (client, failure) -> {};
+  private final RefreshingDynamoCaller dynamoCaller = new RefreshingDynamoCaller();
 
   @ConfigProperty(name = "floecat.kv.table", defaultValue = "floecat_pointers")
   String table = "floecat_pointers";
 
-  @Inject
   public DynamoReconcileJobIndexBackend() {}
-
-  public void bind(DynamoDbClient dynamoDb, String table) {
-    this.dynamoDb = dynamoDb;
-    this.dynamoDbSupplier = () -> dynamoDb;
-    this.clientFailureHandler = (client, failure) -> {};
-    this.table = table;
-  }
 
   public void bind(
       Supplier<DynamoDbClient> dynamoDbSupplier,
       String table,
       BiConsumer<DynamoDbClient, Throwable> clientFailureHandler) {
-    this.dynamoDbSupplier = dynamoDbSupplier;
-    this.clientFailureHandler =
-        clientFailureHandler == null ? (client, failure) -> {} : clientFailureHandler;
+    dynamoCaller.bind(dynamoDbSupplier, clientFailureHandler);
     this.table = table;
-  }
-
-  private DynamoDbClient dynamoDb() {
-    if (dynamoDbSupplier != null) {
-      return dynamoDbSupplier.get();
-    }
-    if (dynamoDbClientManager != null && dynamoDbClientManager.isResolvable()) {
-      DynamoDbClientManager manager = dynamoDbClientManager.get();
-      dynamoDbSupplier = manager::current;
-      clientFailureHandler = manager::refreshAfterFailure;
-      return dynamoDbSupplier.get();
-    }
-    return dynamoDb;
-  }
-
-  private boolean refreshAfterFailure(DynamoDbClient client, Throwable failure) {
-    if (ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
-      clientFailureHandler.accept(client, failure);
-      return true;
-    }
-    return false;
-  }
-
-  private <T> T callDynamo(Function<DynamoDbClient, T> operation) {
-    for (int attempt = 0; ; attempt++) {
-      DynamoDbClient client = dynamoDb();
-      try {
-        return operation.apply(client);
-      } catch (RuntimeException e) {
-        boolean refreshed = refreshAfterFailure(client, e);
-        if (refreshed && attempt == 0) {
-          continue;
-        }
-        throw e;
-      }
-    }
-  }
-
-  private void callDynamoVoid(java.util.function.Consumer<DynamoDbClient> operation) {
-    for (int attempt = 0; ; attempt++) {
-      DynamoDbClient client = dynamoDb();
-      try {
-        operation.accept(client);
-        return;
-      } catch (RuntimeException e) {
-        boolean refreshed = refreshAfterFailure(client, e);
-        if (refreshed && attempt == 0) {
-          continue;
-        }
-        throw e;
-      }
-    }
   }
 
   @Override
@@ -307,12 +240,14 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
       if (exclusiveStartKey != null && !exclusiveStartKey.isEmpty()) {
         request.exclusiveStartKey(exclusiveStartKey);
       }
-      var response = callDynamo(client -> client.scan(request.build()));
+      var response =
+          dynamoCaller.call(dynamoDbClientManager, client -> client.scan(request.build()));
       for (var item : response.items()) {
         if (item == null || item.isEmpty()) {
           continue;
         }
-        callDynamoVoid(
+        dynamoCaller.callVoid(
+            dynamoDbClientManager,
             client ->
                 client.deleteItem(
                     software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest.builder()
@@ -359,7 +294,8 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
       }
     }
     try {
-      callDynamoVoid(
+      dynamoCaller.callVoid(
+          dynamoDbClientManager,
           client ->
               client.transactWriteItems(
                   TransactWriteItemsRequest.builder().transactItems(tx).build()));
@@ -417,7 +353,8 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
   private Optional<JobIndexEntrySnapshot> loadCanonicalPointer(
       JobIndexBackendSupport.CanonicalJobKey key) {
     var response =
-        callDynamo(
+        dynamoCaller.call(
+            dynamoDbClientManager,
             client ->
                 client.getItem(
                     GetItemRequest.builder()
@@ -444,7 +381,8 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
   private Optional<JobIndexEntrySnapshot> loadIndexPointer(
       String partitionKey, String sortKey, String referenceAttributeName) {
     var response =
-        callDynamo(
+        dynamoCaller.call(
+            dynamoDbClientManager,
             client ->
                 client.getItem(
                     GetItemRequest.builder()
@@ -482,7 +420,7 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
               ATTR_PARTITION_KEY, AttributeValue.fromS(partitionKey),
               ATTR_SORT_KEY, AttributeValue.fromS(resumeSortKey)));
     }
-    var response = callDynamo(client -> client.query(query.build()));
+    var response = dynamoCaller.call(dynamoDbClientManager, client -> client.query(query.build()));
     List<JobIndexEntrySnapshot> pointers = new ArrayList<>(response.items().size());
     for (var item : response.items()) {
       pointers.add(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
@@ -22,7 +22,6 @@ import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_SORT_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_VERSION;
 
 import ai.floedb.floecat.service.repo.model.PointerReferences;
-import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
 import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import ai.floedb.floecat.storage.spi.PointerStore.CasDelete;
 import ai.floedb.floecat.storage.spi.PointerStore.CasUpsert;
@@ -38,7 +37,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -57,85 +55,20 @@ import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledExcepti
 public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
   private static final String ATTR_BLOB_URI = "blob_uri";
 
-  @Inject DynamoDbClient dynamoDb;
   @Inject Instance<DynamoDbClientManager> dynamoDbClientManager;
-  private volatile Supplier<DynamoDbClient> dynamoDbSupplier;
-  private volatile BiConsumer<DynamoDbClient, Throwable> clientFailureHandler =
-      (client, failure) -> {};
+  private final RefreshingDynamoCaller dynamoCaller = new RefreshingDynamoCaller();
 
   @ConfigProperty(name = "floecat.kv.table", defaultValue = "floecat_pointers")
   String table = "floecat_pointers";
 
-  @Inject
   public DynamoReconcileLeaseBackend() {}
-
-  public void bind(DynamoDbClient dynamoDb, String table) {
-    this.dynamoDb = dynamoDb;
-    this.dynamoDbSupplier = () -> dynamoDb;
-    this.clientFailureHandler = (client, failure) -> {};
-    this.table = table;
-  }
 
   public void bind(
       Supplier<DynamoDbClient> dynamoDbSupplier,
       String table,
       BiConsumer<DynamoDbClient, Throwable> clientFailureHandler) {
-    this.dynamoDbSupplier = dynamoDbSupplier;
-    this.clientFailureHandler =
-        clientFailureHandler == null ? (client, failure) -> {} : clientFailureHandler;
+    dynamoCaller.bind(dynamoDbSupplier, clientFailureHandler);
     this.table = table;
-  }
-
-  private DynamoDbClient dynamoDb() {
-    if (dynamoDbSupplier != null) {
-      return dynamoDbSupplier.get();
-    }
-    if (dynamoDbClientManager != null && dynamoDbClientManager.isResolvable()) {
-      DynamoDbClientManager manager = dynamoDbClientManager.get();
-      dynamoDbSupplier = manager::current;
-      clientFailureHandler = manager::refreshAfterFailure;
-      return dynamoDbSupplier.get();
-    }
-    return dynamoDb;
-  }
-
-  private boolean refreshAfterFailure(DynamoDbClient client, Throwable failure) {
-    if (ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
-      clientFailureHandler.accept(client, failure);
-      return true;
-    }
-    return false;
-  }
-
-  private <T> T callDynamo(Function<DynamoDbClient, T> operation) {
-    for (int attempt = 0; ; attempt++) {
-      DynamoDbClient client = dynamoDb();
-      try {
-        return operation.apply(client);
-      } catch (RuntimeException e) {
-        boolean refreshed = refreshAfterFailure(client, e);
-        if (refreshed && attempt == 0) {
-          continue;
-        }
-        throw e;
-      }
-    }
-  }
-
-  private void callDynamoVoid(java.util.function.Consumer<DynamoDbClient> operation) {
-    for (int attempt = 0; ; attempt++) {
-      DynamoDbClient client = dynamoDb();
-      try {
-        operation.accept(client);
-        return;
-      } catch (RuntimeException e) {
-        boolean refreshed = refreshAfterFailure(client, e);
-        if (refreshed && attempt == 0) {
-          continue;
-        }
-        throw e;
-      }
-    }
   }
 
   @Override
@@ -155,7 +88,8 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
   @Override
   public Optional<LeaseOwnerSnapshot> loadOwner(String ownerKey) {
     var response =
-        callDynamo(
+        dynamoCaller.call(
+            dynamoDbClientManager,
             client ->
                 client.getItem(
                     GetItemRequest.builder()
@@ -203,7 +137,7 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
               AttributeValue.fromS(token)));
     }
 
-    var response = callDynamo(client -> client.query(query.build()));
+    var response = dynamoCaller.call(dynamoDbClientManager, client -> client.query(query.build()));
     List<ReconcileLeaseStore.LeaseExpiryEntry> entries = new ArrayList<>(response.items().size());
     for (var item : response.items()) {
       entries.add(
@@ -318,7 +252,8 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
       }
     }
     try {
-      callDynamoVoid(
+      dynamoCaller.callVoid(
+          dynamoDbClientManager,
           client ->
               client.transactWriteItems(
                   TransactWriteItemsRequest.builder().transactItems(tx).build()));
@@ -335,7 +270,8 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
   private Optional<LeaseRecordSnapshot> loadLeaseSnapshot(
       LeaseBackendSupport.LeasePointerKey leaseKey) {
     var response =
-        callDynamo(
+        dynamoCaller.call(
+            dynamoDbClientManager,
             client ->
                 client.getItem(
                     GetItemRequest.builder()
@@ -360,7 +296,8 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
   private Optional<LeaseExpirySnapshot> loadLeaseExpirySnapshot(
       LeaseBackendSupport.LeaseExpiryPointerKey expiryKey) {
     var response =
-        callDynamo(
+        dynamoCaller.call(
+            dynamoDbClientManager,
             client ->
                 client.getItem(
                     GetItemRequest.builder()

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
@@ -22,9 +22,12 @@ import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_SORT_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_VERSION;
 
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
+import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import ai.floedb.floecat.storage.spi.PointerStore.CasDelete;
 import ai.floedb.floecat.storage.spi.PointerStore.CasUpsert;
 import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
@@ -34,6 +37,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -52,6 +58,10 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
   private static final String ATTR_BLOB_URI = "blob_uri";
 
   @Inject DynamoDbClient dynamoDb;
+  @Inject Instance<DynamoDbClientManager> dynamoDbClientManager;
+  private volatile Supplier<DynamoDbClient> dynamoDbSupplier;
+  private volatile BiConsumer<DynamoDbClient, Throwable> clientFailureHandler =
+      (client, failure) -> {};
 
   @ConfigProperty(name = "floecat.kv.table", defaultValue = "floecat_pointers")
   String table = "floecat_pointers";
@@ -61,7 +71,71 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
 
   public void bind(DynamoDbClient dynamoDb, String table) {
     this.dynamoDb = dynamoDb;
+    this.dynamoDbSupplier = () -> dynamoDb;
+    this.clientFailureHandler = (client, failure) -> {};
     this.table = table;
+  }
+
+  public void bind(
+      Supplier<DynamoDbClient> dynamoDbSupplier,
+      String table,
+      BiConsumer<DynamoDbClient, Throwable> clientFailureHandler) {
+    this.dynamoDbSupplier = dynamoDbSupplier;
+    this.clientFailureHandler =
+        clientFailureHandler == null ? (client, failure) -> {} : clientFailureHandler;
+    this.table = table;
+  }
+
+  private DynamoDbClient dynamoDb() {
+    if (dynamoDbSupplier != null) {
+      return dynamoDbSupplier.get();
+    }
+    if (dynamoDbClientManager != null && dynamoDbClientManager.isResolvable()) {
+      DynamoDbClientManager manager = dynamoDbClientManager.get();
+      dynamoDbSupplier = manager::current;
+      clientFailureHandler = manager::refreshAfterFailure;
+      return dynamoDbSupplier.get();
+    }
+    return dynamoDb;
+  }
+
+  private boolean refreshAfterFailure(DynamoDbClient client, Throwable failure) {
+    if (ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
+      clientFailureHandler.accept(client, failure);
+      return true;
+    }
+    return false;
+  }
+
+  private <T> T callDynamo(Function<DynamoDbClient, T> operation) {
+    for (int attempt = 0; ; attempt++) {
+      DynamoDbClient client = dynamoDb();
+      try {
+        return operation.apply(client);
+      } catch (RuntimeException e) {
+        boolean refreshed = refreshAfterFailure(client, e);
+        if (refreshed && attempt == 0) {
+          continue;
+        }
+        throw e;
+      }
+    }
+  }
+
+  private void callDynamoVoid(java.util.function.Consumer<DynamoDbClient> operation) {
+    for (int attempt = 0; ; attempt++) {
+      DynamoDbClient client = dynamoDb();
+      try {
+        operation.accept(client);
+        return;
+      } catch (RuntimeException e) {
+        boolean refreshed = refreshAfterFailure(client, e);
+        if (refreshed && attempt == 0) {
+          continue;
+        }
+        throw e;
+      }
+    }
   }
 
   @Override
@@ -81,17 +155,20 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
   @Override
   public Optional<LeaseOwnerSnapshot> loadOwner(String ownerKey) {
     var response =
-        dynamoDb.getItem(
-            GetItemRequest.builder()
-                .tableName(table)
-                .consistentRead(true)
-                .key(
-                    Map.of(
-                        ATTR_PARTITION_KEY,
-                        AttributeValue.fromS(LeaseBackendSupport.ownerPartitionKey(ownerKey)),
-                        ATTR_SORT_KEY,
-                        AttributeValue.fromS(LeaseBackendSupport.LEASE_OWNER_SORT_KEY)))
-                .build());
+        callDynamo(
+            client ->
+                client.getItem(
+                    GetItemRequest.builder()
+                        .tableName(table)
+                        .consistentRead(true)
+                        .key(
+                            Map.of(
+                                ATTR_PARTITION_KEY,
+                                AttributeValue.fromS(
+                                    LeaseBackendSupport.ownerPartitionKey(ownerKey)),
+                                ATTR_SORT_KEY,
+                                AttributeValue.fromS(LeaseBackendSupport.LEASE_OWNER_SORT_KEY)))
+                        .build()));
     if (!response.hasItem() || response.item().isEmpty()) {
       return Optional.empty();
     }
@@ -126,7 +203,7 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
               AttributeValue.fromS(token)));
     }
 
-    var response = dynamoDb.query(query.build());
+    var response = callDynamo(client -> client.query(query.build()));
     List<ReconcileLeaseStore.LeaseExpiryEntry> entries = new ArrayList<>(response.items().size());
     for (var item : response.items()) {
       entries.add(
@@ -241,7 +318,10 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
       }
     }
     try {
-      dynamoDb.transactWriteItems(TransactWriteItemsRequest.builder().transactItems(tx).build());
+      callDynamoVoid(
+          client ->
+              client.transactWriteItems(
+                  TransactWriteItemsRequest.builder().transactItems(tx).build()));
       return true;
     } catch (TransactionCanceledException e) {
       return false;
@@ -255,17 +335,20 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
   private Optional<LeaseRecordSnapshot> loadLeaseSnapshot(
       LeaseBackendSupport.LeasePointerKey leaseKey) {
     var response =
-        dynamoDb.getItem(
-            GetItemRequest.builder()
-                .tableName(table)
-                .consistentRead(true)
-                .key(
-                    Map.of(
-                        ATTR_PARTITION_KEY,
-                        AttributeValue.fromS(LeaseBackendSupport.leasePartitionKey(leaseKey)),
-                        ATTR_SORT_KEY,
-                        AttributeValue.fromS(LeaseBackendSupport.leaseSortKey(leaseKey))))
-                .build());
+        callDynamo(
+            client ->
+                client.getItem(
+                    GetItemRequest.builder()
+                        .tableName(table)
+                        .consistentRead(true)
+                        .key(
+                            Map.of(
+                                ATTR_PARTITION_KEY,
+                                AttributeValue.fromS(
+                                    LeaseBackendSupport.leasePartitionKey(leaseKey)),
+                                ATTR_SORT_KEY,
+                                AttributeValue.fromS(LeaseBackendSupport.leaseSortKey(leaseKey))))
+                        .build()));
     if (!response.hasItem() || response.item().isEmpty()) {
       return Optional.empty();
     }
@@ -277,17 +360,21 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
   private Optional<LeaseExpirySnapshot> loadLeaseExpirySnapshot(
       LeaseBackendSupport.LeaseExpiryPointerKey expiryKey) {
     var response =
-        dynamoDb.getItem(
-            GetItemRequest.builder()
-                .tableName(table)
-                .consistentRead(true)
-                .key(
-                    Map.of(
-                        ATTR_PARTITION_KEY,
-                        AttributeValue.fromS(LeaseBackendSupport.LEASE_EXPIRY_PARTITION_KEY),
-                        ATTR_SORT_KEY,
-                        AttributeValue.fromS(LeaseBackendSupport.leaseExpirySortKey(expiryKey))))
-                .build());
+        callDynamo(
+            client ->
+                client.getItem(
+                    GetItemRequest.builder()
+                        .tableName(table)
+                        .consistentRead(true)
+                        .key(
+                            Map.of(
+                                ATTR_PARTITION_KEY,
+                                AttributeValue.fromS(
+                                    LeaseBackendSupport.LEASE_EXPIRY_PARTITION_KEY),
+                                ATTR_SORT_KEY,
+                                AttributeValue.fromS(
+                                    LeaseBackendSupport.leaseExpirySortKey(expiryKey))))
+                        .build()));
     if (!response.hasItem() || response.item().isEmpty()) {
       return Optional.empty();
     }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackend.java
@@ -20,7 +20,6 @@ import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_PARTITION_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_SORT_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_VERSION;
 
-import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
 import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.enterprise.inject.Instance;
@@ -32,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
@@ -60,89 +58,20 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
   private static final String GLOBAL_POINTER_PARTITION_KEY = "_ACCOUNT_DIR";
   private static final String ATTR_BLOB_URI = "blob_uri";
 
-  private DynamoDbClient dynamoDb;
   @Inject Instance<DynamoDbClientManager> dynamoDbClientManager;
-  private volatile Supplier<DynamoDbClient> dynamoDbSupplier;
-  private volatile BiConsumer<DynamoDbClient, Throwable> clientFailureHandler =
-      (client, failure) -> {};
-  private String table;
+  private final RefreshingDynamoCaller dynamoCaller = new RefreshingDynamoCaller();
 
-  @Inject
-  public DynamoReconcileReadyQueueBackend(
-      DynamoDbClient dynamoDb, @ConfigProperty(name = "floecat.kv.table") String table) {
-    this.dynamoDb = dynamoDb;
-    this.table = table;
-  }
+  @ConfigProperty(name = "floecat.kv.table", defaultValue = "floecat_pointers")
+  String table = "floecat_pointers";
 
   public DynamoReconcileReadyQueueBackend() {}
-
-  public void bind(DynamoDbClient dynamoDb, String table) {
-    this.dynamoDb = dynamoDb;
-    this.dynamoDbSupplier = () -> dynamoDb;
-    this.clientFailureHandler = (client, failure) -> {};
-    this.table = table;
-  }
 
   public void bind(
       Supplier<DynamoDbClient> dynamoDbSupplier,
       String table,
       BiConsumer<DynamoDbClient, Throwable> clientFailureHandler) {
-    this.dynamoDbSupplier = dynamoDbSupplier;
-    this.clientFailureHandler =
-        clientFailureHandler == null ? (client, failure) -> {} : clientFailureHandler;
+    dynamoCaller.bind(dynamoDbSupplier, clientFailureHandler);
     this.table = table;
-  }
-
-  private DynamoDbClient dynamoDb() {
-    if (dynamoDbSupplier != null) {
-      return dynamoDbSupplier.get();
-    }
-    if (dynamoDbClientManager != null && dynamoDbClientManager.isResolvable()) {
-      DynamoDbClientManager manager = dynamoDbClientManager.get();
-      dynamoDbSupplier = manager::current;
-      clientFailureHandler = manager::refreshAfterFailure;
-      return dynamoDbSupplier.get();
-    }
-    return dynamoDb;
-  }
-
-  private boolean refreshAfterFailure(DynamoDbClient client, Throwable failure) {
-    if (ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
-      clientFailureHandler.accept(client, failure);
-      return true;
-    }
-    return false;
-  }
-
-  private <T> T callDynamo(Function<DynamoDbClient, T> operation) {
-    for (int attempt = 0; ; attempt++) {
-      DynamoDbClient client = dynamoDb();
-      try {
-        return operation.apply(client);
-      } catch (RuntimeException e) {
-        boolean refreshed = refreshAfterFailure(client, e);
-        if (refreshed && attempt == 0) {
-          continue;
-        }
-        throw e;
-      }
-    }
-  }
-
-  private void callDynamoVoid(java.util.function.Consumer<DynamoDbClient> operation) {
-    for (int attempt = 0; ; attempt++) {
-      DynamoDbClient client = dynamoDb();
-      try {
-        operation.accept(client);
-        return;
-      } catch (RuntimeException e) {
-        boolean refreshed = refreshAfterFailure(client, e);
-        if (refreshed && attempt == 0) {
-          continue;
-        }
-        throw e;
-      }
-    }
   }
 
   @Override
@@ -173,7 +102,9 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
 
     applyLeaseScanTimeout(query, scanStats);
     var response =
-        runLeaseScanCall(scanStats, () -> callDynamo(client -> client.query(query.build())));
+        runLeaseScanCall(
+            scanStats,
+            () -> dynamoCaller.call(dynamoDbClientManager, client -> client.query(query.build())));
     List<ReconcileReadyQueueStore.ReadyQueueEntry> entries =
         new ArrayList<>(response.items().size());
     for (var item : response.items()) {
@@ -217,7 +148,7 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
               AttributeValue.fromS(cursor.sortKey())));
     }
 
-    var response = callDynamo(client -> client.scan(scan.build()));
+    var response = dynamoCaller.call(dynamoDbClientManager, client -> client.scan(scan.build()));
     List<ReconcileReadyQueueStore.ReadyQueueEntry> entries =
         new ArrayList<>(response.items().size());
     for (var item : response.items()) {
@@ -258,7 +189,8 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
     if (row == null) {
       return false;
     }
-    callDynamoVoid(
+    dynamoCaller.callVoid(
+        dynamoDbClientManager,
         client ->
             client.deleteItem(
                 DeleteItemRequest.builder()
@@ -291,7 +223,11 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
                           JobIndexBackendSupport.canonicalSortKey(canonicalJobKey))));
       applyLeaseScanTimeout(request, scanStats);
       var response =
-          runLeaseScanCall(scanStats, () -> callDynamo(client -> client.getItem(request.build())));
+          runLeaseScanCall(
+              scanStats,
+              () ->
+                  dynamoCaller.call(
+                      dynamoDbClientManager, client -> client.getItem(request.build())));
       if (!response.hasItem() || response.item().isEmpty()) {
         return Optional.empty();
       }
@@ -316,7 +252,11 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
                     ATTR_SORT_KEY, AttributeValue.fromS(key.sortKey())));
     applyLeaseScanTimeout(request, scanStats);
     var response =
-        runLeaseScanCall(scanStats, () -> callDynamo(client -> client.getItem(request.build())));
+        runLeaseScanCall(
+            scanStats,
+            () ->
+                dynamoCaller.call(
+                    dynamoDbClientManager, client -> client.getItem(request.build())));
     if (!response.hasItem() || response.item().isEmpty()) {
       return Optional.empty();
     }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackend.java
@@ -20,7 +20,10 @@ import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_PARTITION_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_SORT_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_VERSION;
 
+import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
+import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.time.Duration;
@@ -28,6 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.exception.AbortedException;
@@ -55,6 +61,10 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
   private static final String ATTR_BLOB_URI = "blob_uri";
 
   private DynamoDbClient dynamoDb;
+  @Inject Instance<DynamoDbClientManager> dynamoDbClientManager;
+  private volatile Supplier<DynamoDbClient> dynamoDbSupplier;
+  private volatile BiConsumer<DynamoDbClient, Throwable> clientFailureHandler =
+      (client, failure) -> {};
   private String table;
 
   @Inject
@@ -68,7 +78,71 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
 
   public void bind(DynamoDbClient dynamoDb, String table) {
     this.dynamoDb = dynamoDb;
+    this.dynamoDbSupplier = () -> dynamoDb;
+    this.clientFailureHandler = (client, failure) -> {};
     this.table = table;
+  }
+
+  public void bind(
+      Supplier<DynamoDbClient> dynamoDbSupplier,
+      String table,
+      BiConsumer<DynamoDbClient, Throwable> clientFailureHandler) {
+    this.dynamoDbSupplier = dynamoDbSupplier;
+    this.clientFailureHandler =
+        clientFailureHandler == null ? (client, failure) -> {} : clientFailureHandler;
+    this.table = table;
+  }
+
+  private DynamoDbClient dynamoDb() {
+    if (dynamoDbSupplier != null) {
+      return dynamoDbSupplier.get();
+    }
+    if (dynamoDbClientManager != null && dynamoDbClientManager.isResolvable()) {
+      DynamoDbClientManager manager = dynamoDbClientManager.get();
+      dynamoDbSupplier = manager::current;
+      clientFailureHandler = manager::refreshAfterFailure;
+      return dynamoDbSupplier.get();
+    }
+    return dynamoDb;
+  }
+
+  private boolean refreshAfterFailure(DynamoDbClient client, Throwable failure) {
+    if (ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
+      clientFailureHandler.accept(client, failure);
+      return true;
+    }
+    return false;
+  }
+
+  private <T> T callDynamo(Function<DynamoDbClient, T> operation) {
+    for (int attempt = 0; ; attempt++) {
+      DynamoDbClient client = dynamoDb();
+      try {
+        return operation.apply(client);
+      } catch (RuntimeException e) {
+        boolean refreshed = refreshAfterFailure(client, e);
+        if (refreshed && attempt == 0) {
+          continue;
+        }
+        throw e;
+      }
+    }
+  }
+
+  private void callDynamoVoid(java.util.function.Consumer<DynamoDbClient> operation) {
+    for (int attempt = 0; ; attempt++) {
+      DynamoDbClient client = dynamoDb();
+      try {
+        operation.accept(client);
+        return;
+      } catch (RuntimeException e) {
+        boolean refreshed = refreshAfterFailure(client, e);
+        if (refreshed && attempt == 0) {
+          continue;
+        }
+        throw e;
+      }
+    }
   }
 
   @Override
@@ -98,7 +172,8 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
     }
 
     applyLeaseScanTimeout(query, scanStats);
-    var response = runLeaseScanCall(scanStats, () -> dynamoDb.query(query.build()));
+    var response =
+        runLeaseScanCall(scanStats, () -> callDynamo(client -> client.query(query.build())));
     List<ReconcileReadyQueueStore.ReadyQueueEntry> entries =
         new ArrayList<>(response.items().size());
     for (var item : response.items()) {
@@ -142,7 +217,7 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
               AttributeValue.fromS(cursor.sortKey())));
     }
 
-    var response = dynamoDb.scan(scan.build());
+    var response = callDynamo(client -> client.scan(scan.build()));
     List<ReconcileReadyQueueStore.ReadyQueueEntry> entries =
         new ArrayList<>(response.items().size());
     for (var item : response.items()) {
@@ -183,14 +258,16 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
     if (row == null) {
       return false;
     }
-    dynamoDb.deleteItem(
-        DeleteItemRequest.builder()
-            .tableName(table)
-            .key(
-                Map.of(
-                    ATTR_PARTITION_KEY, AttributeValue.fromS(row.partitionKey()),
-                    ATTR_SORT_KEY, AttributeValue.fromS(row.sortKey())))
-            .build());
+    callDynamoVoid(
+        client ->
+            client.deleteItem(
+                DeleteItemRequest.builder()
+                    .tableName(table)
+                    .key(
+                        Map.of(
+                            ATTR_PARTITION_KEY, AttributeValue.fromS(row.partitionKey()),
+                            ATTR_SORT_KEY, AttributeValue.fromS(row.sortKey())))
+                    .build()));
     return true;
   }
 
@@ -213,7 +290,8 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
                       AttributeValue.fromS(
                           JobIndexBackendSupport.canonicalSortKey(canonicalJobKey))));
       applyLeaseScanTimeout(request, scanStats);
-      var response = runLeaseScanCall(scanStats, () -> dynamoDb.getItem(request.build()));
+      var response =
+          runLeaseScanCall(scanStats, () -> callDynamo(client -> client.getItem(request.build())));
       if (!response.hasItem() || response.item().isEmpty()) {
         return Optional.empty();
       }
@@ -237,7 +315,8 @@ public class DynamoReconcileReadyQueueBackend implements ReconcileReadyQueueBack
                     ATTR_PARTITION_KEY, AttributeValue.fromS(key.partitionKey()),
                     ATTR_SORT_KEY, AttributeValue.fromS(key.sortKey())));
     applyLeaseScanTimeout(request, scanStats);
-    var response = runLeaseScanCall(scanStats, () -> dynamoDb.getItem(request.build()));
+    var response =
+        runLeaseScanCall(scanStats, () -> callDynamo(client -> client.getItem(request.build())));
     if (!response.hasItem() || response.item().isEmpty()) {
       return Optional.empty();
     }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/RefreshingDynamoCaller.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/RefreshingDynamoCaller.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.jobs.durable.store;
+
+import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
+import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
+import jakarta.enterprise.inject.Instance;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+final class RefreshingDynamoCaller {
+  private volatile Binding binding;
+
+  void bind(
+      Supplier<DynamoDbClient> dynamoDbSupplier,
+      BiConsumer<DynamoDbClient, Throwable> clientFailureHandler) {
+    if (dynamoDbSupplier == null) {
+      throw new IllegalArgumentException("dynamoDbSupplier must not be null");
+    }
+    binding =
+        new Binding(
+            dynamoDbSupplier,
+            clientFailureHandler == null ? (client, failure) -> {} : clientFailureHandler,
+            clientFailureHandler != null);
+  }
+
+  <T> T call(
+      Instance<DynamoDbClientManager> dynamoDbClientManager,
+      Function<DynamoDbClient, T> operation) {
+    Binding currentBinding = binding(dynamoDbClientManager);
+    for (int attempt = 0; ; attempt++) {
+      DynamoDbClient client = currentBinding.dynamoDbSupplier().get();
+      try {
+        return operation.apply(client);
+      } catch (RuntimeException e) {
+        if (currentBinding.supportsRefresh()
+            && ClosedAwsClientDetector.isConnectionPoolShutdown(e)) {
+          currentBinding.clientFailureHandler().accept(client, e);
+          if (attempt == 0) {
+            currentBinding = binding(dynamoDbClientManager);
+            continue;
+          }
+        }
+        throw e;
+      }
+    }
+  }
+
+  void callVoid(
+      Instance<DynamoDbClientManager> dynamoDbClientManager,
+      java.util.function.Consumer<DynamoDbClient> operation) {
+    call(
+        dynamoDbClientManager,
+        client -> {
+          operation.accept(client);
+          return null;
+        });
+  }
+
+  private Binding binding(Instance<DynamoDbClientManager> dynamoDbClientManager) {
+    Binding currentBinding = binding;
+    if (currentBinding != null) {
+      return currentBinding;
+    }
+    if (dynamoDbClientManager == null || !dynamoDbClientManager.isResolvable()) {
+      throw new IllegalStateException("No DynamoDB client manager available");
+    }
+    DynamoDbClientManager manager = dynamoDbClientManager.get();
+    Binding nextBinding = new Binding(manager::current, manager::refreshAfterFailure, true);
+    binding = nextBinding;
+    return nextBinding;
+  }
+
+  private record Binding(
+      Supplier<DynamoDbClient> dynamoDbSupplier,
+      BiConsumer<DynamoDbClient, Throwable> clientFailureHandler,
+      boolean supportsRefresh) {}
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreLeaseOutcomeTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreLeaseOutcomeTest.java
@@ -116,18 +116,18 @@ class DurableReconcileJobStoreLeaseOutcomeTest {
               .DynamoReconcileJobIndexBackend();
       ((ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileJobIndexBackend)
               store.jobIndexBackend)
-          .bind(sharedDynamoDbClient, store.kvTable);
+          .bind(() -> sharedDynamoDbClient, store.kvTable, null);
       store.leaseBackend =
           new ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileLeaseBackend();
       ((ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileLeaseBackend)
               store.leaseBackend)
-          .bind(sharedDynamoDbClient, store.kvTable);
+          .bind(() -> sharedDynamoDbClient, store.kvTable, null);
       store.readyQueueBackend =
           new ai.floedb.floecat.service.reconciler.jobs.durable.store
               .DynamoReconcileReadyQueueBackend();
       ((ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileReadyQueueBackend)
               store.readyQueueBackend)
-          .bind(sharedDynamoDbClient, store.kvTable);
+          .bind(() -> sharedDynamoDbClient, store.kvTable, null);
     } else {
       store.jobIndexStore = new InMemoryReconcileJobIndexStore();
       store.leaseStore = new InMemoryReconcileLeaseStore();

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -144,18 +144,18 @@ class DurableReconcileJobStoreTest {
               .DynamoReconcileJobIndexBackend();
       ((ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileJobIndexBackend)
               store.jobIndexBackend)
-          .bind(sharedDynamoDbClient, store.kvTable);
+          .bind(() -> sharedDynamoDbClient, store.kvTable, null);
       store.leaseBackend =
           new ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileLeaseBackend();
       ((ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileLeaseBackend)
               store.leaseBackend)
-          .bind(sharedDynamoDbClient, store.kvTable);
+          .bind(() -> sharedDynamoDbClient, store.kvTable, null);
       store.readyQueueBackend =
           new ai.floedb.floecat.service.reconciler.jobs.durable.store
               .DynamoReconcileReadyQueueBackend();
       ((ai.floedb.floecat.service.reconciler.jobs.durable.store.DynamoReconcileReadyQueueBackend)
               store.readyQueueBackend)
-          .bind(sharedDynamoDbClient, store.kvTable);
+          .bind(() -> sharedDynamoDbClient, store.kvTable, null);
     } else {
       store.pointerStore = new InMemoryPointerStore();
     }

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackendTest.java
@@ -51,7 +51,7 @@ class DynamoReconcileLeaseBackendTest {
     dynamoDbClient = createDynamoDbClient();
     clearDynamoTable();
     backend = new DynamoReconcileLeaseBackend();
-    backend.bind(dynamoDbClient, kvTable());
+    backend.bind(() -> dynamoDbClient, kvTable(), null);
   }
 
   @AfterEach

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackendTest.java
@@ -21,16 +21,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueBackend.ReadyQueueSlice;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore.LeaseScanStats;
+import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
+import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
 
 class DynamoReconcileReadyQueueBackendTest {
 
@@ -55,6 +59,37 @@ class DynamoReconcileReadyQueueBackendTest {
 
     assertFalse(error.callerCancelled());
     assertTrue(stats.abortedByDeadline);
+  }
+
+  @Test
+  void scanReadySliceRefreshesManagerClientAndRetriesAfterClosedPool() {
+    DynamoDbClient staleClient = mock(DynamoDbClient.class);
+    DynamoDbClient refreshedClient = mock(DynamoDbClient.class);
+    RuntimeException closedPool = new RuntimeException("Connection pool shut down");
+    when(staleClient.query(any(QueryRequest.class))).thenThrow(closedPool);
+    when(refreshedClient.query(any(QueryRequest.class)))
+        .thenReturn(QueryResponse.builder().build());
+
+    DynamoDbClientManager manager = mock(DynamoDbClientManager.class);
+    when(manager.current()).thenReturn(staleClient, refreshedClient);
+    @SuppressWarnings("unchecked")
+    Instance<DynamoDbClientManager> managerInstance = mock(Instance.class);
+    when(managerInstance.isResolvable()).thenReturn(true);
+    when(managerInstance.get()).thenReturn(manager);
+
+    DynamoReconcileReadyQueueBackend backend =
+        new DynamoReconcileReadyQueueBackend(staleClient, "floecat_pointers");
+    backend.dynamoDbClientManager = managerInstance;
+    LeaseScanStats stats = new LeaseScanStats();
+    stats.deadlineAtMs = System.currentTimeMillis() + 5_000L;
+
+    var page =
+        backend.scanReadySlice(
+            new ReadyQueueSlice(ReconcileReadyQueueStore.ReadyIndexType.GLOBAL, ""), 16, "", stats);
+
+    assertTrue(page.entries().isEmpty());
+    verify(manager).refreshAfterFailure(staleClient, closedPool);
+    verify(refreshedClient).query(any(QueryRequest.class));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileReadyQueueBackendTest.java
@@ -42,8 +42,8 @@ class DynamoReconcileReadyQueueBackendTest {
   void scanReadySliceNormalizesApiCallTimeoutAsLeaseScanAbort() {
     DynamoDbClient dynamoDb = mock(DynamoDbClient.class);
     when(dynamoDb.query(any(QueryRequest.class))).thenThrow(ApiCallTimeoutException.create(25L));
-    DynamoReconcileReadyQueueBackend backend =
-        new DynamoReconcileReadyQueueBackend(dynamoDb, "floecat_pointers");
+    DynamoReconcileReadyQueueBackend backend = new DynamoReconcileReadyQueueBackend();
+    backend.bind(() -> dynamoDb, "floecat_pointers", null);
     LeaseScanStats stats = new LeaseScanStats();
     stats.deadlineAtMs = System.currentTimeMillis() + 5_000L;
 
@@ -77,8 +77,7 @@ class DynamoReconcileReadyQueueBackendTest {
     when(managerInstance.isResolvable()).thenReturn(true);
     when(managerInstance.get()).thenReturn(manager);
 
-    DynamoReconcileReadyQueueBackend backend =
-        new DynamoReconcileReadyQueueBackend(staleClient, "floecat_pointers");
+    DynamoReconcileReadyQueueBackend backend = new DynamoReconcileReadyQueueBackend();
     backend.dynamoDbClientManager = managerInstance;
     LeaseScanStats stats = new LeaseScanStats();
     stats.deadlineAtMs = System.currentTimeMillis() + 5_000L;
@@ -97,8 +96,8 @@ class DynamoReconcileReadyQueueBackendTest {
     DynamoDbClient dynamoDb = mock(DynamoDbClient.class);
     when(dynamoDb.getItem(any(GetItemRequest.class)))
         .thenThrow(ApiCallAttemptTimeoutException.create(25L));
-    DynamoReconcileReadyQueueBackend backend =
-        new DynamoReconcileReadyQueueBackend(dynamoDb, "floecat_pointers");
+    DynamoReconcileReadyQueueBackend backend = new DynamoReconcileReadyQueueBackend();
+    backend.bind(() -> dynamoDb, "floecat_pointers", null);
     LeaseScanStats stats = new LeaseScanStats();
     stats.deadlineAtMs = System.currentTimeMillis() + 5_000L;
 

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/RefreshingDynamoCallerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/RefreshingDynamoCallerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.jobs.durable.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+class RefreshingDynamoCallerTest {
+
+  @Test
+  void call_refreshes_manager_client_and_retries_once() {
+    RefreshingDynamoCaller caller = new RefreshingDynamoCaller();
+    DynamoDbClient staleClient = mock(DynamoDbClient.class);
+    DynamoDbClient refreshedClient = mock(DynamoDbClient.class);
+    RuntimeException closedPool = new RuntimeException("Connection pool shut down");
+
+    DynamoDbClientManager manager = mock(DynamoDbClientManager.class);
+    when(manager.current()).thenReturn(staleClient, refreshedClient);
+    @SuppressWarnings("unchecked")
+    Instance<DynamoDbClientManager> managerInstance = mock(Instance.class);
+    when(managerInstance.isResolvable()).thenReturn(true);
+    when(managerInstance.get()).thenReturn(manager);
+
+    int result =
+        caller.call(
+            managerInstance,
+            client -> {
+              if (client == staleClient) {
+                throw closedPool;
+              }
+              return 7;
+            });
+
+    assertEquals(7, result);
+    verify(manager).refreshAfterFailure(staleClient, closedPool);
+  }
+
+  @Test
+  void call_without_refresh_handler_rethrows_closed_pool_without_retry() {
+    RefreshingDynamoCaller caller = new RefreshingDynamoCaller();
+    DynamoDbClient staleClient = mock(DynamoDbClient.class);
+    RuntimeException closedPool = new RuntimeException("Connection pool shut down");
+    caller.bind(() -> staleClient, null);
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                caller.call(
+                    null,
+                    client -> {
+                      throw closedPool;
+                    }));
+
+    assertSame(closedPool, thrown);
+  }
+}

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/AwsClients.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/AwsClients.java
@@ -73,6 +73,10 @@ public class AwsClients {
   @Produces
   @Singleton
   DynamoDbClient dynamoDbClient() {
+    return newDynamoDbClient();
+  }
+
+  public DynamoDbClient newDynamoDbClient() {
     var builder =
         DynamoDbClient.builder()
             .region(region)

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/DynamoDbAsyncClientManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/DynamoDbAsyncClientManager.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.storage.aws;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jboss.logging.Logger;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
@@ -30,25 +31,38 @@ public class DynamoDbAsyncClientManager {
 
   @Inject AwsClients awsClients;
 
+  private final AtomicBoolean closed = new AtomicBoolean();
   private final AtomicReference<DynamoDbAsyncClient> current = new AtomicReference<>();
 
   public DynamoDbAsyncClient current() {
+    requireOpen();
     DynamoDbAsyncClient existing = current.get();
     if (existing != null) {
       return existing;
     }
 
     DynamoDbAsyncClient next = awsClients.newDynamoDbAsyncClient();
+    if (closed.get()) {
+      next.close();
+      requireOpen();
+    }
     if (current.compareAndSet(null, next)) {
+      if (closed.get() && current.compareAndSet(next, null)) {
+        next.close();
+        requireOpen();
+      }
       return next;
     }
 
     next.close();
-    return current.get();
+    return requireOpen(current.get());
   }
 
   public void refreshAfterFailure(DynamoDbAsyncClient failedClient, Throwable failure) {
     if (!ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
+      return;
+    }
+    if (closed.get()) {
       return;
     }
     if (failedClient == null || current.get() != failedClient) {
@@ -56,6 +70,10 @@ public class DynamoDbAsyncClientManager {
     }
 
     DynamoDbAsyncClient next = awsClients.newDynamoDbAsyncClient();
+    if (closed.get()) {
+      next.close();
+      return;
+    }
     if (current.compareAndSet(failedClient, next)) {
       closeQuietly(failedClient);
       LOG.warn("Refreshed DynamoDB async client after closed connection pool");
@@ -66,7 +84,23 @@ public class DynamoDbAsyncClientManager {
 
   @PreDestroy
   void close() {
-    closeQuietly(current.getAndSet(null));
+    if (closed.compareAndSet(false, true)) {
+      closeQuietly(current.getAndSet(null));
+    }
+  }
+
+  private void requireOpen() {
+    if (closed.get()) {
+      throw new IllegalStateException("dynamodb async client manager is shut down");
+    }
+  }
+
+  private DynamoDbAsyncClient requireOpen(DynamoDbAsyncClient client) {
+    requireOpen();
+    if (client == null) {
+      throw new IllegalStateException("dynamodb async client manager is shut down");
+    }
+    return client;
   }
 
   private static void closeQuietly(DynamoDbAsyncClient client) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/DynamoDbClientManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/DynamoDbClientManager.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.storage.aws;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jboss.logging.Logger;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -30,25 +31,38 @@ public class DynamoDbClientManager {
 
   @Inject AwsClients awsClients;
 
+  private final AtomicBoolean closed = new AtomicBoolean();
   private final AtomicReference<DynamoDbClient> current = new AtomicReference<>();
 
   public DynamoDbClient current() {
+    requireOpen();
     DynamoDbClient existing = current.get();
     if (existing != null) {
       return existing;
     }
 
     DynamoDbClient next = awsClients.newDynamoDbClient();
+    if (closed.get()) {
+      next.close();
+      requireOpen();
+    }
     if (current.compareAndSet(null, next)) {
+      if (closed.get() && current.compareAndSet(next, null)) {
+        next.close();
+        requireOpen();
+      }
       return next;
     }
 
     next.close();
-    return current.get();
+    return requireOpen(current.get());
   }
 
   public void refreshAfterFailure(DynamoDbClient failedClient, Throwable failure) {
     if (!ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
+      return;
+    }
+    if (closed.get()) {
       return;
     }
     if (failedClient == null || current.get() != failedClient) {
@@ -56,6 +70,10 @@ public class DynamoDbClientManager {
     }
 
     DynamoDbClient next = awsClients.newDynamoDbClient();
+    if (closed.get()) {
+      next.close();
+      return;
+    }
     if (current.compareAndSet(failedClient, next)) {
       closeQuietly(failedClient);
       LOG.warn("Refreshed DynamoDB client after closed connection pool");
@@ -66,7 +84,23 @@ public class DynamoDbClientManager {
 
   @PreDestroy
   void close() {
-    closeQuietly(current.getAndSet(null));
+    if (closed.compareAndSet(false, true)) {
+      closeQuietly(current.getAndSet(null));
+    }
+  }
+
+  private void requireOpen() {
+    if (closed.get()) {
+      throw new IllegalStateException("dynamodb client manager is shut down");
+    }
+  }
+
+  private DynamoDbClient requireOpen(DynamoDbClient client) {
+    requireOpen();
+    if (client == null) {
+      throw new IllegalStateException("dynamodb client manager is shut down");
+    }
+    return client;
   }
 
   private static void closeQuietly(DynamoDbClient client) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/DynamoDbClientManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/DynamoDbClientManager.java
@@ -21,24 +21,24 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jboss.logging.Logger;
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 @ApplicationScoped
-public class DynamoDbAsyncClientManager {
+public class DynamoDbClientManager {
 
-  private static final Logger LOG = Logger.getLogger(DynamoDbAsyncClientManager.class);
+  private static final Logger LOG = Logger.getLogger(DynamoDbClientManager.class);
 
   @Inject AwsClients awsClients;
 
-  private final AtomicReference<DynamoDbAsyncClient> current = new AtomicReference<>();
+  private final AtomicReference<DynamoDbClient> current = new AtomicReference<>();
 
-  public DynamoDbAsyncClient current() {
-    DynamoDbAsyncClient existing = current.get();
+  public DynamoDbClient current() {
+    DynamoDbClient existing = current.get();
     if (existing != null) {
       return existing;
     }
 
-    DynamoDbAsyncClient next = awsClients.newDynamoDbAsyncClient();
+    DynamoDbClient next = awsClients.newDynamoDbClient();
     if (current.compareAndSet(null, next)) {
       return next;
     }
@@ -47,7 +47,7 @@ public class DynamoDbAsyncClientManager {
     return current.get();
   }
 
-  public void refreshAfterFailure(DynamoDbAsyncClient failedClient, Throwable failure) {
+  public void refreshAfterFailure(DynamoDbClient failedClient, Throwable failure) {
     if (!ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
       return;
     }
@@ -55,10 +55,10 @@ public class DynamoDbAsyncClientManager {
       return;
     }
 
-    DynamoDbAsyncClient next = awsClients.newDynamoDbAsyncClient();
+    DynamoDbClient next = awsClients.newDynamoDbClient();
     if (current.compareAndSet(failedClient, next)) {
       closeQuietly(failedClient);
-      LOG.warn("Refreshed DynamoDB async client after closed connection pool");
+      LOG.warn("Refreshed DynamoDB client after closed connection pool");
     } else {
       next.close();
     }
@@ -69,7 +69,7 @@ public class DynamoDbAsyncClientManager {
     closeQuietly(current.getAndSet(null));
   }
 
-  private static void closeQuietly(DynamoDbAsyncClient client) {
+  private static void closeQuietly(DynamoDbClient client) {
     if (client == null) {
       return;
     }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/S3ClientManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/S3ClientManager.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.storage.aws;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jboss.logging.Logger;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -30,32 +31,51 @@ public class S3ClientManager {
 
   @Inject AwsClients awsClients;
 
+  private final AtomicBoolean closed = new AtomicBoolean();
   private final AtomicReference<S3Client> current = new AtomicReference<>();
 
   public S3Client current() {
+    requireOpen();
     S3Client existing = current.get();
     if (existing != null) {
       return existing;
     }
 
     S3Client next = awsClients.newS3Client();
+    if (closed.get()) {
+      next.close();
+      requireOpen();
+    }
     if (current.compareAndSet(null, next)) {
+      if (closed.get() && current.compareAndSet(next, null)) {
+        next.close();
+        requireOpen();
+      }
       return next;
     }
 
     next.close();
-    return current.get();
+    return requireOpen(current.get());
   }
 
-  public void refreshAfterFailure(Throwable failure) {
+  public void refreshAfterFailure(S3Client failedClient, Throwable failure) {
     if (!ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
       return;
     }
+    if (closed.get()) {
+      return;
+    }
+    if (failedClient == null || current.get() != failedClient) {
+      return;
+    }
 
-    S3Client previous = current.get();
     S3Client next = awsClients.newS3Client();
-    if (current.compareAndSet(previous, next)) {
-      closeQuietly(previous);
+    if (closed.get()) {
+      next.close();
+      return;
+    }
+    if (current.compareAndSet(failedClient, next)) {
+      closeQuietly(failedClient);
       LOG.warn("Refreshed S3 client after closed connection pool");
     } else {
       next.close();
@@ -64,7 +84,23 @@ public class S3ClientManager {
 
   @PreDestroy
   void close() {
-    closeQuietly(current.getAndSet(null));
+    if (closed.compareAndSet(false, true)) {
+      closeQuietly(current.getAndSet(null));
+    }
+  }
+
+  private void requireOpen() {
+    if (closed.get()) {
+      throw new IllegalStateException("s3 client manager is shut down");
+    }
+  }
+
+  private S3Client requireOpen(S3Client client) {
+    requireOpen();
+    if (client == null) {
+      throw new IllegalStateException("s3 client manager is shut down");
+    }
+    return client;
   }
 
   private static void closeQuietly(S3Client client) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/s3/S3BlobStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/s3/S3BlobStore.java
@@ -35,7 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -60,7 +60,7 @@ public class S3BlobStore implements BlobStore {
   private static final String META_CREATED_AT = "floecat-created-at";
 
   private final Supplier<S3Client> s3;
-  private final Consumer<Throwable> clientFailureHandler;
+  private final BiConsumer<S3Client, Throwable> clientFailureHandler;
   private final String bucket;
 
   @Inject
@@ -72,11 +72,13 @@ public class S3BlobStore implements BlobStore {
 
   public S3BlobStore(
       S3Client s3, @ConfigProperty(name = "floecat.blob.s3.bucket") Optional<String> bucketOpt) {
-    this(() -> s3, bucketOpt, failure -> {});
+    this(() -> s3, bucketOpt, (client, failure) -> {});
   }
 
   S3BlobStore(
-      Supplier<S3Client> s3, Optional<String> bucketOpt, Consumer<Throwable> clientFailureHandler) {
+      Supplier<S3Client> s3,
+      Optional<String> bucketOpt,
+      BiConsumer<S3Client, Throwable> clientFailureHandler) {
     this.s3 = s3;
     this.clientFailureHandler = clientFailureHandler;
     this.bucket = bucketOpt.orElseGet(() -> System.getProperty("floecat.blob.s3.bucket", ""));
@@ -88,9 +90,10 @@ public class S3BlobStore implements BlobStore {
   @Override
   public Optional<BlobHeader> head(String key) {
     final String k = normalize(key);
+    S3Client client = s3();
     try {
       HeadObjectResponse r =
-          s3().headObject(HeadObjectRequest.builder().bucket(bucket).key(k).build());
+          client.headObject(HeadObjectRequest.builder().bucket(bucket).key(k).build());
 
       String metaSha = (r.metadata() != null) ? r.metadata().get(META_SHA256) : null;
 
@@ -123,18 +126,20 @@ public class S3BlobStore implements BlobStore {
 
       throw mapAndWrap("HEAD", k, e);
     } catch (SdkClientException e) {
-      clientFailureHandler.accept(e);
+      clientFailureHandler.accept(client, e);
       throw new StorageAbortRetryableException(msg("HEAD", k, e.getMessage()));
     } catch (RuntimeException e) {
-      throw mapClosedPoolOrRethrow("HEAD", k, e);
+      throw mapClosedPoolOrRethrow(client, "HEAD", k, e);
     }
   }
 
   @Override
   public byte[] get(String key) {
     final String k = normalize(key);
+    S3Client client = s3();
     try {
-      return s3().getObject(
+      return client
+          .getObject(
               GetObjectRequest.builder().bucket(bucket).key(k).build(),
               ResponseTransformer.toBytes())
           .asByteArray();
@@ -144,21 +149,22 @@ public class S3BlobStore implements BlobStore {
       }
       throw mapAndWrap("GET", k, e);
     } catch (SdkClientException e) {
-      clientFailureHandler.accept(e);
+      clientFailureHandler.accept(client, e);
       throw new StorageAbortRetryableException(msg("GET", k, e.getMessage()));
     } catch (RuntimeException e) {
-      throw mapClosedPoolOrRethrow("GET", k, e);
+      throw mapClosedPoolOrRethrow(client, "GET", k, e);
     }
   }
 
   @Override
   public void put(String key, byte[] bytes, String contentType) {
     final String k = normalize(key);
+    S3Client client = s3();
     try {
       Long createdAtMs = null;
       try {
         HeadObjectResponse prev =
-            s3().headObject(HeadObjectRequest.builder().bucket(bucket).key(k).build());
+            client.headObject(HeadObjectRequest.builder().bucket(bucket).key(k).build());
         createdAtMs =
             Optional.ofNullable(prev.metadata().get(META_CREATED_AT))
                 .map(Long::parseLong)
@@ -184,14 +190,14 @@ public class S3BlobStore implements BlobStore {
       PutObjectRequest req =
           PutObjectRequest.builder().bucket(bucket).key(k).contentType(ct).metadata(meta).build();
 
-      s3().putObject(req, RequestBody.fromBytes(bytes));
+      client.putObject(req, RequestBody.fromBytes(bytes));
     } catch (S3Exception e) {
       throw mapAndWrap("PUT", k, e);
     } catch (SdkClientException e) {
-      clientFailureHandler.accept(e);
+      clientFailureHandler.accept(client, e);
       throw new StorageAbortRetryableException(msg("PUT", k, e.getMessage()));
     } catch (RuntimeException e) {
-      throw mapClosedPoolOrRethrow("PUT", k, e);
+      throw mapClosedPoolOrRethrow(client, "PUT", k, e);
     }
   }
 
@@ -219,6 +225,7 @@ public class S3BlobStore implements BlobStore {
   public BlobStore.Page list(String prefix, int limit, String pageToken) {
     final String p = normalize(prefix);
     final int lim = Math.max(1, limit);
+    S3Client client = s3();
 
     try {
       ListObjectsV2Request.Builder b =
@@ -228,7 +235,7 @@ public class S3BlobStore implements BlobStore {
         b = b.continuationToken(pageToken);
       }
 
-      ListObjectsV2Response resp = s3().listObjectsV2(b.build());
+      ListObjectsV2Response resp = client.listObjectsV2(b.build());
 
       var keys = resp.contents().stream().map(o -> o.key()).toList();
 
@@ -242,18 +249,19 @@ public class S3BlobStore implements BlobStore {
       }
       throw mapAndWrap("LIST", p, e);
     } catch (SdkClientException e) {
-      clientFailureHandler.accept(e);
+      clientFailureHandler.accept(client, e);
       throw new StorageAbortRetryableException(msg("LIST", p, e.getMessage()));
     } catch (RuntimeException e) {
-      throw mapClosedPoolOrRethrow("LIST", p, e);
+      throw mapClosedPoolOrRethrow(client, "LIST", p, e);
     }
   }
 
   @Override
   public boolean delete(String key) {
     final String k = normalize(key);
+    S3Client client = s3();
     try {
-      s3().deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(k).build());
+      client.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(k).build());
       return true;
     } catch (S3Exception e) {
       if (e.statusCode() == 404) {
@@ -261,10 +269,10 @@ public class S3BlobStore implements BlobStore {
       }
       throw mapAndWrap("DELETE", k, e);
     } catch (SdkClientException e) {
-      clientFailureHandler.accept(e);
+      clientFailureHandler.accept(client, e);
       throw new StorageAbortRetryableException(msg("DELETE", k, e.getMessage()));
     } catch (RuntimeException e) {
-      throw mapClosedPoolOrRethrow("DELETE", k, e);
+      throw mapClosedPoolOrRethrow(client, "DELETE", k, e);
     }
   }
 
@@ -272,6 +280,7 @@ public class S3BlobStore implements BlobStore {
   public void deletePrefix(String prefix) {
     final String p = normalize(prefix);
     String ct = null;
+    S3Client client = s3();
 
     try {
       do {
@@ -283,7 +292,7 @@ public class S3BlobStore implements BlobStore {
                 .continuationToken(ct)
                 .build();
 
-        var resp = s3().listObjectsV2(req);
+        var resp = client.listObjectsV2(req);
 
         if (!resp.contents().isEmpty()) {
           var objs = resp.contents();
@@ -291,7 +300,7 @@ public class S3BlobStore implements BlobStore {
             var slice = objs.subList(i, Math.min(i + 1000, objs.size()));
             var dels =
                 slice.stream().map(o -> ObjectIdentifier.builder().key(o.key()).build()).toList();
-            s3().deleteObjects(b -> b.bucket(bucket).delete(d -> d.objects(dels)));
+            client.deleteObjects(b -> b.bucket(bucket).delete(d -> d.objects(dels)));
           }
         }
 
@@ -301,7 +310,7 @@ public class S3BlobStore implements BlobStore {
 
       if (p.endsWith("/")) {
         try {
-          s3().deleteObject(b -> b.bucket(bucket).key(p));
+          client.deleteObject(b -> b.bucket(bucket).key(p));
         } catch (Throwable ignore) {
         }
       }
@@ -309,10 +318,10 @@ public class S3BlobStore implements BlobStore {
     } catch (S3Exception e) {
       throw mapAndWrap("DELETE_PREFIX", p, e);
     } catch (SdkClientException e) {
-      clientFailureHandler.accept(e);
+      clientFailureHandler.accept(client, e);
       throw new StorageAbortRetryableException(msg("DELETE_PREFIX", p, e.getMessage()));
     } catch (RuntimeException e) {
-      throw mapClosedPoolOrRethrow("DELETE_PREFIX", p, e);
+      throw mapClosedPoolOrRethrow(client, "DELETE_PREFIX", p, e);
     }
   }
 
@@ -321,11 +330,11 @@ public class S3BlobStore implements BlobStore {
   }
 
   private StorageAbortRetryableException mapClosedPoolOrRethrow(
-      String operation, String key, RuntimeException failure) {
+      S3Client client, String operation, String key, RuntimeException failure) {
     if (!ClosedAwsClientDetector.isConnectionPoolShutdown(failure)) {
       throw failure;
     }
-    clientFailureHandler.accept(failure);
+    clientFailureHandler.accept(client, failure);
     return new StorageAbortRetryableException(msg(operation, key, failure.getMessage()), failure);
   }
 

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
@@ -122,18 +122,18 @@ public class ProdSecretsManager implements SecretsManager {
   }
 
   private void putOnce(
-      SecretsManagerClient client, String accountId, String secretType, String secretId, byte[] payload) {
+      SecretsManagerClient client,
+      String accountId,
+      String secretType,
+      String secretId,
+      byte[] payload) {
     ensureAwsCredentialsAvailable();
     String secretName = SecretsManager.buildSecretKey(accountId, secretType, secretId);
     String encoded = encodePayload(payload);
     List<Tag> tags = buildTags(accountId, secretName);
     try {
       client.createSecret(
-          CreateSecretRequest.builder()
-              .name(secretName)
-              .secretString(encoded)
-              .tags(tags)
-              .build());
+          CreateSecretRequest.builder().name(secretName).secretString(encoded).tags(tags).build());
     } catch (ResourceExistsException exists) {
       client.putSecretValue(
           PutSecretValueRequest.builder().secretId(secretName).secretString(encoded).build());
@@ -146,7 +146,8 @@ public class ProdSecretsManager implements SecretsManager {
     ensureAwsCredentialsAvailable();
     String secretName = SecretsManager.buildSecretKey(accountId, secretType, secretId);
     try {
-      var response = client.getSecretValue(GetSecretValueRequest.builder().secretId(secretName).build());
+      var response =
+          client.getSecretValue(GetSecretValueRequest.builder().secretId(secretName).build());
       if (response == null
           || response.secretString() == null
           || response.secretString().isBlank()) {
@@ -159,7 +160,11 @@ public class ProdSecretsManager implements SecretsManager {
   }
 
   private void updateOnce(
-      SecretsManagerClient client, String accountId, String secretType, String secretId, byte[] payload) {
+      SecretsManagerClient client,
+      String accountId,
+      String secretType,
+      String secretId,
+      byte[] payload) {
     ensureAwsCredentialsAvailable();
     String secretName = SecretsManager.buildSecretKey(accountId, secretType, secretId);
     String encoded = encodePayload(payload);

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
@@ -243,12 +244,13 @@ public class ProdSecretsManager implements SecretsManager {
       if (awsClients == null || !ClosedAwsClientDetector.isConnectionPoolShutdown(e)) {
         throw e;
       }
-      refreshAfterClosedPool(accountId, client);
+      refreshAfterClosedPool(accountId, client, e);
       return operation.run(clientForAccount(accountId));
     }
   }
 
-  private void refreshAfterClosedPool(String accountId, SecretsManagerClient failedClient) {
+  private void refreshAfterClosedPool(
+      String accountId, SecretsManagerClient failedClient, Throwable failure) {
     String role = roleArn.map(String::trim).filter(value -> !value.isBlank()).orElse("");
     if (role.isEmpty()) {
       if (failedClient == null) {
@@ -271,16 +273,18 @@ public class ProdSecretsManager implements SecretsManager {
         return;
       }
       closeQuietly(failedClient);
-      StsClient previousSts = stsClient.get();
-      if (previousSts == null) {
-        return;
-      }
-      StsClient nextSts = awsClients.stsClient();
-      if (stsClient.compareAndSet(previousSts, nextSts)) {
-        closeQuietly(previousSts);
-        closePerAccountClients();
-      } else {
-        closeQuietly(nextSts);
+      if (isStsCredentialPoolFailure(failure)) {
+        StsClient previousSts = stsClient.get();
+        if (previousSts == null) {
+          return;
+        }
+        StsClient nextSts = awsClients.stsClient();
+        if (stsClient.compareAndSet(previousSts, nextSts)) {
+          closeQuietly(previousSts);
+          closePerAccountClients();
+        } else {
+          closeQuietly(nextSts);
+        }
       }
     }
   }
@@ -297,6 +301,20 @@ public class ProdSecretsManager implements SecretsManager {
       throw new IllegalStateException("secrets manager is shut down");
     }
     return client;
+  }
+
+  private static boolean isStsCredentialPoolFailure(Throwable failure) {
+    Throwable current = failure;
+    while (current != null) {
+      if (current instanceof SdkClientException) {
+        String message = current.getMessage();
+        if (message != null && message.toLowerCase().contains("credential")) {
+          return true;
+        }
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 
   private static String buildRoleSessionName(String accountId) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
@@ -57,6 +57,7 @@ public class ProdSecretsManager implements SecretsManager {
   private final AtomicReference<StsClient> stsClient;
   private final ConcurrentMap<String, SecretsManagerClient> perAccountClients =
       new ConcurrentHashMap<>();
+  private final Object perAccountClientLock = new Object();
 
   @Inject
   public ProdSecretsManager(AwsClients awsClients) {
@@ -78,12 +79,11 @@ public class ProdSecretsManager implements SecretsManager {
 
   @PreDestroy
   void shutdown() {
-    for (SecretsManagerClient client : perAccountClients.values()) {
-      closeQuietly(client);
+    synchronized (perAccountClientLock) {
+      closePerAccountClients();
+      closeQuietly(stsClient.getAndSet(null));
     }
-    perAccountClients.clear();
     closeQuietly(secretsClient.getAndSet(null));
-    closeQuietly(stsClient.getAndSet(null));
   }
 
   @Override
@@ -204,30 +204,35 @@ public class ProdSecretsManager implements SecretsManager {
   private SecretsManagerClient clientForAccount(String accountId) {
     String role = roleArn.map(String::trim).filter(value -> !value.isBlank()).orElse("");
     if (role.isEmpty()) {
-      return secretsClient.get();
+      return requireOpen(secretsClient.get());
     }
-    return perAccountClients.computeIfAbsent(
-        accountId,
-        id -> {
-          StsAssumeRoleCredentialsProvider creds =
-              StsAssumeRoleCredentialsProvider.builder()
-                  .stsClient(stsClient.get())
-                  .refreshRequest(
-                      builder ->
-                          builder
-                              .roleArn(role)
-                              .roleSessionName(buildRoleSessionName(id))
-                              .tags(
-                                  software.amazon.awssdk.services.sts.model.Tag.builder()
-                                      .key(ACCOUNT_ID_TAG)
-                                      .value(id)
-                                      .build()))
-                  .build();
-          if (awsClients != null) {
-            return awsClients.secretsManagerClient(creds);
-          }
-          return SecretsManagerClient.builder().credentialsProvider(creds).build();
-        });
+    synchronized (perAccountClientLock) {
+      SecretsManagerClient existing = perAccountClients.get(accountId);
+      if (existing != null) {
+        return existing;
+      }
+      StsClient currentSts = requireOpen(stsClient.get());
+      StsAssumeRoleCredentialsProvider creds =
+          StsAssumeRoleCredentialsProvider.builder()
+              .stsClient(currentSts)
+              .refreshRequest(
+                  builder ->
+                      builder
+                          .roleArn(role)
+                          .roleSessionName(buildRoleSessionName(accountId))
+                          .tags(
+                              software.amazon.awssdk.services.sts.model.Tag.builder()
+                                  .key(ACCOUNT_ID_TAG)
+                                  .value(accountId)
+                                  .build()))
+              .build();
+      SecretsManagerClient client =
+          awsClients != null
+              ? awsClients.secretsManagerClient(creds)
+              : SecretsManagerClient.builder().credentialsProvider(creds).build();
+      perAccountClients.put(accountId, client);
+      return client;
+    }
   }
 
   private <T> T withClientRefresh(String accountId, ClientOperation<T> operation) {
@@ -258,20 +263,40 @@ public class ProdSecretsManager implements SecretsManager {
       return;
     }
 
-    if (accountId == null || accountId.isBlank() || failedClient == null) {
-      return;
+    synchronized (perAccountClientLock) {
+      if (accountId == null || accountId.isBlank() || failedClient == null) {
+        return;
+      }
+      if (!perAccountClients.remove(accountId, failedClient)) {
+        return;
+      }
+      closeQuietly(failedClient);
+      StsClient previousSts = stsClient.get();
+      if (previousSts == null) {
+        return;
+      }
+      StsClient nextSts = awsClients.stsClient();
+      if (stsClient.compareAndSet(previousSts, nextSts)) {
+        closeQuietly(previousSts);
+        closePerAccountClients();
+      } else {
+        closeQuietly(nextSts);
+      }
     }
-    if (!perAccountClients.remove(accountId, failedClient)) {
-      return;
+  }
+
+  private void closePerAccountClients() {
+    for (SecretsManagerClient client : perAccountClients.values()) {
+      closeQuietly(client);
     }
-    closeQuietly(failedClient);
-    StsClient previousSts = stsClient.get();
-    StsClient nextSts = awsClients.stsClient();
-    if (stsClient.compareAndSet(previousSts, nextSts)) {
-      closeQuietly(previousSts);
-    } else {
-      closeQuietly(nextSts);
+    perAccountClients.clear();
+  }
+
+  private static <T> T requireOpen(T client) {
+    if (client == null) {
+      throw new IllegalStateException("secrets manager is shut down");
     }
+    return client;
   }
 
   private static String buildRoleSessionName(String accountId) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.storage.aws.secrets;
 
 import ai.floedb.floecat.storage.aws.AwsClients;
+import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
 import ai.floedb.floecat.storage.secrets.SecretsManager;
 import io.quarkus.arc.profile.IfBuildProfile;
 import jakarta.annotation.PreDestroy;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
@@ -51,8 +53,8 @@ public class ProdSecretsManager implements SecretsManager {
   @ConfigProperty(name = "floecat.secrets.aws.role-arn")
   Optional<String> roleArn = Optional.empty();
 
-  private final SecretsManagerClient secretsClient;
-  private final StsClient stsClient;
+  private final AtomicReference<SecretsManagerClient> secretsClient;
+  private final AtomicReference<StsClient> stsClient;
   private final ConcurrentMap<String, SecretsManagerClient> perAccountClients =
       new ConcurrentHashMap<>();
 
@@ -68,8 +70,8 @@ public class ProdSecretsManager implements SecretsManager {
   ProdSecretsManager(
       AwsClients awsClients, SecretsManagerClient secretsClient, StsClient stsClient) {
     this.awsClients = awsClients;
-    this.secretsClient = secretsClient;
-    this.stsClient = stsClient;
+    this.secretsClient = new AtomicReference<>(secretsClient);
+    this.stsClient = new AtomicReference<>(stsClient);
   }
 
   private final AwsClients awsClients;
@@ -77,43 +79,74 @@ public class ProdSecretsManager implements SecretsManager {
   @PreDestroy
   void shutdown() {
     for (SecretsManagerClient client : perAccountClients.values()) {
-      client.close();
+      closeQuietly(client);
     }
     perAccountClients.clear();
-    secretsClient.close();
-    stsClient.close();
+    closeQuietly(secretsClient.getAndSet(null));
+    closeQuietly(stsClient.getAndSet(null));
   }
 
   @Override
   public void put(String accountId, String secretType, String secretId, byte[] payload) {
+    withClientRefresh(
+        accountId,
+        client -> {
+          putOnce(client, accountId, secretType, secretId, payload);
+          return null;
+        });
+  }
+
+  @Override
+  public Optional<byte[]> get(String accountId, String secretType, String secretId) {
+    return withClientRefresh(accountId, client -> getOnce(client, accountId, secretType, secretId));
+  }
+
+  @Override
+  public void update(String accountId, String secretType, String secretId, byte[] payload) {
+    withClientRefresh(
+        accountId,
+        client -> {
+          updateOnce(client, accountId, secretType, secretId, payload);
+          return null;
+        });
+  }
+
+  @Override
+  public void delete(String accountId, String secretType, String secretId) {
+    withClientRefresh(
+        accountId,
+        client -> {
+          deleteOnce(client, accountId, secretType, secretId);
+          return null;
+        });
+  }
+
+  private void putOnce(
+      SecretsManagerClient client, String accountId, String secretType, String secretId, byte[] payload) {
     ensureAwsCredentialsAvailable();
     String secretName = SecretsManager.buildSecretKey(accountId, secretType, secretId);
     String encoded = encodePayload(payload);
     List<Tag> tags = buildTags(accountId, secretName);
     try {
-      clientForAccount(accountId)
-          .createSecret(
-              CreateSecretRequest.builder()
-                  .name(secretName)
-                  .secretString(encoded)
-                  .tags(tags)
-                  .build());
+      client.createSecret(
+          CreateSecretRequest.builder()
+              .name(secretName)
+              .secretString(encoded)
+              .tags(tags)
+              .build());
     } catch (ResourceExistsException exists) {
-      clientForAccount(accountId)
-          .putSecretValue(
-              PutSecretValueRequest.builder().secretId(secretName).secretString(encoded).build());
-      tagSecret(accountId, secretName, tags);
+      client.putSecretValue(
+          PutSecretValueRequest.builder().secretId(secretName).secretString(encoded).build());
+      tagSecret(client, secretName, tags);
     }
   }
 
-  @Override
-  public Optional<byte[]> get(String accountId, String secretType, String secretId) {
+  private Optional<byte[]> getOnce(
+      SecretsManagerClient client, String accountId, String secretType, String secretId) {
     ensureAwsCredentialsAvailable();
     String secretName = SecretsManager.buildSecretKey(accountId, secretType, secretId);
     try {
-      var response =
-          clientForAccount(accountId)
-              .getSecretValue(GetSecretValueRequest.builder().secretId(secretName).build());
+      var response = client.getSecretValue(GetSecretValueRequest.builder().secretId(secretName).build());
       if (response == null
           || response.secretString() == null
           || response.secretString().isBlank()) {
@@ -125,36 +158,29 @@ public class ProdSecretsManager implements SecretsManager {
     }
   }
 
-  @Override
-  public void update(String accountId, String secretType, String secretId, byte[] payload) {
+  private void updateOnce(
+      SecretsManagerClient client, String accountId, String secretType, String secretId, byte[] payload) {
     ensureAwsCredentialsAvailable();
     String secretName = SecretsManager.buildSecretKey(accountId, secretType, secretId);
     String encoded = encodePayload(payload);
     List<Tag> tags = buildTags(accountId, secretName);
     try {
-      clientForAccount(accountId)
-          .putSecretValue(
-              PutSecretValueRequest.builder().secretId(secretName).secretString(encoded).build());
-      tagSecret(accountId, secretName, tags);
+      client.putSecretValue(
+          PutSecretValueRequest.builder().secretId(secretName).secretString(encoded).build());
+      tagSecret(client, secretName, tags);
     } catch (ResourceNotFoundException missing) {
-      clientForAccount(accountId)
-          .createSecret(
-              CreateSecretRequest.builder()
-                  .name(secretName)
-                  .secretString(encoded)
-                  .tags(tags)
-                  .build());
+      client.createSecret(
+          CreateSecretRequest.builder().name(secretName).secretString(encoded).tags(tags).build());
     }
   }
 
-  @Override
-  public void delete(String accountId, String secretType, String secretId) {
+  private void deleteOnce(
+      SecretsManagerClient client, String accountId, String secretType, String secretId) {
     ensureAwsCredentialsAvailable();
     String secretName = SecretsManager.buildSecretKey(accountId, secretType, secretId);
     try {
-      clientForAccount(accountId)
-          .deleteSecret(
-              DeleteSecretRequest.builder().secretId(secretName).recoveryWindowInDays(7L).build());
+      client.deleteSecret(
+          DeleteSecretRequest.builder().secretId(secretName).recoveryWindowInDays(7L).build());
     } catch (ResourceNotFoundException ignored) {
     }
   }
@@ -163,25 +189,24 @@ public class ProdSecretsManager implements SecretsManager {
     return List.of(Tag.builder().key(ACCOUNT_ID_TAG).value(accountId).build());
   }
 
-  private void tagSecret(String accountId, String secretName, List<Tag> tags) {
+  private void tagSecret(SecretsManagerClient client, String secretName, List<Tag> tags) {
     if (tags == null || tags.isEmpty()) {
       return;
     }
-    clientForAccount(accountId)
-        .tagResource(TagResourceRequest.builder().secretId(secretName).tags(tags).build());
+    client.tagResource(TagResourceRequest.builder().secretId(secretName).tags(tags).build());
   }
 
   private SecretsManagerClient clientForAccount(String accountId) {
     String role = roleArn.map(String::trim).filter(value -> !value.isBlank()).orElse("");
     if (role.isEmpty()) {
-      return secretsClient;
+      return secretsClient.get();
     }
     return perAccountClients.computeIfAbsent(
         accountId,
         id -> {
           StsAssumeRoleCredentialsProvider creds =
               StsAssumeRoleCredentialsProvider.builder()
-                  .stsClient(stsClient)
+                  .stsClient(stsClient.get())
                   .refreshRequest(
                       builder ->
                           builder
@@ -198,6 +223,50 @@ public class ProdSecretsManager implements SecretsManager {
           }
           return SecretsManagerClient.builder().credentialsProvider(creds).build();
         });
+  }
+
+  private <T> T withClientRefresh(String accountId, ClientOperation<T> operation) {
+    SecretsManagerClient client = clientForAccount(accountId);
+    try {
+      return operation.run(client);
+    } catch (RuntimeException e) {
+      if (awsClients == null || !ClosedAwsClientDetector.isConnectionPoolShutdown(e)) {
+        throw e;
+      }
+      refreshAfterClosedPool(accountId, client);
+      return operation.run(clientForAccount(accountId));
+    }
+  }
+
+  private void refreshAfterClosedPool(String accountId, SecretsManagerClient failedClient) {
+    String role = roleArn.map(String::trim).filter(value -> !value.isBlank()).orElse("");
+    if (role.isEmpty()) {
+      if (failedClient == null) {
+        return;
+      }
+      SecretsManagerClient next = awsClients.secretsManagerClient();
+      if (secretsClient.compareAndSet(failedClient, next)) {
+        closeQuietly(failedClient);
+      } else {
+        closeQuietly(next);
+      }
+      return;
+    }
+
+    if (accountId == null || accountId.isBlank() || failedClient == null) {
+      return;
+    }
+    if (!perAccountClients.remove(accountId, failedClient)) {
+      return;
+    }
+    closeQuietly(failedClient);
+    StsClient previousSts = stsClient.get();
+    StsClient nextSts = awsClients.stsClient();
+    if (stsClient.compareAndSet(previousSts, nextSts)) {
+      closeQuietly(previousSts);
+    } else {
+      closeQuietly(nextSts);
+    }
   }
 
   private static String buildRoleSessionName(String accountId) {
@@ -225,5 +294,20 @@ public class ProdSecretsManager implements SecretsManager {
     } catch (IllegalArgumentException ignored) {
       return encoded.getBytes(StandardCharsets.UTF_8);
     }
+  }
+
+  private static void closeQuietly(AutoCloseable client) {
+    if (client == null) {
+      return;
+    }
+    try {
+      client.close();
+    } catch (Exception ignored) {
+    }
+  }
+
+  @FunctionalInterface
+  private interface ClientOperation<T> {
+    T run(SecretsManagerClient client);
   }
 }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -45,7 +45,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   private final String table;
 
   public DynamoDbKvStore(DynamoDbAsyncClient ddb, String table) {
-    this(() -> ddb, table, (client, failure) -> {});
+    this(() -> ddb, table, null);
   }
 
   public DynamoDbKvStore(

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -29,7 +29,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
@@ -38,18 +39,21 @@ import software.amazon.awssdk.services.dynamodb.model.*;
 public final class DynamoDbKvStore implements KvStore, KvAttributes {
   static final int DELETE_BATCH_LIMIT = Integer.getInteger("floedb.floecat.delete.batch.size", 25);
   private final Supplier<DynamoDbAsyncClient> ddb;
-  private final Consumer<Throwable> clientFailureHandler;
+  private final BiConsumer<DynamoDbAsyncClient, Throwable> clientFailureHandler;
   private final String table;
 
   public DynamoDbKvStore(DynamoDbAsyncClient ddb, String table) {
-    this(() -> ddb, table, failure -> {});
+    this(() -> ddb, table, (client, failure) -> {});
   }
 
   public DynamoDbKvStore(
-      Supplier<DynamoDbAsyncClient> ddb, String table, Consumer<Throwable> clientFailureHandler) {
+      Supplier<DynamoDbAsyncClient> ddb,
+      String table,
+      BiConsumer<DynamoDbAsyncClient, Throwable> clientFailureHandler) {
     this.ddb = ddb;
     this.table = table;
-    this.clientFailureHandler = clientFailureHandler;
+    this.clientFailureHandler =
+        clientFailureHandler == null ? (client, failure) -> {} : clientFailureHandler;
   }
 
   String getTable() {
@@ -187,20 +191,24 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     return ddb.get();
   }
 
-  private <T> Uni<T> dynamo(Supplier<CompletionStage<T>> operation) {
+  private <T> Uni<T> dynamo(Function<DynamoDbAsyncClient, CompletionStage<T>> operation) {
+    DynamoDbAsyncClient client = ddb();
     try {
-      return fromStage(operation.get()).onFailure().invoke(clientFailureHandler::accept);
+      return fromStage(operation.apply(client))
+          .onFailure()
+          .invoke(failure -> clientFailureHandler.accept(client, failure));
     } catch (Throwable failure) {
-      clientFailureHandler.accept(failure);
+      clientFailureHandler.accept(client, failure);
       throw failure;
     }
   }
 
-  private <T> T dynamoBlocking(Supplier<T> operation) {
+  private <T> T dynamoBlocking(Function<DynamoDbAsyncClient, T> operation) {
+    DynamoDbAsyncClient client = ddb();
     try {
-      return operation.get();
+      return operation.apply(client);
     } catch (Throwable failure) {
-      clientFailureHandler.accept(failure);
+      clientFailureHandler.accept(client, failure);
       throw failure;
     }
   }
@@ -212,7 +220,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     var req =
         GetItemRequest.builder().tableName(table).key(keyMap(key)).consistentRead(true).build();
 
-    return dynamo(() -> ddb().getItem(req))
+    return dynamo(client -> client.getItem(req))
         .map(resp -> resp.hasItem() ? Optional.of(avToRecord(resp.item())) : Optional.empty());
   }
 
@@ -239,7 +247,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
           .expressionAttributeValues(Map.of(":ev", N(expectedVersion)));
     }
 
-    return dynamo(() -> ddb().putItem(b.build()))
+    return dynamo(client -> client.putItem(b.build()))
         .replaceWith(true)
         .onFailure(ConditionalCheckFailedException.class)
         .recoverWithItem(false);
@@ -260,7 +268,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
             .expressionAttributeValues(Map.of(":ev", N(expectedVersion)))
             .build();
 
-    return dynamo(() -> ddb().deleteItem(req))
+    return dynamo(client -> client.deleteItem(req))
         .replaceWith(true)
         .onFailure(ConditionalCheckFailedException.class)
         .recoverWithItem(false);
@@ -292,7 +300,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
     decodeToken(pageToken).ifPresent(qb::exclusiveStartKey);
 
-    return dynamo(() -> ddb().query(qb.build()))
+    return dynamo(client -> client.query(qb.build()))
         .map(
             resp -> {
               var items = new ArrayList<Record>(resp.items().size());
@@ -336,7 +344,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
                             ":skp", S(sortKeyPrefix)));
               }
 
-              return dynamo(() -> ddb().query(qb.build()));
+              return dynamo(client -> client.query(qb.build()));
             })
         .whilst(resp -> resp.lastEvaluatedKey() != null && !resp.lastEvaluatedKey().isEmpty())
         .onItem()
@@ -375,10 +383,9 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
     // Attempt to delete this batch.
     return dynamo(
-            () ->
-                ddb()
-                    .batchWriteItem(
-                        BatchWriteItemRequest.builder().requestItems(Map.of(table, batch)).build()))
+            client ->
+                client.batchWriteItem(
+                    BatchWriteItemRequest.builder().requestItems(Map.of(table, batch)).build()))
         .onItem()
         .transformToUni(
             resp -> {
@@ -470,7 +477,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
     var req = TransactWriteItemsRequest.builder().transactItems(tx).build();
 
-    return dynamo(() -> ddb().transactWriteItems(req))
+    return dynamo(client -> client.transactWriteItems(req))
         .replaceWith(true)
         .onFailure(TransactionCanceledException.class)
         .recoverWithItem(
@@ -514,7 +521,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
             .limit(1) // only need to find one item
             .build();
 
-    return dynamo(() -> ddb().scan(req).thenApply(r -> r.items().isEmpty()));
+    return dynamo(client -> client.scan(req).thenApply(r -> r.items().isEmpty()));
   }
 
   @Override
@@ -529,6 +536,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   }
 
   void listTableIfExists(String header) {
+    DynamoDbAsyncClient client = ddb();
     try {
       var req =
           ScanRequest.builder()
@@ -536,7 +544,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
               .limit(100) // keep logs sane
               .build();
 
-      var resp = ddb().scan(req).get();
+      var resp = client.scan(req).get();
 
       System.out.println("\n=== DUMP TABLE: " + this.table + " " + header + " ===");
 
@@ -553,12 +561,12 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
       System.out.println("=== END TABLE DUMP ===\n");
 
     } catch (ExecutionException e) {
-      clientFailureHandler.accept(e);
+      clientFailureHandler.accept(client, e);
       // Table probably does not exist — safe to ignore in tests
       System.out.println("Table not found: " + this.table);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      clientFailureHandler.accept(e);
+      clientFailureHandler.accept(client, e);
       throw new RuntimeException(e);
     }
   }
@@ -593,8 +601,8 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   private void dropTableIfExists(String tableName) {
     try {
       dynamoBlocking(
-          () ->
-              ddb().deleteTable(DeleteTableRequest.builder().tableName(tableName).build()).join());
+          client ->
+              client.deleteTable(DeleteTableRequest.builder().tableName(tableName).build()).join());
       // Wait until it's really gone (Local is fast, AWS would be slower)
       for (int i = 0; i < 50; i++) {
         if (!tableExists(tableName)) return;
@@ -630,14 +638,14 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
                     .build())
             .build();
 
-    dynamoBlocking(() -> ddb().createTable(req).join());
+    dynamoBlocking(client -> client.createTable(req).join());
   }
 
   private boolean tableExists(String tableName) {
     try {
       dynamoBlocking(
-          () ->
-              ddb()
+          client ->
+              client
                   .describeTable(DescribeTableRequest.builder().tableName(tableName).build())
                   .join());
       return true;
@@ -652,8 +660,8 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
       try {
         var resp =
             dynamoBlocking(
-                () ->
-                    ddb()
+                client ->
+                    client
                         .describeTable(DescribeTableRequest.builder().tableName(tableName).build())
                         .join());
         if (resp.table().tableStatus() == TableStatus.ACTIVE) return;

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -15,6 +15,7 @@
  */
 package ai.floedb.floecat.storage.kv.dynamodb;
 
+import ai.floedb.floecat.storage.aws.ClosedAwsClientDetector;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
 import io.smallrye.mutiny.Multi;
@@ -40,6 +41,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   static final int DELETE_BATCH_LIMIT = Integer.getInteger("floedb.floecat.delete.batch.size", 25);
   private final Supplier<DynamoDbAsyncClient> ddb;
   private final BiConsumer<DynamoDbAsyncClient, Throwable> clientFailureHandler;
+  private final boolean supportsClientRefresh;
   private final String table;
 
   public DynamoDbKvStore(DynamoDbAsyncClient ddb, String table) {
@@ -52,6 +54,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
       BiConsumer<DynamoDbAsyncClient, Throwable> clientFailureHandler) {
     this.ddb = ddb;
     this.table = table;
+    this.supportsClientRefresh = clientFailureHandler != null;
     this.clientFailureHandler =
         clientFailureHandler == null ? (client, failure) -> {} : clientFailureHandler;
   }
@@ -192,25 +195,51 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   }
 
   private <T> Uni<T> dynamo(Function<DynamoDbAsyncClient, CompletionStage<T>> operation) {
+    return dynamo(operation, 0);
+  }
+
+  private <T> Uni<T> dynamo(
+      Function<DynamoDbAsyncClient, CompletionStage<T>> operation, int attempt) {
     DynamoDbAsyncClient client = ddb();
     try {
       return fromStage(operation.apply(client))
           .onFailure()
-          .invoke(failure -> clientFailureHandler.accept(client, failure));
+          .recoverWithUni(
+              failure -> {
+                clientFailureHandler.accept(client, failure);
+                if (shouldRefreshAndRetry(failure, attempt)) {
+                  return dynamo(operation, attempt + 1);
+                }
+                return Uni.createFrom().failure(failure);
+              });
     } catch (Throwable failure) {
       clientFailureHandler.accept(client, failure);
+      if (shouldRefreshAndRetry(failure, attempt)) {
+        return dynamo(operation, attempt + 1);
+      }
       throw failure;
     }
   }
 
   private <T> T dynamoBlocking(Function<DynamoDbAsyncClient, T> operation) {
-    DynamoDbAsyncClient client = ddb();
-    try {
-      return operation.apply(client);
-    } catch (Throwable failure) {
-      clientFailureHandler.accept(client, failure);
-      throw failure;
+    for (int attempt = 0; ; attempt++) {
+      DynamoDbAsyncClient client = ddb();
+      try {
+        return operation.apply(client);
+      } catch (Throwable failure) {
+        clientFailureHandler.accept(client, failure);
+        if (shouldRefreshAndRetry(failure, attempt)) {
+          continue;
+        }
+        throw failure;
+      }
     }
+  }
+
+  private boolean shouldRefreshAndRetry(Throwable failure, int attempt) {
+    return supportsClientRefresh
+        && attempt == 0
+        && ClosedAwsClientDetector.isConnectionPoolShutdown(failure);
   }
 
   // ---- KvStore (reads)

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/DynamoDbAsyncClientManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/DynamoDbAsyncClientManagerTest.java
@@ -78,6 +78,23 @@ class DynamoDbAsyncClientManagerTest {
     assertFalse(clients.handles.get(1).closed);
   }
 
+  @Test
+  void current_after_close_throws_without_recreating_client() {
+    FakeAwsClients clients = new FakeAwsClients();
+    DynamoDbAsyncClientManager manager = new DynamoDbAsyncClientManager();
+    manager.awsClients = clients;
+
+    DynamoDbAsyncClient first = manager.current();
+    manager.close();
+
+    IllegalStateException thrown = assertThrows(IllegalStateException.class, manager::current);
+
+    assertEquals("dynamodb async client manager is shut down", thrown.getMessage());
+    assertEquals(1, clients.handles.size());
+    assertTrue(clients.handles.get(0).closed);
+    assertSame(first, clients.handles.get(0).client);
+  }
+
   private static final class FakeAwsClients extends AwsClients {
     private final List<ClientHandle> handles = new ArrayList<>();
 

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/DynamoDbClientManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/DynamoDbClientManagerTest.java
@@ -24,21 +24,21 @@ import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
-class DynamoDbAsyncClientManagerTest {
+class DynamoDbClientManagerTest {
 
   @Test
   void refreshAfterFailure_replaces_client_on_connection_pool_shutdown() {
     FakeAwsClients clients = new FakeAwsClients();
-    DynamoDbAsyncClientManager manager = new DynamoDbAsyncClientManager();
+    DynamoDbClientManager manager = new DynamoDbClientManager();
     manager.awsClients = clients;
 
-    DynamoDbAsyncClient first = manager.current();
+    DynamoDbClient first = manager.current();
 
     manager.refreshAfterFailure(first, new IllegalStateException("Connection pool shut down"));
 
-    DynamoDbAsyncClient second = manager.current();
+    DynamoDbClient second = manager.current();
     assertNotSame(first, second);
     assertEquals(2, clients.handles.size());
     assertTrue(clients.handles.get(0).closed);
@@ -48,10 +48,10 @@ class DynamoDbAsyncClientManagerTest {
   @Test
   void refreshAfterFailure_ignores_unrelated_failure() {
     FakeAwsClients clients = new FakeAwsClients();
-    DynamoDbAsyncClientManager manager = new DynamoDbAsyncClientManager();
+    DynamoDbClientManager manager = new DynamoDbClientManager();
     manager.awsClients = clients;
 
-    DynamoDbAsyncClient first = manager.current();
+    DynamoDbClient first = manager.current();
 
     manager.refreshAfterFailure(first, new IllegalStateException("throttled"));
 
@@ -63,12 +63,12 @@ class DynamoDbAsyncClientManagerTest {
   @Test
   void refreshAfterFailure_ignores_stale_failed_client() {
     FakeAwsClients clients = new FakeAwsClients();
-    DynamoDbAsyncClientManager manager = new DynamoDbAsyncClientManager();
+    DynamoDbClientManager manager = new DynamoDbClientManager();
     manager.awsClients = clients;
 
-    DynamoDbAsyncClient first = manager.current();
+    DynamoDbClient first = manager.current();
     manager.refreshAfterFailure(first, new IllegalStateException("Connection pool shut down"));
-    DynamoDbAsyncClient second = manager.current();
+    DynamoDbClient second = manager.current();
 
     manager.refreshAfterFailure(first, new IllegalStateException("Connection pool shut down"));
 
@@ -82,7 +82,7 @@ class DynamoDbAsyncClientManagerTest {
     private final List<ClientHandle> handles = new ArrayList<>();
 
     @Override
-    public DynamoDbAsyncClient newDynamoDbAsyncClient() {
+    public DynamoDbClient newDynamoDbClient() {
       ClientHandle handle = new ClientHandle();
       handles.add(handle);
       return handle.client;
@@ -90,12 +90,10 @@ class DynamoDbAsyncClientManagerTest {
   }
 
   private static final class ClientHandle implements InvocationHandler {
-    private final DynamoDbAsyncClient client =
-        (DynamoDbAsyncClient)
+    private final DynamoDbClient client =
+        (DynamoDbClient)
             Proxy.newProxyInstance(
-                DynamoDbAsyncClient.class.getClassLoader(),
-                new Class<?>[] {DynamoDbAsyncClient.class},
-                this);
+                DynamoDbClient.class.getClassLoader(), new Class<?>[] {DynamoDbClient.class}, this);
 
     private boolean closed;
 

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/S3ClientManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/S3ClientManagerTest.java
@@ -24,21 +24,21 @@ import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
-class DynamoDbClientManagerTest {
+class S3ClientManagerTest {
 
   @Test
   void refreshAfterFailure_replaces_client_on_connection_pool_shutdown() {
     FakeAwsClients clients = new FakeAwsClients();
-    DynamoDbClientManager manager = new DynamoDbClientManager();
+    S3ClientManager manager = new S3ClientManager();
     manager.awsClients = clients;
 
-    DynamoDbClient first = manager.current();
+    S3Client first = manager.current();
 
     manager.refreshAfterFailure(first, new IllegalStateException("Connection pool shut down"));
 
-    DynamoDbClient second = manager.current();
+    S3Client second = manager.current();
     assertNotSame(first, second);
     assertEquals(2, clients.handles.size());
     assertTrue(clients.handles.get(0).closed);
@@ -46,29 +46,14 @@ class DynamoDbClientManagerTest {
   }
 
   @Test
-  void refreshAfterFailure_ignores_unrelated_failure() {
-    FakeAwsClients clients = new FakeAwsClients();
-    DynamoDbClientManager manager = new DynamoDbClientManager();
-    manager.awsClients = clients;
-
-    DynamoDbClient first = manager.current();
-
-    manager.refreshAfterFailure(first, new IllegalStateException("throttled"));
-
-    assertSame(first, manager.current());
-    assertEquals(1, clients.handles.size());
-    assertFalse(clients.handles.get(0).closed);
-  }
-
-  @Test
   void refreshAfterFailure_ignores_stale_failed_client() {
     FakeAwsClients clients = new FakeAwsClients();
-    DynamoDbClientManager manager = new DynamoDbClientManager();
+    S3ClientManager manager = new S3ClientManager();
     manager.awsClients = clients;
 
-    DynamoDbClient first = manager.current();
+    S3Client first = manager.current();
     manager.refreshAfterFailure(first, new IllegalStateException("Connection pool shut down"));
-    DynamoDbClient second = manager.current();
+    S3Client second = manager.current();
 
     manager.refreshAfterFailure(first, new IllegalStateException("Connection pool shut down"));
 
@@ -81,15 +66,15 @@ class DynamoDbClientManagerTest {
   @Test
   void current_after_close_throws_without_recreating_client() {
     FakeAwsClients clients = new FakeAwsClients();
-    DynamoDbClientManager manager = new DynamoDbClientManager();
+    S3ClientManager manager = new S3ClientManager();
     manager.awsClients = clients;
 
-    DynamoDbClient first = manager.current();
+    S3Client first = manager.current();
     manager.close();
 
     IllegalStateException thrown = assertThrows(IllegalStateException.class, manager::current);
 
-    assertEquals("dynamodb client manager is shut down", thrown.getMessage());
+    assertEquals("s3 client manager is shut down", thrown.getMessage());
     assertEquals(1, clients.handles.size());
     assertTrue(clients.handles.get(0).closed);
     assertSame(first, clients.handles.get(0).client);
@@ -99,7 +84,7 @@ class DynamoDbClientManagerTest {
     private final List<ClientHandle> handles = new ArrayList<>();
 
     @Override
-    public DynamoDbClient newDynamoDbClient() {
+    public S3Client newS3Client() {
       ClientHandle handle = new ClientHandle();
       handles.add(handle);
       return handle.client;
@@ -107,10 +92,10 @@ class DynamoDbClientManagerTest {
   }
 
   private static final class ClientHandle implements InvocationHandler {
-    private final DynamoDbClient client =
-        (DynamoDbClient)
+    private final S3Client client =
+        (S3Client)
             Proxy.newProxyInstance(
-                DynamoDbClient.class.getClassLoader(), new Class<?>[] {DynamoDbClient.class}, this);
+                S3Client.class.getClassLoader(), new Class<?>[] {S3Client.class}, this);
 
     private boolean closed;
 
@@ -121,7 +106,8 @@ class DynamoDbClientManagerTest {
           closed = true;
           yield null;
         }
-        case "toString" -> "fake-dynamodb-client";
+        case "serviceName" -> "test";
+        case "toString" -> "fake-s3-client";
         case "hashCode" -> System.identityHashCode(proxy);
         case "equals" -> proxy == args[0];
         default -> null;

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.storage.aws.secrets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.storage.aws.AwsClients;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.Base64;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.sts.StsClient;
+
+class ProdSecretsManagerTest {
+
+  @Test
+  void get_refreshes_direct_secrets_client_after_closed_pool() {
+    ClientHandle staleClient =
+        ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
+    ClientHandle refreshedClient =
+        ClientHandle.secretsValue(Base64.getEncoder().encodeToString("alpha".getBytes()));
+    ClientHandle stsClient = ClientHandle.sts();
+
+    FakeAwsClients awsClients = new FakeAwsClients();
+    awsClients.refreshedSecretsClients.addLast(refreshedClient);
+
+    ProdSecretsManager manager =
+        new ProdSecretsManager(awsClients, staleClient.secretsClient, stsClient.stsClient);
+
+    Optional<byte[]> result = manager.get("acct", "connectors", "secret");
+
+    assertArrayEquals("alpha".getBytes(), result.orElseThrow());
+    assertTrue(staleClient.closed);
+    assertEquals(1, awsClients.secretsRefreshes);
+    assertEquals(0, awsClients.stsRefreshes);
+  }
+
+  @Test
+  void get_refreshes_sts_and_per_account_client_after_closed_pool() {
+    ClientHandle bootstrapClient = ClientHandle.secretsValue("unused");
+    ClientHandle staleStsClient = ClientHandle.sts();
+    ClientHandle refreshedStsClient = ClientHandle.sts();
+    ClientHandle stalePerAccountClient =
+        ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
+    ClientHandle refreshedPerAccountClient =
+        ClientHandle.secretsValue(Base64.getEncoder().encodeToString("beta".getBytes()));
+
+    FakeAwsClients awsClients = new FakeAwsClients();
+    awsClients.refreshedStsClients.addLast(refreshedStsClient);
+    awsClients.perAccountSecretsClients.addLast(stalePerAccountClient);
+    awsClients.perAccountSecretsClients.addLast(refreshedPerAccountClient);
+
+    ProdSecretsManager manager =
+        new ProdSecretsManager(awsClients, bootstrapClient.secretsClient, staleStsClient.stsClient);
+    manager.roleArn = Optional.of("arn:aws:iam::123456789012:role/test");
+
+    Optional<byte[]> result = manager.get("acct", "connectors", "secret");
+
+    assertArrayEquals("beta".getBytes(), result.orElseThrow());
+    assertTrue(stalePerAccountClient.closed);
+    assertTrue(staleStsClient.closed);
+    assertEquals(2, awsClients.perAccountClientBuilds);
+    assertEquals(1, awsClients.stsRefreshes);
+  }
+
+  @Test
+  void stale_failed_per_account_client_does_not_evict_newer_client() throws Exception {
+    ClientHandle bootstrapClient = ClientHandle.secretsValue("unused");
+    ClientHandle staleStsClient = ClientHandle.sts();
+    ClientHandle refreshedStsClient = ClientHandle.sts();
+    ClientHandle stalePerAccountClient = ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
+    ClientHandle newerPerAccountClient =
+        ClientHandle.secretsValue(Base64.getEncoder().encodeToString("gamma".getBytes()));
+
+    FakeAwsClients awsClients = new FakeAwsClients();
+    awsClients.refreshedStsClients.addLast(refreshedStsClient);
+    awsClients.perAccountSecretsClients.addLast(stalePerAccountClient);
+    awsClients.perAccountSecretsClients.addLast(newerPerAccountClient);
+
+    ProdSecretsManager manager =
+        new ProdSecretsManager(awsClients, bootstrapClient.secretsClient, staleStsClient.stsClient);
+    manager.roleArn = Optional.of("arn:aws:iam::123456789012:role/test");
+
+    manager.get("acct", "connectors", "secret");
+
+    invokeRefresh(manager, "acct", stalePerAccountClient.secretsClient);
+
+    assertTrue(stalePerAccountClient.closed);
+    assertTrue(!newerPerAccountClient.closed);
+    assertEquals(1, awsClients.stsRefreshes);
+    assertSameMappedClient(manager, "acct", newerPerAccountClient.secretsClient);
+  }
+
+  private static final class FakeAwsClients extends AwsClients {
+    private final Deque<ClientHandle> refreshedSecretsClients = new ArrayDeque<>();
+    private final Deque<ClientHandle> refreshedStsClients = new ArrayDeque<>();
+    private final Deque<ClientHandle> perAccountSecretsClients = new ArrayDeque<>();
+    private int secretsRefreshes;
+    private int stsRefreshes;
+    private int perAccountClientBuilds;
+
+    @Override
+    public SecretsManagerClient secretsManagerClient() {
+      secretsRefreshes++;
+      return refreshedSecretsClients.removeFirst().secretsClient;
+    }
+
+    @Override
+    public StsClient stsClient() {
+      stsRefreshes++;
+      return refreshedStsClients.removeFirst().stsClient;
+    }
+
+    @Override
+    public SecretsManagerClient secretsManagerClient(AwsCredentialsProvider credentialsProvider) {
+      perAccountClientBuilds++;
+      return perAccountSecretsClients.removeFirst().secretsClient;
+    }
+
+    @Override
+    public void ensureCredentialsAvailable() {}
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertSameMappedClient(
+      ProdSecretsManager manager, String accountId, SecretsManagerClient expected) throws Exception {
+    Field field = ProdSecretsManager.class.getDeclaredField("perAccountClients");
+    field.setAccessible(true);
+    Map<String, SecretsManagerClient> clients =
+        (Map<String, SecretsManagerClient>) field.get(manager);
+    assertTrue(clients.get(accountId) == expected);
+  }
+
+  private static void invokeRefresh(
+      ProdSecretsManager manager, String accountId, SecretsManagerClient failedClient)
+      throws Exception {
+    Method refresh =
+        ProdSecretsManager.class.getDeclaredMethod(
+            "refreshAfterClosedPool", String.class, SecretsManagerClient.class);
+    refresh.setAccessible(true);
+    refresh.invoke(manager, accountId, failedClient);
+  }
+
+  private static final class ClientHandle implements InvocationHandler {
+    private final RuntimeException failure;
+    private final String secretString;
+    private boolean closed;
+    private final SecretsManagerClient secretsClient;
+    private final StsClient stsClient;
+
+    private ClientHandle(RuntimeException failure, String secretString) {
+      this.failure = failure;
+      this.secretString = secretString;
+      this.secretsClient =
+          (SecretsManagerClient)
+              Proxy.newProxyInstance(
+                  SecretsManagerClient.class.getClassLoader(),
+                  new Class<?>[] {SecretsManagerClient.class},
+                  this);
+      this.stsClient =
+          (StsClient)
+              Proxy.newProxyInstance(
+                  StsClient.class.getClassLoader(), new Class<?>[] {StsClient.class}, this);
+    }
+
+    static ClientHandle secretsFailure(RuntimeException failure) {
+      return new ClientHandle(failure, null);
+    }
+
+    static ClientHandle secretsValue(String secretString) {
+      return new ClientHandle(null, secretString);
+    }
+
+    static ClientHandle sts() {
+      return new ClientHandle(null, null);
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) {
+      return switch (method.getName()) {
+        case "getSecretValue" -> {
+          if (failure != null) {
+            throw failure;
+          }
+          yield GetSecretValueResponse.builder().secretString(secretString).build();
+        }
+        case "close" -> {
+          closed = true;
+          yield null;
+        }
+        case "serviceName" -> "test";
+        case "toString" -> "client-handle";
+        case "hashCode" -> System.identityHashCode(proxy);
+        case "equals" -> proxy == args[0];
+        default -> null;
+      };
+    }
+  }
+}

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
@@ -21,10 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.storage.aws.AwsClients;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.lang.reflect.Field;
 import java.util.ArrayDeque;
 import java.util.Base64;
 import java.util.Deque;
@@ -33,7 +33,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 
@@ -94,7 +93,8 @@ class ProdSecretsManagerTest {
     ClientHandle bootstrapClient = ClientHandle.secretsValue("unused");
     ClientHandle staleStsClient = ClientHandle.sts();
     ClientHandle refreshedStsClient = ClientHandle.sts();
-    ClientHandle stalePerAccountClient = ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
+    ClientHandle stalePerAccountClient =
+        ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
     ClientHandle newerPerAccountClient =
         ClientHandle.secretsValue(Base64.getEncoder().encodeToString("gamma".getBytes()));
 
@@ -149,7 +149,8 @@ class ProdSecretsManagerTest {
 
   @SuppressWarnings("unchecked")
   private static void assertSameMappedClient(
-      ProdSecretsManager manager, String accountId, SecretsManagerClient expected) throws Exception {
+      ProdSecretsManager manager, String accountId, SecretsManagerClient expected)
+      throws Exception {
     Field field = ProdSecretsManager.class.getDeclaredField("perAccountClients");
     field.setAccessible(true);
     Map<String, SecretsManagerClient> clients =

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -63,17 +64,15 @@ class ProdSecretsManagerTest {
   }
 
   @Test
-  void get_refreshes_sts_and_per_account_client_after_closed_pool() {
+  void get_refreshes_only_failed_per_account_client_after_secrets_closed_pool() {
     ClientHandle bootstrapClient = ClientHandle.secretsValue("unused");
     ClientHandle staleStsClient = ClientHandle.sts();
-    ClientHandle refreshedStsClient = ClientHandle.sts();
     ClientHandle stalePerAccountClient =
         ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
     ClientHandle refreshedPerAccountClient =
         ClientHandle.secretsValue(Base64.getEncoder().encodeToString("beta".getBytes()));
 
     FakeAwsClients awsClients = new FakeAwsClients();
-    awsClients.refreshedStsClients.addLast(refreshedStsClient);
     awsClients.perAccountSecretsClients.addLast(stalePerAccountClient);
     awsClients.perAccountSecretsClients.addLast(refreshedPerAccountClient);
 
@@ -85,20 +84,55 @@ class ProdSecretsManagerTest {
 
     assertArrayEquals("beta".getBytes(), result.orElseThrow());
     assertTrue(stalePerAccountClient.closed);
-    assertTrue(staleStsClient.closed);
+    assertFalse(staleStsClient.closed);
     assertEquals(2, awsClients.perAccountClientBuilds);
-    assertEquals(1, awsClients.stsRefreshes);
+    assertEquals(0, awsClients.stsRefreshes);
   }
 
   @Test
-  void per_account_refresh_closes_all_clients_bound_to_previous_sts() {
+  void per_account_secrets_pool_refresh_does_not_close_other_account_clients() {
+    ClientHandle bootstrapClient = ClientHandle.secretsValue("unused");
+    ClientHandle staleStsClient = ClientHandle.sts();
+    ClientHandle otherAccountClient =
+        ClientHandle.secretsValue(Base64.getEncoder().encodeToString("other".getBytes()));
+    ClientHandle stalePerAccountClient =
+        ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
+    ClientHandle refreshedPerAccountClient =
+        ClientHandle.secretsValue(Base64.getEncoder().encodeToString("beta".getBytes()));
+
+    FakeAwsClients awsClients = new FakeAwsClients();
+    awsClients.perAccountSecretsClients.addLast(otherAccountClient);
+    awsClients.perAccountSecretsClients.addLast(stalePerAccountClient);
+    awsClients.perAccountSecretsClients.addLast(refreshedPerAccountClient);
+
+    ProdSecretsManager manager =
+        new ProdSecretsManager(awsClients, bootstrapClient.secretsClient, staleStsClient.stsClient);
+    manager.roleArn = Optional.of("arn:aws:iam::123456789012:role/test");
+
+    manager.get("acct-other", "connectors", "secret");
+
+    Optional<byte[]> result = manager.get("acct", "connectors", "secret");
+
+    assertArrayEquals("beta".getBytes(), result.orElseThrow());
+    assertTrue(stalePerAccountClient.closed);
+    assertFalse(otherAccountClient.closed);
+    assertFalse(staleStsClient.closed);
+    assertEquals(3, awsClients.perAccountClientBuilds);
+    assertEquals(0, awsClients.stsRefreshes);
+  }
+
+  @Test
+  void credential_pool_refresh_replaces_sts_and_closes_clients_bound_to_previous_sts() {
     ClientHandle bootstrapClient = ClientHandle.secretsValue("unused");
     ClientHandle staleStsClient = ClientHandle.sts();
     ClientHandle refreshedStsClient = ClientHandle.sts();
     ClientHandle otherAccountClient =
         ClientHandle.secretsValue(Base64.getEncoder().encodeToString("other".getBytes()));
-    ClientHandle stalePerAccountClient =
-        ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
+    RuntimeException credentialFailure =
+        SdkClientException.create(
+            "Unable to load credentials from STS",
+            new RuntimeException("Connection pool shut down"));
+    ClientHandle stalePerAccountClient = ClientHandle.secretsFailure(credentialFailure);
     ClientHandle refreshedPerAccountClient =
         ClientHandle.secretsValue(Base64.getEncoder().encodeToString("beta".getBytes()));
 
@@ -128,14 +162,12 @@ class ProdSecretsManagerTest {
   void stale_failed_per_account_client_does_not_evict_newer_client() throws Exception {
     ClientHandle bootstrapClient = ClientHandle.secretsValue("unused");
     ClientHandle staleStsClient = ClientHandle.sts();
-    ClientHandle refreshedStsClient = ClientHandle.sts();
     ClientHandle stalePerAccountClient =
         ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
     ClientHandle newerPerAccountClient =
         ClientHandle.secretsValue(Base64.getEncoder().encodeToString("gamma".getBytes()));
 
     FakeAwsClients awsClients = new FakeAwsClients();
-    awsClients.refreshedStsClients.addLast(refreshedStsClient);
     awsClients.perAccountSecretsClients.addLast(stalePerAccountClient);
     awsClients.perAccountSecretsClients.addLast(newerPerAccountClient);
 
@@ -145,11 +177,15 @@ class ProdSecretsManagerTest {
 
     manager.get("acct", "connectors", "secret");
 
-    invokeRefresh(manager, "acct", stalePerAccountClient.secretsClient);
+    invokeRefresh(
+        manager,
+        "acct",
+        stalePerAccountClient.secretsClient,
+        new RuntimeException("Connection pool shut down"));
 
     assertTrue(stalePerAccountClient.closed);
     assertFalse(newerPerAccountClient.closed);
-    assertEquals(1, awsClients.stsRefreshes);
+    assertEquals(0, awsClients.stsRefreshes);
     assertSameMappedClient(manager, "acct", newerPerAccountClient.secretsClient);
   }
 
@@ -232,13 +268,16 @@ class ProdSecretsManagerTest {
   }
 
   private static void invokeRefresh(
-      ProdSecretsManager manager, String accountId, SecretsManagerClient failedClient)
+      ProdSecretsManager manager,
+      String accountId,
+      SecretsManagerClient failedClient,
+      Throwable failure)
       throws Exception {
     Method refresh =
         ProdSecretsManager.class.getDeclaredMethod(
-            "refreshAfterClosedPool", String.class, SecretsManagerClient.class);
+            "refreshAfterClosedPool", String.class, SecretsManagerClient.class, Throwable.class);
     refresh.setAccessible(true);
-    refresh.invoke(manager, accountId, failedClient);
+    refresh.invoke(manager, accountId, failedClient, failure);
   }
 
   private static final class ClientHandle implements InvocationHandler {

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
@@ -18,6 +18,8 @@ package ai.floedb.floecat.storage.aws.secrets;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.storage.aws.AwsClients;
@@ -89,6 +91,40 @@ class ProdSecretsManagerTest {
   }
 
   @Test
+  void per_account_refresh_closes_all_clients_bound_to_previous_sts() {
+    ClientHandle bootstrapClient = ClientHandle.secretsValue("unused");
+    ClientHandle staleStsClient = ClientHandle.sts();
+    ClientHandle refreshedStsClient = ClientHandle.sts();
+    ClientHandle otherAccountClient =
+        ClientHandle.secretsValue(Base64.getEncoder().encodeToString("other".getBytes()));
+    ClientHandle stalePerAccountClient =
+        ClientHandle.secretsFailure(new RuntimeException("Connection pool shut down"));
+    ClientHandle refreshedPerAccountClient =
+        ClientHandle.secretsValue(Base64.getEncoder().encodeToString("beta".getBytes()));
+
+    FakeAwsClients awsClients = new FakeAwsClients();
+    awsClients.refreshedStsClients.addLast(refreshedStsClient);
+    awsClients.perAccountSecretsClients.addLast(otherAccountClient);
+    awsClients.perAccountSecretsClients.addLast(stalePerAccountClient);
+    awsClients.perAccountSecretsClients.addLast(refreshedPerAccountClient);
+
+    ProdSecretsManager manager =
+        new ProdSecretsManager(awsClients, bootstrapClient.secretsClient, staleStsClient.stsClient);
+    manager.roleArn = Optional.of("arn:aws:iam::123456789012:role/test");
+
+    manager.get("acct-other", "connectors", "secret");
+
+    Optional<byte[]> result = manager.get("acct", "connectors", "secret");
+
+    assertArrayEquals("beta".getBytes(), result.orElseThrow());
+    assertTrue(stalePerAccountClient.closed);
+    assertTrue(otherAccountClient.closed);
+    assertTrue(staleStsClient.closed);
+    assertEquals(3, awsClients.perAccountClientBuilds);
+    assertEquals(1, awsClients.stsRefreshes);
+  }
+
+  @Test
   void stale_failed_per_account_client_does_not_evict_newer_client() throws Exception {
     ClientHandle bootstrapClient = ClientHandle.secretsValue("unused");
     ClientHandle staleStsClient = ClientHandle.sts();
@@ -112,9 +148,46 @@ class ProdSecretsManagerTest {
     invokeRefresh(manager, "acct", stalePerAccountClient.secretsClient);
 
     assertTrue(stalePerAccountClient.closed);
-    assertTrue(!newerPerAccountClient.closed);
+    assertFalse(newerPerAccountClient.closed);
     assertEquals(1, awsClients.stsRefreshes);
     assertSameMappedClient(manager, "acct", newerPerAccountClient.secretsClient);
+  }
+
+  @Test
+  void direct_client_after_shutdown_throws_clear_state_error() {
+    ClientHandle directClient =
+        ClientHandle.secretsValue(Base64.getEncoder().encodeToString("unused".getBytes()));
+    ClientHandle stsClient = ClientHandle.sts();
+    ProdSecretsManager manager =
+        new ProdSecretsManager(
+            new FakeAwsClients(), directClient.secretsClient, stsClient.stsClient);
+
+    manager.shutdown();
+
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class, () -> manager.get("acct", "connectors", "secret"));
+
+    assertEquals("secrets manager is shut down", thrown.getMessage());
+  }
+
+  @Test
+  void role_client_after_shutdown_throws_clear_state_error() {
+    ClientHandle directClient =
+        ClientHandle.secretsValue(Base64.getEncoder().encodeToString("unused".getBytes()));
+    ClientHandle stsClient = ClientHandle.sts();
+    ProdSecretsManager manager =
+        new ProdSecretsManager(
+            new FakeAwsClients(), directClient.secretsClient, stsClient.stsClient);
+    manager.roleArn = Optional.of("arn:aws:iam::123456789012:role/test");
+
+    manager.shutdown();
+
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class, () -> manager.get("acct", "connectors", "secret"));
+
+    assertEquals("secrets manager is shut down", thrown.getMessage());
   }
 
   private static final class FakeAwsClients extends AwsClients {

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
@@ -218,6 +219,48 @@ public class DynamoDbKvStoreTest {
     assertNull(result.get());
     assertNotNull(failure.get());
     assertTrue(failure.get().getMessage().contains("ddb get failed"));
+  }
+
+  @Test
+  void get_refreshes_client_and_retries_once_after_closed_pool() {
+    FakeDynamoDbHandler staleHandler = new FakeDynamoDbHandler();
+    RuntimeException closedPool = new RuntimeException("Connection pool shut down");
+    CompletableFuture<GetItemResponse> failed = new CompletableFuture<>();
+    failed.completeExceptionally(closedPool);
+    staleHandler.setPendingGetFuture(failed);
+    DynamoDbAsyncClient staleClient = clientFor(staleHandler);
+
+    FakeDynamoDbHandler refreshedHandler = new FakeDynamoDbHandler();
+    refreshedHandler.items.put(
+        "pk|sk",
+        Map.of(
+            KvAttributes.ATTR_PARTITION_KEY, AttributeValue.builder().s("pk").build(),
+            KvAttributes.ATTR_SORT_KEY, AttributeValue.builder().s("sk").build(),
+            KvAttributes.ATTR_KIND, AttributeValue.builder().s("K").build(),
+            KvAttributes.ATTR_VALUE,
+                AttributeValue.fromB(software.amazon.awssdk.core.SdkBytes.fromUtf8String("v")),
+            KvAttributes.ATTR_VERSION, AttributeValue.builder().n("3").build()));
+    DynamoDbAsyncClient refreshedClient = clientFor(refreshedHandler);
+
+    AtomicReference<DynamoDbAsyncClient> current = new AtomicReference<>(staleClient);
+    AtomicInteger refreshes = new AtomicInteger();
+    DynamoDbKvStore store =
+        new DynamoDbKvStore(
+            current::get,
+            staleHandler.tableName,
+            (client, failure) -> {
+              assertSame(staleClient, client);
+              assertSame(closedPool, failure);
+              refreshes.incrementAndGet();
+              current.set(refreshedClient);
+            });
+
+    KvStore.Record got = store.get(key("pk", "sk")).await().indefinitely().orElseThrow();
+
+    assertEquals(1, refreshes.get());
+    assertEquals(3L, got.version());
+    assertEquals("pk", got.key().partitionKey());
+    assertEquals("sk", got.key().sortKey());
   }
 
   @Test
@@ -665,13 +708,17 @@ public class DynamoDbKvStoreTest {
   }
 
   private static DynamoDbKvStore newStore(FakeDynamoDbHandler handler) {
+    return new DynamoDbKvStore(clientFor(handler), handler.tableName);
+  }
+
+  private static DynamoDbAsyncClient clientFor(FakeDynamoDbHandler handler) {
     DynamoDbAsyncClient client =
         (DynamoDbAsyncClient)
             Proxy.newProxyInstance(
                 DynamoDbAsyncClient.class.getClassLoader(),
                 new Class<?>[] {DynamoDbAsyncClient.class},
                 handler);
-    return new DynamoDbKvStore(client, handler.tableName);
+    return client;
   }
 
   private static void put(DynamoDbKvStore store, String pk, String sk, long version) {

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
@@ -264,6 +264,23 @@ public class DynamoDbKvStoreTest {
   }
 
   @Test
+  void get_fixed_client_rethrows_closed_pool_without_retry() {
+    FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
+    RuntimeException closedPool = new RuntimeException("Connection pool shut down");
+    CompletableFuture<GetItemResponse> failed = new CompletableFuture<>();
+    failed.completeExceptionally(closedPool);
+    handler.setPendingGetFuture(failed);
+    DynamoDbKvStore store = newStore(handler);
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class, () -> store.get(key("pk", "sk")).await().indefinitely());
+
+    assertSame(closedPool, thrown);
+    assertEquals(1, handler.getItemCalls);
+  }
+
+  @Test
   void get_subscription_cancel_cancels_underlying_future() {
     FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
     DynamoDbKvStore store = newStore(handler);
@@ -756,6 +773,7 @@ public class DynamoDbKvStoreTest {
     private int createTableCalls;
     private int deleteTableCalls;
     private int unprocessedCount;
+    private int getItemCalls;
     private CompletableFuture<GetItemResponse> pendingGetFuture;
 
     private void setQueryResponses(List<QueryResponse> responses) {
@@ -855,6 +873,7 @@ public class DynamoDbKvStoreTest {
     }
 
     private CompletableFuture<GetItemResponse> handleGetItem(GetItemRequest req) {
+      getItemCalls++;
       if (pendingGetFuture != null) {
         var future = pendingGetFuture;
         pendingGetFuture = null;


### PR DESCRIPTION
## Summary

Connection pools to DynamoDB, STS and Secrets manager on synchronous clients time out after a period of inactivity. This change adds a connection pool refresh.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

