### PR TITLE
refactor: rename coverage and test dedupe

### DIFF
--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImplTest.java
@@ -41,13 +41,12 @@ import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.service.testsupport.TestNodes;
+import ai.floedb.floecat.service.testsupport.TestPrincipals;
 import ai.floedb.floecat.stats.spi.StatsStore;
-import ai.floedb.floecat.systemcatalog.graph.model.SystemTableNode;
 import com.google.protobuf.FieldMask;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -125,11 +124,7 @@ class SnapshotServiceImplTest {
     when(svc.tableRepo.update(any(Table.class), eq(7L))).thenReturn(true);
 
     // principal/authz plumbing
-    var pc = mock(PrincipalContext.class);
-    when(svc.principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(svc.authz).require(any(), anyString());
+    var pc = TestPrincipals.stubPrincipal(svc.principal, svc.authz);
 
     // snapshot repo behavior: no existing
     when(svc.snapshotRepo.getById(eq(tableId), anyLong())).thenReturn(Optional.empty());
@@ -156,7 +151,7 @@ class SnapshotServiceImplTest {
   @Test
   void createSnapshotRejectsSystemTableBeforeSnapshotRepoWrite() {
     var tableId = tableId("sys_snapshot_create");
-    var svc = serviceWithVisibleTable(tableId, systemTableNode(tableId));
+    var svc = serviceWithVisibleTable(tableId, TestNodes.systemTableNode(tableId));
 
     StatusRuntimeException ex =
         assertThrows(
@@ -181,7 +176,7 @@ class SnapshotServiceImplTest {
   @Test
   void updateSnapshotRejectsSystemTableBeforeSnapshotRepoWrite() {
     var tableId = tableId("sys_snapshot_update");
-    var svc = serviceWithVisibleTable(tableId, systemTableNode(tableId));
+    var svc = serviceWithVisibleTable(tableId, TestNodes.systemTableNode(tableId));
 
     StatusRuntimeException ex =
         assertThrows(
@@ -207,7 +202,7 @@ class SnapshotServiceImplTest {
   @Test
   void deleteSnapshotRejectsSystemTableBeforeSnapshotRepoWrite() {
     var tableId = tableId("sys_snapshot_delete");
-    var svc = serviceWithVisibleTable(tableId, systemTableNode(tableId));
+    var svc = serviceWithVisibleTable(tableId, TestNodes.systemTableNode(tableId));
 
     StatusRuntimeException ex =
         assertThrows(
@@ -253,11 +248,7 @@ class SnapshotServiceImplTest {
         .thenReturn(MutationMeta.newBuilder().setPointerVersion(7L).build());
     when(svc.tableRepo.update(any(Table.class), eq(7L))).thenReturn(true);
 
-    var pc = mock(PrincipalContext.class);
-    when(svc.principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(svc.authz).require(any(), anyString());
+    var pc = TestPrincipals.stubPrincipal(svc.principal, svc.authz);
 
     when(svc.snapshotRepo.getById(eq(tableId), anyLong())).thenReturn(Optional.empty());
     doNothing().when(svc.snapshotRepo).create(any(Snapshot.class));
@@ -309,11 +300,7 @@ class SnapshotServiceImplTest {
         .thenReturn(MutationMeta.newBuilder().setPointerVersion(7L).build());
     when(svc.tableRepo.update(any(Table.class), eq(7L))).thenReturn(true);
 
-    var pc = mock(PrincipalContext.class);
-    when(svc.principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(svc.authz).require(any(), anyString());
+    var pc = TestPrincipals.stubPrincipal(svc.principal, svc.authz);
 
     when(svc.snapshotRepo.getById(eq(tableId), eq(123L))).thenReturn(Optional.empty());
     doNothing().when(svc.snapshotRepo).create(any(Snapshot.class));
@@ -357,11 +344,7 @@ class SnapshotServiceImplTest {
     var tableRow = Table.newBuilder().setResourceId(tableId).build();
     when(svc.tableRepo.getById(eq(tableId))).thenReturn(Optional.of(tableRow));
 
-    var pc = mock(PrincipalContext.class);
-    when(svc.principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(svc.authz).require(any(), anyString());
+    var pc = TestPrincipals.stubPrincipal(svc.principal, svc.authz);
 
     when(svc.snapshotRepo.getById(eq(tableId), eq(100L))).thenReturn(Optional.empty());
     when(svc.snapshotRepo.getById(eq(tableId), eq(200L)))
@@ -416,11 +399,7 @@ class SnapshotServiceImplTest {
     when(svc.tableRepo.getById(eq(tableId)))
         .thenReturn(Optional.of(Table.newBuilder().setResourceId(tableId).build()));
 
-    var pc = mock(PrincipalContext.class);
-    when(svc.principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(svc.authz).require(any(), anyString());
+    var pc = TestPrincipals.stubPrincipal(svc.principal, svc.authz);
 
     when(svc.snapshotRepo.getById(eq(tableId), eq(123L))).thenReturn(Optional.empty());
     doNothing().when(svc.snapshotRepo).create(any(Snapshot.class));
@@ -704,24 +683,9 @@ class SnapshotServiceImplTest {
 
     when(svc.overlay.resolve(eq(tableId))).thenReturn(Optional.of(node));
 
-    var pc = mock(PrincipalContext.class);
-    when(svc.principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(svc.authz).require(any(), anyString());
+    var pc = TestPrincipals.stubPrincipal(svc.principal, svc.authz);
 
     return svc;
-  }
-
-  private static SystemTableNode systemTableNode(ResourceId tableId) {
-    var namespaceId =
-        ResourceId.newBuilder()
-            .setAccountId(tableId.getAccountId())
-            .setKind(ResourceKind.RK_NAMESPACE)
-            .setId("sys_ns_" + tableId.getId())
-            .build();
-    return new SystemTableNode.EngineSystemTableNode(
-        tableId, 1L, Instant.EPOCH, "engine", "system_table", namespaceId, List.of(), null, null);
   }
 
   private static ResourceId tableId(String id) {

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableIndexServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableIndexServiceImplTest.java
@@ -17,15 +17,11 @@ package ai.floedb.floecat.service.catalog.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.catalog.rpc.PutIndexArtifactsRequest;
-import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
@@ -34,13 +30,12 @@ import ai.floedb.floecat.service.repo.impl.IndexArtifactRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.service.testsupport.TestNodes;
+import ai.floedb.floecat.service.testsupport.TestPrincipals;
 import ai.floedb.floecat.storage.spi.BlobStore;
-import ai.floedb.floecat.systemcatalog.graph.model.SystemTableNode;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.smallrye.mutiny.Multi;
-import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -64,12 +59,8 @@ class TableIndexServiceImplTest {
             .setId("sys_index_table")
             .build();
 
-    when(svc.overlay.resolve(tableId)).thenReturn(Optional.of(systemTableNode(tableId)));
-    var pc = mock(PrincipalContext.class);
-    when(svc.principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(svc.authz).require(any(), anyString());
+    when(svc.overlay.resolve(tableId)).thenReturn(Optional.of(TestNodes.systemTableNode(tableId)));
+    var pc = TestPrincipals.stubPrincipal(svc.principal, svc.authz);
 
     var request =
         PutIndexArtifactsRequest.newBuilder().setTableId(tableId).setSnapshotId(123L).build();
@@ -81,16 +72,5 @@ class TableIndexServiceImplTest {
 
     assertEquals(Status.Code.PERMISSION_DENIED, ex.getStatus().getCode());
     verifyNoInteractions(svc.snapshots, svc.indexArtifacts, svc.blobStore, svc.idempotencyStore);
-  }
-
-  private static SystemTableNode systemTableNode(ResourceId tableId) {
-    var namespaceId =
-        ResourceId.newBuilder()
-            .setAccountId(tableId.getAccountId())
-            .setKind(ResourceKind.RK_NAMESPACE)
-            .setId("sys_ns_" + tableId.getId())
-            .build();
-    return new SystemTableNode.EngineSystemTableNode(
-        tableId, 1L, Instant.EPOCH, "engine", "system_table", namespaceId, List.of(), null, null);
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableServiceImplSystemTableTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableServiceImplSystemTableTest.java
@@ -18,8 +18,6 @@ package ai.floedb.floecat.service.catalog.impl;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,7 +31,6 @@ import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.catalog.rpc.TableSpec;
 import ai.floedb.floecat.catalog.rpc.UpdateTableRequest;
 import ai.floedb.floecat.common.rpc.MutationMeta;
-import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
@@ -47,6 +44,7 @@ import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.service.testsupport.TestPrincipals;
 import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
 import ai.floedb.floecat.systemcatalog.graph.model.SystemTableNode;
 import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
@@ -99,11 +97,7 @@ class TableServiceImplSystemTableTest {
     svc.metadataGraph = metadataGraph;
 
     // Minimal principal + authz behavior
-    var pc = mock(PrincipalContext.class);
-    when(principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(authz).require(any(), anyString());
+    var pc = TestPrincipals.stubPrincipal(principal, authz);
     when(hintCleaner.shouldClearHints(any())).thenReturn(false);
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImplSystemViewTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImplSystemViewTest.java
@@ -19,8 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -35,7 +33,6 @@ import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.catalog.rpc.ViewSpec;
 import ai.floedb.floecat.catalog.rpc.ViewSqlDefinition;
 import ai.floedb.floecat.common.rpc.MutationMeta;
-import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
@@ -50,6 +47,7 @@ import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.service.testsupport.TestPrincipals;
 import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
 import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
 import com.google.protobuf.FieldMask;
@@ -87,11 +85,7 @@ class ViewServiceImplSystemViewTest {
     svc.overlay = overlay;
     svc.metadataGraph = mock(UserGraph.class);
 
-    var pc = mock(PrincipalContext.class);
-    when(principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(authz).require(any(), anyString());
+    var pc = TestPrincipals.stubPrincipal(principal, authz);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceNamespacesTest.java
@@ -141,7 +141,7 @@ class CatalogSurfaceNamespacesTest {
     }
     stubUserNamespaces(many);
 
-    assertEquals(expected, pageAllNamespaceNames(3));
+    assertEquals(expected, pageAllNamespaceNames(surface, 3));
   }
 
   @Test
@@ -155,7 +155,7 @@ class CatalogSurfaceNamespacesTest {
             namespace("bravo", List.of()),
             namespace("charlie", List.of())));
 
-    assertEquals(List.of("alpha", "bravo", "charlie"), pageAllNamespaceNames(1));
+    assertEquals(List.of("alpha", "bravo", "charlie"), pageAllNamespaceNames(surface, 1));
   }
 
   @Test
@@ -181,25 +181,7 @@ class CatalogSurfaceNamespacesTest {
               .build());
     }
 
-    var collected = new java.util.ArrayList<String>();
-    String token = "";
-    for (int guard = 0; guard < 200; guard++) {
-      var response =
-          realSurface.listNamespaces(
-              ListNamespacesRequest.newBuilder()
-                  .setCatalogId(catalogId)
-                  .setPage(PageRequest.newBuilder().setPageSize(7).setPageToken(token))
-                  .build(),
-              ACCOUNT_ID,
-              CORRELATION_ID);
-      collected.addAll(names(response.getNamespacesList()));
-      token = response.getPage().getNextPageToken();
-      if (token.isBlank()) {
-        break;
-      }
-    }
-
-    assertEquals(expected, collected);
+    assertEquals(expected, pageAllNamespaceNames(realSurface, 7));
   }
 
   @Test
@@ -211,7 +193,8 @@ class CatalogSurfaceNamespacesTest {
     overlay.addNode(
         namespaceNode(systemNamespaceId("information_schema"), "information_schema", List.of()));
 
-    assertEquals(List.of("orders", "alpha", "information_schema"), pageAllNamespaceNames(1));
+    assertEquals(
+        List.of("orders", "alpha", "information_schema"), pageAllNamespaceNames(surface, 1));
   }
 
   @Test
@@ -289,12 +272,12 @@ class CatalogSurfaceNamespacesTest {
   }
 
   /** Drains every page (page_size {@code pageSize}) and returns the concatenated display names. */
-  private List<String> pageAllNamespaceNames(int pageSize) {
+  private List<String> pageAllNamespaceNames(CatalogSurfaceNamespaces target, int pageSize) {
     var collected = new java.util.ArrayList<String>();
     String token = "";
     for (int guard = 0; guard < 100; guard++) {
       var response =
-          surface.listNamespaces(
+          target.listNamespaces(
               ListNamespacesRequest.newBuilder()
                   .setCatalogId(catalogId)
                   .setPage(PageRequest.newBuilder().setPageSize(pageSize).setPageToken(token))

--- a/service/src/test/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImplSystemTableTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImplSystemTableTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -37,7 +36,6 @@ import ai.floedb.floecat.catalog.rpc.ListTableConstraintsRequest;
 import ai.floedb.floecat.catalog.rpc.MergeTableConstraintsRequest;
 import ai.floedb.floecat.catalog.rpc.PutTableConstraintsRequest;
 import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
-import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.model.TableNode;
@@ -46,6 +44,7 @@ import ai.floedb.floecat.service.repo.impl.ConstraintRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.service.testsupport.TestPrincipals;
 import ai.floedb.floecat.systemcatalog.graph.model.SystemTableNode;
 import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
 import io.grpc.Status;
@@ -84,11 +83,7 @@ class TableConstraintsServiceImplSystemTableTest {
     service.idempotencyStore = idempotencyStore;
     service.overlay = overlay;
 
-    PrincipalContext pc = mock(PrincipalContext.class);
-    when(principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(authz).require(any(), anyString());
+    var pc = TestPrincipals.stubPrincipal(principal, authz);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraphTest.java
@@ -322,43 +322,7 @@ class MetaGraphTest {
     when(system.resolveNamespace(any(NameRef.class), eq(context)))
         .thenReturn(Optional.of(namespaceId));
 
-    TableNode systemNode =
-        new TableNode() {
-          @Override
-          public ResourceId namespaceId() {
-            return namespaceId;
-          }
-
-          @Override
-          public String displayName() {
-            return "sys_t";
-          }
-
-          @Override
-          public ResourceId id() {
-            return sysTable;
-          }
-
-          @Override
-          public long version() {
-            return 1;
-          }
-
-          @Override
-          public Instant metadataUpdatedAt() {
-            return Instant.EPOCH;
-          }
-
-          @Override
-          public GraphNodeOrigin origin() {
-            return GraphNodeOrigin.SYSTEM;
-          }
-
-          @Override
-          public Map<EngineHintKey, EngineHint> engineHints() {
-            return Map.of();
-          }
-        };
+    TableNode systemNode = prefixSystemTable(sysTable, namespaceId, "sys_t");
 
     when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
         .thenReturn(List.of(systemNode));
@@ -395,43 +359,7 @@ class MetaGraphTest {
     when(system.resolveNamespace(any(NameRef.class), eq(context)))
         .thenReturn(Optional.of(namespaceId));
 
-    TableNode systemNode =
-        new TableNode() {
-          @Override
-          public ResourceId namespaceId() {
-            return namespaceId;
-          }
-
-          @Override
-          public String displayName() {
-            return "system_table";
-          }
-
-          @Override
-          public ResourceId id() {
-            return sysTable;
-          }
-
-          @Override
-          public long version() {
-            return 1;
-          }
-
-          @Override
-          public Instant metadataUpdatedAt() {
-            return Instant.EPOCH;
-          }
-
-          @Override
-          public GraphNodeOrigin origin() {
-            return GraphNodeOrigin.SYSTEM;
-          }
-
-          @Override
-          public Map<EngineHintKey, EngineHint> engineHints() {
-            return Map.of();
-          }
-        };
+    TableNode systemNode = prefixSystemTable(sysTable, namespaceId, "system_table");
 
     when(system.listRelationsInNamespace(ResourceId.getDefaultInstance(), namespaceId, context))
         .thenReturn(List.of(systemNode));

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/TableRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/TableRepositoryTest.java
@@ -218,6 +218,40 @@ class TableRepositoryTest {
   }
 
   @Test
+  void relationClaimBlocksRenameOntoNameHeldByOtherKind() {
+    ResourceId tableId = createTable("sales", "us", "orders");
+    Table table = tableRepo.getById(tableId).orElseThrow();
+    ViewRepository viewRepo = new ViewRepository(ptr, blobs);
+    viewRepo.create(view(table.getCatalogId(), table.getNamespaceId(), "metrics"));
+
+    Table renamed = table.toBuilder().setDisplayName("metrics").build();
+    long version = tableRepo.metaForSafe(tableId).getPointerVersion();
+
+    assertThrows(
+        BaseResourceRepository.NameConflictException.class,
+        () -> tableRepo.update(renamed, version));
+  }
+
+  @Test
+  void renameMovesRelationClaimToTheNewName() {
+    ResourceId tableId = createTable("sales", "us", "orders");
+    Table table = tableRepo.getById(tableId).orElseThrow();
+    String catalogId = table.getCatalogId().getId();
+    String namespaceId = table.getNamespaceId().getId();
+
+    Table renamed = table.toBuilder().setDisplayName("invoices").build();
+    long version = tableRepo.metaForSafe(tableId).getPointerVersion();
+    assertTrue(tableRepo.update(renamed, version));
+
+    assertTrue(
+        tableRepo.relationNameClaim(account, catalogId, namespaceId, "orders").isEmpty(),
+        "old name's claim must be released by the rename");
+    var claimed = tableRepo.relationNameClaim(account, catalogId, namespaceId, "invoices");
+    assertTrue(claimed.isPresent(), "new name's claim must be reserved by the rename");
+    assertEquals(tableId.getId(), claimed.get().getId());
+  }
+
+  @Test
   void relationClaimReleasedOnDeleteFreesNameForOtherKind() {
     ResourceId tableId = createTable("sales", "us", "orders");
     Table table = tableRepo.getById(tableId).orElseThrow();

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImplTest.java
@@ -17,15 +17,11 @@ package ai.floedb.floecat.service.statistics.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.catalog.rpc.PutTargetStatsRequest;
-import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
@@ -33,13 +29,12 @@ import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.service.testsupport.TestNodes;
+import ai.floedb.floecat.service.testsupport.TestPrincipals;
 import ai.floedb.floecat.stats.spi.StatsStore;
-import ai.floedb.floecat.systemcatalog.graph.model.SystemTableNode;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.smallrye.mutiny.Multi;
-import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -62,12 +57,8 @@ class TableStatisticsServiceImplTest {
             .setId("sys_stats_table")
             .build();
 
-    when(svc.overlay.resolve(tableId)).thenReturn(Optional.of(systemTableNode(tableId)));
-    var pc = mock(PrincipalContext.class);
-    when(svc.principal.get()).thenReturn(pc);
-    when(pc.getCorrelationId()).thenReturn("corr");
-    when(pc.getAccountId()).thenReturn("acct");
-    doNothing().when(svc.authz).require(any(), anyString());
+    when(svc.overlay.resolve(tableId)).thenReturn(Optional.of(TestNodes.systemTableNode(tableId)));
+    var pc = TestPrincipals.stubPrincipal(svc.principal, svc.authz);
 
     var request =
         PutTargetStatsRequest.newBuilder().setTableId(tableId).setSnapshotId(123L).build();
@@ -79,16 +70,5 @@ class TableStatisticsServiceImplTest {
 
     assertEquals(Status.Code.PERMISSION_DENIED, ex.getStatus().getCode());
     verifyNoInteractions(svc.snapshots, svc.statsStore, svc.idempotencyStore);
-  }
-
-  private static SystemTableNode systemTableNode(ResourceId tableId) {
-    var namespaceId =
-        ResourceId.newBuilder()
-            .setAccountId(tableId.getAccountId())
-            .setKind(ResourceKind.RK_NAMESPACE)
-            .setId("sys_ns_" + tableId.getId())
-            .build();
-    return new SystemTableNode.EngineSystemTableNode(
-        tableId, 1L, Instant.EPOCH, "engine", "system_table", namespaceId, List.of(), null, null);
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/TestNodes.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/TestNodes.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
+import ai.floedb.floecat.systemcatalog.graph.model.SystemTableNode;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,18 @@ import java.util.Optional;
 public final class TestNodes {
 
   private TestNodes() {}
+
+  /** Engine system-table node for tests exercising system-object write guards. */
+  public static SystemTableNode systemTableNode(ResourceId tableId) {
+    var namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId(tableId.getAccountId())
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .setId("sys_ns_" + tableId.getId())
+            .build();
+    return new SystemTableNode.EngineSystemTableNode(
+        tableId, 1L, Instant.EPOCH, "engine", "system_table", namespaceId, List.of(), null, null);
+  }
 
   public static UserTableNode tableNode(ResourceId tableId, String schemaJson) {
     return new UserTableNode(

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/TestPrincipals.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/TestPrincipals.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.testsupport;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+
+/** Shared principal/authorizer stubbing for service-impl unit tests. */
+public final class TestPrincipals {
+
+  public static final String ACCOUNT_ID = "acct";
+  public static final String CORRELATION_ID = "corr";
+
+  private TestPrincipals() {}
+
+  /**
+   * Wires the standard test principal onto the given mocks: correlation id {@code "corr"}, account
+   * {@code "acct"}, and an authorizer that permits everything. Returns the principal context for
+   * tests that stub more on it.
+   */
+  public static PrincipalContext stubPrincipal(PrincipalProvider principal, Authorizer authz) {
+    var pc = mock(PrincipalContext.class);
+    when(principal.get()).thenReturn(pc);
+    when(pc.getCorrelationId()).thenReturn(CORRELATION_ID);
+    when(pc.getAccountId()).thenReturn(ACCOUNT_ID);
+    doNothing().when(authz).require(any(), anyString());
+    return pc;
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
@@ -808,6 +808,7 @@ class TransactionIntentApplierSupportTest {
     var support = new TransactionIntentApplierSupport();
     inject(support, "pointerStore", pointers);
     inject(support, "blobStore", blobs);
+    inject(support, "overlay", permissiveOverlay());
 
     String accountId = "acct";
     String catalogId = "cat-1";
@@ -827,8 +828,16 @@ class TransactionIntentApplierSupportTest {
     Table current =
         Table.newBuilder()
             .setResourceId(tableRid)
-            .setCatalogId(ResourceId.newBuilder().setAccountId(accountId).setId(catalogId))
-            .setNamespaceId(ResourceId.newBuilder().setAccountId(accountId).setId(namespaceId))
+            .setCatalogId(
+                ResourceId.newBuilder()
+                    .setAccountId(accountId)
+                    .setId(catalogId)
+                    .setKind(ResourceKind.RK_CATALOG))
+            .setNamespaceId(
+                ResourceId.newBuilder()
+                    .setAccountId(accountId)
+                    .setId(namespaceId)
+                    .setKind(ResourceKind.RK_NAMESPACE))
             .setDisplayName("orders")
             .build();
     String currentBlob = "/accounts/acct/tables/table-1/table/current.pb";

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
@@ -799,6 +799,72 @@ class TransactionIntentApplierSupportTest {
         pointers.get(byIdKey).isEmpty(), "table by-id pointer must not be created on conflict");
   }
 
+  @Test
+  void applyTransactionMovesRelationClaimOnRename() throws Exception {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var intentRepo = new TransactionIntentRepository(pointers, blobs);
+
+    var support = new TransactionIntentApplierSupport();
+    inject(support, "pointerStore", pointers);
+    inject(support, "blobStore", blobs);
+
+    String accountId = "acct";
+    String catalogId = "cat-1";
+    String namespaceId = "ns-1";
+    ResourceId tableRid =
+        ResourceId.newBuilder()
+            .setAccountId(accountId)
+            .setId("table-1")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    String byIdKey = Keys.tablePointerById(accountId, tableRid.getId());
+    String oldNameKey = Keys.tablePointerByName(accountId, catalogId, namespaceId, "orders");
+    String oldClaimKey = Keys.relationPointerByName(accountId, catalogId, namespaceId, "orders");
+    String newNameKey = Keys.tablePointerByName(accountId, catalogId, namespaceId, "invoices");
+    String newClaimKey = Keys.relationPointerByName(accountId, catalogId, namespaceId, "invoices");
+
+    Table current =
+        Table.newBuilder()
+            .setResourceId(tableRid)
+            .setCatalogId(ResourceId.newBuilder().setAccountId(accountId).setId(catalogId))
+            .setNamespaceId(ResourceId.newBuilder().setAccountId(accountId).setId(namespaceId))
+            .setDisplayName("orders")
+            .build();
+    String currentBlob = "/accounts/acct/tables/table-1/table/current.pb";
+    blobs.put(currentBlob, current.toByteArray(), "application/x-protobuf");
+    pointers.compareAndSet(byIdKey, 0L, PointerReferences.blobPointer(byIdKey, currentBlob, 1L));
+    pointers.compareAndSet(
+        oldNameKey, 0L, PointerReferences.blobPointer(oldNameKey, currentBlob, 1L));
+    pointers.compareAndSet(
+        oldClaimKey,
+        0L,
+        PointerReferences.blobPointer(oldClaimKey, currentBlob, 1L, tableRid, "orders"));
+
+    Table renamed = current.toBuilder().setDisplayName("invoices").build();
+    String renamedBlob = "/accounts/acct/tables/table-1/table/renamed.pb";
+    blobs.put(renamedBlob, renamed.toByteArray(), "application/x-protobuf");
+
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId(accountId)
+            .setTxId("tx-1")
+            .setTargetPointerKey(byIdKey)
+            .setBlobUri(renamedBlob)
+            .setExpectedVersion(1L)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    var outcome = support.applyTransactionBestEffort(List.of(intent), intentRepo);
+
+    assertEquals(TransactionIntentApplierSupport.ApplyStatus.APPLIED, outcome.status());
+    assertTrue(pointers.get(oldClaimKey).isEmpty(), "old name's claim must be released");
+    assertTrue(pointers.get(oldNameKey).isEmpty(), "old by-name pointer must be released");
+    assertTrue(pointers.get(newClaimKey).isPresent(), "new name's claim must be reserved");
+    assertEquals(tableRid.getId(), pointers.get(newClaimKey).orElseThrow().getResourceId().getId());
+    assertTrue(pointers.get(newNameKey).isPresent(), "new by-name pointer must be reserved");
+  }
+
   private static Transaction readTransaction(InMemoryBlobStore blobs, String blobUri)
       throws Exception {
     return Transaction.parseFrom(blobs.get(blobUri));


### PR DESCRIPTION
## Summary 

Consolidates duplicated test scaffolding.
- **Rename coverage:** tests that a rename onto a name held by the other kind fails with `NameConflictException`, that a successful rename moves the claim, and that the transaction applier releases the old claim and reserves the new one in its batch.
- **Test dedupe:** folds repeated plumbing into shared helpers (`TestNodes.systemTableNode`, `TestPrincipals.stubPrincipal`, a shared page-drain helper, and a `@BeforeEach` harness in the applier test) — ~300 lines of duplication removed, no assertion changes.


## Type of Change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
