### PR TITLE
Fix: Missing namespaces/snapshots should not be retried

### DIFF
--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -793,7 +793,17 @@ public class ReconcilerService {
   }
 
   String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
-    return backend.resolveNamespaceFq(ctx, namespaceId);
+    try {
+      return backend.resolveNamespaceFq(ctx, namespaceId);
+    } catch (RuntimeException e) {
+      if (isMissingObjectFailure(e)) {
+        throw terminalValidation(
+            "Destination namespace id does not exist: "
+                + (namespaceId == null ? "" : namespaceId.getId()),
+            e);
+      }
+      throw e;
+    }
   }
 
   private ReconcileTableTask planStrictTableTask(

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutor.java
@@ -475,6 +475,16 @@ public class RemoteSnapshotPlanningReconcileExecutor implements ReconcileExecuto
         planned.isPresent(),
         planned.map(plan -> plan.dataFiles().size()).orElse(0),
         planned.map(plan -> plan.deleteFiles().size()).orElse(0));
+    if (planned.isEmpty()) {
+      throw new ReconcileFailureException(
+          ExecutionResult.FailureKind.INTERNAL,
+          ExecutionResult.RetryDisposition.TERMINAL,
+          "Snapshot id does not exist: tableId="
+              + task.tableId()
+              + " snapshotId="
+              + task.snapshotId(),
+          null);
+    }
     return planned;
   }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -44,6 +44,8 @@ import ai.floedb.floecat.reconciler.spi.ReconcilerBackend.DestinationTableMetada
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend.DestinationViewMetadata;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.identity.StatsTargetScopeCodec;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -532,6 +534,29 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
             () -> service.planTableTasks(principal, connectorId, ReconcileScope.empty(), null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Pinned destination table id requires connector.source.table");
+  }
+
+  @Test
+  void tablePlannerFailsTerminalWhenExpectedDestinationNamespaceIsMissing() {
+    service.backend =
+        new DefaultBackend() {
+          @Override
+          public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+            return activeConnector();
+          }
+
+          @Override
+          public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+            throw new StatusRuntimeException(
+                Status.NOT_FOUND.withDescription("Namespace not found: " + namespaceId.getId()));
+          }
+        };
+    service.connectorOpener = cfg -> new FakeConnector(List.of());
+
+    assertThatThrownBy(
+            () -> service.planTableTasks(principal, connectorId, ReconcileScope.empty(), null))
+        .isInstanceOf(ReconcileFailureException.class)
+        .hasMessageContaining("Destination namespace id does not exist: ns-1");
   }
 
   @Test

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutorTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutorTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.reconciler.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -265,6 +266,48 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
                             .allMatch(group -> group.filePaths().size() <= 2)),
             argThat(fileGroupJobs -> fileGroupJobs != null && fileGroupJobs.size() == 20),
             argThat(stats -> stats != null && stats.isEmpty()));
+  }
+
+  @Test
+  void executeFailsTerminalWhenExpectedSnapshotIsMissing() {
+    var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
+    var workerClient = mock(RemotePlannerWorkerClient.class);
+    ReconcileWorkerAuthProvider authProvider = ignored -> java.util.Optional.empty();
+    var executor =
+        new RemoteSnapshotPlanningReconcileExecutor(backend, workerClient, authProvider, 2, true);
+
+    ReconcileJobStore.LeasedJob lease = lease(statsOnlyScope());
+    when(workerClient.getPlanSnapshotInput(any()))
+        .thenReturn(
+            new StandalonePlanSnapshotPayload(
+                lease.jobId,
+                lease.leaseEpoch,
+                "",
+                connectorId(),
+                ReconcilerService.CaptureMode.CAPTURE_ONLY,
+                false,
+                statsOnlyScope(),
+                snapshotTask()));
+    when(backend.captureSnapshotTargetStatsDirect(any(), any(), eq(55L), any(), any(), any()))
+        .thenReturn(Optional.empty());
+    when(backend.fetchSnapshotFilePlan(any(), any(), eq(55L))).thenReturn(Optional.empty());
+
+    ReconcileExecutor.ExecutionResult result =
+        executor.execute(
+            new ReconcileExecutor.ExecutionContext(
+                lease, () -> false, (a, b, c, d, e, f, g, h) -> {}));
+
+    assertTrue(!result.success());
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL, result.retryDisposition);
+    verify(workerClient)
+        .submitPlanSnapshotFailure(
+            any(),
+            eq(ReconcileExecutor.ExecutionResult.FailureKind.INTERNAL),
+            eq(ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL),
+            eq(ReconcileExecutor.ExecutionResult.RetryClass.TRANSIENT_ERROR),
+            eq(
+                "ReconcileFailureException: Snapshot id does not exist: tableId=table-1 snapshotId=55"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

A reconcile against an expected but missing namespace or snapshot gets retried. These should be terminal failures.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
