### PR TITLE
Fix parent canonical state race on terminal child completion

### DIFF
--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/ConnectorCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/ConnectorCliSupport.java
@@ -1342,6 +1342,7 @@ final class ConnectorCliSupport {
 
   private static void printReconcileJobsTableHeader(PrintStream out) {
     final int W_JOB_ID = 36;
+    final int W_CONNECTOR_ID = 36;
     final int W_STATE = 10;
     final int W_MODE = 12;
     final int W_STARTED = 24;
@@ -1355,6 +1356,8 @@ final class ConnectorCliSupport {
     out.printf(
         "%-"
             + W_JOB_ID
+            + "s  %-"
+            + W_CONNECTOR_ID
             + "s  %-"
             + W_STATE
             + "s  %-"
@@ -1377,6 +1380,7 @@ final class ConnectorCliSupport {
             + W_ERRORS
             + "s  %s%n",
         "JOB_ID",
+        "CONNECTOR_ID",
         "STATE",
         "MODE",
         "STARTED",
@@ -1393,6 +1397,7 @@ final class ConnectorCliSupport {
   private static void printReconcileJobsTableRows(
       List<GetReconcileJobResponse> jobs, PrintStream out) {
     final int W_JOB_ID = 36;
+    final int W_CONNECTOR_ID = 36;
     final int W_STATE = 10;
     final int W_MODE = 12;
     final int W_STARTED = 24;
@@ -1406,6 +1411,8 @@ final class ConnectorCliSupport {
       out.printf(
           "%-"
               + W_JOB_ID
+              + "s  %-"
+              + W_CONNECTOR_ID
               + "s  %-"
               + W_STATE
               + "s  %-"
@@ -1428,6 +1435,7 @@ final class ConnectorCliSupport {
               + W_ERRORS
               + "d  %s%n",
           job.getJobId(),
+          job.getConnectorId(),
           formatJobState(job),
           job.getFullRescan() ? "full" : "incremental",
           CliUtils.ts(job.getStartedAt()),

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/ConnectorCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/ConnectorCliSupportTest.java
@@ -727,9 +727,11 @@ class ConnectorCliSupportTest {
 
       assertEquals(1, h.reconcileControlService.listReconcileJobsCalls.get());
       assertTrue(buf.toString().contains("JOB_ID"));
+      assertTrue(buf.toString().contains("CONNECTOR_ID"));
       assertTrue(buf.toString().contains("MODE"));
       assertTrue(buf.toString().contains("INDEXES"));
       assertTrue(buf.toString().contains("job-plan-1"));
+      assertTrue(buf.toString().contains(CONNECTOR_UUID));
       assertTrue(buf.toString().contains("0/2"));
       assertTrue(buf.toString().contains("0/1"));
       assertTrue(!buf.toString().contains("job-table-1"));
@@ -827,9 +829,14 @@ class ConnectorCliSupportTest {
           h.directoryStub,
           () -> "acct-1");
 
-      assertTrue(buf.toString().contains("\"jobs\""));
-      assertTrue(buf.toString().contains("job-plan-1"));
-      assertTrue(!buf.toString().contains("JOB_ID"));
+      String output = buf.toString();
+      assertTrue(output.contains("\"jobs\""));
+      assertTrue(output.contains("\"jobId\": \"job-plan-1\""));
+      assertTrue(output.contains("\"connectorId\": \"" + CONNECTOR_UUID + "\""));
+      assertTrue(
+          output.indexOf("\"jobId\": \"job-plan-1\"")
+              < output.indexOf("\"connectorId\": \"" + CONNECTOR_UUID + "\""));
+      assertTrue(!output.contains("JOB_ID"));
     }
   }
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
@@ -854,23 +854,53 @@ public interface ReconcileJobStore {
   }
 
   final class BulkEnqueueItemResult {
+    public enum FailureReason {
+      NONE,
+      CONNECTOR_DELETED
+    }
+
     public final int index;
     public final String jobId;
     public final boolean created;
     public final String error;
     public final boolean invalidRequest;
+    public final FailureReason failureReason;
+    public final String failureSubjectId;
 
     public BulkEnqueueItemResult(int index, String jobId, boolean created, String error) {
-      this(index, jobId, created, error, false);
+      this(index, jobId, created, error, false, FailureReason.NONE);
     }
 
     public BulkEnqueueItemResult(
         int index, String jobId, boolean created, String error, boolean invalidRequest) {
+      this(index, jobId, created, error, invalidRequest, FailureReason.NONE, "");
+    }
+
+    public BulkEnqueueItemResult(
+        int index,
+        String jobId,
+        boolean created,
+        String error,
+        boolean invalidRequest,
+        FailureReason failureReason) {
+      this(index, jobId, created, error, invalidRequest, failureReason, "");
+    }
+
+    public BulkEnqueueItemResult(
+        int index,
+        String jobId,
+        boolean created,
+        String error,
+        boolean invalidRequest,
+        FailureReason failureReason,
+        String failureSubjectId) {
       this.index = Math.max(0, index);
       this.jobId = jobId == null ? "" : jobId;
       this.created = created;
       this.error = error == null ? "" : error;
       this.invalidRequest = invalidRequest;
+      this.failureReason = failureReason == null ? FailureReason.NONE : failureReason;
+      this.failureSubjectId = failureSubjectId == null ? "" : failureSubjectId;
     }
 
     public boolean succeeded() {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerService.java
@@ -32,6 +32,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import io.grpc.Status;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -44,6 +45,7 @@ public class LeasedPlannerWorkerService {
   @Inject ReconcileJobStore jobs;
   @Inject ReconcilerBackend backend;
   @Inject SnapshotPlanBlobStore snapshotPlanBlobStore;
+  @Inject ConnectorRepository connectorRepo;
 
   record PlanConnectorPayload(
       String jobId,
@@ -119,6 +121,9 @@ public class LeasedPlannerWorkerService {
             jobId,
             leaseEpoch,
             ReconcileJobKind.PLAN_CONNECTOR);
+    if (cancelIfCanonicalConnectorMissing(lease)) {
+      return true;
+    }
     long plannedTableJobs =
         nullToEmpty(tableJobs).stream()
             .filter(job -> job != null && !job.tableTask().isEmpty())
@@ -241,6 +246,9 @@ public class LeasedPlannerWorkerService {
     ReconcileJobStore.LeasedJob lease =
         requireLeasedJob(
             principalContext.getCorrelationId(), jobId, leaseEpoch, ReconcileJobKind.PLAN_TABLE);
+    if (cancelIfCanonicalConnectorMissing(lease)) {
+      return true;
+    }
     long plannedSnapshotJobs =
         nullToEmpty(snapshotJobs).stream()
             .filter(job -> job != null && !job.snapshotTask().isEmpty())
@@ -408,7 +416,6 @@ public class LeasedPlannerWorkerService {
                 baseSnapshotTask.directStatsBlobUri(),
                 baseSnapshotTask.directStatsRecordCount())
             : plannedSnapshotTask;
-    List<PlannedFileGroupJob> plannedJobs = plannedFileGroupJobs(finalizedSnapshotTask);
     ReconcileSnapshotTask durableSnapshotTask = durableSnapshotTask(finalizedSnapshotTask);
     if ("JS_SUCCEEDED".equals(currentJob.state)) {
       if (durableSnapshotTask.equals(currentJob.snapshotTask)) {
@@ -421,6 +428,10 @@ public class LeasedPlannerWorkerService {
     ReconcileJobStore.LeasedJob lease =
         requireCompletionLease(
             principalContext.getCorrelationId(), jobId, leaseEpoch, ReconcileJobKind.PLAN_SNAPSHOT);
+    if (cancelIfCanonicalConnectorMissing(lease)) {
+      return true;
+    }
+    List<PlannedFileGroupJob> plannedJobs = plannedFileGroupJobs(finalizedSnapshotTask);
     long plannedFileGroupJobs =
         plannedJobs.stream().filter(job -> job != null && !job.fileGroupTask().isEmpty()).count();
     boolean adopted =
@@ -740,6 +751,45 @@ public class LeasedPlannerWorkerService {
           .asRuntimeException();
     }
     return lease;
+  }
+
+  private boolean cancelIfCanonicalConnectorMissing(ReconcileJobStore.LeasedJob lease) {
+    if (canonicalConnectorExists(lease)) {
+      return false;
+    }
+    jobs.applyLeaseOutcome(
+        lease.jobId,
+        lease.leaseEpoch,
+        ReconcileJobStore.CompletionKind.CANCELLED,
+        System.currentTimeMillis(),
+        "connector deleted: " + lease.connectorId,
+        0L,
+        0L,
+        0L,
+        0L,
+        0L,
+        0L,
+        0L);
+    return true;
+  }
+
+  private boolean canonicalConnectorExists(ReconcileJobStore.LeasedJob lease) {
+    if (connectorRepo == null || lease == null) {
+      return true;
+    }
+    if (lease.accountId == null
+        || lease.accountId.isBlank()
+        || lease.connectorId == null
+        || lease.connectorId.isBlank()) {
+      return false;
+    }
+    ResourceId connectorId =
+        ResourceId.newBuilder()
+            .setAccountId(lease.accountId)
+            .setId(lease.connectorId)
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    return connectorRepo.existsById(connectorId);
   }
 
   private boolean currentSnapshotPlanSuccess(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerService.java
@@ -121,8 +121,9 @@ public class LeasedPlannerWorkerService {
             jobId,
             leaseEpoch,
             ReconcileJobKind.PLAN_CONNECTOR);
-    if (cancelIfCanonicalConnectorMissing(lease)) {
-      return true;
+    Boolean cancelled = cancelIfCanonicalConnectorMissing(lease);
+    if (cancelled != null) {
+      return cancelled;
     }
     long plannedTableJobs =
         nullToEmpty(tableJobs).stream()
@@ -213,8 +214,8 @@ public class LeasedPlannerWorkerService {
       String message) {
     requireLeasedJob(
         principalContext.getCorrelationId(), jobId, leaseEpoch, ReconcileJobKind.PLAN_CONNECTOR);
-    persistPlanFailure(jobId, leaseEpoch, failureKind, retryDisposition, retryClass, message);
-    return true;
+    return persistPlanFailure(
+        jobId, leaseEpoch, failureKind, retryDisposition, retryClass, message);
   }
 
   public PlanTablePayload resolvePlanTable(
@@ -246,8 +247,9 @@ public class LeasedPlannerWorkerService {
     ReconcileJobStore.LeasedJob lease =
         requireLeasedJob(
             principalContext.getCorrelationId(), jobId, leaseEpoch, ReconcileJobKind.PLAN_TABLE);
-    if (cancelIfCanonicalConnectorMissing(lease)) {
-      return true;
+    Boolean cancelled = cancelIfCanonicalConnectorMissing(lease);
+    if (cancelled != null) {
+      return cancelled;
     }
     long plannedSnapshotJobs =
         nullToEmpty(snapshotJobs).stream()
@@ -298,8 +300,8 @@ public class LeasedPlannerWorkerService {
       String message) {
     requireLeasedJob(
         principalContext.getCorrelationId(), jobId, leaseEpoch, ReconcileJobKind.PLAN_TABLE);
-    persistPlanFailure(jobId, leaseEpoch, failureKind, retryDisposition, retryClass, message);
-    return true;
+    return persistPlanFailure(
+        jobId, leaseEpoch, failureKind, retryDisposition, retryClass, message);
   }
 
   public PlanViewPayload resolvePlanView(
@@ -361,8 +363,8 @@ public class LeasedPlannerWorkerService {
       String message) {
     requireLeasedJob(
         principalContext.getCorrelationId(), jobId, leaseEpoch, ReconcileJobKind.PLAN_VIEW);
-    persistPlanFailure(jobId, leaseEpoch, failureKind, retryDisposition, retryClass, message);
-    return true;
+    return persistPlanFailure(
+        jobId, leaseEpoch, failureKind, retryDisposition, retryClass, message);
   }
 
   public PlanSnapshotPayload resolvePlanSnapshot(
@@ -428,8 +430,9 @@ public class LeasedPlannerWorkerService {
     ReconcileJobStore.LeasedJob lease =
         requireCompletionLease(
             principalContext.getCorrelationId(), jobId, leaseEpoch, ReconcileJobKind.PLAN_SNAPSHOT);
-    if (cancelIfCanonicalConnectorMissing(lease)) {
-      return true;
+    Boolean cancelled = cancelIfCanonicalConnectorMissing(lease);
+    if (cancelled != null) {
+      return cancelled;
     }
     List<PlannedFileGroupJob> plannedJobs = plannedFileGroupJobs(finalizedSnapshotTask);
     long plannedFileGroupJobs =
@@ -676,8 +679,8 @@ public class LeasedPlannerWorkerService {
       String message) {
     requireLeasedJob(
         principalContext.getCorrelationId(), jobId, leaseEpoch, ReconcileJobKind.PLAN_SNAPSHOT);
-    persistPlanFailure(jobId, leaseEpoch, failureKind, retryDisposition, retryClass, message);
-    return true;
+    return persistPlanFailure(
+        jobId, leaseEpoch, failureKind, retryDisposition, retryClass, message);
   }
 
   record PlannedTableJob(ReconcileScope scope, ReconcileTableTask tableTask) {}
@@ -753,11 +756,11 @@ public class LeasedPlannerWorkerService {
     return lease;
   }
 
-  private boolean cancelIfCanonicalConnectorMissing(ReconcileJobStore.LeasedJob lease) {
+  private Boolean cancelIfCanonicalConnectorMissing(ReconcileJobStore.LeasedJob lease) {
     if (canonicalConnectorExists(lease)) {
-      return false;
+      return null;
     }
-    jobs.applyLeaseOutcome(
+    return jobs.applyLeaseOutcome(
         lease.jobId,
         lease.leaseEpoch,
         ReconcileJobStore.CompletionKind.CANCELLED,
@@ -770,7 +773,6 @@ public class LeasedPlannerWorkerService {
         0L,
         0L,
         0L);
-    return true;
   }
 
   private boolean canonicalConnectorExists(ReconcileJobStore.LeasedJob lease) {
@@ -802,7 +804,7 @@ public class LeasedPlannerWorkerService {
         .orElse(false);
   }
 
-  private void persistPlanFailure(
+  private boolean persistPlanFailure(
       String jobId,
       String leaseEpoch,
       ai.floedb.floecat.reconciler.impl.ReconcileExecutor.ExecutionResult.FailureKind failureKind,
@@ -812,7 +814,7 @@ public class LeasedPlannerWorkerService {
       String message) {
     long finishedAtMs = System.currentTimeMillis();
     if (isObsoleteFailureKind(failureKind)) {
-      jobs.applyLeaseOutcome(
+      return jobs.applyLeaseOutcome(
           jobId,
           leaseEpoch,
           ReconcileJobStore.CompletionKind.CANCELLED,
@@ -825,12 +827,11 @@ public class LeasedPlannerWorkerService {
           1L,
           0L,
           0L);
-      return;
     }
     if (retryDisposition
         == ai.floedb.floecat.reconciler.impl.ReconcileExecutor.ExecutionResult.RetryDisposition
             .TERMINAL) {
-      jobs.applyLeaseOutcome(
+      return jobs.applyLeaseOutcome(
           jobId,
           leaseEpoch,
           ReconcileJobStore.CompletionKind.FAILED_TERMINAL,
@@ -843,12 +844,11 @@ public class LeasedPlannerWorkerService {
           1L,
           0L,
           0L);
-      return;
     }
     if (retryClass
         == ai.floedb.floecat.reconciler.impl.ReconcileExecutor.ExecutionResult.RetryClass
             .DEPENDENCY_NOT_READY) {
-      jobs.applyLeaseOutcome(
+      return jobs.applyLeaseOutcome(
           jobId,
           leaseEpoch,
           ReconcileJobStore.CompletionKind.FAILED_WAITING_ON_DEPENDENCY,
@@ -861,9 +861,8 @@ public class LeasedPlannerWorkerService {
           1L,
           0L,
           0L);
-      return;
     }
-    jobs.applyLeaseOutcome(
+    return jobs.applyLeaseOutcome(
         jobId,
         leaseEpoch,
         ReconcileJobStore.CompletionKind.FAILED_RETRYABLE,

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
@@ -65,6 +65,7 @@ import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.LogHelper;
 import ai.floedb.floecat.service.error.impl.GeneratedErrorMessages;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import ai.floedb.floecat.service.reconciler.jobs.DurableReconcileJobStore;
 import ai.floedb.floecat.service.reconciler.jobs.ReconcilerSettingsStore;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
@@ -861,14 +862,21 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
       ReconcileExecutionPolicy executionPolicy) {
     ensureExecutorsAvailable(mode, scope);
     requireCanonicalConnectorExists(connectorId);
-    return jobs.enqueuePlan(
-        connectorId.getAccountId(),
-        connectorId.getId(),
-        fullRescan,
-        mode,
-        scope,
-        executionPolicy,
-        "");
+    try {
+      return jobs.enqueuePlan(
+          connectorId.getAccountId(),
+          connectorId.getId(),
+          fullRescan,
+          mode,
+          scope,
+          executionPolicy,
+          "");
+    } catch (DurableReconcileJobStore.ConnectorDeletedException e) {
+      throw GrpcErrors.notFound(
+          correlationId(),
+          GeneratedErrorMessages.MessageKey.CONNECTOR,
+          Map.of("id", e.connectorId));
+    }
   }
 
   private void requireCanonicalConnectorExists(ResourceId connectorId) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImpl.java
@@ -860,6 +860,7 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
       ReconcileScope scope,
       ReconcileExecutionPolicy executionPolicy) {
     ensureExecutorsAvailable(mode, scope);
+    requireCanonicalConnectorExists(connectorId);
     return jobs.enqueuePlan(
         connectorId.getAccountId(),
         connectorId.getId(),
@@ -868,6 +869,15 @@ public class ReconcileControlImpl extends BaseServiceImpl implements ReconcileCo
         scope,
         executionPolicy,
         "");
+  }
+
+  private void requireCanonicalConnectorExists(ResourceId connectorId) {
+    if (!connectorRepo.existsById(connectorId)) {
+      throw GrpcErrors.notFound(
+          correlationId(),
+          GeneratedErrorMessages.MessageKey.CONNECTOR,
+          Map.of("id", connectorId.getId()));
+    }
   }
 
   private void ensureExecutorsAvailable(CaptureMode mode, ReconcileScope scope) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
@@ -79,6 +79,7 @@ import ai.floedb.floecat.reconciler.rpc.SubmitLeasedSnapshotFinalizeResultRespon
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.reconciler.jobs.LeaseScanCapacityExceededException;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.security.RolePermissions;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
@@ -101,6 +102,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
   @Inject PrincipalProvider principalProvider;
   @Inject Authorizer authz;
   @Inject ReconcileJobStore jobs;
+  @Inject ConnectorRepository connectorRepo;
   @Inject ReconcileCancellationRegistry cancellations;
   @Inject LeasedFileGroupExecutionService leasedFileGroupExecutionService;
   @Inject LeasedSnapshotFinalizeInputService leasedSnapshotFinalizeInputService;
@@ -141,12 +143,47 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               if (lease.isEmpty()) {
                 return LeaseReconcileJobResponse.newBuilder().setFound(false).build();
               }
+              if (!canonicalConnectorExists(lease.get())) {
+                jobs.applyLeaseOutcome(
+                    lease.get().jobId,
+                    lease.get().leaseEpoch,
+                    ReconcileJobStore.CompletionKind.CANCELLED,
+                    System.currentTimeMillis(),
+                    "connector deleted: " + lease.get().connectorId,
+                    0L,
+                    0L,
+                    0L,
+                    0L,
+                    0L,
+                    0L,
+                    0L);
+                return LeaseReconcileJobResponse.newBuilder().setFound(false).build();
+              }
               return LeaseReconcileJobResponse.newBuilder()
                   .setFound(true)
                   .setJob(toProtoLease(lease.get()))
                   .build();
             }),
         correlationId());
+  }
+
+  private boolean canonicalConnectorExists(ReconcileJobStore.LeasedJob lease) {
+    if (connectorRepo == null || lease == null) {
+      return true;
+    }
+    if (lease.accountId == null
+        || lease.accountId.isBlank()
+        || lease.connectorId == null
+        || lease.connectorId.isBlank()) {
+      return false;
+    }
+    ResourceId connectorId =
+        ResourceId.newBuilder()
+            .setAccountId(lease.accountId)
+            .setId(lease.connectorId)
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    return connectorRepo.existsById(connectorId);
   }
 
   private Optional<ReconcileJobStore.LeasedJob> leaseNextOrThrowRateLimited(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
@@ -144,20 +144,23 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
                 return LeaseReconcileJobResponse.newBuilder().setFound(false).build();
               }
               if (!canonicalConnectorExists(lease.get())) {
-                jobs.applyLeaseOutcome(
-                    lease.get().jobId,
-                    lease.get().leaseEpoch,
-                    ReconcileJobStore.CompletionKind.CANCELLED,
-                    System.currentTimeMillis(),
-                    "connector deleted: " + lease.get().connectorId,
-                    0L,
-                    0L,
-                    0L,
-                    0L,
-                    0L,
-                    0L,
-                    0L);
-                return LeaseReconcileJobResponse.newBuilder().setFound(false).build();
+                boolean cancelled =
+                    jobs.applyLeaseOutcome(
+                        lease.get().jobId,
+                        lease.get().leaseEpoch,
+                        ReconcileJobStore.CompletionKind.CANCELLED,
+                        System.currentTimeMillis(),
+                        "connector deleted: " + lease.get().connectorId,
+                        0L,
+                        0L,
+                        0L,
+                        0L,
+                        0L,
+                        0L,
+                        0L);
+                if (cancelled) {
+                  return LeaseReconcileJobResponse.newBuilder().setFound(false).build();
+                }
               }
               return LeaseReconcileJobResponse.newBuilder()
                   .setFound(true)

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -64,6 +64,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileLeaseSto
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueBackend;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore.LeaseScanStats;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.spi.BlobStore;
@@ -107,6 +108,15 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 // legacy StoredJobReference indirection, lane queue/head scheduling rows, or separate lease-state
 // blobs.
 public class DurableReconcileJobStore implements ReconcileJobStore {
+  public static final class ConnectorDeletedException extends IllegalStateException {
+    public final String connectorId;
+
+    public ConnectorDeletedException(String connectorId) {
+      super("connector deleted: " + blankToEmpty(connectorId));
+      this.connectorId = blankToEmpty(connectorId);
+    }
+  }
+
   private static final Logger LOG = Logger.getLogger(DurableReconcileJobStore.class);
 
   private static final int DEFAULT_MAX_ATTEMPTS = 8;
@@ -159,6 +169,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   @Inject ReconcileJobMaintenanceService maintenanceService;
   @Inject ReconcileReadyQueueStore readyQueueStore;
   @Inject ReconcileReadyQueueBackend readyQueueBackend;
+  @Inject ConnectorRepository connectorRepo;
   private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
   private long baseBackoffMs = DEFAULT_BASE_BACKOFF_MS;
   private long maxBackoffMs = DEFAULT_MAX_BACKOFF_MS;
@@ -523,7 +534,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       ReconcileExecutionPolicy executionPolicy,
       String parentJobId,
       String pinnedExecutorId) {
-    return bulkEnqueue(
+    BulkEnqueueResult result =
+        bulkEnqueue(
             List.of(
                 BulkEnqueueSpec.of(
                     accountId,
@@ -538,14 +550,60 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
                     fileGroupTask,
                     executionPolicy,
                     parentJobId,
-                    pinnedExecutorId)))
-        .singleJobId();
+                    pinnedExecutorId)));
+    throwIfConnectorDeleted(result);
+    return result.singleJobId();
   }
 
   @Override
   public BulkEnqueueResult bulkEnqueue(List<BulkEnqueueSpec> specs) {
-    BulkEnqueueResult result = onHotPath(() -> enqueuer().bulkEnqueue(specs));
     List<BulkEnqueueSpec> effectiveSpecs = specs == null ? List.of() : specs;
+    var admittedSpecs = new ArrayList<BulkEnqueueSpec>(effectiveSpecs.size());
+    var rejectedItems = new ArrayList<BulkEnqueueItemResult>();
+    for (int index = 0; index < effectiveSpecs.size(); index++) {
+      BulkEnqueueSpec spec = effectiveSpecs.get(index);
+      if (isRootPlanConnector(spec)
+          && !canonicalConnectorExists(spec.accountId, spec.connectorId)) {
+        rejectedItems.add(
+            new BulkEnqueueItemResult(
+                index,
+                "",
+                false,
+                "connector deleted: " + blankToEmpty(spec.connectorId),
+                false,
+                BulkEnqueueItemResult.FailureReason.CONNECTOR_DELETED,
+                blankToEmpty(spec.connectorId)));
+        continue;
+      }
+      admittedSpecs.add(spec);
+    }
+    BulkEnqueueResult admittedResult = onHotPath(() -> enqueuer().bulkEnqueue(admittedSpecs));
+    var itemsByIndex = new java.util.HashMap<Integer, BulkEnqueueItemResult>();
+    for (BulkEnqueueItemResult item : rejectedItems) {
+      itemsByIndex.put(item.index, item);
+    }
+    int admittedIndex = 0;
+    for (int originalIndex = 0; originalIndex < effectiveSpecs.size(); originalIndex++) {
+      if (itemsByIndex.containsKey(originalIndex)) {
+        continue;
+      }
+      BulkEnqueueItemResult item = admittedResult.items.get(admittedIndex++);
+      itemsByIndex.put(
+          originalIndex,
+          new BulkEnqueueItemResult(
+              originalIndex,
+              item.jobId,
+              item.created,
+              item.error,
+              item.invalidRequest,
+              item.failureReason,
+              item.failureSubjectId));
+    }
+    BulkEnqueueResult result =
+        new BulkEnqueueResult(
+            java.util.stream.IntStream.range(0, effectiveSpecs.size())
+                .mapToObj(itemsByIndex::get)
+                .toList());
     for (BulkEnqueueItemResult item : result.items) {
       if (item == null || !item.succeeded()) {
         continue;
@@ -569,6 +627,40 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       }
     }
     return result;
+  }
+
+  private boolean isRootPlanConnector(BulkEnqueueSpec spec) {
+    return spec != null
+        && spec.jobKind == ReconcileJobKind.PLAN_CONNECTOR
+        && blankToEmpty(spec.parentJobId).isBlank();
+  }
+
+  private void throwIfConnectorDeleted(BulkEnqueueResult result) {
+    if (result == null || result.items.size() != 1) {
+      return;
+    }
+    BulkEnqueueItemResult item = result.items.getFirst();
+    if (item == null
+        || item.failureReason != BulkEnqueueItemResult.FailureReason.CONNECTOR_DELETED) {
+      return;
+    }
+    throw new ConnectorDeletedException(item.failureSubjectId);
+  }
+
+  private boolean canonicalConnectorExists(String accountId, String connectorId) {
+    if (connectorRepo == null) {
+      return true;
+    }
+    if (blankToEmpty(accountId).isBlank() || blankToEmpty(connectorId).isBlank()) {
+      return false;
+    }
+    var resourceId =
+        ai.floedb.floecat.common.rpc.ResourceId.newBuilder()
+            .setAccountId(accountId)
+            .setId(connectorId)
+            .setKind(ai.floedb.floecat.common.rpc.ResourceKind.RK_CONNECTOR)
+            .build();
+    return connectorRepo.existsById(resourceId);
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -2518,6 +2518,25 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       long errors,
       long snapshotsProcessed,
       long statsProcessed) {
+    String terminalState = terminalStateForCompletionKind(completionKind);
+    if (terminalState.isBlank()) {
+      return onHotPath(
+          () ->
+              completer()
+                  .applyLeaseOutcome(
+                      jobId,
+                      leaseEpoch,
+                      completionKind,
+                      finishedAtMs,
+                      message,
+                      tablesScanned,
+                      tablesChanged,
+                      viewsScanned,
+                      viewsChanged,
+                      errors,
+                      snapshotsProcessed,
+                      statsProcessed));
+    }
     if (applyLeaseOutcomeTransactionally(
         jobId,
         leaseEpoch,
@@ -2547,36 +2566,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         statsProcessed)) {
       return true;
     }
-    boolean accepted =
-        onHotPath(
-            () ->
-                completer()
-                    .applyLeaseOutcome(
-                        jobId,
-                        leaseEpoch,
-                        completionKind,
-                        finishedAtMs,
-                        message,
-                        tablesScanned,
-                        tablesChanged,
-                        viewsScanned,
-                        viewsChanged,
-                        errors,
-                        snapshotsProcessed,
-                        statsProcessed));
-    return accepted
-        || isIdempotentTerminalLeaseOutcome(
-            jobId,
-            completionKind,
-            finishedAtMs,
-            message,
-            tablesScanned,
-            tablesChanged,
-            viewsScanned,
-            viewsChanged,
-            errors,
-            snapshotsProcessed,
-            statsProcessed);
+    return false;
   }
 
   private boolean applyLeaseOutcomeTransactionally(
@@ -2664,6 +2654,14 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         StoredReconcileJob nextParent = jobIndexStore().cloneStoredRecord(previousParent);
         applyCanonicalParentSchedulingState(nextParent, rollup);
         if (canonicalSchedulingEquivalent(previousParent, nextParent)) {
+          // Even when the parent still appears semantically unchanged, keep it in the CAS set.
+          // Concurrent sibling completions can otherwise each commit child-only updates against the
+          // same waiting parent snapshot and strand canonical state behind the last terminal child.
+          mutations.add(
+              new ReconcileJobIndexStore.CanonicalRecordMutation(
+                  parentSnapshot, previousParent, nextParent));
+          changedRecords.add(nextParent);
+          updatedRecordsByJobId.put(nextParent.jobId, nextParent);
           currentParentJobId = blankToEmpty(previousParent.parentJobId);
           continue;
         }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
@@ -30,8 +30,6 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotSelection;
 import ai.floedb.floecat.service.gc.ReconcileJobGcScheduler;
-import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
-import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexStore;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.telemetry.ServiceMetrics;
@@ -66,7 +64,6 @@ public class ReconcilePlannerScheduler {
   @Inject AccountRepository accounts;
   @Inject ConnectorRepository connectors;
   @Inject ReconcileJobStore jobs;
-  @Inject ReconcileJobIndexStore jobIndexStore;
   @Inject ReconcileExecutorRegistry executorRegistry;
   @Inject ReconcilerSettingsStore settings;
   @Inject Observability observability;
@@ -251,7 +248,7 @@ public class ReconcilePlannerScheduler {
     }
 
     String key = connector.getResourceId().getAccountId() + ":" + connector.getResourceId().getId();
-    if (connectors.getById(connector.getResourceId()).isEmpty()) {
+    if (!canonicalConnectorExists(connector)) {
       lastEnqueueMs.remove(key);
       observePlannerEnqueue("skipped", mode, "stale_connector");
       return;
@@ -280,6 +277,11 @@ public class ReconcilePlannerScheduler {
         observePlannerEnqueue("skipped", mode, "active_root");
         return;
       }
+      if (!canonicalConnectorExists(connector)) {
+        lastEnqueueMs.remove(key);
+        observePlannerEnqueue("skipped", mode, "stale_connector");
+        return;
+      }
       jobs.enqueuePlan(
           connector.getResourceId().getAccountId(),
           connector.getResourceId().getId(),
@@ -306,38 +308,24 @@ public class ReconcilePlannerScheduler {
     }
   }
 
+  private boolean canonicalConnectorExists(Connector connector) {
+    return connector != null
+        && connector.hasResourceId()
+        && connectors.existsById(connector.getResourceId());
+  }
+
   private boolean hasActiveRootJob(Connector connector) {
     if (connector == null || !connector.hasResourceId()) {
       return false;
     }
-    if (jobIndexStore == null) {
-      return !jobs.listRootJobs(
-              connector.getResourceId().getAccountId(),
-              1,
-              "",
-              connector.getResourceId().getId(),
-              ACTIVE_ROOT_STATES)
-          .jobs
-          .isEmpty();
-    }
-    String accountId = connector.getResourceId().getAccountId();
-    String connectorId = connector.getResourceId().getId();
-    String pageToken = "";
-    while (true) {
-      var page =
-          jobIndexStore.listStoredJobs(accountId, 256, pageToken, connectorId, ACTIVE_ROOT_STATES);
-      for (StoredReconcileJob job : page.records()) {
-        if (job != null && (job.parentJobId == null || job.parentJobId.isBlank())) {
-          return true;
-        }
-      }
-      if (page.nextPageToken() == null
-          || page.nextPageToken().isBlank()
-          || page.nextPageToken().equals(pageToken)) {
-        return false;
-      }
-      pageToken = page.nextPageToken();
-    }
+    return !jobs.listRootJobs(
+            connector.getResourceId().getAccountId(),
+            1,
+            "",
+            connector.getResourceId().getId(),
+            ACTIVE_ROOT_STATES)
+        .jobs
+        .isEmpty();
   }
 
   private static long effectiveIntervalMs(Connector connector, long defaultIntervalMs) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
@@ -30,6 +30,8 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotSelection;
 import ai.floedb.floecat.service.gc.ReconcileJobGcScheduler;
+import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
+import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexStore;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.telemetry.ServiceMetrics;
@@ -64,6 +66,7 @@ public class ReconcilePlannerScheduler {
   @Inject AccountRepository accounts;
   @Inject ConnectorRepository connectors;
   @Inject ReconcileJobStore jobs;
+  @Inject ReconcileJobIndexStore jobIndexStore;
   @Inject ReconcileExecutorRegistry executorRegistry;
   @Inject ReconcilerSettingsStore settings;
   @Inject Observability observability;
@@ -307,14 +310,34 @@ public class ReconcilePlannerScheduler {
     if (connector == null || !connector.hasResourceId()) {
       return false;
     }
-    return !jobs.listRootJobs(
-            connector.getResourceId().getAccountId(),
-            1,
-            "",
-            connector.getResourceId().getId(),
-            ACTIVE_ROOT_STATES)
-        .jobs
-        .isEmpty();
+    if (jobIndexStore == null) {
+      return !jobs.listRootJobs(
+              connector.getResourceId().getAccountId(),
+              1,
+              "",
+              connector.getResourceId().getId(),
+              ACTIVE_ROOT_STATES)
+          .jobs
+          .isEmpty();
+    }
+    String accountId = connector.getResourceId().getAccountId();
+    String connectorId = connector.getResourceId().getId();
+    String pageToken = "";
+    while (true) {
+      var page =
+          jobIndexStore.listStoredJobs(accountId, 256, pageToken, connectorId, ACTIVE_ROOT_STATES);
+      for (StoredReconcileJob job : page.records()) {
+        if (job != null && (job.parentJobId == null || job.parentJobId.isBlank())) {
+          return true;
+        }
+      }
+      if (page.nextPageToken() == null
+          || page.nextPageToken().isBlank()
+          || page.nextPageToken().equals(pageToken)) {
+        return false;
+      }
+      pageToken = page.nextPageToken();
+    }
   }
 
   private static long effectiveIntervalMs(Connector connector, long defaultIntervalMs) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
@@ -73,6 +73,11 @@ public class ConnectorRepository {
         new ConnectorKey(connectorResourceId.getAccountId(), connectorResourceId.getId()));
   }
 
+  public boolean existsById(ResourceId connectorResourceId) {
+    return repo.existsByKey(
+        new ConnectorKey(connectorResourceId.getAccountId(), connectorResourceId.getId()));
+  }
+
   public Optional<Connector> getByName(String accountId, String displayName) {
     return repo.get(Keys.connectorPointerByName(accountId, displayName));
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -60,8 +60,16 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     return observeRepository("get_by_key", () -> getByKeyUnobserved(key));
   }
 
+  public boolean existsByKey(K key) {
+    return observeRepository("exists_by_key", () -> existsByKeyUnobserved(key));
+  }
+
   private Optional<T> getByKeyUnobserved(K key) {
     return read(schema.canonicalPointerForKey.apply(key));
+  }
+
+  private boolean existsByKeyUnobserved(K key) {
+    return pointerStore.get(schema.canonicalPointerForKey.apply(key)).isPresent();
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
@@ -20,10 +20,12 @@ import ai.floedb.floecat.catalog.rpc.StatsTarget;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService;
 import ai.floedb.floecat.reconciler.jobs.ReconcileCapturePolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.telemetry.ServiceMetrics;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
@@ -161,6 +163,7 @@ public class StatsOrchestrator {
   private final StatsStore statsStore;
   private final ReconcileJobStore reconcileJobStore;
   private final TableRepository tableRepository;
+  private final ConnectorRepository connectorRepository;
   private final StatsSyncCapture statsSyncCapture;
   private final boolean syncEnabled;
   private final ConcurrentMap<TableKey, String> lastEnqueuedJobByTable = new ConcurrentHashMap<>();
@@ -171,6 +174,7 @@ public class StatsOrchestrator {
       StatsStore statsStore,
       ReconcileJobStore reconcileJobStore,
       TableRepository tableRepository,
+      ConnectorRepository connectorRepository,
       StatsSyncCapture statsSyncCapture,
       @ConfigProperty(name = "floecat.stats.sync.enabled", defaultValue = "true")
           boolean syncEnabled,
@@ -178,6 +182,7 @@ public class StatsOrchestrator {
     this.statsStore = statsStore;
     this.reconcileJobStore = reconcileJobStore;
     this.tableRepository = tableRepository;
+    this.connectorRepository = connectorRepository;
     this.statsSyncCapture = statsSyncCapture;
     this.syncEnabled = syncEnabled;
     this.observability =
@@ -185,12 +190,16 @@ public class StatsOrchestrator {
   }
 
   public StatsOrchestrator(
-      StatsStore statsStore, ReconcileJobStore reconcileJobStore, TableRepository tableRepository) {
+      StatsStore statsStore,
+      ReconcileJobStore reconcileJobStore,
+      TableRepository tableRepository,
+      ConnectorRepository connectorRepository) {
     this(
         statsStore,
         reconcileJobStore,
         tableRepository,
-        new StatsSyncCapture(reconcileJobStore),
+        connectorRepository,
+        new StatsSyncCapture(reconcileJobStore, connectorRepository),
         true,
         null);
   }
@@ -745,6 +754,15 @@ public class StatsOrchestrator {
             "blank_connector_id",
             "Skipping async enqueue because upstream connector id is blank");
       }
+      ResourceId connectorId =
+          connectorResourceId(
+              first.tableId().getAccountId(), table.get().getUpstream().getConnectorId().getId());
+      if (!connectorRepository.existsById(connectorId)) {
+        return recordAsyncSkipGroup(
+            groupedRequests,
+            "missing_connector",
+            "Skipping async enqueue because canonical connector lookup failed");
+      }
       LinkedHashSet<ReconcileScope.ScopedCaptureRequest> captureRequests = new LinkedHashSet<>();
       for (IndexedRequest indexedRequest : groupedRequests) {
         StatsCaptureRequest request = indexedRequest.request();
@@ -812,6 +830,14 @@ public class StatsOrchestrator {
                           indexedRequest.request(), "failed to enqueue reconcile capture")))
           .toList();
     }
+  }
+
+  private static ResourceId connectorResourceId(String accountId, String connectorId) {
+    return ResourceId.newBuilder()
+        .setAccountId(accountId)
+        .setId(connectorId)
+        .setKind(ResourceKind.RK_CONNECTOR)
+        .build();
   }
 
   private List<IndexedResult> recordAsyncSkipGroup(

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsSyncCapture.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsSyncCapture.java
@@ -16,9 +16,12 @@
 
 package ai.floedb.floecat.service.statistics;
 
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.stats.spi.StatsSyncOutcome;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -40,10 +43,12 @@ class StatsSyncCapture {
   private static final long POLL_INTERVAL_MS = 100L;
 
   private final ReconcileJobStore reconcileJobStore;
+  private final ConnectorRepository connectorRepository;
 
   @Inject
-  StatsSyncCapture(ReconcileJobStore reconcileJobStore) {
+  StatsSyncCapture(ReconcileJobStore reconcileJobStore, ConnectorRepository connectorRepository) {
     this.reconcileJobStore = reconcileJobStore;
+    this.connectorRepository = connectorRepository;
   }
 
   /**
@@ -56,6 +61,12 @@ class StatsSyncCapture {
   StatsSyncOutcome capture(
       String accountId, String connectorId, ReconcileScope scope, Duration budget) {
     try {
+      if (!connectorRepository.existsById(connectorResourceId(accountId, connectorId))) {
+        LOG.debugf(
+            "stats_sync_capture skipped missing connector account=%s connector=%s",
+            accountId, connectorId);
+        return StatsSyncOutcome.FAILED;
+      }
       String jobId =
           reconcileJobStore.enqueue(
               accountId, connectorId, false, ReconcilerService.CaptureMode.CAPTURE_ONLY, scope);
@@ -68,6 +79,14 @@ class StatsSyncCapture {
           e, "stats_sync_capture enqueue failed account=%s connector=%s", accountId, connectorId);
       return StatsSyncOutcome.FAILED;
     }
+  }
+
+  private static ResourceId connectorResourceId(String accountId, String connectorId) {
+    return ResourceId.newBuilder()
+        .setAccountId(accountId)
+        .setId(connectorId)
+        .setKind(ResourceKind.RK_CONNECTOR)
+        .build();
   }
 
   private StatsSyncOutcome pollUntilTerminal(String accountId, String jobId, Duration budget) {

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
@@ -1236,6 +1236,12 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         || tableId.isBlank()) {
       return;
     }
+    if (!connectorRepo.existsById(connector.getResourceId())) {
+      LOG.infof(
+          "Skipping post-commit capture for deleted connector tx=%s connector=%s table=%s",
+          txId, connector.getResourceId().getId(), tableId);
+      return;
+    }
     reconcileJobs.enqueuePlan(
         accountId,
         connector.getResourceId().getId(),

--- a/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplDeleteConnectorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplDeleteConnectorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.connector.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.DeleteConnectorRequest;
+import ai.floedb.floecat.connector.spi.CredentialResolver;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class ConnectorsImplDeleteConnectorTest {
+  @Test
+  void deleteConnectorDeletesCanonicalConnectorAndCredentialsOnly() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("connector-1")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    var principal =
+        PrincipalContext.newBuilder()
+            .setAccountId("acct")
+            .setCorrelationId("corr-1")
+            .addPermissions("connector.manage")
+            .build();
+    var meta =
+        MutationMeta.newBuilder()
+            .setPointerKey("/accounts/acct/connectors/by-id/connector-1")
+            .setBlobUri("blob://connector-1")
+            .setPointerVersion(7L)
+            .build();
+
+    when(service.principalProvider.get()).thenReturn(principal);
+    when(service.connectorRepo.metaFor(connectorId)).thenReturn(meta);
+    when(service.connectorRepo.deleteWithPrecondition(connectorId, 7L)).thenReturn(true);
+    when(service.connectorRepo.metaForSafe(connectorId)).thenReturn(meta);
+
+    var response =
+        service
+            .deleteConnector(
+                DeleteConnectorRequest.newBuilder().setConnectorId(connectorId).build())
+            .await()
+            .indefinitely();
+
+    assertEquals(7L, response.getMeta().getPointerVersion());
+    verify(service.connectorRepo).deleteWithPrecondition(connectorId, 7L);
+    verify(service.credentialResolver).delete("acct", "connector-1");
+  }
+
+  private static void installBasePrincipal(
+      ConnectorsImpl service, PrincipalProvider principalProvider) {
+    try {
+      Field field =
+          ai.floedb.floecat.service.common.BaseServiceImpl.class.getDeclaredField("principal");
+      field.setAccessible(true);
+      field.set(service, principalProvider);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to inject BaseServiceImpl principal provider", e);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
@@ -948,7 +948,9 @@ class PlannerStatsBundleServiceTest extends PlannerStatsBundleServiceTestSupport
         new StatsOrchestrator(
             repository,
             org.mockito.Mockito.mock(ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.class),
-            tableRepository);
+            tableRepository,
+            org.mockito.Mockito.mock(
+                ai.floedb.floecat.service.repo.impl.ConnectorRepository.class));
     StatsProviderFactory factory = new StatsProviderFactory(orchestrator, tableRepository, store);
 
     PlannerStatsBundleService service =

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTestSupport.java
@@ -103,7 +103,11 @@ abstract class PlannerStatsBundleServiceTestSupport {
       int maxTargets) {
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
     StatsOrchestrator orchestrator =
-        new StatsOrchestrator(repository, Mockito.mock(ReconcileJobStore.class), tableRepository);
+        new StatsOrchestrator(
+            repository,
+            Mockito.mock(ReconcileJobStore.class),
+            tableRepository,
+            Mockito.mock(ai.floedb.floecat.service.repo.impl.ConnectorRepository.class));
     StatsProviderFactory factory = new StatsProviderFactory(orchestrator, tableRepository, store);
     return PlannerStatsBundleService.forTesting(
         factory, constraintProvider, repository, maxTables, maxTargets, chunkSize);
@@ -118,7 +122,11 @@ abstract class PlannerStatsBundleServiceTestSupport {
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
     Mockito.when(tableRepository.getById(TABLE)).thenReturn(Optional.of(TABLE_RECORD));
     StatsOrchestrator orchestrator =
-        new StatsOrchestrator(repository, Mockito.mock(ReconcileJobStore.class), tableRepository);
+        new StatsOrchestrator(
+            repository,
+            Mockito.mock(ReconcileJobStore.class),
+            tableRepository,
+            Mockito.mock(ai.floedb.floecat.service.repo.impl.ConnectorRepository.class));
     StatsProviderFactory factory = new StatsProviderFactory(orchestrator, tableRepository, store);
     return PlannerStatsBundleService.forTestingWithRealLookup(
         orchestrator, tableRepository, factory, maxTables, maxTargets, chunkSize);

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
@@ -501,7 +501,12 @@ class StatsProviderFactoryTest {
       SnapshotRepository snapshots) {
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(repository, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(
+            repository,
+            jobStore,
+            tableRepository,
+            Mockito.mock(ai.floedb.floecat.service.repo.impl.ConnectorRepository.class));
     return new StatsProviderFactory(
         orchestrator, tableRepository, store, snapshots, defaultSyncConfig());
   }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -168,7 +168,10 @@ class UserObjectBundleServiceTest {
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
     StatsOrchestrator orchestrator =
         new StatsOrchestrator(
-            statsRepository, Mockito.mock(ReconcileJobStore.class), tableRepository);
+            statsRepository,
+            Mockito.mock(ReconcileJobStore.class),
+            tableRepository,
+            Mockito.mock(ai.floedb.floecat.service.repo.impl.ConnectorRepository.class));
     statsFactory = new StatsProviderFactory(orchestrator, tableRepository, queryStore);
     service =
         new UserObjectBundleService(
@@ -268,7 +271,10 @@ class UserObjectBundleServiceTest {
     TableRepository localTableRepository = Mockito.mock(TableRepository.class);
     StatsOrchestrator localOrchestrator =
         new StatsOrchestrator(
-            localStatsRepository, Mockito.mock(ReconcileJobStore.class), localTableRepository);
+            localStatsRepository,
+            Mockito.mock(ReconcileJobStore.class),
+            localTableRepository,
+            Mockito.mock(ai.floedb.floecat.service.repo.impl.ConnectorRepository.class));
     StatsProviderFactory localStatsFactory =
         new StatsProviderFactory(localOrchestrator, localTableRepository, localStore);
     UserObjectBundleService localService =

--- a/service/src/test/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImplTest.java
@@ -349,7 +349,10 @@ class PlannerStatsServiceImplTest {
     StatsProviderFactory factory =
         new StatsProviderFactory(
             new StatsOrchestrator(
-                repository, Mockito.mock(ReconcileJobStore.class), tableRepository),
+                repository,
+                Mockito.mock(ReconcileJobStore.class),
+                tableRepository,
+                Mockito.mock(ai.floedb.floecat.service.repo.impl.ConnectorRepository.class)),
             tableRepository,
             store);
     return PlannerStatsBundleService.forTesting(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerServiceTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.reconciler.impl.PlannedFileGroupJob;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.impl.SnapshotPlanBlobStore;
@@ -41,6 +43,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +53,7 @@ class LeasedPlannerWorkerServiceTest {
   private LeasedPlannerWorkerService service;
   private ReconcileJobStore jobs;
   private SnapshotPlanBlobStore snapshotPlanBlobStore;
+  private ConnectorRepository connectorRepo;
   private PrincipalContext principal;
 
   @BeforeEach
@@ -57,6 +61,7 @@ class LeasedPlannerWorkerServiceTest {
     service = new LeasedPlannerWorkerService();
     jobs = mock(ReconcileJobStore.class);
     snapshotPlanBlobStore = mock(SnapshotPlanBlobStore.class);
+    connectorRepo = mock(ConnectorRepository.class);
     principal = mock(PrincipalContext.class);
     service.jobs = jobs;
     service.snapshotPlanBlobStore = snapshotPlanBlobStore;
@@ -849,7 +854,7 @@ class LeasedPlannerWorkerServiceTest {
                 service.persistPlanSnapshotSuccess(
                     principal, "job-1", "lease-1", submittedSnapshotTask));
 
-    verify(snapshotPlanBlobStore).loadPlanJobs(submittedSnapshotTask);
+    verify(snapshotPlanBlobStore, never()).loadPlanJobs(any());
     verify(jobs, never()).adoptSnapshotPlanManifest(any(), any(), any(), any(), anyBoolean());
   }
 
@@ -1319,6 +1324,106 @@ class LeasedPlannerWorkerServiceTest {
         .enqueueViewPlan(any(), any(), anyBoolean(), any(), any(), any(), any(), any(), any());
   }
 
+  @Test
+  void persistPlanConnectorSuccessCancelsDeletedConnectorWithoutChildFanout() {
+    service.connectorRepo = connectorRepo;
+    when(connectorRepo.existsById(any())).thenReturn(false);
+    when(jobs.renewLease("job-1", "lease-1")).thenReturn(true);
+    when(jobs.getLeaseView("job-1"))
+        .thenReturn(java.util.Optional.of(job("job-1", ReconcileJobKind.PLAN_CONNECTOR)));
+    when(jobs.applyLeaseOutcome(
+            any(), any(), any(), anyLong(), any(), anyLong(), anyLong(), anyLong(), anyLong(),
+            anyLong(), anyLong(), anyLong()))
+        .thenReturn(true);
+
+    boolean accepted =
+        service.persistPlanConnectorSuccess(
+            principal,
+            "job-1",
+            "lease-1",
+            List.of(
+                new LeasedPlannerWorkerService.PlannedTableJob(
+                    ReconcileScope.empty(),
+                    ai.floedb.floecat.reconciler.jobs.ReconcileTableTask.of(
+                        "db", "orders", "orders-id", "orders"))),
+            List.of());
+
+    assertTrue(accepted);
+    verify(connectorRepo).existsById(activeConnectorId());
+    verify(jobs, never())
+        .bulkEnqueueAndApplyLeaseOutcome(
+            any(), any(), any(), any(), anyLong(), any(), anyLong(), anyLong(), anyLong(),
+            anyLong(), anyLong(), anyLong(), anyLong());
+    verify(jobs)
+        .applyLeaseOutcome(
+            eq("job-1"),
+            eq("lease-1"),
+            eq(ReconcileJobStore.CompletionKind.CANCELLED),
+            anyLong(),
+            eq("connector deleted: connector-1"),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L));
+  }
+
+  @Test
+  void persistPlanSnapshotSuccessCancelsDeletedConnectorBeforeLoadingPlanManifest() {
+    service.connectorRepo = connectorRepo;
+    ReconcileSnapshotTask submittedSnapshotTask =
+        ReconcileSnapshotTask.of(
+            "table-1",
+            55L,
+            "db",
+            "events",
+            List.of(),
+            true,
+            ReconcileSnapshotTask.CompletionMode.FILE_GROUPS,
+            "/accounts/acct/reconcile/jobs/job-1/snapshot-plan/plan.json",
+            1);
+    when(connectorRepo.existsById(any())).thenReturn(false);
+    when(jobs.getLeaseView("job-1"))
+        .thenReturn(java.util.Optional.of(job("job-1", ReconcileJobKind.PLAN_SNAPSHOT)));
+    when(jobs.getCompletionLeaseView("job-1", "lease-1", true))
+        .thenReturn(
+            java.util.Optional.of(
+                new ReconcileJobStore.LeasedJob(
+                    "job-1",
+                    "acct",
+                    "connector-1",
+                    false,
+                    CaptureMode.METADATA_AND_CAPTURE,
+                    ReconcileScope.empty(),
+                    ReconcileExecutionPolicy.defaults(),
+                    "lease-1",
+                    "remote-executor",
+                    "remote_snapshot_planner_worker",
+                    ReconcileJobKind.PLAN_SNAPSHOT,
+                    ai.floedb.floecat.reconciler.jobs.ReconcileTableTask.empty(),
+                    ai.floedb.floecat.reconciler.jobs.ReconcileViewTask.empty(),
+                    submittedSnapshotTask,
+                    ReconcileFileGroupTask.empty(),
+                    "parent-1")));
+    when(jobs.applyLeaseOutcome(
+            any(), any(), any(), anyLong(), any(), anyLong(), anyLong(), anyLong(), anyLong(),
+            anyLong(), anyLong(), anyLong()))
+        .thenReturn(true);
+
+    boolean accepted =
+        service.persistPlanSnapshotSuccess(principal, "job-1", "lease-1", submittedSnapshotTask);
+
+    assertTrue(accepted);
+    verify(connectorRepo).existsById(activeConnectorId());
+    verify(snapshotPlanBlobStore, never()).loadPlanJobs(any());
+    verify(jobs, never()).bulkEnqueue(any());
+    verify(jobs, never())
+        .enqueueSnapshotFinalization(
+            any(), any(), anyBoolean(), any(), any(), any(), any(), any(), any());
+  }
+
   private static ReconcileJobStore.ReconcileJob job(String jobId, ReconcileJobKind jobKind) {
     return new ReconcileJobStore.ReconcileJob(
         jobId,
@@ -1347,5 +1452,13 @@ class LeasedPlannerWorkerServiceTest {
         ReconcileSnapshotTask.empty(),
         ReconcileFileGroupTask.empty(),
         "parent-1");
+  }
+
+  private static ResourceId activeConnectorId() {
+    return ResourceId.newBuilder()
+        .setAccountId("acct")
+        .setKind(ResourceKind.RK_CONNECTOR)
+        .setId("connector-1")
+        .build();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerServiceTest.java
@@ -622,6 +622,42 @@ class LeasedPlannerWorkerServiceTest {
   }
 
   @Test
+  void persistPlanTableFailureReturnsFalseWhenObsoleteCancelDoesNotCommit() {
+    when(jobs.renewLease("job-2c", "lease-2c")).thenReturn(true);
+    when(jobs.getLeaseView("job-2c"))
+        .thenReturn(java.util.Optional.of(job("job-2c", ReconcileJobKind.PLAN_TABLE)));
+    when(jobs.applyLeaseOutcome(
+            eq("job-2c"),
+            eq("lease-2c"),
+            eq(ReconcileJobStore.CompletionKind.CANCELLED),
+            anyLong(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong()))
+        .thenReturn(false);
+
+    boolean accepted =
+        service.persistPlanTableFailure(
+            principal,
+            "job-2c",
+            "lease-2c",
+            ai.floedb.floecat.reconciler.impl.ReconcileExecutor.ExecutionResult.FailureKind
+                .CONNECTOR_MISSING,
+            ai.floedb.floecat.reconciler.impl.ReconcileExecutor.ExecutionResult.RetryDisposition
+                .RETRYABLE,
+            ai.floedb.floecat.reconciler.impl.ReconcileExecutor.ExecutionResult.RetryClass
+                .TRANSIENT_ERROR,
+            "getConnector failed: connector-1");
+
+    assertTrue(!accepted);
+  }
+
+  @Test
   void persistPlanSnapshotFailureMarksRetryableFailure() {
     when(jobs.renewLease("job-3", "lease-3")).thenReturn(true);
     when(jobs.getLeaseView("job-3"))
@@ -1368,6 +1404,38 @@ class LeasedPlannerWorkerServiceTest {
             eq(0L),
             eq(0L),
             eq(0L));
+  }
+
+  @Test
+  void persistPlanConnectorSuccessReturnsFalseWhenDeleteCancelDoesNotCommit() {
+    service.connectorRepo = connectorRepo;
+    when(connectorRepo.existsById(any())).thenReturn(false);
+    when(jobs.renewLease("job-1", "lease-1")).thenReturn(true);
+    when(jobs.getLeaseView("job-1"))
+        .thenReturn(java.util.Optional.of(job("job-1", ReconcileJobKind.PLAN_CONNECTOR)));
+    when(jobs.applyLeaseOutcome(
+            any(), any(), any(), anyLong(), any(), anyLong(), anyLong(), anyLong(), anyLong(),
+            anyLong(), anyLong(), anyLong()))
+        .thenReturn(false);
+
+    boolean accepted =
+        service.persistPlanConnectorSuccess(
+            principal,
+            "job-1",
+            "lease-1",
+            List.of(
+                new LeasedPlannerWorkerService.PlannedTableJob(
+                    ReconcileScope.empty(),
+                    ai.floedb.floecat.reconciler.jobs.ReconcileTableTask.of(
+                        "db", "orders", "orders-id", "orders"))),
+            List.of());
+
+    assertTrue(!accepted);
+    verify(connectorRepo).existsById(activeConnectorId());
+    verify(jobs, never())
+        .bulkEnqueueAndApplyLeaseOutcome(
+            any(), any(), any(), any(), anyLong(), any(), anyLong(), anyLong(), anyLong(),
+            anyLong(), anyLong(), anyLong(), anyLong());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -51,6 +52,7 @@ import ai.floedb.floecat.reconciler.rpc.CaptureScope;
 import ai.floedb.floecat.reconciler.rpc.GetReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.GetReconcileJobTreeRequest;
 import ai.floedb.floecat.reconciler.rpc.ListReconcileJobsRequest;
+import ai.floedb.floecat.service.reconciler.jobs.DurableReconcileJobStore;
 import ai.floedb.floecat.service.reconciler.jobs.ReconcilerSettingsStore;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
@@ -296,6 +298,40 @@ class ReconcileControlImplTest {
     assertEquals(Status.Code.NOT_FOUND, ex.getStatus().getCode());
     verify(service.jobs, never())
         .enqueuePlan(anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString());
+  }
+
+  @Test
+  void startCaptureMapsDeletedConnectorRaceDuringEnqueueToNotFound() {
+    ResourceId connectorId = accountScopedConnectorId();
+    when(service.connectorRepo.getById(connectorId))
+        .thenReturn(Optional.of(connector(connectorId, ConnectorState.CS_ACTIVE)));
+    when(service.connectorRepo.existsById(connectorId)).thenReturn(true);
+    when(service.jobs.enqueuePlan(
+            eq(connectorId.getAccountId()),
+            eq(connectorId.getId()),
+            anyBoolean(),
+            any(),
+            any(),
+            any(),
+            anyString()))
+        .thenThrow(new DurableReconcileJobStore.ConnectorDeletedException(connectorId.getId()));
+
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .startCapture(
+                        ai.floedb.floecat.reconciler.rpc.StartCaptureRequest.newBuilder()
+                            .setMode(
+                                ai.floedb.floecat.reconciler.rpc.CaptureMode
+                                    .CM_METADATA_AND_CAPTURE)
+                            .setScope(captureScope())
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.NOT_FOUND, ex.getStatus().getCode());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
@@ -92,6 +92,7 @@ class ReconcileControlImplTest {
             .build();
     when(service.connectorRepo.getById(any()))
         .thenReturn(Optional.of(connector(connectorId, ConnectorState.CS_ACTIVE)));
+    when(service.connectorRepo.existsById(any())).thenReturn(true);
     when(service.jobs.childJobsPage(anyString(), anyString(), anyInt(), anyString()))
         .thenReturn(new ReconcileJobStore.ReconcileJobPage(java.util.List.of(), ""));
   }
@@ -266,6 +267,33 @@ class ReconcileControlImplTest {
                     .indefinitely());
 
     assertEquals(Status.Code.FAILED_PRECONDITION, ex.getStatus().getCode());
+    verify(service.jobs, never())
+        .enqueuePlan(anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString());
+  }
+
+  @Test
+  void startCaptureRejectsDeletedConnectorAtEnqueueBoundary() {
+    ResourceId connectorId = accountScopedConnectorId();
+    when(service.connectorRepo.getById(connectorId))
+        .thenReturn(Optional.of(connector(connectorId, ConnectorState.CS_ACTIVE)));
+    when(service.connectorRepo.existsById(connectorId)).thenReturn(false);
+
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .startCapture(
+                        ai.floedb.floecat.reconciler.rpc.StartCaptureRequest.newBuilder()
+                            .setMode(
+                                ai.floedb.floecat.reconciler.rpc.CaptureMode
+                                    .CM_METADATA_AND_CAPTURE)
+                            .setScope(captureScope())
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.NOT_FOUND, ex.getStatus().getCode());
     verify(service.jobs, never())
         .enqueuePlan(anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString());
   }

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
@@ -54,6 +54,7 @@ import ai.floedb.floecat.reconciler.rpc.ReportReconcileProgressRequest;
 import ai.floedb.floecat.reconciler.rpc.SubmitLeasedFileGroupExecutionResultRequest;
 import ai.floedb.floecat.reconciler.rpc.SubmitLeasedSnapshotFinalizeResultRequest;
 import ai.floedb.floecat.service.reconciler.jobs.LeaseScanCapacityExceededException;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.security.RolePermissions;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
@@ -74,6 +75,7 @@ class ReconcileExecutorControlImplTest {
     service.principalProvider = mock(PrincipalProvider.class);
     service.authz = mock(Authorizer.class);
     service.jobs = mock(ReconcileJobStore.class);
+    service.connectorRepo = null;
     service.cancellations = mock(ReconcileCancellationRegistry.class);
     service.leasedFileGroupExecutionService = mock(LeasedFileGroupExecutionService.class);
     service.leasedSnapshotFinalizeInputService = mock(LeasedSnapshotFinalizeInputService.class);
@@ -286,6 +288,69 @@ class ReconcileExecutorControlImplTest {
   }
 
   @Test
+  void leaseReconcileJobCancelsAndWithholdsDeletedConnectorWork() {
+    service.connectorRepo = mock(ConnectorRepository.class);
+    when(service.jobs.leaseNext(any()))
+        .thenReturn(
+            Optional.of(
+                new ReconcileJobStore.LeasedJob(
+                    "job-deleted",
+                    "acct",
+                    "connector-deleted",
+                    false,
+                    CaptureMode.METADATA_AND_CAPTURE,
+                    ReconcileScope.empty(),
+                    ReconcileExecutionPolicy.defaults(),
+                    "lease-deleted",
+                    "",
+                    "",
+                    ReconcileJobKind.PLAN_CONNECTOR,
+                    ReconcileTableTask.empty(),
+                    ReconcileViewTask.empty(),
+                    ReconcileSnapshotTask.empty(),
+                    ReconcileFileGroupTask.empty(),
+                    "")));
+    when(service.connectorRepo.existsById(deletedConnectorId())).thenReturn(false);
+    when(service.jobs.applyLeaseOutcome(
+            eq("job-deleted"),
+            eq("lease-deleted"),
+            eq(ReconcileJobStore.CompletionKind.CANCELLED),
+            anyLong(),
+            eq("connector deleted: connector-deleted"),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L)))
+        .thenReturn(true);
+
+    var response =
+        service
+            .leaseReconcileJob(LeaseReconcileJobRequest.getDefaultInstance())
+            .await()
+            .indefinitely();
+
+    assertTrue(!response.getFound());
+    verify(service.connectorRepo).existsById(deletedConnectorId());
+    verify(service.jobs)
+        .applyLeaseOutcome(
+            eq("job-deleted"),
+            eq("lease-deleted"),
+            eq(ReconcileJobStore.CompletionKind.CANCELLED),
+            anyLong(),
+            eq("connector deleted: connector-deleted"),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L));
+  }
+
+  @Test
   void renewReconcileLeaseReturnsCancellationSignal() {
     when(service.jobs.renewLease("job-1", "lease-1")).thenReturn(true);
     when(service.jobs.isCancellationRequested("job-1")).thenReturn(true);
@@ -302,6 +367,14 @@ class ReconcileExecutorControlImplTest {
 
     assertTrue(response.getRenewed());
     assertTrue(response.getCancellationRequested());
+  }
+
+  private static ResourceId deletedConnectorId() {
+    return ResourceId.newBuilder()
+        .setAccountId("acct")
+        .setKind(ResourceKind.RK_CONNECTOR)
+        .setId("connector-deleted")
+        .build();
   }
 
   @Test
@@ -435,6 +508,34 @@ class ReconcileExecutorControlImplTest {
     assertTrue(response.getAccepted());
     verify(service.leasedFileGroupExecutionService)
         .persistSuccess(any(), eq("job-1"), eq("lease-1"), eq("result-1"), eq(2), any());
+  }
+
+  @Test
+  void submitLeasedFileGroupExecutionResultAllowsRunningLeafToFinishAfterConnectorDelete() {
+    service.connectorRepo = mock(ConnectorRepository.class);
+    when(service.connectorRepo.existsById(any())).thenReturn(false);
+    when(service.leasedFileGroupExecutionService.persistSuccess(
+            any(), eq("leaf-1"), eq("lease-1"), eq("result-1"), eq(1), any()))
+        .thenReturn(true);
+
+    var response =
+        service
+            .submitLeasedFileGroupExecutionResult(
+                SubmitLeasedFileGroupExecutionResultRequest.newBuilder()
+                    .setJobId("leaf-1")
+                    .setLeaseEpoch("lease-1")
+                    .setSuccess(
+                        SubmitLeasedFileGroupExecutionResultRequest.Success.newBuilder()
+                            .setResultId("result-1")
+                            .setChunkCount(1)
+                            .build())
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertTrue(response.getAccepted());
+    verify(service.leasedFileGroupExecutionService)
+        .persistSuccess(any(), eq("leaf-1"), eq("lease-1"), eq("result-1"), eq(1), any());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
@@ -351,6 +351,56 @@ class ReconcileExecutorControlImplTest {
   }
 
   @Test
+  void leaseReconcileJobKeepsDeletedConnectorWorkVisibleWhenCancelDoesNotCommit() {
+    service.connectorRepo = mock(ConnectorRepository.class);
+    when(service.jobs.leaseNext(any()))
+        .thenReturn(
+            Optional.of(
+                new ReconcileJobStore.LeasedJob(
+                    "job-deleted",
+                    "acct",
+                    "connector-deleted",
+                    false,
+                    CaptureMode.METADATA_AND_CAPTURE,
+                    ReconcileScope.empty(),
+                    ReconcileExecutionPolicy.defaults(),
+                    "lease-deleted",
+                    "",
+                    "",
+                    ReconcileJobKind.PLAN_CONNECTOR,
+                    ReconcileTableTask.empty(),
+                    ReconcileViewTask.empty(),
+                    ReconcileSnapshotTask.empty(),
+                    ReconcileFileGroupTask.empty(),
+                    "")));
+    when(service.connectorRepo.existsById(deletedConnectorId())).thenReturn(false);
+    when(service.jobs.applyLeaseOutcome(
+            eq("job-deleted"),
+            eq("lease-deleted"),
+            eq(ReconcileJobStore.CompletionKind.CANCELLED),
+            anyLong(),
+            eq("connector deleted: connector-deleted"),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L),
+            eq(0L)))
+        .thenReturn(false);
+
+    var response =
+        service
+            .leaseReconcileJob(LeaseReconcileJobRequest.getDefaultInstance())
+            .await()
+            .indefinitely();
+
+    assertTrue(response.getFound());
+    assertEquals("job-deleted", response.getJob().getJobId());
+    verify(service.connectorRepo).existsById(deletedConnectorId());
+  }
+
+  @Test
   void renewReconcileLeaseReturnsCancellationSignal() {
     when(service.jobs.renewLease("job-1", "lease-1")).thenReturn(true);
     when(service.jobs.isCancellationRequested("job-1")).thenReturn(true);

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -49,6 +49,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.store.MemoryReconcileJo
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.MemoryReconcileLeaseBackend;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.MemoryReconcileReadyQueueBackend;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexBackend;
+import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexStore;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileLeaseStore;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.storage.aws.dynamodb.DynamoPointerStore;
@@ -70,6 +71,7 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterAll;
@@ -646,6 +648,96 @@ class DurableReconcileJobStoreTest {
     assertEquals("JS_WAITING", parentRecord.state);
     assertEquals(24L, parentRecord.expectedDirectChildren);
     assertEquals(24, store.childJobs(ACCOUNT_ID, connectorJobId).size());
+  }
+
+  @Test
+  void connectorParentCanonicalStateSucceedsWhenSiblingTerminalCompletionsRace() {
+    InMemoryPointerStore pointerStore = new InMemoryPointerStore();
+    MemoryReconcileJobIndexBackend delegateBackend = new MemoryReconcileJobIndexBackend();
+    delegateBackend.bind(pointerStore);
+    HookedCompareAndSetBatchBackend hookedBackend =
+        new HookedCompareAndSetBatchBackend(delegateBackend);
+    store = newIsolatedInMemoryStore(pointerStore, new InMemoryBlobStore(), hookedBackend);
+
+    String connectorJobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.empty());
+    var connectorLease = leaseJob(connectorJobId);
+    store.markRunning(connectorJobId, connectorLease.leaseEpoch, 100L, "executor-connector");
+
+    List<ReconcileJobStore.BulkEnqueueSpec> childSpecs =
+        java.util.stream.IntStream.range(0, 2)
+            .mapToObj(
+                i ->
+                    ReconcileJobStore.BulkEnqueueSpec.of(
+                        ACCOUNT_ID,
+                        CONNECTOR_ID,
+                        false,
+                        CaptureMode.METADATA_AND_CAPTURE,
+                        ReconcileScope.of(List.of(), "table-" + i),
+                        ReconcileJobKind.PLAN_TABLE,
+                        ReconcileTableTask.of("db", "orders_" + i, "table-" + i, "orders_" + i),
+                        ReconcileViewTask.empty(),
+                        ReconcileSnapshotTask.empty(),
+                        ReconcileFileGroupTask.empty(),
+                        ReconcileExecutionPolicy.defaults(),
+                        connectorJobId,
+                        ""))
+            .toList();
+
+    assertTrue(
+        store.bulkEnqueueAndApplyLeaseOutcome(
+            childSpecs,
+            connectorJobId,
+            connectorLease.leaseEpoch,
+            ReconcileJobStore.CompletionKind.SUCCEEDED_WAITING,
+            200L,
+            "Planned 2 table job(s)",
+            2L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L));
+
+    List<ReconcileJob> children = store.childJobsPage(ACCOUNT_ID, connectorJobId, 20, "").jobs;
+    assertEquals(2, children.size());
+    ReconcileJob firstChild = children.get(0);
+    ReconcileJob secondChild = children.get(1);
+    var firstLease = leaseJob(firstChild.jobId);
+    var secondLease = leaseJob(secondChild.jobId);
+    store.markRunning(firstChild.jobId, firstLease.leaseEpoch, 300L, "executor-table-a");
+    store.markRunning(secondChild.jobId, secondLease.leaseEpoch, 300L, "executor-table-b");
+
+    String parentCanonicalKey = Keys.reconcileJobPointerById(ACCOUNT_ID, connectorJobId);
+    String firstChildCanonicalKey = Keys.reconcileJobPointerById(ACCOUNT_ID, firstChild.jobId);
+    AtomicBoolean injectedSiblingCompletion = new AtomicBoolean(false);
+    hookedBackend.beforeCompareAndSetBatch(
+        batch -> {
+          if (injectedSiblingCompletion.get()) {
+            return;
+          }
+          if (!batchContainsCanonicalMutation(batch, firstChildCanonicalKey)
+              || batchContainsCanonicalMutation(batch, parentCanonicalKey)) {
+            return;
+          }
+          injectedSiblingCompletion.set(true);
+          store.markSucceeded(
+              secondChild.jobId, secondLease.leaseEpoch, 400L, 1L, 1L, 0L, 0L, 0L, 0L);
+        });
+
+    store.markSucceeded(firstChild.jobId, firstLease.leaseEpoch, 400L, 1L, 1L, 0L, 0L, 0L, 0L);
+
+    StoredReconcileJob parentRecord =
+        readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, connectorJobId));
+    assertTrue(injectedSiblingCompletion.get());
+    assertEquals("JS_SUCCEEDED", parentRecord.state);
+    assertEquals("Succeeded", parentRecord.message);
   }
 
   @Test
@@ -2823,6 +2915,17 @@ class DurableReconcileJobStoreTest {
     return isolatedStore;
   }
 
+  private static boolean batchContainsCanonicalMutation(
+      ReconcileJobIndexStore.JobIndexWriteBatch batch, String canonicalPointerKey) {
+    if (batch == null || canonicalPointerKey == null || canonicalPointerKey.isBlank()) {
+      return false;
+    }
+    return batch.writes().stream()
+        .filter(ReconcileJobIndexStore.JobIndexUpsert.class::isInstance)
+        .map(ReconcileJobIndexStore.JobIndexUpsert.class::cast)
+        .anyMatch(upsert -> canonicalPointerKey.equals(upsert.pointerKey()));
+  }
+
   private boolean deleteReadyEntry(String readyPointerKey) {
     assertDoesNotThrow(() -> invokePrivateMethod(store, "readyQueue", new Class<?>[] {}));
     return store.readyQueueBackend.deleteReadyEntry(readyPointerKey);
@@ -3034,6 +3137,75 @@ class DurableReconcileJobStoreTest {
         onFailedCompareAndSetBatch.run();
         return false;
       }
+      return delegate.compareAndSetBatch(batch);
+    }
+
+    @Override
+    public JobIndexQueryPage listCanonicalEntries(String accountId, int limit, String pageToken) {
+      return delegate.listCanonicalEntries(accountId, limit, pageToken);
+    }
+
+    @Override
+    public JobIndexQueryPage listDedupeEntries(String accountId, int limit, String pageToken) {
+      return delegate.listDedupeEntries(accountId, limit, pageToken);
+    }
+
+    @Override
+    public JobIndexQueryPage listParentEntries(
+        String accountId, String parentJobId, int limit, String pageToken) {
+      return delegate.listParentEntries(accountId, parentJobId, limit, pageToken);
+    }
+
+    @Override
+    public JobIndexQueryPage listConnectorEntries(
+        String accountId, String connectorId, int limit, String pageToken) {
+      return delegate.listConnectorEntries(accountId, connectorId, limit, pageToken);
+    }
+
+    @Override
+    public JobIndexQueryPage listGlobalStateEntries(String state, int limit, String pageToken) {
+      return delegate.listGlobalStateEntries(state, limit, pageToken);
+    }
+
+    @Override
+    public JobIndexQueryPage listAccountStateEntries(
+        String accountId, String state, int limit, String pageToken) {
+      return delegate.listAccountStateEntries(accountId, state, limit, pageToken);
+    }
+
+    @Override
+    public JobIndexQueryPage listConnectorStateEntries(
+        String accountId, String connectorId, String state, int limit, String pageToken) {
+      return delegate.listConnectorStateEntries(accountId, connectorId, state, limit, pageToken);
+    }
+
+    @Override
+    public boolean purgeEntriesByCanonicalReference(String canonicalPointerKey) {
+      return delegate.purgeEntriesByCanonicalReference(canonicalPointerKey);
+    }
+  }
+
+  private static final class HookedCompareAndSetBatchBackend implements ReconcileJobIndexBackend {
+    private final ReconcileJobIndexBackend delegate;
+    private volatile Consumer<ReconcileJobIndexStore.JobIndexWriteBatch> beforeCompareAndSetBatch =
+        batch -> {};
+
+    private HookedCompareAndSetBatchBackend(ReconcileJobIndexBackend delegate) {
+      this.delegate = delegate;
+    }
+
+    void beforeCompareAndSetBatch(Consumer<ReconcileJobIndexStore.JobIndexWriteBatch> callback) {
+      beforeCompareAndSetBatch = callback == null ? batch -> {} : callback;
+    }
+
+    @Override
+    public Optional<JobIndexEntrySnapshot> loadIndexEntry(String pointerKey) {
+      return delegate.loadIndexEntry(pointerKey);
+    }
+
+    @Override
+    public boolean compareAndSetBatch(ReconcileJobIndexStore.JobIndexWriteBatch batch) {
+      beforeCompareAndSetBatch.accept(batch);
       return delegate.compareAndSetBatch(batch);
     }
 

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
@@ -51,6 +53,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.store.MemoryReconcileRe
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexBackend;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexStore;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileLeaseStore;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.storage.aws.dynamodb.DynamoPointerStore;
 import ai.floedb.floecat.storage.kv.dynamodb.DynamoDbKvStore;
@@ -79,6 +82,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -171,6 +175,65 @@ class DurableReconcileJobStoreTest {
         store.enqueue(ACCOUNT_ID, CONNECTOR_ID, false, CaptureMode.METADATA_AND_CAPTURE, scope);
 
     assertEquals(first, second);
+  }
+
+  @Test
+  void enqueuePlanRejectsDeletedConnectorBeforeCreatingRootJob() {
+    store.connectorRepo = Mockito.mock(ConnectorRepository.class);
+    Mockito.when(store.connectorRepo.existsById(connectorResourceId())).thenReturn(false);
+
+    ReconcileJobStore.BulkEnqueueResult result =
+        store.bulkEnqueue(
+            List.of(
+                ReconcileJobStore.BulkEnqueueSpec.of(
+                    ACCOUNT_ID,
+                    CONNECTOR_ID,
+                    false,
+                    CaptureMode.METADATA_AND_CAPTURE,
+                    ReconcileScope.empty(),
+                    ReconcileJobKind.PLAN_CONNECTOR,
+                    ReconcileTableTask.empty(),
+                    ReconcileViewTask.empty(),
+                    ReconcileSnapshotTask.empty(),
+                    ReconcileFileGroupTask.empty(),
+                    ReconcileExecutionPolicy.defaults(),
+                    "",
+                    "")));
+
+    assertEquals(
+        ReconcileJobStore.BulkEnqueueItemResult.FailureReason.CONNECTOR_DELETED,
+        result.items.getFirst().failureReason);
+    assertEquals(CONNECTOR_ID, result.items.getFirst().failureSubjectId);
+
+    var thrown =
+        assertThrows(
+            DurableReconcileJobStore.ConnectorDeletedException.class,
+            () ->
+                store.enqueue(
+                    ACCOUNT_ID,
+                    CONNECTOR_ID,
+                    false,
+                    CaptureMode.METADATA_AND_CAPTURE,
+                    ReconcileScope.empty()));
+
+    assertEquals("connector deleted: " + CONNECTOR_ID, thrown.getMessage());
+    assertTrue(store.listRootJobs(ACCOUNT_ID, 10, "", "", null).jobs.isEmpty());
+  }
+
+  @Test
+  void enqueuePlanAllowsExistingCanonicalConnector() {
+    store.connectorRepo = Mockito.mock(ConnectorRepository.class);
+    Mockito.when(store.connectorRepo.existsById(connectorResourceId())).thenReturn(true);
+
+    String jobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.empty());
+
+    assertTrue(store.get(ACCOUNT_ID, jobId).isPresent());
   }
 
   @Test
@@ -3370,5 +3433,13 @@ class DurableReconcileJobStoreTest {
       }
       startKey = response.lastEvaluatedKey();
     } while (startKey != null && !startKey.isEmpty());
+  }
+
+  private static ResourceId connectorResourceId() {
+    return ResourceId.newBuilder()
+        .setAccountId(ACCOUNT_ID)
+        .setId(CONNECTOR_ID)
+        .setKind(ResourceKind.RK_CONNECTOR)
+        .build();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
@@ -44,6 +44,8 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.ReconcileJob;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.ReconcileJobPage;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
+import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexStore;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import java.util.ArrayList;
@@ -468,6 +470,39 @@ class ReconcilePlannerSchedulerTest {
         .enqueuePlan(anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString());
   }
 
+  @Test
+  void runPlannerPassUsesCanonicalJobsWhenRootSummaryProjectionLags() {
+    TestScheduler scheduler = new TestScheduler();
+    scheduler.accounts = mock(AccountRepository.class);
+    scheduler.connectors = mock(ConnectorRepository.class);
+    scheduler.jobs = mock(ReconcileJobStore.class);
+    scheduler.jobIndexStore = mock(ReconcileJobIndexStore.class);
+    scheduler.executorRegistry = mock(ReconcileExecutorRegistry.class);
+
+    when(scheduler.executorRegistry.hasExecutorForJobKind(any())).thenReturn(true);
+    when(scheduler.accounts.list(anyInt(), anyString(), any()))
+        .thenReturn(List.of(account("acct-a", "alpha")));
+    when(scheduler.connectors.list(anyString(), anyInt(), anyString(), any()))
+        .thenReturn(List.of(connector("acct-a", "conn-a1", "alpha-1")));
+    stubConnectorLookup(scheduler.connectors, connector("acct-a", "conn-a1", "alpha-1"));
+    when(scheduler.jobs.listRootJobs(anyString(), anyInt(), anyString(), anyString(), any()))
+        .thenReturn(new ReconcileJobPage(List.of(), ""));
+    when(scheduler.jobIndexStore.listStoredJobs(
+            eq("acct-a"),
+            eq(256),
+            eq(""),
+            eq("conn-a1"),
+            eq(java.util.Set.of("JS_QUEUED", "JS_WAITING", "JS_RUNNING", "JS_CANCELLING"))))
+        .thenReturn(
+            new ReconcileJobIndexStore.StoredJobPage(
+                List.of(storedRootJob("acct-a", "conn-a1", "root-1", "JS_WAITING")), ""));
+
+    scheduler.runPlannerPass(100L, 10, 10, 1L, ReconcileMode.RM_INCREMENTAL);
+
+    verify(scheduler.jobs, never())
+        .enqueuePlan(anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString());
+  }
+
   private static Account account(String accountId, String displayName) {
     return Account.newBuilder()
         .setResourceId(
@@ -493,6 +528,17 @@ class ReconcilePlannerSchedulerTest {
         .setState(ConnectorState.CS_ACTIVE)
         .setPolicy(ReconcilePolicy.newBuilder().setEnabled(policyEnabled).build())
         .build();
+  }
+
+  private static StoredReconcileJob storedRootJob(
+      String accountId, String connectorId, String jobId, String state) {
+    StoredReconcileJob job = new StoredReconcileJob();
+    job.accountId = accountId;
+    job.connectorId = connectorId;
+    job.jobId = jobId;
+    job.state = state;
+    job.parentJobId = "";
+    return job;
   }
 
   private static final class TestScheduler extends ReconcilePlannerScheduler {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
@@ -44,8 +44,6 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.ReconcileJob;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.ReconcileJobPage;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
-import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
-import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexStore;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import java.util.ArrayList;
@@ -61,8 +59,8 @@ class ReconcilePlannerSchedulerTest {
 
   private static void stubConnectorLookup(ConnectorRepository connectors, Connector... rows) {
     for (Connector row : rows) {
-      when(connectors.getById(argThat(id -> sameResourceId(id, row.getResourceId()))))
-          .thenReturn(java.util.Optional.of(row));
+      when(connectors.existsById(argThat(id -> sameResourceId(id, row.getResourceId()))))
+          .thenReturn(true);
     }
   }
 
@@ -471,31 +469,23 @@ class ReconcilePlannerSchedulerTest {
   }
 
   @Test
-  void runPlannerPassUsesCanonicalJobsWhenRootSummaryProjectionLags() {
+  void runPlannerPassRejectsConnectorDeletedBeforeSchedulerRootEnqueue() {
     TestScheduler scheduler = new TestScheduler();
     scheduler.accounts = mock(AccountRepository.class);
     scheduler.connectors = mock(ConnectorRepository.class);
     scheduler.jobs = mock(ReconcileJobStore.class);
-    scheduler.jobIndexStore = mock(ReconcileJobIndexStore.class);
     scheduler.executorRegistry = mock(ReconcileExecutorRegistry.class);
 
+    Connector row = connector("acct-a", "conn-a1", "alpha-1");
     when(scheduler.executorRegistry.hasExecutorForJobKind(any())).thenReturn(true);
     when(scheduler.accounts.list(anyInt(), anyString(), any()))
         .thenReturn(List.of(account("acct-a", "alpha")));
     when(scheduler.connectors.list(anyString(), anyInt(), anyString(), any()))
-        .thenReturn(List.of(connector("acct-a", "conn-a1", "alpha-1")));
-    stubConnectorLookup(scheduler.connectors, connector("acct-a", "conn-a1", "alpha-1"));
-    when(scheduler.jobs.listRootJobs(anyString(), anyInt(), anyString(), anyString(), any()))
-        .thenReturn(new ReconcileJobPage(List.of(), ""));
-    when(scheduler.jobIndexStore.listStoredJobs(
-            eq("acct-a"),
-            eq(256),
-            eq(""),
-            eq("conn-a1"),
-            eq(java.util.Set.of("JS_QUEUED", "JS_WAITING", "JS_RUNNING", "JS_CANCELLING"))))
-        .thenReturn(
-            new ReconcileJobIndexStore.StoredJobPage(
-                List.of(storedRootJob("acct-a", "conn-a1", "root-1", "JS_WAITING")), ""));
+        .thenReturn(List.of(row));
+    when(scheduler.connectors.existsById(argThat(id -> sameResourceId(id, row.getResourceId()))))
+        .thenReturn(true)
+        .thenReturn(false);
+    stubNoActiveRootJobs(scheduler.jobs);
 
     scheduler.runPlannerPass(100L, 10, 10, 1L, ReconcileMode.RM_INCREMENTAL);
 
@@ -528,17 +518,6 @@ class ReconcilePlannerSchedulerTest {
         .setState(ConnectorState.CS_ACTIVE)
         .setPolicy(ReconcilePolicy.newBuilder().setEnabled(policyEnabled).build())
         .build();
-  }
-
-  private static StoredReconcileJob storedRootJob(
-      String accountId, String connectorId, String jobId, String state) {
-    StoredReconcileJob job = new StoredReconcileJob();
-    job.accountId = accountId;
-    job.connectorId = connectorId;
-    job.jobId = jobId;
-    job.state = state;
-    job.parentJobId = "";
-    return job;
   }
 
   private static final class TestScheduler extends ReconcilePlannerScheduler {

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
@@ -41,6 +41,7 @@ import ai.floedb.floecat.reconciler.impl.ReconcilerService;
 import ai.floedb.floecat.reconciler.jobs.ReconcileCapturePolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.spi.StatsCaptureBatchRequest;
@@ -180,7 +181,8 @@ class StatsOrchestratorTest {
     StatsStore statsStore = Mockito.mock(StatsStore.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(statsStore, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryWith());
 
     StatsCaptureRequest request = tableRequest(StatsExecutionMode.SYNC);
     when(statsStore.getTargetStats(request.tableId(), request.snapshotId(), request.target()))
@@ -212,6 +214,26 @@ class StatsOrchestratorTest {
     assertThat(scope.capturePolicy().selectorsForStats()).containsExactlyInAnyOrder("id", "region");
   }
 
+  @Test
+  void missDoesNotEnqueueWhenCanonicalConnectorIsDeleted() {
+    StatsStore statsStore = Mockito.mock(StatsStore.class);
+    ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
+    TableRepository tableRepository = Mockito.mock(TableRepository.class);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryMissing());
+
+    StatsCaptureRequest request = tableRequest(StatsExecutionMode.SYNC);
+    when(statsStore.getTargetStats(request.tableId(), request.snapshotId(), request.target()))
+        .thenReturn(Optional.empty());
+    when(tableRepository.getById(request.tableId())).thenReturn(Optional.of(upstreamTable()));
+
+    StatsResolutionResult result = orchestrator.resolve(request);
+
+    assertThat(result.outcome()).isEqualTo(StatsSyncOutcome.SKIPPED);
+    assertThat(result.stats()).isEmpty();
+    verify(jobStore, never()).enqueue(anyString(), anyString(), anyBoolean(), any(), any());
+  }
+
   // ---------------------------------------------------------------------------
   // triggerBatch path (unchanged semantics)
   // ---------------------------------------------------------------------------
@@ -221,7 +243,8 @@ class StatsOrchestratorTest {
     StatsStore statsStore = Mockito.mock(StatsStore.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(statsStore, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryWith());
 
     StatsCaptureRequest tableRequest = tableRequest(StatsExecutionMode.ASYNC);
     StatsCaptureRequest columnRequest =
@@ -268,7 +291,8 @@ class StatsOrchestratorTest {
     StatsStore statsStore = Mockito.mock(StatsStore.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(statsStore, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryWith());
 
     StatsCaptureRequest columnRequest =
         StatsCaptureRequest.builder(
@@ -305,7 +329,8 @@ class StatsOrchestratorTest {
     StatsStore statsStore = Mockito.mock(StatsStore.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(statsStore, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryWith());
 
     StatsCaptureRequest request =
         StatsCaptureRequest.builder(
@@ -342,7 +367,8 @@ class StatsOrchestratorTest {
     StatsStore statsStore = Mockito.mock(StatsStore.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(statsStore, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryWith());
 
     StatsCaptureRequest request =
         StatsCaptureRequest.builder(
@@ -381,7 +407,8 @@ class StatsOrchestratorTest {
     StatsStore statsStore = Mockito.mock(StatsStore.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(statsStore, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryWith());
 
     StatsCaptureRequest request = tableRequest(StatsExecutionMode.ASYNC);
     when(tableRepository.getById(request.tableId())).thenReturn(Optional.empty());
@@ -405,7 +432,8 @@ class StatsOrchestratorTest {
     StatsStore statsStore = Mockito.mock(StatsStore.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(statsStore, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryWith());
 
     StatsCaptureRequest request = tableRequest(StatsExecutionMode.ASYNC);
     when(tableRepository.getById(request.tableId()))
@@ -430,7 +458,8 @@ class StatsOrchestratorTest {
     StatsStore statsStore = Mockito.mock(StatsStore.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(statsStore, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryWith());
 
     StatsCaptureRequest request = tableRequest(StatsExecutionMode.ASYNC);
     when(tableRepository.getById(request.tableId())).thenReturn(Optional.of(upstreamTable()));
@@ -456,7 +485,8 @@ class StatsOrchestratorTest {
     StatsStore statsStore = Mockito.mock(StatsStore.class);
     ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
     TableRepository tableRepository = Mockito.mock(TableRepository.class);
-    StatsOrchestrator orchestrator = new StatsOrchestrator(statsStore, jobStore, tableRepository);
+    StatsOrchestrator orchestrator =
+        new StatsOrchestrator(statsStore, jobStore, tableRepository, connectorRepositoryWith());
 
     StatsCaptureRequest accepted = tableRequest(StatsExecutionMode.ASYNC);
     StatsCaptureRequest skipped =
@@ -550,7 +580,20 @@ class StatsOrchestratorTest {
       ReconcileJobStore jobStore,
       TableRepository tableRepository,
       StatsSyncCapture syncCapture) {
-    return new StatsOrchestrator(statsStore, jobStore, tableRepository, syncCapture, true, null);
+    return new StatsOrchestrator(
+        statsStore, jobStore, tableRepository, connectorRepositoryWith(), syncCapture, true, null);
+  }
+
+  private static ConnectorRepository connectorRepositoryWith() {
+    ConnectorRepository connectorRepository = Mockito.mock(ConnectorRepository.class);
+    when(connectorRepository.existsById(any())).thenReturn(true);
+    return connectorRepository;
+  }
+
+  private static ConnectorRepository connectorRepositoryMissing() {
+    ConnectorRepository connectorRepository = Mockito.mock(ConnectorRepository.class);
+    when(connectorRepository.existsById(any())).thenReturn(false);
+    return connectorRepository;
   }
 
   private static StatsCaptureRequest tableRequest(StatsExecutionMode mode) {

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsSyncCaptureTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsSyncCaptureTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.when;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.stats.spi.StatsSyncOutcome;
 import java.time.Duration;
 import java.util.Optional;
@@ -45,7 +47,7 @@ class StatsSyncCaptureTest {
         .thenReturn("job-1");
     when(jobStore.get("acct", "job-1")).thenReturn(Optional.of(job("JS_SUCCEEDED")));
 
-    StatsSyncCapture capture = new StatsSyncCapture(jobStore);
+    StatsSyncCapture capture = capture(jobStore);
     StatsSyncOutcome outcome = capture.capture("acct", "conn-1", SCOPE, Duration.ofSeconds(5));
 
     assertThat(outcome).isEqualTo(StatsSyncOutcome.CAPTURED);
@@ -58,7 +60,7 @@ class StatsSyncCaptureTest {
         .thenReturn("job-1");
     when(jobStore.get("acct", "job-1")).thenReturn(Optional.of(job("JS_FAILED")));
 
-    StatsSyncCapture capture = new StatsSyncCapture(jobStore);
+    StatsSyncCapture capture = capture(jobStore);
     StatsSyncOutcome outcome = capture.capture("acct", "conn-1", SCOPE, Duration.ofSeconds(5));
 
     assertThat(outcome).isEqualTo(StatsSyncOutcome.FAILED);
@@ -71,7 +73,7 @@ class StatsSyncCaptureTest {
         .thenReturn("job-1");
     when(jobStore.get("acct", "job-1")).thenReturn(Optional.of(job("JS_CANCELLED")));
 
-    StatsSyncCapture capture = new StatsSyncCapture(jobStore);
+    StatsSyncCapture capture = capture(jobStore);
     StatsSyncOutcome outcome = capture.capture("acct", "conn-1", SCOPE, Duration.ofSeconds(5));
 
     assertThat(outcome).isEqualTo(StatsSyncOutcome.FAILED);
@@ -86,7 +88,7 @@ class StatsSyncCaptureTest {
         .thenReturn(Optional.of(job("JS_CANCELLING")))
         .thenReturn(Optional.of(job("JS_CANCELLED")));
 
-    StatsSyncCapture capture = new StatsSyncCapture(jobStore);
+    StatsSyncCapture capture = capture(jobStore);
     StatsSyncOutcome outcome = capture.capture("acct", "conn-1", SCOPE, Duration.ofMillis(250));
 
     assertThat(outcome).isEqualTo(StatsSyncOutcome.FAILED);
@@ -99,7 +101,7 @@ class StatsSyncCaptureTest {
     when(jobStore.enqueue(anyString(), anyString(), anyBoolean(), any(), any()))
         .thenThrow(new RuntimeException("store unavailable"));
 
-    StatsSyncCapture capture = new StatsSyncCapture(jobStore);
+    StatsSyncCapture capture = capture(jobStore);
     StatsSyncOutcome outcome = capture.capture("acct", "conn-1", SCOPE, Duration.ofSeconds(5));
 
     assertThat(outcome).isEqualTo(StatsSyncOutcome.FAILED);
@@ -112,7 +114,7 @@ class StatsSyncCaptureTest {
         .thenReturn("job-1");
     when(jobStore.get("acct", "job-1")).thenReturn(Optional.empty());
 
-    StatsSyncCapture capture = new StatsSyncCapture(jobStore);
+    StatsSyncCapture capture = capture(jobStore);
     StatsSyncOutcome outcome = capture.capture("acct", "conn-1", SCOPE, Duration.ofSeconds(5));
 
     assertThat(outcome).isEqualTo(StatsSyncOutcome.FAILED);
@@ -126,11 +128,30 @@ class StatsSyncCaptureTest {
     // Job stays running indefinitely.
     when(jobStore.get("acct", "job-1")).thenReturn(Optional.of(job("JS_RUNNING")));
 
-    StatsSyncCapture capture = new StatsSyncCapture(jobStore);
+    StatsSyncCapture capture = capture(jobStore);
     // Tiny budget so it times out immediately.
     StatsSyncOutcome outcome = capture.capture("acct", "conn-1", SCOPE, Duration.ofNanos(1));
 
     assertThat(outcome).isEqualTo(StatsSyncOutcome.TIMEOUT);
+  }
+
+  @Test
+  void returnsFailedWithoutEnqueueWhenConnectorDeleted() {
+    ReconcileJobStore jobStore = Mockito.mock(ReconcileJobStore.class);
+    ConnectorRepository connectorRepository = Mockito.mock(ConnectorRepository.class);
+    when(connectorRepository.existsById(any())).thenReturn(false);
+
+    StatsSyncCapture capture = new StatsSyncCapture(jobStore, connectorRepository);
+    StatsSyncOutcome outcome = capture.capture("acct", "conn-1", SCOPE, Duration.ofSeconds(5));
+
+    assertThat(outcome).isEqualTo(StatsSyncOutcome.FAILED);
+    verify(jobStore, never()).enqueue(anyString(), anyString(), anyBoolean(), any(), any());
+  }
+
+  private static StatsSyncCapture capture(ReconcileJobStore jobStore) {
+    ConnectorRepository connectorRepository = Mockito.mock(ConnectorRepository.class);
+    when(connectorRepository.existsById(any())).thenReturn(true);
+    return new StatsSyncCapture(jobStore, connectorRepository);
   }
 
   private static ReconcileJobStore.ReconcileJob job(String state) {

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.inOrder;
@@ -45,6 +46,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotSelection;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.metagraph.resolver.NameResolver;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
@@ -1101,13 +1103,16 @@ class TransactionsServiceImplTest {
   void enqueuePostCommitCaptureUsesMetadataAndCaptureMode() throws Exception {
     var service = new TransactionsServiceImpl();
     var reconcileJobs = Mockito.mock(ReconcileJobStore.class);
+    var connectorRepo = Mockito.mock(ConnectorRepository.class);
 
     inject(service, "reconcileJobs", reconcileJobs);
+    inject(service, "connectorRepo", connectorRepo);
 
     Connector connector =
         Connector.newBuilder()
             .setResourceId(resourceId("conn-1", ResourceKind.RK_CONNECTOR))
             .build();
+    when(connectorRepo.existsById(connector.getResourceId())).thenReturn(true);
 
     invokeEnqueuePostCommitCapture(service, "acct", "tx-1", connector, "table-1", null);
 
@@ -1132,13 +1137,16 @@ class TransactionsServiceImplTest {
   void enqueuePostCommitCapturePinsCommittedSnapshotWhenKnown() throws Exception {
     var service = new TransactionsServiceImpl();
     var reconcileJobs = Mockito.mock(ReconcileJobStore.class);
+    var connectorRepo = Mockito.mock(ConnectorRepository.class);
 
     inject(service, "reconcileJobs", reconcileJobs);
+    inject(service, "connectorRepo", connectorRepo);
 
     Connector connector =
         Connector.newBuilder()
             .setResourceId(resourceId("conn-1", ResourceKind.RK_CONNECTOR))
             .build();
+    when(connectorRepo.existsById(connector.getResourceId())).thenReturn(true);
 
     invokeEnqueuePostCommitCapture(service, "acct", "tx-1", connector, "table-1", 123L);
 
@@ -1158,6 +1166,27 @@ class TransactionsServiceImplTest {
             org.mockito.ArgumentMatchers.any(
                 ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy.class),
             org.mockito.ArgumentMatchers.eq(""));
+  }
+
+  @Test
+  void enqueuePostCommitCaptureSkipsDeletedConnector() throws Exception {
+    var service = new TransactionsServiceImpl();
+    var reconcileJobs = Mockito.mock(ReconcileJobStore.class);
+    var connectorRepo = Mockito.mock(ConnectorRepository.class);
+
+    inject(service, "reconcileJobs", reconcileJobs);
+    inject(service, "connectorRepo", connectorRepo);
+
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(resourceId("conn-1", ResourceKind.RK_CONNECTOR))
+            .build();
+    when(connectorRepo.existsById(connector.getResourceId())).thenReturn(false);
+
+    invokeEnqueuePostCommitCapture(service, "acct", "tx-1", connector, "table-1", null);
+
+    verify(reconcileJobs, never())
+        .enqueuePlan(any(), any(), anyBoolean(), any(), any(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Keep terminal reconcile completion on the transactional path and remove the
non-transactional fallback for terminal outcomes. Add a regression test for
concurrent sibling completions leaving the parent stuck in WAITING.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

