### PR TITLE
fix: correct Catalog Surface pagination (precise cursors, phased system/user listing)

### DIFF
--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -95,6 +95,15 @@ public interface KvStore {
       String partitionKey, String sortKeyPrefix, int limit, Optional<String> pageToken);
 
   /**
+   * Returns a page token that resumes a {@link #queryByPartitionKeyPrefix} scan immediately after
+   * the given key, in this store's native token encoding. The default throws; stores that serve
+   * paging must override.
+   */
+  default String pageTokenAfterKey(Key key) {
+    throw new UnsupportedOperationException("pageTokenAfterKey is not supported by this store");
+  }
+
+  /**
    * Remove items
    *
    * @param partitionKey

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
@@ -80,6 +80,19 @@ public interface PointerStore {
   List<Pointer> listPointersByPrefix(
       String prefix, int limit, String pageToken, StringBuilder nextTokenOut);
 
+  /**
+   * Returns a page token that resumes a {@link #listPointersByPrefix} scan immediately after the
+   * given pointer key, as if a previous page had ended exactly at that key. This lets callers that
+   * post-filter scanned rows emit a cursor at the last row they actually consumed rather than at
+   * the end of an over-fetched batch.
+   *
+   * <p>Stores that serve filtered pagination must override this with their native token encoding.
+   * The default throws, so legacy or test stores that never need it are unaffected.
+   */
+  default String pageTokenAfterKey(String key) {
+    throw new UnsupportedOperationException("pageTokenAfterKey is not supported by this store");
+  }
+
   int deleteByPrefix(String prefix);
 
   int countByPrefix(String prefix);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePageSource.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePageSource.java
