### PR TITLE
perf: cut redundant storage reads on the query resolution path

### DIFF
--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -161,6 +161,20 @@ public interface CatalogOverlay {
 
   Optional<ResourceId> resolveName(String correlationId, NameRef ref);
 
+  /**
+   * Batch kind-agnostic name resolution. The default loops {@link #resolveName}; overlays backed by
+   * per-name storage reads should override so names sharing a catalog/namespace resolve their scope
+   * once per batch instead of once per name.
+   */
+  default java.util.Map<NameRef, Optional<ResourceId>> resolveNames(
+      String correlationId, List<NameRef> refs) {
+    var out = new java.util.LinkedHashMap<NameRef, Optional<ResourceId>>(refs.size());
+    for (NameRef ref : refs) {
+      out.computeIfAbsent(ref, r -> resolveName(correlationId, r));
+    }
+    return out;
+  }
+
   /** Resolves a system table name without involving the user graph. */
   Optional<ResourceId> resolveSystemTable(NameRef ref);
 

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -95,6 +95,15 @@ public interface KvStore {
       String partitionKey, String sortKeyPrefix, int limit, Optional<String> pageToken);
 
   /**
+   * Returns a page token that resumes a {@link #queryByPartitionKeyPrefix} scan immediately after
+   * the given key, in this store's native token encoding. The default throws; stores that serve
+   * paging must override.
+   */
+  default String pageTokenAfterKey(Key key) {
+    throw new UnsupportedOperationException("pageTokenAfterKey is not supported by this store");
+  }
+
+  /**
    * Remove items
    *
    * @param partitionKey

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
@@ -80,6 +80,19 @@ public interface PointerStore {
   List<Pointer> listPointersByPrefix(
       String prefix, int limit, String pageToken, StringBuilder nextTokenOut);
 
+  /**
+   * Returns a page token that resumes a {@link #listPointersByPrefix} scan immediately after the
+   * given pointer key, as if a previous page had ended exactly at that key. This lets callers that
+   * post-filter scanned rows emit a cursor at the last row they actually consumed rather than at
+   * the end of an over-fetched batch.
+   *
+   * <p>Stores that serve filtered pagination must override this with their native token encoding.
+   * The default throws, so legacy or test stores that never need it are unaffected.
+   */
+  default String pageTokenAfterKey(String key) {
+    throw new UnsupportedOperationException("pageTokenAfterKey is not supported by this store");
+  }
+
   int deleteByPrefix(String prefix);
 
   int countByPrefix(String prefix);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePageSource.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePageSource.java
@@ -19,6 +19,7 @@ import ai.floedb.floecat.catalog.rpc.Namespace;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import java.util.ArrayList;
 import java.util.List;
 
 final class CatalogSurfaceNamespacePageSource implements CatalogSurfaceNamespacePager.Source {
@@ -66,6 +67,13 @@ final class CatalogSurfaceNamespacePageSource implements CatalogSurfaceNamespace
   @Override
   public List<Namespace> listRepo(int limit, String cursor, StringBuilder next) {
     return repo.list(accountId, catalogId.getId(), parentPath, limit, cursor, next);
+  }
+
+  @Override
+  public String cursorAfter(Namespace namespace) {
+    var fullPath = new ArrayList<>(namespace.getParentsList());
+    fullPath.add(namespace.getDisplayName());
+    return repo.listTokenAfter(accountId, catalogId.getId(), fullPath);
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -101,11 +101,16 @@ final class CatalogSurfaceNamespacePager {
             .sorted(Comparator.comparing(SysItem::rel))
             .toList();
 
+    // A full page is not the same as having another row to return: only advertise a continuation
+    // when the loop actually stopped before an un-emitted system namespace. Otherwise a page that
+    // exactly consumes the last system row would hand out a token whose next page is empty.
+    boolean hasMoreSystem = false;
     for (var it : sysItems) {
       if (!resumeSystemRel.isBlank() && it.rel().compareTo(resumeSystemRel) <= 0) {
         continue;
       }
       if (out.size() >= want) {
+        hasMoreSystem = true;
         break;
       }
       out.add(source.mapSystemNode(it.namespace()));
@@ -113,7 +118,7 @@ final class CatalogSurfaceNamespacePager {
     }
 
     String nextToken =
-        out.size() == want && !lastSystemRel.isBlank()
+        hasMoreSystem && !lastSystemRel.isBlank()
             ? CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastSystemRel)
             : "";
 

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -27,60 +27,76 @@ import java.util.Map;
 
 final class CatalogSurfaceNamespacePager {
 
+  // System-phase resume token: the carried relative name is a *system* namespace name.
   private static final String NS_TOKEN_PREFIX = "ns:";
+  // Repo-phase resume token: the carried relative name is a *user* namespace name.
+  private static final String NSU_TOKEN_PREFIX = "nsu:";
 
   private CatalogSurfaceNamespacePager() {}
 
   static Page list(int want, String pageToken, Source source, String corr) {
 
     final int batch = Math.max(want * 4, 64);
-    final boolean isServiceToken = pageToken != null && pageToken.startsWith(NS_TOKEN_PREFIX);
-    final String resumeAfterRel =
-        isServiceToken ? CatalogSurfaceSupport.decodeToken(NS_TOKEN_PREFIX, pageToken, corr) : "";
-    String cursor = isServiceToken ? "" : pageToken;
+    final boolean isSystemToken = pageToken != null && pageToken.startsWith(NS_TOKEN_PREFIX);
+    final boolean isUserToken = pageToken != null && pageToken.startsWith(NSU_TOKEN_PREFIX);
+    // Resume keys are scoped to their own phase: a user relative name must never filter system
+    // namespaces (and vice versa), since the two are independent, independently-ordered keyspaces.
+    final String resumeSystemRel =
+        isSystemToken ? CatalogSurfaceSupport.decodeToken(NS_TOKEN_PREFIX, pageToken, corr) : "";
+    final String resumeUserRel =
+        isUserToken ? CatalogSurfaceSupport.decodeToken(NSU_TOKEN_PREFIX, pageToken, corr) : "";
+    // Raw repo cursors carry no service prefix; service tokens restart the scan and resume by name.
+    String cursor = (isSystemToken || isUserToken) ? "" : pageToken;
 
     var out = new ArrayList<Namespace>(want);
-    String lastEmittedRel = "";
+    String lastUserRel = "";
+    String lastSystemRel = "";
 
-    // The repo phase must run for continuation tokens too: a batch that exhausts the cursor can
-    // hold
-    // more matches than fit on one page, so later pages re-scan from the start and skip already-
-    // emitted namespaces by name via resumeAfterRel. Skipping the scan for service tokens would
-    // drop
-    // every remaining user namespace once a page-filling batch exhausted the cursor.
-    while (out.size() < want) {
-      var next = new StringBuilder();
-      final List<Namespace> scanned;
-      try {
-        scanned = source.listRepo(batch, cursor, next);
-      } catch (IllegalArgumentException badToken) {
-        throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", cursor));
-      }
-
-      for (var ns : scanned) {
-        if (!matches(ns, source)) {
-          continue;
+    // Repo (user) phase. Runs for the first page, raw-cursor pages, and user-phase resume tokens;
+    // it
+    // is skipped only once we have advanced into the system phase (system-phase token). A batch
+    // that
+    // exhausts the cursor can hold more matches than fit on one page, so a user-phase resume token
+    // re-scans from the start and skips already-emitted rows by name via resumeUserRel.
+    if (!isSystemToken) {
+      while (out.size() < want) {
+        var next = new StringBuilder();
+        final List<Namespace> scanned;
+        try {
+          scanned = source.listRepo(batch, cursor, next);
+        } catch (IllegalArgumentException badToken) {
+          throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", cursor));
         }
 
-        var rel = relativeQualifiedName(ns, source.parentPath());
-        if (!resumeAfterRel.isBlank() && rel.compareTo(resumeAfterRel) <= 0) {
-          continue;
+        for (var ns : scanned) {
+          if (!matches(ns, source)) {
+            continue;
+          }
+
+          var rel = relativeQualifiedName(ns, source.parentPath());
+          if (!resumeUserRel.isBlank() && rel.compareTo(resumeUserRel) <= 0) {
+            continue;
+          }
+
+          out.add(ns);
+          lastUserRel = rel;
+          if (out.size() >= want) {
+            break;
+          }
         }
 
-        out.add(ns);
-        lastEmittedRel = rel;
-        if (out.size() >= want) {
+        cursor = next.toString();
+        if (cursor.isBlank() || out.size() >= want) {
           break;
         }
       }
-
-      cursor = next.toString();
-      if (cursor.isBlank() || out.size() >= want) {
-        break;
-      }
     }
 
-    if (cursor.isBlank() && out.size() < want) {
+    // System phase: only once the repo cursor is exhausted, or when resuming directly into it. When
+    // transitioning here from the repo phase, resumeSystemRel is blank, so system namespaces are
+    // emitted from the beginning regardless of where the user phase left off.
+    boolean enteredSystemPhase = false;
+    if ((isSystemToken || cursor.isBlank()) && out.size() < want) {
       record SysItem(NamespaceNode namespace, String rel) {}
 
       var sysItems =
@@ -91,20 +107,24 @@ final class CatalogSurfaceNamespacePager {
               .toList();
 
       for (var it : sysItems) {
-        if (!resumeAfterRel.isBlank() && it.rel().compareTo(resumeAfterRel) <= 0) {
+        if (!resumeSystemRel.isBlank() && it.rel().compareTo(resumeSystemRel) <= 0) {
           continue;
         }
         if (out.size() >= want) {
           break;
         }
         out.add(source.mapSystemNode(it.namespace()));
-        lastEmittedRel = it.rel();
+        lastSystemRel = it.rel();
+        enteredSystemPhase = true;
       }
     }
 
     String nextToken = cursor;
     if (nextToken.isBlank() && out.size() == want) {
-      nextToken = CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastEmittedRel);
+      nextToken =
+          enteredSystemPhase
+              ? CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastSystemRel)
+              : CatalogSurfaceSupport.encodeToken(NSU_TOKEN_PREFIX, lastUserRel);
     }
 
     int total = countNamespaces(source, corr);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -42,37 +42,41 @@ final class CatalogSurfaceNamespacePager {
     var out = new ArrayList<Namespace>(want);
     String lastEmittedRel = "";
 
-    if (!isServiceToken) {
-      while (out.size() < want) {
-        var next = new StringBuilder();
-        final List<Namespace> scanned;
-        try {
-          scanned = source.listRepo(batch, cursor, next);
-        } catch (IllegalArgumentException badToken) {
-          throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", cursor));
+    // The repo phase must run for continuation tokens too: a batch that exhausts the cursor can
+    // hold
+    // more matches than fit on one page, so later pages re-scan from the start and skip already-
+    // emitted namespaces by name via resumeAfterRel. Skipping the scan for service tokens would
+    // drop
+    // every remaining user namespace once a page-filling batch exhausted the cursor.
+    while (out.size() < want) {
+      var next = new StringBuilder();
+      final List<Namespace> scanned;
+      try {
+        scanned = source.listRepo(batch, cursor, next);
+      } catch (IllegalArgumentException badToken) {
+        throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", cursor));
+      }
+
+      for (var ns : scanned) {
+        if (!matches(ns, source)) {
+          continue;
         }
 
-        for (var ns : scanned) {
-          if (!matches(ns, source)) {
-            continue;
-          }
-
-          var rel = relativeQualifiedName(ns, source.parentPath());
-          if (!resumeAfterRel.isBlank() && rel.compareTo(resumeAfterRel) <= 0) {
-            continue;
-          }
-
-          out.add(ns);
-          lastEmittedRel = rel;
-          if (out.size() >= want) {
-            break;
-          }
+        var rel = relativeQualifiedName(ns, source.parentPath());
+        if (!resumeAfterRel.isBlank() && rel.compareTo(resumeAfterRel) <= 0) {
+          continue;
         }
 
-        cursor = next.toString();
-        if (cursor.isBlank() || out.size() >= want) {
+        out.add(ns);
+        lastEmittedRel = rel;
+        if (out.size() >= want) {
           break;
         }
+      }
+
+      cursor = next.toString();
+      if (cursor.isBlank() || out.size() >= want) {
+        break;
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -33,6 +33,11 @@ final class CatalogSurfaceNamespacePager {
   private CatalogSurfaceNamespacePager() {}
 
   static Page list(int want, String pageToken, Source source, String corr) {
+    if (want <= 0) {
+      // The fill-return path dereferences the last emitted row, which requires want >= 1; the
+      // single caller clamps, but guard against future call sites.
+      throw new IllegalArgumentException("want must be >= 1");
+    }
 
     final int batch = Math.max(want * 4, 64);
     final boolean isSystemToken = pageToken != null && pageToken.startsWith(NS_TOKEN_PREFIX);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacePager.java
@@ -29,8 +29,6 @@ final class CatalogSurfaceNamespacePager {
 
   // System-phase resume token: the carried relative name is a *system* namespace name.
   private static final String NS_TOKEN_PREFIX = "ns:";
-  // Repo-phase resume token: the carried relative name is a *user* namespace name.
-  private static final String NSU_TOKEN_PREFIX = "nsu:";
 
   private CatalogSurfaceNamespacePager() {}
 
@@ -38,26 +36,19 @@ final class CatalogSurfaceNamespacePager {
 
     final int batch = Math.max(want * 4, 64);
     final boolean isSystemToken = pageToken != null && pageToken.startsWith(NS_TOKEN_PREFIX);
-    final boolean isUserToken = pageToken != null && pageToken.startsWith(NSU_TOKEN_PREFIX);
-    // Resume keys are scoped to their own phase: a user relative name must never filter system
-    // namespaces (and vice versa), since the two are independent, independently-ordered keyspaces.
     final String resumeSystemRel =
         isSystemToken ? CatalogSurfaceSupport.decodeToken(NS_TOKEN_PREFIX, pageToken, corr) : "";
-    final String resumeUserRel =
-        isUserToken ? CatalogSurfaceSupport.decodeToken(NSU_TOKEN_PREFIX, pageToken, corr) : "";
-    // Raw repo cursors carry no service prefix; service tokens restart the scan and resume by name.
-    String cursor = (isSystemToken || isUserToken) ? "" : pageToken;
+    // Anything else (blank or a raw store cursor) resumes the repo scan directly.
+    String cursor = isSystemToken ? "" : (pageToken == null ? "" : pageToken);
 
     var out = new ArrayList<Namespace>(want);
-    String lastUserRel = "";
-    String lastSystemRel = "";
+    Namespace lastEmitted = null;
 
-    // Repo (user) phase. Runs for the first page, raw-cursor pages, and user-phase resume tokens;
-    // it
-    // is skipped only once we have advanced into the system phase (system-phase token). A batch
-    // that
-    // exhausts the cursor can hold more matches than fit on one page, so a user-phase resume token
-    // re-scans from the start and skips already-emitted rows by name via resumeUserRel.
+    // Repo (user) phase. The scan over-fetches and post-filters, so when the page fills the
+    // continuation must resume after the last *emitted* row, not after the scanned batch:
+    // source.cursorAfter(lastEmitted) is that precise position. Rows the batch read past (and even
+    // rows read after the store reported exhaustion) are still in the store and are re-served by
+    // the next page's scan.
     if (!isSystemToken) {
       while (out.size() < want) {
         var next = new StringBuilder();
@@ -73,13 +64,8 @@ final class CatalogSurfaceNamespacePager {
             continue;
           }
 
-          var rel = relativeQualifiedName(ns, source.parentPath());
-          if (!resumeUserRel.isBlank() && rel.compareTo(resumeUserRel) <= 0) {
-            continue;
-          }
-
           out.add(ns);
-          lastUserRel = rel;
+          lastEmitted = ns;
           if (out.size() >= want) {
             break;
           }
@@ -90,42 +76,41 @@ final class CatalogSurfaceNamespacePager {
           break;
         }
       }
-    }
 
-    // System phase: only once the repo cursor is exhausted, or when resuming directly into it. When
-    // transitioning here from the repo phase, resumeSystemRel is blank, so system namespaces are
-    // emitted from the beginning regardless of where the user phase left off.
-    boolean enteredSystemPhase = false;
-    if ((isSystemToken || cursor.isBlank()) && out.size() < want) {
-      record SysItem(NamespaceNode namespace, String rel) {}
-
-      var sysItems =
-          source.systemNamespaces().stream()
-              .filter(ns -> matches(ns, source))
-              .map(ns -> new SysItem(ns, relativeQualifiedName(ns, source.parentPath())))
-              .sorted(Comparator.comparing(SysItem::rel))
-              .toList();
-
-      for (var it : sysItems) {
-        if (!resumeSystemRel.isBlank() && it.rel().compareTo(resumeSystemRel) <= 0) {
-          continue;
-        }
-        if (out.size() >= want) {
-          break;
-        }
-        out.add(source.mapSystemNode(it.namespace()));
-        lastSystemRel = it.rel();
-        enteredSystemPhase = true;
+      if (out.size() >= want) {
+        return new Page(out, source.cursorAfter(lastEmitted), countNamespaces(source, corr));
       }
+      // Repo exhausted with room left: fall through to the system phase from its start.
     }
 
-    String nextToken = cursor;
-    if (nextToken.isBlank() && out.size() == want) {
-      nextToken =
-          enteredSystemPhase
-              ? CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastSystemRel)
-              : CatalogSurfaceSupport.encodeToken(NSU_TOKEN_PREFIX, lastUserRel);
+    // System phase: entered once the repo is exhausted, or directly via a system-phase token. When
+    // transitioning from the repo phase resumeSystemRel is blank, so system namespaces are emitted
+    // from the beginning regardless of where the user phase left off.
+    String lastSystemRel = "";
+    record SysItem(NamespaceNode namespace, String rel) {}
+
+    var sysItems =
+        source.systemNamespaces().stream()
+            .filter(ns -> matches(ns, source))
+            .map(ns -> new SysItem(ns, relativeQualifiedName(ns, source.parentPath())))
+            .sorted(Comparator.comparing(SysItem::rel))
+            .toList();
+
+    for (var it : sysItems) {
+      if (!resumeSystemRel.isBlank() && it.rel().compareTo(resumeSystemRel) <= 0) {
+        continue;
+      }
+      if (out.size() >= want) {
+        break;
+      }
+      out.add(source.mapSystemNode(it.namespace()));
+      lastSystemRel = it.rel();
     }
+
+    String nextToken =
+        out.size() == want && !lastSystemRel.isBlank()
+            ? CatalogSurfaceSupport.encodeToken(NS_TOKEN_PREFIX, lastSystemRel)
+            : "";
 
     int total = countNamespaces(source, corr);
 
@@ -257,6 +242,9 @@ final class CatalogSurfaceNamespacePager {
     boolean recursive();
 
     List<Namespace> listRepo(int limit, String cursor, StringBuilder next);
+
+    /** Repo cursor that resumes the {@link #listRepo} scan immediately after {@code namespace}. */
+    String cursorAfter(Namespace namespace);
 
     List<NamespaceNode> systemNamespaces();
 

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceSupport.java
@@ -22,10 +22,9 @@ import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
 import ai.floedb.floecat.metagraph.model.NamespaceNode;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.service.common.PageTokens;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
-import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
-import java.util.Base64;
 import java.util.Map;
 
 final class CatalogSurfaceSupport {
@@ -86,32 +85,10 @@ final class CatalogSurfaceSupport {
   }
 
   static String encodeToken(String prefix, String resumeAfterRel) {
-    if (resumeAfterRel == null) {
-      resumeAfterRel = "";
-    }
-    if (resumeAfterRel.isBlank()) {
-      return prefix;
-    }
-    return prefix
-        + Base64.getUrlEncoder()
-            .withoutPadding()
-            .encodeToString(resumeAfterRel.getBytes(StandardCharsets.UTF_8));
+    return PageTokens.encode(prefix, resumeAfterRel);
   }
 
   static String decodeToken(String prefix, String token, String corr) {
-    if (token == null || token.isBlank() || !token.startsWith(prefix)) {
-      return "";
-    }
-    if (token.length() == prefix.length()) {
-      return "";
-    }
-    var s = token.substring(prefix.length());
-    final byte[] bytes;
-    try {
-      bytes = Base64.getUrlDecoder().decode(s);
-    } catch (IllegalArgumentException badToken) {
-      throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", token));
-    }
-    return new String(bytes, StandardCharsets.UTF_8);
+    return PageTokens.decode(prefix, token, corr);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/common/PageTokens.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/PageTokens.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.common;
+
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.PAGE_TOKEN_INVALID;
+
+import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+/**
+ * Phase-scoped page tokens shared by the Catalog Surface pagers and the MetaGraph phased prefix
+ * listing. A token is a phase {@code prefix} followed by the base64url encoding of the "resume
+ * after" payload (empty payload → just the prefix). Decoding strips the prefix and base64-decodes,
+ * rejecting a structurally invalid token with {@code PAGE_TOKEN_INVALID}.
+ */
+public final class PageTokens {
+
+  private PageTokens() {}
+
+  /** Encodes {@code prefix + base64url(resumeAfter)}; a blank payload yields just the prefix. */
+  public static String encode(String prefix, String resumeAfter) {
+    if (resumeAfter == null || resumeAfter.isBlank()) {
+      return prefix;
+    }
+    return prefix
+        + Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(resumeAfter.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Decodes a token produced by {@link #encode}. Returns "" for a null/blank token, one that does
+   * not carry {@code prefix}, or a prefix-only token; throws {@code PAGE_TOKEN_INVALID} when the
+   * payload after the prefix is not valid base64url.
+   */
+  public static String decode(String prefix, String token, String corr) {
+    if (token == null || token.isBlank() || !token.startsWith(prefix)) {
+      return "";
+    }
+    if (token.length() == prefix.length()) {
+      return "";
+    }
+    var payload = token.substring(prefix.length());
+    try {
+      return new String(Base64.getUrlDecoder().decode(payload), StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException badToken) {
+      throw GrpcErrors.invalidArgument(corr, PAGE_TOKEN_INVALID, Map.of("page_token", token));
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/loader/NodeLoader.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/loader/NodeLoader.java
@@ -79,25 +79,23 @@ public class NodeLoader {
     return catalogRepository.listIds(accountId);
   }
 
+  // These fetch the pointer-only meta once and hydrate from the blob it names (via load), rather
+  // than reading the canonical pointer twice — once in getById and again in pointerMetaForSafe.
+  // Called per-item in listing loops, so the extra pointer read added up.
+
   public Optional<NamespaceNode> namespace(ResourceId id) {
     if (id.getKind() != ResourceKind.RK_NAMESPACE) return Optional.empty();
-    return namespaceRepository
-        .getById(id)
-        .map(ns -> toNamespaceNode(ns, namespaceRepository.pointerMetaForSafe(id)));
+    return mutationMeta(id).flatMap(meta -> load(id, meta)).map(NamespaceNode.class::cast);
   }
 
   public Optional<UserTableNode> table(ResourceId id) {
     if (id.getKind() != ResourceKind.RK_TABLE) return Optional.empty();
-    return tableRepository
-        .getById(id)
-        .map(t -> toTableNode(t, tableRepository.pointerMetaForSafe(id)));
+    return mutationMeta(id).flatMap(meta -> load(id, meta)).map(UserTableNode.class::cast);
   }
 
   public Optional<ViewNode> view(ResourceId id) {
     if (id.getKind() != ResourceKind.RK_VIEW) return Optional.empty();
-    return viewRepository
-        .getById(id)
-        .map(v -> toViewNode(v, viewRepository.pointerMetaForSafe(id)));
+    return mutationMeta(id).flatMap(meta -> load(id, meta)).map(ViewNode.class::cast);
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/loader/NodeLoader.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/loader/NodeLoader.java
@@ -83,28 +83,35 @@ public class NodeLoader {
     if (id.getKind() != ResourceKind.RK_NAMESPACE) return Optional.empty();
     return namespaceRepository
         .getById(id)
-        .map(ns -> toNamespaceNode(ns, namespaceRepository.metaForSafe(id)));
+        .map(ns -> toNamespaceNode(ns, namespaceRepository.pointerMetaForSafe(id)));
   }
 
   public Optional<UserTableNode> table(ResourceId id) {
     if (id.getKind() != ResourceKind.RK_TABLE) return Optional.empty();
-    return tableRepository.getById(id).map(t -> toTableNode(t, tableRepository.metaForSafe(id)));
+    return tableRepository
+        .getById(id)
+        .map(t -> toTableNode(t, tableRepository.pointerMetaForSafe(id)));
   }
 
   public Optional<ViewNode> view(ResourceId id) {
     if (id.getKind() != ResourceKind.RK_VIEW) return Optional.empty();
-    return viewRepository.getById(id).map(v -> toViewNode(v, viewRepository.metaForSafe(id)));
+    return viewRepository
+        .getById(id)
+        .map(v -> toViewNode(v, viewRepository.pointerMetaForSafe(id)));
   }
 
-  /** Loads the mutation metadata for the provided resource. */
+  /**
+   * Loads the mutation metadata for the provided resource. Graph consumers only use the pointer
+   * version (cache key) and timestamps, so this is a pointer-only read — no blob HEAD, blank etag.
+   */
   public Optional<MutationMeta> mutationMeta(ResourceId id) {
     try {
       ResourceKind kind = id.getKind();
       return switch (kind) {
-        case RK_CATALOG -> Optional.of(catalogRepository.metaForSafe(id));
-        case RK_NAMESPACE -> Optional.of(namespaceRepository.metaForSafe(id));
-        case RK_TABLE -> Optional.of(tableRepository.metaForSafe(id));
-        case RK_VIEW -> Optional.of(viewRepository.metaForSafe(id));
+        case RK_CATALOG -> Optional.of(catalogRepository.pointerMetaForSafe(id));
+        case RK_NAMESPACE -> Optional.of(namespaceRepository.pointerMetaForSafe(id));
+        case RK_TABLE -> Optional.of(tableRepository.pointerMetaForSafe(id));
+        case RK_VIEW -> Optional.of(viewRepository.pointerMetaForSafe(id));
         default -> Optional.empty();
       };
     } catch (StorageNotFoundException snf) {
@@ -112,14 +119,35 @@ public class NodeLoader {
     }
   }
 
-  /** Rehydrates the relation node for the provided metadata snapshot. */
+  /**
+   * Rehydrates the relation node for the provided metadata snapshot. The metadata already names the
+   * blob, so the blob is fetched directly — skipping the pointer re-read {@code getById} would do —
+   * and the node content stays consistent with the metadata's pointer version. Falls back to a
+   * pointer-based read when the blob has moved (e.g. updated and garbage-collected in between).
+   */
   public Optional<GraphNode> load(ResourceId id, MutationMeta meta) {
+    String blobUri = meta.getBlobUri();
     return switch (id.getKind()) {
-      case RK_CATALOG -> catalogRepository.getById(id).map(catalog -> toCatalogNode(catalog, meta));
+      case RK_CATALOG ->
+          catalogRepository
+              .getByBlobUri(blobUri)
+              .or(() -> catalogRepository.getById(id))
+              .map(catalog -> toCatalogNode(catalog, meta));
       case RK_NAMESPACE ->
-          namespaceRepository.getById(id).map(namespace -> toNamespaceNode(namespace, meta));
-      case RK_TABLE -> tableRepository.getById(id).map(table -> toTableNode(table, meta));
-      case RK_VIEW -> viewRepository.getById(id).map(view -> toViewNode(view, meta));
+          namespaceRepository
+              .getByBlobUri(blobUri)
+              .or(() -> namespaceRepository.getById(id))
+              .map(namespace -> toNamespaceNode(namespace, meta));
+      case RK_TABLE ->
+          tableRepository
+              .getByBlobUri(blobUri)
+              .or(() -> tableRepository.getById(id))
+              .map(table -> toTableNode(table, meta));
+      case RK_VIEW ->
+          viewRepository
+              .getByBlobUri(blobUri)
+              .or(() -> viewRepository.getById(id))
+              .map(view -> toViewNode(view, meta));
       default -> Optional.empty();
     };
   }

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -305,6 +305,32 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     return system.isPresent() ? system : userGraph.resolveName(correlationId, ref);
   }
 
+  /**
+   * Batch kind-agnostic name resolution: system names answer from the in-memory registry; the rest
+   * resolve through the user graph in one batch so names sharing a catalog/namespace resolve their
+   * scope once.
+   */
+  @Override
+  public Map<NameRef, Optional<ResourceId>> resolveNames(String correlationId, List<NameRef> refs) {
+    EngineContext ctx = engineContext();
+    var out = new LinkedHashMap<NameRef, Optional<ResourceId>>(refs.size());
+    var userRefs = new ArrayList<NameRef>(refs.size());
+    for (NameRef ref : refs) {
+      if (out.containsKey(ref)) {
+        continue;
+      }
+      Optional<ResourceId> system = systemGraph.resolveName(ref, ctx);
+      out.put(ref, system);
+      if (system.isEmpty()) {
+        userRefs.add(ref);
+      }
+    }
+    if (!userRefs.isEmpty()) {
+      out.putAll(userGraph.resolveNames(correlationId, userRefs));
+    }
+    return out;
+  }
+
   @Override
   public Optional<ResourceId> resolveSystemTable(NameRef ref) {
     EngineContext ctx = engineContext();

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -393,31 +393,7 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
   @Override
   public ResolveResult batchResolveTables(
       String correlationId, List<NameRef> items, int limit, String token) {
-
-    validateListToken(correlationId, token);
-
-    if (items == null || items.isEmpty()) {
-      return new ResolveResult(List.of(), 0, "");
-    }
-
-    EngineContext ctx = engineContext();
-    int max = Math.min(items.size(), normalizeLimit(limit));
-
-    List<NameRef> subset = items.subList(0, max);
-    Map<String, CatalogOverlay.QualifiedRelation> merged =
-        collectSystemRelationsForNames(subset, ctx, true);
-
-    List<NameRef> userRefs = unresolvedUserRefs(subset, merged);
-    if (!userRefs.isEmpty() && merged.size() < max) {
-      ResolveResult userResult =
-          toResolveResult(
-              userGraph.resolveTables(correlationId, userRefs, max - merged.size(), token));
-      for (CatalogOverlay.QualifiedRelation userRelation : userResult.relations()) {
-        merged.put(canonicalName(userRelation.name()), userRelation);
-      }
-    }
-
-    return new ResolveResult(new ArrayList<>(merged.values()), merged.size(), "");
+    return batchResolveRelations(correlationId, items, limit, token, true);
   }
 
   /**
@@ -449,6 +425,16 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
   @Override
   public ResolveResult batchResolveViews(
       String correlationId, List<NameRef> items, int limit, String token) {
+    return batchResolveRelations(correlationId, items, limit, token, false);
+  }
+
+  /**
+   * Shared list-resolution behind {@link #batchResolveTables} and {@link #batchResolveViews}:
+   * system names answer from the in-memory registry (aliased back to the user-facing catalog), the
+   * rest resolve through the user graph.
+   */
+  private ResolveResult batchResolveRelations(
+      String correlationId, List<NameRef> items, int limit, String token, boolean tables) {
 
     validateListToken(correlationId, token);
 
@@ -461,13 +447,15 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
 
     List<NameRef> subset = items.subList(0, max);
     Map<String, CatalogOverlay.QualifiedRelation> merged =
-        collectSystemRelationsForNames(subset, ctx, false);
+        collectSystemRelationsForNames(subset, ctx, tables);
 
     List<NameRef> userRefs = unresolvedUserRefs(subset, merged);
     if (!userRefs.isEmpty() && merged.size() < max) {
       ResolveResult userResult =
           toResolveResult(
-              userGraph.resolveViews(correlationId, userRefs, max - merged.size(), token));
+              tables
+                  ? userGraph.resolveTables(correlationId, userRefs, max - merged.size(), token)
+                  : userGraph.resolveViews(correlationId, userRefs, max - merged.size(), token));
       for (CatalogOverlay.QualifiedRelation userRelation : userResult.relations()) {
         merged.put(canonicalName(userRelation.name()), userRelation);
       }

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -479,14 +479,22 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     final boolean userPhase = !sysToken && token != null && !token.isBlank();
     final String userToken = userPhase ? decodeUserToken(token) : "";
 
-    // Collected on every page (bounded, in-memory) so totals can include the system rows.
-    List<CatalogOverlay.QualifiedRelation> systemAll =
-        new ArrayList<>(collectSystemRelationsInNamespace(prefix, ctx, tables, Integer.MAX_VALUE));
-    systemAll.sort(Comparator.comparing(rel -> canonicalName(rel.name())));
-
     var merged = new ArrayList<CatalogOverlay.QualifiedRelation>(Math.min(max, 64));
 
-    if (!userPhase) {
+    // System-relation total for the combined count. On a user-phase page the system rows were all
+    // emitted on earlier pages, so only their count is needed here — skip the sorted collect (with
+    // its per-relation name resolution) and count the bounded in-memory nodes directly. The sorted
+    // list is built only while the system phase is actually emitting rows.
+    int systemTotal;
+    if (userPhase) {
+      systemTotal = countSystemRelationsInNamespace(prefix, ctx, tables);
+    } else {
+      List<CatalogOverlay.QualifiedRelation> systemAll =
+          new ArrayList<>(
+              collectSystemRelationsInNamespace(prefix, ctx, tables, Integer.MAX_VALUE));
+      systemAll.sort(Comparator.comparing(rel -> canonicalName(rel.name())));
+      systemTotal = systemAll.size();
+
       String lastSystemName = "";
       for (CatalogOverlay.QualifiedRelation rel : systemAll) {
         String name = canonicalName(rel.name());
@@ -497,7 +505,7 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
           // System rows remain: continue the system phase next page; the user cursor is untouched.
           return new ResolveResult(
               merged,
-              systemAll.size() + userTotalByPrefix(correlationId, prefix, tables),
+              systemTotal + userTotalByPrefix(correlationId, prefix, tables),
               SYS_TOKEN_PREFIX + encodeSysName(lastSystemName));
         }
         merged.add(rel);
@@ -508,7 +516,7 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
         // advancing its cursor. The next page starts the user scan from the beginning.
         return new ResolveResult(
             merged,
-            systemAll.size() + userTotalByPrefix(correlationId, prefix, tables),
+            systemTotal + userTotalByPrefix(correlationId, prefix, tables),
             USER_TOKEN_PREFIX);
       }
     }
@@ -526,19 +534,17 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
       merged.add(rel);
     }
     return new ResolveResult(
-        merged, systemAll.size() + user.totalSize(), encodeUserToken(user.nextToken()));
+        merged, systemTotal + user.totalSize(), encodeUserToken(user.nextToken()));
   }
 
   /**
-   * User-relation total for combined counts on system-phase pages. The one-row probe's rows and
-   * cursor are discarded; the user phase later starts from a blank cursor, so nothing is skipped.
+   * User-relation total for combined counts on system-phase pages. Uses a count-only path (a plain
+   * repo countByPrefix) rather than fetching and discarding a one-row probe.
    */
   private int userTotalByPrefix(String correlationId, NameRef prefix, boolean tables) {
-    return toResolveResult(
-            tables
-                ? userGraph.resolveTables(correlationId, prefix, 1, "")
-                : userGraph.resolveViews(correlationId, prefix, 1, ""))
-        .totalSize();
+    return tables
+        ? userGraph.countTablesByPrefix(correlationId, prefix)
+        : userGraph.countViewsByPrefix(correlationId, prefix);
   }
 
   /**
@@ -813,6 +819,28 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
       }
     }
     return out;
+  }
+
+  /**
+   * Counts system relations of the requested kind under a prefix, without the per-relation name
+   * resolution and {@link NameRef} construction {@link #collectSystemRelationsInNamespace} does.
+   * Used for the combined total on user-phase pages, where the sorted system list is not needed.
+   */
+  private int countSystemRelationsInNamespace(NameRef prefix, EngineContext ctx, boolean tables) {
+    Optional<ResourceId> sysNsId =
+        systemGraph.resolveNamespace(
+            SystemCatalogTranslator.toSystemNamespaceRef(prefix, ctx), ctx);
+    if (sysNsId.isEmpty()) {
+      return 0;
+    }
+    int count = 0;
+    for (RelationNode n :
+        systemGraph.listRelationsInNamespace(ResourceId.getDefaultInstance(), sysNsId.get(), ctx)) {
+      if ((tables && n instanceof TableNode) || (!tables && n instanceof ViewNode)) {
+        count++;
+      }
+    }
+    return count;
   }
 
   private List<CatalogOverlay.QualifiedRelation> collectSystemRelationsInNamespace(

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -518,12 +518,12 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
         lastSystemName = name;
       }
       if (merged.size() >= max) {
-        // Page filled exactly as the system rows ran out: hand off to the user phase without
-        // advancing its cursor. The next page starts the user scan from the beginning.
+        // Page filled exactly as the system rows ran out. Hand off to the user phase only when
+        // there are user rows to continue into; with none, USER_TOKEN_PREFIX would advertise a
+        // next page that is always empty. The next page starts the user scan from the beginning.
+        int userTotal = userTotalByPrefix(correlationId, prefix, tables);
         return new ResolveResult(
-            merged,
-            systemTotal + userTotalByPrefix(correlationId, prefix, tables),
-            USER_TOKEN_PREFIX);
+            merged, systemTotal + userTotal, userTotal > 0 ? USER_TOKEN_PREFIX : "");
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -36,6 +36,7 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.scanner.spi.TopologyGraph;
 import ai.floedb.floecat.scanner.spi.TopologyNames;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.common.PageTokens;
 import ai.floedb.floecat.service.context.EngineContextProvider;
 import ai.floedb.floecat.service.error.impl.GeneratedErrorMessages;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
@@ -49,9 +50,7 @@ import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -475,7 +474,8 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     int max = normalizeLimit(limit);
 
     final boolean sysToken = token != null && token.startsWith(SYS_TOKEN_PREFIX);
-    final String sysResume = sysToken ? decodeSysToken(correlationId, token) : "";
+    final String sysResume =
+        sysToken ? PageTokens.decode(SYS_TOKEN_PREFIX, token, correlationId) : "";
     final boolean userPhase = !sysToken && token != null && !token.isBlank();
     final String userToken = userPhase ? decodeUserToken(token) : "";
 
@@ -506,7 +506,7 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
           return new ResolveResult(
               merged,
               systemTotal + userTotalByPrefix(correlationId, prefix, tables),
-              SYS_TOKEN_PREFIX + encodeSysName(lastSystemName));
+              PageTokens.encode(SYS_TOKEN_PREFIX, lastSystemName));
         }
         merged.add(rel);
         lastSystemName = name;
@@ -746,25 +746,6 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
       return token.substring(USER_TOKEN_PREFIX.length());
     }
     return token;
-  }
-
-  private static String encodeSysName(String name) {
-    return Base64.getUrlEncoder()
-        .withoutPadding()
-        .encodeToString(name.getBytes(StandardCharsets.UTF_8));
-  }
-
-  private String decodeSysToken(String correlationId, String token) {
-    try {
-      return new String(
-          Base64.getUrlDecoder().decode(token.substring(SYS_TOKEN_PREFIX.length())),
-          StandardCharsets.UTF_8);
-    } catch (IllegalArgumentException badToken) {
-      throw GrpcErrors.invalidArgument(
-          correlationId,
-          GeneratedErrorMessages.MessageKey.PAGE_TOKEN_INVALID,
-          Map.of("page_token", token));
-    }
   }
 
   private static String encodeUserToken(String token) {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -466,6 +466,12 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
    * user-phase token is the user graph's own cursor. The user graph is only consulted for rows once
    * the system rows are fully emitted, so a page filled by system rows never advances — and can
    * never drop — user results. Reported totals combine both sources.
+   *
+   * <p>NOTE: this reimplements the same "system phase, then user phase, phase-scoped resume token"
+   * shape that {@code CatalogSurfaceRelationPager} generalizes via its {@code Source<P, N>}
+   * abstraction. The duplication is deliberate for now (this path is the just-fixed headline of the
+   * pagination-correctness work); unifying the two phased pagers onto one abstraction is tracked as
+   * a follow-up so a future fix to one does not silently miss the other.
    */
   private ResolveResult listRelationsByPrefix(
       String correlationId, NameRef prefix, int limit, String token, boolean tables) {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -49,7 +49,10 @@ import ai.floedb.floecat.systemcatalog.util.NameRefUtil;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -400,19 +403,7 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
   @Override
   public ResolveResult listTablesByPrefix(
       String correlationId, NameRef prefix, int limit, String token) {
-
-    EngineContext ctx = engineContext();
-    int max = normalizeLimit(limit);
-    String userToken = decodeUserToken(token);
-    boolean firstPage = userToken.isBlank();
-
-    List<CatalogOverlay.QualifiedRelation> system =
-        firstPage ? collectSystemRelationsInNamespace(prefix, ctx, true, max) : List.of();
-    int userLimit = Math.max(1, max - system.size());
-    ResolveResult user =
-        toResolveResult(userGraph.resolveTables(correlationId, prefix, userLimit, userToken));
-
-    return mergePrefixResults(system, user, max);
+    return listRelationsByPrefix(correlationId, prefix, limit, token, true);
   }
 
   /**
@@ -465,19 +456,89 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
   @Override
   public ResolveResult listViewsByPrefix(
       String correlationId, NameRef prefix, int limit, String token) {
+    return listRelationsByPrefix(correlationId, prefix, limit, token, false);
+  }
+
+  /**
+   * Phased prefix listing: system relations first (sorted by canonical name), then user relations.
+   *
+   * <p>Tokens are phase-scoped so neither cursor can advance past rows the page did not emit. A
+   * {@code sys:} token resumes the (bounded, in-memory) system list after the carried name; the
+   * user-phase token is the user graph's own cursor. The user graph is only consulted for rows once
+   * the system rows are fully emitted, so a page filled by system rows never advances — and can
+   * never drop — user results. Reported totals combine both sources.
+   */
+  private ResolveResult listRelationsByPrefix(
+      String correlationId, NameRef prefix, int limit, String token, boolean tables) {
 
     EngineContext ctx = engineContext();
     int max = normalizeLimit(limit);
-    String userToken = decodeUserToken(token);
-    boolean firstPage = userToken.isBlank();
 
-    List<CatalogOverlay.QualifiedRelation> system =
-        firstPage ? collectSystemRelationsInNamespace(prefix, ctx, false, max) : List.of();
-    int userLimit = Math.max(1, max - system.size());
+    final boolean sysToken = token != null && token.startsWith(SYS_TOKEN_PREFIX);
+    final String sysResume = sysToken ? decodeSysToken(correlationId, token) : "";
+    final boolean userPhase = !sysToken && token != null && !token.isBlank();
+    final String userToken = userPhase ? decodeUserToken(token) : "";
+
+    // Collected on every page (bounded, in-memory) so totals can include the system rows.
+    List<CatalogOverlay.QualifiedRelation> systemAll =
+        new ArrayList<>(collectSystemRelationsInNamespace(prefix, ctx, tables, Integer.MAX_VALUE));
+    systemAll.sort(Comparator.comparing(rel -> canonicalName(rel.name())));
+
+    var merged = new ArrayList<CatalogOverlay.QualifiedRelation>(Math.min(max, 64));
+
+    if (!userPhase) {
+      String lastSystemName = "";
+      for (CatalogOverlay.QualifiedRelation rel : systemAll) {
+        String name = canonicalName(rel.name());
+        if (!sysResume.isBlank() && name.compareTo(sysResume) <= 0) {
+          continue;
+        }
+        if (merged.size() >= max) {
+          // System rows remain: continue the system phase next page; the user cursor is untouched.
+          return new ResolveResult(
+              merged,
+              systemAll.size() + userTotalByPrefix(correlationId, prefix, tables),
+              SYS_TOKEN_PREFIX + encodeSysName(lastSystemName));
+        }
+        merged.add(rel);
+        lastSystemName = name;
+      }
+      if (merged.size() >= max) {
+        // Page filled exactly as the system rows ran out: hand off to the user phase without
+        // advancing its cursor. The next page starts the user scan from the beginning.
+        return new ResolveResult(
+            merged,
+            systemAll.size() + userTotalByPrefix(correlationId, prefix, tables),
+            USER_TOKEN_PREFIX);
+      }
+    }
+
+    int room = max - merged.size();
     ResolveResult user =
-        toResolveResult(userGraph.resolveViews(correlationId, prefix, userLimit, userToken));
+        toResolveResult(
+            tables
+                ? userGraph.resolveTables(correlationId, prefix, room, userToken)
+                : userGraph.resolveViews(correlationId, prefix, room, userToken));
+    for (CatalogOverlay.QualifiedRelation rel : user.relations()) {
+      if (merged.size() >= max) {
+        break;
+      }
+      merged.add(rel);
+    }
+    return new ResolveResult(
+        merged, systemAll.size() + user.totalSize(), encodeUserToken(user.nextToken()));
+  }
 
-    return mergePrefixResults(system, user, max);
+  /**
+   * User-relation total for combined counts on system-phase pages. The one-row probe's rows and
+   * cursor are discarded; the user phase later starts from a blank cursor, so nothing is skipped.
+   */
+  private int userTotalByPrefix(String correlationId, NameRef prefix, boolean tables) {
+    return toResolveResult(
+            tables
+                ? userGraph.resolveTables(correlationId, prefix, 1, "")
+                : userGraph.resolveViews(correlationId, prefix, 1, ""))
+        .totalSize();
   }
 
   /**
@@ -661,6 +722,8 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
    */
   private static final String USER_TOKEN_PREFIX = "u:";
 
+  private static final String SYS_TOKEN_PREFIX = "sys:";
+
   private static int normalizeLimit(int limit) {
     return Math.max(1, limit > 0 ? limit : 50);
   }
@@ -677,6 +740,25 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
       return token.substring(USER_TOKEN_PREFIX.length());
     }
     return token;
+  }
+
+  private static String encodeSysName(String name) {
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(name.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private String decodeSysToken(String correlationId, String token) {
+    try {
+      return new String(
+          Base64.getUrlDecoder().decode(token.substring(SYS_TOKEN_PREFIX.length())),
+          StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException badToken) {
+      throw GrpcErrors.invalidArgument(
+          correlationId,
+          GeneratedErrorMessages.MessageKey.PAGE_TOKEN_INVALID,
+          Map.of("page_token", token));
+    }
   }
 
   private static String encodeUserToken(String token) {
@@ -769,27 +851,6 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     }
 
     return out;
-  }
-
-  private ResolveResult mergePrefixResults(
-      List<CatalogOverlay.QualifiedRelation> system, ResolveResult user, int max) {
-    List<CatalogOverlay.QualifiedRelation> merged = new ArrayList<>();
-
-    for (CatalogOverlay.QualifiedRelation rel : system) {
-      if (merged.size() >= max) {
-        break;
-      }
-      merged.add(rel);
-    }
-
-    for (CatalogOverlay.QualifiedRelation rel : user.relations()) {
-      if (merged.size() >= max) {
-        break;
-      }
-      merged.add(rel);
-    }
-
-    return new ResolveResult(merged, user.totalSize(), encodeUserToken(user.nextToken()));
   }
 
   // ---- Lightweight ref listing and topology-cache invalidation ----

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -341,8 +341,13 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
       ResourceId tableId,
       SnapshotRef override,
       Optional<Timestamp> asOfDefault) {
-    // System objects don't need snapshot pins
-    if (resolve(tableId).filter(SystemTableNode.class::isInstance).isPresent()) {
+    // System objects don't need snapshot pins. The system graph is an in-memory registry, so probe
+    // it directly instead of the merged resolve, which would hydrate the full user node from
+    // storage just to conclude the table is not a system table.
+    if (systemGraph
+        .resolve(tableId, engineContext())
+        .filter(SystemTableNode.class::isInstance)
+        .isPresent()) {
       return null;
     }
     return userGraph.snapshotPinFor(correlationId, tableId, override, asOfDefault);

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -255,24 +255,35 @@ public final class UserGraph {
    */
   public Optional<GraphNode> resolve(ResourceId id) {
 
-    // ----- Regular nodes (cached in graph) ------------------------------------
-    MutationMeta meta = cache.getMeta(id);
-    if (meta == null) {
-      Optional<MutationMeta> metaOpt = nodes.mutationMeta(id);
-      if (metaOpt.isEmpty()) {
-        return Optional.empty();
+    // ----- Hot path: cached meta names the version key for an already-hydrated node --------------
+    MutationMeta cachedMeta = cache.getMeta(id);
+    if (cachedMeta != null) {
+      GraphNode hit = cache.get(id, new GraphCacheKey(id, cachedMeta.getPointerVersion()));
+      if (hit != null) {
+        return Optional.of(hit);
       }
-      meta = metaOpt.get();
-      cache.putMeta(id, meta);
     }
-    GraphCacheKey key = new GraphCacheKey(id, meta.getPointerVersion());
+
+    // ----- Hydration path: re-read a fresh pointer before loading -------------------------------
+    // The meta cache is a per-process Caffeine cache with no cross-instance invalidation, so a
+    // cached meta can name a superseded blob that is still readable (CAS blobs outlive the meta
+    // TTL). Hydrating from that stale blobUri would serve stale content as current. Only a freshly
+    // read pointer is safe to hand to load(); the meta cache is trusted solely to short-circuit to
+    // an already-cached node above.
+    Optional<MutationMeta> freshOpt = nodes.mutationMeta(id);
+    if (freshOpt.isEmpty()) {
+      return Optional.empty();
+    }
+    MutationMeta fresh = freshOpt.get();
+    cache.putMeta(id, fresh);
+    GraphCacheKey key = new GraphCacheKey(id, fresh.getPointerVersion());
 
     GraphNode cached = cache.get(id, key);
     if (cached != null) return Optional.of(cached);
 
     long loadStart = System.nanoTime();
     try {
-      Optional<GraphNode> loaded = nodes.load(id, meta);
+      Optional<GraphNode> loaded = nodes.load(id, fresh);
       loaded.ifPresent(node -> cache.put(id, key, node));
       cache.recordLoad(Duration.ofNanos(System.nanoTime() - loadStart));
       return loaded;

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -360,6 +360,17 @@ public final class UserGraph {
   }
 
   /**
+   * Batch variant of {@link #resolveName}: names sharing a catalog/namespace resolve their scope
+   * (catalog + namespace reads) once per call instead of once per name.
+   */
+  public java.util.Map<NameRef, Optional<ResourceId>> resolveNames(
+      String cid, java.util.List<NameRef> refs) {
+    refs.forEach(ref -> validateNameRef(cid, ref));
+    String accountId = requireAccountId(cid);
+    return names.resolveRelationIds(accountId, refs);
+  }
+
+  /**
    * Gets the schema JSON for a table at a specific snapshot.
    *
    * @param cid correlation ID for error reporting

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -449,6 +449,18 @@ public final class UserGraph {
     return new ResolveResult(fqResult);
   }
 
+  /** Counts user tables under a prefix without fetching any rows. */
+  public int countTablesByPrefix(String cid, NameRef prefix) {
+    validateNameRef(cid, prefix);
+    return fq.countTablesByPrefix(cid, requireAccountId(cid), prefix);
+  }
+
+  /** Counts user views under a prefix without fetching any rows. */
+  public int countViewsByPrefix(String cid, NameRef prefix) {
+    validateNameRef(cid, prefix);
+    return fq.countViewsByPrefix(cid, requireAccountId(cid), prefix);
+  }
+
   // ----------------------------------------------------------------------
   // Unified relation listing (tables + views)
   // ----------------------------------------------------------------------

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -374,8 +374,7 @@ public final class UserGraph {
    * Batch variant of {@link #resolveName}: names sharing a catalog/namespace resolve their scope
    * (catalog + namespace reads) once per call instead of once per name.
    */
-  public java.util.Map<NameRef, Optional<ResourceId>> resolveNames(
-      String cid, java.util.List<NameRef> refs) {
+  public Map<NameRef, Optional<ResourceId>> resolveNames(String cid, List<NameRef> refs) {
     refs.forEach(ref -> validateNameRef(cid, ref));
     String accountId = requireAccountId(cid);
     return names.resolveRelationIds(accountId, refs);

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/FullyQualifiedResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/FullyQualifiedResolver.java
@@ -30,6 +30,7 @@ import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -77,9 +78,10 @@ public class FullyQualifiedResolver {
 
     int max = Math.min(names.size(), normalizeLimit(limit));
     List<QualifiedRelation> out = new ArrayList<>(max);
+    var memo = new ScopeMemo();
 
     for (int i = 0; i < max; i++) {
-      var tblEntry = resolveTableEntry(cid, accountId, names.get(i));
+      var tblEntry = resolveTableEntry(memo, cid, accountId, names.get(i));
       if (tblEntry.isPresent()) {
         out.add(tblEntry.get());
       }
@@ -99,9 +101,10 @@ public class FullyQualifiedResolver {
 
     int max = Math.min(names.size(), normalizeLimit(limit));
     List<QualifiedRelation> out = new ArrayList<>(max);
+    var memo = new ScopeMemo();
 
     for (int i = 0; i < max; i++) {
-      var viewEntry = resolveViewEntry(cid, accountId, names.get(i));
+      var viewEntry = resolveViewEntry(memo, cid, accountId, names.get(i));
       if (viewEntry.isPresent()) {
         out.add(viewEntry.get());
       }
@@ -233,18 +236,38 @@ public class FullyQualifiedResolver {
   // Internal helpers (canonical entry resolution)
   // ----------------------------------------------------------------------
 
-  private Optional<QualifiedRelation> resolveTableEntry(String cid, String accountId, NameRef ref) {
+  /**
+   * Per-call scope memo: a batch of names typically shares one catalog.namespace, so resolve each
+   * distinct scope once instead of re-reading catalog and namespace for every name.
+   */
+  private final class ScopeMemo {
+    private final Map<String, Optional<Catalog>> catalogs = new HashMap<>();
+    private final Map<String, Optional<Namespace>> namespaces = new HashMap<>();
+
+    Optional<Catalog> catalog(String cid, String accountId, String name) {
+      return catalogs.computeIfAbsent(name, n -> catalogByName(cid, accountId, n));
+    }
+
+    Optional<Namespace> namespace(
+        String cid, String accountId, Catalog catalog, List<String> path) {
+      String key = catalog.getResourceId().getId() + "\u001F" + String.join("\u001F", path);
+      return namespaces.computeIfAbsent(key, k -> namespaceByPath(cid, accountId, catalog, path));
+    }
+  }
+
+  private Optional<QualifiedRelation> resolveTableEntry(
+      ScopeMemo memo, String cid, String accountId, NameRef ref) {
 
     validateNameRef(cid, ref);
     validateRelationName(cid, ref, "table");
 
-    Optional<Catalog> catalogOpt = catalogByName(cid, accountId, ref.getCatalog());
+    Optional<Catalog> catalogOpt = memo.catalog(cid, accountId, ref.getCatalog());
     if (catalogOpt.isEmpty()) {
       return Optional.empty();
     }
     Catalog catalog = catalogOpt.get();
 
-    Optional<Namespace> nsOpt = namespaceByPath(cid, accountId, catalog, ref.getPathList());
+    Optional<Namespace> nsOpt = memo.namespace(cid, accountId, catalog, ref.getPathList());
     if (nsOpt.isEmpty()) {
       return Optional.empty();
     }
@@ -267,18 +290,19 @@ public class FullyQualifiedResolver {
             });
   }
 
-  private Optional<QualifiedRelation> resolveViewEntry(String cid, String accountId, NameRef ref) {
+  private Optional<QualifiedRelation> resolveViewEntry(
+      ScopeMemo memo, String cid, String accountId, NameRef ref) {
 
     validateNameRef(cid, ref);
     validateRelationName(cid, ref, "view");
 
-    Optional<Catalog> catalogOpt = catalogByName(cid, accountId, ref.getCatalog());
+    Optional<Catalog> catalogOpt = memo.catalog(cid, accountId, ref.getCatalog());
     if (catalogOpt.isEmpty()) {
       return Optional.empty();
     }
     Catalog catalog = catalogOpt.get();
 
-    Optional<Namespace> nsOpt = namespaceByPath(cid, accountId, catalog, ref.getPathList());
+    Optional<Namespace> nsOpt = memo.namespace(cid, accountId, catalog, ref.getPathList());
     if (nsOpt.isEmpty()) {
       return Optional.empty();
     }

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/FullyQualifiedResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/FullyQualifiedResolver.java
@@ -192,6 +192,43 @@ public class FullyQualifiedResolver {
     return new ResolveResult(out, total, next.toString());
   }
 
+  /**
+   * Counts user tables under a prefix without fetching any rows. Unlike {@link
+   * #resolveTablesByPrefix}, this skips the row listing entirely — callers that only need the total
+   * (e.g. combined system+user counts on a system-phase page) should use this rather than a one-row
+   * probe whose rows and cursor are discarded.
+   */
+  public int countTablesByPrefix(String cid, String accountId, NameRef prefix) {
+    Optional<Catalog> catalogOpt = catalogByName(cid, accountId, prefix.getCatalog());
+    if (catalogOpt.isEmpty()) {
+      return 0;
+    }
+    Catalog catalog = catalogOpt.get();
+    Optional<Namespace> nsOpt = namespaceByPath(cid, accountId, catalog, namespacePath(prefix));
+    if (nsOpt.isEmpty()) {
+      return 0;
+    }
+    return tableRepository.count(
+        accountId, catalog.getResourceId().getId(), nsOpt.get().getResourceId().getId());
+  }
+
+  /**
+   * Counts user views under a prefix without fetching any rows. See {@link #countTablesByPrefix}.
+   */
+  public int countViewsByPrefix(String cid, String accountId, NameRef prefix) {
+    Optional<Catalog> catalogOpt = catalogByName(cid, accountId, prefix.getCatalog());
+    if (catalogOpt.isEmpty()) {
+      return 0;
+    }
+    Catalog catalog = catalogOpt.get();
+    Optional<Namespace> nsOpt = namespaceByPath(cid, accountId, catalog, namespacePath(prefix));
+    if (nsOpt.isEmpty()) {
+      return 0;
+    }
+    return viewRepository.count(
+        accountId, catalog.getResourceId().getId(), nsOpt.get().getResourceId().getId());
+  }
+
   // ----------------------------------------------------------------------
   // Internal helpers (canonical entry resolution)
   // ----------------------------------------------------------------------

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/FullyQualifiedResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/FullyQualifiedResolver.java
@@ -30,7 +30,6 @@ import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,7 +77,10 @@ public class FullyQualifiedResolver {
 
     int max = Math.min(names.size(), normalizeLimit(limit));
     List<QualifiedRelation> out = new ArrayList<>(max);
-    var memo = new ScopeMemo();
+    var memo =
+        new ScopeMemo(
+            name -> catalogByName(cid, accountId, name),
+            (catalog, path) -> namespaceByPath(cid, accountId, catalog, path));
 
     for (int i = 0; i < max; i++) {
       var tblEntry = resolveTableEntry(memo, cid, accountId, names.get(i));
@@ -101,7 +103,10 @@ public class FullyQualifiedResolver {
 
     int max = Math.min(names.size(), normalizeLimit(limit));
     List<QualifiedRelation> out = new ArrayList<>(max);
-    var memo = new ScopeMemo();
+    var memo =
+        new ScopeMemo(
+            name -> catalogByName(cid, accountId, name),
+            (catalog, path) -> namespaceByPath(cid, accountId, catalog, path));
 
     for (int i = 0; i < max; i++) {
       var viewEntry = resolveViewEntry(memo, cid, accountId, names.get(i));
@@ -236,38 +241,19 @@ public class FullyQualifiedResolver {
   // Internal helpers (canonical entry resolution)
   // ----------------------------------------------------------------------
 
-  /**
-   * Per-call scope memo: a batch of names typically shares one catalog.namespace, so resolve each
-   * distinct scope once instead of re-reading catalog and namespace for every name.
-   */
-  private final class ScopeMemo {
-    private final Map<String, Optional<Catalog>> catalogs = new HashMap<>();
-    private final Map<String, Optional<Namespace>> namespaces = new HashMap<>();
-
-    Optional<Catalog> catalog(String cid, String accountId, String name) {
-      return catalogs.computeIfAbsent(name, n -> catalogByName(cid, accountId, n));
-    }
-
-    Optional<Namespace> namespace(
-        String cid, String accountId, Catalog catalog, List<String> path) {
-      String key = catalog.getResourceId().getId() + "\u001F" + String.join("\u001F", path);
-      return namespaces.computeIfAbsent(key, k -> namespaceByPath(cid, accountId, catalog, path));
-    }
-  }
-
   private Optional<QualifiedRelation> resolveTableEntry(
       ScopeMemo memo, String cid, String accountId, NameRef ref) {
 
     validateNameRef(cid, ref);
     validateRelationName(cid, ref, "table");
 
-    Optional<Catalog> catalogOpt = memo.catalog(cid, accountId, ref.getCatalog());
+    Optional<Catalog> catalogOpt = memo.catalog(ref.getCatalog());
     if (catalogOpt.isEmpty()) {
       return Optional.empty();
     }
     Catalog catalog = catalogOpt.get();
 
-    Optional<Namespace> nsOpt = memo.namespace(cid, accountId, catalog, ref.getPathList());
+    Optional<Namespace> nsOpt = memo.namespace(catalog, ref.getPathList());
     if (nsOpt.isEmpty()) {
       return Optional.empty();
     }
@@ -296,13 +282,13 @@ public class FullyQualifiedResolver {
     validateNameRef(cid, ref);
     validateRelationName(cid, ref, "view");
 
-    Optional<Catalog> catalogOpt = memo.catalog(cid, accountId, ref.getCatalog());
+    Optional<Catalog> catalogOpt = memo.catalog(ref.getCatalog());
     if (catalogOpt.isEmpty()) {
       return Optional.empty();
     }
     Catalog catalog = catalogOpt.get();
 
-    Optional<Namespace> nsOpt = memo.namespace(cid, accountId, catalog, ref.getPathList());
+    Optional<Namespace> nsOpt = memo.namespace(catalog, ref.getPathList());
     if (nsOpt.isEmpty()) {
       return Optional.empty();
     }

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -35,7 +35,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -174,12 +177,32 @@ public final class NameResolver {
    * the shared relation-name claim), so the table-first order is deterministic.
    */
   public Optional<ResourceId> resolveRelationId(String accountId, NameRef ref) {
+    return resolveRelationId(accountId, ref, new HashMap<>());
+  }
+
+  /**
+   * Batch variant of {@link #resolveRelationId}: names sharing a catalog/namespace resolve their
+   * scope once per call instead of once per name.
+   */
+  public Map<NameRef, Optional<ResourceId>> resolveRelationIds(
+      String accountId, List<NameRef> refs) {
+    Map<String, Optional<Scope>> scopes = new HashMap<>();
+    var out = new LinkedHashMap<NameRef, Optional<ResourceId>>(refs.size());
+    for (NameRef ref : refs) {
+      out.computeIfAbsent(ref, r -> resolveRelationId(accountId, r, scopes));
+    }
+    return out;
+  }
+
+  private Optional<ResourceId> resolveRelationId(
+      String accountId, NameRef ref, Map<String, Optional<Scope>> scopeMemo) {
     return diagnose(
         "resolve_relation_id",
         "",
         accountId,
         () ->
-            resolveScope(accountId, ref)
+            scopeMemo
+                .computeIfAbsent(scopeKey(ref), k -> resolveScope(accountId, ref))
                 .flatMap(
                     scope -> {
                       String catalogId = scope.catalog().getResourceId().getId();
@@ -196,6 +219,10 @@ public final class NameResolver {
                           .getByName(accountId, catalogId, namespaceId, ref.getName())
                           .map(View::getResourceId);
                     }));
+  }
+
+  private static String scopeKey(NameRef ref) {
+    return ref.getCatalog() + "\u001F" + String.join("\u001F", ref.getPathList());
   }
 
   public Optional<ResolvedRelation> resolveTableRelation(String accountId, NameRef ref) {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -207,6 +207,19 @@ public final class NameResolver {
                     scope -> {
                       String catalogId = scope.catalog().getResourceId().getId();
                       String namespaceId = scope.namespace().getResourceId().getId();
+                      // One pointer read (no blob fetch) answers both kind and id via the shared
+                      // relation-name claim written by every table/view create and rename.
+                      Optional<ResourceId> claimed =
+                          tableRepository.relationNameClaim(
+                              accountId, catalogId, namespaceId, ref.getName());
+                      if (claimed.isPresent()) {
+                        ResourceId rid = claimed.get();
+                        return Optional.of(
+                            rid.getKind() == ResourceKind.RK_TABLE
+                                ? requireCanonicalTableId(rid)
+                                : rid);
+                      }
+                      // Claimless rows (created before the claim existed): kind-specific probes.
                       Optional<ResourceId> table =
                           tableRepository
                               .getByName(accountId, catalogId, namespaceId, ref.getName())

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -200,38 +200,45 @@ public final class NameResolver {
         "resolve_relation_id",
         "",
         accountId,
-        () ->
-            scopeMemo
-                .computeIfAbsent(scopeKey(ref), k -> resolveScope(accountId, ref))
-                .flatMap(
-                    scope -> {
-                      String catalogId = scope.catalog().getResourceId().getId();
-                      String namespaceId = scope.namespace().getResourceId().getId();
-                      // One pointer read (no blob fetch) answers both kind and id via the shared
-                      // relation-name claim written by every table/view create and rename.
-                      Optional<ResourceId> claimed =
-                          tableRepository.relationNameClaim(
-                              accountId, catalogId, namespaceId, ref.getName());
-                      if (claimed.isPresent()) {
-                        ResourceId rid = claimed.get();
-                        return Optional.of(
-                            rid.getKind() == ResourceKind.RK_TABLE
-                                ? requireCanonicalTableId(rid)
-                                : rid);
-                      }
-                      // Claimless rows (created before the claim existed): kind-specific probes.
-                      Optional<ResourceId> table =
-                          tableRepository
-                              .getByName(accountId, catalogId, namespaceId, ref.getName())
-                              .map(Table::getResourceId)
-                              .map(this::requireCanonicalTableId);
-                      if (table.isPresent()) {
-                        return table;
-                      }
-                      return viewRepository
-                          .getByName(accountId, catalogId, namespaceId, ref.getName())
-                          .map(View::getResourceId);
-                    }));
+        () -> {
+          // Name validity is per-ref; check it here, not inside resolveScope, so a blank-name ref
+          // does not cache Optional.empty() under the name-independent scope key and starve valid
+          // siblings sharing the same catalog/path in this batch.
+          if (!validName(ref)) {
+            return Optional.<ResourceId>empty();
+          }
+          return scopeMemo
+              .computeIfAbsent(scopeKey(ref), k -> resolveScope(accountId, ref))
+              .flatMap(
+                  scope -> {
+                    String catalogId = scope.catalog().getResourceId().getId();
+                    String namespaceId = scope.namespace().getResourceId().getId();
+                    // One pointer read (no blob fetch) answers both kind and id via the shared
+                    // relation-name claim written by every table/view create and rename.
+                    Optional<ResourceId> claimed =
+                        tableRepository.relationNameClaim(
+                            accountId, catalogId, namespaceId, ref.getName());
+                    if (claimed.isPresent()) {
+                      ResourceId rid = claimed.get();
+                      return Optional.of(
+                          rid.getKind() == ResourceKind.RK_TABLE
+                              ? requireCanonicalTableId(rid)
+                              : rid);
+                    }
+                    // Claimless rows (created before the claim existed): kind-specific probes.
+                    Optional<ResourceId> table =
+                        tableRepository
+                            .getByName(accountId, catalogId, namespaceId, ref.getName())
+                            .map(Table::getResourceId)
+                            .map(this::requireCanonicalTableId);
+                    if (table.isPresent()) {
+                      return table;
+                    }
+                    return viewRepository
+                        .getByName(accountId, catalogId, namespaceId, ref.getName())
+                        .map(View::getResourceId);
+                  });
+        });
   }
 
   private static String scopeKey(NameRef ref) {
@@ -243,27 +250,31 @@ public final class NameResolver {
         "resolve_table_relation",
         "",
         accountId,
-        () ->
-            resolveScope(accountId, ref)
-                .flatMap(
-                    scope ->
-                        tableRepository
-                            .getByName(
-                                accountId,
-                                scope.catalog().getResourceId().getId(),
-                                scope.namespace().getResourceId().getId(),
-                                ref.getName())
-                            .map(
-                                t -> {
-                                  ResourceId tableId = requireCanonicalTableId(t.getResourceId());
-                                  return new ResolvedRelation(
-                                      tableId,
-                                      canonicalName(
-                                          scope.catalog(),
-                                          scope.namespace(),
-                                          t.getDisplayName(),
-                                          tableId));
-                                })));
+        () -> {
+          if (!validName(ref)) {
+            return Optional.<ResolvedRelation>empty();
+          }
+          return resolveScope(accountId, ref)
+              .flatMap(
+                  scope ->
+                      tableRepository
+                          .getByName(
+                              accountId,
+                              scope.catalog().getResourceId().getId(),
+                              scope.namespace().getResourceId().getId(),
+                              ref.getName())
+                          .map(
+                              t -> {
+                                ResourceId tableId = requireCanonicalTableId(t.getResourceId());
+                                return new ResolvedRelation(
+                                    tableId,
+                                    canonicalName(
+                                        scope.catalog(),
+                                        scope.namespace(),
+                                        t.getDisplayName(),
+                                        tableId));
+                              }));
+        });
   }
 
   // ----------------------------------------------------------------------
@@ -274,11 +285,13 @@ public final class NameResolver {
   private record Scope(Catalog catalog, Namespace namespace) {}
 
   /**
-   * Resolves the catalog and namespace a relation name lives in, validating the reference first.
-   * Shared by the relation resolution methods so the catalog+namespace lookup is written once.
+   * Resolves the catalog and namespace a relation name lives in. The scope depends only on the
+   * catalog and path, not the relation name — so callers that memoize by {@code scopeKey} (catalog
+   * + path) must gate on {@link #validName} themselves rather than have a blank-name ref poison the
+   * shared scope entry. Shared by the relation resolution methods so the lookup is written once.
    */
   private Optional<Scope> resolveScope(String accountId, NameRef ref) {
-    if (!validCatalog(ref) || !validName(ref)) {
+    if (!validCatalog(ref)) {
       return Optional.empty();
     }
     Optional<Catalog> catalogOpt = catalogRepository.getByName(accountId, ref.getCatalog());

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -35,7 +35,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -177,7 +176,7 @@ public final class NameResolver {
    * the shared relation-name claim), so the table-first order is deterministic.
    */
   public Optional<ResourceId> resolveRelationId(String accountId, NameRef ref) {
-    return resolveRelationId(accountId, ref, new HashMap<>());
+    return resolveRelationId(accountId, ref, newScopeMemo(accountId));
   }
 
   /**
@@ -186,63 +185,65 @@ public final class NameResolver {
    */
   public Map<NameRef, Optional<ResourceId>> resolveRelationIds(
       String accountId, List<NameRef> refs) {
-    Map<String, Optional<Scope>> scopes = new HashMap<>();
+    ScopeMemo memo = newScopeMemo(accountId);
     var out = new LinkedHashMap<NameRef, Optional<ResourceId>>(refs.size());
     for (NameRef ref : refs) {
-      out.computeIfAbsent(ref, r -> resolveRelationId(accountId, r, scopes));
+      out.computeIfAbsent(ref, r -> resolveRelationId(accountId, r, memo));
     }
     return out;
   }
 
-  private Optional<ResourceId> resolveRelationId(
-      String accountId, NameRef ref, Map<String, Optional<Scope>> scopeMemo) {
+  private ScopeMemo newScopeMemo(String accountId) {
+    return new ScopeMemo(
+        name -> catalogByName(accountId, name),
+        (catalog, path) -> namespaceByPath(accountId, catalog, path));
+  }
+
+  private Optional<ResourceId> resolveRelationId(String accountId, NameRef ref, ScopeMemo memo) {
     return diagnose(
         "resolve_relation_id",
         "",
         accountId,
         () -> {
-          // Name validity is per-ref; check it here, not inside resolveScope, so a blank-name ref
-          // does not cache Optional.empty() under the name-independent scope key and starve valid
-          // siblings sharing the same catalog/path in this batch.
-          if (!validName(ref)) {
+          // Name validity is per-ref; a blank name must not consult the shared scope memo (keyed by
+          // catalog + path, name-independent) or it would starve valid siblings in this batch.
+          if (!validName(ref) || !validCatalog(ref)) {
             return Optional.<ResourceId>empty();
           }
-          return scopeMemo
-              .computeIfAbsent(scopeKey(ref), k -> resolveScope(accountId, ref))
+          return memo.catalog(ref.getCatalog())
               .flatMap(
-                  scope -> {
-                    String catalogId = scope.catalog().getResourceId().getId();
-                    String namespaceId = scope.namespace().getResourceId().getId();
-                    // One pointer read (no blob fetch) answers both kind and id via the shared
-                    // relation-name claim written by every table/view create and rename.
-                    Optional<ResourceId> claimed =
-                        tableRepository.relationNameClaim(
-                            accountId, catalogId, namespaceId, ref.getName());
-                    if (claimed.isPresent()) {
-                      ResourceId rid = claimed.get();
-                      return Optional.of(
-                          rid.getKind() == ResourceKind.RK_TABLE
-                              ? requireCanonicalTableId(rid)
-                              : rid);
-                    }
-                    // Claimless rows (created before the claim existed): kind-specific probes.
-                    Optional<ResourceId> table =
-                        tableRepository
-                            .getByName(accountId, catalogId, namespaceId, ref.getName())
-                            .map(Table::getResourceId)
-                            .map(this::requireCanonicalTableId);
-                    if (table.isPresent()) {
-                      return table;
-                    }
-                    return viewRepository
-                        .getByName(accountId, catalogId, namespaceId, ref.getName())
-                        .map(View::getResourceId);
-                  });
+                  catalog ->
+                      memo.namespace(catalog, ref.getPathList())
+                          .flatMap(
+                              ns -> {
+                                String catalogId = catalog.getResourceId().getId();
+                                String namespaceId = ns.getResourceId().getId();
+                                // One pointer read (no blob fetch) answers both kind and id via the
+                                // shared relation-name claim written by every create and rename.
+                                Optional<ResourceId> claimed =
+                                    tableRepository.relationNameClaim(
+                                        accountId, catalogId, namespaceId, ref.getName());
+                                if (claimed.isPresent()) {
+                                  ResourceId rid = claimed.get();
+                                  return Optional.of(
+                                      rid.getKind() == ResourceKind.RK_TABLE
+                                          ? requireCanonicalTableId(rid)
+                                          : rid);
+                                }
+                                // Claimless rows (pre-claim): kind-specific probes.
+                                Optional<ResourceId> table =
+                                    tableRepository
+                                        .getByName(accountId, catalogId, namespaceId, ref.getName())
+                                        .map(Table::getResourceId)
+                                        .map(this::requireCanonicalTableId);
+                                if (table.isPresent()) {
+                                  return table;
+                                }
+                                return viewRepository
+                                    .getByName(accountId, catalogId, namespaceId, ref.getName())
+                                    .map(View::getResourceId);
+                              }));
         });
-  }
-
-  private static String scopeKey(NameRef ref) {
-    return ref.getCatalog() + "\u001F" + String.join("\u001F", ref.getPathList());
   }
 
   public Optional<ResolvedRelation> resolveTableRelation(String accountId, NameRef ref) {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/ScopeMemo.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/ScopeMemo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.metagraph.resolver;
+
+import ai.floedb.floecat.catalog.rpc.Catalog;
+import ai.floedb.floecat.catalog.rpc.Namespace;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Per-call memo for the (catalog, namespace) scope a batch of relation names resolves within.
+ * Shared by {@link FullyQualifiedResolver} and {@link NameResolver} so the same batch optimization
+ * has one implementation rather than two that drift.
+ *
+ * <p>Catalogs are cached by name and namespaces by (catalog id + path), in separate maps, so a
+ * catalog shared by many namespaces in the batch is resolved once. Construct one per top-level call
+ * with lookups already bound to the correlation id and account; it is not thread-safe.
+ */
+final class ScopeMemo {
+
+  private static final String DELIM = "\u001F";
+
+  private final Function<String, Optional<Catalog>> catalogByName;
+  private final BiFunction<Catalog, List<String>, Optional<Namespace>> namespaceByPath;
+
+  private final Map<String, Optional<Catalog>> catalogs = new HashMap<>();
+  private final Map<String, Optional<Namespace>> namespaces = new HashMap<>();
+
+  ScopeMemo(
+      Function<String, Optional<Catalog>> catalogByName,
+      BiFunction<Catalog, List<String>, Optional<Namespace>> namespaceByPath) {
+    this.catalogByName = catalogByName;
+    this.namespaceByPath = namespaceByPath;
+  }
+
+  Optional<Catalog> catalog(String name) {
+    return catalogs.computeIfAbsent(name, catalogByName);
+  }
+
+  Optional<Namespace> namespace(Catalog catalog, List<String> path) {
+    String key = catalog.getResourceId().getId() + DELIM + String.join(DELIM, path);
+    return namespaces.computeIfAbsent(key, k -> namespaceByPath.apply(catalog, path));
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -196,6 +196,16 @@ public class QueryInputResolver {
         new ResolutionState(
             correlationId, asOfDefault, defaultCatalog, currentSnapshotPinCache, diag);
 
+    // Batch-resolve all NAME inputs up front: names sharing a catalog/namespace resolve their
+    // scope once instead of once per input.
+    List<NameRef> nameInputs =
+        inputs.stream()
+            .filter(in -> in.getTargetCase() == QueryInput.TargetCase.NAME)
+            .map(QueryInput::getName)
+            .toList();
+    Map<NameRef, Optional<ResourceId>> resolvedNames =
+        nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
+
     for (QueryInput in : inputs) {
       diag.count("pin.resolver_inputs");
       SnapshotRef override = in.getSnapshot();
@@ -205,8 +215,8 @@ public class QueryInputResolver {
           diag.count("pin.name_inputs");
           long nameResolveStartNs = System.nanoTime();
           ResourceId rid =
-              metadataGraph
-                  .resolveName(correlationId, in.getName())
+              resolvedNames
+                  .getOrDefault(in.getName(), Optional.empty())
                   .orElseThrow(
                       () ->
                           GrpcErrors.notFound(
@@ -352,17 +362,28 @@ public class QueryInputResolver {
     state.diagnostics.nanos("pin.view_node_resolve", System.nanoTime() - viewResolveStartNs);
     view.ifPresent(
         resolvedView -> {
-          for (var base : resolvedView.baseRelations()) {
+          // Batch-resolve the view's base relations: bases typically share the view's
+          // catalog/namespace, so the scope resolves once for the whole set.
+          List<NameRef> baseRefs =
+              resolvedView.baseRelations().stream()
+                  .map(
+                      base ->
+                          ViewContextUtils.enrichForViewContext(
+                              base, resolvedView, state.defaultCatalog.orElse("")))
+                  .toList();
+          if (baseRefs.isEmpty()) {
+            return;
+          }
+          long baseNameStartNs = System.nanoTime();
+          Map<NameRef, Optional<ResourceId>> baseIds =
+              metadataGraph.resolveNames(state.correlationId, baseRefs);
+          state.diagnostics.nanos(
+              "pin.view_base_name_resolve", System.nanoTime() - baseNameStartNs);
+          for (NameRef baseRef : baseRefs) {
             state.diagnostics.count("pin.view_base_name_resolutions");
-            long baseNameStartNs = System.nanoTime();
-            Optional<ResourceId> baseId =
-                metadataGraph.resolveName(
-                    state.correlationId,
-                    ViewContextUtils.enrichForViewContext(
-                        base, resolvedView, state.defaultCatalog.orElse("")));
-            state.diagnostics.nanos(
-                "pin.view_base_name_resolve", System.nanoTime() - baseNameStartNs);
-            baseId.ifPresent(rid -> collectBaseTables(state, rid, effectiveAsOf, seen));
+            baseIds
+                .getOrDefault(baseRef, Optional.empty())
+                .ifPresent(rid -> collectBaseTables(state, rid, effectiveAsOf, seen));
           }
         });
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
@@ -98,6 +98,17 @@ public class CatalogRepository {
         new CatalogKey(catalogResourceId.getAccountId(), catalogResourceId.getId()));
   }
 
+  /** Pointer-only meta (no blob HEAD, blank etag) for metadata-graph consumers. */
+  public MutationMeta pointerMetaForSafe(ResourceId catalogResourceId) {
+    return repo.pointerMetaForSafe(
+        new CatalogKey(catalogResourceId.getAccountId(), catalogResourceId.getId()));
+  }
+
+  /** Blob-direct read for graph hydration from resolved metadata; empty if the blob moved. */
+  public Optional<Catalog> getByBlobUri(String blobUri) {
+    return repo.getByBlobUri(blobUri);
+  }
+
   public List<ResourceId> listIds(String accountId) {
     String prefix = Keys.catalogPointerByNamePrefix(accountId);
     List<Catalog> catalogs = repo.listByPrefix(prefix, Integer.MAX_VALUE, "", new StringBuilder());

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -39,9 +39,11 @@ import java.util.Set;
 public class NamespaceRepository {
 
   private final GenericResourceRepository<Namespace, NamespaceKey> repo;
+  private final PointerStore pointerStore;
 
   @Inject
   public NamespaceRepository(PointerStore pointerStore, BlobStore blobStore) {
+    this.pointerStore = pointerStore;
     this.repo =
         new GenericResourceRepository<>(
             pointerStore,
@@ -96,6 +98,16 @@ public class NamespaceRepository {
   public int count(String accountId, String catalogId, List<String> parentSegmentsOrEmpty) {
     String prefix = Keys.namespacePointerByPathPrefix(accountId, catalogId, parentSegmentsOrEmpty);
     return repo.countByPrefix(prefix);
+  }
+
+  /**
+   * Page token resuming a {@link #list} scan immediately after the namespace at {@code fullPath}.
+   * Lets callers that post-filter scanned rows continue exactly after the last row they emitted
+   * instead of after the whole over-fetched batch.
+   */
+  public String listTokenAfter(String accountId, String catalogId, List<String> fullPath) {
+    return pointerStore.pageTokenAfterKey(
+        Keys.namespacePointerByPath(accountId, catalogId, fullPath));
   }
 
   public List<ResourceId> listIds(String accountId, String catalogId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -206,4 +206,15 @@ public class NamespaceRepository {
     return repo.metaForSafe(
         new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
   }
+
+  /** Pointer-only meta (no blob HEAD, blank etag) for metadata-graph consumers. */
+  public MutationMeta pointerMetaForSafe(ResourceId namespaceResourceId) {
+    return repo.pointerMetaForSafe(
+        new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
+  }
+
+  /** Blob-direct read for graph hydration from resolved metadata; empty if the blob moved. */
+  public Optional<Namespace> getByBlobUri(String blobUri) {
+    return repo.getByBlobUri(blobUri);
+  }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
@@ -154,4 +154,15 @@ public class TableRepository {
   public MutationMeta metaForSafe(ResourceId tableResourceId) {
     return repo.metaForSafe(new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()));
   }
+
+  /** Pointer-only meta (no blob HEAD, blank etag) for metadata-graph consumers. */
+  public MutationMeta pointerMetaForSafe(ResourceId tableResourceId) {
+    return repo.pointerMetaForSafe(
+        new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()));
+  }
+
+  /** Blob-direct read for graph hydration from resolved metadata; empty if the blob moved. */
+  public Optional<Table> getByBlobUri(String blobUri) {
+    return repo.getByBlobUri(blobUri);
+  }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
@@ -109,6 +109,23 @@ public class TableRepository {
     return refs;
   }
 
+  /**
+   * Reads the shared, kind-agnostic relation-name claim ({@link Keys#relationPointerByName}) and
+   * returns the owning relation's id — kind {@code RK_TABLE} or {@code RK_VIEW} — in one pointer
+   * read, with no blob fetch. Tables and views both reserve this claim on create/rename, so a hit
+   * answers kind-agnostic name resolution outright. Empty when the claim is absent (rows created
+   * before the claim existed) or carries no owner; callers must then fall back to the kind-specific
+   * by-name probes.
+   */
+  public Optional<ResourceId> relationNameClaim(
+      String accountId, String catalogId, String namespaceId, String name) {
+    return repo.refByPointer(Keys.relationPointerByName(accountId, catalogId, namespaceId, name))
+        .map(p -> p.getResourceId())
+        .filter(rid -> !rid.getId().isEmpty())
+        .filter(
+            rid -> rid.getKind() == ResourceKind.RK_TABLE || rid.getKind() == ResourceKind.RK_VIEW);
+  }
+
   /** Reads exact by-name table pointers and returns refs without fetching blobs from S3. */
   public List<RelationRef> listRefsByName(
       String accountId, String catalogId, String namespaceId, Set<String> names) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
@@ -136,4 +136,15 @@ public class ViewRepository {
   public MutationMeta metaForSafe(ResourceId viewResourceId) {
     return repo.metaForSafe(new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()));
   }
+
+  /** Pointer-only meta (no blob HEAD, blank etag) for metadata-graph consumers. */
+  public MutationMeta pointerMetaForSafe(ResourceId viewResourceId) {
+    return repo.pointerMetaForSafe(
+        new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()));
+  }
+
+  /** Blob-direct read for graph hydration from resolved metadata; empty if the blob moved. */
+  public Optional<View> getByBlobUri(String blobUri) {
+    return repo.getByBlobUri(blobUri);
+  }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -419,33 +419,6 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
         .build();
   }
 
-  /**
-   * Fetches and parses a resource directly by blob URI, skipping the pointer read. Intended for
-   * callers that already resolved the pointer (e.g. graph hydration from cached metadata). Returns
-   * empty when the blob is absent — callers should fall back to a pointer-based read, since the
-   * pointer may have moved to a new blob in the meantime.
-   */
-  public Optional<T> getByBlobUri(String blobUri) {
-    if (blobUri == null || blobUri.isBlank()) {
-      return Optional.empty();
-    }
-    try {
-      byte[] bytes = blobStore.get(blobUri);
-      if (bytes == null) {
-        return Optional.empty();
-      }
-      return Optional.of(parser.parse(bytes));
-    } catch (StorageNotFoundException snf) {
-      return Optional.empty();
-    } catch (InvalidProtocolBufferException ipbe) {
-      throw new CorruptionException("parse failed: " + blobUri, ipbe);
-    } catch (StorageAbortRetryableException sar) {
-      throw new AbortRetryableException("blob read retryable: " + blobUri);
-    } catch (Exception e) {
-      throw new CorruptionException("parse failed: " + blobUri, e);
-    }
-  }
-
   protected static void deleteQuietly(Runnable runnable) {
     try {
       runnable.run();

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -397,7 +397,15 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
   }
 
   protected MutationMeta readMetaOrDefault(String pointerKey, String blobUri, Timestamp nowTs) {
-    var pointerOpt = pointerStore.get(pointerKey);
+    return readMetaOrDefault(pointerStore.get(pointerKey), pointerKey, blobUri, nowTs);
+  }
+
+  /**
+   * Meta assembly for callers that already hold the canonical pointer — avoids re-reading the
+   * pointer that was fetched moments earlier to derive {@code blobUri}.
+   */
+  protected MutationMeta readMetaOrDefault(
+      Optional<Pointer> pointerOpt, String pointerKey, String blobUri, Timestamp nowTs) {
     var header = blobStore.head(blobUri);
     long version = pointerOpt.map(Pointer::getVersion).orElse(0L);
     String etag = header.map(BlobHeader::getEtag).orElse("");
@@ -409,6 +417,33 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
         .setEtag(etag)
         .setUpdatedAt(nowTs)
         .build();
+  }
+
+  /**
+   * Fetches and parses a resource directly by blob URI, skipping the pointer read. Intended for
+   * callers that already resolved the pointer (e.g. graph hydration from cached metadata). Returns
+   * empty when the blob is absent — callers should fall back to a pointer-based read, since the
+   * pointer may have moved to a new blob in the meantime.
+   */
+  public Optional<T> getByBlobUri(String blobUri) {
+    if (blobUri == null || blobUri.isBlank()) {
+      return Optional.empty();
+    }
+    try {
+      byte[] bytes = blobStore.get(blobUri);
+      if (bytes == null) {
+        return Optional.empty();
+      }
+      return Optional.of(parser.parse(bytes));
+    } catch (StorageNotFoundException snf) {
+      return Optional.empty();
+    } catch (InvalidProtocolBufferException ipbe) {
+      throw new CorruptionException("parse failed: " + blobUri, ipbe);
+    } catch (StorageAbortRetryableException sar) {
+      throw new AbortRetryableException("blob read retryable: " + blobUri);
+    } catch (Exception e) {
+      throw new CorruptionException("parse failed: " + blobUri, e);
+    }
   }
 
   protected static void deleteQuietly(Runnable runnable) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -606,7 +606,8 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
                                   + schema.resourceName
                                   + ": "
                                   + canonicalPointer));
-          return readMetaOrDefault(canonicalPointer, pointer.getBlobUri(), nowTs);
+          return readMetaOrDefault(
+              Optional.of(pointer), canonicalPointer, pointer.getBlobUri(), nowTs);
         });
   }
 
@@ -629,17 +630,42 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
                 .setUpdatedAt(nowTs)
                 .build();
           }
-          String blobUri;
-          if (schema.casBlobs) {
-            blobUri =
-                (ptrOpt.isPresent() && ptrOpt.get().getBlobUri() != null)
-                    ? ptrOpt.get().getBlobUri()
-                    : "";
-          } else {
-            blobUri = schema.blobUriForKey.apply(key);
-          }
-          return readMetaOrDefault(canonical, blobUri, nowTs);
+          String blobUri = blobUriFor(key, ptrOpt);
+          return readMetaOrDefault(ptrOpt, canonical, blobUri, nowTs);
         });
+  }
+
+  /**
+   * Pointer-only mutation meta: one pointer read, no blob HEAD, blank etag. For consumers that only
+   * need the pointer version and key (e.g. metadata-graph cache keys and node hydration) — callers
+   * returning meta to RPC clients must keep using {@link #metaForSafe}, whose etag feeds
+   * precondition checks.
+   */
+  public MutationMeta pointerMetaForSafe(K key) {
+    return observeRepository(
+        "pointer_meta_for_safe",
+        () -> {
+          Timestamp nowTs = Timestamps.fromMillis(clock.millis());
+          String canonical = schema.canonicalPointerForKey.apply(key);
+          var ptrOpt = pointerStore.get(canonical);
+          String blobUri = ptrOpt.isEmpty() && schema.casBlobs ? "" : blobUriFor(key, ptrOpt);
+          return MutationMeta.newBuilder()
+              .setPointerKey(canonical)
+              .setBlobUri(blobUri)
+              .setPointerVersion(ptrOpt.map(Pointer::getVersion).orElse(0L))
+              .setEtag("")
+              .setUpdatedAt(nowTs)
+              .build();
+        });
+  }
+
+  private String blobUriFor(K key, Optional<Pointer> ptrOpt) {
+    if (schema.casBlobs) {
+      return (ptrOpt.isPresent() && ptrOpt.get().getBlobUri() != null)
+          ? ptrOpt.get().getBlobUri()
+          : "";
+    }
+    return schema.blobUriForKey.apply(key);
   }
 
   private String resolveBlobUriForDelete(K key, String canonicalPointer) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -648,7 +648,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           Timestamp nowTs = Timestamps.fromMillis(clock.millis());
           String canonical = schema.canonicalPointerForKey.apply(key);
           var ptrOpt = pointerStore.get(canonical);
-          String blobUri = ptrOpt.isEmpty() && schema.casBlobs ? "" : blobUriFor(key, ptrOpt);
+          String blobUri = blobUriFor(key, ptrOpt);
           return MutationMeta.newBuilder()
               .setPointerKey(canonical)
               .setBlobUri(blobUri)

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -23,11 +23,14 @@ import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.model.ResourceKey;
 import ai.floedb.floecat.service.repo.model.ResourceSchema;
 import ai.floedb.floecat.service.telemetry.ServiceMetrics;
+import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
+import ai.floedb.floecat.storage.errors.StorageNotFoundException;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import ai.floedb.floecat.systemcatalog.graph.SystemResourceIdGenerator;
 import ai.floedb.floecat.telemetry.Tag;
 import ai.floedb.floecat.telemetry.Telemetry.TagKey;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import java.util.ArrayList;
@@ -60,6 +63,39 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
   public Optional<T> getByKey(K key) {
     return observeRepository("get_by_key", () -> getByKeyUnobserved(key));
+  }
+
+  /**
+   * Graph-hydration primitive: fetches and parses a resource directly by blob URI, skipping the
+   * pointer read, for callers that already resolved a <em>fresh</em> pointer (see {@code
+   * NodeLoader#load}). Returns empty when the blob is absent so the caller can fall back to a
+   * pointer read.
+   *
+   * <p>This reads by content and ignores the current pointer, so it is <b>only</b> safe for
+   * hydration and only exposed by the relation/scope repositories NodeLoader uses (catalog,
+   * namespace, table, view). It deliberately lives here rather than on {@link
+   * BaseResourceRepository} so repositories with GC or lifecycle semantics tied to pointer state do
+   * not inherit a "read regardless of the pointer" primitive.
+   */
+  public Optional<T> getByBlobUri(String blobUri) {
+    if (blobUri == null || blobUri.isBlank()) {
+      return Optional.empty();
+    }
+    try {
+      byte[] bytes = blobStore.get(blobUri);
+      if (bytes == null) {
+        return Optional.empty();
+      }
+      return Optional.of(parser.parse(bytes));
+    } catch (StorageNotFoundException snf) {
+      return Optional.empty();
+    } catch (InvalidProtocolBufferException ipbe) {
+      throw new CorruptionException("parse failed: " + blobUri, ipbe);
+    } catch (StorageAbortRetryableException sar) {
+      throw new AbortRetryableException("blob read retryable: " + blobUri);
+    } catch (Exception e) {
+      throw new CorruptionException("parse failed: " + blobUri, e);
+    }
   }
 
   public boolean existsByKey(K key) {

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -132,6 +132,18 @@ class CatalogSurfaceNamespacesTest {
   }
 
   @Test
+  void listNamespacesDoesNotDropSystemNamespacesSortingBeforeLastUserNamespace() {
+    // Regression: the system phase must resume by a system relative name, not by the last user
+    // relative name. "alpha" sorts before the last user namespace "orders" and must still appear.
+    stubUserNamespaces(List.of(namespace("orders", List.of())));
+    overlay.addNode(namespaceNode(systemNamespaceId("alpha"), "alpha", List.of()));
+    overlay.addNode(
+        namespaceNode(systemNamespaceId("information_schema"), "information_schema", List.of()));
+
+    assertEquals(List.of("orders", "alpha", "information_schema"), pageAllNamespaceNames(1));
+  }
+
+  @Test
   void listNamespacesRejectsMalformedServicePageToken() {
     StatusRuntimeException ex =
         assertThrows(

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -99,7 +99,32 @@ class CatalogSurfaceNamespacesTest {
             CORRELATION_ID);
 
     assertEquals(List.of("information_schema"), names(systemPage.getNamespacesList()));
-    assertTrue(systemPage.getPage().getNextPageToken().startsWith("ns:"));
+    // It is the only system namespace and it exactly fills the page, so there is no next page —
+    // the system phase must not advertise a continuation whose next page would be empty.
+    assertTrue(systemPage.getPage().getNextPageToken().isEmpty());
+  }
+
+  @Test
+  void listNamespacesSystemExactlyFillsPageEmitsNoToken() {
+    // Regression: a page that exactly consumes the last system namespace must not advertise an
+    // ns: continuation, whose next page would come back empty.
+    stubUserNamespaces(List.of());
+    overlay.addNode(
+        namespaceNode(systemNamespaceId("information_schema"), "information_schema", List.of()));
+
+    var page =
+        surface.listNamespaces(
+            ListNamespacesRequest.newBuilder()
+                .setCatalogId(catalogId)
+                .setPage(PageRequest.newBuilder().setPageSize(1))
+                .build(),
+            ACCOUNT_ID,
+            CORRELATION_ID);
+
+    assertEquals(List.of("information_schema"), names(page.getNamespacesList()));
+    assertTrue(
+        page.getPage().getNextPageToken().isEmpty(),
+        "exact-fill on the last system namespace must not emit a continuation token");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -70,26 +70,9 @@ class CatalogSurfaceNamespacesTest {
 
   @Test
   void listNamespacesKeepsRepoPhaseBeforeSystemPhase() {
-    Namespace userNamespace = namespace("alpha", List.of());
-    var systemNamespace =
-        namespaceNode(systemNamespaceId("information_schema"), "information_schema", List.of());
-    overlay.addNode(systemNamespace);
-
-    when(namespaceRepo.list(eq(ACCOUNT_ID), eq("cat"), eq(List.of()), anyInt(), anyString(), any()))
-        .thenAnswer(
-            invocation -> {
-              int limit = invocation.getArgument(3);
-              String cursor = invocation.getArgument(4);
-              StringBuilder nextOut = invocation.getArgument(5);
-              if (limit == 64 && cursor.isBlank()) {
-                nextOut.append("repo-next");
-                return List.of(userNamespace);
-              }
-              if (limit == 1000 && cursor.isBlank()) {
-                return List.of(userNamespace);
-              }
-              return List.of();
-            });
+    stubUserNamespaces(List.of(namespace("alpha", List.of())));
+    overlay.addNode(
+        namespaceNode(systemNamespaceId("information_schema"), "information_schema", List.of()));
 
     var firstPage =
         surface.listNamespaces(
@@ -101,20 +84,39 @@ class CatalogSurfaceNamespacesTest {
             CORRELATION_ID);
 
     assertEquals(List.of("alpha"), names(firstPage.getNamespacesList()));
-    assertEquals("repo-next", firstPage.getPage().getNextPageToken());
+    // Page filled in the repo phase: the token is a precise repo cursor, not a system-phase token.
+    String repoCursor = firstPage.getPage().getNextPageToken();
+    assertTrue(!repoCursor.isBlank() && !repoCursor.startsWith("ns:"));
     assertEquals(2, firstPage.getPage().getTotalSize());
 
     var systemPage =
         surface.listNamespaces(
             ListNamespacesRequest.newBuilder()
                 .setCatalogId(catalogId)
-                .setPage(PageRequest.newBuilder().setPageSize(1).setPageToken("repo-next"))
+                .setPage(PageRequest.newBuilder().setPageSize(1).setPageToken(repoCursor))
                 .build(),
             ACCOUNT_ID,
             CORRELATION_ID);
 
     assertEquals(List.of("information_schema"), names(systemPage.getNamespacesList()));
     assertTrue(systemPage.getPage().getNextPageToken().startsWith("ns:"));
+  }
+
+  @Test
+  void listNamespacesDoesNotSkipMatchesWhenPageFillsMidBatch() {
+    // Regression: the repo scan over-fetches (batch >= 64) and post-filters, so with more matching
+    // children than one batch the continuation must resume after the last *emitted* row, not after
+    // the scanned batch. A batch-end cursor silently skips every match scanned past the page fill.
+    var many = new java.util.ArrayList<Namespace>();
+    var expected = new java.util.ArrayList<String>();
+    for (int i = 0; i < 70; i++) {
+      String name = String.format("ns%02d", i);
+      many.add(namespace(name, List.of()));
+      expected.add(name);
+    }
+    stubUserNamespaces(many);
+
+    assertEquals(expected, pageAllNamespaceNames(3));
   }
 
   @Test
@@ -180,14 +182,40 @@ class CatalogSurfaceNamespacesTest {
     return namespaces.stream().map(Namespace::getDisplayName).toList();
   }
 
-  /** Stubs the repo so all user namespaces come back in a single exhausting batch. */
+  /**
+   * Stubs the repo mock as a faithful pager backend: rows are served in name order, {@code list}
+   * returns up to {@code limit} rows strictly after the cursor name (blank = start) and sets the
+   * next cursor to the last returned name when more remain, and {@code listTokenAfter} returns the
+   * row's name — mirroring the real store's "resume after this key" semantics.
+   */
   private void stubUserNamespaces(List<Namespace> userNamespaces) {
+    var sorted = new java.util.ArrayList<>(userNamespaces);
+    sorted.sort(java.util.Comparator.comparing(Namespace::getDisplayName));
     when(namespaceRepo.list(eq(ACCOUNT_ID), eq("cat"), eq(List.of()), anyInt(), anyString(), any()))
         .thenAnswer(
             invocation -> {
+              int limit = invocation.getArgument(3);
               String cursor = invocation.getArgument(4);
-              // Leave the "next" cursor blank: a blank next-token signals repo exhaustion.
-              return cursor == null || cursor.isBlank() ? userNamespaces : List.of();
+              StringBuilder nextOut = invocation.getArgument(5);
+              var remaining =
+                  sorted.stream()
+                      .filter(
+                          ns ->
+                              cursor == null
+                                  || cursor.isBlank()
+                                  || ns.getDisplayName().compareTo(cursor) > 0)
+                      .toList();
+              var page = remaining.subList(0, Math.min(limit, remaining.size()));
+              if (!page.isEmpty() && page.size() < remaining.size()) {
+                nextOut.append(page.get(page.size() - 1).getDisplayName());
+              }
+              return page;
+            });
+    when(namespaceRepo.listTokenAfter(eq(ACCOUNT_ID), eq("cat"), any()))
+        .thenAnswer(
+            invocation -> {
+              List<String> fullPath = invocation.getArgument(2);
+              return fullPath.get(fullPath.size() - 1);
             });
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -118,6 +118,20 @@ class CatalogSurfaceNamespacesTest {
   }
 
   @Test
+  void listNamespacesPagesThroughAllUserNamespacesWhenRepoExhaustsInOneBatch() {
+    // Regression: a single repo batch that exhausts the cursor may contain more matches than fit
+    // on one page. Later pages must keep returning the remaining user namespaces rather than
+    // jumping straight to the (empty) system phase.
+    stubUserNamespaces(
+        List.of(
+            namespace("alpha", List.of()),
+            namespace("bravo", List.of()),
+            namespace("charlie", List.of())));
+
+    assertEquals(List.of("alpha", "bravo", "charlie"), pageAllNamespaceNames(1));
+  }
+
+  @Test
   void listNamespacesRejectsMalformedServicePageToken() {
     StatusRuntimeException ex =
         assertThrows(
@@ -152,6 +166,39 @@ class CatalogSurfaceNamespacesTest {
 
   private static List<String> names(List<Namespace> namespaces) {
     return namespaces.stream().map(Namespace::getDisplayName).toList();
+  }
+
+  /** Stubs the repo so all user namespaces come back in a single exhausting batch. */
+  private void stubUserNamespaces(List<Namespace> userNamespaces) {
+    when(namespaceRepo.list(eq(ACCOUNT_ID), eq("cat"), eq(List.of()), anyInt(), anyString(), any()))
+        .thenAnswer(
+            invocation -> {
+              String cursor = invocation.getArgument(4);
+              // Leave the "next" cursor blank: a blank next-token signals repo exhaustion.
+              return cursor == null || cursor.isBlank() ? userNamespaces : List.of();
+            });
+  }
+
+  /** Drains every page (page_size {@code pageSize}) and returns the concatenated display names. */
+  private List<String> pageAllNamespaceNames(int pageSize) {
+    var collected = new java.util.ArrayList<String>();
+    String token = "";
+    for (int guard = 0; guard < 100; guard++) {
+      var response =
+          surface.listNamespaces(
+              ListNamespacesRequest.newBuilder()
+                  .setCatalogId(catalogId)
+                  .setPage(PageRequest.newBuilder().setPageSize(pageSize).setPageToken(token))
+                  .build(),
+              ACCOUNT_ID,
+              CORRELATION_ID);
+      collected.addAll(names(response.getNamespacesList()));
+      token = response.getPage().getNextPageToken();
+      if (token.isBlank()) {
+        return collected;
+      }
+    }
+    throw new AssertionError("pagination did not terminate; collected so far: " + collected);
   }
 
   private Namespace namespace(String name, List<String> path) {

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -134,6 +134,50 @@ class CatalogSurfaceNamespacesTest {
   }
 
   @Test
+  void listNamespacesPagesCompletelyOverARealRepositoryAndStore() {
+    // End-to-end over the real chain: pager -> NamespaceRepository -> InMemoryPointerStore,
+    // including listTokenAfter -> pageTokenAfterKey cursor synthesis. Catches any drift between
+    // the pointer keys the repository writes and the keys the pager resumes from — mocked-repo
+    // tests re-implement the cursor contract and cannot.
+    var pointers = new ai.floedb.floecat.storage.memory.InMemoryPointerStore();
+    var blobs = new ai.floedb.floecat.storage.memory.InMemoryBlobStore();
+    var realRepo = new NamespaceRepository(pointers, blobs);
+    var realSurface = new CatalogSurfaceNamespaces(realRepo, overlay);
+
+    var expected = new java.util.ArrayList<String>();
+    for (int i = 0; i < 150; i++) {
+      String name = String.format("ns%03d", i);
+      expected.add(name);
+      realRepo.create(
+          Namespace.newBuilder()
+              .setResourceId(id(ResourceKind.RK_NAMESPACE, "id_" + name))
+              .setCatalogId(catalogId)
+              .setDisplayName(name)
+              .build());
+    }
+
+    var collected = new java.util.ArrayList<String>();
+    String token = "";
+    for (int guard = 0; guard < 200; guard++) {
+      var response =
+          realSurface.listNamespaces(
+              ListNamespacesRequest.newBuilder()
+                  .setCatalogId(catalogId)
+                  .setPage(PageRequest.newBuilder().setPageSize(7).setPageToken(token))
+                  .build(),
+              ACCOUNT_ID,
+              CORRELATION_ID);
+      collected.addAll(names(response.getNamespacesList()));
+      token = response.getPage().getNextPageToken();
+      if (token.isBlank()) {
+        break;
+      }
+    }
+
+    assertEquals(expected, collected);
+  }
+
+  @Test
   void listNamespacesDoesNotDropSystemNamespacesSortingBeforeLastUserNamespace() {
     // Regression: the system phase must resume by a system relative name, not by the last user
     // relative name. "alpha" sorts before the last user namespace "orders" and must still appear.

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/loader/NodeLoaderTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/loader/NodeLoaderTest.java
@@ -16,12 +16,53 @@
 
 package ai.floedb.floecat.service.metagraph.loader;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import ai.floedb.floecat.catalog.rpc.Table;
+import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.testsupport.FakeCatalogRepository;
+import ai.floedb.floecat.service.testsupport.FakeNamespaceRepository;
+import ai.floedb.floecat.service.testsupport.FakeTableRepository;
+import ai.floedb.floecat.service.testsupport.FakeViewRepository;
 import org.junit.jupiter.api.Test;
 
 class NodeLoaderTest {
+
+  @Test
+  void tableHydratesWithASinglePointerReadAndNoGetById() {
+    FakeTableRepository tableRepo = new FakeTableRepository();
+    NodeLoader loader =
+        new NodeLoader(
+            new FakeCatalogRepository(),
+            new FakeNamespaceRepository(),
+            tableRepo,
+            new FakeViewRepository());
+
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("account")
+            .setId("t1")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    tableRepo.put(
+        Table.newBuilder()
+            .setResourceId(tableId)
+            .setDisplayName("orders")
+            .setSchemaJson("{}")
+            .build(),
+        MutationMeta.newBuilder().setPointerVersion(1L).setBlobUri("blob/t1").build());
+
+    assertThat(loader.table(tableId)).isPresent();
+
+    // One pointer read (the meta), then hydrate from the blob it names — not a second pointer read
+    // via getById.
+    assertThat(tableRepo.metaForSafeCount(tableId)).isEqualTo(1);
+    assertThat(tableRepo.getByIdCount(tableId)).isEqualTo(0);
+  }
 
   @Test
   void parseFqn_nameOnly() {

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -548,6 +548,140 @@ class MetaGraphTest {
     assertThat(collected).containsExactly(sysTable, sysTableB);
   }
 
+  @Test
+  void listTablesByPrefix_mixedPageEmitsSystemThenUserWithUserCursor() {
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(List.of(prefixSystemTable(sysTable, namespaceId, "system_table")));
+    when(system.tableName(sysTable, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("system_table").build()));
+
+    ResourceId userTableB =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("usr-b")
+            .build();
+    UserGraph.ResolveResult userResult =
+        userResolveResult(
+            5,
+            "more",
+            new CatalogOverlay.QualifiedRelation(
+                NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("u1").build(),
+                usrTable),
+            new CatalogOverlay.QualifiedRelation(
+                NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("u2").build(),
+                userTableB));
+    when(user.resolveTables(eq("cid"), eq(prefix), eq(2), eq(""))).thenReturn(userResult);
+
+    CatalogOverlay.ResolveResult page = meta.listTablesByPrefix("cid", prefix, 3, "");
+
+    assertThat(page.relations()).hasSize(3);
+    assertThat(page.relations().get(0).resourceId()).isEqualTo(sysTable);
+    assertThat(page.relations().get(1).resourceId()).isEqualTo(usrTable);
+    assertThat(page.relations().get(2).resourceId()).isEqualTo(userTableB);
+    // System row count + user total; continuation carries the user graph's cursor.
+    assertThat(page.totalSize()).isEqualTo(6);
+    assertThat(page.nextToken()).isEqualTo("u:more");
+  }
+
+  @Test
+  void listViewsByPrefix_systemFillingPageDoesNotSkipUserRows() {
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    ResourceId sysView =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_VIEW)
+            .setId("sys-view")
+            .build();
+    ResourceId usrView =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_VIEW)
+            .setId("usr-view")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(List.of(prefixSystemView(sysView, namespaceId, "system_view")));
+    when(system.viewName(sysView, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("system_view").build()));
+
+    UserGraph.ResolveResult userResult =
+        userResolveResult(
+            1,
+            "",
+            new CatalogOverlay.QualifiedRelation(
+                NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("uv").build(),
+                usrView));
+    when(user.resolveViews(eq("cid"), eq(prefix), eq(1), eq(""))).thenReturn(userResult);
+
+    CatalogOverlay.ResolveResult firstPage = meta.listViewsByPrefix("cid", prefix, 1, "");
+
+    assertThat(firstPage.relations()).hasSize(1);
+    assertThat(firstPage.relations().get(0).resourceId()).isEqualTo(sysView);
+    assertThat(firstPage.totalSize()).isEqualTo(2);
+
+    CatalogOverlay.ResolveResult secondPage =
+        meta.listViewsByPrefix("cid", prefix, 1, firstPage.nextToken());
+
+    assertThat(secondPage.relations()).hasSize(1);
+    assertThat(secondPage.relations().get(0).resourceId()).isEqualTo(usrView);
+    verify(user, times(2)).resolveViews(eq("cid"), eq(prefix), eq(1), eq(""));
+  }
+
+  @Test
+  void listTablesByPrefix_rejectsMalformedSystemToken() {
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+
+    assertThatThrownBy(() -> meta.listTablesByPrefix("cid", prefix, 1, "sys:%%%"))
+        .isInstanceOf(io.grpc.StatusRuntimeException.class)
+        .satisfies(
+            ex ->
+                assertThat(((io.grpc.StatusRuntimeException) ex).getStatus().getCode())
+                    .isEqualTo(io.grpc.Status.Code.INVALID_ARGUMENT));
+  }
+
+  private static ai.floedb.floecat.metagraph.model.ViewNode prefixSystemView(
+      ResourceId id, ResourceId namespaceId, String name) {
+    return new ai.floedb.floecat.metagraph.model.ViewNode(
+        id,
+        1L,
+        Instant.EPOCH,
+        ResourceId.getDefaultInstance(),
+        namespaceId,
+        name,
+        "select 1",
+        "sql",
+        List.of(),
+        List.of(),
+        List.of(),
+        GraphNodeOrigin.SYSTEM,
+        Map.of(),
+        Optional.empty(),
+        Map.of(),
+        Map.of());
+  }
+
   private static TableNode prefixSystemTable(ResourceId id, ResourceId namespaceId, String name) {
     return new TableNode() {
       @Override

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -451,6 +451,143 @@ class MetaGraphTest {
   }
 
   @Test
+  void listTablesByPrefix_systemFillingPageDoesNotSkipUserRows() {
+    // Regression: when system rows fill the page, the user graph must not be consulted for rows
+    // (its cursor would advance past a row the page drops). The user row must surface on the next
+    // page, fetched from a blank cursor.
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(List.of(prefixSystemTable(sysTable, namespaceId, "system_table")));
+    when(system.tableName(sysTable, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("system_table").build()));
+
+    UserGraph.ResolveResult userResult =
+        userResolveResult(
+            1,
+            "",
+            new CatalogOverlay.QualifiedRelation(
+                NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("user_t").build(),
+                usrTable));
+    when(user.resolveTables(eq("cid"), eq(prefix), eq(1), eq(""))).thenReturn(userResult);
+
+    CatalogOverlay.ResolveResult firstPage = meta.listTablesByPrefix("cid", prefix, 1, "");
+
+    assertThat(firstPage.relations()).hasSize(1);
+    assertThat(firstPage.relations().get(0).resourceId()).isEqualTo(sysTable);
+    assertThat(firstPage.totalSize()).isEqualTo(2);
+
+    CatalogOverlay.ResolveResult secondPage =
+        meta.listTablesByPrefix("cid", prefix, 1, firstPage.nextToken());
+
+    assertThat(secondPage.relations()).hasSize(1);
+    assertThat(secondPage.relations().get(0).resourceId()).isEqualTo(usrTable);
+    assertThat(secondPage.totalSize()).isEqualTo(2);
+    // Probe on the boundary page plus the second page's fetch, always from a blank cursor.
+    verify(user, times(2)).resolveTables(eq("cid"), eq(prefix), eq(1), eq(""));
+  }
+
+  @Test
+  void listTablesByPrefix_pagesThroughSystemOverflowWithoutLoss() {
+    // Regression: system rows beyond the page size were dropped (system was collected first-page
+    // only, capped at the page size). They must flow across pages via the system-phase token.
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    ResourceId sysTableB =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("sys-t-b")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(
+            List.of(
+                prefixSystemTable(sysTableB, namespaceId, "b_sys"),
+                prefixSystemTable(sysTable, namespaceId, "a_sys")));
+    when(system.tableName(sysTable, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("a_sys").build()));
+    when(system.tableName(sysTableB, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("b_sys").build()));
+    when(user.resolveTables(eq("cid"), eq(prefix), eq(1), eq("")))
+        .thenReturn(
+            new UserGraph.ResolveResult(
+                new FullyQualifiedResolver.ResolveResult(List.of(), 0, "")));
+
+    var collected = new java.util.ArrayList<ResourceId>();
+    String token = "";
+    for (int guard = 0; guard < 10 && collected.size() < 2; guard++) {
+      CatalogOverlay.ResolveResult page = meta.listTablesByPrefix("cid", prefix, 1, token);
+      page.relations().forEach(rel -> collected.add(rel.resourceId()));
+      assertThat(page.totalSize()).isEqualTo(2);
+      token = page.nextToken();
+      if (token.isBlank()) {
+        break;
+      }
+    }
+
+    // Sorted by canonical name: a_sys then b_sys, no gaps, no duplicates.
+    assertThat(collected).containsExactly(sysTable, sysTableB);
+  }
+
+  private static TableNode prefixSystemTable(ResourceId id, ResourceId namespaceId, String name) {
+    return new TableNode() {
+      @Override
+      public ResourceId namespaceId() {
+        return namespaceId;
+      }
+
+      @Override
+      public String displayName() {
+        return name;
+      }
+
+      @Override
+      public ResourceId id() {
+        return id;
+      }
+
+      @Override
+      public long version() {
+        return 1;
+      }
+
+      @Override
+      public Instant metadataUpdatedAt() {
+        return Instant.EPOCH;
+      }
+
+      @Override
+      public GraphNodeOrigin origin() {
+        return GraphNodeOrigin.SYSTEM;
+      }
+
+      @Override
+      public Map<EngineHintKey, EngineHint> engineHints() {
+        return Map.of();
+      }
+    };
+  }
+
+  @Test
   void resolveTables_prefix_resolvesSystemNamespaceWithNameSegment() {
     NameRef prefix =
         NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -479,6 +479,7 @@ class MetaGraphTest {
                 NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("user_t").build(),
                 usrTable));
     when(user.resolveTables(eq("cid"), eq(prefix), eq(1), eq(""))).thenReturn(userResult);
+    when(user.countTablesByPrefix(eq("cid"), eq(prefix))).thenReturn(1);
 
     CatalogOverlay.ResolveResult firstPage = meta.listTablesByPrefix("cid", prefix, 1, "");
 
@@ -492,8 +493,10 @@ class MetaGraphTest {
     assertThat(secondPage.relations()).hasSize(1);
     assertThat(secondPage.relations().get(0).resourceId()).isEqualTo(usrTable);
     assertThat(secondPage.totalSize()).isEqualTo(2);
-    // Probe on the boundary page plus the second page's fetch, always from a blank cursor.
-    verify(user, times(2)).resolveTables(eq("cid"), eq(prefix), eq(1), eq(""));
+    // The boundary page's total now uses the count-only path (no discarded one-row probe); only the
+    // second page fetches rows, from a blank cursor.
+    verify(user, times(1)).resolveTables(eq("cid"), eq(prefix), eq(1), eq(""));
+    verify(user).countTablesByPrefix(eq("cid"), eq(prefix));
   }
 
   @Test
@@ -633,6 +636,7 @@ class MetaGraphTest {
                 NameRef.newBuilder().setCatalog("examples").addPath("ns").setName("uv").build(),
                 usrView));
     when(user.resolveViews(eq("cid"), eq(prefix), eq(1), eq(""))).thenReturn(userResult);
+    when(user.countViewsByPrefix(eq("cid"), eq(prefix))).thenReturn(1);
 
     CatalogOverlay.ResolveResult firstPage = meta.listViewsByPrefix("cid", prefix, 1, "");
 
@@ -645,7 +649,10 @@ class MetaGraphTest {
 
     assertThat(secondPage.relations()).hasSize(1);
     assertThat(secondPage.relations().get(0).resourceId()).isEqualTo(usrView);
-    verify(user, times(2)).resolveViews(eq("cid"), eq(prefix), eq(1), eq(""));
+    // The boundary page's total now uses the count-only path (no discarded one-row probe); only the
+    // second page fetches rows, from a blank cursor.
+    verify(user, times(1)).resolveViews(eq("cid"), eq(prefix), eq(1), eq(""));
+    verify(user).countViewsByPrefix(eq("cid"), eq(prefix));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -500,6 +500,37 @@ class MetaGraphTest {
   }
 
   @Test
+  void listTablesByPrefix_systemExactlyFillsPageWithNoUserRows_emitsNoToken() {
+    // Regression: system rows exactly fill the page and there are no user rows. The handoff must
+    // not advertise a user-phase page that would come back empty.
+    NameRef prefix =
+        NameRef.newBuilder().setCatalog("examples").addPath("information_schema").build();
+    ResourceId namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(SystemNodeRegistry.SYSTEM_ACCOUNT)
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys-ns")
+            .build();
+    when(system.resolveNamespace(any(NameRef.class), eq(context)))
+        .thenReturn(Optional.of(namespaceId));
+    when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
+        .thenReturn(List.of(prefixSystemTable(sysTable, namespaceId, "system_table")));
+    when(system.tableName(sysTable, context))
+        .thenReturn(
+            Optional.of(NameRef.newBuilder().setCatalog("engine").setName("system_table").build()));
+    when(user.countTablesByPrefix(eq("cid"), eq(prefix))).thenReturn(0);
+
+    CatalogOverlay.ResolveResult page = meta.listTablesByPrefix("cid", prefix, 1, "");
+
+    assertThat(page.relations()).hasSize(1);
+    assertThat(page.relations().get(0).resourceId()).isEqualTo(sysTable);
+    assertThat(page.totalSize()).isEqualTo(1);
+    assertThat(page.nextToken()).isEmpty();
+    // No user-phase row fetch — there is nothing to continue into.
+    verify(user, never()).resolveTables(eq("cid"), eq(prefix), eq(1), eq(""));
+  }
+
+  @Test
   void listTablesByPrefix_pagesThroughSystemOverflowWithoutLoss() {
     // Regression: system rows beyond the page size were dropped (system was collected first-page
     // only, capped at the page size). They must flow across pages via the system-phase token.

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraphTest.java
@@ -285,6 +285,45 @@ class UserGraphTest {
   }
 
   @Test
+  void resolveHydratesFromAFreshPointerNotAStaleCachedMeta() {
+    // Node cache disabled + meta cache enabled: every resolve reaches the hydration path while the
+    // meta cache stays warm — the exact condition under which a stale cached meta (a per-process
+    // cache with no cross-instance invalidation) could hydrate an old-but-still-readable blob.
+    UserGraph g =
+        new UserGraph(
+            catalogRepository,
+            namespaceRepository,
+            snapshotRepository,
+            tableRepository,
+            viewRepository,
+            observability,
+            principalProvider,
+            0L, // node cache disabled
+            null);
+
+    ResourceId catalogId = rid("account", "cat", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = rid("account", "ns", ResourceKind.RK_NAMESPACE);
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("account")
+            .setId("table-stale")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    tableRepository.put(
+        tableWithSchema(tableId, catalogId, namespaceId, "{\"v\":1}"), blobMeta(1L, "blob/v1"));
+    assertThat(schemaOf(g, tableId)).contains("\"v\":1");
+
+    // Cross-instance-style update: the pointer now names blob/v2, but blob/v1 is still readable and
+    // this instance's meta cache still holds v1. Hydration must read the fresh pointer, not trust
+    // the cached meta's blob URI.
+    tableRepository.put(
+        tableWithSchema(tableId, catalogId, namespaceId, "{\"v\":2}"), blobMeta(2L, "blob/v2"));
+
+    assertThat(schemaOf(g, tableId)).contains("\"v\":2");
+  }
+
+  @Test
   void graphLoadRecordsLatency() {
     var ids = seedTable("load-metric", "{}");
     UserTableNode node = graph.table(ids.tableId()).orElseThrow();
@@ -826,6 +865,36 @@ class UserGraphTest {
             .setNanos(updatedAt.getNano())
             .build();
     return MutationMeta.newBuilder().setPointerVersion(version).setUpdatedAt(ts).build();
+  }
+
+  private static MutationMeta blobMeta(long version, String blobUri) {
+    return MutationMeta.newBuilder()
+        .setPointerVersion(version)
+        .setBlobUri(blobUri)
+        .setUpdatedAt(Timestamp.newBuilder().setSeconds(version).build())
+        .build();
+  }
+
+  private static Table tableWithSchema(
+      ResourceId tableId, ResourceId catalogId, ResourceId namespaceId, String schemaJson) {
+    return Table.newBuilder()
+        .setResourceId(tableId)
+        .setCatalogId(catalogId)
+        .setNamespaceId(namespaceId)
+        .setDisplayName("orders")
+        .setSchemaJson(schemaJson)
+        .setUpstream(
+            UpstreamRef.newBuilder()
+                .setFormat(TableFormat.TF_ICEBERG)
+                .setColumnIdAlgorithm(ColumnIdAlgorithm.CID_FIELD_ID)
+                .setUri("s3://x")
+                .build())
+        .build();
+  }
+
+  private static String schemaOf(UserGraph g, ResourceId tableId) {
+    UserTableNode node = g.table(tableId).orElseThrow();
+    return g.schemaJsonFor("corr", node, null);
   }
 
   private static ResourceId rid(String account, String id, ResourceKind kind) {

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/resolver/NameResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/resolver/NameResolverTest.java
@@ -117,6 +117,19 @@ class NameResolverTest {
   }
 
   @Test
+  void resolveRelationIdsBlankNameDoesNotPoisonValidSibling() {
+    // Regression: a blank-name ref processed first must not cache an empty scope under the
+    // name-independent (catalog + path) memo key and starve a valid sibling in the same batch.
+    NameRef blank = NameRef.newBuilder().setCatalog("cat").addPath("ns").setName("").build();
+    NameRef valid = NameRef.newBuilder().setCatalog("cat").addPath("ns").setName("orders").build();
+
+    var resolved = resolver.resolveRelationIds("account", List.of(blank, valid));
+
+    assertThat(resolved.get(blank)).isEmpty();
+    assertThat(resolved.get(valid)).hasValueSatisfying(r -> assertThat(r.getId()).isEqualTo("tbl"));
+  }
+
+  @Test
   void listTableIdsCollectsAcrossNamespaces() {
     ResourceId catalogId = rid("account", "cat", ResourceKind.RK_CATALOG);
 

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
@@ -81,6 +81,11 @@ final class RepoTestPointerStores {
     public boolean isEmpty() {
       return delegate.isEmpty();
     }
+
+    @Override
+    public String pageTokenAfterKey(String key) {
+      return delegate.pageTokenAfterKey(key);
+    }
   }
 
   /** Fails every batch CAS, simulating a transient storage error that aborts the transaction. */

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/TableRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/TableRepositoryTest.java
@@ -194,6 +194,30 @@ class TableRepositoryTest {
   }
 
   @Test
+  void relationNameClaimResolvesTableAndViewInOnePointerRead() {
+    ResourceId tableId = createTable("sales", "us", "orders");
+    Table table = tableRepo.getById(tableId).orElseThrow();
+    String catalogId = table.getCatalogId().getId();
+    String namespaceId = table.getNamespaceId().getId();
+
+    var claimedTable = tableRepo.relationNameClaim(account, catalogId, namespaceId, "orders");
+    assertTrue(claimedTable.isPresent());
+    assertEquals(tableId.getId(), claimedTable.get().getId());
+    assertEquals(ResourceKind.RK_TABLE, claimedTable.get().getKind());
+
+    ViewRepository viewRepo = new ViewRepository(ptr, blobs);
+    View metrics = view(table.getCatalogId(), table.getNamespaceId(), "metrics");
+    viewRepo.create(metrics);
+
+    var claimedView = tableRepo.relationNameClaim(account, catalogId, namespaceId, "metrics");
+    assertTrue(claimedView.isPresent());
+    assertEquals(metrics.getResourceId().getId(), claimedView.get().getId());
+    assertEquals(ResourceKind.RK_VIEW, claimedView.get().getKind());
+
+    assertTrue(tableRepo.relationNameClaim(account, catalogId, namespaceId, "absent").isEmpty());
+  }
+
+  @Test
   void relationClaimReleasedOnDeleteFreesNameForOtherKind() {
     ResourceId tableId = createTable("sales", "us", "orders");
     Table table = tableRepo.getById(tableId).orElseThrow();

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeCatalogRepository.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeCatalogRepository.java
@@ -31,6 +31,8 @@ public final class FakeCatalogRepository extends CatalogRepository {
   private final Map<ResourceId, Catalog> entries = new HashMap<>();
   private final Map<ResourceId, MutationMeta> metas = new HashMap<>();
   private final Map<ResourceId, Integer> gets = new HashMap<>();
+  // blobUri -> catalog, so the getByBlobUri hydration fast path is exercised.
+  private final Map<String, Catalog> byBlob = new HashMap<>();
 
   public FakeCatalogRepository() {
     super(new InMemoryPointerStore(), new InMemoryBlobStore());
@@ -39,6 +41,9 @@ public final class FakeCatalogRepository extends CatalogRepository {
   public void put(Catalog catalog, MutationMeta meta) {
     entries.put(catalog.getResourceId(), catalog);
     metas.put(catalog.getResourceId(), meta);
+    if (meta != null && meta.getBlobUri() != null && !meta.getBlobUri().isBlank()) {
+      byBlob.put(meta.getBlobUri(), catalog);
+    }
   }
 
   public void putMeta(ResourceId id, MutationMeta meta) {
@@ -49,6 +54,14 @@ public final class FakeCatalogRepository extends CatalogRepository {
   public Optional<Catalog> getById(ResourceId id) {
     gets.merge(id, 1, Integer::sum);
     return Optional.ofNullable(entries.get(id));
+  }
+
+  @Override
+  public Optional<Catalog> getByBlobUri(String blobUri) {
+    if (blobUri != null && byBlob.containsKey(blobUri)) {
+      return Optional.of(byBlob.get(blobUri));
+    }
+    return super.getByBlobUri(blobUri);
   }
 
   @Override

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeCatalogRepository.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeCatalogRepository.java
@@ -70,6 +70,12 @@ public final class FakeCatalogRepository extends CatalogRepository {
     return meta;
   }
 
+  @Override
+  public MutationMeta pointerMetaForSafe(ResourceId id) {
+    // The fake's meta map is the single source of truth for both meta variants.
+    return metaForSafe(id);
+  }
+
   public int getByIdCount(ResourceId id) {
     return gets.getOrDefault(id, 0);
   }

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeNamespaceRepository.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeNamespaceRepository.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 public final class FakeNamespaceRepository extends NamespaceRepository {
   private final Map<ResourceId, Namespace> entries = new HashMap<>();
   private final Map<ResourceId, MutationMeta> metas = new HashMap<>();
+  // blobUri -> namespace, so the getByBlobUri hydration fast path is exercised.
+  private final Map<String, Namespace> byBlob = new HashMap<>();
 
   public FakeNamespaceRepository() {
     super(new InMemoryPointerStore(), new InMemoryBlobStore());
@@ -39,6 +41,9 @@ public final class FakeNamespaceRepository extends NamespaceRepository {
   public void put(Namespace namespace, MutationMeta meta) {
     entries.put(namespace.getResourceId(), namespace);
     metas.put(namespace.getResourceId(), meta);
+    if (meta != null && meta.getBlobUri() != null && !meta.getBlobUri().isBlank()) {
+      byBlob.put(meta.getBlobUri(), namespace);
+    }
   }
 
   @Override
@@ -52,6 +57,14 @@ public final class FakeNamespaceRepository extends NamespaceRepository {
   @Override
   public Optional<Namespace> getById(ResourceId id) {
     return Optional.ofNullable(entries.get(id));
+  }
+
+  @Override
+  public Optional<Namespace> getByBlobUri(String blobUri) {
+    if (blobUri != null && byBlob.containsKey(blobUri)) {
+      return Optional.of(byBlob.get(blobUri));
+    }
+    return super.getByBlobUri(blobUri);
   }
 
   @Override

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeNamespaceRepository.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeNamespaceRepository.java
@@ -74,6 +74,12 @@ public final class FakeNamespaceRepository extends NamespaceRepository {
     return meta;
   }
 
+  @Override
+  public MutationMeta pointerMetaForSafe(ResourceId id) {
+    // The fake's meta map is the single source of truth for both meta variants.
+    return metaForSafe(id);
+  }
+
   private boolean matchesPath(Namespace namespace, List<String> path) {
     if (path.isEmpty()) {
       return namespace.getDisplayName().isBlank() && namespace.getParentsCount() == 0;

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeTableRepository.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeTableRepository.java
@@ -35,6 +35,10 @@ public final class FakeTableRepository extends TableRepository {
   private final Map<ResourceId, MutationMeta> metas = new HashMap<>();
   private final Map<ResourceId, Integer> gets = new HashMap<>();
   private final Map<ResourceId, Integer> metaGets = new HashMap<>();
+  // blobUri -> table, so the getByBlobUri hydration fast path is actually exercised (put() does not
+  // touch the real blob store). Keeps old blobs addressable, mirroring CAS blobs outliving a
+  // pointer move.
+  private final Map<String, Table> byBlob = new HashMap<>();
 
   public FakeTableRepository() {
     super(new InMemoryPointerStore(), new InMemoryBlobStore());
@@ -43,13 +47,16 @@ public final class FakeTableRepository extends TableRepository {
   public void put(Table table, MutationMeta meta) {
     entries.put(table.getResourceId(), table);
     metas.put(table.getResourceId(), meta);
+    indexBlob(meta, table);
   }
 
   @Override
   public void create(Table table) {
     super.create(table);
     entries.put(table.getResourceId(), table);
-    metas.put(table.getResourceId(), super.metaForSafe(table.getResourceId()));
+    MutationMeta meta = super.metaForSafe(table.getResourceId());
+    metas.put(table.getResourceId(), meta);
+    indexBlob(meta, table);
   }
 
   @Override
@@ -57,9 +64,17 @@ public final class FakeTableRepository extends TableRepository {
     boolean updated = super.update(table, expectedPointerVersion);
     if (updated) {
       entries.put(table.getResourceId(), table);
-      metas.put(table.getResourceId(), super.metaForSafe(table.getResourceId()));
+      MutationMeta meta = super.metaForSafe(table.getResourceId());
+      metas.put(table.getResourceId(), meta);
+      indexBlob(meta, table);
     }
     return updated;
+  }
+
+  private void indexBlob(MutationMeta meta, Table table) {
+    if (meta != null && meta.getBlobUri() != null && !meta.getBlobUri().isBlank()) {
+      byBlob.put(meta.getBlobUri(), table);
+    }
   }
 
   public void putMeta(ResourceId id, MutationMeta meta) {
@@ -70,6 +85,20 @@ public final class FakeTableRepository extends TableRepository {
   public Optional<Table> getById(ResourceId id) {
     gets.merge(id, 1, Integer::sum);
     return Optional.ofNullable(entries.get(id));
+  }
+
+  @Override
+  public Optional<Table> getByBlobUri(String blobUri) {
+    if (blobUri != null && byBlob.containsKey(blobUri)) {
+      return Optional.of(byBlob.get(blobUri));
+    }
+    return super.getByBlobUri(blobUri);
+  }
+
+  @Override
+  public Optional<ResourceId> relationNameClaim(
+      String accountId, String catalogId, String namespaceId, String name) {
+    return getByName(accountId, catalogId, namespaceId, name).map(Table::getResourceId);
   }
 
   @Override

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeTableRepository.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeTableRepository.java
@@ -120,6 +120,12 @@ public final class FakeTableRepository extends TableRepository {
     return meta;
   }
 
+  @Override
+  public MutationMeta pointerMetaForSafe(ResourceId id) {
+    // The fake's meta map is the single source of truth for both meta variants.
+    return metaForSafe(id);
+  }
+
   public int getByIdCount(ResourceId id) {
     return gets.getOrDefault(id, 0);
   }

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeViewRepository.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeViewRepository.java
@@ -33,6 +33,9 @@ import java.util.Optional;
 public final class FakeViewRepository extends ViewRepository {
   private final Map<ResourceId, View> entries = new HashMap<>();
   private final Map<ResourceId, MutationMeta> metas = new HashMap<>();
+  // blobUri -> view, so the getByBlobUri hydration fast path is exercised (put() does not touch the
+  // real blob store).
+  private final Map<String, View> byBlob = new HashMap<>();
 
   public FakeViewRepository() {
     super(new InMemoryPointerStore(), new InMemoryBlobStore());
@@ -41,6 +44,9 @@ public final class FakeViewRepository extends ViewRepository {
   public void put(View view, MutationMeta meta) {
     entries.put(view.getResourceId(), view);
     metas.put(view.getResourceId(), meta);
+    if (meta != null && meta.getBlobUri() != null && !meta.getBlobUri().isBlank()) {
+      byBlob.put(meta.getBlobUri(), view);
+    }
   }
 
   public void putMeta(ResourceId id, MutationMeta meta) {
@@ -73,6 +79,14 @@ public final class FakeViewRepository extends ViewRepository {
   @Override
   public Optional<View> getById(ResourceId id) {
     return Optional.ofNullable(entries.get(id));
+  }
+
+  @Override
+  public Optional<View> getByBlobUri(String blobUri) {
+    if (blobUri != null && byBlob.containsKey(blobUri)) {
+      return Optional.of(byBlob.get(blobUri));
+    }
+    return super.getByBlobUri(blobUri);
   }
 
   @Override

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeViewRepository.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/FakeViewRepository.java
@@ -122,6 +122,12 @@ public final class FakeViewRepository extends ViewRepository {
     return meta;
   }
 
+  @Override
+  public MutationMeta pointerMetaForSafe(ResourceId id) {
+    // The fake's meta map is the single source of truth for both meta variants.
+    return metaForSafe(id);
+  }
+
   private List<View> matchingViews(String accountId, String catalogId, String namespaceId) {
     return entries.values().stream()
         .filter(

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/UserRepositoryTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/UserRepositoryTestSupport.java
@@ -69,6 +69,11 @@ public final class UserRepositoryTestSupport {
     public MutationMeta metaForSafe(ResourceId id) {
       throw new StorageNotFoundException("unused");
     }
+
+    @Override
+    public MutationMeta pointerMetaForSafe(ResourceId id) {
+      return metaForSafe(id);
+    }
   }
 
   public static final class FakeNamespaceRepository extends NamespaceRepository {
@@ -121,6 +126,11 @@ public final class UserRepositoryTestSupport {
     @Override
     public MutationMeta metaForSafe(ResourceId id) {
       throw new StorageNotFoundException("unused");
+    }
+
+    @Override
+    public MutationMeta pointerMetaForSafe(ResourceId id) {
+      return metaForSafe(id);
     }
   }
 
@@ -193,6 +203,11 @@ public final class UserRepositoryTestSupport {
     @Override
     public MutationMeta metaForSafe(ResourceId id) {
       throw new StorageNotFoundException("unused");
+    }
+
+    @Override
+    public MutationMeta pointerMetaForSafe(ResourceId id) {
+      return metaForSafe(id);
     }
 
     private int startIndexForToken(List<Table> sorted, String pageToken) {
@@ -277,6 +292,11 @@ public final class UserRepositoryTestSupport {
     @Override
     public MutationMeta metaForSafe(ResourceId id) {
       throw new StorageNotFoundException("unused");
+    }
+
+    @Override
+    public MutationMeta pointerMetaForSafe(ResourceId id) {
+      return metaForSafe(id);
     }
 
     private int startIndexForToken(List<View> sorted, String pageToken) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -160,6 +160,15 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     return Optional.of(Map.of(ATTR_PARTITION_KEY, S(parts[0]), ATTR_SORT_KEY, S(parts[1])));
   }
 
+  @Override
+  public String pageTokenAfterKey(Key key) {
+    // Tokens are the (pk, sk) position encoded exactly as lastEvaluatedKey tokens are; DynamoDB's
+    // exclusiveStartKey is a position, not an item reference, so the key need not still exist.
+    return encodeToken(
+            Map.of(ATTR_PARTITION_KEY, S(key.partitionKey()), ATTR_SORT_KEY, S(key.sortKey())))
+        .orElseThrow();
+  }
+
   private static <T> Uni<T> fromStage(CompletionStage<T> stage) {
     return Uni.createFrom()
         .emitter(

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -164,9 +164,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   public String pageTokenAfterKey(Key key) {
     // Tokens are the (pk, sk) position encoded exactly as lastEvaluatedKey tokens are; DynamoDB's
     // exclusiveStartKey is a position, not an item reference, so the key need not still exist.
-    return encodeToken(
-            Map.of(ATTR_PARTITION_KEY, S(key.partitionKey()), ATTR_SORT_KEY, S(key.sortKey())))
-        .orElseThrow();
+    return encodeToken(keyMap(key)).orElseThrow();
   }
 
   private static <T> Uni<T> fromStage(CompletionStage<T> stage) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
@@ -77,6 +77,11 @@ public abstract class KvPointerStore implements PointerStore {
   }
 
   @Override
+  public String pageTokenAfterKey(String key) {
+    return pointers.pageTokenAfterKey(key);
+  }
+
+  @Override
   public int deleteByPrefix(String prefix) {
     return await(() -> pointers.deleteByPrefix(prefix).await().indefinitely());
   }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -299,6 +299,11 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
                     page.items().stream().map(this::decode).toList(), page.nextToken()));
   }
 
+  /** Page token resuming a {@link #listByPrefix} scan immediately after the given pointer key. */
+  public String pageTokenAfterKey(String key) {
+    return kv.pageTokenAfterKey(pointerKey(key));
+  }
+
   /**
    * List pointer keys by prefix.
    *

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStorePageTokenTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStorePageTokenTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv.dynamodb;
+
+import static ai.floedb.floecat.storage.kv.dynamodb.DynamoDbKvStore.decodeToken;
+import static ai.floedb.floecat.storage.kv.dynamodb.DynamoDbKvStore.encodeToken;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.floedb.floecat.storage.kv.KvAttributes;
+import ai.floedb.floecat.storage.kv.KvStore;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Pins the token contract behind {@link DynamoDbKvStore#pageTokenAfterKey}: a synthesized token
+ * must be byte-identical to the lastEvaluatedKey token the store would emit for the same (pk, sk)
+ * position, so callers can resume a scan exactly after a row they consumed.
+ */
+class DynamoDbKvStorePageTokenTest implements KvAttributes {
+
+  private final DynamoDbKvStore store =
+      new DynamoDbKvStore((software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient) null, "t");
+
+  @Test
+  void pageTokenAfterKeyMatchesLastEvaluatedKeyEncoding() {
+    var key = new KvStore.Key("accounts/acct-1", "catalogs/cat/namespaces/by-path/sales");
+    Map<String, AttributeValue> lek =
+        Map.of(
+            ATTR_PARTITION_KEY, AttributeValue.fromS(key.partitionKey()),
+            ATTR_SORT_KEY, AttributeValue.fromS(key.sortKey()));
+
+    assertEquals(encodeToken(lek).orElseThrow(), store.pageTokenAfterKey(key));
+  }
+
+  @Test
+  void pageTokenAfterKeyRoundTripsToTheSamePosition() {
+    var key = new KvStore.Key("accounts/acct-1", "tables/by-name/order%20items");
+
+    Map<String, AttributeValue> decoded =
+        decodeToken(Optional.of(store.pageTokenAfterKey(key))).orElseThrow();
+
+    assertEquals(key.partitionKey(), decoded.get(ATTR_PARTITION_KEY).s());
+    assertEquals(key.sortKey(), decoded.get(ATTR_SORT_KEY).s());
+  }
+}

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -91,10 +91,21 @@ public final class InMemoryKvStore implements KvStore {
           break;
         }
       }
-      if (index < 0) {
+      if (index >= 0) {
+        start = index + 1;
+      } else if (token.startsWith(skPrefix)) {
+        // The token names a position inside this keyspace whose row has since been deleted.
+        // Resume at the insertion point, matching DynamoDB's positional exclusiveStartKey
+        // semantics; tokens outside the keyspace are still rejected as malformed.
+        int insertion = 0;
+        while (insertion < matching.size()
+            && matching.get(insertion).key().sortKey().compareTo(token) <= 0) {
+          insertion++;
+        }
+        start = insertion;
+      } else {
         throw new IllegalArgumentException("Bad page token");
       }
-      start = index + 1;
     }
 
     if (start >= matching.size()) {

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -212,6 +212,12 @@ public final class InMemoryKvStore implements KvStore {
   }
 
   private static String encodeToken(String sortKey) {
+    if (sortKey.isEmpty()) {
+      // base64("") is "", which is this codebase's "no more pages" sentinel: an empty sort key
+      // would emit a token indistinguishable from "done" and silently truncate pagination. No key
+      // uses an empty sort key today, so fail loud rather than produce an ambiguous token.
+      throw new IllegalArgumentException("cannot encode a page token for an empty sort key");
+    }
     return Base64.getUrlEncoder()
         .withoutPadding()
         .encodeToString(sortKey.getBytes(StandardCharsets.UTF_8));

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -111,6 +111,12 @@ public final class InMemoryKvStore implements KvStore {
   }
 
   @Override
+  public String pageTokenAfterKey(Key key) {
+    // Same encoding as end-of-page tokens: base64 of the sort key to resume after.
+    return encodeToken(key.sortKey());
+  }
+
+  @Override
   public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
     String pk = partitionKey == null ? "" : partitionKey;
     String skPrefix = sortKeyPrefix == null ? "" : sortKeyPrefix;

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -93,10 +93,13 @@ public final class InMemoryKvStore implements KvStore {
       }
       if (index >= 0) {
         start = index + 1;
-      } else if (token.startsWith(skPrefix)) {
+      } else if (skPrefix.isEmpty() || token.startsWith(skPrefix)) {
         // The token names a position inside this keyspace whose row has since been deleted.
         // Resume at the insertion point, matching DynamoDB's positional exclusiveStartKey
-        // semantics; tokens outside the keyspace are still rejected as malformed.
+        // semantics. With a non-blank prefix, a token outside it is rejected as malformed below;
+        // a blank prefix scans the whole partition, so there is no keyspace boundary to reject
+        // against and any decodable token is a valid position (decodeToken already rejects tokens
+        // that are not valid base64).
         int insertion = 0;
         while (insertion < matching.size()
             && matching.get(insertion).key().sortKey().compareTo(token) <= 0) {

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
@@ -77,10 +77,16 @@ public class InMemoryPointerStore implements PointerStore {
     int start = 0;
     if (pageToken != null && !pageToken.isEmpty()) {
       int idx = Collections.binarySearch(keys, pageToken);
-      if (idx < 0) {
+      if (idx >= 0) {
+        start = idx + 1;
+      } else if (pageToken.startsWith(pfx)) {
+        // The token names a position inside this keyspace whose row has since been deleted.
+        // Resume at the insertion point, matching DynamoDB's positional exclusiveStartKey
+        // semantics; tokens outside the keyspace are still rejected as malformed.
+        start = -idx - 1;
+      } else {
         throw new IllegalArgumentException("bad page token");
       }
-      start = idx + 1;
     }
 
     if (start >= keys.size()) {

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
@@ -112,6 +112,14 @@ public class InMemoryPointerStore implements PointerStore {
   }
 
   @Override
+  public String pageTokenAfterKey(String key) {
+    // This store's page tokens are raw pointer keys ("resume after this key"), so the key itself
+    // is the token. Resuming after a since-deleted key fails the same way an ordinary end-of-page
+    // token for that key would.
+    return key;
+  }
+
+  @Override
   public int countByPrefix(String prefix) {
     final String pfx = prefix == null ? "" : prefix;
     int n = 0;

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
@@ -79,10 +79,12 @@ public class InMemoryPointerStore implements PointerStore {
       int idx = Collections.binarySearch(keys, pageToken);
       if (idx >= 0) {
         start = idx + 1;
-      } else if (pageToken.startsWith(pfx)) {
+      } else if (pfx.isEmpty() || pageToken.startsWith(pfx)) {
         // The token names a position inside this keyspace whose row has since been deleted.
         // Resume at the insertion point, matching DynamoDB's positional exclusiveStartKey
-        // semantics; tokens outside the keyspace are still rejected as malformed.
+        // semantics. With a non-blank prefix, a token outside it is rejected as malformed below;
+        // a blank prefix scans the whole store, so there is no keyspace boundary to reject against
+        // and any token is a valid resume position.
         start = -idx - 1;
       } else {
         throw new IllegalArgumentException("bad page token");

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -85,6 +85,21 @@ class KvStoreContractTest {
   }
 
   @Test
+  void queryByPartitionKeyPrefix_blankPrefix_resumesPositionallyForAbsentKey() {
+    assertTrue(kv.putCas(record("pk1", "sk0", 1L, "v0"), 0L).await().indefinitely());
+    assertTrue(kv.putCas(record("pk1", "sk2", 1L, "v2"), 0L).await().indefinitely());
+
+    // Token names an absent sort key ("sk1"); a blank prefix has no keyspace boundary, so the
+    // scan resumes positionally (DynamoDB exclusiveStartKey semantics) rather than throwing.
+    String token = kv.pageTokenAfterKey(key("pk1", "sk1"));
+    var page =
+        kv.queryByPartitionKeyPrefix("pk1", "", 10, Optional.of(token)).await().indefinitely();
+
+    assertEquals(1, page.items().size());
+    assertEquals("sk2", page.items().get(0).key().sortKey());
+  }
+
+  @Test
   void deleteByPrefix_removes_matching_records() {
     putSeries("pk1", "sk", 3);
     putSeries("pk2", "sk", 2);

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -100,6 +100,12 @@ class KvStoreContractTest {
   }
 
   @Test
+  void pageTokenAfterKey_emptySortKey_throwsInsteadOfEmptyToken() {
+    // An empty sort key would base64-encode to "", colliding with the "no more pages" sentinel.
+    assertThrows(IllegalArgumentException.class, () -> kv.pageTokenAfterKey(key("pk1", "")));
+  }
+
+  @Test
   void deleteByPrefix_removes_matching_records() {
     putSeries("pk1", "sk", 3);
     putSeries("pk2", "sk", 2);

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
@@ -148,6 +148,34 @@ public class PointerStoreContractTest {
   }
 
   @Test
+  void pageTokenAfterKey_resumesScanImmediatelyAfterThatKey() {
+    store.compareAndSet(key(1), 0L, pointer(key(1), 1L));
+    store.compareAndSet(key(2), 0L, pointer(key(2), 1L));
+    store.compareAndSet(key(3), 0L, pointer(key(3), 1L));
+
+    String token = store.pageTokenAfterKey(key(1));
+    StringBuilder next = new StringBuilder();
+    List<Pointer> page = store.listPointersByPrefix(prefix(), 10, token, next);
+
+    assertEquals(keysOf(List.of(pointer(key(2), 1L), pointer(key(3), 1L))), keysOf(page));
+  }
+
+  @Test
+  void pageTokenAfterKey_resumesPositionallyWhenTheKeyWasDeleted() {
+    store.compareAndSet(key(1), 0L, pointer(key(1), 1L));
+    store.compareAndSet(key(2), 0L, pointer(key(2), 1L));
+    store.compareAndSet(key(3), 0L, pointer(key(3), 1L));
+
+    String token = store.pageTokenAfterKey(key(2));
+    assertTrue(store.compareAndDelete(key(2), 1L));
+
+    StringBuilder next = new StringBuilder();
+    List<Pointer> page = store.listPointersByPrefix(prefix(), 10, token, next);
+
+    assertEquals(keysOf(List.of(pointer(key(3), 1L))), keysOf(page));
+  }
+
+  @Test
   void compareAndSetBatch_emptyOps_returns_true() {
     assertTrue(store.compareAndSetBatch(List.of()));
   }

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
@@ -176,6 +176,20 @@ public class PointerStoreContractTest {
   }
 
   @Test
+  void listPointersByPrefix_blankPrefix_resumesPositionallyForAbsentToken() {
+    store.compareAndSet(key(1), 0L, pointer(key(1), 1L));
+    store.compareAndSet(key(3), 0L, pointer(key(3), 1L));
+
+    // Under a blank prefix there is no keyspace boundary, so a token naming a position with no
+    // live row resumes positionally (DynamoDB exclusiveStartKey semantics) rather than being
+    // rejected as malformed.
+    StringBuilder next = new StringBuilder();
+    List<Pointer> page = store.listPointersByPrefix("", 10, key(2), next);
+
+    assertEquals(keysOf(List.of(pointer(key(3), 1L))), keysOf(page));
+  }
+
+  @Test
   void compareAndSetBatch_emptyOps_returns_true() {
     assertTrue(store.compareAndSetBatch(List.of()));
   }


### PR DESCRIPTION
## Summary

Removes repeated pointer/blob reads on the cold query path (name → id → pin → hydrate); most of these paths had no cache at all, so the wins apply warm too.
Effect: on a typical N-table-by-name query, roughly a 60–65% reduction in storage ops on the resolve+pin segment (view resolution benefits most).

## What's in here

- snapshotPinFor answers the "is this a system table?" check from the in-memory system graph instead of hydrating the full user node from storage.
- Metadata/hydration read trimming: metaFor* no longer re-reads the pointer it just fetched; graph consumers use a pointer-only meta (no S3 HEAD, no etag); node hydration fetches the blob the meta already names instead of re-reading the pointer via getById. Cold hydration drops from 3 pointer + HEAD + GET to 1 pointer + GET.
- Batch scope memoization: fully-qualified list resolution and query-input name resolution resolve each catalog/namespace once per call instead of once per name (new CatalogOverlay.resolveNames, default-safe for other overlays).
- Kind-agnostic name resolution answers from the shared relation-name claim (1 pointer, no blob) instead of a table-then-view probe.
- Folds the batchResolveTables/batchResolveViews twins into one shared method.


## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
