### PR TITLE
Context-loss hardening: loud failures, disagreement detectors, deterministic interceptor ordering

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/common/GrpcInterceptorPriorities.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/GrpcInterceptorPriorities.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.common;
+
+/**
+ * Priorities for floecat's global gRPC server interceptors.
+ *
+ * <p>Quarkus sorts global interceptors ascending by the CDI {@link
+ * jakarta.enterprise.inject.spi.Prioritized} <em>interface</em> and hands the sorted list to {@code
+ * ServerInterceptors.intercept}, which makes the <b>last</b> element the <b>outermost</b>
+ * interceptor — so a higher priority value means running earlier on call entry. {@code
+ * jakarta.annotation.Priority} annotations are silently ignored by that comparator; before these
+ * constants existed our three interceptors all tied at 0 with nondeterministic relative order.
+ *
+ * <p>Quarkus's built-in interceptors sit near {@code Integer.MAX_VALUE} ({@code
+ * io.quarkus.grpc.runtime.Interceptors}) and deterministically stay outermost of all; these values
+ * only order floecat's own interceptors below them.
+ */
+public final class GrpcInterceptorPriorities {
+
+  /**
+   * Outermost floecat interceptor: resolves the call context and populates {@code io.grpc.Context},
+   * MDC, and the duplicated-context carrier before telemetry and logging read them — and clears MDC
+   * after they are done (outer close runs last).
+   */
+  public static final int INBOUND_CONTEXT = 1_000_000;
+
+  public static final int TELEMETRY = 300;
+
+  public static final int RPC_LOGGING = 200;
+
+  /** Innermost: localizes error payloads before the outer logging interceptor observes them. */
+  public static final int LOCALIZE_ERRORS = 100;
+
+  private GrpcInterceptorPriorities() {}
+}

