### PR TITLE
Fix silent call-context loss: carry the whole ResolvedCallContext on one write-once channel

### DIFF
--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -30,6 +30,7 @@ import ai.floedb.floecat.metagraph.model.TypeNode;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import com.google.protobuf.Timestamp;
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +49,18 @@ public interface CatalogOverlay {
 
   /** Resolves any graph node for the given resource. Engine context is resolved implicitly. */
   Optional<GraphNode> resolve(ResourceId id);
+
+  /**
+   * Resolves any graph node for the given resource using an explicit engine context.
+   *
+   * <p>Prefer this overload wherever the caller already holds the request's engine context (e.g.
+   * from a {@link MetadataResolutionContext}): re-reading the engine from the request context on
+   * every lookup is fragile across executor hops, and a silently empty engine makes engine-gated
+   * system objects unresolvable.
+   */
+  default Optional<GraphNode> resolve(ResourceId id, EngineContext engineContext) {
+    return resolve(id);
+  }
 
   /**
    * Lists every relation under the requested catalog (namespaces, tables, views, plus system
@@ -173,6 +186,17 @@ public interface CatalogOverlay {
       out.computeIfAbsent(ref, r -> resolveName(correlationId, r));
     }
     return out;
+  }
+
+  /**
+   * Resolves a relation (table or view) by name reference using an explicit engine context.
+   *
+   * <p>Prefer this overload wherever the caller already holds the request's engine context — see
+   * {@link #resolve(ResourceId, EngineContext)}.
+   */
+  default Optional<ResourceId> resolveName(
+      String correlationId, NameRef ref, EngineContext engineContext) {
+    return resolveName(correlationId, ref);
   }
 
   /** Resolves a system table name without involving the user graph. */

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -57,6 +57,11 @@ public interface CatalogOverlay {
    * from a {@link MetadataResolutionContext}): re-reading the engine from the request context on
    * every lookup is fragile across executor hops, and a silently empty engine makes engine-gated
    * system objects unresolvable.
+   *
+   * <p><b>Implementers beware:</b> this default delegates to {@link #resolve(ResourceId)} and
+   * <em>ignores</em> the passed engine context. Any implementation that serves engine-gated objects
+   * must override it, or callers passing an explicit engine silently lose it (test doubles included
+   * — a fake inheriting this default cannot catch engine-threading regressions).
    */
   default Optional<GraphNode> resolve(ResourceId id, EngineContext engineContext) {
     return resolve(id);
@@ -192,7 +197,8 @@ public interface CatalogOverlay {
    * Resolves a relation (table or view) by name reference using an explicit engine context.
    *
    * <p>Prefer this overload wherever the caller already holds the request's engine context — see
-   * {@link #resolve(ResourceId, EngineContext)}.
+   * {@link #resolve(ResourceId, EngineContext)}, including its note that this default ignores the
+   * passed engine context for implementations that do not override it.
    */
   default Optional<ResourceId> resolveName(
       String correlationId, NameRef ref, EngineContext engineContext) {

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/utils/EngineContext.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/utils/EngineContext.java
@@ -138,4 +138,31 @@ public final class EngineContext {
   public boolean hasEngineHeaders() {
     return hasEngineKind;
   }
+
+  /**
+   * Value equality over the declared kind/version (the derived normalized fields and flag follow
+   * from them, but are included for safety since one constructor takes them verbatim). Needed so
+   * carriers can compare contexts by value — e.g. the write-once duplicated-context local's
+   * overwrite guard (eng-floe/floecat#361).
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof EngineContext other)) {
+      return false;
+    }
+    return hasEngineKind == other.hasEngineKind
+        && engineKind.equals(other.engineKind)
+        && engineVersion.equals(other.engineVersion)
+        && normalizedKind.equals(other.normalizedKind)
+        && normalizedVersion.equals(other.normalizedVersion);
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(
+        engineKind, engineVersion, normalizedKind, normalizedVersion, hasEngineKind);
+  }
 }

--- a/flight/src/main/java/ai/floedb/floecat/flight/context/ResolvedCallContext.java
+++ b/flight/src/main/java/ai/floedb/floecat/flight/context/ResolvedCallContext.java
@@ -32,4 +32,16 @@ public record ResolvedCallContext(
     return new ResolvedCallContext(
         PrincipalContext.getDefaultInstance(), "", "", EngineContext.empty(), null, null);
   }
+
+  /**
+   * The correlation id service bodies should report: the resolved one, falling back to the id
+   * stamped on the principal. One definition so the fallback cannot drift between call sites again
+   * (it did once, pre-#361: one site fell back to a grpc-context key instead).
+   */
+  public String effectiveCorrelationId() {
+    if (correlationId != null && !correlationId.isBlank()) {
+      return correlationId;
+    }
+    return principalContext.getCorrelationId();
+  }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
@@ -25,6 +25,8 @@ import ai.floedb.floecat.common.rpc.Precondition;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
@@ -85,16 +87,23 @@ public abstract class BaseServiceImpl {
 
   protected <T> Uni<T> run(Supplier<T> body) {
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
+    // Read the resolved call context at method entry — before any executor hop — and carry it by
+    // reference into the body. The captured io.grpc.Context alone is unreliable across the hop
+    // (eng-floe/floecat#361).
+    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrNull();
     Context otelCtx = Context.current();
     return Uni.createFrom()
         .item(
             () ->
                 grpcCtx.call(
-                    () -> {
-                      try (Scope ignored = otelCtx.makeCurrent()) {
-                        return body.get();
-                      }
-                    }));
+                    () ->
+                        ResolvedCallContexts.callWith(
+                            callCtx,
+                            () -> {
+                              try (Scope ignored = otelCtx.makeCurrent()) {
+                                return body.get();
+                              }
+                            })));
   }
 
   protected <T> Uni<T> runWithRetry(Supplier<T> body) {
@@ -213,6 +222,10 @@ public abstract class BaseServiceImpl {
   }
 
   protected String correlationId() {
+    ResolvedCallContext resolved = ResolvedCallContexts.currentOrNull();
+    if (resolved != null && !resolved.correlationId().isBlank()) {
+      return resolved.correlationId();
+    }
     var pctx = principal != null ? principal.get() : null;
     return pctx != null ? pctx.getCorrelationId() : "";
   }

--- a/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
@@ -44,7 +44,10 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.MultiEmitter;
 import jakarta.inject.Inject;
 import java.net.URI;
 import java.security.MessageDigest;
@@ -65,6 +68,8 @@ import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -104,6 +109,55 @@ public abstract class BaseServiceImpl {
                                 return body.get();
                               }
                             })));
+  }
+
+  /**
+   * Streaming analogue of {@link #run} for {@code Multi}-returning RPC methods: reads the resolved
+   * call context once at method entry — before the subscription hop onto the Mutiny default
+   * executor — and carries it by reference into {@code body}, which runs under the captured
+   * gRPC/OTel contexts and an explicit {@link ResolvedCallContexts} scope. Service methods should
+   * build their streams through this (or {@link #runStreamEmitter}) rather than hand-rolling the
+   * capture-and-wrap sequence, so the read-before-hop discipline is structural
+   * (eng-floe/floecat#361).
+   */
+  protected <T> Multi<T> runStream(Function<ResolvedCallContext, Multi<T>> body) {
+    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
+    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
+    Context otelCtx = Context.current();
+    return Multi.createFrom()
+        .<T>deferred(
+            () ->
+                grpcCtx.call(
+                    () ->
+                        ResolvedCallContexts.callWith(
+                            callCtx,
+                            () -> {
+                              try (Scope ignored = otelCtx.makeCurrent()) {
+                                return body.apply(callCtx);
+                              }
+                            })))
+        .runSubscriptionOn(Infrastructure.getDefaultExecutor());
+  }
+
+  /** Emitter-based analogue of {@link #runStream} for bodies that drive a {@link MultiEmitter}. */
+  protected <T> Multi<T> runStreamEmitter(
+      BiConsumer<ResolvedCallContext, MultiEmitter<? super T>> body) {
+    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
+    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
+    Context otelCtx = Context.current();
+    return Multi.createFrom()
+        .<T>emitter(
+            emitter ->
+                grpcCtx.run(
+                    () ->
+                        ResolvedCallContexts.runWith(
+                            callCtx,
+                            () -> {
+                              try (Scope ignored = otelCtx.makeCurrent()) {
+                                body.accept(callCtx, emitter);
+                              }
+                            })))
+        .runSubscriptionOn(Infrastructure.getDefaultExecutor());
   }
 
   protected <T> Uni<T> runWithRetry(Supplier<T> body) {
@@ -223,8 +277,8 @@ public abstract class BaseServiceImpl {
 
   protected String correlationId() {
     ResolvedCallContext resolved = ResolvedCallContexts.currentOrNull();
-    if (resolved != null && !resolved.correlationId().isBlank()) {
-      return resolved.correlationId();
+    if (resolved != null) {
+      return resolved.effectiveCorrelationId();
     }
     var pctx = principal != null ? principal.get() : null;
     return pctx != null ? pctx.getCorrelationId() : "";

--- a/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
@@ -16,11 +16,20 @@
 
 package ai.floedb.floecat.service.context;
 
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Optional;
 
+/**
+ * Resolves the engine context declared by the current call.
+ *
+ * <p>Reads the {@link ResolvedCallContexts} carrier first — the {@code io.grpc.Context} keys alone
+ * are unreliable across Quarkus's worker thread-hops, and an engine context that silently reads
+ * back empty makes engine-gated system objects unresolvable (eng-floe/floecat#361).
+ */
 @ApplicationScoped
 public final class EngineContextProvider {
 
@@ -49,6 +58,10 @@ public final class EngineContextProvider {
   }
 
   public EngineContext engineContext() {
+    ResolvedCallContext resolved = ResolvedCallContexts.currentOrNull();
+    if (resolved != null) {
+      return resolved.engineContext();
+    }
     EngineContext ctx = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
     if (ctx != null) {
       return ctx;

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundCallContextHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundCallContextHelper.java
@@ -150,6 +150,12 @@ public final class InboundCallContextHelper {
             : resolvePrincipal(headerReader, queryId);
 
     PrincipalContext principalContext = resolvedPrincipal.pc();
+    // Stamp the correlation id onto the principal so every principal-carrying channel can also
+    // answer "which request is this" — sites that only have the principal (e.g. error building
+    // deep in service bodies) would otherwise report an empty correlation id.
+    if (!allowUnauthenticated && principalContext.getCorrelationId().isBlank()) {
+      principalContext = principalContext.toBuilder().setCorrelationId(correlationId).build();
+    }
     // queryId from header takes precedence; fall back to what the auth path extracted
     String effectiveQueryId = queryId.isBlank() ? resolvedPrincipal.queryId() : queryId;
 

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
@@ -120,10 +120,11 @@ public class InboundContextInterceptor {
     Context context = contextWithResolvedCallContext(Context.current(), resolved);
 
     populateMdc(resolved);
-    // Mirror the principal onto the Vert.x duplicated context (same channel as MDC) so it survives
-    // Quarkus's gRPC dispatch worker thread-hop into the service body, where the io.grpc.Context
-    // key alone is unreliable. See PrincipalProvider for the full rationale.
-    PrincipalProvider.storeOnDuplicatedContext(resolved.principalContext());
+    // Mirror the whole resolved call context onto the Vert.x duplicated context (same channel as
+    // MDC) so principal, correlation id, and engine context together survive Quarkus's gRPC
+    // dispatch worker thread-hops into the service body, where the io.grpc.Context keys alone are
+    // unreliable. See ResolvedCallContexts for the full rationale.
+    ResolvedCallContexts.storeOnDuplicatedContext(resolved);
 
     var forwarding =
         new SimpleForwardingServerCall<ReqT, RespT>(call) {

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptor.java
@@ -24,7 +24,6 @@ import io.grpc.ClientCall;
 import io.grpc.ForwardingClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.opentelemetry.api.baggage.Baggage;
 import io.quarkus.grpc.GlobalInterceptor;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Optional;
@@ -62,72 +61,42 @@ public class OutboundContextClientInterceptor implements io.grpc.ClientIntercept
 
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
-        // Prefer the resolved-call-context carrier: the io.grpc.Context keys alone are unreliable
-        // on executor threads, which used to silently drop engine/correlation metadata from
-        // outbound RPCs (eng-floe/floecat#361). Once the carrier is present it is trusted
-        // entirely — falling back per-field would let a reused worker's stale io.grpc.Context
-        // keys leak a previous call's values into a request that legitimately has none.
+        // The resolved-call-context carrier is the single source of outbound propagation. The
+        // io.grpc.Context keys are unreliable on executor threads and can be stale on reused
+        // workers, and nothing in the stack ever populates OTel baggage with these entries, so
+        // the old key/baggage fallbacks could only propagate wrong values or none
+        // (eng-floe/floecat#361). The carrier itself still reads the io.grpc keys as its last
+        // channel, so callers that only drive io.grpc.Context (tests) keep working.
         ResolvedCallContext resolved = ResolvedCallContexts.currentOrNull();
-
-        String sessionHeaderValue;
-        String authorizationHeaderValue;
-        String queryId;
-        String engineKind;
-        String engineVersion;
-        String correlationId;
-        if (resolved != null) {
-          sessionHeaderValue = resolved.sessionHeaderValue();
-          authorizationHeaderValue = resolved.authorizationHeaderValue();
-          queryId = resolved.queryId();
-          EngineContext engineContext = resolved.engineContext();
-          engineKind = engineContext.hasEngineKind() ? engineContext.engineKind() : null;
-          engineVersion = engineContext.engineVersion();
-          correlationId = resolved.correlationId();
-        } else {
-          sessionHeaderValue = InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
-          authorizationHeaderValue = InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
-          queryId =
-              Optional.ofNullable(InboundContextInterceptor.QUERY_KEY.get())
-                  .orElseGet(() -> Baggage.current().getEntryValue("query_id"));
-          EngineContext engineContext = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
-          engineKind =
-              firstNonBlank(
-                  engineContext != null && engineContext.hasEngineKind()
-                      ? engineContext.engineKind()
-                      : null,
-                  InboundContextInterceptor.ENGINE_KIND_KEY.get(),
-                  Baggage.current().getEntryValue("engine_kind"));
-          engineVersion =
-              firstNonBlank(
-                  engineContext != null ? engineContext.engineVersion() : null,
-                  InboundContextInterceptor.ENGINE_VERSION_KEY.get(),
-                  Baggage.current().getEntryValue("engine_version"));
-          correlationId =
-              Optional.ofNullable(InboundContextInterceptor.CORR_KEY.get())
-                  .orElseGet(() -> Baggage.current().getEntryValue("correlation_id"));
+        if (resolved == null) {
+          // Machine-initiated call outside any request scope: nothing to propagate.
+          super.start(responseListener, headers);
+          return;
         }
+
+        EngineContext engineContext = resolved.engineContext();
+        String engineKind = engineContext.hasEngineKind() ? engineContext.engineKind() : null;
         // Only propagate an engine version if we are propagating an engine kind.
-        if (engineKind == null || engineKind.isBlank()) {
-          engineVersion = null;
-        }
+        String engineVersion =
+            (engineKind == null || engineKind.isBlank()) ? null : engineContext.engineVersion();
 
-        if (sessionHeaderValue != null && sessionHeader.isPresent()) {
+        if (resolved.sessionHeaderValue() != null && sessionHeader.isPresent()) {
           Metadata.Key<String> key =
               Metadata.Key.of(sessionHeader.orElseThrow(), Metadata.ASCII_STRING_MARSHALLER);
-          headers.put(key, sessionHeaderValue);
+          headers.put(key, resolved.sessionHeaderValue());
         }
-        if (authorizationHeaderValue != null
+        if (resolved.authorizationHeaderValue() != null
             && authorizationHeader.isPresent()
             && !hasAuthorizationHeader(headers)) {
           Metadata.Key<String> key =
               Metadata.Key.of(authorizationHeader.orElseThrow(), Metadata.ASCII_STRING_MARSHALLER);
-          headers.put(key, authorizationHeaderValue);
+          headers.put(key, resolved.authorizationHeaderValue());
         }
 
-        putIfNonBlank(headers, QUERY_ID, queryId);
+        putIfNonBlank(headers, QUERY_ID, resolved.queryId());
         putIfNonBlank(headers, ENGINE_KIND, engineKind);
         putIfNonBlank(headers, ENGINE_VERSION, engineVersion);
-        putIfNonBlank(headers, CORR, correlationId);
+        putIfNonBlank(headers, CORR, resolved.correlationId());
         super.start(responseListener, headers);
       }
     };
@@ -137,15 +106,6 @@ public class OutboundContextClientInterceptor implements io.grpc.ClientIntercept
     if (value != null && !value.isBlank()) {
       headers.put(key, value);
     }
-  }
-
-  private static String firstNonBlank(String... candidates) {
-    for (String candidate : candidates) {
-      if (candidate != null && !candidate.isBlank()) {
-        return candidate;
-      }
-    }
-    return null;
   }
 
   private boolean hasAuthorizationHeader(Metadata headers) {

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptor.java
@@ -64,52 +64,52 @@ public class OutboundContextClientInterceptor implements io.grpc.ClientIntercept
       public void start(Listener<RespT> responseListener, Metadata headers) {
         // Prefer the resolved-call-context carrier: the io.grpc.Context keys alone are unreliable
         // on executor threads, which used to silently drop engine/correlation metadata from
-        // outbound RPCs (eng-floe/floecat#361).
+        // outbound RPCs (eng-floe/floecat#361). Once the carrier is present it is trusted
+        // entirely — falling back per-field would let a reused worker's stale io.grpc.Context
+        // keys leak a previous call's values into a request that legitimately has none.
         ResolvedCallContext resolved = ResolvedCallContexts.currentOrNull();
 
-        String sessionHeaderValue =
-            resolved != null && resolved.sessionHeaderValue() != null
-                ? resolved.sessionHeaderValue()
-                : InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
-        String authorizationHeaderValue =
-            resolved != null && resolved.authorizationHeaderValue() != null
-                ? resolved.authorizationHeaderValue()
-                : InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
-        var queryId =
-            Optional.ofNullable(
-                    firstNonBlank(
-                        resolved != null ? resolved.queryId() : null,
-                        InboundContextInterceptor.QUERY_KEY.get()))
-                .orElseGet(() -> Baggage.current().getEntryValue("query_id"));
-
-        EngineContext engineContext =
-            resolved != null && resolved.engineContext().hasEngineKind()
-                ? resolved.engineContext()
-                : InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
-
-        String engineKind =
-            firstNonBlank(
-                engineContext != null && engineContext.hasEngineKind()
-                    ? engineContext.engineKind()
-                    : null,
-                InboundContextInterceptor.ENGINE_KIND_KEY.get(),
-                Baggage.current().getEntryValue("engine_kind"));
-
+        String sessionHeaderValue;
+        String authorizationHeaderValue;
+        String queryId;
+        String engineKind;
+        String engineVersion;
+        String correlationId;
+        if (resolved != null) {
+          sessionHeaderValue = resolved.sessionHeaderValue();
+          authorizationHeaderValue = resolved.authorizationHeaderValue();
+          queryId = resolved.queryId();
+          EngineContext engineContext = resolved.engineContext();
+          engineKind = engineContext.hasEngineKind() ? engineContext.engineKind() : null;
+          engineVersion = engineContext.engineVersion();
+          correlationId = resolved.correlationId();
+        } else {
+          sessionHeaderValue = InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
+          authorizationHeaderValue = InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
+          queryId =
+              Optional.ofNullable(InboundContextInterceptor.QUERY_KEY.get())
+                  .orElseGet(() -> Baggage.current().getEntryValue("query_id"));
+          EngineContext engineContext = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
+          engineKind =
+              firstNonBlank(
+                  engineContext != null && engineContext.hasEngineKind()
+                      ? engineContext.engineKind()
+                      : null,
+                  InboundContextInterceptor.ENGINE_KIND_KEY.get(),
+                  Baggage.current().getEntryValue("engine_kind"));
+          engineVersion =
+              firstNonBlank(
+                  engineContext != null ? engineContext.engineVersion() : null,
+                  InboundContextInterceptor.ENGINE_VERSION_KEY.get(),
+                  Baggage.current().getEntryValue("engine_version"));
+          correlationId =
+              Optional.ofNullable(InboundContextInterceptor.CORR_KEY.get())
+                  .orElseGet(() -> Baggage.current().getEntryValue("correlation_id"));
+        }
         // Only propagate an engine version if we are propagating an engine kind.
-        String engineVersion =
-            (engineKind == null || engineKind.isBlank())
-                ? null
-                : firstNonBlank(
-                    engineContext != null ? engineContext.engineVersion() : null,
-                    InboundContextInterceptor.ENGINE_VERSION_KEY.get(),
-                    Baggage.current().getEntryValue("engine_version"));
-
-        var correlationId =
-            Optional.ofNullable(
-                    firstNonBlank(
-                        resolved != null ? resolved.correlationId() : null,
-                        InboundContextInterceptor.CORR_KEY.get()))
-                .orElseGet(() -> Baggage.current().getEntryValue("correlation_id"));
+        if (engineKind == null || engineKind.isBlank()) {
+          engineVersion = null;
+        }
 
         if (sessionHeaderValue != null && sessionHeader.isPresent()) {
           Metadata.Key<String> key =

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptor.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.context.impl;
 
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -61,14 +62,30 @@ public class OutboundContextClientInterceptor implements io.grpc.ClientIntercept
 
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
-        String sessionHeaderValue = InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
+        // Prefer the resolved-call-context carrier: the io.grpc.Context keys alone are unreliable
+        // on executor threads, which used to silently drop engine/correlation metadata from
+        // outbound RPCs (eng-floe/floecat#361).
+        ResolvedCallContext resolved = ResolvedCallContexts.currentOrNull();
+
+        String sessionHeaderValue =
+            resolved != null && resolved.sessionHeaderValue() != null
+                ? resolved.sessionHeaderValue()
+                : InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
         String authorizationHeaderValue =
-            InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
+            resolved != null && resolved.authorizationHeaderValue() != null
+                ? resolved.authorizationHeaderValue()
+                : InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
         var queryId =
-            Optional.ofNullable(InboundContextInterceptor.QUERY_KEY.get())
+            Optional.ofNullable(
+                    firstNonBlank(
+                        resolved != null ? resolved.queryId() : null,
+                        InboundContextInterceptor.QUERY_KEY.get()))
                 .orElseGet(() -> Baggage.current().getEntryValue("query_id"));
 
-        EngineContext engineContext = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
+        EngineContext engineContext =
+            resolved != null && resolved.engineContext().hasEngineKind()
+                ? resolved.engineContext()
+                : InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
 
         String engineKind =
             firstNonBlank(
@@ -88,7 +105,10 @@ public class OutboundContextClientInterceptor implements io.grpc.ClientIntercept
                     Baggage.current().getEntryValue("engine_version"));
 
         var correlationId =
-            Optional.ofNullable(InboundContextInterceptor.CORR_KEY.get())
+            Optional.ofNullable(
+                    firstNonBlank(
+                        resolved != null ? resolved.correlationId() : null,
+                        InboundContextInterceptor.CORR_KEY.get()))
                 .orElseGet(() -> Baggage.current().getEntryValue("correlation_id"));
 
         if (sessionHeaderValue != null && sessionHeader.isPresent()) {

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.context.impl;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Vertx;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import org.jboss.logging.Logger;
+
+/**
+ * Write-once carrier for the fully resolved inbound call context (principal, correlation id, engine
+ * context, query id, session/authorization header values).
+ *
+ * <p>The resolved context is carried on three channels, consulted in order of reliability:
+ *
+ * <ol>
+ *   <li><b>Explicit scope</b> ({@link #callWith}/{@link #runWith}) — a thread-confined override for
+ *       code that was handed the context by reference across an executor hop. This is the only
+ *       channel that works on arbitrary executor threads.
+ *   <li><b>Vert.x duplicated-context local</b> ({@link #storeOnDuplicatedContext}) — written once
+ *       by the inbound interceptor on the same per-call duplicated context that carries MDC. It
+ *       survives Quarkus's gRPC dispatch worker hops and Mutiny's contextualized callbacks for
+ *       exactly the same reason MDC does, and cannot bleed between concurrent calls.
+ *   <li><b>{@code io.grpc.Context} keys</b> — the legacy channel. Under Quarkus, attach/detach on a
+ *       duplicated context is a read/write of one shared last-writer-wins slot that several threads
+ *       of the same call race; keys can read back empty (or stale, via the thread-local fallback on
+ *       a reused worker) on a subset of calls. Kept as a fallback for callers that drive {@code
+ *       io.grpc.Context} directly (unit tests, non-Vert.x threads).
+ * </ol>
+ *
+ * <p>History: mirroring only the principal onto the duplicated context moved the context-loss
+ * failure from a loud {@code PERMISSION_DENIED} into a silent engine-gated {@code NOT_FOUND}
+ * (eng-floe/floecat#361). Carrying the whole {@link ResolvedCallContext} on one channel keeps the
+ * principal, correlation id, and engine context from ever diverging again.
+ */
+public final class ResolvedCallContexts {
+
+  private static final Logger LOG = Logger.getLogger(ResolvedCallContexts.class);
+
+  /** Vert.x duplicated-context local key under which the resolved call context is stored. */
+  private static final String CONTEXT_LOCAL = "floecat.resolved-call-context";
+
+  private static final ThreadLocal<ResolvedCallContext> SCOPE = new ThreadLocal<>();
+
+  private ResolvedCallContexts() {}
+
+  /**
+   * Stores the resolved call context on the current Vert.x duplicated context so it survives the
+   * gRPC dispatch worker thread-hop into the service-method body. Called once per call from the
+   * inbound interceptor, alongside MDC population, on the same context MDC is written to.
+   *
+   * <p>No-op when the current call is not on a Vert.x duplicated context (the {@code
+   * io.grpc.Context} keys remain the carrier in that case), so it is safe to call unconditionally.
+   * The local is write-once per call: overwriting a different previously stored context is a
+   * plumbing bug and is logged loudly rather than silently masked.
+   */
+  public static void storeOnDuplicatedContext(ResolvedCallContext resolved) {
+    Objects.requireNonNull(resolved, "resolved");
+    io.vertx.core.Context ctx = Vertx.currentContext();
+    if (ctx == null || !VertxContext.isDuplicatedContext(ctx)) {
+      return;
+    }
+    Object existing = ctx.getLocal(CONTEXT_LOCAL);
+    if (existing != null && !existing.equals(resolved)) {
+      LOG.warnf(
+          "Overwriting a different resolved call context on the same duplicated context"
+              + " (existing correlation_id=%s, new correlation_id=%s) — duplicated contexts are"
+              + " per-call and this indicates a context-propagation bug",
+          existing instanceof ResolvedCallContext previous ? previous.correlationId() : "?",
+          resolved.correlationId());
+    }
+    ctx.putLocal(CONTEXT_LOCAL, resolved);
+  }
+
+  /**
+   * Returns the resolved call context for the current thread, or {@code null} when no channel
+   * carries one. Channels are consulted in reliability order: explicit scope, duplicated-context
+   * local, {@code io.grpc.Context} keys.
+   */
+  public static ResolvedCallContext currentOrNull() {
+    ResolvedCallContext scoped = SCOPE.get();
+    if (scoped != null) {
+      return scoped;
+    }
+    ResolvedCallContext fromDuplicatedContext = fromDuplicatedContext();
+    if (fromDuplicatedContext != null) {
+      return fromDuplicatedContext;
+    }
+    return fromGrpcContextKeys();
+  }
+
+  /** Like {@link #currentOrNull()} but degrades to {@link ResolvedCallContext#unauthenticated}. */
+  public static ResolvedCallContext currentOrUnauthenticated() {
+    ResolvedCallContext current = currentOrNull();
+    return current != null ? current : ResolvedCallContext.unauthenticated();
+  }
+
+  /**
+   * Runs {@code body} with {@code resolved} as the current thread's call context. Use to carry the
+   * context by reference across an executor hop: read the context once before the hop, then wrap
+   * the hopped body. Passing {@code null} is allowed and runs the body unscoped.
+   */
+  public static void runWith(ResolvedCallContext resolved, Runnable body) {
+    Objects.requireNonNull(body, "body");
+    ResolvedCallContext previous = SCOPE.get();
+    SCOPE.set(resolved);
+    try {
+      body.run();
+    } finally {
+      restore(previous);
+    }
+  }
+
+  /**
+   * Calls {@code body} with {@code resolved} as the current thread's call context and returns the
+   * result. Checked exceptions are wrapped in a {@link RuntimeException}.
+   */
+  public static <T> T callWith(ResolvedCallContext resolved, Callable<T> body) {
+    Objects.requireNonNull(body, "body");
+    ResolvedCallContext previous = SCOPE.get();
+    SCOPE.set(resolved);
+    try {
+      return body.call();
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      restore(previous);
+    }
+  }
+
+  private static void restore(ResolvedCallContext previous) {
+    if (previous == null) {
+      SCOPE.remove();
+    } else {
+      SCOPE.set(previous);
+    }
+  }
+
+  private static ResolvedCallContext fromDuplicatedContext() {
+    io.vertx.core.Context ctx = Vertx.currentContext();
+    if (ctx != null && VertxContext.isDuplicatedContext(ctx)) {
+      Object value = ctx.getLocal(CONTEXT_LOCAL);
+      if (value instanceof ResolvedCallContext resolved) {
+        return resolved;
+      }
+    }
+    return null;
+  }
+
+  private static ResolvedCallContext fromGrpcContextKeys() {
+    PrincipalContext principal = InboundContextInterceptor.PC_KEY.get();
+    if (principal == null) {
+      return null;
+    }
+    String queryId = InboundContextInterceptor.QUERY_KEY.get();
+    String correlationId = InboundContextInterceptor.CORR_KEY.get();
+    EngineContext engineContext = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
+    String sessionHeaderValue = InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
+    String authorizationHeaderValue =
+        InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
+    return new ResolvedCallContext(
+        principal,
+        queryId != null ? queryId : "",
+        correlationId != null ? correlationId : "",
+        engineContext != null ? engineContext : EngineContext.empty(),
+        sessionHeaderValue,
+        authorizationHeaderValue);
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
 
 @ApplicationScoped
 public final class MetaGraph implements CatalogOverlay, TopologyGraph {
@@ -324,14 +325,18 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     Optional<ResourceId> resolved =
         system.isPresent() ? system : userGraph.resolveName(correlationId, ref);
     if (resolved.isEmpty() && !ctx.hasEngineKind()) {
-      // A lookup that misses both graphs while the engine context is empty is how a lost engine
-      // context manifests: engine-gated system objects (sys.*, pg_catalog.*) silently resolve to
-      // NOT_FOUND and the engine reports a wrong-answer-shaped 42P01 (eng-floe/floecat#361).
-      // Legitimate no-engine requests that miss also log here, which is rare and still useful.
-      LOG.warnf(
-          "resolveName miss with empty engine context: ref=%s correlation_id=%s — if the request"
-              + " declared an engine, its context was lost before resolution",
-          NameRefUtil.canonical(ref), correlationId);
+      // A lookup that misses both graphs with an empty engine context while MDC proves the
+      // request DID declare an engine is how a lost engine context manifests: engine-gated system
+      // objects (sys.*, pg_catalog.*) silently resolve to NOT_FOUND and the engine reports a
+      // wrong-answer-shaped 42P01 (eng-floe/floecat#361). The MDC gate keeps legitimately
+      // engine-less callers (e.g. client-cli) from tripping this on every name typo.
+      Object mdcEngineKind = MDC.get("floecat_engine_kind");
+      if (mdcEngineKind instanceof String declaredEngineKind && !declaredEngineKind.isBlank()) {
+        LOG.warnf(
+            "resolveName miss with empty engine context: ref=%s correlation_id=%s — the request"
+                + " declared engine_kind=%s but its context was lost before resolution",
+            NameRefUtil.canonical(ref), correlationId, declaredEngineKind);
+      }
     }
     return resolved;
   }

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -58,9 +58,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public final class MetaGraph implements CatalogOverlay, TopologyGraph {
+
+  private static final Logger LOG = Logger.getLogger(MetaGraph.class);
 
   private final UserGraph userGraph;
   private final LogicalSchemaMapper schemaMapper;
@@ -86,6 +89,11 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     return engine.isPresent() ? engine.engineContext() : EngineContext.empty();
   }
 
+  private static EngineContext orRequestEngine(
+      EngineContext ctx, Supplier<EngineContext> fallback) {
+    return ctx != null ? ctx : fallback.get();
+  }
+
   /**
    * Resolves a graph node by ID, checking system graph first, then user graph.
    *
@@ -97,7 +105,12 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
    */
   @Override
   public Optional<GraphNode> resolve(ResourceId id) {
-    EngineContext ctx = engineContext();
+    return resolve(id, engineContext());
+  }
+
+  @Override
+  public Optional<GraphNode> resolve(ResourceId id, EngineContext engineContext) {
+    EngineContext ctx = orRequestEngine(engineContext, this::engineContext);
     Optional<GraphNode> sys = systemGraph.resolve(id, ctx);
     if (sys.isPresent()) {
       return sys;
@@ -300,9 +313,27 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
    */
   @Override
   public Optional<ResourceId> resolveName(String correlationId, NameRef ref) {
-    EngineContext ctx = engineContext();
+    return resolveName(correlationId, ref, engineContext());
+  }
+
+  @Override
+  public Optional<ResourceId> resolveName(
+      String correlationId, NameRef ref, EngineContext engineContext) {
+    EngineContext ctx = orRequestEngine(engineContext, this::engineContext);
     Optional<ResourceId> system = systemGraph.resolveName(ref, ctx);
-    return system.isPresent() ? system : userGraph.resolveName(correlationId, ref);
+    Optional<ResourceId> resolved =
+        system.isPresent() ? system : userGraph.resolveName(correlationId, ref);
+    if (resolved.isEmpty() && !ctx.hasEngineKind()) {
+      // A lookup that misses both graphs while the engine context is empty is how a lost engine
+      // context manifests: engine-gated system objects (sys.*, pg_catalog.*) silently resolve to
+      // NOT_FOUND and the engine reports a wrong-answer-shaped 42P01 (eng-floe/floecat#361).
+      // Legitimate no-engine requests that miss also log here, which is rare and still useful.
+      LOG.warnf(
+          "resolveName miss with empty engine context: ref=%s correlation_id=%s — if the request"
+              + " declared an engine, its context was lost before resolution",
+          NameRefUtil.canonical(ref), correlationId);
+    }
+    return resolved;
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1812,7 +1812,11 @@ public class UserObjectBundleService {
       }
       long startNs = System.nanoTime();
       try {
-        Optional<ResourceId> resolved = overlay.resolveName(correlationId, ref);
+        // Pass the engine captured at iterator construction: re-reading it from the request
+        // context per lookup is fragile across executor hops, and an empty engine silently
+        // un-resolves engine-gated system objects (eng-floe/floecat#361).
+        Optional<ResourceId> resolved =
+            overlay.resolveName(correlationId, ref, resolutionContext.engineContext());
         nameResolutionCache.put(key, resolved);
         nameResolutionCacheMisses++;
         return resolved;
@@ -1830,7 +1834,9 @@ public class UserObjectBundleService {
       }
       long startNs = System.nanoTime();
       try {
-        Optional<GraphNode> resolved = overlay.resolve(id);
+        // Pass the engine captured at iterator construction: re-reading it from the request
+        // context per lookup is fragile across executor hops (eng-floe/floecat#361).
+        Optional<GraphNode> resolved = overlay.resolve(id, resolutionContext.engineContext());
         nodeResolutionCache.put(id, resolved);
         nodeResolutionCacheMisses++;
         return resolved;

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -560,7 +560,10 @@ public class UserObjectBundleService {
       builder.setViewDefinition(viewBuilder);
     }
 
-    EngineContext ctx = engineContext.engineContext();
+    // The engine captured at iterator construction, not a live provider re-read: this runs on
+    // executor threads where the request context is unreliable, and a silently empty engine would
+    // skip engine-specific decoration with no log line (eng-floe/floecat#361).
+    EngineContext ctx = resolutionContext.engineContext();
     boolean decorationRequired = decorationRequired(ctx);
     Optional<EngineMetadataDecorator> decorator = currentDecorator(ctx);
     RelationDecoration relationDecoration = null;

--- a/service/src/main/java/ai/floedb/floecat/service/query/flight/GrpcResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/flight/GrpcResolvedCallContexts.java
@@ -16,10 +16,8 @@
 
 package ai.floedb.floecat.service.query.flight;
 
-import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.flight.context.ResolvedCallContext;
-import ai.floedb.floecat.scanner.utils.EngineContext;
-import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 
 /** Resolves Floecat Flight call context from the current shared gRPC request context. */
 final class GrpcResolvedCallContexts {
@@ -27,24 +25,6 @@ final class GrpcResolvedCallContexts {
   private GrpcResolvedCallContexts() {}
 
   static ResolvedCallContext currentOrUnauthenticated() {
-    PrincipalContext principal = InboundContextInterceptor.PC_KEY.get();
-    if (principal == null) {
-      return ResolvedCallContext.unauthenticated();
-    }
-
-    String queryId = InboundContextInterceptor.QUERY_KEY.get();
-    String correlationId = InboundContextInterceptor.CORR_KEY.get();
-    EngineContext engineContext = InboundContextInterceptor.ENGINE_CONTEXT_KEY.get();
-    String sessionHeaderValue = InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
-    String authorizationHeaderValue =
-        InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
-
-    return new ResolvedCallContext(
-        principal,
-        queryId != null ? queryId : "",
-        correlationId != null ? correlationId : "",
-        engineContext != null ? engineContext : EngineContext.empty(),
-        sessionHeaderValue,
-        authorizationHeaderValue);
+    return ResolvedCallContexts.currentOrUnauthenticated();
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImpl.java
@@ -18,16 +18,13 @@ package ai.floedb.floecat.service.query.impl;
 
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
-import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.query.rpc.FetchTableConstraintsRequest;
 import ai.floedb.floecat.query.rpc.FetchTargetStatsRequest;
 import ai.floedb.floecat.query.rpc.PlannerStatsService;
 import ai.floedb.floecat.query.rpc.TableConstraintsBundleChunk;
 import ai.floedb.floecat.query.rpc.TargetStatsBundleChunk;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
-import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
-import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.catalog.PlannerStatsBundleService;
@@ -35,7 +32,6 @@ import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -58,33 +54,18 @@ public class PlannerStatsServiceImpl extends BaseServiceImpl implements PlannerS
   @Override
   public Multi<TargetStatsBundleChunk> getTargetStats(FetchTargetStatsRequest request) {
     var L = LogHelper.start(LOG, "GetTargetStats");
-    // Read the resolved call context at method entry — before the executor hop — and carry it by
-    // reference into the body; the captured io.grpc.Context alone is unreliable across the hop
-    // (eng-floe/floecat#361). The bundle builder itself is context-free.
-    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
-    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
+    // runStream reads the resolved call context at method entry — before the executor hop — and
+    // carries it by reference into the body; the bundle builder itself is context-free.
+    return this.<TargetStatsBundleChunk>runStream(
+            callCtx -> {
+              var principalContext = callCtx.principalContext();
+              var correlationId = callCtx.effectiveCorrelationId();
+              authz.require(principalContext, "catalog.read");
 
-    return Multi.createFrom()
-        .<TargetStatsBundleChunk>deferred(
-            () ->
-                grpcCtx.call(
-                    () ->
-                        ResolvedCallContexts.callWith(
-                            callCtx,
-                            () -> {
-                              var principalContext = callCtx.principalContext();
-                              var correlationId =
-                                  !callCtx.correlationId().isBlank()
-                                      ? callCtx.correlationId()
-                                      : principalContext.getCorrelationId();
-                              authz.require(principalContext, "catalog.read");
-
-                              String queryId =
-                                  mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-                              QueryContext ctx = requireActiveQuery(correlationId, queryId);
-                              return bundles.streamTargets(correlationId, ctx, request);
-                            })))
-        .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+              String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+              QueryContext ctx = requireActiveQuery(correlationId, queryId);
+              return bundles.streamTargets(correlationId, ctx, request);
+            })
         .onFailure()
         .invoke(L::fail)
         .onCompletion()
@@ -96,30 +77,16 @@ public class PlannerStatsServiceImpl extends BaseServiceImpl implements PlannerS
   public Multi<TableConstraintsBundleChunk> getTableConstraints(
       FetchTableConstraintsRequest request) {
     var L = LogHelper.start(LOG, "GetTableConstraints");
-    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
-    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
+    return this.<TableConstraintsBundleChunk>runStream(
+            callCtx -> {
+              var principalContext = callCtx.principalContext();
+              var correlationId = callCtx.effectiveCorrelationId();
+              authz.require(principalContext, "catalog.read");
 
-    return Multi.createFrom()
-        .<TableConstraintsBundleChunk>deferred(
-            () ->
-                grpcCtx.call(
-                    () ->
-                        ResolvedCallContexts.callWith(
-                            callCtx,
-                            () -> {
-                              var principalContext = callCtx.principalContext();
-                              var correlationId =
-                                  !callCtx.correlationId().isBlank()
-                                      ? callCtx.correlationId()
-                                      : principalContext.getCorrelationId();
-                              authz.require(principalContext, "catalog.read");
-
-                              String queryId =
-                                  mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-                              QueryContext ctx = requireActiveQuery(correlationId, queryId);
-                              return bundles.streamConstraints(correlationId, ctx, request);
-                            })))
-        .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+              String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+              QueryContext ctx = requireActiveQuery(correlationId, queryId);
+              return bundles.streamConstraints(correlationId, ctx, request);
+            })
         .onFailure()
         .invoke(L::fail)
         .onCompletion()

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/PlannerStatsServiceImpl.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.query.impl;
 
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.query.rpc.FetchTableConstraintsRequest;
 import ai.floedb.floecat.query.rpc.FetchTargetStatsRequest;
 import ai.floedb.floecat.query.rpc.PlannerStatsService;
@@ -26,6 +27,7 @@ import ai.floedb.floecat.query.rpc.TargetStatsBundleChunk;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.catalog.PlannerStatsBundleService;
@@ -56,24 +58,32 @@ public class PlannerStatsServiceImpl extends BaseServiceImpl implements PlannerS
   @Override
   public Multi<TargetStatsBundleChunk> getTargetStats(FetchTargetStatsRequest request) {
     var L = LogHelper.start(LOG, "GetTargetStats");
-    // Capture the incoming gRPC context so the principal/correlation-id stays available
-    // while authz/QueryContext lookup happen; the bundle builder itself is context-free.
+    // Read the resolved call context at method entry — before the executor hop — and carry it by
+    // reference into the body; the captured io.grpc.Context alone is unreliable across the hop
+    // (eng-floe/floecat#361). The bundle builder itself is context-free.
+    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
 
     return Multi.createFrom()
         .<TargetStatsBundleChunk>deferred(
             () ->
                 grpcCtx.call(
-                    () -> {
-                      var principalContext = principal.get();
-                      var correlationId = principalContext.getCorrelationId();
-                      authz.require(principalContext, "catalog.read");
+                    () ->
+                        ResolvedCallContexts.callWith(
+                            callCtx,
+                            () -> {
+                              var principalContext = callCtx.principalContext();
+                              var correlationId =
+                                  !callCtx.correlationId().isBlank()
+                                      ? callCtx.correlationId()
+                                      : principalContext.getCorrelationId();
+                              authz.require(principalContext, "catalog.read");
 
-                      String queryId =
-                          mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-                      QueryContext ctx = requireActiveQuery(correlationId, queryId);
-                      return bundles.streamTargets(correlationId, ctx, request);
-                    }))
+                              String queryId =
+                                  mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+                              QueryContext ctx = requireActiveQuery(correlationId, queryId);
+                              return bundles.streamTargets(correlationId, ctx, request);
+                            })))
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())
         .onFailure()
         .invoke(L::fail)
@@ -86,22 +96,29 @@ public class PlannerStatsServiceImpl extends BaseServiceImpl implements PlannerS
   public Multi<TableConstraintsBundleChunk> getTableConstraints(
       FetchTableConstraintsRequest request) {
     var L = LogHelper.start(LOG, "GetTableConstraints");
+    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
 
     return Multi.createFrom()
         .<TableConstraintsBundleChunk>deferred(
             () ->
                 grpcCtx.call(
-                    () -> {
-                      var principalContext = principal.get();
-                      var correlationId = principalContext.getCorrelationId();
-                      authz.require(principalContext, "catalog.read");
+                    () ->
+                        ResolvedCallContexts.callWith(
+                            callCtx,
+                            () -> {
+                              var principalContext = callCtx.principalContext();
+                              var correlationId =
+                                  !callCtx.correlationId().isBlank()
+                                      ? callCtx.correlationId()
+                                      : principalContext.getCorrelationId();
+                              authz.require(principalContext, "catalog.read");
 
-                      String queryId =
-                          mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-                      QueryContext ctx = requireActiveQuery(correlationId, queryId);
-                      return bundles.streamConstraints(correlationId, ctx, request);
-                    }))
+                              String queryId =
+                                  mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+                              QueryContext ctx = requireActiveQuery(correlationId, queryId);
+                              return bundles.streamConstraints(correlationId, ctx, request);
+                            })))
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())
         .onFailure()
         .invoke(L::fail)

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
@@ -19,7 +19,6 @@ package ai.floedb.floecat.service.query.impl;
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
 import ai.floedb.floecat.common.rpc.ResourceId;
-import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.query.rpc.DataFileBatch;
 import ai.floedb.floecat.query.rpc.DeleteFileBatch;
 import ai.floedb.floecat.query.rpc.InitScanRequest;
@@ -28,9 +27,7 @@ import ai.floedb.floecat.query.rpc.QueryScanService;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
-import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
-import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.execution.impl.ScanBundleService;
 import ai.floedb.floecat.service.query.QueryContextStore;
@@ -40,7 +37,6 @@ import com.google.protobuf.Empty;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.inject.Inject;
 import java.util.Map;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -123,33 +119,21 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
    */
   public Multi<DeleteFileBatch> streamDeleteFiles(ScanHandle handle) {
     var L = LogHelper.start(LOG, "StreamDeleteFiles");
-    // Read the resolved call context at method entry — before the executor hop — and carry it by
-    // reference into the body; the captured io.grpc.Context alone is unreliable across the hop
-    // (eng-floe/floecat#361).
-    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
-    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
-    return Multi.createFrom()
-        .deferred(
-            () ->
-                grpcCtx.call(
-                    () ->
-                        ResolvedCallContexts.callWith(
-                            callCtx,
-                            () -> {
-                              String correlationId = correlationIdOf(callCtx);
-                              ScanSession session = requireSession(handle, correlationId);
-                              return scanBundles
-                                  .streamDeleteFiles(session, correlationId)
-                                  .onFailure()
-                                  .invoke(e -> markPlanningFailed(session, correlationId))
-                                  .onFailure()
-                                  .invoke(e -> queryStore.removeScanSession(handle))
-                                  .onFailure()
-                                  .transform(e -> toStatus(e, correlationId))
-                                  .onCompletion()
-                                  .invoke(L::ok);
-                            })))
-        .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+    return this.<DeleteFileBatch>runStream(
+            callCtx -> {
+              String correlationId = callCtx.effectiveCorrelationId();
+              ScanSession session = requireSession(handle, correlationId);
+              return scanBundles
+                  .streamDeleteFiles(session, correlationId)
+                  .onFailure()
+                  .invoke(e -> markPlanningFailed(session, correlationId))
+                  .onFailure()
+                  .invoke(e -> queryStore.removeScanSession(handle))
+                  .onFailure()
+                  .transform(e -> toStatus(e, correlationId))
+                  .onCompletion()
+                  .invoke(L::ok);
+            })
         .onFailure()
         .invoke(L::fail);
   }
@@ -161,34 +145,25 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
    */
   public Multi<DataFileBatch> streamDataFiles(ScanHandle handle) {
     var L = LogHelper.start(LOG, "StreamDataFiles");
-    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
-    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
-    return Multi.createFrom()
-        .deferred(
-            () ->
-                grpcCtx.call(
-                    () ->
-                        ResolvedCallContexts.callWith(
-                            callCtx,
-                            () -> {
-                              String correlationId = correlationIdOf(callCtx);
-                              ScanSession session = requireSession(handle, correlationId);
-                              return scanBundles
-                                  .streamDataFiles(session, correlationId)
-                                  .onFailure()
-                                  .invoke(e -> markPlanningFailed(session, correlationId))
-                                  .onFailure()
-                                  .invoke(e -> queryStore.removeScanSession(handle))
-                                  .onFailure()
-                                  .transform(e -> toStatus(e, correlationId))
-                                  .onCompletion()
-                                  .invoke(
-                                      () -> {
-                                        markPlanningCompleted(session, correlationId);
-                                        L.ok();
-                                      });
-                            })))
-        .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+    return this.<DataFileBatch>runStream(
+            callCtx -> {
+              String correlationId = callCtx.effectiveCorrelationId();
+              ScanSession session = requireSession(handle, correlationId);
+              return scanBundles
+                  .streamDataFiles(session, correlationId)
+                  .onFailure()
+                  .invoke(e -> markPlanningFailed(session, correlationId))
+                  .onFailure()
+                  .invoke(e -> queryStore.removeScanSession(handle))
+                  .onFailure()
+                  .transform(e -> toStatus(e, correlationId))
+                  .onCompletion()
+                  .invoke(
+                      () -> {
+                        markPlanningCompleted(session, correlationId);
+                        L.ok();
+                      });
+            })
         .onTermination()
         .invoke(() -> queryStore.removeScanSession(handle))
         .onFailure()
@@ -225,12 +200,6 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
         .orElseThrow(
             () ->
                 GrpcErrors.notFound(correlationId, SCAN_HANDLE, Map.of("handle", handle.getId())));
-  }
-
-  private static String correlationIdOf(ResolvedCallContext callCtx) {
-    return !callCtx.correlationId().isBlank()
-        ? callCtx.correlationId()
-        : callCtx.principalContext().getCorrelationId();
   }
 
   private void markPlanningFailed(ScanSession session, String correlationId) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryScanServiceImpl.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.query.impl;
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.query.rpc.DataFileBatch;
 import ai.floedb.floecat.query.rpc.DeleteFileBatch;
 import ai.floedb.floecat.query.rpc.InitScanRequest;
@@ -29,6 +30,7 @@ import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.execution.impl.ScanBundleService;
 import ai.floedb.floecat.service.query.QueryContextStore;
@@ -121,25 +123,32 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
    */
   public Multi<DeleteFileBatch> streamDeleteFiles(ScanHandle handle) {
     var L = LogHelper.start(LOG, "StreamDeleteFiles");
+    // Read the resolved call context at method entry — before the executor hop — and carry it by
+    // reference into the body; the captured io.grpc.Context alone is unreliable across the hop
+    // (eng-floe/floecat#361).
+    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
     return Multi.createFrom()
         .deferred(
             () ->
                 grpcCtx.call(
-                    () -> {
-                      String correlationId = principal.get().getCorrelationId();
-                      ScanSession session = requireSession(handle, correlationId);
-                      return scanBundles
-                          .streamDeleteFiles(session, correlationId)
-                          .onFailure()
-                          .invoke(e -> markPlanningFailed(session, correlationId))
-                          .onFailure()
-                          .invoke(e -> queryStore.removeScanSession(handle))
-                          .onFailure()
-                          .transform(e -> toStatus(e, correlationId))
-                          .onCompletion()
-                          .invoke(L::ok);
-                    }))
+                    () ->
+                        ResolvedCallContexts.callWith(
+                            callCtx,
+                            () -> {
+                              String correlationId = correlationIdOf(callCtx);
+                              ScanSession session = requireSession(handle, correlationId);
+                              return scanBundles
+                                  .streamDeleteFiles(session, correlationId)
+                                  .onFailure()
+                                  .invoke(e -> markPlanningFailed(session, correlationId))
+                                  .onFailure()
+                                  .invoke(e -> queryStore.removeScanSession(handle))
+                                  .onFailure()
+                                  .transform(e -> toStatus(e, correlationId))
+                                  .onCompletion()
+                                  .invoke(L::ok);
+                            })))
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())
         .onFailure()
         .invoke(L::fail);
@@ -152,29 +161,33 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
    */
   public Multi<DataFileBatch> streamDataFiles(ScanHandle handle) {
     var L = LogHelper.start(LOG, "StreamDataFiles");
+    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
     return Multi.createFrom()
         .deferred(
             () ->
                 grpcCtx.call(
-                    () -> {
-                      String correlationId = principal.get().getCorrelationId();
-                      ScanSession session = requireSession(handle, correlationId);
-                      return scanBundles
-                          .streamDataFiles(session, correlationId)
-                          .onFailure()
-                          .invoke(e -> markPlanningFailed(session, correlationId))
-                          .onFailure()
-                          .invoke(e -> queryStore.removeScanSession(handle))
-                          .onFailure()
-                          .transform(e -> toStatus(e, correlationId))
-                          .onCompletion()
-                          .invoke(
-                              () -> {
-                                markPlanningCompleted(session, correlationId);
-                                L.ok();
-                              });
-                    }))
+                    () ->
+                        ResolvedCallContexts.callWith(
+                            callCtx,
+                            () -> {
+                              String correlationId = correlationIdOf(callCtx);
+                              ScanSession session = requireSession(handle, correlationId);
+                              return scanBundles
+                                  .streamDataFiles(session, correlationId)
+                                  .onFailure()
+                                  .invoke(e -> markPlanningFailed(session, correlationId))
+                                  .onFailure()
+                                  .invoke(e -> queryStore.removeScanSession(handle))
+                                  .onFailure()
+                                  .transform(e -> toStatus(e, correlationId))
+                                  .onCompletion()
+                                  .invoke(
+                                      () -> {
+                                        markPlanningCompleted(session, correlationId);
+                                        L.ok();
+                                      });
+                            })))
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())
         .onTermination()
         .invoke(() -> queryStore.removeScanSession(handle))
@@ -212,6 +225,12 @@ public class QueryScanServiceImpl extends BaseServiceImpl implements QueryScanSe
         .orElseThrow(
             () ->
                 GrpcErrors.notFound(correlationId, SCAN_HANDLE, Map.of("handle", handle.getId())));
+  }
+
+  private static String correlationIdOf(ResolvedCallContext callCtx) {
+    return !callCtx.correlationId().isBlank()
+        ? callCtx.correlationId()
+        : callCtx.principalContext().getCorrelationId();
   }
 
   private void markPlanningFailed(ScanSession session, String correlationId) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySystemScanServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySystemScanServiceImpl.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNullElse;
 import ai.floedb.floecat.arrow.ArrowScanPlan;
 import ai.floedb.floecat.common.rpc.Predicate;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.expr.Expr;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
@@ -34,6 +35,7 @@ import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
 import ai.floedb.floecat.service.context.EngineContextProvider;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.catalog.ConstraintProviderFactory;
@@ -93,10 +95,18 @@ public class QuerySystemScanServiceImpl extends BaseServiceImpl implements Query
   @Override
   public Multi<ScanSystemTableChunk> scanSystemTable(ScanSystemTableRequest request) {
     var L = LogHelper.start(LOG, "ScanSystemTable");
+    // Read the resolved call context at method entry — before the executor hop — and carry it by
+    // reference into the body; the captured io.grpc.Context alone is unreliable across the hop
+    // (eng-floe/floecat#361). The providers the body reads (principal, engine context) pull from
+    // this scope.
+    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
 
     return Multi.createFrom()
-        .<ScanSystemTableChunk>emitter(emitter -> grpcCtx.run(() -> execute(request, emitter)))
+        .<ScanSystemTableChunk>emitter(
+            emitter ->
+                grpcCtx.run(
+                    () -> ResolvedCallContexts.runWith(callCtx, () -> execute(request, emitter))))
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())
         .onFailure()
         .invoke(L::fail)

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySystemScanServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySystemScanServiceImpl.java
@@ -22,7 +22,6 @@ import static java.util.Objects.requireNonNullElse;
 import ai.floedb.floecat.arrow.ArrowScanPlan;
 import ai.floedb.floecat.common.rpc.Predicate;
 import ai.floedb.floecat.common.rpc.ResourceId;
-import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.expr.Expr;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
@@ -32,10 +31,8 @@ import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
 import ai.floedb.floecat.scanner.spi.SystemScanRequest;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
-import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
 import ai.floedb.floecat.service.context.EngineContextProvider;
-import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.catalog.ConstraintProviderFactory;
@@ -58,7 +55,6 @@ import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import jakarta.inject.Inject;
 import java.util.Iterator;
@@ -95,19 +91,11 @@ public class QuerySystemScanServiceImpl extends BaseServiceImpl implements Query
   @Override
   public Multi<ScanSystemTableChunk> scanSystemTable(ScanSystemTableRequest request) {
     var L = LogHelper.start(LOG, "ScanSystemTable");
-    // Read the resolved call context at method entry — before the executor hop — and carry it by
-    // reference into the body; the captured io.grpc.Context alone is unreliable across the hop
-    // (eng-floe/floecat#361). The providers the body reads (principal, engine context) pull from
-    // this scope.
-    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
-    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
-
-    return Multi.createFrom()
-        .<ScanSystemTableChunk>emitter(
-            emitter ->
-                grpcCtx.run(
-                    () -> ResolvedCallContexts.runWith(callCtx, () -> execute(request, emitter))))
-        .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+    // runStreamEmitter reads the resolved call context at method entry — before the executor hop —
+    // and scopes the body to it; the providers the body reads (principal, engine context) pull
+    // from that scope.
+    return this.<ScanSystemTableChunk>runStreamEmitter(
+            (callCtx, emitter) -> execute(request, emitter))
         .onFailure()
         .invoke(L::fail)
         .onCompletion()

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
@@ -18,24 +18,18 @@ package ai.floedb.floecat.service.query.impl;
 
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
-import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.query.rpc.GetUserObjectsRequest;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
 import ai.floedb.floecat.query.rpc.UserObjectsService;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
-import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
-import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.catalog.UserObjectBundleService;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -66,66 +60,46 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
     AtomicBoolean completed = new AtomicBoolean(false);
     AtomicBoolean failed = new AtomicBoolean(false);
     AtomicReference<String> correlationRef = new AtomicReference<>("");
-    // Read the resolved call context at method entry — before any executor hop — and carry it by
-    // reference into the emitter body. Capturing only the io.grpc.Context is unreliable across
-    // the hop: its shared per-call slot races the call's own trailing listener events, which used
-    // to silently drop the engine context and correlation id here (eng-floe/floecat#361).
-    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
-    GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
-    Context otelCtx = Context.current();
+    // runStreamEmitter reads the resolved call context at method entry — before any executor hop —
+    // and carries it by reference into the emitter body. Capturing only the io.grpc.Context is
+    // unreliable across the hop: its shared per-call slot races the call's own trailing listener
+    // events, which used to silently drop the engine context and correlation id here
+    // (eng-floe/floecat#361).
+    return this.<UserObjectsBundleChunk>runStreamEmitter(
+            (callCtx, emitter) -> {
+              workStartNs.compareAndSet(0L, System.nanoTime());
+              var principalContext = callCtx.principalContext();
+              var correlationId = callCtx.effectiveCorrelationId();
+              correlationRef.set(correlationId);
+              authz.require(principalContext, "catalog.read");
 
-    return Multi.createFrom()
-        .<UserObjectsBundleChunk>emitter(
-            emitter -> {
-              grpcCtx.run(
-                  () ->
-                      ResolvedCallContexts.runWith(
-                          callCtx,
-                          () -> {
-                            try (Scope ignored = otelCtx.makeCurrent()) {
-                              workStartNs.compareAndSet(0L, System.nanoTime());
-                              var principalContext = callCtx.principalContext();
-                              var correlationId =
-                                  !callCtx.correlationId().isBlank()
-                                      ? callCtx.correlationId()
-                                      : principalContext.getCorrelationId();
-                              correlationRef.set(correlationId == null ? "" : correlationId);
-                              authz.require(principalContext, "catalog.read");
+              String queryId = mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+              var ctxOpt = queryStore.get(queryId);
+              if (ctxOpt.isEmpty()) {
+                emitter.fail(
+                    GrpcErrors.notFound(
+                        correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId)));
+                return;
+              }
 
-                              String queryId =
-                                  mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-                              var ctxOpt = queryStore.get(queryId);
-                              if (ctxOpt.isEmpty()) {
-                                emitter.fail(
-                                    GrpcErrors.notFound(
-                                        correlationId,
-                                        QUERY_NOT_FOUND,
-                                        Map.of("query_id", queryId)));
-                                return;
-                              }
+              QueryContext ctx = ctxOpt.get();
+              if (!ctx.isActive()) {
+                emitter.fail(
+                    GrpcErrors.preconditionFailed(
+                        correlationId,
+                        QUERY_NOT_ACTIVE,
+                        Map.of("query_id", queryId, "state", ctx.getState().name())));
+                return;
+              }
 
-                              QueryContext ctx = ctxOpt.get();
-                              if (!ctx.isActive()) {
-                                emitter.fail(
-                                    GrpcErrors.preconditionFailed(
-                                        correlationId,
-                                        QUERY_NOT_ACTIVE,
-                                        Map.of(
-                                            "query_id", queryId, "state", ctx.getState().name())));
-                                return;
-                              }
+              var subscription =
+                  bundles.stream(correlationId, ctx, request.getTablesList())
+                      .subscribe()
+                      .with(emitter::emit, emitter::fail, emitter::complete);
 
-                              var subscription =
-                                  bundles.stream(correlationId, ctx, request.getTablesList())
-                                      .subscribe()
-                                      .with(emitter::emit, emitter::fail, emitter::complete);
-
-                              emitter.onTermination(subscription::cancel);
-                              emitter.onCancellation(subscription::cancel);
-                            }
-                          }));
+              emitter.onTermination(subscription::cancel);
+              emitter.onCancellation(subscription::cancel);
             })
-        .runSubscriptionOn(Infrastructure.getDefaultExecutor())
         .onCompletion()
         .invoke(() -> completed.set(true))
         .onFailure()

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
@@ -18,13 +18,14 @@ package ai.floedb.floecat.service.query.impl;
 
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.query.rpc.GetUserObjectsRequest;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
 import ai.floedb.floecat.query.rpc.UserObjectsService;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.GrpcContextUtil;
 import ai.floedb.floecat.service.common.LogHelper;
-import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.catalog.UserObjectBundleService;
@@ -65,9 +66,11 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
     AtomicBoolean completed = new AtomicBoolean(false);
     AtomicBoolean failed = new AtomicBoolean(false);
     AtomicReference<String> correlationRef = new AtomicReference<>("");
-    // Capture the incoming gRPC context so the principal/correlation-id stays available
-    // throughout the entire streaming response — including lazy item emission from the
-    // UserObjectBundleIterator, which calls principal.get() for name resolution.
+    // Read the resolved call context at method entry — before any executor hop — and carry it by
+    // reference into the emitter body. Capturing only the io.grpc.Context is unreliable across
+    // the hop: its shared per-call slot races the call's own trailing listener events, which used
+    // to silently drop the engine context and correlation id here (eng-floe/floecat#361).
+    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
     Context otelCtx = Context.current();
 
@@ -75,48 +78,52 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
         .<UserObjectsBundleChunk>emitter(
             emitter -> {
               grpcCtx.run(
-                  () -> {
-                    try (Scope ignored = otelCtx.makeCurrent()) {
-                      workStartNs.compareAndSet(0L, System.nanoTime());
-                      var principalContext = principal.get();
-                      var contextCorrelationId = InboundContextInterceptor.CORR_KEY.get();
-                      var principalCorrelationId = principalContext.getCorrelationId();
-                      var correlationId =
-                          contextCorrelationId != null && !contextCorrelationId.isBlank()
-                              ? contextCorrelationId
-                              : principalCorrelationId;
-                      correlationRef.set(correlationId == null ? "" : correlationId);
-                      authz.require(principalContext, "catalog.read");
+                  () ->
+                      ResolvedCallContexts.runWith(
+                          callCtx,
+                          () -> {
+                            try (Scope ignored = otelCtx.makeCurrent()) {
+                              workStartNs.compareAndSet(0L, System.nanoTime());
+                              var principalContext = callCtx.principalContext();
+                              var correlationId =
+                                  !callCtx.correlationId().isBlank()
+                                      ? callCtx.correlationId()
+                                      : principalContext.getCorrelationId();
+                              correlationRef.set(correlationId == null ? "" : correlationId);
+                              authz.require(principalContext, "catalog.read");
 
-                      String queryId =
-                          mustNonEmpty(request.getQueryId(), "query_id", correlationId);
-                      var ctxOpt = queryStore.get(queryId);
-                      if (ctxOpt.isEmpty()) {
-                        emitter.fail(
-                            GrpcErrors.notFound(
-                                correlationId, QUERY_NOT_FOUND, Map.of("query_id", queryId)));
-                        return;
-                      }
+                              String queryId =
+                                  mustNonEmpty(request.getQueryId(), "query_id", correlationId);
+                              var ctxOpt = queryStore.get(queryId);
+                              if (ctxOpt.isEmpty()) {
+                                emitter.fail(
+                                    GrpcErrors.notFound(
+                                        correlationId,
+                                        QUERY_NOT_FOUND,
+                                        Map.of("query_id", queryId)));
+                                return;
+                              }
 
-                      QueryContext ctx = ctxOpt.get();
-                      if (!ctx.isActive()) {
-                        emitter.fail(
-                            GrpcErrors.preconditionFailed(
-                                correlationId,
-                                QUERY_NOT_ACTIVE,
-                                Map.of("query_id", queryId, "state", ctx.getState().name())));
-                        return;
-                      }
+                              QueryContext ctx = ctxOpt.get();
+                              if (!ctx.isActive()) {
+                                emitter.fail(
+                                    GrpcErrors.preconditionFailed(
+                                        correlationId,
+                                        QUERY_NOT_ACTIVE,
+                                        Map.of(
+                                            "query_id", queryId, "state", ctx.getState().name())));
+                                return;
+                              }
 
-                      var subscription =
-                          bundles.stream(correlationId, ctx, request.getTablesList())
-                              .subscribe()
-                              .with(emitter::emit, emitter::fail, emitter::complete);
+                              var subscription =
+                                  bundles.stream(correlationId, ctx, request.getTablesList())
+                                      .subscribe()
+                                      .with(emitter::emit, emitter::fail, emitter::complete);
 
-                      emitter.onTermination(subscription::cancel);
-                      emitter.onCancellation(subscription::cancel);
-                    }
-                  });
+                              emitter.onTermination(subscription::cancel);
+                              emitter.onCancellation(subscription::cancel);
+                            }
+                          }));
             })
         .runSubscriptionOn(Infrastructure.getDefaultExecutor())
         .onCompletion()

--- a/service/src/main/java/ai/floedb/floecat/service/security/impl/PrincipalProvider.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/impl/PrincipalProvider.java
@@ -17,84 +17,41 @@
 package ai.floedb.floecat.service.security.impl;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import io.grpc.Context;
-import io.smallrye.common.vertx.VertxContext;
-import io.vertx.core.Vertx;
 import jakarta.enterprise.context.ApplicationScoped;
 
 /**
- * Resolves the principal for the current call. The principal is carried on two channels:
+ * Resolves the principal for the current call.
  *
- * <ul>
- *   <li>an {@link io.grpc.Context} key ({@link #KEY}), read by gRPC server interceptors that run
- *       <i>before</i> the call is dispatched to the service method; and
- *   <li>a Vert.x duplicated-context local ({@link #PRINCIPAL_LOCAL}), read by the service-method
- *       body, which runs <i>after</i> Quarkus's gRPC dispatch has hopped the call onto a Vert.x
- *       worker.
- * </ul>
+ * <p>The principal travels as part of the whole {@link ResolvedCallContext} carried by {@link
+ * ResolvedCallContexts} (explicit scope, then the per-call Vert.x duplicated-context local written
+ * by the inbound interceptor, then the {@code io.grpc.Context} keys). This method prefers that
+ * carrier and falls back to reading {@link #KEY} directly for callers that drive {@link
+ * io.grpc.Context} without the interceptor (e.g. unit tests), and to the empty default when no
+ * channel carries a principal.
  *
- * <p>The second channel exists because {@link io.grpc.Context} is not reliable across that worker
- * thread-hop: {@code io.grpc.override.ContextStorageOverride} stores the context as a
- * duplicated-context local only while it is attached on a duplicated context, and otherwise falls
- * back to a plain {@link ThreadLocal}. When the principal is attached on one context and read on a
- * different worker without a re-attach, the thread-local fallback diverges and {@link #KEY} reads
- * back empty — surfacing as a misleading {@code PERMISSION_DENIED}. A duplicated-context local, on
- * the other hand, is keyed off the (per-call) duplicated context itself, so it survives the hop for
- * exactly the same reason MDC does, and cannot bleed between concurrent calls.
+ * <p>The carrier exists because {@link io.grpc.Context} is not reliable across Quarkus's worker
+ * thread-hops: {@code io.grpc.override.ContextStorageOverride} stores the attached context in one
+ * shared per-call slot that several threads of the same call race, so {@link #KEY} can read back
+ * empty (historically surfacing as a misleading {@code PERMISSION_DENIED}) or — via its
+ * thread-local fallback on a reused worker — stale. See {@link ResolvedCallContexts}.
  */
 @ApplicationScoped
 public class PrincipalProvider {
   public static final Context.Key<PrincipalContext> KEY = Context.key("principal");
 
-  /** Vert.x duplicated-context local key under which the resolved principal is mirrored. */
-  private static final String PRINCIPAL_LOCAL = "floecat.principal";
-
-  /**
-   * Returns the principal for the current call.
-   *
-   * <p>The duplicated-context local is preferred over {@link #KEY}: every read through this method
-   * happens in the service-method body (the interceptors read {@link #KEY} directly), where the
-   * local is the per-call value that survived the worker hop, while {@link #KEY} may be empty or —
-   * via its thread-local fallback on a reused worker — carry a stale value. Falls back to {@link
-   * #KEY} for callers that resolve the principal without a Vert.x duplicated context (e.g. unit
-   * tests that drive {@link io.grpc.Context} directly), and to the empty default when neither
-   * channel carries a principal.
-   */
+  /** Returns the principal for the current call, or the empty default when none is carried. */
   public PrincipalContext get() {
-    PrincipalContext fromContextLocal = fromDuplicatedContext();
-    if (fromContextLocal != null) {
-      return fromContextLocal;
+    ResolvedCallContext resolved = ResolvedCallContexts.currentOrNull();
+    if (resolved != null) {
+      return resolved.principalContext();
     }
     PrincipalContext fromGrpc = KEY.get();
     if (fromGrpc != null) {
       return fromGrpc;
     }
     return PrincipalContext.getDefaultInstance();
-  }
-
-  /**
-   * Mirrors the resolved principal onto the current Vert.x duplicated context so it survives the
-   * gRPC dispatch worker thread-hop into the service-method body. Called from the inbound
-   * interceptor alongside MDC population, on the same context MDC is written to.
-   *
-   * <p>No-op when the current call is not on a Vert.x duplicated context (the {@link
-   * io.grpc.Context} key remains the carrier in that case), so it is safe to call unconditionally.
-   */
-  public static void storeOnDuplicatedContext(PrincipalContext principalContext) {
-    io.vertx.core.Context ctx = Vertx.currentContext();
-    if (ctx != null && VertxContext.isDuplicatedContext(ctx)) {
-      ctx.putLocal(PRINCIPAL_LOCAL, principalContext);
-    }
-  }
-
-  private static PrincipalContext fromDuplicatedContext() {
-    io.vertx.core.Context ctx = Vertx.currentContext();
-    if (ctx != null && VertxContext.isDuplicatedContext(ctx)) {
-      Object value = ctx.getLocal(PRINCIPAL_LOCAL);
-      if (value instanceof PrincipalContext principalContext) {
-        return principalContext;
-      }
-    }
-    return null;
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/OutboundContextClientInterceptorTest.java
@@ -18,10 +18,12 @@ package ai.floedb.floecat.service.context.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
-import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import java.io.ByteArrayInputStream;
@@ -68,12 +70,8 @@ final class OutboundContextClientInterceptorTest {
         new OutboundContextClientInterceptor(Optional.empty(), Optional.of("authorization"));
     AtomicReference<Metadata> captured = new AtomicReference<>();
 
-    Context context =
-        Context.current()
-            .withValue(
-                InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY, "Bearer propagated");
-
-    context.run(
+    ResolvedCallContexts.runWith(
+        resolvedWithAuthorizationHeader("Bearer propagated"),
         () -> {
           ClientCall<String, String> call =
               interceptor.interceptCall(
@@ -108,12 +106,8 @@ final class OutboundContextClientInterceptorTest {
         new OutboundContextClientInterceptor(Optional.empty(), Optional.of("authorization"));
     AtomicReference<Metadata> captured = new AtomicReference<>();
 
-    Context context =
-        Context.current()
-            .withValue(
-                InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY, "Bearer propagated");
-
-    context.run(
+    ResolvedCallContexts.runWith(
+        resolvedWithAuthorizationHeader("Bearer propagated"),
         () -> {
           ClientCall<String, String> call =
               interceptor.interceptCall(
@@ -128,6 +122,11 @@ final class OutboundContextClientInterceptorTest {
     Metadata.Key<String> authKey =
         Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
     assertThat(captured.get().get(authKey)).isEqualTo("Bearer explicit");
+  }
+
+  private static ResolvedCallContext resolvedWithAuthorizationHeader(String value) {
+    return new ResolvedCallContext(
+        PrincipalContext.getDefaultInstance(), "", "", EngineContext.empty(), null, value);
   }
 
   private static MethodDescriptor<String, String> testMethod(String fullMethodName) {

--- a/service/src/test/java/ai/floedb/floecat/service/it/QueryContextPropagationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QueryContextPropagationIT.java
@@ -16,16 +16,22 @@
 
 package ai.floedb.floecat.service.it;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import ai.floedb.floecat.catalog.rpc.CatalogServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.CatalogSpec;
 import ai.floedb.floecat.catalog.rpc.CreateCatalogRequest;
+import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.query.rpc.BeginQueryRequest;
 import ai.floedb.floecat.query.rpc.GetUserObjectsRequest;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
+import ai.floedb.floecat.query.rpc.RelationResolution;
+import ai.floedb.floecat.query.rpc.ResolutionStatus;
+import ai.floedb.floecat.query.rpc.TableReferenceCandidate;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
 import ai.floedb.floecat.query.rpc.UserObjectsServiceGrpc;
 import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
@@ -55,22 +61,28 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Stress reproducer for the prod intermittent {@code PERMISSION_DENIED: missing permission:
- * catalog.read} on {@code QueryService.BeginQuery} and {@code UserObjectsService.GetUserObjects}.
+ * Stress reproducer for the intermittent loss of the inbound call context (principal, correlation
+ * id, engine context) between the gRPC interceptor and service bodies running on Mutiny workers.
  *
- * <p>Both methods run their authorization check ({@code authz.require(pc, "catalog.read")}) inside
- * a Mutiny {@code Uni}/{@code Multi} body subscribed on {@code
- * Infrastructure.getDefaultExecutor()}. The principal they read is whatever {@code
- * GrpcContextUtil.capture()} grabbed at service-method entry. The reported failure is that some
- * fraction of calls land on the worker with an empty principal — {@code authz.require} then throws
- * {@code PERMISSION_DENIED}. This test fires many concurrent calls through the real OIDC
- * session-JWT path and fails the moment any inbound call gets that response.
+ * <p>The context loss has two observable forms, both exercised here:
  *
- * <p>Two scenarios exercised:
+ * <ul>
+ *   <li><b>Loud form</b> — the principal is lost, {@code authz.require(pc, "catalog.read")} throws
+ *       {@code PERMISSION_DENIED} (historical manifestation, before the principal gained its
+ *       duplicated-context mirror).
+ *   <li><b>Silent form</b> — the principal survives via its mirror but the engine context and
+ *       correlation id (grpc-context-keys only) are lost. An engine-gated system object such as
+ *       {@code sys.const} then resolves as {@code RESOLUTION_STATUS_NOT_FOUND} with a completed
+ *       stream (wrong answer, no error), and error payloads built in the service body carry an
+ *       empty correlation id. See eng-floe/floecat#361.
+ * </ul>
+ *
+ * <p>Scenarios:
  *
  * <ul>
  *   <li>{@code beginQuery} on its own — the {@link
@@ -78,7 +90,11 @@ import org.junit.jupiter.api.Test;
  *       {@code Uni}.
  *   <li>{@code beginQuery + getUserObjects} per attempt — the {@code Multi.createFrom().emitter(
  *       ...).runSubscriptionOn(...)} path, with the in-body {@code grpcCtx.run(...)} that the
- *       handler uses for streaming.
+ *       handler uses for streaming. Each attempt resolves an engine-gated system table and fails on
+ *       any non-FOUND resolution (silent-form detector).
+ *   <li>{@code getUserObjects} against an unknown query id — the returned {@code NOT_FOUND} error
+ *       payload must echo the request's correlation id, which the service body read from the
+ *       fragile context channel (silent-form detector for the correlation channel).
  * </ul>
  *
  * <p>Tunable via {@code -Dfloecat.test.query-ctx.threads} / {@code .iterations}. Defaults are sized
@@ -92,6 +108,19 @@ class QueryContextPropagationIT {
       Metadata.Key.of("x-floe-session", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> CORRELATION_HEADER =
       Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> ENGINE_KIND_HEADER =
+      Metadata.Key.of("x-engine-kind", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> ENGINE_VERSION_HEADER =
+      Metadata.Key.of("x-engine-version", Metadata.ASCII_STRING_MARSHALLER);
+
+  /**
+   * Engine kind whose system catalog snapshot contains {@code sys.const} (provided by {@link
+   * ai.floedb.floecat.service.catalog.it.TestCatalogExtension}). Resolution of that name is
+   * engine-gated: it succeeds only while the request's engine context is visible to the resolving
+   * thread, which is exactly the property under test. With a lost engine context the resolver falls
+   * back to the default snapshot, which does not contain the table.
+   */
+  private static final String ENGINE_KIND = "test-engine";
 
   private static final int DEFAULT_THREADS = 16;
   private static final int DEFAULT_ITERATIONS_PER_THREAD = 25;
@@ -156,7 +185,21 @@ class QueryContextPropagationIT {
   }
 
   @Test
-  void concurrentGetUserObjectsDoesNotLosePrincipalContext() throws Exception {
+  void concurrentGetUserObjectsDoesNotLoseCallContext() throws Exception {
+    // Silent-form detector: sys.const only resolves while the engine context declared in the
+    // request headers is visible to the resolving thread. A NOT_FOUND here means the engine
+    // context was lost mid-call even though the stream completed OK.
+    TableReferenceCandidate systemTableCandidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(
+                QueryInput.newBuilder()
+                    .setName(NameRef.newBuilder().addPath("sys").setName("const"))
+                    .build())
+            .build();
+
+    AtomicInteger silentNotFound = new AtomicInteger();
+    AtomicReference<String> firstSilentSample = new AtomicReference<>();
+
     runStress(
         "getUserObjects",
         (threadIdx, iteration) -> {
@@ -175,13 +218,121 @@ class QueryContextPropagationIT {
 
           Iterator<UserObjectsBundleChunk> it =
               userObjectsStub.getUserObjects(
-                  GetUserObjectsRequest.newBuilder().setQueryId(queryId).build());
+                  GetUserObjectsRequest.newBuilder()
+                      .setQueryId(queryId)
+                      .addTables(systemTableCandidate)
+                      .build());
 
-          // Drain the stream so any PERMISSION_DENIED emitted by the server surfaces here.
+          // Drain the stream so any PERMISSION_DENIED emitted by the server surfaces here, and
+          // inspect every resolution: any non-FOUND outcome for the engine-gated system table is
+          // the silent context-loss form.
           while (it.hasNext()) {
-            it.next();
+            UserObjectsBundleChunk chunk = it.next();
+            if (!chunk.hasResolutions()) {
+              continue;
+            }
+            for (RelationResolution resolution : chunk.getResolutions().getItemsList()) {
+              if (resolution.getStatus() != ResolutionStatus.RESOLUTION_STATUS_FOUND) {
+                silentNotFound.incrementAndGet();
+                firstSilentSample.compareAndSet(
+                    null,
+                    "t="
+                        + threadIdx
+                        + " i="
+                        + iteration
+                        + " status="
+                        + resolution.getStatus()
+                        + " failure="
+                        + resolution.getFailure().getMessage());
+              }
+            }
           }
         });
+
+    assertEquals(
+        0,
+        silentNotFound.get(),
+        () ->
+            "Silent context-propagation failure: sys.const resolved as non-FOUND "
+                + silentNotFound.get()
+                + " time(s) despite x-engine-kind="
+                + ENGINE_KIND
+                + " on every call — the engine context was lost between the inbound interceptor"
+                + " and engine-gated system-graph resolution. First sample: "
+                + firstSilentSample.get());
+  }
+
+  @Test
+  void getUserObjectsErrorCarriesRequestCorrelationId() throws Exception {
+    // The NOT_FOUND error for an unknown query id is built inside the service body from the
+    // correlation id read off the fragile context channel. If that channel is lost, the error
+    // payload carries an empty correlation id — the same loss that produces empty
+    // `correlation_id=` ok-lines in production logs.
+    AtomicInteger mismatches = new AtomicInteger();
+    AtomicReference<String> firstMismatchSample = new AtomicReference<>();
+
+    runStress(
+        "getUserObjectsCorrelation",
+        (threadIdx, iteration) -> {
+          String correlationId =
+              "ctx-prop-corr-t" + threadIdx + "-i" + iteration + "-" + UUID.randomUUID();
+          Metadata md = new Metadata();
+          md.put(SESSION_HEADER, jwt);
+          md.put(CORRELATION_HEADER, correlationId);
+          md.put(ENGINE_KIND_HEADER, ENGINE_KIND);
+          md.put(ENGINE_VERSION_HEADER, "");
+
+          var userObjectsStub =
+              UserObjectsServiceGrpc.newBlockingStub(channel)
+                  .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(md));
+
+          Iterator<UserObjectsBundleChunk> it =
+              userObjectsStub.getUserObjects(
+                  GetUserObjectsRequest.newBuilder()
+                      .setQueryId("unknown-" + UUID.randomUUID())
+                      .build());
+          try {
+            while (it.hasNext()) {
+              it.next();
+            }
+            fail("expected NOT_FOUND for unknown query id");
+          } catch (StatusRuntimeException e) {
+            if (e.getStatus().getCode() != Status.Code.NOT_FOUND) {
+              throw e;
+            }
+            ai.floedb.floecat.common.rpc.Error error;
+            try {
+              error = TestSupport.unpackMcError(e);
+            } catch (Exception unpackFailure) {
+              throw new IllegalStateException("could not unpack error details", unpackFailure);
+            }
+            String echoed = error == null ? null : error.getCorrelationId();
+            if (!correlationId.equals(echoed)) {
+              mismatches.incrementAndGet();
+              firstMismatchSample.compareAndSet(
+                  null,
+                  "t="
+                      + threadIdx
+                      + " i="
+                      + iteration
+                      + " sent="
+                      + correlationId
+                      + " got="
+                      + echoed);
+            }
+          }
+        });
+
+    assertEquals(
+        0,
+        mismatches.get(),
+        () ->
+            "Silent context-propagation failure: "
+                + mismatches.get()
+                + " NOT_FOUND error payload(s) did not echo the request correlation id — the"
+                + " correlation id was lost between the inbound interceptor and the service body."
+                + " First sample: "
+                + firstMismatchSample.get());
   }
 
   // ---------- stress harness ----------
@@ -293,6 +444,10 @@ class QueryContextPropagationIT {
     Metadata md = new Metadata();
     md.put(SESSION_HEADER, jwt);
     md.put(CORRELATION_HEADER, correlationId + "-" + UUID.randomUUID());
+    // Production planners always declare their engine; sending it on every call keeps the stress
+    // path representative and arms the engine-gated resolution assertions.
+    md.put(ENGINE_KIND_HEADER, ENGINE_KIND);
+    md.put(ENGINE_VERSION_HEADER, "");
     return md;
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/it/TestCatalogExtension.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/TestCatalogExtension.java
@@ -17,15 +17,18 @@
 package ai.floedb.floecat.service.catalog.it;
 
 import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.query.rpc.TableBackendKind;
 import ai.floedb.floecat.scanner.spi.SystemObjectScanner;
 import ai.floedb.floecat.systemcatalog.def.SystemAggregateDef;
 import ai.floedb.floecat.systemcatalog.def.SystemCastDef;
 import ai.floedb.floecat.systemcatalog.def.SystemCastMethod;
 import ai.floedb.floecat.systemcatalog.def.SystemCollationDef;
+import ai.floedb.floecat.systemcatalog.def.SystemColumnDef;
 import ai.floedb.floecat.systemcatalog.def.SystemFunctionDef;
 import ai.floedb.floecat.systemcatalog.def.SystemNamespaceDef;
 import ai.floedb.floecat.systemcatalog.def.SystemObjectDef;
 import ai.floedb.floecat.systemcatalog.def.SystemOperatorDef;
+import ai.floedb.floecat.systemcatalog.def.SystemTableDef;
 import ai.floedb.floecat.systemcatalog.def.SystemTypeDef;
 import ai.floedb.floecat.systemcatalog.engine.EngineSpecificRule;
 import ai.floedb.floecat.systemcatalog.registry.SystemCatalogData;
@@ -74,7 +77,7 @@ public final class TestCatalogExtension implements EngineSystemCatalogExtension 
         collations(),
         aggregates(),
         namespaces(),
-        /* tables= */ List.of(),
+        tables(),
         /* views= */ List.of(),
         /* registryEngineSpecific= */ List.of());
   }
@@ -212,9 +215,33 @@ public final class TestCatalogExtension implements EngineSystemCatalogExtension 
             List.of()));
   }
 
-  /** Namespace declaration for {@code pg_catalog}. */
+  /** Namespace declarations for {@code pg_catalog} and {@code sys}. */
   private static List<SystemNamespaceDef> namespaces() {
-    return List.of(new SystemNamespaceDef(nr("pg_catalog"), "pg_catalog", List.of()));
+    return List.of(
+        new SystemNamespaceDef(nr("pg_catalog"), "pg_catalog", List.of()),
+        new SystemNamespaceDef(nr("sys"), "sys", List.of()));
+  }
+
+  /**
+   * One engine-gated system table, {@code sys.const}, mirroring the shape of engine-extension
+   * catalogs deployed in production. It exists only in the {@code test-engine} snapshot — never in
+   * the default one — so resolving it by name succeeds only while the request's engine context is
+   * visible to the resolving thread. {@code QueryContextPropagationIT} relies on this to detect
+   * silent engine-context loss (eng-floe/floecat#361).
+   */
+  private static List<SystemTableDef> tables() {
+    return List.of(
+        new SystemTableDef(
+            nr("sys.const"),
+            "const",
+            List.of(new SystemColumnDef("value", nr("pg_catalog.int4"), false, 1, null, List.of())),
+            TableBackendKind.TABLE_BACKEND_KIND_STORAGE,
+            /* scannerId= */ "",
+            /* storagePath= */ "memory://test-engine/sys/const",
+            /* storageEndpointKey= */ "",
+            List.of(),
+            /* flightEndpoint= */ null,
+            List.of()));
   }
 
   // ---------------------------------------------------------------------------

--- a/service/src/test/java/ai/floedb/floecat/service/security/impl/PrincipalProviderTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/impl/PrincipalProviderTest.java
@@ -19,6 +19,9 @@ package ai.floedb.floecat.service.security.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import io.grpc.Context;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
@@ -28,13 +31,14 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit coverage for the dual-channel principal carrier in {@link PrincipalProvider}.
+ * Unit coverage for the resolved-call-context carrier as read through {@link PrincipalProvider}.
  *
- * <p>These tests model the production failure deterministically: the resolved principal is mirrored
- * onto a Vert.x duplicated context by the inbound interceptor, then read back from the
- * service-method body, which runs on a worker after Quarkus's gRPC dispatch thread-hop — a point
- * where the {@code io.grpc.Context} key is absent (or, on a reused worker, stale). The
- * duplicated-context local must carry the principal across that hop the same way MDC does.
+ * <p>These tests model the production failure deterministically: the whole {@link
+ * ResolvedCallContext} is stored on a Vert.x duplicated context by the inbound interceptor, then
+ * read back from the service-method body, which runs on a worker after Quarkus's gRPC dispatch
+ * thread-hop — a point where the {@code io.grpc.Context} keys are absent (or, on a reused worker,
+ * stale). The duplicated-context local must carry principal, correlation id, and engine context
+ * across that hop the same way MDC does.
  */
 class PrincipalProviderTest {
 
@@ -45,14 +49,18 @@ class PrincipalProviderTest {
           .addPermissions("catalog.read")
           .build();
 
+  private static final ResolvedCallContext RESOLVED =
+      new ResolvedCallContext(
+          PRINCIPAL, "q-1", "corr-1", EngineContext.of("test-engine", "16.0"), null, null);
+
   @FunctionalInterface
   private interface Body {
     PrincipalContext run();
   }
 
   /**
-   * The core fix: a principal stored on the duplicated context survives the worker thread-hop into
-   * the service body and is read back even though {@code io.grpc.Context} carries no principal
+   * The core fix: a call context stored on the duplicated context survives the worker thread-hop
+   * into the service body and is read back even though {@code io.grpc.Context} carries no principal
    * there. Before the fix this returned {@link PrincipalContext#getDefaultInstance()} → missing
    * {@code catalog.read}.
    */
@@ -63,6 +71,46 @@ class PrincipalProviderTest {
       PrincipalContext observed = storeThenRunOnWorker(vertx, () -> new PrincipalProvider().get());
       assertEquals("dev-user", observed.getSubject());
       assertEquals(List.of("catalog.read"), observed.getPermissionsList());
+    } finally {
+      close(vertx);
+    }
+  }
+
+  /**
+   * The whole context — not just the principal — survives the hop: correlation id and engine
+   * context read back intact. Guards against the piecemeal-mirroring regression where the principal
+   * survived but engine/correlation silently degraded (eng-floe/floecat#361).
+   */
+  @Test
+  void correlationAndEngineSurviveWorkerHopWithPrincipal() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      CompletableFuture<ResolvedCallContext> result = new CompletableFuture<>();
+      io.vertx.core.Context dup =
+          VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+      dup.runOnContext(
+          ignored -> {
+            try {
+              ResolvedCallContexts.storeOnDuplicatedContext(RESOLVED);
+              Vertx.currentContext()
+                  .<ResolvedCallContext>executeBlocking(
+                      ResolvedCallContexts::currentOrUnauthenticated, false)
+                  .onComplete(
+                      ar -> {
+                        if (ar.succeeded()) {
+                          result.complete(ar.result());
+                        } else {
+                          result.completeExceptionally(ar.cause());
+                        }
+                      });
+            } catch (Throwable t) {
+              result.completeExceptionally(t);
+            }
+          });
+      ResolvedCallContext observed = result.get(10, TimeUnit.SECONDS);
+      assertEquals("corr-1", observed.correlationId());
+      assertEquals("test-engine", observed.engineContext().engineKind());
+      assertEquals("dev-user", observed.principalContext().getSubject());
     } finally {
       close(vertx);
     }
@@ -98,6 +146,22 @@ class PrincipalProviderTest {
     }
   }
 
+  /**
+   * An explicit scope ({@code callWith}) outranks every other channel: it is the by-reference
+   * handoff service bodies use across executor hops, where even the duplicated context may be
+   * absent.
+   */
+  @Test
+  void explicitScopeOutranksGrpcKey() throws Exception {
+    PrincipalContext scoped =
+        Context.ROOT.call(
+            () -> ResolvedCallContexts.callWith(RESOLVED, () -> new PrincipalProvider().get()));
+    assertEquals("dev-user", scoped.getSubject());
+    // Outside the scope the channel is cleared again.
+    PrincipalContext outside = Context.ROOT.call(() -> new PrincipalProvider().get());
+    assertEquals(PrincipalContext.getDefaultInstance(), outside);
+  }
+
   /** Off any Vert.x duplicated context, the {@code io.grpc.Context} key remains the carrier. */
   @Test
   void fallsBackToGrpcKeyOffDuplicatedContext() {
@@ -127,7 +191,7 @@ class PrincipalProviderTest {
     PrincipalContext got =
         Context.ROOT.call(
             () -> {
-              PrincipalProvider.storeOnDuplicatedContext(PRINCIPAL);
+              ResolvedCallContexts.storeOnDuplicatedContext(RESOLVED);
               return new PrincipalProvider().get();
             });
     assertEquals(PrincipalContext.getDefaultInstance(), got);
@@ -136,10 +200,10 @@ class PrincipalProviderTest {
   // ---------- helpers ----------
 
   /**
-   * Models the real call shape: store the principal on a fresh per-call duplicated context (the
-   * inbound interceptor), then run {@code body} on a worker hop that stays on that same duplicated
-   * context (the service body, dispatched off the event loop). The completion is chained back
-   * asynchronously so the event loop is never blocked.
+   * Models the real call shape: store the resolved call context on a fresh per-call duplicated
+   * context (the inbound interceptor), then run {@code body} on a worker hop that stays on that
+   * same duplicated context (the service body, dispatched off the event loop). The completion is
+   * chained back asynchronously so the event loop is never blocked.
    */
   private static PrincipalContext storeThenRunOnWorker(Vertx vertx, Body body) throws Exception {
     CompletableFuture<PrincipalContext> result = new CompletableFuture<>();
@@ -147,7 +211,7 @@ class PrincipalProviderTest {
     dup.runOnContext(
         ignored -> {
           try {
-            PrincipalProvider.storeOnDuplicatedContext(PRINCIPAL);
+            ResolvedCallContexts.storeOnDuplicatedContext(RESOLVED);
             Vertx.currentContext()
                 .<PrincipalContext>executeBlocking(body::run, false)
                 .onComplete(


### PR DESCRIPTION
Part 1 of 2 for #361 (part 2: context-loss hardening, stacked on this branch).

## Problem

One request's context rides three channels with very different reliability. MDC and the principal survive Quarkus's executor hops via Vert.x duplicated-context locals, but the **correlation id and engine context lived only on `io.grpc.Context` keys** — which, under Quarkus, are one shared last-writer-wins slot that the call's *own* threads race (event loop, blocking-wrap workers, Mutiny emitter). Mirroring only the principal (the earlier partial fix) moved the failure past authz: instead of a loud `PERMISSION_DENIED`, the engine context silently reads back empty, the engine-keyed system graph resolves nothing, and `GetUserObjects` completes OK with `sys.const` → `RESOLUTION_STATUS_NOT_FOUND` — surfacing as a wrong-answer-shaped `42P01` in the engine with no floecat-side trace (see the RCA in #361).

## Fix

**Commit 1 — test first.** `QueryContextPropagationIT` gains two silent-form detectors: every streaming attempt resolves `sys.const`, an engine-gated system table served by the test-only `TestCatalogExtension` (mirroring how engine extensions ship system catalogs in production; only resolvable while the request's engine context is visible), and a new scenario asserts the `NOT_FOUND` error payload echoes the request correlation id — that value is read *inside the service body* from the fragile channel, so it probes exactly the read that went empty in CI.

**Commit 2 — one write-once carrier.** New `ResolvedCallContexts` stores the whole `ResolvedCallContext` (principal + correlation + engine + query id + auth header values) once per call on the same duplicated-context local that carries MDC, plus an explicit `callWith`/`runWith` scope for handing it by reference across executor hops. All readers now go carrier-first, grpc-keys last:
- `PrincipalProvider.get()` (replaces the principal-only mirror)
- `EngineContextProvider.engineContext()` (previously grpc-keys only — the resolution-side hole)
- `GrpcResolvedCallContexts` (Flight path)
- `OutboundContextClientInterceptor` (outbound RPCs from executor threads no longer drop engine/correlation headers)
- `BaseServiceImpl.run` (every unary body)

The four streaming services (`UserObjects`, `QueryScan`, `QuerySystemScan`, `PlannerStats`) read the resolved context **once at method entry**, before any hop, and carry it by reference into their bodies. `InboundCallContextHelper` also stamps the correlation id onto the `PrincipalContext` — the field existed but was never set.

**Commit 3 — engine by value through resolution.** `CatalogOverlay` gains engine-explicit `resolveName`/`resolve` overloads (default-delegating, so other implementers are unaffected); the bundle iterator passes the engine captured at construction instead of re-reading the request context per lookup (`resolve(id)` had the same per-lookup hole as `resolveName` — fixing only names would have moved the failure to the node stage). `MetaGraph.resolveName` now WARNs when a lookup misses both graphs with an empty engine instead of silently returning NOT_FOUND.

## Verification

- 926 unit tests + 29 ITs green after every commit; re-verified after rebasing onto `origin/main`.
- Stress: 9,600 calls at 32 threads across the three IT scenarios — zero context losses, zero silent NOT_FOUNDs, zero correlation mismatches.
- Honest caveat: the race does not reproduce locally even pre-fix (same reason the original PERMISSION_DENIED IT went quiet), so the new tests are armed detectors validated against the fixed code. The acceptance signal is the two CI signatures from #361 staying gone on core test-sql runs: empty `correlation_id=` on `GetUserObjects` ok-lines, and `sys.*` NOT_FOUND on constant-only statements.

Engine-side follow-up (bare `42P01` without the `ResolutionFailure` payload) stays tracked in eng-floe/core#1692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