@@ -19,6 +19,7 @@ import ai.floedb.floecat.catalog.rpc.Namespace;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import java.util.ArrayList;
 import java.util.List;
 
 final class CatalogSurfaceNamespacePageSource implements CatalogSurfaceNamespacePager.Source {
@@ -66,6 +67,13 @@ final class CatalogSurfaceNamespacePageSource implements CatalogSurfaceNamespace
   @Override
   public List<Namespace> listRepo(int limit, String cursor, StringBuilder next) {
     return repo.list(accountId, catalogId.getId(), parentPath, limit, cursor, next);
+  }
+
+  @Override
+  public String cursorAfter(Namespace namespace) {
+    var fullPath = new ArrayList<>(namespace.getParentsList());
+    fullPath.add(namespace.getDisplayName());
+    return repo.listTokenAfter(accountId, catalogId.getId(), fullPath);
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -101,11 +101,16 @@ final class CatalogSurfaceNamespacePager {
             .sorted(Comparator.comparing(SysItem::rel))
             .toList();
 
+    // A full page is not the same as having another row to return: only advertise a continuation
+    // when the loop actually stopped before an un-emitted system namespace. Otherwise a page that
+    // exactly consumes the last system row would hand out a token whose next page is empty.
+    boolean hasMoreSystem = false;
     for (var it : sysItems) {
       if (!resumeSystemRel.isBlank() && it.rel().compareTo(resumeSystemRel) <= 0) {
         continue;
       }
       if (out.size() >= want) {
+        hasMoreSystem = true;
         break;
       }
       out.add(source.mapSystemNode(it.namespace()));
@@ -113,7 +118,7 @@ final class CatalogSurfaceNamespacePager {
     }
 
     String nextToken =
-        out.size() == want && !lastSystemRel.isBlank()
+        hasMoreSystem && !lastSystemRel.isBlank()
             ? CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastSystemRel)
             : "";
 

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -27,60 +27,76 @@ import java.util.Map;
 
 final class CatalogSurfaceNamespacePager {
 
+  // System-phase resume token: the carried relative name is a *system* namespace name.
   private static final String NS_TOKEN_PREFIX = "ns:";
+  // Repo-phase resume token: the carried relative name is a *user* namespace name.
+  private static final String NSU_TOKEN_PREFIX = "nsu:";
 
   private CatalogSurfaceNamespacePager() {}
 
   static Page list(int want, String pageToken, Source source, String corr) {
 
     final int batch = Math.max(want * 4, 64);
-    final boolean isServiceToken = pageToken != null && pageToken.startsWith(NS_TOKEN_PREFIX);
-    final String resumeAfterRel =
-        isServiceToken ? CatalogSurfaceSupport.decodeToken(NS_TOKEN_PREFIX, pageToken, corr) : "";
-    String cursor = isServiceToken ? "" : pageToken;
+    final boolean isSystemToken = pageToken != null && pageToken.startsWith(NS_TOKEN_PREFIX);
+    final boolean isUserToken = pageToken != null && pageToken.startsWith(NSU_TOKEN_PREFIX);
+    // Resume keys are scoped to their own phase: a user relative name must never filter system
+    // namespaces (and vice versa), since the two are independent, independently-ordered keyspaces.
+    final String resumeSystemRel =
+        isSystemToken ? CatalogSurfaceSupport.decodeToken(NS_TOKEN_PREFIX, pageToken, corr) : "";
+    final String resumeUserRel =
+        isUserToken ? CatalogSurfaceSupport.decodeToken(NSU_TOKEN_PREFIX, pageToken, corr) : "";
+    // Raw repo cursors carry no service prefix; service tokens restart the scan and resume by name.
+    String cursor = (isSystemToken || isUserToken) ? "" : pageToken;
 
     var out = new ArrayList<Namespace>(want);
-    String lastEmittedRel = "";
+    String lastUserRel = "";
+    String lastSystemRel = "";
 
-    // The repo phase must run for continuation tokens too: a batch that exhausts the cursor can
-    // hold
-    // more matches than fit on one page, so later pages re-scan from the start and skip already-
-    // emitted namespaces by name via resumeAfterRel. Skipping the scan for service tokens would
-    // drop
-    // every remaining user namespace once a page-filling batch exhausted the cursor.
-    while (out.size() < want) {
-      var next = new StringBuilder();
-      final List<Namespace> scanned;
-      try {
-        scanned = source.listRepo(batch, cursor, next);
-      } catch (IllegalArgumentException badToken) {
-        throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", cursor));
-      }
-
-      for (var ns : scanned) {
-        if (!matches(ns, source)) {
-          continue;
+    // Repo (user) phase. Runs for the first page, raw-cursor pages, and user-phase resume tokens;
+    // it
+    // is skipped only once we have advanced into the system phase (system-phase token). A batch
+    // that
+    // exhausts the cursor can hold more matches than fit on one page, so a user-phase resume token
+    // re-scans from the start and skips already-emitted rows by name via resumeUserRel.
+    if (!isSystemToken) {
+      while (out.size() < want) {
+        var next = new StringBuilder();
+        final List<Namespace> scanned;
+        try {
+          scanned = source.listRepo(batch, cursor, next);
+        } catch (IllegalArgumentException badToken) {
+          throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", cursor));
         }
 
-        var rel = relativeQualifiedName(ns, source.parentPath());
-        if (!resumeAfterRel.isBlank() && rel.compareTo(resumeAfterRel) <= 0) {
-          continue;
+        for (var ns : scanned) {
+          if (!matches(ns, source)) {
+            continue;
+          }
+
+          var rel = relativeQualifiedName(ns, source.parentPath());
+          if (!resumeUserRel.isBlank() && rel.compareTo(resumeUserRel) <= 0) {
+            continue;
+          }
+
+          out.add(ns);
+          lastUserRel = rel;
+          if (out.size() >= want) {
+            break;
+          }
         }
 
-        out.add(ns);
-        lastEmittedRel = rel;
-        if (out.size() >= want) {
+        cursor = next.toString();
+        if (cursor.isBlank() || out.size() >= want) {
           break;
         }
       }
-
-      cursor = next.toString();
-      if (cursor.isBlank() || out.size() >= want) {
-        break;
-      }
     }
 
-    if (cursor.isBlank() && out.size() < want) {
+    // System phase: only once the repo cursor is exhausted, or when resuming directly into it. When
+    // transitioning here from the repo phase, resumeSystemRel is blank, so system namespaces are
+    // emitted from the beginning regardless of where the user phase left off.
+    boolean enteredSystemPhase = false;
+    if ((isSystemToken || cursor.isBlank()) && out.size() < want) {
       record SysItem(NamespaceNode namespace, String rel) {}
 
       var sysItems =
@@ -91,20 +107,24 @@ final class CatalogSurfaceNamespacePager {
               .toList();
 
       for (var it : sysItems) {
-        if (!resumeAfterRel.isBlank() && it.rel().compareTo(resumeAfterRel) <= 0) {
+        if (!resumeSystemRel.isBlank() && it.rel().compareTo(resumeSystemRel) <= 0) {
           continue;
         }
         if (out.size() >= want) {
           break;
         }
         out.add(source.mapSystemNode(it.namespace()));
-        lastEmittedRel = it.rel();
+        lastSystemRel = it.rel();
+        enteredSystemPhase = true;
       }
     }
 
     String nextToken = cursor;
     if (nextToken.isBlank() && out.size() == want) {
-      nextToken = CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastEmittedRel);
+      nextToken =
+          enteredSystemPhase
+              ? CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastSystemRel)
+              : CatalogSurfaceSupport.encodeToken(NSU_TOKEN_PREFIX, lastUserRel);
     }
 
     int total = countNamespaces(source, corr);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -42,37 +42,41 @@ final class CatalogSurfaceNamespacePager {
     var out = new ArrayList<Namespace>(want);
     String lastEmittedRel = "";
 
-    if (!isServiceToken) {
-      while (out.size() < want) {
-        var next = new StringBuilder();
-        final List<Namespace> scanned;
-        try {
-          scanned = source.listRepo(batch, cursor, next);
-        } catch (IllegalArgumentException badToken) {
-          throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", cursor));
+    // The repo phase must run for continuation tokens too: a batch that exhausts the cursor can
+    // hold
+    // more matches than fit on one page, so later pages re-scan from the start and skip already-
+    // emitted namespaces by name via resumeAfterRel. Skipping the scan for service tokens would
+    // drop
+    // every remaining user namespace once a page-filling batch exhausted the cursor.
+    while (out.size() < want) {
+      var next = new StringBuilder();
+      final List<Namespace> scanned;
+      try {
+        scanned = source.listRepo(batch, cursor, next);
+      } catch (IllegalArgumentException badToken) {
+        throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", cursor));
+      }
+
+      for (var ns : scanned) {
+        if (!matches(ns, source)) {
+          continue;
         }
 
-        for (var ns : scanned) {
-          if (!matches(ns, source)) {
-            continue;
-          }
-
-          var rel = relativeQualifiedName(ns, source.parentPath());
-          if (!resumeAfterRel.isBlank() && rel.compareTo(resumeAfterRel) <= 0) {
-            continue;
-          }
-
-          out.add(ns);
-          lastEmittedRel = rel;
-          if (out.size() >= want) {
-            break;
-          }
+        var rel = relativeQualifiedName(ns, source.parentPath());
+        if (!resumeAfterRel.isBlank() && rel.compareTo(resumeAfterRel) <= 0) {
+          continue;
         }
 
-        cursor = next.toString();
-        if (cursor.isBlank() || out.size() >= want) {
+        out.add(ns);
+        lastEmittedRel = rel;
+        if (out.size() >= want) {
           break;
         }
+      }
+
+      cursor = next.toString();
+      if (cursor.isBlank() || out.size() >= want) {
+        break;
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -33,6 +33,11 @@ final class CatalogSurfaceNamespacePager {
   private CatalogSurfaceNamespacePager() {}
 
   static Page list(int want, String pageToken, Source source, String corr) {
+    if (want <= 0) {
+      // The fill-return path dereferences the last emitted row, which requires want >= 1; the
+      // single caller clamps, but guard against future call sites.
+      throw new IllegalArgumentException("want must be >= 1");
+    }
 
     final int batch = Math.max(want * 4, 64);
     final boolean isSystemToken = pageToken != null && pageToken.startsWith(NS_TOKEN_PREFIX);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -29,8 +29,6 @@ final class CatalogSurfaceNamespacePager {
 
   // System-phase resume token: the carried relative name is a *system* namespace name.
   private static final String NS_TOKEN_PREFIX = "ns:";
-  // Repo-phase resume token: the carried relative name is a *user* namespace name.
-  private static final String NSU_TOKEN_PREFIX = "nsu:";
 
   private CatalogSurfaceNamespacePager() {}
 
@@ -38,26 +36,19 @@ final class CatalogSurfaceNamespacePager {
 
     final int batch = Math.max(want * 4, 64);
     final boolean isSystemToken = pageToken != null && pageToken.startsWith(NS_TOKEN_PREFIX);
-    final boolean isUserToken = pageToken != null && pageToken.startsWith(NSU_TOKEN_PREFIX);
-    // Resume keys are scoped to their own phase: a user relative name must never filter system
-    // namespaces (and vice versa), since the two are independent, independently-ordered keyspaces.
     final String resumeSystemRel =
         isSystemToken ? CatalogSurfaceSupport.decodeToken(NS_TOKEN_PREFIX, pageToken, corr) : "";
-    final String resumeUserRel =
-        isUserToken ? CatalogSurfaceSupport.decodeToken(NSU_TOKEN_PREFIX, pageToken, corr) : "";
-    // Raw repo cursors carry no service prefix; service tokens restart the scan and resume by name.
-    String cursor = (isSystemToken || isUserToken) ? "" : pageToken;
+    // Anything else (blank or a raw store cursor) resumes the repo scan directly.
+    String cursor = isSystemToken ? "" : (pageToken == null ? "" : pageToken);
 
     var out = new ArrayList<Namespace>(want);
-    String lastUserRel = "";
-    String lastSystemRel = "";
+    Namespace lastEmitted = null;
 
-    // Repo (user) phase. Runs for the first page, raw-cursor pages, and user-phase resume tokens;
-    // it
-    // is skipped only once we have advanced into the system phase (system-phase token). A batch
-    // that
-    // exhausts the cursor can hold more matches than fit on one page, so a user-phase resume token
-    // re-scans from the start and skips already-emitted rows by name via resumeUserRel.
+    // Repo (user) phase. The scan over-fetches and post-filters, so when the page fills the
+    // continuation must resume after the last *emitted* row, not after the scanned batch:
+    // source.cursorAfter(lastEmitted) is that precise position. Rows the batch read past (and even
+    // rows read after the store reported exhaustion) are still in the store and are re-served by
+    // the next page's scan.
     if (!isSystemToken) {
       while (out.size() < want) {
         var next = new StringBuilder();
@@ -73,13 +64,8 @@ final class CatalogSurfaceNamespacePager {
             continue;
           }
 
-          var rel = relativeQualifiedName(ns, source.parentPath());
-          if (!resumeUserRel.isBlank() && rel.compareTo(resumeUserRel) <= 0) {
-            continue;
-          }
-
           out.add(ns);
-          lastUserRel = rel;
+          lastEmitted = ns;
           if (out.size() >= want) {
             break;
           }
@@ -90,42 +76,41 @@ final class CatalogSurfaceNamespacePager {
           break;
         }
       }
-    }
 
-    // System phase: only once the repo cursor is exhausted, or when resuming directly into it. When
-    // transitioning here from the repo phase, resumeSystemRel is blank, so system namespaces are
-    // emitted from the beginning regardless of where the user phase left off.
-    boolean enteredSystemPhase = false;
-    if ((isSystemToken || cursor.isBlank()) && out.size() < want) {
-      record SysItem(NamespaceNode namespace, String rel) {}
-
-      var sysItems =
-          source.systemNamespaces().stream()
-              .filter(ns -> matches(ns, source))
-              .map(ns -> new SysItem(ns, relativeQualifiedName(ns, source.parentPath())))
-              .sorted(Comparator.comparing(SysItem::rel))
-              .toList();
-
-      for (var it : sysItems) {
-        if (!resumeSystemRel.isBlank() && it.rel().compareTo(resumeSystemRel) <= 0) {
-          continue;
-        }
-        if (out.size() >= want) {
-          break;
-        }
-        out.add(source.mapSystemNode(it.namespace()));
-        lastSystemRel = it.rel();
-        enteredSystemPhase = true;
+      if (out.size() >= want) {
+        return new Page(out, source.cursorAfter(lastEmitted), countNamespaces(source, corr));
       }
+      // Repo exhausted with room left: fall through to the system phase from its start.
     }
 
-    String nextToken = cursor;
-    if (nextToken.isBlank() && out.size() == want) {
-      nextToken =
-          enteredSystemPhase
-              ? CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastSystemRel)
-              : CatalogSurfaceSupport.encodeToken(NSU_TOKEN_PREFIX, lastUserRel);
+    // System phase: entered once the repo is exhausted, or directly via a system-phase token. When
+    // transitioning from the repo phase resumeSystemRel is blank, so system namespaces are emitted
+    // from the beginning regardless of where the user phase left off.
+    String lastSystemRel = "";
+    record SysItem(NamespaceNode namespace, String rel) {}
+
+    var sysItems =
+        source.systemNamespaces().stream()
+            .filter(ns -> matches(ns, source))
+            .map(ns -> new SysItem(ns, relativeQualifiedName(ns, source.parentPath())))
+            .sorted(Comparator.comparing(SysItem::rel))
+            .toList();
+
+    for (var it : sysItems) {
+      if (!resumeSystemRel.isBlank() && it.rel().compareTo(resumeSystemRel) <= 0) {
+        continue;
+      }
+      if (out.size() >= want) {
+        break;
+      }
+      out.add(source.mapSystemNode(it.namespace()));
+      lastSystemRel = it.rel();
     }
+
+    String nextToken =
+        out.size() == want && !lastSystemRel.isBlank()
+            ? CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastSystemRel)
+            : "";
 
     int total = countNamespaces(source, corr);
 
@@ -257,6 +242,9 @@ final class CatalogSurfaceNamespacePager {
     boolean recursive();
 
     List<Namespace> listRepo(int limit, String cursor, StringBuilder next);
+
+    /** Repo cursor that resumes the {@link #listRepo} scan immediately after {@code namespace}. */
+    String cursorAfter(Namespace namespace);
 
     List<NamespaceNode> systemNamespaces();
 

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceSupport.java
@@ -22,10 +22,9 @@ import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
 import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.service.common.PageTokens;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
-import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
-import java.util.Base64;
 import java.util.Map;
 
 final class CatalogSurfaceSupport {
@@ -86,32 +85,10 @@ final class CatalogSurfaceSupport {
   }
 
   static String encodeToken(String prefix, String resumeAfterRel) {
-    if (resumeAfterRel == null) {
-      resumeAfterRel = "";
-    }
-    if (resumeAfterRel.isBlank()) {
-      return prefix;
-    }
-    return prefix
-        + Base64.getUrlEncoder()
-            .withoutPadding()
-            .encodeToString(resumeAfterRel.getBytes(StandardCharsets.UTF_8));
+    return PageTokens.encode(prefix, resumeAfterRel);
   }
 
   static String decodeToken(String prefix, String token, String corr) {
-    if (token == null || token.isBlank() || !token.startsWith(prefix)) {
-      return "";
-    }
-    if (token.length() == prefix.length()) {
-      return "";
-    }
-    var s = token.substring(prefix.length());
-    final byte[] bytes;
-    try {
-      bytes = Base64.getUrlDecoder().decode(s);
-    } catch (IllegalArgumentException badToken) {
-      throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", token));
-    }
-    return new String(bytes, StandardCharsets.UTF_8);
+    return PageTokens.decode(prefix, token, corr);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/common/PageTokens.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/PageTokens.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.common;
+
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.PAGE_TOKEN_INVALID;
+
+import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+/**
+ * Phase-scoped page tokens shared by the Catalog Surface pagers and the MetaGraph phased prefix
+ * listing. A token is a phase {@code prefix} followed by the base64url encoding of the "resume
+ * after" payload (empty payload → just the prefix). Decoding strips the prefix and base64-decodes,
+ * rejecting a structurally invalid token with {@code PAGE_TOKEN_INVALID}.
+ */
+public final class PageTokens {
+
+  private PageTokens() {}
+
+  /** Encodes {@code prefix + base64url(resumeAfter)}; a blank payload yields just the prefix. */
+  public static String encode(String prefix, String resumeAfter) {
+    if (resumeAfter == null || resumeAfter.isBlank()) {
+      return prefix;
+    }
+    return prefix
+        + Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(resumeAfter.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Decodes a token produced by {@link #encode}. Returns "" for a null/blank token, one that does
+   * not carry {@code prefix}, or a prefix-only token; throws {@code PAGE_TOKEN_INVALID} when the
+   * payload after the prefix is not valid base64url.
+   */
+  public static String decode(String prefix, String token, String corr) {
+    if (token == null || token.isBlank() || !token.startsWith(prefix)) {
+      return "";
+    }
+    if (token.length() == prefix.length()) {
+      return "";
+    }
+    var payload = token.substring(prefix.length());
+    try {
+      return new String(Base64.getUrlDecoder().decode(payload), StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException badToken) {
+      throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", token));
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -479,14 +479,22 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     final boolean userPhase = !sysToken && token != null && !token.isBlank();
     final String userToken = userPhase ? decodeUserToken(token) : "";
 
-    // Collected on every page (bounded, in-memory) so totals can include the system rows.
-    List<CatalogOverlay.QualifiedRelation> systemAll =
-        new ArrayList<>(collectSystemRelationsInNamespace(prefix, ctx, tables, Integer.MAX_VALUE));
-    systemAll.sort(Comparator.comparing(rel -> canonicalName(rel.name())));
-
     var merged = new ArrayList<CatalogOverlay.QualifiedRelation>(Math.min(max, 64));
 
-    if (!userPhase) {
+    // System-relation total for the combined count. On a user-phase page the system rows were all
+    // emitted on earlier pages, so only their count is needed here — skip the sorted collect (with
+    // its per-relation name resolution) and count the bounded in-memory nodes directly. The sorted
+    // list is built only while the system phase is actually emitting rows.
+    int systemTotal;
+    if (userPhase) {
+      systemTotal = countSystemRelationsInNamespace(prefix, ctx, tables);
+    } else {
+      List<CatalogOverlay.QualifiedRelation> systemAll =
+          new ArrayList<>(
+              collectSystemRelationsInNamespace(prefix, ctx, tables, Integer.MAX_VALUE));
+      systemAll.sort(Comparator.comparing(rel -> canonicalName(rel.name())));
+      systemTotal = systemAll.size();
+
       String lastSystemName = "";
       for (CatalogOverlay.QualifiedRelation rel : systemAll) {
         String name = canonicalName(rel.name());
@@ -497,7 +505,7 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
           // System rows remain: continue the system phase next page; the user cursor is untouched.
           return new ResolveResult(
               merged,
-              systemAll.size() + userTotalByPrefix(correlationId, prefix, tables),
+              systemTotal + userTotalByPrefix(correlationId, prefix, tables),
               SYS_TOKEN_PREFIX + encodeSysName(lastSystemName));
         }
         merged.add(rel);
@@ -508,7 +516,7 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
         // advancing its cursor. The next page starts the user scan from the beginning.
         return new ResolveResult(
             merged,
-            systemAll.size() + userTotalByPrefix(correlationId, prefix, tables),
+            systemTotal + userTotalByPrefix(correlationId, prefix, tables),
             USER_TOKEN_PREFIX);
       }
     }
@@ -526,19 +534,17 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
       merged.add(rel);
     }
     return new ResolveResult(
-        merged, systemAll.size() + user.totalSize(), encodeUserToken(user.nextToken()));
+        merged, systemTotal + user.totalSize(), encodeUserToken(user.nextToken()));
   }
 
   /**
-   * User-relation total for combined counts on system-phase pages. The one-row probe's rows and
-   * cursor are discarded; the user phase later starts from a blank cursor, so nothing is skipped.
+   * User-relation total for combined counts on system-phase pages. Uses a count-only path (a plain
+   * repo countByPrefix) rather than fetching and discarding a one-row probe.
    */
   private int userTotalByPrefix(String correlationId, NameRef prefix, boolean tables) {
-    return toResolveResult(
-            tables
-                ? userGraph.resolveTables(correlationId, prefix, 1, "")
-                : userGraph.resolveViews(correlationId, prefix, 1, ""))
-        .totalSize();
+    return tables
+        ? userGraph.countTablesByPrefix(correlationId, prefix)
+        : userGraph.countViewsByPrefix(correlationId, prefix);
   }
 
   /**
@@ -813,6 +819,28 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
       }
     }
     return out;
+  }
+
+  /**
+   * Counts system relations of the requested kind under a prefix, without the per-relation name
+   * resolution and {@link NameRef} construction {@link #collectSystemRelationsInNamespace} does.
+   * Used for the combined total on user-phase pages, where the sorted system list is not needed.
+   */
+  private int countSystemRelationsInNamespace(NameRef prefix, EngineContext ctx, boolean tables) {
+    Optional<ResourceId> sysNsId =
+        systemGraph.resolveNamespace(
+            SystemCatalogTranslator.toSystemNamespaceRef(prefix, ctx), ctx);
+    if (sysNsId.isEmpty()) {
+      return 0;
+    }
+    int count = 0;
+    for (RelationNode n :
+        systemGraph.listRelationsInNamespace(ResourceId.getDefaultInstance(), sysNsId.get(), ctx)) {
+      if ((tables && n instanceof TableNode) || (!tables && n instanceof ViewNode)) {
+        count++;
+      }
+    }
+    return count;
   }
 
   private List<CatalogOverlay.QualifiedRelation> collectSystemRelationsInNamespace(

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -518,12 +518,12 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
         lastSystemName = name;
       }
       if (merged.size() >= max) {
-        // Page filled exactly as the system rows ran out: hand off to the user phase without
-        // advancing its cursor. The next page starts the user scan from the beginning.
+        // Page filled exactly as the system rows ran out. Hand off to the user phase only when
+        // there are user rows to continue into; with none, USER_TOKEN_PREFIX would advertise a
+        // next page that is always empty. The next page starts the user scan from the beginning.
+        int userTotal = userTotalByPrefix(correlationId, prefix, tables);
         return new ResolveResult(
-            merged,
-            systemTotal + userTotalByPrefix(correlationId, prefix, tables),
-            USER_TOKEN_PREFIX);
+            merged, systemTotal + userTotal, userTotal > 0 ? USER_TOKEN_PREFIX : "");
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -36,6 +36,7 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.scanner.spi.TopologyGraph;
 import ai.floedb.floecat.scanner.spi.TopologyNames;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.common.PageTokens;
 import ai.floedb.floecat.service.context.EngineContextProvider;
 import ai.floedb.floecat.service.error.impl.GeneratedErrorMessages;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
@@ -49,9 +50,7 @@ import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -475,7 +474,8 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     int max = normalizeLimit(limit);
 
     final boolean sysToken = token != null && token.startsWith(SYS_TOKEN_PREFIX);
-    final String sysResume = sysToken ? decodeSysToken(correlationId, token) : "";
+    final String sysResume =
+        sysToken ? PageTokens.decode(SYS_TOKEN_PREFIX, token, correlationId) : "";
     final boolean userPhase = !sysToken && token != null && !token.isBlank();
     final String userToken = userPhase ? decodeUserToken(token) : "";
 
@@ -506,7 +506,7 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
           return new ResolveResult(
               merged,
               systemTotal + userTotalByPrefix(correlationId, prefix, tables),
-              SYS_TOKEN_PREFIX + encodeSysName(lastSystemName));
+              PageTokens.encode(SYS_TOKEN_PREFIX, lastSystemName));
         }
         merged.add(rel);
         lastSystemName = name;
@@ -746,25 +746,6 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
       return token.substring(USER_TOKEN_PREFIX.length());
     }
     return token;
-  }
-
-  private static String encodeSysName(String name) {
-    return Base64.getUrlEncoder()
-        .withoutPadding()
-        .encodeToString(name.getBytes(StandardCharsets.UTF_8));
-  }
-
-  private String decodeSysToken(String correlationId, String token) {
-    try {
-      return new String(
-          Base64.getUrlDecoder().decode(token.substring(SYS_TOKEN_PREFIX.length())),
-          StandardCharsets.UTF_8);
-    } catch (IllegalArgumentException badToken) {
-      throw GrpcErrors.invalidArgument(
-          correlationId,
-          GeneratedErrorMessages.MessageKey.PAGE_TOKEN_INVALID,
-          Map.of("page_token", token));
-    }
   }
 
   private static String encodeUserToken(String token) {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -466,6 +466,12 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
    * user-phase token is the user graph's own cursor. The user graph is only consulted for rows once
    * the system rows are fully emitted, so a page filled by system rows never advances — and can
    * never drop — user results. Reported totals combine both sources.
+   *
+   * <p>NOTE: this reimplements the same "system phase, then user phase, phase-scoped resume token"
+   * shape that {@code CatalogSurfaceRelationPager} generalizes via its {@code Source<P, N>}
+   * abstraction. The duplication is deliberate for now (this path is the just-fixed headline of the
+   * pagination-correctness work); unifying the two phased pagers onto one abstraction is tracked as
+   * a follow-up so a future fix to one does not silently miss the other.
    */
   private ResolveResult listRelationsByPrefix(
       String correlationId, NameRef prefix, int limit, String token, boolean tables) {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -49,7 +49,10 @@ import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -400,19 +403,7 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
   @Override
   public ResolveResult listTablesByPrefix(
       String correlationId, NameRef prefix, int limit, String token) {
-
-    EngineContext ctx = engineContext();
-    int max = normalizeLimit(limit);
-    String userToken = decodeUserToken(token);
-    boolean firstPage = userToken.isBlank();
-
-    List<CatalogOverlay.QualifiedRelation> system =
-        firstPage ? collectSystemRelationsInNamespace(prefix, ctx, true, max) : List.of();
-    int userLimit = Math.max(1, max - system.size());
-    ResolveResult user =
-        toResolveResult(userGraph.resolveTables(correlationId, prefix, userLimit, userToken));
-
-    return mergePrefixResults(system, user, max);
+    return listRelationsByPrefix(correlationId, prefix, limit, token, true);
   }
 
   /**
@@ -465,19 +456,89 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
   @Override
   public ResolveResult listViewsByPrefix(
       String correlationId, NameRef prefix, int limit, String token) {
+    return listRelationsByPrefix(correlationId, prefix, limit, token, false);
+  }
+
+  /**
+   * Phased prefix listing: system relations first (sorted by canonical name), then user relations.
+   *
+   * <p>Tokens are phase-scoped so neither cursor can advance past rows the page did not emit. A
+   * {@code sys:} token resumes the (bounded, in-memory) system list after the carried name; the
+   * user-phase token is the user graph's own cursor. The user graph is only consulted for rows once
+   * the system rows are fully emitted, so a page filled by system rows never advances — and can
+   * never drop — user results. Reported totals combine both sources.
+   */
+  private ResolveResult listRelationsByPrefix(
+      String correlationId, NameRef prefix, int limit, String token, boolean tables) {
 
     EngineContext ctx = engineContext();
     int max = normalizeLimit(limit);
-    String userToken = decodeUserToken(token);
-    boolean firstPage = userToken.isBlank();
 
-    List<CatalogOverlay.QualifiedRelation> system =
-        firstPage ? collectSystemRelationsInNamespace(prefix, ctx, false, max) : List.of();
-    int userLimit = Math.max(1, max - system.size());
+    final boolean sysToken = token != null && token.startsWith(SYS_TOKEN_PREFIX);
+    final String sysResume = sysToken ? decodeSysToken(correlationId, token) : "";
+    final boolean userPhase = !sysToken && token != null && !token.isBlank();
+    final String userToken = userPhase ? decodeUserToken(token) : "";
+
+    // Collected on every page (bounded, in-memory) so totals can include the system rows.
+    List<CatalogOverlay.QualifiedRelation> systemAll =
+        new ArrayList<>(collectSystemRelationsInNamespace(prefix, ctx, tables, Integer.MAX_VALUE));
+    systemAll.sort(Comparator.comparing(rel -> canonicalName(rel.name())));
+
+    var merged = new ArrayList<CatalogOverlay.QualifiedRelation>(Math.min(max, 64));
+
+    if (!userPhase) {
+      String lastSystemName = "";
+      for (CatalogOverlay.QualifiedRelation rel : systemAll) {
+        String name = canonicalName(rel.name());
+        if (!sysResume.isBlank() && name.compareTo(sysResume) <= 0) {
+          continue;
+        }
+        if (merged.size() >= max) {
+          // System rows remain: continue the system phase next page; the user cursor is untouched.
+          return new ResolveResult(
+              merged,
+              systemAll.size() + userTotalByPrefix(correlationId, prefix, tables),
+              SYS_TOKEN_PREFIX + encodeSysName(lastSystemName));
+        }
+        merged.add(rel);
+        lastSystemName = name;
+      }
+      if (merged.size() >= max) {
+        // Page filled exactly as the system rows ran out: hand off to the user phase without
+        // advancing its cursor. The next page starts the user scan from the beginning.
+        return new ResolveResult(
+            merged,
+            systemAll.size() + userTotalByPrefix(correlationId, prefix, tables),
+            USER_TOKEN_PREFIX);
+      }
+    }
+
+    int room = max - merged.size();
     ResolveResult user =
-        toResolveResult(userGraph.resolveViews(correlationId, prefix, userLimit, userToken));
+        toResolveResult(
+            tables
+                ? userGraph.resolveTables(correlationId, prefix, room, userToken)
+                : userGraph.resolveViews(correlationId, prefix, room, userToken));
+    for (CatalogOverlay.QualifiedRelation rel : user.relations()) {
+      if (merged.size() >= max) {
+        break;
+      }
+      merged.add(rel);
+    }
+    return new ResolveResult(
+        merged, systemAll.size() + user.totalSize(), encodeUserToken(user.nextToken()));
+  }
 
-    return mergePrefixResults(system, user, max);
+  /**
+   * User-relation total for combined counts on system-phase pages. The one-row probe's rows and
+   * cursor are discarded; the user phase later starts from a blank cursor, so nothing is skipped.
+   */
+  private int userTotalByPrefix(String correlationId, NameRef prefix, boolean tables) {
+    return toResolveResult(
+            tables
+                ? userGraph.resolveTables(correlationId, prefix, 1, "")
+                : userGraph.resolveViews(correlationId, prefix, 1, ""))
+        .totalSize();
   }
 
   /**
@@ -661,6 +722,8 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
    */
   private static final String USER_TOKEN_PREFIX = "u:";
 
+  private static final String SYS_TOKEN_PREFIX = "sys:";
+
   private static int normalizeLimit(int limit) {
     return Math.max(1, limit > 0 ? limit : 50);
   }
@@ -677,6 +740,25 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
       return token.substring(USER_TOKEN_PREFIX.length());
     }
     return token;
+  }
+
+  private static String encodeSysName(String name) {
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(name.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private String decodeSysToken(String correlationId, String token) {
+    try {
+      return new String(
+          Base64.getUrlDecoder().decode(token.substring(SYS_TOKEN_PREFIX.length())),
+          StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException badToken) {
+      throw GrpcErrors.invalidArgument(
+          correlationId,
+          GeneratedErrorMessages.MessageKey.PAGE_TOKEN_INVALID,
+          Map.of("page_token", token));
+    }
   }
 
   private static String encodeUserToken(String token) {
@@ -769,27 +851,6 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     }
 
     return out;
-  }
-
-  private ResolveResult mergePrefixResults(
-      List<CatalogOverlay.QualifiedRelation> system, ResolveResult user, int max) {
-    List<CatalogOverlay.QualifiedRelation> merged = new ArrayList<>();
-
-    for (CatalogOverlay.QualifiedRelation rel : system) {
-      if (merged.size() >= max) {
-        break;
-      }
-      merged.add(rel);
-    }
-
-    for (CatalogOverlay.QualifiedRelation rel : user.relations()) {
-      if (merged.size() >= max) {
-        break;
-      }
-      merged.add(rel);
-    }
-
-    return new ResolveResult(merged, user.totalSize(), encodeUserToken(user.nextToken()));
   }
 
   // ---- Lightweight ref listing and topology-cache invalidation ----

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -449,6 +449,18 @@ public final class UserGraph {
     return new ResolveResult(fqResult);
   }
 
+  /** Counts user tables under a prefix without fetching any rows. */
+  public int countTablesByPrefix(String cid, NameRef prefix) {
+    validateNameRef(cid, prefix);
+    return fq.countTablesByPrefix(cid, requireAccountId(cid), prefix);
+  }
+
+  /** Counts user views under a prefix without fetching any rows. */
+  public int countViewsByPrefix(String cid, NameRef prefix) {
+    validateNameRef(cid, prefix);
+    return fq.countViewsByPrefix(cid, requireAccountId(cid), prefix);
+  }
+
   // ----------------------------------------------------------------------
   // Unified relation listing (tables + views)
   // ----------------------------------------------------------------------

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/FullyQualifiedResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/FullyQualifiedResolver.java
@@ -192,6 +192,43 @@ public class FullyQualifiedResolver {
     return new ResolveResult(out, total, next.toString());
   }
 
+  /**
+   * Counts user tables under a prefix without fetching any rows. Unlike {@link
+   * #resolveTablesByPrefix}, this skips the row listing entirely — callers that only need the total
+   * (e.g. combined system+user counts on a system-phase page) should use this rather than a one-row
+   * probe whose rows and cursor are discarded.
+   */
+  public int countTablesByPrefix(String cid, String accountId, NameRef prefix) {
+    Optional<Catalog> catalogOpt = catalogByName(cid, accountId, prefix.getCatalog());
+    if (catalogOpt.isEmpty()) {
+      return 0;
+    }
+    Catalog catalog = catalogOpt.get();
+    Optional<Namespace> nsOpt = namespaceByPath(cid, accountId, catalog, namespacePath(prefix));
+    if (nsOpt.isEmpty()) {
+      return 0;
+    }
+    return tableRepository.count(
+        accountId, catalog.getResourceId().getId(), nsOpt.get().getResourceId().getId());
+  }
+
+  /**
+   * Counts user views under a prefix without fetching any rows. See {@link #countTablesByPrefix}.
+   */
+  public int countViewsByPrefix(String cid, String accountId, NameRef prefix) {
+    Optional<Catalog> catalogOpt = catalogByName(cid, accountId, prefix.getCatalog());
+    if (catalogOpt.isEmpty()) {
+      return 0;
+    }
+    Catalog catalog = catalogOpt.get();
+    Optional<Namespace> nsOpt = namespaceByPath(cid, accountId, catalog, namespacePath(prefix));
+    if (nsOpt.isEmpty()) {
+      return 0;
+    }
+    return viewRepository.count(
+        accountId, catalog.getResourceId().getId(), nsOpt.get().getResourceId().getId());
+  }
+
   // ----------------------------------------------------------------------
   // Internal helpers (canonical entry resolution)
   // ----------------------------------------------------------------------

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -39,9 +39,11 @@ import java.util.Set;
 public class NamespaceRepository {
 
   private final GenericResourceRepository<Namespace, NamespaceKey> repo;
+  private final PointerStore pointerStore;
 
   @Inject
   public NamespaceRepository(PointerStore pointerStore, BlobStore blobStore) {
+    this.pointerStore = pointerStore;
     this.repo =
         new GenericResourceRepository<>(
             pointerStore,
@@ -96,6 +98,16 @@ public class NamespaceRepository {
   public int count(String accountId, String catalogId, List<String> parentSegmentsOrEmpty) {
     String prefix = Keys.namespacePointerByPathPrefix(accountId, catalogId, parentSegmentsOrEmpty);
     return repo.countByPrefix(prefix);
+  }
+
+  /**
+   * Page token resuming a {@link #list} scan immediately after the namespace at {@code fullPath}.
+   * Lets callers that post-filter scanned rows continue exactly after the last row they emitted
+   * instead of after the whole over-fetched batch.
+   */
+  public String listTokenAfter(String accountId, String catalogId, List<String> fullPath) {
+    return pointerStore.pageTokenAfterKey(
+        Keys.namespacePointerByPath(accountId, catalogId, fullPath));
   }
 
   public List<ResourceId> listIds(String accountId, String catalogId) {

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -132,6 +132,18 @@ class CatalogSurfaceNamespacesTest {
   }
 
   @Test
+  void listNamespacesDoesNotDropSystemNamespacesSortingBeforeLastUserNamespace() {
+    // Regression: the system phase must resume by a system relative name, not by the last user
+    // relative name. "alpha" sorts before the last user namespace "orders" and must still appear.
+    stubUserNamespaces(List.of(namespace("orders", List.of())));
+    overlay.addNode(namespaceNode(systemNamespaceId("alpha"), "alpha", List.of()));
+    overlay.addNode(
+        namespaceNode(systemNamespaceId("information_schema"), "information_schema", List.of()));
+
+    assertEquals(List.of("orders", "alpha", "information_schema"), pageAllNamespaceNames(1));
+  }
+
+  @Test
   void listNamespacesRejectsMalformedServicePageToken() {
     StatusRuntimeException ex =
         assertThrows(

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -99,7 +99,32 @@ class CatalogSurfaceNamespacesTest {
             CORRELATION_ID);
 
     assertEquals(List.of("information_schema"), names(systemPage.getNamespacesList()));
-    assertTrue(systemPage.getPage().getNextPageToken().startsWith("ns:"));
+    // It is the only system namespace and it exactly fills the page, so there is no next page —
+    // the system phase must not advertise a continuation whose next page would be empty.
+    assertTrue(systemPage.getPage().getNextPageToken().isEmpty());
+  }
+
+  @Test
+  void listNamespacesSystemExactlyFillsPageEmitsNoToken() {
+    // Regression: a page that exactly consumes the last system namespace must not advertise an
+    // ns: continuation, whose next page would come back empty.
+    stubUserNamespaces(List.of());
+    overlay.addNode(
+        namespaceNode(systemNamespaceId("information_schema"), "information_schema", List.of()));
+
+    var page =
+        surface.listNamespaces(
+            ListNamespacesRequest.newBuilder()
+                .setCatalogId(catalogId)
+                .setPage(PageRequest.newBuilder().setPageSize(1))
+                .build(),
+            ACCOUNT_ID,
+            CORRELATION_ID);
+
+    assertEquals(List.of("information_schema"), names(page.getNamespacesList()));
+    assertTrue(
+        page.getPage().getNextPageToken().isEmpty(),
+        "exact-fill on the last system namespace must not emit a continuation token");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -70,26 +70,9 @@ class CatalogSurfaceNamespacesTest {
 
   @Test
   void listNamespacesKeepsRepoPhaseBeforeSystemPhase() {
-    Namespace userNamespace = namespace("alpha", List.of());
-    var systemNamespace =
-        namespaceNode(systemNamespaceId("information_schema"), "information_schema", List.of());
-    overlay.addNode(systemNamespace);
-
-    when(namespaceRepo.list(eq(ACCOUNT_ID), eq("cat"), eq(List.of()), anyInt(), anyString(), any()))
-        .thenAnswer(
-            invocation -> {
-              int limit = invocation.getArgument(3);
-              String cursor = invocation.getArgument(4);
-              StringBuilder nextOut = invocation.getArgument(5);
-              if (limit == 64 && cursor.isBlank()) {
-                nextOut.append("repo-next");
-                return List.of(userNamespace);
-              }
-              if (limit == 1000 && cursor.isBlank()) {
-                return List.of(userNamespace);
-              }
-              return List.of();
-            });
+    stubUserNamespaces(List.of(namespace("alpha", List.of())));
+    overlay.addNode(
+        namespaceNode(systemNamespaceId("information_schema"), "information_schema", List.of()));
 
     var firstPage =
         surface.listNamespaces(
@@ -101,20 +84,39 @@ class CatalogSurfaceNamespacesTest {
             CORRELATION_ID);
 
     assertEquals(List.of("alpha"), names(firstPage.getNamespacesList()));
-    assertEquals("repo-next", firstPage.getPage().getNextPageToken());
+    // Page filled in the repo phase: the token is a precise repo cursor, not a system-phase token.
+    String repoCursor = firstPage.getPage().getNextPageToken();
+    assertTrue(!repoCursor.isBlank() && !repoCursor.startsWith("ns:"));
     assertEquals(2, firstPage.getPage().getTotalSize());
 
     var systemPage =
         surface.listNamespaces(
             ListNamespacesRequest.newBuilder()
                 .setCatalogId(catalogId)
-                .setPage(PageRequest.newBuilder().setPageSize(1).setPageToken("repo-next"))
+                .setPage(PageRequest.newBuilder().setPageSize(1).setPageToken(repoCursor))
                 .build(),
             ACCOUNT_ID,
             CORRELATION_ID);
 
     assertEquals(List.of("information_schema"), names(systemPage.getNamespacesList()));
     assertTrue(systemPage.getPage().getNextPageToken().startsWith("ns:"));
+  }
+
+  @Test
+  void listNamespacesDoesNotSkipMatchesWhenPageFillsMidBatch() {
+    // Regression: the repo scan over-fetches (batch >= 64) and post-filters, so with more matching
+    // children than one batch the continuation must resume after the last *emitted* row, not after
+    // the scanned batch. A batch-end cursor silently skips every match scanned past the page fill.
+    var many = new java.util.ArrayList<Namespace>();
+    var expected = new java.util.ArrayList<String>();
+    for (int i = 0; i < 70; i++) {
+      String name = String.format("ns%02d", i);
+      many.add(namespace(name, List.of()));
+      expected.add(name);
+    }
+    stubUserNamespaces(many);
+
+    assertEquals(expected, pageAllNamespaceNames(3));
   }
 
   @Test
@@ -180,14 +182,40 @@ class CatalogSurfaceNamespacesTest {
     return namespaces.stream().map(Namespace::getDisplayName).toList();
   }
 
-  /** Stubs the repo so all user namespaces come back in a single exhausting batch. */
+  /**
+   * Stubs the repo mock as a faithful pager backend: rows are served in name order, {@code list}
+   * returns up to {@code limit} rows strictly after the cursor name (blank = start) and sets the
+   * next cursor to the last returned name when more remain, and {@code listTokenAfter} returns the
+   * row's name — mirroring the real store's "resume after this key" semantics.
+   */
   private void stubUserNamespaces(List<Namespace> userNamespaces) {
+    var sorted = new java.util.ArrayList<>(userNamespaces);
+    sorted.sort(java.util.Comparator.comparing(Namespace::getDisplayName));
     when(namespaceRepo.list(eq(ACCOUNT_ID), eq("cat"), eq(List.of()), anyInt(), anyString(), any()))
         .thenAnswer(
             invocation -> {
+              int limit = invocation.getArgument(3);
               String cursor = invocation.getArgument(4);
-              // Leave the "next" cursor blank: a blank next-token signals repo exhaustion.
-              return cursor == null || cursor.isBlank() ? userNamespaces : List.of();
+              StringBuilder nextOut = invocation.getArgument(5);
+              var remaining =
+                  sorted.stream()
+                      .filter(
+                          ns ->
+                              cursor == null
+                                  || cursor.isBlank()
+                                  || ns.getDisplayName().compareTo(cursor) > 0)
+                      .toList();
+              var page = remaining.subList(0, Math.min(limit, remaining.size()));
+              if (!page.isEmpty() && page.size() < remaining.size()) {
+                nextOut.append(page.get(page.size() - 1).getDisplayName());
+              }
+              return page;
+            });
+    when(namespaceRepo.listTokenAfter(eq(ACCOUNT_ID), eq("cat"), any()))
+        .thenAnswer(
+            invocation -> {
+              List<String> fullPath = invocation.getArgument(2);
+              return fullPath.get(fullPath.size() - 1);
             });
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -118,6 +118,20 @@ class CatalogSurfaceNamespacesTest {
   }
 
   @Test
+  void listNamespacesPagesThroughAllUserNamespacesWhenRepoExhaustsInOneBatch() {
+    // Regression: a single repo batch that exhausts the cursor may contain more matches than fit
+    // on one page. Later pages must keep returning the remaining user namespaces rather than
+    // jumping straight to the (empty) system phase.
+    stubUserNamespaces(
+        List.of(
+            namespace("alpha", List.of()),
+            namespace("bravo", List.of()),
+            namespace("charlie", List.of())));
+
+    assertEquals(List.of("alpha", "bravo", "charlie"), pageAllNamespaceNames(1));
+  }
+
+  @Test
   void listNamespacesRejectsMalformedServicePageToken() {
     StatusRuntimeException ex =
         assertThrows(
@@ -152,6 +166,39 @@ class CatalogSurfaceNamespacesTest {
 
   private static List<String> names(List<Namespace> namespaces) {
     return namespaces.stream().map(Namespace::getDisplayName).toList();
+  }
+
+  /** Stubs the repo so all user namespaces come back in a single exhausting batch. */
+  private void stubUserNamespaces(List<Namespace> userNamespaces) {
+    when(namespaceRepo.list(eq(ACCOUNT_ID), eq("cat"), eq(List.of()), anyInt(), anyString(), any()))
+        .thenAnswer(
+            invocation -> {
+              String cursor = invocation.getArgument(4);
+              // Leave the "next" cursor blank: a blank next-token signals repo exhaustion.
+              return cursor == null || cursor.isBlank() ? userNamespaces : List.of();
+            });
+  }
+
+  /** Drains every page (page_size {@code pageSize}) and returns the concatenated display names. */
+  private List<String> pageAllNamespaceNames(int pageSize) {
+    var collected = new java.util.ArrayList<String>();
+    String token = "";
+    for (int guard = 0; guard < 100; guard++) {
+      var response =
+          surface.listNamespaces(
+              ListNamespacesRequest.newBuilder()
+                  .setCatalogId(catalogId)
+                  .setPage(PageRequest.newBuilder().setPageSize(pageSize).setPageToken(token))
+                  .build(),
+              ACCOUNT_ID,
+              CORRELATION_ID);
+      collected.addAll(names(response.getNamespacesList()));
+      token = response.getPage().getNextPageToken();
+      if (token.isBlank()) {
+        return collected;
+      }
+    }
+    throw new AssertionError("pagination did not terminate; collected so far: " + collected);
   }
 
   private Namespace namespace(String name, List<String> path) {

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -134,6 +134,50 @@ class CatalogSurfaceNamespacesTest {
   }
 
   @Test
+  void listNamespacesPagesCompletelyOverARealRepositoryAndStore() {
+    // End-to-end over the real chain: pager -> NamespaceRepository -> InMemoryPointerStore,
+    // including listTokenAfter -> pageTokenAfterKey cursor synthesis. Catches any drift between
+    // the pointer keys the repository writes and the keys the pager resumes from — mocked-repo
+    // tests re-implement the cursor contract and cannot.
+    var pointers = new ai.floedb.floecat.storage.memory.InMemoryPointerStore();
+    var blobs = new ai.floedb.floecat.storage.memory.InMemoryBlobStore();
+    var realRepo = new NamespaceRepository(pointers, blobs);
+    var realSurface = new CatalogSurfaceNamespaces(realRepo, overlay);
+
+    var expected = new java.util.ArrayList<String>();
+    for (int i = 0; i < 150; i++) {
+      String name = String.format("ns%03d", i);
+      expected.add(name);
+      realRepo.create(
+          Namespace.newBuilder()
+              .setResourceId(id(ResourceKind.RK_NAMESPACE, "id_" + name))
+              .setCatalogId(catalogId)
+              .setDisplayName(name)
+              .build());
+    }
+
+    var collected = new java.util.ArrayList<String>();
+    String token = "";
+    for (int guard = 0; guard < 200; guard++) {
+      var response =
+          realSurface.listNamespaces(
+              ListNamespacesRequest.newBuilder()
+                  .setCatalogId(catalogId)
+                  .setPage(PageRequest.newBuilder().setPageSize(7).setPageToken(token))
+                  .build(),
+              ACCOUNT_ID,
+              CORRELATION_ID);
+      collected.addAll(names(response.getNamespacesList()));
+      token = response.getPage().getNextPageToken();
+      if (token.isBlank()) {
+        break;
+      }
+    }
+
+    assertEquals(expected, collected);
+  }
+
+  @Test
   void listNamespacesDoesNotDropSystemNamespacesSortingBeforeLastUserNamespace() {
     // Regression: the system phase must resume by a system relative name, not by the last user
     // relative name. "alpha" sorts before the last user namespace "orders" and must still appear.

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -548,6 +548,140 @@ class MetaGraphTest {
     assertThat(collected).containsExactly(sysTable, sysTableB);
   }
 
+  @Test
+  void listTablesByPrefix_mixedPageEmitsSystemThenUserWithUserCursor() {
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(List.of(prefixSystemTable(sysTable, namespaceId, "system_table")));
+    when(system.tableName(sysTable, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("system_table").build()));
+
+    ResourceId userTableB =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("usr-b")
+            .build();
+    UserGraph.ResolveResult userResult =
+        userResolveResult(
+            5,
+            "more",
+            new CatalogOverlay.QualifiedRelation(
+                NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("u1").build(),
+                usrTable),
+            new CatalogOverlay.QualifiedRelation(
+                NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("u2").build(),
+                userTableB));
+    when(user.resolveTables(eq("cid"), eq(prefix), eq(2), eq(""))).thenReturn(userResult);
+
+    CatalogOverlay.ResolveResult page = meta.listTablesByPrefix("cid", prefix, 3, "");
+
+    assertThat(page.relations()).hasSize(3);
+    assertThat(page.relations().get(0).resourceId()).isEqualTo(sysTable);
+    assertThat(page.relations().get(1).resourceId()).isEqualTo(usrTable);
+    assertThat(page.relations().get(2).resourceId()).isEqualTo(userTableB);
+    // System row count + user total; continuation carries the user graph's cursor.
+    assertThat(page.totalSize()).isEqualTo(6);
+    assertThat(page.nextToken()).isEqualTo("u:more");
+  }
+
+  @Test
+  void listViewsByPrefix_systemFillingPageDoesNotSkipUserRows() {
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    ResourceId sysView =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_VIEW)
+            .setId("sys-view")
+            .build();
+    ResourceId usrView =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_VIEW)
+            .setId("usr-view")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(List.of(prefixSystemView(sysView, namespaceId, "system_view")));
+    when(system.viewName(sysView, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("system_view").build()));
+
+    UserGraph.ResolveResult userResult =
+        userResolveResult(
+            1,
+            "",
+            new CatalogOverlay.QualifiedRelation(
+                NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("uv").build(),
+                usrView));
+    when(user.resolveViews(eq("cid"), eq(prefix), eq(1), eq(""))).thenReturn(userResult);
+
+    CatalogOverlay.ResolveResult firstPage = meta.listViewsByPrefix("cid", prefix, 1, "");
+
+    assertThat(firstPage.relations()).hasSize(1);
+    assertThat(firstPage.relations().get(0).resourceId()).isEqualTo(sysView);
+    assertThat(firstPage.totalSize()).isEqualTo(2);
+
+    CatalogOverlay.ResolveResult secondPage =
+        meta.listViewsByPrefix("cid", prefix, 1, firstPage.nextToken());
+
+    assertThat(secondPage.relations()).hasSize(1);
+    assertThat(secondPage.relations().get(0).resourceId()).isEqualTo(usrView);
+    verify(user, times(2)).resolveViews(eq("cid"), eq(prefix), eq(1), eq(""));
+  }
+
+  @Test
+  void listTablesByPrefix_rejectsMalformedSystemToken() {
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+
+    assertThatThrownBy(() -> meta.listTablesByPrefix("cid", prefix, 1, "sys:%%%"))
+        .isInstanceOf(io.grpc.StatusRuntimeException.class)
+        .satisfies(
+            ex ->
+                assertThat(((io.grpc.StatusRuntimeException) ex).getStatus().getCode())
+                    .isEqualTo(io.grpc.Status.Code.INVALID_ARGUMENT));
+  }
+
+  private static ai.floedb.floecat.metagraph.model.ViewNode prefixSystemView(
+      ResourceId id, ResourceId namespaceId, String name) {
+    return new ai.floedb.floecat.metagraph.model.ViewNode(
+        id,
+        1L,
+        Instant.EPOCH,
+        ResourceId.getDefaultInstance(),
+        namespaceId,
+        name,
+        "select 1",
+        "sql",
+        List.of(),
+        List.of(),
+        List.of(),
+        GraphNodeOrigin.SYSTEM,
+        Map.of(),
+        Optional.empty(),
+        Map.of(),
+        Map.of());
+  }
+
   private static TableNode prefixSystemTable(ResourceId id, ResourceId namespaceId, String name) {
     return new TableNode() {
       @Override

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -451,6 +451,143 @@ class MetaGraphTest {
   }
 
   @Test
+  void listTablesByPrefix_systemFillingPageDoesNotSkipUserRows() {
+    // Regression: when system rows fill the page, the user graph must not be consulted for rows
+    // (its cursor would advance past a row the page drops). The user row must surface on the next
+    // page, fetched from a blank cursor.
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(List.of(prefixSystemTable(sysTable, namespaceId, "system_table")));
+    when(system.tableName(sysTable, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("system_table").build()));
+
+    UserGraph.ResolveResult userResult =
+        userResolveResult(
+            1,
+            "",
+            new CatalogOverlay.QualifiedRelation(
+                NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("user_t").build(),
+                usrTable));
+    when(user.resolveTables(eq("cid"), eq(prefix), eq(1), eq(""))).thenReturn(userResult);
+
+    CatalogOverlay.ResolveResult firstPage = meta.listTablesByPrefix("cid", prefix, 1, "");
+
+    assertThat(firstPage.relations()).hasSize(1);
+    assertThat(firstPage.relations().get(0).resourceId()).isEqualTo(sysTable);
+    assertThat(firstPage.totalSize()).isEqualTo(2);
+
+    CatalogOverlay.ResolveResult secondPage =
+        meta.listTablesByPrefix("cid", prefix, 1, firstPage.nextToken());
+
+    assertThat(secondPage.relations()).hasSize(1);
+    assertThat(secondPage.relations().get(0).resourceId()).isEqualTo(usrTable);
+    assertThat(secondPage.totalSize()).isEqualTo(2);
+    // Probe on the boundary page plus the second page's fetch, always from a blank cursor.
+    verify(user, times(2)).resolveTables(eq("cid"), eq(prefix), eq(1), eq(""));
+  }
+
+  @Test
+  void listTablesByPrefix_pagesThroughSystemOverflowWithoutLoss() {
+    // Regression: system rows beyond the page size were dropped (system was collected first-page
+    // only, capped at the page size). They must flow across pages via the system-phase token.
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    ResourceId sysTableB =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("sys-t-b")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(
+            List.of(
+                prefixSystemTable(sysTableB, namespaceId, "b_sys"),
+                prefixSystemTable(sysTable, namespaceId, "a_sys")));
+    when(system.tableName(sysTable, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("a_sys").build()));
+    when(system.tableName(sysTableB, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("b_sys").build()));
+    when(user.resolveTables(eq("cid"), eq(prefix), eq(1), eq("")))
+        .thenReturn(
+            new UserGraph.ResolveResult(
+                new FullyQualifiedResolver.ResolveResult(List.of(), 0, "")));
+
+    var collected = new java.util.ArrayList<ResourceId>();
+    String token = "";
+    for (int guard = 0; guard < 10 && collected.size() < 2; guard++) {
+      CatalogOverlay.ResolveResult page = meta.listTablesByPrefix("cid", prefix, 1, token);
+      page.relations().forEach(rel -> collected.add(rel.resourceId()));
+      assertThat(page.totalSize()).isEqualTo(2);
+      token = page.nextToken();
+      if (token.isBlank()) {
+        break;
+      }
+    }
+
+    // Sorted by canonical name: a_sys then b_sys, no gaps, no duplicates.
+    assertThat(collected).containsExactly(sysTable, sysTableB);
+  }
+
+  private static TableNode prefixSystemTable(ResourceId id, ResourceId namespaceId, String name) {
+    return new TableNode() {
+      @Override
+      public ResourceId namespaceId() {
+        return namespaceId;
+      }
+
+      @Override
+      public String displayName() {
+        return name;
+      }
+
+      @Override
+      public ResourceId id() {
+        return id;
+      }
+
+      @Override
+      public long version() {
+        return 1;
+      }
+
+      @Override
+      public Instant metadataUpdatedAt() {
+        return Instant.EPOCH;
+      }
+
+      @Override
+      public GraphNodeOrigin origin() {
+        return GraphNodeOrigin.SYSTEM;
+      }
+
+      @Override
+      public Map<EngineHintKey, EngineHint> engineHints() {
+        return Map.of();
+      }
+    };
+  }
+
+  @Test
   void resolveTables_prefix_resolvesSystemNamespaceWithNameSegment() {
     NameRef prefix =
         NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -479,6 +479,7 @@ class MetaGraphTest {
                 NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("user_t").build(),
                 usrTable));
     when(user.resolveTables(eq("cid"), eq(prefix), eq(1), eq(""))).thenReturn(userResult);
+    when(user.countTablesByPrefix(eq("cid"), eq(prefix))).thenReturn(1);
 
     CatalogOverlay.ResolveResult firstPage = meta.listTablesByPrefix("cid", prefix, 1, "");
 
@@ -492,8 +493,10 @@ class MetaGraphTest {
     assertThat(secondPage.relations()).hasSize(1);
     assertThat(secondPage.relations().get(0).resourceId()).isEqualTo(usrTable);
     assertThat(secondPage.totalSize()).isEqualTo(2);
-    // Probe on the boundary page plus the second page's fetch, always from a blank cursor.
-    verify(user, times(2)).resolveTables(eq("cid"), eq(prefix), eq(1), eq(""));
+    // The boundary page's total now uses the count-only path (no discarded one-row probe); only the
+    // second page fetches rows, from a blank cursor.
+    verify(user, times(1)).resolveTables(eq("cid"), eq(prefix), eq(1), eq(""));
+    verify(user).countTablesByPrefix(eq("cid"), eq(prefix));
   }
 
   @Test
@@ -633,6 +636,7 @@ class MetaGraphTest {
                 NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("uv").build(),
                 usrView));
     when(user.resolveViews(eq("cid"), eq(prefix), eq(1), eq(""))).thenReturn(userResult);
+    when(user.countViewsByPrefix(eq("cid"), eq(prefix))).thenReturn(1);
 
     CatalogOverlay.ResolveResult firstPage = meta.listViewsByPrefix("cid", prefix, 1, "");
 
@@ -645,7 +649,10 @@ class MetaGraphTest {
 
     assertThat(secondPage.relations()).hasSize(1);
     assertThat(secondPage.relations().get(0).resourceId()).isEqualTo(usrView);
-    verify(user, times(2)).resolveViews(eq("cid"), eq(prefix), eq(1), eq(""));
+    // The boundary page's total now uses the count-only path (no discarded one-row probe); only the
+    // second page fetches rows, from a blank cursor.
+    verify(user, times(1)).resolveViews(eq("cid"), eq(prefix), eq(1), eq(""));
+    verify(user).countViewsByPrefix(eq("cid"), eq(prefix));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -500,6 +500,37 @@ class MetaGraphTest {
   }
 
   @Test
+  void listTablesByPrefix_systemExactlyFillsPageWithNoUserRows_emitsNoToken() {
+    // Regression: system rows exactly fill the page and there are no user rows. The handoff must
+    // not advertise a user-phase page that would come back empty.
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(List.of(prefixSystemTable(sysTable, namespaceId, "system_table")));
+    when(system.tableName(sysTable, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("system_table").build()));
+    when(user.countTablesByPrefix(eq("cid"), eq(prefix))).thenReturn(0);
+
+    CatalogOverlay.ResolveResult page = meta.listTablesByPrefix("cid", prefix, 1, "");
+
+    assertThat(page.relations()).hasSize(1);
+    assertThat(page.relations().get(0).resourceId()).isEqualTo(sysTable);
+    assertThat(page.totalSize()).isEqualTo(1);
+    assertThat(page.nextToken()).isEmpty();
+    // No user-phase row fetch — there is nothing to continue into.
+    verify(user, never()).resolveTables(eq("cid"), eq(prefix), eq(1), eq(""));
+  }
+
+  @Test
   void listTablesByPrefix_pagesThroughSystemOverflowWithoutLoss() {
     // Regression: system rows beyond the page size were dropped (system was collected first-page
     // only, capped at the page size). They must flow across pages via the system-phase token.

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
@@ -81,6 +81,11 @@ final class RepoTestPointerStores {
     public boolean isEmpty() {
       return delegate.isEmpty();
     }
+
+    @Override
+    public String pageTokenAfterKey(String key) {
+      return delegate.pageTokenAfterKey(key);
+    }
   }
 
   /** Fails every batch CAS, simulating a transient storage error that aborts the transaction. */

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -160,6 +160,15 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     return Optional.of(Map.of(ATTR_PARTITION_KEY, S(parts[0]), ATTR_SORT_KEY, S(parts[1])));
   }
 
+  @Override
+  public String pageTokenAfterKey(Key key) {
+    // Tokens are the (pk, sk) position encoded exactly as lastEvaluatedKey tokens are; DynamoDB's
+    // exclusiveStartKey is a position, not an item reference, so the key need not still exist.
+    return encodeToken(
+            Map.of(ATTR_PARTITION_KEY, S(key.partitionKey()), ATTR_SORT_KEY, S(key.sortKey())))
+        .orElseThrow();
+  }
+
   private static <T> Uni<T> fromStage(CompletionStage<T> stage) {
     return Uni.createFrom()
         .emitter(

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -164,9 +164,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   public String pageTokenAfterKey(Key key) {
     // Tokens are the (pk, sk) position encoded exactly as lastEvaluatedKey tokens are; DynamoDB's
     // exclusiveStartKey is a position, not an item reference, so the key need not still exist.
-    return encodeToken(
-            Map.of(ATTR_PARTITION_KEY, S(key.partitionKey()), ATTR_SORT_KEY, S(key.sortKey())))
-        .orElseThrow();
+    return encodeToken(keyMap(key)).orElseThrow();
   }
 
   private static <T> Uni<T> fromStage(CompletionStage<T> stage) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
@@ -77,6 +77,11 @@ public abstract class KvPointerStore implements PointerStore {
   }
 
   @Override
+  public String pageTokenAfterKey(String key) {
+    return pointers.pageTokenAfterKey(key);
+  }
+
+  @Override
   public int deleteByPrefix(String prefix) {
     return await(() -> pointers.deleteByPrefix(prefix).await().indefinitely());
   }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -299,6 +299,11 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
                     page.items().stream().map(this::decode).toList(), page.nextToken()));
   }
 
+  /** Page token resuming a {@link #listByPrefix} scan immediately after the given pointer key. */
+  public String pageTokenAfterKey(String key) {
+    return kv.pageTokenAfterKey(pointerKey(key));
+  }
+
   /**
    * List pointer keys by prefix.
    *

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStorePageTokenTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStorePageTokenTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv.dynamodb;
+
+import static ai.floedb.floecat.storage.kv.dynamodb.DynamoDbKvStore.decodeToken;
+import static ai.floedb.floecat.storage.kv.dynamodb.DynamoDbKvStore.encodeToken;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.floedb.floecat.storage.kv.KvAttributes;
+import ai.floedb.floecat.storage.kv.KvStore;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Pins the token contract behind {@link DynamoDbKvStore#pageTokenAfterKey}: a synthesized token
+ * must be byte-identical to the lastEvaluatedKey token the store would emit for the same (pk, sk)
+ * position, so callers can resume a scan exactly after a row they consumed.
+ */
+class DynamoDbKvStorePageTokenTest implements KvAttributes {
+
+  private final DynamoDbKvStore store =
+      new DynamoDbKvStore((software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient) null, "t");
+
+  @Test
+  void pageTokenAfterKeyMatchesLastEvaluatedKeyEncoding() {
+    var key = new KvStore.Key("accounts/acct-1", "catalogs/cat/namespaces/by-path/sales");
+    Map<String, AttributeValue> lek =
+        Map.of(
+            ATTR_PARTITION_KEY, AttributeValue.fromS(key.partitionKey()),
+            ATTR_SORT_KEY, AttributeValue.fromS(key.sortKey()));
+
+    assertEquals(encodeToken(lek).orElseThrow(), store.pageTokenAfterKey(key));
+  }
+
+  @Test
+  void pageTokenAfterKeyRoundTripsToTheSamePosition() {
+    var key = new KvStore.Key("accounts/acct-1", "tables/by-name/order%20items");
+
+    Map<String, AttributeValue> decoded =
+        decodeToken(Optional.of(store.pageTokenAfterKey(key))).orElseThrow();
+
+    assertEquals(key.partitionKey(), decoded.get(ATTR_PARTITION_KEY).s());
+    assertEquals(key.sortKey(), decoded.get(ATTR_SORT_KEY).s());
+  }
+}

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -91,10 +91,21 @@ public final class InMemoryKvStore implements KvStore {
           break;
         }
       }
-      if (index < 0) {
+      if (index >= 0) {
+        start = index + 1;
+      } else if (token.startsWith(skPrefix)) {
+        // The token names a position inside this keyspace whose row has since been deleted.
+        // Resume at the insertion point, matching DynamoDB's positional exclusiveStartKey
+        // semantics; tokens outside the keyspace are still rejected as malformed.
+        int insertion = 0;
+        while (insertion < matching.size()
+            && matching.get(insertion).key().sortKey().compareTo(token) <= 0) {
+          insertion++;
+        }
+        start = insertion;
+      } else {
         throw new IllegalArgumentException("Bad page token");
       }
-      start = index + 1;
     }
 
     if (start >= matching.size()) {

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -212,6 +212,12 @@ public final class InMemoryKvStore implements KvStore {
   }
 
   private static String encodeToken(String sortKey) {
+    if (sortKey.isEmpty()) {
+      // base64("") is "", which is this codebase's "no more pages" sentinel: an empty sort key
+      // would emit a token indistinguishable from "done" and silently truncate pagination. No key
+      // uses an empty sort key today, so fail loud rather than produce an ambiguous token.
+      throw new IllegalArgumentException("cannot encode a page token for an empty sort key");
+    }
     return Base64.getUrlEncoder()
         .withoutPadding()
         .encodeToString(sortKey.getBytes(StandardCharsets.UTF_8));

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -111,6 +111,12 @@ public final class InMemoryKvStore implements KvStore {
   }
 
   @Override
+  public String pageTokenAfterKey(Key key) {
+    // Same encoding as end-of-page tokens: base64 of the sort key to resume after.
+    return encodeToken(key.sortKey());
+  }
+
+  @Override
   public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
     String pk = partitionKey == null ? "" : partitionKey;
     String skPrefix = sortKeyPrefix == null ? "" : sortKeyPrefix;

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -93,10 +93,13 @@ public final class InMemoryKvStore implements KvStore {
       }
       if (index >= 0) {
         start = index + 1;
-      } else if (token.startsWith(skPrefix)) {
+      } else if (skPrefix.isEmpty() || token.startsWith(skPrefix)) {
         // The token names a position inside this keyspace whose row has since been deleted.
         // Resume at the insertion point, matching DynamoDB's positional exclusiveStartKey
-        // semantics; tokens outside the keyspace are still rejected as malformed.
+        // semantics. With a non-blank prefix, a token outside it is rejected as malformed below;
+        // a blank prefix scans the whole partition, so there is no keyspace boundary to reject
+        // against and any decodable token is a valid position (decodeToken already rejects tokens
+        // that are not valid base64).
         int insertion = 0;
         while (insertion < matching.size()
             && matching.get(insertion).key().sortKey().compareTo(token) <= 0) {

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
@@ -77,10 +77,16 @@ public class InMemoryPointerStore implements PointerStore {
     int start = 0;
     if (pageToken != null && !pageToken.isEmpty()) {
       int idx = Collections.binarySearch(keys, pageToken);
-      if (idx < 0) {
+      if (idx >= 0) {
+        start = idx + 1;
+      } else if (pageToken.startsWith(pfx)) {
+        // The token names a position inside this keyspace whose row has since been deleted.
+        // Resume at the insertion point, matching DynamoDB's positional exclusiveStartKey
+        // semantics; tokens outside the keyspace are still rejected as malformed.
+        start = -idx - 1;
+      } else {
         throw new IllegalArgumentException("bad page token");
       }
-      start = idx + 1;
     }
 
     if (start >= keys.size()) {

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
@@ -112,6 +112,14 @@ public class InMemoryPointerStore implements PointerStore {
   }
 
   @Override
+  public String pageTokenAfterKey(String key) {
+    // This store's page tokens are raw pointer keys ("resume after this key"), so the key itself
+    // is the token. Resuming after a since-deleted key fails the same way an ordinary end-of-page
+    // token for that key would.
+    return key;
+  }
+
+  @Override
   public int countByPrefix(String prefix) {
     final String pfx = prefix == null ? "" : prefix;
     int n = 0;

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
@@ -79,10 +79,12 @@ public class InMemoryPointerStore implements PointerStore {
       int idx = Collections.binarySearch(keys, pageToken);
       if (idx >= 0) {
         start = idx + 1;
-      } else if (pageToken.startsWith(pfx)) {
+      } else if (pfx.isEmpty() || pageToken.startsWith(pfx)) {
         // The token names a position inside this keyspace whose row has since been deleted.
         // Resume at the insertion point, matching DynamoDB's positional exclusiveStartKey
-        // semantics; tokens outside the keyspace are still rejected as malformed.
+        // semantics. With a non-blank prefix, a token outside it is rejected as malformed below;
+        // a blank prefix scans the whole store, so there is no keyspace boundary to reject against
+        // and any token is a valid resume position.
         start = -idx - 1;
       } else {
         throw new IllegalArgumentException("bad page token");

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -85,6 +85,21 @@ class KvStoreContractTest {
   }
 
   @Test
+  void queryByPartitionKeyPrefix_blankPrefix_resumesPositionallyForAbsentKey() {
+    assertTrue(kv.putCas(record("pk1", "sk0", 1L, "v0"), 0L).await().indefinitely());
+    assertTrue(kv.putCas(record("pk1", "sk2", 1L, "v2"), 0L).await().indefinitely());
+
+    // Token names an absent sort key ("sk1"); a blank prefix has no keyspace boundary, so the
+    // scan resumes positionally (DynamoDB exclusiveStartKey semantics) rather than throwing.
+    String token = kv.pageTokenAfterKey(key("pk1", "sk1"));
+    var page =
+        kv.queryByPartitionKeyPrefix("pk1", "", 10, Optional.of(token)).await().indefinitely();
+
+    assertEquals(1, page.items().size());
+    assertEquals("sk2", page.items().get(0).key().sortKey());
+  }
+
+  @Test
   void deleteByPrefix_removes_matching_records() {
     putSeries("pk1", "sk", 3);
     putSeries("pk2", "sk", 2);

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -100,6 +100,12 @@ class KvStoreContractTest {
   }
 
   @Test
+  void pageTokenAfterKey_emptySortKey_throwsInsteadOfEmptyToken() {
+    // An empty sort key would base64-encode to "", colliding with the "no more pages" sentinel.
+    assertThrows(IllegalArgumentException.class, () -> kv.pageTokenAfterKey(key("pk1", "")));
+  }
+
+  @Test
   void deleteByPrefix_removes_matching_records() {
     putSeries("pk1", "sk", 3);
     putSeries("pk2", "sk", 2);

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
@@ -148,6 +148,34 @@ public class PointerStoreContractTest {
   }
 
   @Test
+  void pageTokenAfterKey_resumesScanImmediatelyAfterThatKey() {
+    store.compareAndSet(key(1), 0L, pointer(key(1), 1L));
+    store.compareAndSet(key(2), 0L, pointer(key(2), 1L));
+    store.compareAndSet(key(3), 0L, pointer(key(3), 1L));
+
+    String token = store.pageTokenAfterKey(key(1));
+    StringBuilder next = new StringBuilder();
+    List<Pointer> page = store.listPointersByPrefix(prefix(), 10, token, next);
+
+    assertEquals(keysOf(List.of(pointer(key(2), 1L), pointer(key(3), 1L))), keysOf(page));
+  }
+
+  @Test
+  void pageTokenAfterKey_resumesPositionallyWhenTheKeyWasDeleted() {
+    store.compareAndSet(key(1), 0L, pointer(key(1), 1L));
+    store.compareAndSet(key(2), 0L, pointer(key(2), 1L));
+    store.compareAndSet(key(3), 0L, pointer(key(3), 1L));
+
+    String token = store.pageTokenAfterKey(key(2));
+    assertTrue(store.compareAndDelete(key(2), 1L));
+
+    StringBuilder next = new StringBuilder();
+    List<Pointer> page = store.listPointersByPrefix(prefix(), 10, token, next);
+
+    assertEquals(keysOf(List.of(pointer(key(3), 1L))), keysOf(page));
+  }
+
+  @Test
   void compareAndSetBatch_emptyOps_returns_true() {
     assertTrue(store.compareAndSetBatch(List.of()));
   }

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
@@ -176,6 +176,20 @@ public class PointerStoreContractTest {
   }
 
   @Test
+  void listPointersByPrefix_blankPrefix_resumesPositionallyForAbsentToken() {
+    store.compareAndSet(key(1), 0L, pointer(key(1), 1L));
+    store.compareAndSet(key(3), 0L, pointer(key(3), 1L));
+
+    // Under a blank prefix there is no keyspace boundary, so a token naming a position with no
+    // live row resumes positionally (DynamoDB exclusiveStartKey semantics) rather than being
+    // rejected as malformed.
+    StringBuilder next = new StringBuilder();
+    List<Pointer> page = store.listPointersByPrefix("", 10, key(2), next);
+
+    assertEquals(keysOf(List.of(pointer(key(3), 1L))), keysOf(page));
+  }
+
+  @Test
   void compareAndSetBatch_emptyOps_returns_true() {
     assertTrue(store.compareAndSetBatch(List.of()));
   }


### PR DESCRIPTION
## Summary

Fixes several ways paginated listings could silently drop rows at page boundaries, and adds the store primitive that makes precise resumption possible.

## What's in here

- Namespace pager now runs the repo phase for continuation tokens and scopes page tokens to their phase (user vs system), then resumes precisely after the last emitted row rather than after the over-fetched batch — via a new PointerStore.pageTokenAfterKey / KvStore.pageTokenAfterKey SPI implemented for the in-memory and DynamoDB stores.
- Prefix listing (listTablesByPrefix / listViewsByPrefix) is now phase-scoped so system rows can neither hide nor overflow past user rows; reported totals combine system + user.
- In-memory stores resume a prefix scan positionally when the cursor row was deleted between pages, matching DynamoDB's exclusiveStartKey semantics.
- Guards the namespace pager against non-positive page sizes.
- Adds real-store coverage for pageTokenAfterKey (contract tests + a Dynamo token-format pin + an end-to-end 150-namespace drain) and mixed-page / views-path / malformed-token prefix tests.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