--- a/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
@@ -22,6 +22,8 @@ import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Optional;
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
 
 /**
  * Resolves the engine context declared by the current call.
@@ -32,6 +34,8 @@ import java.util.Optional;
  */
 @ApplicationScoped
 public final class EngineContextProvider {
+
+  private static final Logger LOG = Logger.getLogger(EngineContextProvider.class);
 
   public String engineKind() {
     return engineContext().engineKind();
@@ -69,6 +73,27 @@ public final class EngineContextProvider {
     String kind = Optional.ofNullable(InboundContextInterceptor.ENGINE_KIND_KEY.get()).orElse("");
     String version =
         Optional.ofNullable(InboundContextInterceptor.ENGINE_VERSION_KEY.get()).orElse("");
-    return EngineContext.of(kind, version);
+    EngineContext fallback = EngineContext.of(kind, version);
+    if (!fallback.hasEngineKind()) {
+      warnIfRequestDeclaredEngine();
+    }
+    return fallback;
+  }
+
+  /**
+   * Channel-disagreement detector: MDC carrying an engine kind proves the request declared an
+   * engine, so resolving an empty engine context here is a propagation loss — the exact condition
+   * that silently un-resolves engine-gated system objects (eng-floe/floecat#361). This should never
+   * fire; any occurrence is a regression in context propagation.
+   */
+  private static void warnIfRequestDeclaredEngine() {
+    Object mdcEngineKind = MDC.get("floecat_engine_kind");
+    if (mdcEngineKind instanceof String engineKind && !engineKind.isBlank()) {
+      LOG.warnf(
+          "engine-context channels disagree: MDC floecat_engine_kind=%s is populated but no"
+              + " channel carries an engine context — the call context was lost on the way to"
+              + " this thread (correlation_id=%s)",
+          engineKind, MDC.get("correlation_id"));
+    }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/EngineContextProvider.java
@@ -22,8 +22,6 @@ import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Optional;
-import org.jboss.logging.Logger;
-import org.jboss.logging.MDC;
 
 /**
  * Resolves the engine context declared by the current call.
@@ -34,8 +32,6 @@ import org.jboss.logging.MDC;
  */
 @ApplicationScoped
 public final class EngineContextProvider {
-
-  private static final Logger LOG = Logger.getLogger(EngineContextProvider.class);
 
   public String engineKind() {
     return engineContext().engineKind();
@@ -75,25 +71,12 @@ public final class EngineContextProvider {
         Optional.ofNullable(InboundContextInterceptor.ENGINE_VERSION_KEY.get()).orElse("");
     EngineContext fallback = EngineContext.of(kind, version);
     if (!fallback.hasEngineKind()) {
-      warnIfRequestDeclaredEngine();
+      // MDC carrying an engine kind proves the request declared an engine, so an empty engine
+      // context here is the exact condition that silently un-resolves engine-gated system
+      // objects (eng-floe/floecat#361).
+      ResolvedCallContexts.warnOnChannelDisagreement(
+          "floecat_engine_kind", "no channel carries an engine context");
     }
     return fallback;
-  }
-
-  /**
-   * Channel-disagreement detector: MDC carrying an engine kind proves the request declared an
-   * engine, so resolving an empty engine context here is a propagation loss — the exact condition
-   * that silently un-resolves engine-gated system objects (eng-floe/floecat#361). This should never
-   * fire; any occurrence is a regression in context propagation.
-   */
-  private static void warnIfRequestDeclaredEngine() {
-    Object mdcEngineKind = MDC.get("floecat_engine_kind");
-    if (mdcEngineKind instanceof String engineKind && !engineKind.isBlank()) {
-      LOG.warnf(
-          "engine-context channels disagree: MDC floecat_engine_kind=%s is populated but no"
-              + " channel carries an engine context — the call context was lost on the way to"
-              + " this thread (correlation_id=%s)",
-          engineKind, MDC.get("correlation_id"));
-    }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/BlockingInboundContextInterceptor.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.context.impl;
 
+import ai.floedb.floecat.service.common.GrpcInterceptorPriorities;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -24,16 +25,15 @@ import io.grpc.ServerInterceptor;
 import io.quarkus.grpc.GlobalInterceptor;
 import io.quarkus.oidc.TenantIdentityProvider;
 import io.vertx.core.Vertx;
-import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Prioritized;
 import jakarta.inject.Inject;
 import java.util.Optional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
 @GlobalInterceptor
-@Priority(0) // Must run before other interceptors
-public class BlockingInboundContextInterceptor implements ServerInterceptor {
+public class BlockingInboundContextInterceptor implements ServerInterceptor, Prioritized {
   private final ServerInterceptor delegate;
 
   @Inject
@@ -81,5 +81,16 @@ public class BlockingInboundContextInterceptor implements ServerInterceptor {
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
       ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
     return delegate.interceptCall(call, headers, next);
+  }
+
+  /**
+   * Highest of floecat's interceptors so this one runs outermost among them (higher = outer; see
+   * {@link GrpcInterceptorPriorities}): the call context and MDC must be populated before
+   * telemetry/logging read them. Only the {@code Prioritized} interface is honored by Quarkus's
+   * interceptor comparator — a {@code @Priority} annotation is silently ignored.
+   */
+  @Override
+  public int getPriority() {
+    return GrpcInterceptorPriorities.INBOUND_CONTEXT;
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
@@ -24,6 +24,7 @@ import io.vertx.core.Vertx;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
 
 /**
  * Write-once carrier for the fully resolved inbound call context (principal, correlation id, engine
@@ -104,7 +105,28 @@ public final class ResolvedCallContexts {
     if (fromDuplicatedContext != null) {
       return fromDuplicatedContext;
     }
-    return fromGrpcContextKeys();
+    ResolvedCallContext fromKeys = fromGrpcContextKeys();
+    if (fromKeys == null) {
+      warnIfMdcDisagrees();
+    }
+    return fromKeys;
+  }
+
+  /**
+   * Channel-disagreement detector: MDC carrying a correlation id proves this thread is inside a
+   * resolved request, so a miss on every context channel is a propagation loss — the failure mode
+   * of eng-floe/floecat#361, turned from a silent wrong answer into a countable signal. This should
+   * never fire; any occurrence is a regression in context propagation.
+   */
+  private static void warnIfMdcDisagrees() {
+    Object mdcCorrelationId = MDC.get("correlation_id");
+    if (mdcCorrelationId instanceof String correlationId && !correlationId.isBlank()) {
+      LOG.warnf(
+          "call-context channels disagree: MDC correlation_id=%s is populated but no channel"
+              + " (scope, duplicated-context local, io.grpc.Context) carries a resolved call"
+              + " context — the call context was lost on the way to this thread",
+          correlationId);
+    }
   }
 
   /** Like {@link #currentOrNull()} but degrades to {@link ResolvedCallContext#unauthenticated}. */

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
@@ -107,25 +107,31 @@ public final class ResolvedCallContexts {
     }
     ResolvedCallContext fromKeys = fromGrpcContextKeys();
     if (fromKeys == null) {
-      warnIfMdcDisagrees();
+      warnOnChannelDisagreement(
+          "correlation_id",
+          "no channel (scope, duplicated-context local, io.grpc.Context) carries a resolved call"
+              + " context");
     }
     return fromKeys;
   }
 
   /**
-   * Channel-disagreement detector: MDC carrying a correlation id proves this thread is inside a
-   * resolved request, so a miss on every context channel is a propagation loss — the failure mode
-   * of eng-floe/floecat#361, turned from a silent wrong answer into a countable signal. This should
-   * never fire; any occurrence is a regression in context propagation.
+   * Channel-disagreement detector shared by every carrier-backed reader: a populated MDC key proves
+   * the inbound interceptor resolved this request on this very call path (MDC and the carrier are
+   * written together), so a miss on the actual context channels is a propagation loss — the failure
+   * mode of eng-floe/floecat#361, turned from a silent wrong answer into a countable signal. This
+   * should never fire; any occurrence is a regression in context propagation.
+   *
+   * @param mdcKey the MDC key whose presence proves the request declared the lost value
+   * @param missingWhat what the context channels failed to deliver, for the log message
    */
-  private static void warnIfMdcDisagrees() {
-    Object mdcCorrelationId = MDC.get("correlation_id");
-    if (mdcCorrelationId instanceof String correlationId && !correlationId.isBlank()) {
+  public static void warnOnChannelDisagreement(String mdcKey, String missingWhat) {
+    Object mdcValue = MDC.get(mdcKey);
+    if (mdcValue instanceof String value && !value.isBlank()) {
       LOG.warnf(
-          "call-context channels disagree: MDC correlation_id=%s is populated but no channel"
-              + " (scope, duplicated-context local, io.grpc.Context) carries a resolved call"
-              + " context — the call context was lost on the way to this thread",
-          correlationId);
+          "call-context channels disagree: MDC %s=%s is populated but %s — the call context was"
+              + " lost on the way to this thread (correlation_id=%s)",
+          mdcKey, value, missingWhat, MDC.get("correlation_id"));
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/LocalizeErrorsInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/LocalizeErrorsInterceptor.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.error.impl;
 
 import ai.floedb.floecat.common.rpc.Error;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.service.common.GrpcInterceptorPriorities;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import com.google.protobuf.Any;
 import com.google.rpc.Status;
@@ -28,15 +29,14 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.protobuf.StatusProto;
 import io.quarkus.grpc.GlobalInterceptor;
-import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Prioritized;
 import java.util.Locale;
 import java.util.Optional;
 
 @GlobalInterceptor
 @ApplicationScoped
-@Priority(10)
-public class LocalizeErrorsInterceptor implements ServerInterceptor {
+public class LocalizeErrorsInterceptor implements ServerInterceptor, Prioritized {
   private static final Metadata.Key<String> ACCEPT_LANGUAGE =
       Metadata.Key.of("accept-language", Metadata.ASCII_STRING_MARSHALLER);
 
@@ -122,5 +122,11 @@ public class LocalizeErrorsInterceptor implements ServerInterceptor {
     }
 
     return "en";
+  }
+
+  /** Higher = outer; see {@link GrpcInterceptorPriorities}. */
+  @Override
+  public int getPriority() {
+    return GrpcInterceptorPriorities.LOCALIZE_ERRORS;
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.error.impl;
 
 import ai.floedb.floecat.common.rpc.Error;
+import ai.floedb.floecat.service.common.GrpcInterceptorPriorities;
 import ai.floedb.floecat.service.context.impl.InboundCallContextHelper;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import com.google.protobuf.Any;
@@ -30,8 +31,8 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.protobuf.StatusProto;
 import io.quarkus.grpc.GlobalInterceptor;
-import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Prioritized;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -40,8 +41,7 @@ import org.jboss.logging.Logger;
 
 @ApplicationScoped
 @GlobalInterceptor
-@Priority(5)
-public class RpcLoggingInterceptor implements ServerInterceptor {
+public class RpcLoggingInterceptor implements ServerInterceptor, Prioritized {
   private static final Logger LOG = Logger.getLogger(RpcLoggingInterceptor.class);
   private static final String MISSING = "-";
 
@@ -244,5 +244,11 @@ public class RpcLoggingInterceptor implements ServerInterceptor {
       }
     }
     return "";
+  }
+
+  /** Higher = outer; see {@link GrpcInterceptorPriorities}. */
+  @Override
+  public int getPriority() {
+    return GrpcInterceptorPriorities.RPC_LOGGING;
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/security/impl/Authorizer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/impl/Authorizer.java
@@ -40,13 +40,17 @@ public class Authorizer {
   }
 
   /**
-   * A principal with no subject and no permissions is not a caller that lacks a grant — it is a
-   * caller whose identity never arrived (interceptor bypassed, or the call context lost before
-   * authorization; eng-floe/floecat#361). Reporting that as UNAUTHENTICATED instead of
-   * PERMISSION_DENIED keeps the next propagation bug diagnosable.
+   * The exact default instance is not a caller that lacks a grant — it is a caller whose identity
+   * never arrived (interceptor bypassed, or the call context lost before authorization;
+   * eng-floe/floecat#361): every channel degrades to {@link PrincipalContext#getDefaultInstance} on
+   * a total miss, while every auth path populates at least a subject, account id, or correlation
+   * id. Reporting the default instance as UNAUTHENTICATED instead of PERMISSION_DENIED keeps the
+   * next propagation bug diagnosable, without re-coding any legitimately-denied principal a future
+   * auth mode might produce (even one with a blank subject and no permissions, as long as it
+   * carries any other field).
    */
   private static RuntimeException denied(PrincipalContext principalContext, String detail) {
-    if (principalContext.getSubject().isBlank() && principalContext.getPermissionsCount() == 0) {
+    if (PrincipalContext.getDefaultInstance().equals(principalContext)) {
       return Status.UNAUTHENTICATED
           .withDescription("no authenticated principal on this call (" + detail + ")")
           .asRuntimeException();

--- a/service/src/main/java/ai/floedb/floecat/service/security/impl/Authorizer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/impl/Authorizer.java
@@ -27,9 +27,7 @@ public class Authorizer {
     if (principalContext.getPermissionsList().contains(permission)) {
       return;
     }
-    throw Status.PERMISSION_DENIED
-        .withDescription("missing permission: " + permission)
-        .asRuntimeException();
+    throw denied(principalContext, "missing permission: " + permission);
   }
 
   public void require(PrincipalContext principalContext, List<String> permissions) {
@@ -38,8 +36,21 @@ public class Authorizer {
         return;
       }
     }
-    throw Status.PERMISSION_DENIED
-        .withDescription("missing permissions: " + permissions)
-        .asRuntimeException();
+    throw denied(principalContext, "missing permissions: " + permissions);
+  }
+
+  /**
+   * A principal with no subject and no permissions is not a caller that lacks a grant — it is a
+   * caller whose identity never arrived (interceptor bypassed, or the call context lost before
+   * authorization; eng-floe/floecat#361). Reporting that as UNAUTHENTICATED instead of
+   * PERMISSION_DENIED keeps the next propagation bug diagnosable.
+   */
+  private static RuntimeException denied(PrincipalContext principalContext, String detail) {
+    if (principalContext.getSubject().isBlank() && principalContext.getPermissionsCount() == 0) {
+      return Status.UNAUTHENTICATED
+          .withDescription("no authenticated principal on this call (" + detail + ")")
+          .asRuntimeException();
+    }
+    return Status.PERMISSION_DENIED.withDescription(detail).asRuntimeException();
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryInterceptor.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.telemetry;
 
 import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.service.common.GrpcInterceptorPriorities;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.grpc.GrpcTelemetryServerInterceptor;
@@ -28,8 +29,8 @@ import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.opentelemetry.api.trace.Span;
 import io.quarkus.grpc.GlobalInterceptor;
-import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Prioritized;
 import jakarta.inject.Inject;
 import java.util.Objects;
 import org.jboss.logging.MDC;
@@ -37,8 +38,7 @@ import org.jboss.logging.MDC;
 /** Service-specific gRPC interceptor that publishes RPC metrics through the telemetry hub. */
 @ApplicationScoped
 @GlobalInterceptor
-@Priority(2)
-public final class ServiceTelemetryInterceptor implements ServerInterceptor {
+public final class ServiceTelemetryInterceptor implements ServerInterceptor, Prioritized {
   private final GrpcTelemetryServerInterceptor delegate;
 
   @Inject
@@ -102,5 +102,11 @@ public final class ServiceTelemetryInterceptor implements ServerInterceptor {
       MDC.remove("floecat_operation");
       throw e;
     }
+  }
+
+  /** Higher = outer; see {@link GrpcInterceptorPriorities}. */
+  @Override
+  public int getPriority() {
+    return GrpcInterceptorPriorities.TELEMETRY;
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/CtxPropagatingBlockingWrapTest.java
@@ -26,6 +26,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import io.grpc.Attributes;
 import io.grpc.Context;
 import io.grpc.Contexts;
@@ -520,6 +523,182 @@ class CtxPropagatingBlockingWrapTest {
       assertEquals("set-by-inner", observed.get());
     } finally {
       executor.shutdownNow();
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  /**
+   * The full streaming-relay shape from eng-floe/floecat#361: inbound interceptor (production key
+   * wiring + duplicated-context carrier) → blocking wrap → a service body that reads the resolved
+   * call context at entry and re-emits on a bare executor ({@code runSubscriptionOn} shape) — while
+   * extra listener events fire concurrently, flipping the shared io.grpc.Context slot the way the
+   * call's own trailing events do in production.
+   *
+   * <p>Asserts principal, correlation id, and engine context integrity at both layers: the service
+   * entry (listener callback on a worker) and the emitter (bare executor thread where no
+   * io.grpc.Context and no duplicated context exist — only the explicit {@code runWith} scope).
+   */
+  @Test
+  void resolvedCallContextSurvivesStreamingRelayUnderConcurrentEvents() throws Exception {
+    int n = 50;
+    Vertx vertx = Vertx.vertx();
+    ExecutorService subscriptionPool = Executors.newFixedThreadPool(4);
+    try {
+      Metadata.Key<String> subjectHeader =
+          Metadata.Key.of("x-test-subject", Metadata.ASCII_STRING_MARSHALLER);
+      Metadata.Key<String> correlationHeader =
+          Metadata.Key.of("x-test-correlation", Metadata.ASCII_STRING_MARSHALLER);
+      Metadata.Key<String> engineHeader =
+          Metadata.Key.of("x-test-engine", Metadata.ASCII_STRING_MARSHALLER);
+
+      // Models InboundContextInterceptor: resolve the call context from headers, store it on the
+      // per-call duplicated context, and populate the production io.grpc.Context keys.
+      ServerInterceptor inner =
+          new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call,
+                Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+              PrincipalContext principal =
+                  PrincipalContext.newBuilder()
+                      .setSubject(headers.get(subjectHeader))
+                      .setAccountId("acct")
+                      .addPermissions("catalog.read")
+                      .build();
+              ResolvedCallContext resolved =
+                  new ResolvedCallContext(
+                      principal,
+                      "q-1",
+                      headers.get(correlationHeader),
+                      EngineContext.of(headers.get(engineHeader), "16.0"),
+                      null,
+                      null);
+              ResolvedCallContexts.storeOnDuplicatedContext(resolved);
+              Context ctx =
+                  InboundContextInterceptor.contextWithResolvedCallContext(
+                      Context.current(), resolved);
+              return Contexts.interceptCall(ctx, call, headers, next);
+            }
+          };
+      ServerInterceptor wrap = makeWrap(vertx, inner);
+
+      ConcurrentMap<Integer, String> violations = new ConcurrentHashMap<>();
+      CountDownLatch done = new CountDownLatch(n);
+
+      for (int i = 0; i < n; i++) {
+        final int id = i;
+        final String expectedSubject = "subject-" + id;
+        final String expectedCorrelation = "corr-" + id;
+        final String expectedEngine = "engine-" + id;
+
+        ServerCallHandler<Object, Object> handler =
+            (call, headers) ->
+                new ServerCall.Listener<>() {
+                  @Override
+                  public void onHalfClose() {
+                    // Service entry: read once, before any executor hop.
+                    ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
+                    if (!expectedSubject.equals(callCtx.principalContext().getSubject())
+                        || !expectedCorrelation.equals(callCtx.correlationId())
+                        || !expectedEngine.equals(callCtx.engineContext().engineKind())) {
+                      violations.putIfAbsent(
+                          id,
+                          "entry: subject="
+                              + callCtx.principalContext().getSubject()
+                              + " corr="
+                              + callCtx.correlationId()
+                              + " engine="
+                              + callCtx.engineContext().engineKind());
+                      done.countDown();
+                      return;
+                    }
+                    // Emitter layer: a bare pool thread with no io.grpc.Context and no duplicated
+                    // context. Only the explicit runWith scope can carry the call context here,
+                    // and the providers must read through it (as the bundle iterator does).
+                    subscriptionPool.execute(
+                        () ->
+                            ResolvedCallContexts.runWith(
+                                callCtx,
+                                () -> {
+                                  try {
+                                    String subject =
+                                        new ai.floedb.floecat.service.security.impl
+                                                .PrincipalProvider()
+                                            .get()
+                                            .getSubject();
+                                    String engine =
+                                        new ai.floedb.floecat.service.context
+                                                .EngineContextProvider()
+                                            .engineContext()
+                                            .engineKind();
+                                    String correlation =
+                                        ResolvedCallContexts.currentOrUnauthenticated()
+                                            .correlationId();
+                                    if (!expectedSubject.equals(subject)
+                                        || !expectedCorrelation.equals(correlation)
+                                        || !expectedEngine.equals(engine)) {
+                                      violations.putIfAbsent(
+                                          id,
+                                          "emitter: subject="
+                                              + subject
+                                              + " corr="
+                                              + correlation
+                                              + " engine="
+                                              + engine);
+                                    }
+                                  } finally {
+                                    done.countDown();
+                                  }
+                                }));
+                  }
+                };
+
+        Metadata md = new Metadata();
+        md.put(subjectHeader, expectedSubject);
+        md.put(correlationHeader, expectedCorrelation);
+        md.put(engineHeader, expectedEngine);
+
+        // Each call gets its own per-call duplicated context, as Quarkus's outermost
+        // duplicated-context interceptor provides in production.
+        io.vertx.core.Context dup =
+            io.smallrye.common.vertx.VertxContext.createNewDuplicatedContext(
+                vertx.getOrCreateContext());
+        dup.runOnContext(
+            ignored -> {
+              try {
+                ServerCall.Listener<Object> listener = wrap.interceptCall(stubCall(), md, handler);
+                // Stir the shared io.grpc.Context slot with trailing events around the real work,
+                // like the call's own listener-event replay does in production.
+                listener.onReady();
+                listener.onHalfClose();
+                listener.onReady();
+                listener.onComplete();
+              } catch (Throwable t) {
+                violations.putIfAbsent(id, "dispatch-failed=" + t);
+                done.countDown();
+              }
+            });
+      }
+
+      assertTrue(
+          done.await(30, TimeUnit.SECONDS),
+          () -> "did not complete in 30s; remaining=" + done.getCount());
+      if (!violations.isEmpty()) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("call-context integrity violations: ")
+            .append(violations.size())
+            .append(" / ")
+            .append(n);
+        int printed = 0;
+        for (Map.Entry<Integer, String> e : violations.entrySet()) {
+          if (printed++ >= 5) break;
+          sb.append("\n  id=").append(e.getKey()).append(' ').append(e.getValue());
+        }
+        fail(sb.toString());
+      }
+    } finally {
+      subscriptionPool.shutdownNow();
       vertx.close().toCompletionStage().toCompletableFuture().get();
     }
   }

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/TestEngineVersionCaptureInterceptor.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/TestEngineVersionCaptureInterceptor.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.context.impl;
 
+import ai.floedb.floecat.service.common.GrpcInterceptorPriorities;
 import io.grpc.ForwardingServerCall;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
@@ -23,8 +24,8 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.quarkus.grpc.GlobalInterceptor;
-import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Prioritized;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -33,8 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @ApplicationScoped
 @GlobalInterceptor
-@Priority(1000)
-public class TestEngineVersionCaptureInterceptor implements ServerInterceptor {
+public class TestEngineVersionCaptureInterceptor implements ServerInterceptor, Prioritized {
   private static final Metadata.Key<String> ENGINE_VERSION =
       Metadata.Key.of("x-engine-version", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> CORR =
@@ -72,5 +72,16 @@ public class TestEngineVersionCaptureInterceptor implements ServerInterceptor {
               }
             },
             headers)) {};
+  }
+
+  /**
+   * Outermost of floecat's interceptors so the raw headers are captured before anything else
+   * touches the call (higher = outer; see {@link GrpcInterceptorPriorities}). Only the {@code
+   * Prioritized} interface is honored — the {@code @Priority(1000)} annotation this replaces was
+   * silently ignored.
+   */
+  @Override
+  public int getPriority() {
+    return GrpcInterceptorPriorities.INBOUND_CONTEXT + 100;
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/it/QueryContextPropagationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QueryContextPropagationIT.java
@@ -400,8 +400,12 @@ class QueryContextPropagationIT {
       fail(label + " stress did not complete within " + TIMEOUT_SECONDS + "s");
     }
 
-    int permissionDenied =
-        failuresByCode.getOrDefault(Status.Code.PERMISSION_DENIED, new AtomicInteger()).get();
+    // Both codes mark a lost call context: PERMISSION_DENIED was the historical form (empty
+    // principal reaching authz), UNAUTHENTICATED is the loud form after the Authorizer learned to
+    // distinguish a missing identity from a missing grant.
+    int contextLosses =
+        failuresByCode.getOrDefault(Status.Code.PERMISSION_DENIED, new AtomicInteger()).get()
+            + failuresByCode.getOrDefault(Status.Code.UNAUTHENTICATED, new AtomicInteger()).get();
 
     StringBuilder summary = new StringBuilder();
     summary
@@ -423,16 +427,17 @@ class QueryContextPropagationIT {
         });
     System.out.println(summary);
 
-    if (permissionDenied > 0) {
+    if (contextLosses > 0) {
       fail(
           "Context propagation failure: "
-              + permissionDenied
+              + contextLosses
               + "/"
               + total
               + " "
               + label
-              + " calls returned PERMISSION_DENIED — the principal context was lost between the"
-              + " inbound interceptor and the service body running on a Mutiny worker. "
+              + " calls returned PERMISSION_DENIED or UNAUTHENTICATED — the principal context was"
+              + " lost between the inbound interceptor and the service body running on a Mutiny"
+              + " worker. "
               + summary);
     }
 

--- a/service/src/test/java/ai/floedb/floecat/service/security/impl/AuthorizerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/impl/AuthorizerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.security.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the missing-identity vs. missing-grant distinction in {@link Authorizer}
+ * (eng-floe/floecat#361): only the exact default-instance principal — what every context channel
+ * degrades to on a total propagation miss — is reported as UNAUTHENTICATED. Any populated
+ * principal, however sparse, is a real caller and keeps getting PERMISSION_DENIED.
+ */
+class AuthorizerTest {
+
+  private final Authorizer authz = new Authorizer();
+
+  @Test
+  void grantedPermissionPasses() {
+    PrincipalContext principal =
+        PrincipalContext.newBuilder()
+            .setSubject("tester")
+            .setAccountId("acct")
+            .addPermissions("catalog.read")
+            .build();
+    assertDoesNotThrow(() -> authz.require(principal, "catalog.read"));
+    assertDoesNotThrow(() -> authz.require(principal, List.of("other", "catalog.read")));
+  }
+
+  @Test
+  void populatedPrincipalWithoutGrantIsPermissionDenied() {
+    PrincipalContext principal =
+        PrincipalContext.newBuilder().setSubject("tester").setAccountId("acct").build();
+    StatusRuntimeException e =
+        assertThrows(StatusRuntimeException.class, () -> authz.require(principal, "catalog.read"));
+    assertEquals(Status.Code.PERMISSION_DENIED, e.getStatus().getCode());
+  }
+
+  /**
+   * The drift guard from review: a future auth mode could legitimately produce a principal with a
+   * blank subject and zero permissions. As long as it carries anything at all (here a correlation
+   * id), it is a real — denied — caller, not a lost context.
+   */
+  @Test
+  void blankSubjectNoPermissionsButOtherwisePopulatedIsStillPermissionDenied() {
+    PrincipalContext principal = PrincipalContext.newBuilder().setCorrelationId("corr-1").build();
+    StatusRuntimeException e =
+        assertThrows(StatusRuntimeException.class, () -> authz.require(principal, "catalog.read"));
+    assertEquals(Status.Code.PERMISSION_DENIED, e.getStatus().getCode());
+  }
+
+  /** The default instance is what a lost call context degrades to — reported as UNAUTHENTICATED. */
+  @Test
+  void defaultInstancePrincipalIsUnauthenticated() {
+    StatusRuntimeException single =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> authz.require(PrincipalContext.getDefaultInstance(), "catalog.read"));
+    assertEquals(Status.Code.UNAUTHENTICATED, single.getStatus().getCode());
+
+    StatusRuntimeException multi =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                authz.require(
+                    PrincipalContext.getDefaultInstance(), List.of("catalog.read", "other")));
+    assertEquals(Status.Code.UNAUTHENTICATED, multi.getStatus().getCode());
+  }
+}


### PR DESCRIPTION
Part 2 of 2 for #361, stacked on #372 (the fix). Closes #361.

Every context channel without a loud-failure guard fails **silently** when the next propagation bug arrives — that is the lesson of the `PERMISSION_DENIED` → silent `NOT_FOUND` shift documented in the #361 RCA. This PR adds the guards, the detection, and the deterministic interceptor ordering so a future loss is loud, countable, and diagnosable.

## Commit 1 — loud failures + channel-disagreement detectors

- **`Authorizer`**: a principal with no subject and no permissions is not a caller lacking a grant — it is a caller whose identity never arrived. Report `UNAUTHENTICATED` (with the attempted permission in the description) instead of the misleading `PERMISSION_DENIED`. Real authz failures (subject present, grant missing) still get `PERMISSION_DENIED`.
- **`ResolvedCallContexts`**: WARN when MDC carries a correlation id but no context channel delivers a resolved call context. MDC and the carrier are written together in the inbound interceptor, so any disagreement is a propagation loss — turned into a countable signal.
- **`EngineContextProvider`**: the analogous WARN when MDC says the request declared an engine but resolution sees an empty engine context — the exact condition that silently un-resolves engine-gated system objects.
- `QueryContextPropagationIT` treats `UNAUTHENTICATED` in the stress loop as a context-loss failure alongside `PERMISSION_DENIED`.

Both WARNs should sit at flat zero in CI logs; any occurrence is a propagation regression, caught before it becomes a wrong answer.

## Commit 2 — deterministic interceptor ordering + relay test

Quarkus's gRPC interceptor comparator only honors the CDI `Prioritized` **interface** (verified against the Quarkus 3.31.4 sources); the `@Priority` annotations on our three global interceptors were silently ignored, so they all tied at 0 with nondeterministic relative order — and the `@Priority(0) // Must run before other interceptors` comment had the sort semantics backwards either way (ascending sort, last element outermost per `ServerInterceptors.intercept`).

- Implement `Prioritized` on all four global interceptors with the intended, now-guaranteed order (outermost first): inbound context → telemetry → rpc logging → error localization. Quarkus's built-ins near `Integer.MAX_VALUE` stay outermost of all.
- Priorities and the sort semantics are documented in one place, `GrpcInterceptorPriorities`.
- Add the relay-level test from the RCA: inbound interceptor (production key wiring + carrier) → `CtxPropagatingBlockingWrap` → a streaming-shaped body that reads the resolved context at entry and re-emits on a bare executor, under concurrent listener events — asserting principal, correlation id, and engine context integrity at both the service and emitter layers, including on threads where only the explicit `runWith` scope can carry the context.

## Verification

926 unit tests + 29 ITs green (including with the new deterministic interceptor order); propagation IT stress at 32×100 clean. Re-verified after rebasing onto `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
