### PR TITLE
Support multiple source/destination mappings per connector

### DIFF
--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/ConnectorCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/ConnectorCliSupport.java
@@ -48,6 +48,7 @@ import ai.floedb.floecat.connector.rpc.NamespacePath;
 import ai.floedb.floecat.connector.rpc.ReconcileMode;
 import ai.floedb.floecat.connector.rpc.ReconcilePolicy;
 import ai.floedb.floecat.connector.rpc.ReconcileSnapshotScope;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
 import ai.floedb.floecat.connector.rpc.SourceSelector;
 import ai.floedb.floecat.connector.rpc.UpdateConnectorRequest;
 import ai.floedb.floecat.connector.rpc.ValidateConnectorRequest;
@@ -274,16 +275,18 @@ final class ConnectorCliSupport {
                 .setAuth(auth)
                 .setPolicy(policy);
 
-        boolean haveSource =
-            !sourceNamespace.isBlank() || !sourceTable.isBlank() || !sourceCols.isEmpty();
-        if (haveSource) {
-          spec.setSource(buildSource(sourceNamespace, sourceTable, sourceCols));
-        }
-
-        boolean haveDest =
-            !destCatalog.isBlank() || !destNamespace.isBlank() || !destTable.isBlank();
-        if (haveDest) {
-          spec.setDestination(buildDest(destCatalog, destNamespace, destTable));
+        boolean haveMapping =
+            !sourceNamespace.isBlank()
+                || !sourceTable.isBlank()
+                || !sourceCols.isEmpty()
+                || !destCatalog.isBlank()
+                || !destNamespace.isBlank()
+                || !destTable.isBlank();
+        if (haveMapping) {
+          spec.addMappings(
+              SourceMapping.newBuilder()
+                  .setSource(buildSource(sourceNamespace, sourceTable, sourceCols))
+                  .setDestination(buildDest(destCatalog, destNamespace, destTable)));
         }
 
         var resp =
@@ -414,20 +417,45 @@ final class ConnectorCliSupport {
           if (notBeforeSec != 0L) mask.add("policy.not_before");
         }
 
-        boolean sourceSet = !sourceNs.isBlank() || !sourceTable.isBlank() || !sourceCols.isEmpty();
-        if (sourceSet) {
-          spec.setSource(buildSource(sourceNs, sourceTable, sourceCols));
-          if (!sourceNs.isBlank()) mask.add("source.namespace");
-          if (!sourceTable.isBlank()) mask.add("source.table");
-          if (!sourceCols.isEmpty()) mask.add("source.columns");
-        }
-
-        boolean destSet = !destCatalog.isBlank() || !destNs.isBlank() || !destTable.isBlank();
-        if (destSet) {
-          spec.setDestination(buildDest(destCatalog, destNs, destTable));
-          if (!destCatalog.isBlank()) mask.add("destination.catalog_display_name");
-          if (!destNs.isBlank()) mask.add("destination.namespace");
-          if (!destTable.isBlank()) mask.add("destination.table_display_name");
+        boolean mappingSet =
+            !sourceNs.isBlank()
+                || !sourceTable.isBlank()
+                || !sourceCols.isEmpty()
+                || !destCatalog.isBlank()
+                || !destNs.isBlank()
+                || !destTable.isBlank();
+        if (mappingSet) {
+          var current =
+              connectors
+                  .getConnector(
+                      GetConnectorRequest.newBuilder().setConnectorId(connectorId).build())
+                  .getConnector();
+          if (current.getMappingsCount() > 1) {
+            out.println(
+                "Connector has multiple mappings; --source-*/--dest-* flags only support"
+                    + " single-mapping connectors.");
+            return;
+          }
+          var base =
+              current.getMappingsCount() == 1
+                  ? current.getMappings(0)
+                  : SourceMapping.getDefaultInstance();
+          var sourceB = base.getSource().toBuilder();
+          if (!sourceNs.isBlank()) sourceB.setNamespace(toNsPath(sourceNs));
+          if (!sourceTable.isBlank()) sourceB.setTable(sourceTable);
+          if (!sourceCols.isEmpty()) sourceB.clearColumns().addAllColumns(sourceCols);
+          var destB = base.getDestination().toBuilder();
+          if (!destCatalog.isBlank()) {
+            destB.clearCatalogId().setCatalogDisplayName(destCatalog);
+          }
+          if (!destNs.isBlank()) {
+            destB.clearNamespaceId().setNamespace(toNsPath(destNs));
+          }
+          if (!destTable.isBlank()) {
+            destB.clearTableId().setTableDisplayName(destTable);
+          }
+          spec.addMappings(SourceMapping.newBuilder().setSource(sourceB).setDestination(destB));
+          mask.add("mappings");
         }
 
         if (mask.isEmpty()) {
@@ -537,11 +565,19 @@ final class ConnectorCliSupport {
                   notBeforeSec));
         }
 
-        boolean sourceSet = !sourceNs.isBlank() || !sourceTable.isBlank() || !sourceCols.isEmpty();
-        if (sourceSet) spec.setSource(buildSource(sourceNs, sourceTable, sourceCols));
-
-        boolean destSet = !destCatalog.isBlank() || !destNs.isBlank() || !destTable.isBlank();
-        if (destSet) spec.setDestination(buildDest(destCatalog, destNs, destTable));
+        boolean mappingSet =
+            !sourceNs.isBlank()
+                || !sourceTable.isBlank()
+                || !sourceCols.isEmpty()
+                || !destCatalog.isBlank()
+                || !destNs.isBlank()
+                || !destTable.isBlank();
+        if (mappingSet) {
+          spec.addMappings(
+              SourceMapping.newBuilder()
+                  .setSource(buildSource(sourceNs, sourceTable, sourceCols))
+                  .setDestination(buildDest(destCatalog, destNs, destTable)));
+        }
 
         var resp =
             connectors.validateConnector(
@@ -1120,6 +1156,18 @@ final class ConnectorCliSupport {
     }
   }
 
+  private static SourceSelector primarySource(Connector connector) {
+    return connector != null && connector.getMappingsCount() > 0
+        ? connector.getMappings(0).getSource()
+        : SourceSelector.getDefaultInstance();
+  }
+
+  private static DestinationTarget primaryDestination(Connector connector) {
+    return connector != null && connector.getMappingsCount() > 0
+        ? connector.getMappings(0).getDestination()
+        : DestinationTarget.getDefaultInstance();
+  }
+
   private static SourceSelector buildSource(String ns, String table, List<String> cols) {
     var b = SourceSelector.newBuilder();
     if (ns != null && !ns.isBlank()) b.setNamespace(toNsPath(ns));
@@ -1191,11 +1239,11 @@ final class ConnectorCliSupport {
       String updated = CliUtils.ts(c.getUpdatedAt());
 
       String destCat = "";
-      if (c.hasDestination()) {
+      if (c.getMappingsCount() > 0 && c.getMappings(0).getDestination().hasCatalogId()) {
         var resp =
             directory.lookupCatalog(
                 LookupCatalogRequest.newBuilder()
-                    .setResourceId(c.getDestination().getCatalogId())
+                    .setResourceId(c.getMappings(0).getDestination().getCatalogId())
                     .build());
         destCat = resp.getDisplayName();
       }
@@ -1228,43 +1276,44 @@ final class ConnectorCliSupport {
           CliUtils.trunc(state, CONNECTOR_W_STATE),
           (CONNECTOR_W_URI > 0 ? CliUtils.trunc(uri, CONNECTOR_W_URI) : uri));
 
-      if (c.hasDestination()) {
+      for (int m = 0; m < c.getMappingsCount(); m++) {
+        var mapping = c.getMappings(m);
+        String label = c.getMappingsCount() > 1 ? "[" + m + "]" : "";
+        var dest = mapping.getDestination();
         String destCatDisplay = "";
         List<String> destNsParts = List.of();
         String destTableDisplay = null;
 
-        if (c.getDestination().hasCatalogId()) {
+        if (dest.hasCatalogId()) {
           var resp =
               directory.lookupCatalog(
-                  LookupCatalogRequest.newBuilder()
-                      .setResourceId(c.getDestination().getCatalogId())
-                      .build());
+                  LookupCatalogRequest.newBuilder().setResourceId(dest.getCatalogId()).build());
           destCatDisplay = resp.getDisplayName();
         }
 
-        if (c.getDestination().hasNamespaceId()) {
+        if (dest.hasNamespaceId()) {
           var nsResp =
               directory.lookupNamespace(
-                  LookupNamespaceRequest.newBuilder()
-                      .setResourceId(c.getDestination().getNamespaceId())
-                      .build());
+                  LookupNamespaceRequest.newBuilder().setResourceId(dest.getNamespaceId()).build());
           var ref = nsResp.getRef();
           ArrayList<String> parts = new ArrayList<>(ref.getPathList());
           if (!ref.getName().isBlank()) parts.add(ref.getName());
           destNsParts = parts;
+        } else if (dest.hasNamespace()) {
+          destNsParts = dest.getNamespace().getSegmentsList();
         }
 
-        if (c.getDestination().hasTableId()) {
+        if (dest.hasTableId()) {
           var tblResp =
               directory.lookupTable(
-                  LookupTableRequest.newBuilder()
-                      .setResourceId(c.getDestination().getTableId())
-                      .build());
+                  LookupTableRequest.newBuilder().setResourceId(dest.getTableId()).build());
           destTableDisplay = tblResp.getName().getName();
+        } else if (dest.hasTableDisplayName() && !dest.getTableDisplayName().isBlank()) {
+          destTableDisplay = dest.getTableDisplayName();
         }
 
-        if (destCatDisplay.isBlank() && c.getDestination().hasCatalogId()) {
-          destCatDisplay = c.getDestination().getCatalogId().getId();
+        if (destCatDisplay.isBlank() && dest.hasCatalogId()) {
+          destCatDisplay = dest.getCatalogId().getId();
         }
 
         boolean anyDest =
@@ -1273,19 +1322,19 @@ final class ConnectorCliSupport {
                 || (destTableDisplay != null && !destTableDisplay.isBlank());
         if (anyDest) {
           String fq = NameRefUtil.joinFqQuoted(destCatDisplay, destNsParts, destTableDisplay);
-          out.println("  destination: " + fq);
+          out.println("  destination" + label + ": " + fq);
         }
-      }
 
-      if (c.hasSource()) {
-        var s = c.getSource();
+        var s = mapping.getSource();
         String sNs = s.hasNamespace() ? String.join(".", s.getNamespace().getSegmentsList()) : "";
         String sTbl = s.getTable();
         String sCols = String.join(",", s.getColumnsList());
         boolean anyS = !sNs.isEmpty() || (sTbl != null && !sTbl.isBlank()) || !sCols.isEmpty();
         if (anyS) {
           out.println(
-              "  source:"
+              "  source"
+                  + label
+                  + ":"
                   + (sNs.isEmpty() ? "" : sNs)
                   + (sTbl == null || sTbl.isBlank() ? "" : "." + sTbl)
                   + (sCols.isEmpty() ? "" : " cols=[" + sCols + "]"));
@@ -1916,7 +1965,7 @@ final class ConnectorCliSupport {
       String destTable,
       List<String> columns,
       DirectoryServiceGrpc.DirectoryServiceBlockingStub directory) {
-    DestinationTarget destination = connector.getDestination();
+    DestinationTarget destination = primaryDestination(connector);
     String effectiveTable =
         !destTable.isBlank() ? destTable : resolveDestinationTableDisplayName(connector, directory);
     if (effectiveTable == null || effectiveTable.isBlank()) {
@@ -1949,10 +1998,10 @@ final class ConnectorCliSupport {
       Connector connector,
       String destNs,
       DirectoryServiceGrpc.DirectoryServiceBlockingStub directory) {
-    if (connector == null || !connector.hasDestination()) {
+    if (connector == null || connector.getMappingsCount() == 0) {
       throw new IllegalArgumentException("--dest-ns requires a connector destination");
     }
-    DestinationTarget destination = connector.getDestination();
+    DestinationTarget destination = primaryDestination(connector);
     if (destination.hasNamespaceId() && destNs.isBlank()) {
       return destination.getNamespaceId();
     }
@@ -1995,10 +2044,7 @@ final class ConnectorCliSupport {
 
   private static String resolveDestinationCatalogDisplayName(
       Connector connector, DirectoryServiceGrpc.DirectoryServiceBlockingStub directory) {
-    if (connector == null || !connector.hasDestination()) {
-      return "";
-    }
-    DestinationTarget destination = connector.getDestination();
+    DestinationTarget destination = primaryDestination(connector);
     if (!destination.hasCatalogId()) {
       return "";
     }
@@ -2012,10 +2058,7 @@ final class ConnectorCliSupport {
 
   private static List<String> resolveDestinationNamespacePath(
       Connector connector, DirectoryServiceGrpc.DirectoryServiceBlockingStub directory) {
-    if (connector == null || !connector.hasDestination()) {
-      return List.of();
-    }
-    DestinationTarget destination = connector.getDestination();
+    DestinationTarget destination = primaryDestination(connector);
     if (destination.hasNamespaceId()) {
       var ref =
           directory
@@ -2033,18 +2076,15 @@ final class ConnectorCliSupport {
     if (destination.hasNamespace() && destination.getNamespace().getSegmentsCount() > 0) {
       return List.copyOf(destination.getNamespace().getSegmentsList());
     }
-    if (connector.hasSource() && connector.getSource().hasNamespace()) {
-      return List.copyOf(connector.getSource().getNamespace().getSegmentsList());
+    if (primarySource(connector).hasNamespace()) {
+      return List.copyOf(primarySource(connector).getNamespace().getSegmentsList());
     }
     return List.of();
   }
 
   private static String resolveDestinationTableDisplayName(
       Connector connector, DirectoryServiceGrpc.DirectoryServiceBlockingStub directory) {
-    if (connector == null || !connector.hasDestination()) {
-      return "";
-    }
-    DestinationTarget destination = connector.getDestination();
+    DestinationTarget destination = primaryDestination(connector);
     if (destination.hasTableDisplayName() && !destination.getTableDisplayName().isBlank()) {
       return destination.getTableDisplayName();
     }
@@ -2055,10 +2095,8 @@ final class ConnectorCliSupport {
           .getName()
           .getName();
     }
-    if (connector.hasSource()
-        && connector.getSource().hasTable()
-        && !connector.getSource().getTable().isBlank()) {
-      return connector.getSource().getTable();
+    if (primarySource(connector).hasTable() && !primarySource(connector).getTable().isBlank()) {
+      return primarySource(connector).getTable();
     }
     return "";
   }

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/ConnectorCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/ConnectorCliSupportTest.java
@@ -48,6 +48,7 @@ import ai.floedb.floecat.connector.rpc.GetConnectorResponse;
 import ai.floedb.floecat.connector.rpc.ListConnectorsRequest;
 import ai.floedb.floecat.connector.rpc.ListConnectorsResponse;
 import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
 import ai.floedb.floecat.connector.rpc.ValidateConnectorRequest;
 import ai.floedb.floecat.connector.rpc.ValidateConnectorResponse;
 import ai.floedb.floecat.reconciler.rpc.CancelReconcileJobRequest;
@@ -246,10 +247,12 @@ class ConnectorCliSupportTest {
       h.connectorsService.connectorToReturn =
           Connector.newBuilder()
               .setResourceId(connectorId())
-              .setDestination(
-                  DestinationTarget.newBuilder()
-                      .setCatalogId(ResourceId.newBuilder().setId("catalog-1").build())
-                      .build())
+              .addMappings(
+                  SourceMapping.newBuilder()
+                      .setDestination(
+                          DestinationTarget.newBuilder()
+                              .setCatalogId(ResourceId.newBuilder().setId("catalog-1").build())
+                              .build()))
               .build();
 
       ByteArrayOutputStream buf = new ByteArrayOutputStream();
@@ -354,11 +357,13 @@ class ConnectorCliSupportTest {
       h.connectorsService.connectorToReturn =
           Connector.newBuilder()
               .setResourceId(connectorId())
-              .setDestination(
-                  DestinationTarget.newBuilder()
-                      .setTableId(ResourceId.newBuilder().setId("table-1").build())
-                      .setNamespace(NamespacePath.newBuilder().addSegments("ns").build())
-                      .build())
+              .addMappings(
+                  SourceMapping.newBuilder()
+                      .setDestination(
+                          DestinationTarget.newBuilder()
+                              .setTableId(ResourceId.newBuilder().setId("table-1").build())
+                              .setNamespace(NamespacePath.newBuilder().addSegments("ns").build())
+                              .build()))
               .build();
       h.directoryService.tableDisplayName = "events";
       h.snapshotService.currentSnapshotId = 42L;
@@ -426,11 +431,13 @@ class ConnectorCliSupportTest {
       h.connectorsService.connectorToReturn =
           Connector.newBuilder()
               .setResourceId(connectorId())
-              .setDestination(
-                  DestinationTarget.newBuilder()
-                      .setTableId(ResourceId.newBuilder().setId("table-1").build())
-                      .setNamespace(NamespacePath.newBuilder().addSegments("ns").build())
-                      .build())
+              .addMappings(
+                  SourceMapping.newBuilder()
+                      .setDestination(
+                          DestinationTarget.newBuilder()
+                              .setTableId(ResourceId.newBuilder().setId("table-1").build())
+                              .setNamespace(NamespacePath.newBuilder().addSegments("ns").build())
+                              .build()))
               .build();
       h.directoryService.tableDisplayName = "events";
       h.snapshotService.currentSnapshotId = 42L;
@@ -466,11 +473,13 @@ class ConnectorCliSupportTest {
       h.connectorsService.connectorToReturn =
           Connector.newBuilder()
               .setResourceId(connectorId())
-              .setDestination(
-                  DestinationTarget.newBuilder()
-                      .setTableId(ResourceId.newBuilder().setId("table-1").build())
-                      .setNamespace(NamespacePath.newBuilder().addSegments("ns").build())
-                      .build())
+              .addMappings(
+                  SourceMapping.newBuilder()
+                      .setDestination(
+                          DestinationTarget.newBuilder()
+                              .setTableId(ResourceId.newBuilder().setId("table-1").build())
+                              .setNamespace(NamespacePath.newBuilder().addSegments("ns").build())
+                              .build()))
               .build();
       h.directoryService.tableDisplayName = "events";
 
@@ -535,11 +544,13 @@ class ConnectorCliSupportTest {
       h.connectorsService.connectorToReturn =
           Connector.newBuilder()
               .setResourceId(connectorId())
-              .setDestination(
-                  DestinationTarget.newBuilder()
-                      .setTableId(ResourceId.newBuilder().setId("table-1").build())
-                      .setNamespace(NamespacePath.newBuilder().addSegments("ns").build())
-                      .build())
+              .addMappings(
+                  SourceMapping.newBuilder()
+                      .setDestination(
+                          DestinationTarget.newBuilder()
+                              .setTableId(ResourceId.newBuilder().setId("table-1").build())
+                              .setNamespace(NamespacePath.newBuilder().addSegments("ns").build())
+                              .build()))
               .build();
       h.directoryService.tableDisplayName = "events";
       h.snapshotService.currentSnapshotId = 42L;
@@ -575,10 +586,12 @@ class ConnectorCliSupportTest {
       h.connectorsService.connectorToReturn =
           Connector.newBuilder()
               .setResourceId(connectorId())
-              .setDestination(
-                  DestinationTarget.newBuilder()
-                      .setCatalogId(ResourceId.newBuilder().setId("catalog-1").build())
-                      .build())
+              .addMappings(
+                  SourceMapping.newBuilder()
+                      .setDestination(
+                          DestinationTarget.newBuilder()
+                              .setCatalogId(ResourceId.newBuilder().setId("catalog-1").build())
+                              .build()))
               .build();
       h.directoryService.resolvedViewId = "view-1";
 

--- a/core/proto/src/main/proto/floecat/connector/connector.proto
+++ b/core/proto/src/main/proto/floecat/connector/connector.proto
@@ -68,8 +68,10 @@ message Connector {
   string display_name = 2;
   optional string description = 3;
   ConnectorKind kind = 4;
-  SourceSelector source = 10;
-  DestinationTarget destination = 11;
+  // Legacy storage only — normalized into mappings on read; never written.
+  SourceSelector source = 10 [deprecated = true];
+  // Legacy storage only — normalized into mappings on read; never written.
+  DestinationTarget destination = 11 [deprecated = true];
   repeated SourceMapping mappings = 12;
   string uri = 20;
   AuthConfig auth = 22;
@@ -198,8 +200,8 @@ message ConnectorSpec {
   optional string display_name = 1;
   optional string description = 2;
   ConnectorKind kind = 3;
-  SourceSelector source = 10;
-  DestinationTarget destination = 11;
+  reserved 10, 11;
+  reserved "source", "destination";
   repeated SourceMapping mappings = 12;
   optional string uri = 20;
   AuthConfig auth = 21;

--- a/core/proto/src/main/proto/floecat/connector/connector.proto
+++ b/core/proto/src/main/proto/floecat/connector/connector.proto
@@ -58,6 +58,11 @@ message DestinationTarget {
   }
 }
 
+message SourceMapping {
+  SourceSelector source = 1;
+  DestinationTarget destination = 2;
+}
+
 message Connector {
   ai.floedb.floecat.common.ResourceId resource_id = 1;
   string display_name = 2;
@@ -65,6 +70,7 @@ message Connector {
   ConnectorKind kind = 4;
   SourceSelector source = 10;
   DestinationTarget destination = 11;
+  repeated SourceMapping mappings = 12;
   string uri = 20;
   AuthConfig auth = 22;
   ReconcilePolicy policy = 30;
@@ -76,9 +82,10 @@ message Connector {
 
 enum ConnectorState {
   CS_UNSPECIFIED = 0;
-  CS_ACTIVE = 1;
-  CS_PAUSED = 2;
-  CS_DELETING = 3;
+  CS_CREATING = 1;
+  CS_ACTIVE = 2;
+  CS_PAUSED = 3;
+  CS_DELETING = 4;
 }
 
 message AuthConfig {
@@ -193,6 +200,7 @@ message ConnectorSpec {
   ConnectorKind kind = 3;
   SourceSelector source = 10;
   DestinationTarget destination = 11;
+  repeated SourceMapping mappings = 12;
   optional string uri = 20;
   AuthConfig auth = 21;
   ReconcilePolicy policy = 30;

--- a/core/proto/src/main/proto/floecat/connector/connector.proto
+++ b/core/proto/src/main/proto/floecat/connector/connector.proto
@@ -82,10 +82,10 @@ message Connector {
 
 enum ConnectorState {
   CS_UNSPECIFIED = 0;
-  CS_CREATING = 1;
-  CS_ACTIVE = 2;
-  CS_PAUSED = 3;
-  CS_DELETING = 4;
+  CS_ACTIVE = 1;
+  CS_PAUSED = 2;
+  CS_DELETING = 3;
+  CS_CREATING = 4;
 }
 
 message AuthConfig {

--- a/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcilerBackend.java
+++ b/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/ReconcilerBackend.java
@@ -27,7 +27,6 @@ import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.connector.rpc.Connector;
-import ai.floedb.floecat.connector.rpc.DestinationTarget;
 import ai.floedb.floecat.connector.spi.ConnectorFormat;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
@@ -198,9 +197,6 @@ public interface ReconcilerBackend {
   String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId);
 
   Connector lookupConnector(ReconcileContext ctx, ResourceId connectorId);
-
-  void updateConnectorDestination(
-      ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination);
 
   Optional<ResourceId> lookupView(ReconcileContext ctx, NameRef view);
 

--- a/docs/connectors-spi.md
+++ b/docs/connectors-spi.md
@@ -112,9 +112,15 @@ and per-column stats for planner scan paths. Snapshot bundles also carry manifes
 maps so downstream APIs can mirror Iceberg’s REST contract.
 
 `ConnectorConfig` encodes:
-- Kind + source/destination selectors (`SourceSelector`, `DestinationTarget`).
+- Kind, display name.
 - URI and arbitrary `properties` map.
 - Authentication configuration (scheme, credentials, headers, properties).
+
+It does not carry source/destination selectors. A connector may have multiple independent
+source->destination pairs (`Connector.mappings`, falling back to the singular
+`source`/`destination` pair when empty); `ReconcilerService` resolves each mapping separately and
+passes its `SourceSelector`/`DestinationTarget` into the per-mapping planning request
+(`TablePlanningRequest`/`ViewPlanningRequest`) rather than into `ConnectorConfig`.
 
 `ConnectorProvider` is a lightweight registry allowing CDI discovery of connector factories.
 

--- a/docs/connectors-spi.md
+++ b/docs/connectors-spi.md
@@ -117,8 +117,9 @@ maps so downstream APIs can mirror Iceberg’s REST contract.
 - Authentication configuration (scheme, credentials, headers, properties).
 
 It does not carry source/destination selectors. A connector may have multiple independent
-source->destination pairs (`Connector.mappings`, falling back to the singular
-`source`/`destination` pair when empty); `ReconcilerService` resolves each mapping separately and
+source->destination pairs (`Connector.mappings`; the deprecated singular `source`/`destination`
+pair on stored connectors is normalized into a single mapping when the connector is read);
+`ReconcilerService` resolves each mapping separately and
 passes its `SourceSelector`/`DestinationTarget` into the per-mapping planning request
 (`TablePlanningRequest`/`ViewPlanningRequest`) rather than into `ConnectorConfig`.
 

--- a/docs/reconciler.md
+++ b/docs/reconciler.md
@@ -40,8 +40,9 @@ The current job model is split by responsibility:
   plane.
 - **`ReconcilerService`**: core planning/orchestration:
   1. Resolves connector metadata via the service's `Connectors` RPC.
-  2. Plans connector-scoped table and view work while preserving destination namespace/table
-     overrides.
+  2. Plans table work across every entry in the connector's `mappings` list (falling back to the
+     singular `source`/`destination` pair when `mappings` is empty), unioning the results,
+     while preserving destination namespace/table overrides per mapping.
   3. Ensures destination catalogs/namespaces/tables exist and updates connector metadata with
      resolved destination IDs.
   4. Instantiates the connector via `ConnectorFactory`.
@@ -84,9 +85,10 @@ reconcile control RPCs:
 Internally, the worker poller exposes `pollEvery` via `@Scheduled` (default every second).
 
 ## Important Internal Details
-- **Destination binding**: when reconciling, the service ensures the connector's declared
-  destination catalog/namespace/table IDs align with actual resources. Any mismatch triggers a
-  `ConnectorState` update or raises conflicts.
+- **Destination binding**: when reconciling, the service ensures each mapping's declared
+  destination catalog/namespace/table IDs align with actual resources (or the singular
+  destination, for connectors with no `mappings`). Any mismatch triggers a `ConnectorState`
+  update or raises conflicts.
 - **Statistics ingestion**: stats persistence is centralized behind the stats control plane
   and the reconcile executor control plane. `CAPTURE_ONLY` routes capture planning through the
   same reconcile job tree without metadata reconciliation. `METADATA_AND_CAPTURE` performs metadata

--- a/docs/reconciler.md
+++ b/docs/reconciler.md
@@ -40,9 +40,10 @@ The current job model is split by responsibility:
   plane.
 - **`ReconcilerService`**: core planning/orchestration:
   1. Resolves connector metadata via the service's `Connectors` RPC.
-  2. Plans table work across every entry in the connector's `mappings` list (falling back to the
-     singular `source`/`destination` pair when `mappings` is empty), unioning the results,
-     while preserving destination namespace/table overrides per mapping.
+  2. Plans table and view work across every entry in the connector's `mappings` list (legacy
+     stored connectors are normalized so their singular `source`/`destination` pair becomes
+     `mappings[0]` on read), unioning the results, while preserving destination namespace/table
+     overrides per mapping.
   3. Ensures destination catalogs/namespaces/tables exist and updates connector metadata with
      resolved destination IDs.
   4. Instantiates the connector via `ConnectorFactory`.
@@ -86,9 +87,8 @@ Internally, the worker poller exposes `pollEvery` via `@Scheduled` (default ever
 
 ## Important Internal Details
 - **Destination binding**: when reconciling, the service ensures each mapping's declared
-  destination catalog/namespace/table IDs align with actual resources (or the singular
-  destination, for connectors with no `mappings`). Any mismatch triggers a `ConnectorState`
-  update or raises conflicts.
+  destination catalog/namespace/table IDs align with actual resources. Any mismatch triggers a
+  `ConnectorState` update or raises conflicts.
 - **Statistics ingestion**: stats persistence is centralized behind the stats control plane
   and the reconcile executor control plane. `CAPTURE_ONLY` routes capture planning through the
   same reconcile job tree without metadata reconciliation. `METADATA_AND_CAPTURE` performs metadata

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -76,9 +76,7 @@ import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.connector.common.auth.CredentialResolverSupport;
 import ai.floedb.floecat.connector.rpc.Connector;
-import ai.floedb.floecat.connector.rpc.ConnectorSpec;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
-import ai.floedb.floecat.connector.rpc.DestinationTarget;
 import ai.floedb.floecat.connector.spi.AuthResolutionContext;
 import ai.floedb.floecat.connector.spi.ConnectorConfig;
 import ai.floedb.floecat.connector.spi.ConnectorConfigMapper;
@@ -1229,20 +1227,6 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
         && current.getBaseRelationsList().equals(spec.getBaseRelationsList())
         && current.getCreationSearchPathList().equals(spec.getCreationSearchPathList())
         && current.getOutputColumnsList().equals(spec.getOutputColumnsList());
-  }
-
-  @Override
-  public void updateConnectorDestination(
-      ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {
-    var spec = ConnectorSpec.newBuilder().setDestination(destination).build();
-    var mask = FieldMask.newBuilder().addPaths("destination").build();
-    connector(ctx)
-        .updateConnector(
-            ai.floedb.floecat.connector.rpc.UpdateConnectorRequest.newBuilder()
-                .setConnectorId(connectorId)
-                .setSpec(spec)
-                .setUpdateMask(mask)
-                .build());
   }
 
   @Override

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
@@ -28,6 +28,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.common.resolver.LogicalSchemaMapper;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
 import ai.floedb.floecat.connector.rpc.SourceSelector;
 import ai.floedb.floecat.connector.spi.ConnectorConfig;
 import ai.floedb.floecat.connector.spi.ConnectorFormat;
@@ -460,12 +461,14 @@ class QueuedReconcileWorkerSupport {
           toExecutionResult(new Result(0, 0, 0, 0, 1, 0, 0, e)), null);
     }
 
+    SourceMapping mapping =
+        ReconcilerService.effectiveMappingForTask(active, viewTask.sourceNamespace(), "", null);
     ResourceId destNamespaceId =
         resolveOrCreateDiscoveryNamespaceId(
             ctx,
             connectorId,
-            active.source(),
-            active.destination(),
+            mapping.getSource(),
+            mapping.getDestination(),
             viewTask.destinationNamespaceId());
     if (!scope.matchesNamespaceId(destNamespaceId.getId())) {
       return new PlannedViewMutationResult(
@@ -484,7 +487,7 @@ class QueuedReconcileWorkerSupport {
                           + " does not match requested scope"))),
           null);
     }
-    ResourceId destCatalogId = active.destination().getCatalogId();
+    ResourceId destCatalogId = mapping.getDestination().getCatalogId();
     String destNsFq = reconcilerService.resolveNamespaceFq(ctx, destNamespaceId);
     String displayName =
         viewTask.destinationViewDisplayName().isBlank()
@@ -776,12 +779,18 @@ class QueuedReconcileWorkerSupport {
       return new Result(0, 0, 0, 0, 1, 0, 0, e);
     }
 
+    SourceMapping mapping =
+        ReconcilerService.effectiveMappingForTask(
+            active,
+            tableTask.sourceNamespace(),
+            tableTask.sourceTable(),
+            tableTask.destinationTableId());
     ResourceId destNamespaceId =
         resolveOrCreateDiscoveryNamespaceId(
             ctx,
             connectorId,
-            active.source(),
-            active.destination(),
+            mapping.getSource(),
+            mapping.getDestination(),
             tableTask.destinationNamespaceId());
     if (!scope.matchesNamespaceId(destNamespaceId.getId())) {
       return new Result(
@@ -827,13 +836,9 @@ class QueuedReconcileWorkerSupport {
 
     try (FloecatConnector connector =
         reconcilerService.connectorOpener.open(active.resolvedConfig())) {
-      ResourceId destCatalogId = active.destination().getCatalogId();
+      ResourceId destCatalogId = mapping.getDestination().getCatalogId();
       Set<String> defaultColumnSelectors =
-          ReconcilerService.effectiveColumnSelectors(
-              active,
-              tableTask.sourceNamespace(),
-              tableTask.sourceTable(),
-              tableTask.destinationTableId());
+          ReconcilerService.normalizeSelectors(mapping.getSource().getColumnsList());
       boolean includeCoreMetadata =
           ReconcilerService.includesMetadata(captureMode)
               && !ReconcilerService.isCaptureOnlyConnector(active.connector());

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
@@ -612,7 +612,6 @@ class QueuedReconcileWorkerSupport {
                   + tableTask.destinationTableId()));
     }
 
-    SourceSelector source = active.source();
     TableExecutionProgress tableProgress = new TableExecutionProgress();
     ProgressListener trackingProgress =
         (tablesScanned,
@@ -684,7 +683,11 @@ class QueuedReconcileWorkerSupport {
                     return DestinationTableResolution.resolved(
                         destinationTableId, tableMetadataChanged);
                   }),
-              ReconcilerService.normalizeSelectors(source.getColumnsList()),
+              ReconcilerService.effectiveColumnSelectors(
+                  active,
+                  tableTask.sourceNamespace(),
+                  tableTask.sourceTable(),
+                  tableTask.destinationTableId()),
               cancelCheck,
               trackingProgress,
               tableProgress,
@@ -826,7 +829,11 @@ class QueuedReconcileWorkerSupport {
         reconcilerService.connectorOpener.open(active.resolvedConfig())) {
       ResourceId destCatalogId = active.destination().getCatalogId();
       Set<String> defaultColumnSelectors =
-          ReconcilerService.normalizeSelectors(active.source().getColumnsList());
+          ReconcilerService.effectiveColumnSelectors(
+              active,
+              tableTask.sourceNamespace(),
+              tableTask.sourceTable(),
+              tableTask.destinationTableId());
       boolean includeCoreMetadata =
           ReconcilerService.includesMetadata(captureMode)
               && !ReconcilerService.isCaptureOnlyConnector(active.connector());

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -28,6 +28,7 @@ import ai.floedb.floecat.connector.common.auth.CredentialResolverSupport;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
 import ai.floedb.floecat.connector.rpc.SourceSelector;
 import ai.floedb.floecat.connector.spi.AuthResolutionContext;
 import ai.floedb.floecat.connector.spi.ConnectorConfig;
@@ -110,80 +111,105 @@ public class ReconcilerService {
     ReconcileContext ctx = buildContext(principal, Optional.ofNullable(bearerToken));
 
     ActiveConnector active = activeConnectorForResult(ctx, connectorId);
-    SourceSelector source = active.source();
-    DestinationTarget dest = active.destination();
 
     try (FloecatConnector connector = connectorOpener.open(active.resolvedConfig())) {
       if (scope.hasTableFilter()) {
         return List.of(
             planStrictTableTask(ctx, connectorId, scope.destinationTableId(), connector));
       }
-      if (!source.hasNamespace() || source.getNamespace().getSegmentsList().isEmpty()) {
-        throw new IllegalArgumentException("connector.source.namespace is required");
-      }
 
-      ResourceId destCatalogId = dest.getCatalogId();
-      String sourceNsFq = fq(source.getNamespace().getSegmentsList());
-      String destNsFq;
-      String tableDisplayHint;
-      Optional<ResourceId> destNamespaceId;
-      destNsFq =
-          dest.hasNamespaceId()
-              ? resolveNamespaceFq(ctx, dest.getNamespaceId())
-              : (dest.hasNamespace() && !dest.getNamespace().getSegmentsList().isEmpty())
-                  ? fq(dest.getNamespace().getSegmentsList())
-                  : sourceNsFq;
-      tableDisplayHint =
-          dest.getTableDisplayName() == null || dest.getTableDisplayName().isBlank()
-              ? null
-              : dest.getTableDisplayName();
-      destNamespaceId = ensureDestinationNamespaceId(ctx, destCatalogId, dest, destNsFq);
-
-      if (dest.hasTableId() && (source.getTable() == null || source.getTable().isBlank())) {
-        throw new IllegalArgumentException(
-            "Pinned destination table id requires connector.source.table; "
-                + "namespace discovery connectors must not set destination.tableId");
+      List<ReconcileTableTask> tasks = new ArrayList<>();
+      for (SourceMapping mapping : effectiveMappings(active)) {
+        tasks.addAll(
+            planTableTasksForMapping(
+                ctx, connector, mapping.getSource(), mapping.getDestination(), scope));
       }
-
-      List<FloecatConnector.PlannedTableTask> planned =
-          connector
-              .planTableTasks(
-                  new FloecatConnector.TablePlanningRequest(
-                      sourceNsFq,
-                      source.getTable(),
-                      destNsFq,
-                      tableDisplayHint,
-                      destinationNamespacePlanningPaths(destNsFq),
-                      null))
-              .stream()
-              .filter(task -> matchesPlannedNamespaceScope(destNamespaceId.orElse(null), scope))
-              .toList();
-      if (dest.hasTableId()) {
-        return List.of(pinnedDestinationTableTask(dest.getTableId(), planned));
-      }
-      return planned.stream()
-          .map(
-              task ->
-                  ReconcileTableTask.discovery(
-                      task.sourceNamespaceFq(),
-                      task.sourceTable(),
-                      destNamespaceId.map(ResourceId::getId).orElse(""),
-                      lookupDestinationTableIdByName(
-                              ctx,
-                              destCatalogId,
-                              destNamespaceId.orElse(null),
-                              destNsFq,
-                              task.destinationTableDisplayName())
-                          .map(ResourceId::getId)
-                          .orElse(null),
-                      task.destinationTableDisplayName()))
-          .toList();
+      return tasks;
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new RuntimeException(
           "Failed to plan reconcile tasks for connector " + connectorId.getId(), e);
     }
+  }
+
+  private List<ReconcileTableTask> planTableTasksForMapping(
+      ReconcileContext ctx,
+      FloecatConnector connector,
+      SourceSelector source,
+      DestinationTarget dest,
+      ReconcileScope scope) {
+    if (!source.hasNamespace() || source.getNamespace().getSegmentsList().isEmpty()) {
+      throw new IllegalArgumentException("connector.source.namespace is required");
+    }
+
+    ResourceId destCatalogId = dest.getCatalogId();
+    String sourceNsFq = fq(source.getNamespace().getSegmentsList());
+    String destNsFq =
+        dest.hasNamespaceId()
+            ? resolveNamespaceFq(ctx, dest.getNamespaceId())
+            : (dest.hasNamespace() && !dest.getNamespace().getSegmentsList().isEmpty())
+                ? fq(dest.getNamespace().getSegmentsList())
+                : sourceNsFq;
+    String tableDisplayHint =
+        dest.getTableDisplayName() == null || dest.getTableDisplayName().isBlank()
+            ? null
+            : dest.getTableDisplayName();
+    Optional<ResourceId> destNamespaceId =
+        ensureDestinationNamespaceId(ctx, destCatalogId, dest, destNsFq);
+
+    if (dest.hasTableId() && (source.getTable() == null || source.getTable().isBlank())) {
+      throw new IllegalArgumentException(
+          "Pinned destination table id requires connector.source.table; "
+              + "namespace discovery connectors must not set destination.tableId");
+    }
+
+    List<FloecatConnector.PlannedTableTask> planned =
+        connector
+            .planTableTasks(
+                new FloecatConnector.TablePlanningRequest(
+                    sourceNsFq,
+                    source.getTable(),
+                    destNsFq,
+                    tableDisplayHint,
+                    destinationNamespacePlanningPaths(destNsFq),
+                    null))
+            .stream()
+            .filter(task -> matchesPlannedNamespaceScope(destNamespaceId.orElse(null), scope))
+            .toList();
+    if (dest.hasTableId()) {
+      return List.of(pinnedDestinationTableTask(dest.getTableId(), planned));
+    }
+    return planned.stream()
+        .map(
+            task ->
+                ReconcileTableTask.discovery(
+                    task.sourceNamespaceFq(),
+                    task.sourceTable(),
+                    destNamespaceId.map(ResourceId::getId).orElse(""),
+                    lookupDestinationTableIdByName(
+                            ctx,
+                            destCatalogId,
+                            destNamespaceId.orElse(null),
+                            destNsFq,
+                            task.destinationTableDisplayName())
+                        .map(ResourceId::getId)
+                        .orElse(null),
+                    task.destinationTableDisplayName()))
+        .toList();
+  }
+
+  /** Falls back to the legacy singular source/destination pair when mappings is empty. */
+  private static List<SourceMapping> effectiveMappings(ActiveConnector active) {
+    List<SourceMapping> mappings = active.connector().getMappingsList();
+    if (!mappings.isEmpty()) {
+      return mappings;
+    }
+    return List.of(
+        SourceMapping.newBuilder()
+            .setSource(active.source())
+            .setDestination(active.destination())
+            .build());
   }
 
   /** Plans either strict destination-view-id work or namespace discovery view tasks. */

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -199,6 +199,54 @@ public class ReconcilerService {
         .toList();
   }
 
+  /**
+   * Resolves the column selectors configured for the mapping that produced this table task, falling
+   * back to the legacy top-level source when no mapping matches.
+   */
+  static Set<String> effectiveColumnSelectors(
+      ActiveConnector active,
+      String sourceNamespaceFq,
+      String sourceTable,
+      String destinationTableId) {
+    return normalizeSelectors(
+        effectiveSourceForTask(active, sourceNamespaceFq, sourceTable, destinationTableId)
+            .getColumnsList());
+  }
+
+  private static SourceSelector effectiveSourceForTask(
+      ActiveConnector active,
+      String sourceNamespaceFq,
+      String sourceTable,
+      String destinationTableId) {
+    List<SourceMapping> mappings = effectiveMappings(active);
+    if (mappings.size() == 1) {
+      return mappings.getFirst().getSource();
+    }
+    SourceSelector tableMatch = null;
+    SourceSelector namespaceMatch = null;
+    for (SourceMapping mapping : mappings) {
+      SourceSelector source = mapping.getSource();
+      DestinationTarget dest = mapping.getDestination();
+      if (!blank(destinationTableId)
+          && dest.hasTableId()
+          && destinationTableId.equals(dest.getTableId().getId())) {
+        return source;
+      }
+      if (!fq(source.getNamespace().getSegmentsList()).equals(sourceNamespaceFq)) {
+        continue;
+      }
+      if (!blank(sourceTable) && sourceTable.equals(source.getTable())) {
+        tableMatch = tableMatch == null ? source : tableMatch;
+      } else if (blank(source.getTable()) && namespaceMatch == null) {
+        namespaceMatch = source;
+      }
+    }
+    if (tableMatch != null) {
+      return tableMatch;
+    }
+    return namespaceMatch != null ? namespaceMatch : active.source();
+  }
+
   /** Falls back to the legacy singular source/destination pair when mappings is empty. */
   private static List<SourceMapping> effectiveMappings(ActiveConnector active) {
     List<SourceMapping> mappings = active.connector().getMappingsList();
@@ -324,7 +372,12 @@ public class ReconcilerService {
     boolean captureOnly = captureMode == CaptureMode.CAPTURE_ONLY;
     Set<Long> knownSnapshotIds =
         (captureOnly || !fullRescan) ? backend.existingSnapshotIds(ctx, tableId) : Set.of();
-    Set<String> defaultColumnSelectors = normalizeSelectors(active.source().getColumnsList());
+    Set<String> defaultColumnSelectors =
+        effectiveColumnSelectors(
+            active,
+            effectiveTask.sourceNamespace(),
+            effectiveTask.sourceTable(),
+            effectiveTask.destinationTableId());
     ReconcileCapturePolicy capturePolicy = effectiveCapturePolicy(scope, captureMode);
     boolean requiresCaptureOutputs =
         capturePolicy.requestsStats() || capturePolicy.requestsIndexes();

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -119,7 +119,7 @@ public class ReconcilerService {
       }
 
       List<ReconcileTableTask> tasks = new ArrayList<>();
-      for (SourceMapping mapping : effectiveMappings(active)) {
+      for (SourceMapping mapping : active.mappings()) {
         tasks.addAll(
             planTableTasksForMapping(
                 ctx, connector, mapping.getSource(), mapping.getDestination(), scope));
@@ -199,65 +199,63 @@ public class ReconcilerService {
         .toList();
   }
 
-  /**
-   * Resolves the column selectors configured for the mapping that produced this table task, falling
-   * back to the legacy top-level source when no mapping matches.
-   */
+  /** Resolves the column selectors configured for the mapping that produced this table task. */
   static Set<String> effectiveColumnSelectors(
       ActiveConnector active,
       String sourceNamespaceFq,
       String sourceTable,
       String destinationTableId) {
     return normalizeSelectors(
-        effectiveSourceForTask(active, sourceNamespaceFq, sourceTable, destinationTableId)
+        effectiveMappingForTask(active, sourceNamespaceFq, sourceTable, destinationTableId)
+            .getSource()
             .getColumnsList());
   }
 
-  private static SourceSelector effectiveSourceForTask(
+  /**
+   * Resolves the mapping that produced this table task. Throws a terminal validation failure when
+   * the connector's mappings no longer cover the task, so stale or mis-planned tasks fail loudly
+   * instead of silently running with a default configuration.
+   */
+  static SourceMapping effectiveMappingForTask(
       ActiveConnector active,
       String sourceNamespaceFq,
       String sourceTable,
       String destinationTableId) {
-    List<SourceMapping> mappings = effectiveMappings(active);
+    List<SourceMapping> mappings = active.mappings();
     if (mappings.size() == 1) {
-      return mappings.getFirst().getSource();
+      return mappings.getFirst();
     }
-    SourceSelector tableMatch = null;
-    SourceSelector namespaceMatch = null;
+    SourceMapping tableMatch = null;
+    SourceMapping namespaceMatch = null;
     for (SourceMapping mapping : mappings) {
       SourceSelector source = mapping.getSource();
       DestinationTarget dest = mapping.getDestination();
       if (!blank(destinationTableId)
           && dest.hasTableId()
           && destinationTableId.equals(dest.getTableId().getId())) {
-        return source;
+        return mapping;
       }
       if (!fq(source.getNamespace().getSegmentsList()).equals(sourceNamespaceFq)) {
         continue;
       }
       if (!blank(sourceTable) && sourceTable.equals(source.getTable())) {
-        tableMatch = tableMatch == null ? source : tableMatch;
+        tableMatch = tableMatch == null ? mapping : tableMatch;
       } else if (blank(source.getTable()) && namespaceMatch == null) {
-        namespaceMatch = source;
+        namespaceMatch = mapping;
       }
     }
     if (tableMatch != null) {
       return tableMatch;
     }
-    return namespaceMatch != null ? namespaceMatch : active.source();
-  }
-
-  /** Falls back to the legacy singular source/destination pair when mappings is empty. */
-  private static List<SourceMapping> effectiveMappings(ActiveConnector active) {
-    List<SourceMapping> mappings = active.connector().getMappingsList();
-    if (!mappings.isEmpty()) {
-      return mappings;
+    if (namespaceMatch != null) {
+      return namespaceMatch;
     }
-    return List.of(
-        SourceMapping.newBuilder()
-            .setSource(active.source())
-            .setDestination(active.destination())
-            .build());
+    throw terminalValidation(
+        "No connector mapping matches task source="
+            + sourceNamespaceFq
+            + (blank(sourceTable) ? "" : "." + sourceTable)
+            + " for connector "
+            + active.connector().getResourceId().getId());
   }
 
   /** Plans either strict destination-view-id work or namespace discovery view tasks. */
@@ -289,51 +287,64 @@ public class ReconcilerService {
       if (scope.hasViewFilter()) {
         return List.of(planStrictViewTask(ctx, connectorId, scope.destinationViewId(), connector));
       }
-      SourceSelector source = active.source();
-      DestinationTarget dest = active.destination();
-      if (!source.hasNamespace() || source.getNamespace().getSegmentsList().isEmpty()) {
-        throw new IllegalArgumentException("connector.source.namespace is required");
+      List<ReconcileViewTask> tasks = new ArrayList<>();
+      for (SourceMapping mapping : active.mappings()) {
+        tasks.addAll(
+            planViewTasksForMapping(
+                ctx, connector, mapping.getSource(), mapping.getDestination(), scope));
       }
-      ResourceId destCatalogId = dest.getCatalogId();
-      String sourceNsFq = fq(source.getNamespace().getSegmentsList());
-      String destNsFq =
-          dest.hasNamespaceId()
-              ? resolveNamespaceFq(ctx, dest.getNamespaceId())
-              : (dest.hasNamespace() && !dest.getNamespace().getSegmentsList().isEmpty())
-                  ? fq(dest.getNamespace().getSegmentsList())
-                  : sourceNsFq;
-      Optional<ResourceId> destNamespaceId =
-          ensureDestinationNamespaceId(ctx, destCatalogId, dest, destNsFq);
-      if (!matchesPlannedNamespaceScope(destNamespaceId.orElse(null), scope)) {
-        return List.of();
-      }
-      return connector
-          .planViewTasks(
-              new FloecatConnector.ViewPlanningRequest(
-                  sourceNsFq, destNsFq, destinationNamespacePlanningPaths(destNsFq)))
-          .stream()
-          .map(
-              task ->
-                  ReconcileViewTask.discovery(
-                      task.sourceNamespaceFq(),
-                      task.sourceView(),
-                      destNamespaceId.map(ResourceId::getId).orElse(""),
-                      lookupDestinationViewIdByName(
-                              ctx,
-                              destCatalogId,
-                              destNamespaceId.orElse(null),
-                              destNsFq,
-                              task.destinationViewDisplayName())
-                          .map(ResourceId::getId)
-                          .orElse(null),
-                      task.destinationViewDisplayName()))
-          .toList();
+      return tasks;
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new RuntimeException(
           "Failed to plan reconcile view tasks for connector " + connectorId.getId(), e);
     }
+  }
+
+  private List<ReconcileViewTask> planViewTasksForMapping(
+      ReconcileContext ctx,
+      FloecatConnector connector,
+      SourceSelector source,
+      DestinationTarget dest,
+      ReconcileScope scope) {
+    if (!source.hasNamespace() || source.getNamespace().getSegmentsList().isEmpty()) {
+      throw new IllegalArgumentException("connector.source.namespace is required");
+    }
+    ResourceId destCatalogId = dest.getCatalogId();
+    String sourceNsFq = fq(source.getNamespace().getSegmentsList());
+    String destNsFq =
+        dest.hasNamespaceId()
+            ? resolveNamespaceFq(ctx, dest.getNamespaceId())
+            : (dest.hasNamespace() && !dest.getNamespace().getSegmentsList().isEmpty())
+                ? fq(dest.getNamespace().getSegmentsList())
+                : sourceNsFq;
+    Optional<ResourceId> destNamespaceId =
+        ensureDestinationNamespaceId(ctx, destCatalogId, dest, destNsFq);
+    if (!matchesPlannedNamespaceScope(destNamespaceId.orElse(null), scope)) {
+      return List.of();
+    }
+    return connector
+        .planViewTasks(
+            new FloecatConnector.ViewPlanningRequest(
+                sourceNsFq, destNsFq, destinationNamespacePlanningPaths(destNsFq)))
+        .stream()
+        .map(
+            task ->
+                ReconcileViewTask.discovery(
+                    task.sourceNamespaceFq(),
+                    task.sourceView(),
+                    destNamespaceId.map(ResourceId::getId).orElse(""),
+                    lookupDestinationViewIdByName(
+                            ctx,
+                            destCatalogId,
+                            destNamespaceId.orElse(null),
+                            destNsFq,
+                            task.destinationViewDisplayName())
+                        .map(ResourceId::getId)
+                        .orElse(null),
+                    task.destinationViewDisplayName()))
+        .toList();
   }
 
   public List<ReconcileSnapshotTask> planSnapshotTasks(
@@ -1278,14 +1289,26 @@ public class ReconcilerService {
             connector,
             resolveCredentials(config, connector.getAuth(), connectorId),
             sourceStorageLocation(config));
-    return new ActiveConnector(
-        connector,
-        connector.hasSource() ? connector.getSource() : SourceSelector.getDefaultInstance(),
-        connector.hasDestination()
-            ? connector.getDestination()
-            : DestinationTarget.getDefaultInstance(),
-        config,
-        resolved);
+    return new ActiveConnector(connector, connectorMappings(connector), config, resolved);
+  }
+
+  /**
+   * The service normalizes stored connectors so mappings is the single representation; the
+   * deprecated top-level pair is only synthesized here as a defense against reading a legacy
+   * connector through an un-normalized path (e.g. mixed-version deployments).
+   */
+  private static List<SourceMapping> connectorMappings(Connector connector) {
+    if (connector.getMappingsCount() > 0) {
+      return connector.getMappingsList();
+    }
+    if (!connector.hasSource() && !connector.hasDestination()) {
+      return List.of();
+    }
+    return List.of(
+        SourceMapping.newBuilder()
+            .setSource(connector.getSource())
+            .setDestination(connector.getDestination())
+            .build());
   }
 
   ActiveConnector activeConnectorForResult(ReconcileContext ctx, ResourceId connectorId) {
@@ -1546,8 +1569,7 @@ public class ReconcilerService {
 
   record ActiveConnector(
       Connector connector,
-      SourceSelector source,
-      DestinationTarget destination,
+      List<SourceMapping> mappings,
       ConnectorConfig config,
       ConnectorConfig resolvedConfig) {}
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
@@ -336,12 +336,6 @@ abstract class AbstractReconcilerServiceTestBase {
     }
 
     @Override
-    public void updateConnectorDestination(
-        ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public ReconcilerBackend.ViewMutationResult ensureView(
         ReconcileContext ctx, ViewSpec spec, String idempotencyKey) {
       throw new UnsupportedOperationException();
@@ -434,12 +428,6 @@ abstract class AbstractReconcilerServiceTestBase {
               connector.getDestination().getCatalogId(),
               connector.getDestination().getNamespaceId(),
               "revenue_view"));
-    }
-
-    @Override
-    public void updateConnectorDestination(
-        ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {
-      // no-op
     }
   }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
@@ -31,6 +31,10 @@ import ai.floedb.floecat.connector.rpc.AuthCredentials;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorKind;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
+import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
+import ai.floedb.floecat.connector.rpc.SourceSelector;
 import ai.floedb.floecat.connector.spi.ConnectorConfig;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.reconciler.spi.ReconcilerBackend.DestinationTableMetadata;
@@ -245,6 +249,109 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
             any(), any(), any(), locationCaptor.capture(), eq(connector), any());
     assertThat(locationCaptor.getValue())
         .contains("s3://bucket/table/metadata/00001.metadata.json");
+  }
+
+  @Test
+  void effectiveColumnSelectorsResolvesMatchingMappingBySourceTable() {
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setState(ConnectorState.CS_ACTIVE)
+            .addMappings(mapping("db.sales", "orders", List.of("order_id", "amount")))
+            .addMappings(mapping("db.sales", "customers", List.of("customer_id")))
+            .build();
+    ReconcilerService.ActiveConnector active = activeConnector(connector);
+
+    assertThat(ReconcilerService.effectiveColumnSelectors(active, "db.sales", "orders", "tbl-1"))
+        .containsExactly("order_id", "amount");
+    assertThat(ReconcilerService.effectiveColumnSelectors(active, "db.sales", "customers", "tbl-2"))
+        .containsExactly("customer_id");
+  }
+
+  @Test
+  void effectiveColumnSelectorsResolvesMatchingMappingByNamespaceDiscovery() {
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setState(ConnectorState.CS_ACTIVE)
+            .addMappings(mapping("db.sales", "", List.of("order_id")))
+            .addMappings(mapping("db.hr", "", List.of("employee_id")))
+            .build();
+    ReconcilerService.ActiveConnector active = activeConnector(connector);
+
+    assertThat(
+            ReconcilerService.effectiveColumnSelectors(active, "db.hr", "employees", "tbl-emp"))
+        .containsExactly("employee_id");
+  }
+
+  @Test
+  void effectiveColumnSelectorsPrefersPinnedDestinationTableId() {
+    ResourceId pinnedTableId =
+        ResourceId.newBuilder()
+            .setAccountId(connectorId.getAccountId())
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("tbl-pinned")
+            .build();
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setState(ConnectorState.CS_ACTIVE)
+            .addMappings(mapping("db.sales", "orders", List.of("order_id")))
+            .addMappings(
+                mapping("db.sales", "orders", List.of("pinned_col")).toBuilder()
+                    .setDestination(DestinationTarget.newBuilder().setTableId(pinnedTableId))
+                    .build())
+            .build();
+    ReconcilerService.ActiveConnector active = activeConnector(connector);
+
+    assertThat(
+            ReconcilerService.effectiveColumnSelectors(active, "db.sales", "orders", "tbl-pinned"))
+        .containsExactly("pinned_col");
+  }
+
+  @Test
+  void effectiveColumnSelectorsFallsBackToLegacySourceWithoutMappings() {
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setState(ConnectorState.CS_ACTIVE)
+            .setSource(sourceSelector("db.sales", "orders", List.of("legacy_col")))
+            .build();
+    ReconcilerService.ActiveConnector active = activeConnector(connector);
+
+    assertThat(ReconcilerService.effectiveColumnSelectors(active, "db.sales", "orders", "tbl-1"))
+        .containsExactly("legacy_col");
+  }
+
+  private ReconcilerService.ActiveConnector activeConnector(Connector connector) {
+    return new ReconcilerService.ActiveConnector(
+        connector,
+        connector.hasSource() ? connector.getSource() : SourceSelector.getDefaultInstance(),
+        connector.hasDestination()
+            ? connector.getDestination()
+            : DestinationTarget.getDefaultInstance(),
+        null,
+        null);
+  }
+
+  private static SourceMapping mapping(String namespaceFq, String table, List<String> columns) {
+    return SourceMapping.newBuilder()
+        .setSource(sourceSelector(namespaceFq, table, columns))
+        .setDestination(DestinationTarget.getDefaultInstance())
+        .build();
+  }
+
+  private static SourceSelector sourceSelector(
+      String namespaceFq, String table, List<String> columns) {
+    SourceSelector.Builder source =
+        SourceSelector.newBuilder()
+            .setNamespace(
+                NamespacePath.newBuilder().addAllSegments(List.of(namespaceFq.split("\\."))))
+            .addAllColumns(columns);
+    if (!table.isBlank()) {
+      source.setTable(table);
+    }
+    return source.build();
   }
 
   @Test

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.reconciler.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -279,8 +280,7 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
             .build();
     ReconcilerService.ActiveConnector active = activeConnector(connector);
 
-    assertThat(
-            ReconcilerService.effectiveColumnSelectors(active, "db.hr", "employees", "tbl-emp"))
+    assertThat(ReconcilerService.effectiveColumnSelectors(active, "db.hr", "employees", "tbl-emp"))
         .containsExactly("employee_id");
   }
 
@@ -310,6 +310,66 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
   }
 
   @Test
+  void effectiveMappingForTaskCarriesPerMappingDestinationCatalog() {
+    ResourceId salesCatalog =
+        ResourceId.newBuilder()
+            .setAccountId(connectorId.getAccountId())
+            .setKind(ResourceKind.RK_CATALOG)
+            .setId("cat-sales")
+            .build();
+    ResourceId hrCatalog =
+        ResourceId.newBuilder()
+            .setAccountId(connectorId.getAccountId())
+            .setKind(ResourceKind.RK_CATALOG)
+            .setId("cat-hr")
+            .build();
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setState(ConnectorState.CS_ACTIVE)
+            .addMappings(
+                mapping("db.sales", "", List.of()).toBuilder()
+                    .setDestination(DestinationTarget.newBuilder().setCatalogId(salesCatalog))
+                    .build())
+            .addMappings(
+                mapping("db.hr", "", List.of()).toBuilder()
+                    .setDestination(DestinationTarget.newBuilder().setCatalogId(hrCatalog))
+                    .build())
+            .build();
+    ReconcilerService.ActiveConnector active = activeConnector(connector);
+
+    SourceMapping resolved =
+        ReconcilerService.effectiveMappingForTask(active, "db.hr", "employees", "tbl-emp");
+
+    assertThat(resolved.getDestination().getCatalogId().getId()).isEqualTo("cat-hr");
+    assertThat(
+            ReconcilerService.effectiveMappingForTask(active, "db.sales", "orders", "tbl-ord")
+                .getDestination()
+                .getCatalogId()
+                .getId())
+        .isEqualTo("cat-sales");
+  }
+
+  @Test
+  void effectiveMappingForTaskThrowsWhenNoMappingMatches() {
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setState(ConnectorState.CS_ACTIVE)
+            .addMappings(mapping("db.sales", "", List.of()))
+            .addMappings(mapping("db.hr", "", List.of()))
+            .build();
+    ReconcilerService.ActiveConnector active = activeConnector(connector);
+
+    assertThatThrownBy(
+            () ->
+                ReconcilerService.effectiveMappingForTask(active, "db.unknown", "orders", "tbl-1"))
+        .isInstanceOf(ReconcileFailureException.class)
+        .hasMessageContaining("No connector mapping matches")
+        .hasMessageContaining("db.unknown.orders");
+  }
+
+  @Test
   void effectiveColumnSelectorsFallsBackToLegacySourceWithoutMappings() {
     Connector connector =
         Connector.newBuilder()
@@ -324,14 +384,17 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
   }
 
   private ReconcilerService.ActiveConnector activeConnector(Connector connector) {
-    return new ReconcilerService.ActiveConnector(
-        connector,
-        connector.hasSource() ? connector.getSource() : SourceSelector.getDefaultInstance(),
-        connector.hasDestination()
-            ? connector.getDestination()
-            : DestinationTarget.getDefaultInstance(),
-        null,
-        null);
+    List<SourceMapping> mappings =
+        connector.getMappingsCount() > 0
+            ? connector.getMappingsList()
+            : (connector.hasSource() || connector.hasDestination())
+                ? List.of(
+                    SourceMapping.newBuilder()
+                        .setSource(connector.getSource())
+                        .setDestination(connector.getDestination())
+                        .build())
+                : List.of();
+    return new ReconcilerService.ActiveConnector(connector, mappings, null, null);
   }
 
   private static SourceMapping mapping(String namespaceFq, String table, List<String> columns) {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -31,6 +31,9 @@ import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorKind;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
+import ai.floedb.floecat.connector.rpc.SourceSelector;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.reconciler.jobs.ReconcileCapturePolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
@@ -780,6 +783,204 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
             ReconcileTableTask.discovery("src_cat.src_ns", "new_tbl", "ns-obs2", "new_tbl"));
     assertThat(lookupNamespaceCalls[0]).isEqualTo(1);
     assertThat(ensureNamespaceCalls[0]).isEqualTo(1);
+  }
+
+  @Test
+  void tablePlannerPlansDiscoveryTasksForEachMapping() {
+    configureTwoNamespaceMappingConnector();
+
+    List<ReconcileTableTask> tasks =
+        service.planTableTasks(principal, connectorId, ReconcileScope.empty(), null);
+
+    assertThat(tasks)
+        .containsExactly(
+            ReconcileTableTask.discovery("src_cat.ns_a", "tbl_a", "ns-a", "tbl_a"),
+            ReconcileTableTask.discovery("src_cat.ns_b", "tbl_b", "ns-b", "tbl_b"));
+  }
+
+  @Test
+  void tablePlannerScopeNarrowsAcrossMappingsToMatchingDestinationNamespace() {
+    configureTwoNamespaceMappingConnector();
+
+    List<ReconcileTableTask> tasks =
+        service.planTableTasks(
+            principal, connectorId, ReconcileScope.of(List.of("ns-a"), null), null);
+
+    assertThat(tasks)
+        .containsExactly(ReconcileTableTask.discovery("src_cat.ns_a", "tbl_a", "ns-a", "tbl_a"));
+  }
+
+  @Test
+  void tablePlannerCombinesPinnedAndDiscoveryMappings() {
+    ResourceId destCatalogId =
+        ResourceId.newBuilder().setAccountId("acct").setId(DEST_CATALOG).build();
+    ResourceId pinnedNamespaceId =
+        ResourceId.newBuilder().setAccountId("acct").setId("ns-pinned").build();
+    ResourceId pinnedTableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_TABLE)
+            .setId("table-pinned")
+            .build();
+    ResourceId destNamespaceIdB =
+        ResourceId.newBuilder().setAccountId("acct").setId("ns-b").build();
+
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setState(ConnectorState.CS_ACTIVE)
+            .setKind(ConnectorKind.CK_DELTA)
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(
+                        SourceSelector.newBuilder()
+                            .setTable("tbl_pinned")
+                            .setNamespace(
+                                NamespacePath.newBuilder()
+                                    .addSegments("src_cat")
+                                    .addSegments("ns_pinned")))
+                    .setDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogId(destCatalogId)
+                            .setNamespaceId(pinnedNamespaceId)
+                            .setTableId(pinnedTableId)))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(
+                        SourceSelector.newBuilder()
+                            .setNamespace(
+                                NamespacePath.newBuilder()
+                                    .addSegments("src_cat")
+                                    .addSegments("ns_b")))
+                    .setDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogId(destCatalogId)
+                            .setNamespaceId(destNamespaceIdB)))
+            .build();
+
+    service.backend =
+        new DefaultBackend() {
+          @Override
+          public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+            return connector;
+          }
+
+          @Override
+          public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+            return "dest_ns";
+          }
+
+          @Override
+          public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+            return "dest_cat";
+          }
+
+          @Override
+          public Optional<ResourceId> lookupTable(ReconcileContext ctx, NameRef table) {
+            return Optional.empty();
+          }
+        };
+    service.connectorOpener =
+        mappingAwarePlanner(
+            Map.of(
+                "src_cat.ns_pinned",
+                List.of(
+                    new FloecatConnector.PlannedTableTask(
+                        "src_cat.ns_pinned", "tbl_pinned", "tbl_pinned")),
+                "src_cat.ns_b",
+                List.of(new FloecatConnector.PlannedTableTask("src_cat.ns_b", "tbl_b", "tbl_b"))));
+
+    List<ReconcileTableTask> tasks =
+        service.planTableTasks(principal, connectorId, ReconcileScope.empty(), null);
+
+    assertThat(tasks)
+        .containsExactly(
+            ReconcileTableTask.of("src_cat.ns_pinned", "tbl_pinned", "table-pinned", "tbl_pinned"),
+            ReconcileTableTask.discovery("src_cat.ns_b", "tbl_b", "ns-b", "tbl_b"));
+  }
+
+  private Connector configureTwoNamespaceMappingConnector() {
+    ResourceId destCatalogId =
+        ResourceId.newBuilder().setAccountId("acct").setId(DEST_CATALOG).build();
+    ResourceId destNamespaceIdA =
+        ResourceId.newBuilder().setAccountId("acct").setId("ns-a").build();
+    ResourceId destNamespaceIdB =
+        ResourceId.newBuilder().setAccountId("acct").setId("ns-b").build();
+
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setState(ConnectorState.CS_ACTIVE)
+            .setKind(ConnectorKind.CK_DELTA)
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(
+                        SourceSelector.newBuilder()
+                            .setNamespace(
+                                NamespacePath.newBuilder()
+                                    .addSegments("src_cat")
+                                    .addSegments("ns_a")))
+                    .setDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogId(destCatalogId)
+                            .setNamespaceId(destNamespaceIdA)))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(
+                        SourceSelector.newBuilder()
+                            .setNamespace(
+                                NamespacePath.newBuilder()
+                                    .addSegments("src_cat")
+                                    .addSegments("ns_b")))
+                    .setDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogId(destCatalogId)
+                            .setNamespaceId(destNamespaceIdB)))
+            .build();
+
+    service.backend =
+        new DefaultBackend() {
+          @Override
+          public Connector lookupConnector(ReconcileContext ctx, ResourceId ignoredConnectorId) {
+            return connector;
+          }
+
+          @Override
+          public String resolveNamespaceFq(ReconcileContext ctx, ResourceId namespaceId) {
+            return "dest_ns";
+          }
+
+          @Override
+          public String lookupCatalogName(ReconcileContext ctx, ResourceId catalogId) {
+            return "dest_cat";
+          }
+
+          @Override
+          public Optional<ResourceId> lookupTable(ReconcileContext ctx, NameRef table) {
+            return Optional.empty();
+          }
+        };
+    service.connectorOpener =
+        mappingAwarePlanner(
+            Map.of(
+                "src_cat.ns_a",
+                List.of(new FloecatConnector.PlannedTableTask("src_cat.ns_a", "tbl_a", "tbl_a")),
+                "src_cat.ns_b",
+                List.of(new FloecatConnector.PlannedTableTask("src_cat.ns_b", "tbl_b", "tbl_b"))));
+
+    return connector;
+  }
+
+  private ReconcilerService.ConnectorOpener mappingAwarePlanner(
+      Map<String, List<FloecatConnector.PlannedTableTask>> plannedBySourceNamespace) {
+    return cfg ->
+        new FakeConnector(List.of()) {
+          @Override
+          public List<FloecatConnector.PlannedTableTask> planTableTasks(
+              FloecatConnector.TablePlanningRequest request) {
+            return plannedBySourceNamespace.getOrDefault(request.sourceNamespaceFq(), List.of());
+          }
+        };
   }
 
   @Test

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -221,7 +221,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
             .setId("ns-existing")
             .build();
     int[] ensureNamespaceCalls = {0};
-    int[] updateConnectorCalls = {0};
     int[] listTablesCalls = {0};
     int[] updateTableCalls = {0};
 
@@ -287,12 +286,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           }
 
           @Override
-          public void updateConnectorDestination(
-              ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {
-            updateConnectorCalls[0]++;
-          }
-
-          @Override
           public Set<Long> existingSnapshotIds(ReconcileContext ctx, ResourceId ignoredTableId) {
             return Set.of();
           }
@@ -330,7 +323,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
     assertThat(result.tablesChanged).isEqualTo(1);
     assertThat(ensureNamespaceCalls[0]).isZero();
     assertThat(updateTableCalls[0]).isEqualTo(1);
-    assertThat(updateConnectorCalls[0]).isZero();
     assertThat(listTablesCalls[0]).isZero();
   }
 
@@ -984,6 +976,45 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
   }
 
   @Test
+  void viewPlannerPlansViewsForEachMapping() {
+    configureTwoNamespaceMappingConnector();
+    var viewA =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
+            "src_cat.ns_a",
+            "view_a",
+            "SELECT 1",
+            "spark",
+            List.of("ns_a"),
+            "{\"type\":\"struct\",\"fields\":[{\"name\":\"v\",\"type\":\"int\",\"nullable\":true}]}");
+    var viewB =
+        new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
+            "src_cat.ns_b",
+            "view_b",
+            "SELECT 2",
+            "spark",
+            List.of("ns_b"),
+            "{\"type\":\"struct\",\"fields\":[{\"name\":\"v\",\"type\":\"int\",\"nullable\":true}]}");
+    service.connectorOpener =
+        cfg ->
+            new FakeConnector(List.of(viewA, viewB)) {
+              @Override
+              public List<FloecatConnector.ViewDescriptor> listViewDescriptors(String namespaceFq) {
+                return java.util.stream.Stream.of(viewA, viewB)
+                    .filter(view -> view.namespaceFq().equals(namespaceFq))
+                    .toList();
+              }
+            };
+
+    List<ReconcileViewTask> tasks =
+        service.planViewTasks(principal, connectorId, ReconcileScope.empty(), null);
+
+    assertThat(tasks)
+        .containsExactly(
+            ReconcileViewTask.discovery("src_cat.ns_a", "view_a", "ns-a", "view_a"),
+            ReconcileViewTask.discovery("src_cat.ns_b", "view_b", "ns-b", "view_b"));
+  }
+
+  @Test
   void viewPlannerEmitsDiscoveryTasksWithoutDestinationViewId() {
     var viewDesc =
         new ai.floedb.floecat.connector.spi.FloecatConnector.ViewDescriptor(
@@ -1410,10 +1441,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
         this.putConstraints = constraints;
         return true;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class ConstraintsConnector extends FakeConnector {
@@ -1609,10 +1636,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return false;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     Backend backend = new Backend();
@@ -1754,10 +1777,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return targetKind == ai.floedb.floecat.catalog.rpc.StatsTargetKind.STK_TABLE;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     Backend backend = new Backend();
@@ -2482,10 +2501,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return false;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class TwoSnapshotConnector extends FakeConnector {
@@ -2797,10 +2812,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return false;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class KnownSnapshotConnector extends FakeConnector {
@@ -3085,10 +3096,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
 
       @Override
       public void putTargetStats(ReconcileContext ctx, List<TargetStatsRecord> stats) {}
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     Backend backend = new Backend();
@@ -3234,10 +3241,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
         putConstraintsCalls++;
         return true;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class ConstraintsConnector extends FakeConnector {
@@ -3384,10 +3387,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           ai.floedb.floecat.catalog.rpc.StatsTargetKind targetKind) {
         return false;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class NewSnapshotConnector extends FakeConnector {
@@ -3526,10 +3525,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
         putConstraintsCalls++;
         return false;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class KnownSnapshotConnector extends FakeConnector {
@@ -3688,10 +3683,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
         putConstraintsCalls++;
         return true;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class ThrowingConnector extends FakeConnector {
@@ -3820,10 +3811,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           SnapshotConstraints constraints) {
         throw new RuntimeException("backend-constraints-fail");
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class ConstraintsConnector extends FakeConnector {
@@ -3956,10 +3943,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
         putConstraintsCalls++;
         return true;
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class EmptyConstraintsConnector extends FakeConnector {
@@ -4089,10 +4072,6 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           SnapshotConstraints constraints) {
         throw new RuntimeException("stats-captured-constraints-fail");
       }
-
-      @Override
-      public void updateConnectorDestination(
-          ReconcileContext ctx, ResourceId connectorId, DestinationTarget destination) {}
     }
 
     class ConstraintsConnector extends FakeConnector {

--- a/service/src/main/java/ai/floedb/floecat/service/bootstrap/impl/SeedRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/bootstrap/impl/SeedRunner.java
@@ -34,6 +34,7 @@ import ai.floedb.floecat.connector.rpc.ConnectorKind;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
 import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
 import ai.floedb.floecat.connector.rpc.SourceSelector;
 import ai.floedb.floecat.gateway.iceberg.rest.common.InMemoryS3FileIO;
 import ai.floedb.floecat.gateway.iceberg.rest.common.TestDeltaFixtures;
@@ -707,13 +708,17 @@ public class SeedRunner {
             .setKind(ConnectorKind.CK_ICEBERG)
             .setState(ConnectorState.CS_ACTIVE)
             .setUri(fixture.metadataLocation())
-            .setSource(
-                SourceSelector.newBuilder().setNamespace(sourceNs).setTable(fixture.tableName()))
-            .setDestination(
-                DestinationTarget.newBuilder()
-                    .setCatalogId(catalogId)
-                    .setNamespace(destNs)
-                    .setTableDisplayName(fixture.tableName()))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(
+                        SourceSelector.newBuilder()
+                            .setNamespace(sourceNs)
+                            .setTable(fixture.tableName()))
+                    .setDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogId(catalogId)
+                            .setNamespace(destNs)
+                            .setTableDisplayName(fixture.tableName())))
             .setAuth(AuthConfig.newBuilder().setScheme("none").build())
             .setCreatedAt(Timestamps.fromMillis(now))
             .setUpdatedAt(Timestamps.fromMillis(now))
@@ -849,13 +854,17 @@ public class SeedRunner {
             .setKind(ConnectorKind.CK_DELTA)
             .setState(ConnectorState.CS_ACTIVE)
             .setUri("http://localhost")
-            .setSource(
-                SourceSelector.newBuilder().setNamespace(sourceNs).setTable(fixture.tableName()))
-            .setDestination(
-                DestinationTarget.newBuilder()
-                    .setCatalogId(catalogId)
-                    .setNamespace(destNs)
-                    .setTableDisplayName(fixture.tableName()))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(
+                        SourceSelector.newBuilder()
+                            .setNamespace(sourceNs)
+                            .setTable(fixture.tableName()))
+                    .setDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogId(catalogId)
+                            .setNamespace(destNs)
+                            .setTableDisplayName(fixture.tableName())))
             .setAuth(AuthConfig.newBuilder().setScheme("none").build())
             .setCreatedAt(Timestamps.fromMillis(now))
             .setUpdatedAt(Timestamps.fromMillis(now))

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -96,17 +96,6 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
           "kind",
           "uri",
           "properties",
-          "source",
-          "source.namespace",
-          "source.table",
-          "source.columns",
-          "destination",
-          "destination.catalog_id",
-          "destination.catalog_display_name",
-          "destination.namespace",
-          "destination.namespace_id",
-          "destination.table_display_name",
-          "destination.table_id",
           "mappings",
           "auth",
           "auth.scheme",
@@ -252,20 +241,12 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                   validatePersistedAuthConfig(spec.getAuth(), corr);
                   validateReconcilePolicy(spec.getPolicy(), corr);
 
-                  boolean hasLegacySourceOrDest = spec.hasSource() || spec.hasDestination();
                   var mappingsIn = spec.getMappingsList();
-                  boolean hasMappings = !mappingsIn.isEmpty();
-
-                  if (hasLegacySourceOrDest && hasMappings) {
-                    throw GrpcErrors.invalidArgument(
-                        corr, null, Map.of("field", "source|destination|mappings"));
-                  }
-                  boolean isShell = !hasLegacySourceOrDest && !hasMappings;
+                  boolean isShell = mappingsIn.isEmpty();
 
                   List<SourceMapping> resolvedMappings = List.of();
-                  DestinationTarget resolvedLegacyDest = null;
 
-                  if (hasMappings) {
+                  if (!isShell) {
                     if (mappingsIn.size() > 1 && spec.getPolicy().getEnabled()) {
                       throw GrpcErrors.invalidArgument(
                           corr, null, Map.of("field", "policy.enabled"));
@@ -274,17 +255,8 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                     for (int i = 0; i < mappingsIn.size(); i++) {
                       built.add(resolveMapping(mappingsIn.get(i), accountId, corr, i));
                     }
+                    validateUniqueMappings(built, corr);
                     resolvedMappings = built;
-                  } else if (!isShell) {
-                    if (!spec.hasSource()
-                        || !spec.getSource().hasNamespace()
-                        || spec.getSource().getNamespace().getSegmentsCount() == 0) {
-                      throw GrpcErrors.invalidArgument(
-                          corr,
-                          GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_SOURCE_NAMESPACE,
-                          Map.of("field", "source.namespace"));
-                    }
-                    resolvedLegacyDest = resolveDestination(spec.getDestination(), accountId, corr);
                   }
 
                   var builder =
@@ -301,16 +273,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                               isShell ? ConnectorState.CS_CREATING : ConnectorState.CS_ACTIVE);
 
                   if (spec.hasDescription()) builder.setDescription(spec.getDescription());
-                  if (hasMappings) {
-                    builder.addAllMappings(resolvedMappings);
-                    if (resolvedMappings.size() == 1) {
-                      var only = resolvedMappings.get(0);
-                      builder.setSource(only.getSource()).setDestination(only.getDestination());
-                    }
-                  } else if (!isShell) {
-                    builder.setSource(spec.getSource());
-                    builder.setDestination(resolvedLegacyDest);
-                  }
+                  builder.addAllMappings(resolvedMappings);
 
                   if (idempotencyKey == null) {
                     var existing = connectorRepo.getByName(accountId, display);
@@ -654,8 +617,8 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                   try (var connector = ConnectorFactory.create(resolved)) {
                     var namespaces = connector.listNamespaces();
 
-                    if (spec.hasSource()) {
-                      var src = spec.getSource();
+                    for (var mapping : spec.getMappingsList()) {
+                      var src = mapping.getSource();
                       var ns =
                           (src.hasNamespace()
                               ? String.join(".", src.getNamespace().getSegmentsList())
@@ -1024,7 +987,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
 
   private SourceMapping resolveMapping(
       SourceMapping mapping, String accountId, String corr, int index) {
-    var source = mapping.getSource();
+    var source = normalizeSourceSelector(mapping.getSource());
     if (!source.hasNamespace() || source.getNamespace().getSegmentsCount() == 0) {
       throw GrpcErrors.invalidArgument(
           corr,
@@ -1040,6 +1003,40 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
     }
 
     return SourceMapping.newBuilder().setSource(source).setDestination(resolvedDest).build();
+  }
+
+  /** Trims source identifiers so stored mappings match the trimmed reconcile task records. */
+  private static SourceSelector normalizeSourceSelector(SourceSelector source) {
+    var b = source.toBuilder();
+    if (source.hasNamespace()) {
+      var cleaned =
+          source.getNamespace().getSegmentsList().stream()
+              .map(s -> s == null ? "" : s.trim())
+              .filter(s -> !s.isEmpty())
+              .toList();
+      b.setNamespace(NamespacePath.newBuilder().addAllSegments(cleaned));
+    }
+    if (source.hasTable()) {
+      var table = source.getTable().trim();
+      if (table.isEmpty()) {
+        b.clearTable();
+      } else {
+        b.setTable(table);
+      }
+    }
+    return b.build();
+  }
+
+  /** Rejects mappings whose (source namespace, source table) selector is ambiguous. */
+  private static void validateUniqueMappings(List<SourceMapping> mappings, String corr) {
+    var seen = new java.util.HashSet<String>();
+    for (int i = 0; i < mappings.size(); i++) {
+      var source = mappings.get(i).getSource();
+      var key = String.join(".", source.getNamespace().getSegmentsList()) + "|" + source.getTable();
+      if (!seen.add(key)) {
+        throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "mappings[" + i + "].source"));
+      }
+    }
   }
 
   private ResourceId scopedConnectorId(String accountId, ResourceId connectorId, String corr) {
@@ -1101,168 +1098,14 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
       b.clearProperties().putAllProperties(spec.getPropertiesMap());
     }
 
-    var curSrc = current.hasSource() ? current.getSource() : SourceSelector.getDefaultInstance();
-    var inSrc = spec.hasSource() ? spec.getSource() : SourceSelector.getDefaultInstance();
-
-    if (maskTargets(mask, "source")) {
-      if (!(inSrc.hasNamespace() && inSrc.getNamespace().getSegmentsCount() > 0)) {
-        throw GrpcErrors.invalidArgument(
-            corr,
-            GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_SOURCE_NAMESPACE,
-            Map.of("field", "source.namespace"));
-      }
-      b.setSource(inSrc);
-    } else if (maskTargetsUnder(mask, "source")) {
-      var sb = curSrc.toBuilder();
-
-      if (maskTargets(mask, "source.namespace")) {
-        if (!(inSrc.hasNamespace() && inSrc.getNamespace().getSegmentsCount() > 0)) {
-          throw GrpcErrors.invalidArgument(
-              corr,
-              GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_SOURCE_NAMESPACE,
-              Map.of("field", "source.namespace"));
-        }
-        sb.setNamespace(inSrc.getNamespace());
-      }
-
-      if (maskTargets(mask, "source.table")) {
-        if (inSrc.hasTable()) {
-          sb.setTable(inSrc.getTable());
-        } else {
-          sb.clearTable();
-        }
-      }
-
-      if (maskTargets(mask, "source.columns")) {
-        sb.clearColumns().addAllColumns(inSrc.getColumnsList());
-      }
-
-      b.setSource(sb.build());
-    }
-
-    var curDst =
-        current.hasDestination()
-            ? current.getDestination()
-            : DestinationTarget.getDefaultInstance();
-    var inDst =
-        spec.hasDestination() ? spec.getDestination() : DestinationTarget.getDefaultInstance();
-
-    if (maskTargets(mask, "destination")) {
-      boolean hasCatalogRef =
-          inDst.hasCatalogId()
-              || (inDst.hasCatalogDisplayName() && !inDst.getCatalogDisplayName().isBlank());
-      boolean hasNamespaceRef =
-          inDst.hasNamespaceId()
-              || (inDst.hasNamespace() && inDst.getNamespace().getSegmentsCount() > 0);
-
-      if (!hasCatalogRef) {
-        throw GrpcErrors.invalidArgument(
-            corr,
-            GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_DESTINATION_CATALOG,
-            Map.of("field", "destination.catalog"));
-      }
-      if (!hasNamespaceRef) {
-        throw GrpcErrors.invalidArgument(
-            corr,
-            GeneratedErrorMessages.MessageKey.FIELD,
-            Map.of("field", "destination.namespace"));
-      }
-      if (inDst.hasCatalogId()) {
-        ensureKind(
-            inDst.getCatalogId(), ResourceKind.RK_CATALOG, "spec.destination.catalog_id", corr);
-      }
-      if (inDst.hasNamespaceId()) {
-        ensureKind(
-            inDst.getNamespaceId(),
-            ResourceKind.RK_NAMESPACE,
-            "spec.destination.namespace_id",
-            corr);
-      }
-      if (inDst.hasTableId()) {
-        ensureKind(inDst.getTableId(), ResourceKind.RK_TABLE, "spec.destination.table_id", corr);
-      }
-      b.setDestination(inDst);
-
-    } else if (maskTargetsUnder(mask, "destination")) {
-      var db = curDst.toBuilder();
-
-      boolean touchingCatalogRef =
-          maskTargets(mask, "destination.catalog_id")
-              || maskTargets(mask, "destination.catalog_display_name");
-      if (touchingCatalogRef) {
-        boolean incomingHasCatalog =
-            inDst.hasCatalogId()
-                || (inDst.hasCatalogDisplayName() && !inDst.getCatalogDisplayName().isBlank());
-        if (!incomingHasCatalog) {
-          throw GrpcErrors.invalidArgument(
-              corr,
-              GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_DESTINATION_CATALOG,
-              Map.of("field", "destination.catalog"));
-        }
-        if (inDst.hasCatalogId()) {
-          ensureKind(
-              inDst.getCatalogId(), ResourceKind.RK_CATALOG, "spec.destination.catalog_id", corr);
-          db.setCatalogId(inDst.getCatalogId());
-        } else {
-          db.setCatalogDisplayName(inDst.getCatalogDisplayName());
-        }
-      }
-
-      boolean touchingNamespaceRef =
-          maskTargets(mask, "destination.namespace_id")
-              || maskTargets(mask, "destination.namespace");
-      if (touchingNamespaceRef) {
-        boolean incomingHasNs =
-            inDst.hasNamespaceId()
-                || (inDst.hasNamespace() && inDst.getNamespace().getSegmentsCount() > 0);
-        if (!incomingHasNs) {
-          throw GrpcErrors.invalidArgument(
-              corr,
-              GeneratedErrorMessages.MessageKey.FIELD,
-              Map.of("field", "destination.namespace"));
-        }
-        if (inDst.hasNamespaceId()) {
-          ensureKind(
-              inDst.getNamespaceId(),
-              ResourceKind.RK_NAMESPACE,
-              "spec.destination.namespace_id",
-              corr);
-          db.setNamespaceId(inDst.getNamespaceId());
-        } else {
-          db.setNamespace(inDst.getNamespace());
-        }
-      }
-
-      if (maskTargets(mask, "destination.table_id")) {
-        if (inDst.hasTableId()) {
-          ensureKind(inDst.getTableId(), ResourceKind.RK_TABLE, "spec.destination.table_id", corr);
-          db.setTableId(inDst.getTableId());
-        } else {
-          db.clearTableId();
-        }
-      }
-      if (maskTargets(mask, "destination.table_display_name")) {
-        if (inDst.hasTableDisplayName()) {
-          db.setTableDisplayName(inDst.getTableDisplayName());
-        } else {
-          db.clearTableDisplayName();
-        }
-      }
-
-      b.setDestination(db.build());
-    }
-
     if (maskTargets(mask, "mappings")) {
       var inMappings = spec.getMappingsList();
       var resolvedMappings = new java.util.ArrayList<SourceMapping>(inMappings.size());
       for (int i = 0; i < inMappings.size(); i++) {
         resolvedMappings.add(resolveMapping(inMappings.get(i), accountId, corr, i));
       }
+      validateUniqueMappings(resolvedMappings, corr);
       b.clearMappings().addAllMappings(resolvedMappings);
-      if (resolvedMappings.size() == 1) {
-        var only = resolvedMappings.get(0);
-        b.setSource(only.getSource()).setDestination(only.getDestination());
-      }
     }
 
     var curAuth = current.hasAuth() ? current.getAuth() : AuthConfig.getDefaultInstance();
@@ -1346,40 +1189,6 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
 
     var out = b.build();
 
-    boolean touchedDest = maskTargets(mask, "destination") || maskTargetsUnder(mask, "destination");
-    boolean touchedSrc = maskTargets(mask, "source") || maskTargetsUnder(mask, "source");
-
-    if (touchedDest) {
-      var d = out.getDestination();
-      boolean hasCatalogRef =
-          d.hasCatalogId() || (d.hasCatalogDisplayName() && !d.getCatalogDisplayName().isBlank());
-      if (!hasCatalogRef) {
-        throw GrpcErrors.invalidArgument(
-            corr,
-            GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_DESTINATION_CATALOG,
-            Map.of("field", "destination.catalog"));
-      }
-      boolean hasNamespaceRef =
-          d.hasNamespaceId() || (d.hasNamespace() && d.getNamespace().getSegmentsCount() > 0);
-      if (!hasNamespaceRef) {
-        throw GrpcErrors.invalidArgument(
-            corr,
-            GeneratedErrorMessages.MessageKey.FIELD,
-            Map.of("field", "destination.namespace"));
-      }
-    }
-
-    if (touchedSrc && out.hasSource()) {
-      var s = out.getSource();
-      boolean hasNs = s.hasNamespace() && s.getNamespace().getSegmentsCount() > 0;
-      if (!hasNs) {
-        throw GrpcErrors.invalidArgument(
-            corr,
-            GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_SOURCE_NAMESPACE,
-            Map.of("field", "source.namespace"));
-      }
-    }
-
     if (out.getMappingsCount() > 1 && out.getPolicy().getEnabled()) {
       throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "policy.enabled"));
     }
@@ -1410,25 +1219,6 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
         .scalar("description", s.getDescription())
         .scalar("kind", s.getKind())
         .scalar("uri", s.getUri());
-
-    var source = s.getSource();
-    c.group(
-        "source",
-        g ->
-            g.list("namespace", source.getNamespace().getSegmentsList())
-                .scalar("table", source.getTable())
-                .list("columns", source.getColumnsList()));
-
-    var dest = s.getDestination();
-    c.group(
-        "destination",
-        g ->
-            g.scalar("catalog_id", nullSafeId(dest.getCatalogId()))
-                .scalar("catalog_display_name", dest.getCatalogDisplayName())
-                .scalar("namespace_id", nullSafeId(dest.getNamespaceId()))
-                .list("namespace", dest.getNamespace().getSegmentsList())
-                .scalar("table_id", nullSafeId(dest.getTableId()))
-                .scalar("table_display_name", dest.getTableDisplayName()));
 
     var mappings = s.getMappingsList();
     for (int i = 0; i < mappings.size(); i++) {
@@ -1484,12 +1274,6 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
             .setKind(connector.getKind())
             .setUri(connector.getUri())
             .putAllProperties(connector.getPropertiesMap());
-    if (connector.hasSource()) {
-      b.setSource(connector.getSource());
-    }
-    if (connector.hasDestination()) {
-      b.setDestination(connector.getDestination());
-    }
     if (connector.getMappingsCount() > 0) {
       b.addAllMappings(connector.getMappingsList());
     }

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -39,6 +39,7 @@ import ai.floedb.floecat.connector.rpc.ListConnectorsResponse;
 import ai.floedb.floecat.connector.rpc.NamespacePath;
 import ai.floedb.floecat.connector.rpc.ReconcilePolicy;
 import ai.floedb.floecat.connector.rpc.ReconcileSnapshotScope;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
 import ai.floedb.floecat.connector.rpc.SourceSelector;
 import ai.floedb.floecat.connector.rpc.UpdateConnectorRequest;
 import ai.floedb.floecat.connector.rpc.UpdateConnectorResponse;
@@ -106,6 +107,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
           "destination.namespace_id",
           "destination.table_display_name",
           "destination.table_id",
+          "mappings",
           "auth",
           "auth.scheme",
           "auth.credentials",
@@ -250,117 +252,39 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                   validatePersistedAuthConfig(spec.getAuth(), corr);
                   validateReconcilePolicy(spec.getPolicy(), corr);
 
-                  if (!spec.hasDestination()
-                      || (!spec.getDestination().hasCatalogId()
-                          && spec.getDestination().getCatalogDisplayName().isBlank())) {
+                  boolean hasLegacySourceOrDest = spec.hasSource() || spec.hasDestination();
+                  var mappingsIn = spec.getMappingsList();
+                  boolean hasMappings = !mappingsIn.isEmpty();
+
+                  if (hasLegacySourceOrDest && hasMappings) {
                     throw GrpcErrors.invalidArgument(
-                        corr,
-                        GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_DESTINATION_CATALOG,
-                        Map.of("id", "destination.catalog_id|catalog_display_name"));
+                        corr, null, Map.of("field", "source|destination|mappings"));
                   }
+                  boolean isShell = !hasLegacySourceOrDest && !hasMappings;
 
-                  var dest = spec.getDestination();
-                  var destB = dest.toBuilder();
+                  List<SourceMapping> resolvedMappings = List.of();
+                  DestinationTarget resolvedLegacyDest = null;
 
-                  if (dest.hasCatalogDisplayName() && !dest.hasCatalogId()) {
-                    final String dName = dest.getCatalogDisplayName().trim();
-                    catalogRepo
-                        .getByName(accountId, dName)
-                        .ifPresentOrElse(
-                            cat -> {
-                              destB.setCatalogId(cat.getResourceId());
-                              destB.clearCatalogDisplayName();
-                            },
-                            () -> {
-                              throw GrpcErrors.notFound(
-                                  corr,
-                                  GeneratedErrorMessages.MessageKey
-                                      .CONNECTOR_DESTINATION_CATALOG_NOT_FOUND,
-                                  Map.of("display_name", dName));
-                            });
-                  }
-
-                  if (dest.hasCatalogId() && dest.hasCatalogDisplayName()) {
-                    var byName =
-                        catalogRepo.getByName(accountId, dest.getCatalogDisplayName().trim());
-                    if (byName.isEmpty()
-                        || !byName
-                            .get()
-                            .getResourceId()
-                            .getId()
-                            .equals(dest.getCatalogId().getId())) {
+                  if (hasMappings) {
+                    if (mappingsIn.size() > 1 && spec.getPolicy().getEnabled()) {
+                      throw GrpcErrors.invalidArgument(
+                          corr, null, Map.of("field", "policy.enabled"));
+                    }
+                    var built = new java.util.ArrayList<SourceMapping>(mappingsIn.size());
+                    for (int i = 0; i < mappingsIn.size(); i++) {
+                      built.add(resolveMapping(mappingsIn.get(i), accountId, corr, i));
+                    }
+                    resolvedMappings = built;
+                  } else if (!isShell) {
+                    if (!spec.hasSource()
+                        || !spec.getSource().hasNamespace()
+                        || spec.getSource().getNamespace().getSegmentsCount() == 0) {
                       throw GrpcErrors.invalidArgument(
                           corr,
-                          GeneratedErrorMessages.MessageKey.CONNECTOR_DESTINATION_CATALOG_MISMATCH,
-                          Map.of(
-                              "catalog_id",
-                              dest.getCatalogId().getId(),
-                              "catalog_display_name",
-                              dest.getCatalogDisplayName()));
+                          GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_SOURCE_NAMESPACE,
+                          Map.of("field", "source.namespace"));
                     }
-                    destB.clearCatalogDisplayName();
-                  }
-
-                  if (!spec.hasSource()
-                      || !spec.getSource().hasNamespace()
-                      || spec.getSource().getNamespace().getSegmentsCount() == 0) {
-                    throw GrpcErrors.invalidArgument(
-                        corr,
-                        GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_SOURCE_NAMESPACE,
-                        Map.of("field", "source.namespace"));
-                  }
-
-                  if (destB.hasCatalogId() && dest.hasNamespace() && !dest.hasNamespaceId()) {
-                    NamespacePath dNs = dest.getNamespace();
-                    namespaceRepo
-                        .getByPath(accountId, destB.getCatalogId().getId(), dNs.getSegmentsList())
-                        .ifPresent(
-                            ns -> {
-                              destB.setNamespaceId(ns.getResourceId());
-                              destB.clearNamespace();
-                            });
-                  }
-
-                  if (destB.hasCatalogId()
-                      && destB.hasNamespaceId()
-                      && dest.hasTableDisplayName()
-                      && !dest.hasTableId()) {
-                    String dTbl = dest.getTableDisplayName().trim();
-                    var tblOpt =
-                        tableRepo.getByName(
-                            accountId,
-                            destB.getCatalogId().getId(),
-                            destB.getNamespaceId().getId(),
-                            dTbl);
-
-                    if (tblOpt.isPresent()) {
-                      destB.setTableId(tblOpt.get().getResourceId());
-                      destB.clearTableDisplayName();
-                    } else {
-                      destB.setTableDisplayName(dTbl);
-                    }
-                  }
-
-                  if (destB.hasCatalogId()) {
-                    ensureKind(
-                        destB.getCatalogId(),
-                        ResourceKind.RK_CATALOG,
-                        "spec.destination.catalog_id",
-                        corr);
-                  }
-                  if (destB.hasNamespaceId()) {
-                    ensureKind(
-                        destB.getNamespaceId(),
-                        ResourceKind.RK_NAMESPACE,
-                        "spec.destination.namespace_id",
-                        corr);
-                  }
-                  if (destB.hasTableId()) {
-                    ensureKind(
-                        destB.getTableId(),
-                        ResourceKind.RK_TABLE,
-                        "spec.destination.table_id",
-                        corr);
+                    resolvedLegacyDest = resolveDestination(spec.getDestination(), accountId, corr);
                   }
 
                   var builder =
@@ -373,11 +297,20 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                           .setPolicy(spec.getPolicy())
                           .setCreatedAt(tsNow)
                           .setUpdatedAt(tsNow)
-                          .setState(ConnectorState.CS_ACTIVE);
+                          .setState(
+                              isShell ? ConnectorState.CS_CREATING : ConnectorState.CS_ACTIVE);
 
                   if (spec.hasDescription()) builder.setDescription(spec.getDescription());
-                  if (spec.hasSource()) builder.setSource(spec.getSource());
-                  builder.setDestination(destB.build());
+                  if (hasMappings) {
+                    builder.addAllMappings(resolvedMappings);
+                    if (resolvedMappings.size() == 1) {
+                      var only = resolvedMappings.get(0);
+                      builder.setSource(only.getSource()).setDestination(only.getDestination());
+                    }
+                  } else if (!isShell) {
+                    builder.setSource(spec.getSource());
+                    builder.setDestination(resolvedLegacyDest);
+                  }
 
                   if (idempotencyKey == null) {
                     var existing = connectorRepo.getByName(accountId, display);
@@ -521,7 +454,8 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
 
                   FieldMask normalizedMask = normalizeMask(request.getUpdateMask());
                   var desired =
-                      applyConnectorSpecPatch(current, request.getSpec(), normalizedMask, corr)
+                      applyConnectorSpecPatch(
+                              current, request.getSpec(), normalizedMask, pc.getAccountId(), corr)
                           .toBuilder()
                           .setUpdatedAt(nowTs())
                           .build();
@@ -1001,13 +935,120 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
         .toList();
   }
 
+  private DestinationTarget resolveDestination(
+      DestinationTarget dest, String accountId, String corr) {
+    if (!dest.hasCatalogId() && dest.getCatalogDisplayName().isBlank()) {
+      throw GrpcErrors.invalidArgument(
+          corr,
+          GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_DESTINATION_CATALOG,
+          Map.of("id", "destination.catalog_id|catalog_display_name"));
+    }
+
+    var destB = dest.toBuilder();
+
+    if (dest.hasCatalogDisplayName() && !dest.hasCatalogId()) {
+      final String dName = dest.getCatalogDisplayName().trim();
+      catalogRepo
+          .getByName(accountId, dName)
+          .ifPresentOrElse(
+              cat -> {
+                destB.setCatalogId(cat.getResourceId());
+                destB.clearCatalogDisplayName();
+              },
+              () -> {
+                throw GrpcErrors.notFound(
+                    corr,
+                    GeneratedErrorMessages.MessageKey.CONNECTOR_DESTINATION_CATALOG_NOT_FOUND,
+                    Map.of("display_name", dName));
+              });
+    }
+
+    if (dest.hasCatalogId() && dest.hasCatalogDisplayName()) {
+      var byName = catalogRepo.getByName(accountId, dest.getCatalogDisplayName().trim());
+      if (byName.isEmpty()
+          || !byName.get().getResourceId().getId().equals(dest.getCatalogId().getId())) {
+        throw GrpcErrors.invalidArgument(
+            corr,
+            GeneratedErrorMessages.MessageKey.CONNECTOR_DESTINATION_CATALOG_MISMATCH,
+            Map.of(
+                "catalog_id",
+                dest.getCatalogId().getId(),
+                "catalog_display_name",
+                dest.getCatalogDisplayName()));
+      }
+      destB.clearCatalogDisplayName();
+    }
+
+    if (destB.hasCatalogId() && dest.hasNamespace() && !dest.hasNamespaceId()) {
+      NamespacePath dNs = dest.getNamespace();
+      namespaceRepo
+          .getByPath(accountId, destB.getCatalogId().getId(), dNs.getSegmentsList())
+          .ifPresent(
+              ns -> {
+                destB.setNamespaceId(ns.getResourceId());
+                destB.clearNamespace();
+              });
+    }
+
+    if (destB.hasCatalogId()
+        && destB.hasNamespaceId()
+        && dest.hasTableDisplayName()
+        && !dest.hasTableId()) {
+      String dTbl = dest.getTableDisplayName().trim();
+      var tblOpt =
+          tableRepo.getByName(
+              accountId, destB.getCatalogId().getId(), destB.getNamespaceId().getId(), dTbl);
+
+      if (tblOpt.isPresent()) {
+        destB.setTableId(tblOpt.get().getResourceId());
+        destB.clearTableDisplayName();
+      } else {
+        destB.setTableDisplayName(dTbl);
+      }
+    }
+
+    if (destB.hasCatalogId()) {
+      ensureKind(
+          destB.getCatalogId(), ResourceKind.RK_CATALOG, "spec.destination.catalog_id", corr);
+    }
+    if (destB.hasNamespaceId()) {
+      ensureKind(
+          destB.getNamespaceId(), ResourceKind.RK_NAMESPACE, "spec.destination.namespace_id", corr);
+    }
+    if (destB.hasTableId()) {
+      ensureKind(destB.getTableId(), ResourceKind.RK_TABLE, "spec.destination.table_id", corr);
+    }
+
+    return destB.build();
+  }
+
+  private SourceMapping resolveMapping(
+      SourceMapping mapping, String accountId, String corr, int index) {
+    var source = mapping.getSource();
+    if (!source.hasNamespace() || source.getNamespace().getSegmentsCount() == 0) {
+      throw GrpcErrors.invalidArgument(
+          corr,
+          GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_SOURCE_NAMESPACE,
+          Map.of("field", "mappings[" + index + "].source.namespace"));
+    }
+
+    var resolvedDest = resolveDestination(mapping.getDestination(), accountId, corr);
+
+    if (resolvedDest.hasTableId() && (!source.hasTable() || source.getTable().isBlank())) {
+      throw GrpcErrors.invalidArgument(
+          corr, null, Map.of("field", "mappings[" + index + "].source.table"));
+    }
+
+    return SourceMapping.newBuilder().setSource(source).setDestination(resolvedDest).build();
+  }
+
   private ResourceId scopedConnectorId(String accountId, ResourceId connectorId, String corr) {
     ensureKind(connectorId, ResourceKind.RK_CONNECTOR, "connector_id", corr);
     return connectorId.toBuilder().setAccountId(accountId).build();
   }
 
   private Connector applyConnectorSpecPatch(
-      Connector current, ConnectorSpec spec, FieldMask mask, String corr) {
+      Connector current, ConnectorSpec spec, FieldMask mask, String accountId, String corr) {
     mask = normalizeMask(mask);
 
     var paths = normalizedMaskPaths(mask);
@@ -1211,6 +1252,19 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
       b.setDestination(db.build());
     }
 
+    if (maskTargets(mask, "mappings")) {
+      var inMappings = spec.getMappingsList();
+      var resolvedMappings = new java.util.ArrayList<SourceMapping>(inMappings.size());
+      for (int i = 0; i < inMappings.size(); i++) {
+        resolvedMappings.add(resolveMapping(inMappings.get(i), accountId, corr, i));
+      }
+      b.clearMappings().addAllMappings(resolvedMappings);
+      if (resolvedMappings.size() == 1) {
+        var only = resolvedMappings.get(0);
+        b.setSource(only.getSource()).setDestination(only.getDestination());
+      }
+    }
+
     var curAuth = current.hasAuth() ? current.getAuth() : AuthConfig.getDefaultInstance();
     var inAuth = spec.hasAuth() ? spec.getAuth() : AuthConfig.getDefaultInstance();
 
@@ -1326,6 +1380,10 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
       }
     }
 
+    if (out.getMappingsCount() > 1 && out.getPolicy().getEnabled()) {
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "policy.enabled"));
+    }
+
     return out;
   }
 
@@ -1372,6 +1430,24 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                 .scalar("table_id", nullSafeId(dest.getTableId()))
                 .scalar("table_display_name", dest.getTableDisplayName()));
 
+    var mappings = s.getMappingsList();
+    for (int i = 0; i < mappings.size(); i++) {
+      var mSource = mappings.get(i).getSource();
+      var mDest = mappings.get(i).getDestination();
+      c.group(
+          "mappings[" + i + "]",
+          g ->
+              g.list("source.namespace", mSource.getNamespace().getSegmentsList())
+                  .scalar("source.table", mSource.getTable())
+                  .list("source.columns", mSource.getColumnsList())
+                  .scalar("destination.catalog_id", nullSafeId(mDest.getCatalogId()))
+                  .scalar("destination.catalog_display_name", mDest.getCatalogDisplayName())
+                  .scalar("destination.namespace_id", nullSafeId(mDest.getNamespaceId()))
+                  .list("destination.namespace", mDest.getNamespace().getSegmentsList())
+                  .scalar("destination.table_id", nullSafeId(mDest.getTableId()))
+                  .scalar("destination.table_display_name", mDest.getTableDisplayName()));
+    }
+
     var auth = s.getAuth();
     c.group(
         "auth",
@@ -1413,6 +1489,9 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
     }
     if (connector.hasDestination()) {
       b.setDestination(connector.getDestination());
+    }
+    if (connector.getMappingsCount() > 0) {
+      b.addAllMappings(connector.getMappingsList());
     }
     if (connector.hasAuth()) {
       b.setAuth(connector.getAuth());

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.repo.impl;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
 import ai.floedb.floecat.service.repo.model.ConnectorKey;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.Schemas;
@@ -43,9 +44,29 @@ public class ConnectorRepository {
             pointerStore,
             blobStore,
             Schemas.CONNECTOR,
-            Connector::parseFrom,
+            bytes -> normalizeLegacyMapping(Connector.parseFrom(bytes)),
             Connector::toByteArray,
             "application/x-protobuf");
+  }
+
+  /**
+   * Connectors written before multi-mapping support carry only the deprecated top-level
+   * source/destination pair. Normalize them into mappings[0] on read so the rest of the system can
+   * commit to the mappings list as the single representation.
+   */
+  public static Connector normalizeLegacyMapping(Connector connector) {
+    if (connector.getMappingsCount() > 0
+        || (!connector.hasSource() && !connector.hasDestination())) {
+      return connector;
+    }
+    return connector.toBuilder()
+        .addMappings(
+            SourceMapping.newBuilder()
+                .setSource(connector.getSource())
+                .setDestination(connector.getDestination()))
+        .clearSource()
+        .clearDestination()
+        .build();
   }
 
   public void create(Connector connector) {

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.transaction.impl;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
@@ -111,7 +112,7 @@ public class TransactionIntentApplierSupport {
         LOG.debugf("connector blob missing: %s", blobUri);
         return null;
       }
-      return Connector.parseFrom(bytes);
+      return ConnectorRepository.normalizeLegacyMapping(Connector.parseFrom(bytes));
     } catch (Exception e) {
       LOG.debugf("connector blob parse failed: %s", blobUri, e);
       return null;

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
@@ -33,6 +33,7 @@ import ai.floedb.floecat.connector.rpc.ConnectorKind;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
 import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
 import ai.floedb.floecat.connector.rpc.SourceSelector;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService;
 import ai.floedb.floecat.reconciler.jobs.ReconcileCapturePolicy;
@@ -974,18 +975,21 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
             .setResourceId(connectorId)
             .setDisplayName(displayName)
             .setKind(ConnectorKind.CK_ICEBERG)
-            .setSource(
-                SourceSelector.newBuilder()
-                    .setNamespace(NamespacePath.newBuilder().addAllSegments(namespacePath).build())
-                    .setTable(sourceTableName)
-                    .build())
-            .setDestination(
-                DestinationTarget.newBuilder()
-                    .setCatalogId(table.getCatalogId())
-                    .setNamespaceId(table.getNamespaceId())
-                    .setTableDisplayName(tableName)
-                    .setTableId(tableId)
-                    .build())
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(
+                        SourceSelector.newBuilder()
+                            .setNamespace(
+                                NamespacePath.newBuilder().addAllSegments(namespacePath).build())
+                            .setTable(sourceTableName)
+                            .build())
+                    .setDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogId(table.getCatalogId())
+                            .setNamespaceId(table.getNamespaceId())
+                            .setTableDisplayName(tableName)
+                            .setTableId(tableId)
+                            .build()))
             .setUri(connectorUri)
             .setAuth(AuthConfig.newBuilder().setScheme("none").build())
             .setCreatedAt(connectorTimestamp == null ? nowTs() : connectorTimestamp)
@@ -1018,13 +1022,16 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
                 .setFormat(TableFormat.TF_ICEBERG)
                 .setColumnIdAlgorithm(ColumnIdAlgorithm.CID_FIELD_ID);
     upstream.setConnectorId(connector.getResourceId());
-    if (connector.hasSource() && connector.getSource().hasNamespace()) {
-      upstream
-          .clearNamespacePath()
-          .addAllNamespacePath(connector.getSource().getNamespace().getSegmentsList());
-    }
-    if (connector.hasDestination() && !connector.getDestination().getTableDisplayName().isBlank()) {
-      upstream.setTableDisplayName(connector.getDestination().getTableDisplayName());
+    if (connector.getMappingsCount() > 0) {
+      SourceMapping mapping = connector.getMappings(0);
+      if (mapping.getSource().hasNamespace()) {
+        upstream
+            .clearNamespacePath()
+            .addAllNamespacePath(mapping.getSource().getNamespace().getSegmentsList());
+      }
+      if (!mapping.getDestination().getTableDisplayName().isBlank()) {
+        upstream.setTableDisplayName(mapping.getDestination().getTableDisplayName());
+      }
     }
     if (table.hasUpstream() && !table.getUpstream().getUri().isBlank()) {
       upstream.setUri(table.getUpstream().getUri());
@@ -1124,21 +1131,19 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         if (connector == null
             || !connector.hasResourceId()
             || !isGatewayManagedIcebergConnector(connector)
-            || !connector.hasDestination()
-            || !connector.getDestination().hasTableId()
-            || connector.getDestination().getTableId().getId().isBlank()) {
+            || connector.getMappingsCount() == 0
+            || !connector.getMappings(0).getDestination().hasTableId()
+            || connector.getMappings(0).getDestination().getTableId().getId().isBlank()) {
           continue;
         }
+        String destinationTableId = connector.getMappings(0).getDestination().getTableId().getId();
         candidates.putIfAbsent(
-            connector.getResourceId().getId()
-                + "|"
-                + connector.getDestination().getTableId().getId(),
+            connector.getResourceId().getId() + "|" + destinationTableId,
             new PostCommitCaptureCandidate(
                 connector.getResourceId(),
-                connector.getDestination().getTableId().getId(),
+                destinationTableId,
                 true,
-                committedCurrentSnapshotsByTable.get(
-                    connector.getDestination().getTableId().getId())));
+                committedCurrentSnapshotsByTable.get(destinationTableId)));
         continue;
       }
       if (!isTableByIdPointer(intent.getTargetPointerKey())) {
@@ -1730,7 +1735,9 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     }
     try {
       byte[] bytes = blobStore.get(blobUri);
-      return bytes == null ? null : Connector.parseFrom(bytes);
+      return bytes == null
+          ? null
+          : ConnectorRepository.normalizeLegacyMapping(Connector.parseFrom(bytes));
     } catch (Exception e) {
       return null;
     }

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
@@ -181,8 +181,10 @@ public class ConnectorIT {
                 .setDisplayName("dummy-conn")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://ignored")
-                .setSource(source(List.of("db")))
-                .setDestination(dest("cat-e2e"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("db")))
+                        .setDestination(dest("cat-e2e")))
                 .setAuth(AuthConfig.newBuilder().setScheme("none").build())
                 .build());
 
@@ -198,8 +200,10 @@ public class ConnectorIT {
                 .setDisplayName("dummy-conn2")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://ignored")
-                .setSource(source(List.of("examples", "iceberg")))
-                .setDestination(dest("cat-e2e"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("examples", "iceberg")))
+                        .setDestination(dest("cat-e2e")))
                 .setAuth(AuthConfig.newBuilder().setScheme("none").build())
                 .build());
 
@@ -274,8 +278,10 @@ public class ConnectorIT {
                 .setDisplayName("dummy-stats")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://ignored")
-                .setSource(source(List.of("db")))
-                .setDestination(dest("cat-stats"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("db")))
+                        .setDestination(dest("cat-stats")))
                 .setAuth(AuthConfig.newBuilder().setScheme("none").build())
                 .build());
 
@@ -352,8 +358,10 @@ public class ConnectorIT {
                 .setDisplayName("fixture-iceberg-simple")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri(metadataLocation)
-                .setSource(source(List.of("fixtures", "simple")))
-                .setDestination(dest)
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("fixtures", "simple")))
+                        .setDestination(dest))
                 .setAuth(icebergFixtureStorageAuth())
                 .putAllProperties(props)
                 .build());
@@ -412,8 +420,10 @@ public class ConnectorIT {
                 .setDisplayName("fixture-iceberg-plan-files")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri(metadataLocation)
-                .setSource(source(List.of("fixtures", "simple")))
-                .setDestination(dest)
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("fixtures", "simple")))
+                        .setDestination(dest))
                 .setAuth(icebergFixtureStorageAuth())
                 .putAllProperties(props)
                 .build());
@@ -532,8 +542,10 @@ public class ConnectorIT {
                 .setDisplayName("fixture-iceberg-rust-sidecar")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri(YB_TPCDS_METADATA_LOCATION)
-                .setSource(source(List.of("fixtures", "yb_iceberg_tpcds")))
-                .setDestination(dest)
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("fixtures", "yb_iceberg_tpcds")))
+                        .setDestination(dest))
                 .setAuth(icebergFixtureStorageAuth())
                 .putAllProperties(props)
                 .build());
@@ -628,8 +640,10 @@ public class ConnectorIT {
                 .setDisplayName("fixture-iceberg-deferred-contract")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri(metadataLocation)
-                .setSource(source(List.of("fixtures", "simple")))
-                .setDestination(dest)
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("fixtures", "simple")))
+                        .setDestination(dest))
                 .setAuth(icebergFixtureStorageAuth())
                 .putAllProperties(props)
                 .build());
@@ -692,8 +706,10 @@ public class ConnectorIT {
                 .setDisplayName("fixture-iceberg-incremental")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri(metadataLocation)
-                .setSource(source(List.of("fixtures", "simple")))
-                .setDestination(dest)
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("fixtures", "simple")))
+                        .setDestination(dest))
                 .setAuth(icebergFixtureStorageAuth())
                 .putAllProperties(props)
                 .build());
@@ -766,8 +782,10 @@ public class ConnectorIT {
                 .setDisplayName("fixture-iceberg-incremental-advance")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri(metadataLocation)
-                .setSource(source(List.of("fixtures", "simple")))
-                .setDestination(dest)
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("fixtures", "simple")))
+                        .setDestination(dest))
                 .setAuth(icebergFixtureStorageAuth())
                 .putAllProperties(props)
                 .build());
@@ -848,8 +866,10 @@ public class ConnectorIT {
                 .setDisplayName("fixture-iceberg-incremental-delete")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri(metadataLocation)
-                .setSource(source(List.of("fixtures", "simple")))
-                .setDestination(dest)
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("fixtures", "simple")))
+                        .setDestination(dest))
                 .setAuth(icebergFixtureStorageAuth())
                 .putAllProperties(props)
                 .build());
@@ -930,8 +950,10 @@ public class ConnectorIT {
                 .setDisplayName("fixture-iceberg-complex")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri(metadataLocation)
-                .setSource(source(List.of("sales", "us")))
-                .setDestination(dest)
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("sales", "us")))
+                        .setDestination(dest))
                 .setAuth(icebergFixtureStorageAuth())
                 .putAllProperties(props)
                 .build());
@@ -1000,8 +1022,7 @@ public class ConnectorIT {
                 .setDisplayName("dummy-dest-table")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://ignored")
-                .setSource(src)
-                .setDestination(dest)
+                .addMappings(SourceMapping.newBuilder().setSource(src).setDestination(dest))
                 .setAuth(AuthConfig.newBuilder().setScheme("none").build())
                 .build());
 
@@ -1041,8 +1062,10 @@ public class ConnectorIT {
                 .setDisplayName("dummy-scope-miss")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://ignored")
-                .setSource(source(List.of("db")))
-                .setDestination(dest("cat-scope-miss"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("db")))
+                        .setDestination(dest("cat-scope-miss")))
                 .setAuth(AuthConfig.newBuilder().setScheme("none").build())
                 .build());
 
@@ -1074,12 +1097,15 @@ public class ConnectorIT {
                 .setDisplayName("dummy-plan-views")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://ignored")
-                .setSource(source(List.of("db")))
-                .setDestination(
-                    DestinationTarget.newBuilder()
-                        .setCatalogDisplayName("cat-plan-views")
-                        .setNamespace(NamespacePath.newBuilder().addSegments("analytics").build())
-                        .build())
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("db")))
+                        .setDestination(
+                            DestinationTarget.newBuilder()
+                                .setCatalogDisplayName("cat-plan-views")
+                                .setNamespace(
+                                    NamespacePath.newBuilder().addSegments("analytics").build())
+                                .build()))
                 .setAuth(AuthConfig.newBuilder().setScheme("none").build())
                 .putProperties("dummy.view.enabled", "true")
                 .putProperties("dummy.view.namespace", "db")
@@ -1140,15 +1166,17 @@ public class ConnectorIT {
               .setDisplayName("delta-conn")
               .setKind(ConnectorKind.CK_DELTA)
               .setUri(uc.baseUri())
-              .setSource(
-                  SourceSelector.newBuilder()
-                      .setNamespace(
-                          NamespacePath.newBuilder()
-                              .addSegments("main")
-                              .addSegments("tpcds")
-                              .build())
-                      .setTable("call_center"))
-              .setDestination(dest("cat-delta"))
+              .addMappings(
+                  SourceMapping.newBuilder()
+                      .setSource(
+                          SourceSelector.newBuilder()
+                              .setNamespace(
+                                  NamespacePath.newBuilder()
+                                      .addSegments("main")
+                                      .addSegments("tpcds")
+                                      .build())
+                              .setTable("call_center"))
+                      .setDestination(dest("cat-delta")))
               .setAuth(deltaFixtureStorageAuth())
               .putAllProperties(deltaFixtureNonSecretS3Options())
               .build();
@@ -1214,15 +1242,17 @@ public class ConnectorIT {
                   .setDisplayName("delta-plan-files")
                   .setKind(ConnectorKind.CK_DELTA)
                   .setUri(uc.baseUri())
-                  .setSource(
-                      SourceSelector.newBuilder()
-                          .setNamespace(
-                              NamespacePath.newBuilder()
-                                  .addSegments("main")
-                                  .addSegments("tpcds")
-                                  .build())
-                          .setTable("call_center"))
-                  .setDestination(dest("cat-delta-plan-files"))
+                  .addMappings(
+                      SourceMapping.newBuilder()
+                          .setSource(
+                              SourceSelector.newBuilder()
+                                  .setNamespace(
+                                      NamespacePath.newBuilder()
+                                          .addSegments("main")
+                                          .addSegments("tpcds")
+                                          .build())
+                                  .setTable("call_center"))
+                          .setDestination(dest("cat-delta-plan-files")))
                   .setAuth(deltaFixtureStorageAuth())
                   .putAllProperties(deltaFixtureNonSecretS3Options())
                   .build());
@@ -1337,8 +1367,10 @@ public class ConnectorIT {
                 .setDisplayName("Glue Iceberg")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri("https://glue.us-east-1.amazonaws.com/iceberg/")
-                .setSource(source(List.of("tpcds_iceberg")))
-                .setDestination(dest("glue-iceberg-rest"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("tpcds_iceberg")))
+                        .setDestination(dest("glue-iceberg-rest")))
                 .setAuth(AuthConfig.newBuilder().setScheme("aws-sigv4").build())
                 .build());
 
@@ -2050,6 +2082,33 @@ public class ConnectorIT {
   }
 
   @Test
+  void createConnectorRejectsDuplicateSourceMappings() {
+    TestSupport.createCatalog(catalogService, "cat-dup", "");
+    var spec =
+        ConnectorSpec.newBuilder()
+            .setDisplayName("dup-mappings")
+            .setKind(ConnectorKind.CK_UNITY)
+            .setUri("dummy://x")
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(source(List.of("a", "b")))
+                    .setDestination(dest("cat-dup")))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(source(List.of("a", "b")))
+                    .setDestination(dest("cat-dup")))
+            .build();
+
+    var ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                connectors.createConnector(
+                    CreateConnectorRequest.newBuilder().setSpec(spec).build()));
+    assertEquals(Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode());
+  }
+
+  @Test
   void createConnectorIdempotent() {
     TestSupport.createCatalog(catalogService, "cat-idem", "");
     var spec =
@@ -2057,8 +2116,10 @@ public class ConnectorIT {
             .setDisplayName("idem-1")
             .setKind(ConnectorKind.CK_UNITY)
             .setUri("dummy://x")
-            .setSource(source(List.of("a", "b")))
-            .setDestination(dest("cat-idem"))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(source(List.of("a", "b")))
+                    .setDestination(dest("cat-idem")))
             .build();
 
     var idem = IdempotencyKey.newBuilder().setKey("fixed-key-1").build();
@@ -2083,8 +2144,10 @@ public class ConnectorIT {
             .setDisplayName("kind-check")
             .setKind(ConnectorKind.CK_UNITY)
             .setUri("dummy://x")
-            .setSource(source(List.of("a", "b")))
-            .setDestination(dest("cat-kind"))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(source(List.of("a", "b")))
+                    .setDestination(dest("cat-kind")))
             .build();
 
     var created =
@@ -2130,8 +2193,10 @@ public class ConnectorIT {
             .setDisplayName("auth-mask")
             .setKind(ConnectorKind.CK_UNITY)
             .setUri("dummy://x")
-            .setSource(source(List.of("a", "b")))
-            .setDestination(dest("cat-auth"))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(source(List.of("a", "b")))
+                    .setDestination(dest("cat-auth")))
             .setAuth(auth)
             .build();
 
@@ -2169,8 +2234,10 @@ public class ConnectorIT {
                                 .setDisplayName("auth-reject")
                                 .setKind(ConnectorKind.CK_UNITY)
                                 .setUri("dummy://x")
-                                .setSource(source(List.of("a", "b")))
-                                .setDestination(dest("cat-auth-reject"))
+                                .addMappings(
+                                    SourceMapping.newBuilder()
+                                        .setSource(source(List.of("a", "b")))
+                                        .setDestination(dest("cat-auth-reject")))
                                 .setAuth(
                                     AuthConfig.newBuilder()
                                         .setScheme("oauth2")
@@ -2203,8 +2270,10 @@ public class ConnectorIT {
                         .setDisplayName("iceberg-auth-store")
                         .setKind(ConnectorKind.CK_ICEBERG)
                         .setUri("s3://bucket/table/metadata/00001.metadata.json")
-                        .setSource(source(List.of("raw")))
-                        .setDestination(dest("cat-iceberg-auth"))
+                        .addMappings(
+                            SourceMapping.newBuilder()
+                                .setSource(source(List.of("raw")))
+                                .setDestination(dest("cat-iceberg-auth")))
                         .putProperties("iceberg.source", "filesystem")
                         .putProperties("external.namespace", "raw")
                         .setAuth(
@@ -2223,6 +2292,90 @@ public class ConnectorIT {
         credentialResolver.resolve(connectorId.getAccountId(), connectorId.getId()).orElseThrow());
   }
 
+  @SuppressWarnings("deprecation")
+  @Test
+  void legacySourceDestinationConnectorIsNormalizedOnRead() {
+    var connectorId =
+        ResourceId.newBuilder()
+            .setAccountId(seedAccountId.getId())
+            .setId(java.util.UUID.randomUUID().toString())
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    connectorRepo.create(
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setDisplayName("legacy-conn")
+            .setKind(ConnectorKind.CK_UNITY)
+            .setUri("dummy://ignored")
+            .setState(ConnectorState.CS_ACTIVE)
+            .setSource(source(List.of("db")).toBuilder().setTable("orders").build())
+            .setDestination(dest("cat-legacy"))
+            .build());
+
+    var fetched =
+        connectors
+            .getConnector(GetConnectorRequest.newBuilder().setConnectorId(connectorId).build())
+            .getConnector();
+    assertFalse(fetched.hasSource());
+    assertFalse(fetched.hasDestination());
+    assertEquals(1, fetched.getMappingsCount());
+    assertEquals(
+        List.of("db"), fetched.getMappings(0).getSource().getNamespace().getSegmentsList());
+    assertEquals("orders", fetched.getMappings(0).getSource().getTable());
+    assertEquals("cat-legacy", fetched.getMappings(0).getDestination().getCatalogDisplayName());
+
+    var listed =
+        connectors
+            .listConnectors(ListConnectorsRequest.newBuilder().build())
+            .getConnectorsList()
+            .stream()
+            .filter(c -> c.getResourceId().getId().equals(connectorId.getId()))
+            .findFirst()
+            .orElseThrow();
+    assertFalse(listed.hasSource());
+    assertFalse(listed.hasDestination());
+    assertEquals(1, listed.getMappingsCount());
+    assertEquals("orders", listed.getMappings(0).getSource().getTable());
+  }
+
+  @Test
+  void multiMappingConnectorRoundTripsAllMappings() {
+    TestSupport.createCatalog(catalogService, "cat-multi", "");
+    var created =
+        TestSupport.createConnector(
+            connectors,
+            ConnectorSpec.newBuilder()
+                .setDisplayName("multi-mapping-conn")
+                .setKind(ConnectorKind.CK_UNITY)
+                .setUri("dummy://ignored")
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("db")))
+                        .setDestination(dest("cat-multi")))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("examples", "iceberg")))
+                        .setDestination(dest("cat-multi")))
+                .setAuth(AuthConfig.newBuilder().setScheme("none"))
+                .build());
+
+    assertEquals(2, created.getMappingsCount());
+
+    var fetched =
+        connectors
+            .getConnector(
+                GetConnectorRequest.newBuilder().setConnectorId(created.getResourceId()).build())
+            .getConnector();
+    assertFalse(fetched.hasSource());
+    assertFalse(fetched.hasDestination());
+    assertEquals(2, fetched.getMappingsCount());
+    assertEquals(
+        List.of("db"), fetched.getMappings(0).getSource().getNamespace().getSegmentsList());
+    assertEquals(
+        List.of("examples", "iceberg"),
+        fetched.getMappings(1).getSource().getNamespace().getSegmentsList());
+  }
+
   @Test
   void icebergConnectorRejectsSecretBearingPropertiesOnCreateAndUpdate() throws Exception {
     TestSupport.createCatalog(catalogService, "cat-iceberg-props", "");
@@ -2238,8 +2391,10 @@ public class ConnectorIT {
                                 .setDisplayName("iceberg-secret-props")
                                 .setKind(ConnectorKind.CK_ICEBERG)
                                 .setUri("s3://bucket/table/metadata/00001.metadata.json")
-                                .setSource(source(List.of("raw")))
-                                .setDestination(dest("cat-iceberg-props"))
+                                .addMappings(
+                                    SourceMapping.newBuilder()
+                                        .setSource(source(List.of("raw")))
+                                        .setDestination(dest("cat-iceberg-props")))
                                 .putProperties("iceberg.source", "filesystem")
                                 .putProperties("s3.secret-access-key", "should-not-store")
                                 .build())
@@ -2254,8 +2409,10 @@ public class ConnectorIT {
                 .setDisplayName("iceberg-safe-props")
                 .setKind(ConnectorKind.CK_ICEBERG)
                 .setUri("s3://bucket/table/metadata/00001.metadata.json")
-                .setSource(source(List.of("raw")))
-                .setDestination(dest("cat-iceberg-props"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("raw")))
+                        .setDestination(dest("cat-iceberg-props")))
                 .putProperties("iceberg.source", "filesystem")
                 .putProperties("s3.region", "us-east-1")
                 .build());
@@ -2288,8 +2445,10 @@ public class ConnectorIT {
                                 .setDisplayName("polaris-inline-s3-creds")
                                 .setKind(ConnectorKind.CK_ICEBERG)
                                 .setUri("http://polaris:8181/api/catalog")
-                                .setSource(source(List.of("sales")))
-                                .setDestination(dest("cat-polaris-props"))
+                                .addMappings(
+                                    SourceMapping.newBuilder()
+                                        .setSource(source(List.of("sales")))
+                                        .setDestination(dest("cat-polaris-props")))
                                 .putProperties("iceberg.source", "rest")
                                 .putProperties("rest.flavor", "polaris")
                                 .putProperties("warehouse", "quickstart_catalog")
@@ -2315,8 +2474,10 @@ public class ConnectorIT {
                                 .setDisplayName("delta-inline-s3-creds")
                                 .setKind(ConnectorKind.CK_DELTA)
                                 .setUri("dummy://x")
-                                .setSource(source(List.of("main", "tpcds")))
-                                .setDestination(dest("cat-delta-props"))
+                                .addMappings(
+                                    SourceMapping.newBuilder()
+                                        .setSource(source(List.of("main", "tpcds")))
+                                        .setDestination(dest("cat-delta-props")))
                                 .putProperties("delta.source", "unity")
                                 .putProperties("s3.access-key-id", "should-not-store")
                                 .build())
@@ -2340,8 +2501,10 @@ public class ConnectorIT {
                                 .setDisplayName("glue-inline-s3-creds")
                                 .setKind(ConnectorKind.CK_GLUE)
                                 .setUri("dummy://x")
-                                .setSource(source(List.of("main", "sales")))
-                                .setDestination(dest("cat-glue-props"))
+                                .addMappings(
+                                    SourceMapping.newBuilder()
+                                        .setSource(source(List.of("main", "sales")))
+                                        .setDestination(dest("cat-glue-props")))
                                 .putProperties("s3.access-key-id", "should-not-store")
                                 .build())
                         .build()));
@@ -2364,8 +2527,10 @@ public class ConnectorIT {
                                 .setDisplayName("unity-inline-s3-creds")
                                 .setKind(ConnectorKind.CK_UNITY)
                                 .setUri("dummy://x")
-                                .setSource(source(List.of("main", "sales")))
-                                .setDestination(dest("cat-unity-props"))
+                                .addMappings(
+                                    SourceMapping.newBuilder()
+                                        .setSource(source(List.of("main", "sales")))
+                                        .setDestination(dest("cat-unity-props")))
                                 .putProperties("s3.secret-access-key", "should-not-store")
                                 .build())
                         .build()));
@@ -2381,8 +2546,10 @@ public class ConnectorIT {
             .setDisplayName("idem-2")
             .setKind(ConnectorKind.CK_UNITY)
             .setUri("dummy://x")
-            .setSource(source(List.of("a", "b")))
-            .setDestination(dest("cat-idem-2"))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(source(List.of("a", "b")))
+                    .setDestination(dest("cat-idem-2")))
             .build();
 
     var specB =
@@ -2390,8 +2557,10 @@ public class ConnectorIT {
             .setDisplayName("idem-2")
             .setKind(ConnectorKind.CK_UNITY)
             .setUri("dummy://y")
-            .setSource(source(List.of("a", "b")))
-            .setDestination(dest("cat-idem-2"))
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(source(List.of("a", "b")))
+                    .setDestination(dest("cat-idem-2")))
             .build();
 
     var idem = IdempotencyKey.newBuilder().setKey("fixed-key-2").build();
@@ -2439,8 +2608,10 @@ public class ConnectorIT {
               .setDisplayName("p-" + i)
               .setKind(ConnectorKind.CK_UNITY)
               .setUri("dummy://x")
-              .setSource(source(List.of("a", "b")))
-              .setDestination(dest("cat-p"))
+              .addMappings(
+                  SourceMapping.newBuilder()
+                      .setSource(source(List.of("a", "b")))
+                      .setDestination(dest("cat-p")))
               .build());
     }
     String token = "";
@@ -2470,8 +2641,10 @@ public class ConnectorIT {
                 .setDisplayName("u-a")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://x")
-                .setSource(source(List.of("a", "b")))
-                .setDestination(dest("cat-u"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("a", "b")))
+                        .setDestination(dest("cat-u")))
                 .build());
 
     var b =
@@ -2481,8 +2654,10 @@ public class ConnectorIT {
                 .setDisplayName("u-b")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://x")
-                .setSource(source(List.of("a", "b")))
-                .setDestination(dest("cat-u"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("a", "b")))
+                        .setDestination(dest("cat-u")))
                 .build());
 
     // rename u-a -> u-a1
@@ -2522,8 +2697,10 @@ public class ConnectorIT {
                 .setDisplayName("pre-a")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://x")
-                .setSource(source(List.of("a", "b")))
-                .setDestination(dest("cat-pre"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("a", "b")))
+                        .setDestination(dest("cat-pre")))
                 .build());
 
     FieldMask mask = FieldMask.newBuilder().addPaths("uri").build();
@@ -2559,8 +2736,10 @@ public class ConnectorIT {
                                 .setDisplayName("policy-create-invalid")
                                 .setKind(ConnectorKind.CK_UNITY)
                                 .setUri("dummy://x")
-                                .setSource(source(List.of("a", "b")))
-                                .setDestination(dest("cat-policy-create"))
+                                .addMappings(
+                                    SourceMapping.newBuilder()
+                                        .setSource(source(List.of("a", "b")))
+                                        .setDestination(dest("cat-policy-create")))
                                 .setPolicy(
                                     ReconcilePolicy.newBuilder()
                                         .setScope(ReconcileSnapshotScope.RSS_LATEST_N)
@@ -2582,8 +2761,10 @@ public class ConnectorIT {
                 .setDisplayName("policy-update-invalid")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://x")
-                .setSource(source(List.of("a", "b")))
-                .setDestination(dest("cat-policy-update"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("a", "b")))
+                        .setDestination(dest("cat-policy-update")))
                 .build());
 
     var ex =
@@ -2617,8 +2798,10 @@ public class ConnectorIT {
                 .setDisplayName("del-1")
                 .setKind(ConnectorKind.CK_UNITY)
                 .setUri("dummy://x")
-                .setSource(source(List.of("a", "b")))
-                .setDestination(dest("cat-del"))
+                .addMappings(
+                    SourceMapping.newBuilder()
+                        .setSource(source(List.of("a", "b")))
+                        .setDestination(dest("cat-del")))
                 .build());
 
     connectors.deleteConnector(
@@ -2676,7 +2859,7 @@ public class ConnectorIT {
                         .setDisplayName("v-ok")
                         .setKind(ConnectorKind.CK_UNITY)
                         .setUri("dummy://x")
-                        .setDestination(dest("cat-v")))
+                        .addMappings(SourceMapping.newBuilder().setDestination(dest("cat-v"))))
                 .build());
     assertTrue(ok.getOk());
 
@@ -2691,7 +2874,8 @@ public class ConnectorIT {
                                 .setDisplayName("v-bad")
                                 .setKind(ConnectorKind.CK_UNSPECIFIED)
                                 .setUri("dummy://x")
-                                .setDestination(dest("cat-v")))
+                                .addMappings(
+                                    SourceMapping.newBuilder().setDestination(dest("cat-v"))))
                         .build()));
 
     TestSupport.assertGrpcAndMc(

--- a/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
@@ -356,8 +356,7 @@ class QueryScanServiceIT {
             .setDisplayName("qs-" + suffix)
             .setKind(ConnectorKind.CK_UNITY)
             .setUri("dummy://ignored")
-            .setSource(source)
-            .setDestination(destination)
+            .addMappings(SourceMapping.newBuilder().setSource(source).setDestination(destination))
             .setAuth(AuthConfig.newBuilder().setScheme("none"))
             .build();
 

--- a/service/src/test/java/ai/floedb/floecat/service/it/StatsOrchestratorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/StatsOrchestratorIT.java
@@ -357,8 +357,7 @@ class StatsOrchestratorIT {
             .setDisplayName(PREFIX + suffix)
             .setKind(ConnectorKind.CK_UNITY)
             .setUri("dummy://ignored")
-            .setSource(source)
-            .setDestination(destination)
+            .addMappings(SourceMapping.newBuilder().setSource(source).setDestination(destination))
             .setAuth(AuthConfig.newBuilder().setScheme("none"))
             .build();
     return TestSupport.createConnector(connectors, spec);

--- a/service/src/test/java/ai/floedb/floecat/service/it/UserObjectsServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/UserObjectsServiceIT.java
@@ -409,8 +409,7 @@ class UserObjectsServiceIT {
             .setDisplayName("qc-" + suffix)
             .setKind(ConnectorKind.CK_UNITY)
             .setUri("dummy://ignored")
-            .setSource(source)
-            .setDestination(destination)
+            .addMappings(SourceMapping.newBuilder().setSource(source).setDestination(destination))
             .setAuth(AuthConfig.newBuilder().setScheme("none"))
             .build();
 

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/ConnectorRepositoryNormalizeTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/ConnectorRepositoryNormalizeTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceMapping;
+import ai.floedb.floecat.connector.rpc.SourceSelector;
+import org.junit.jupiter.api.Test;
+
+class ConnectorRepositoryNormalizeTest {
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void legacyOnlyConnectorIsNormalizedIntoSingleMapping() {
+    Connector legacy =
+        Connector.newBuilder()
+            .setSource(
+                SourceSelector.newBuilder()
+                    .setNamespace(NamespacePath.newBuilder().addSegments("db"))
+                    .setTable("orders")
+                    .addColumns("order_id"))
+            .setDestination(
+                DestinationTarget.newBuilder().setCatalogId(ResourceId.newBuilder().setId("cat-1")))
+            .build();
+
+    Connector normalized = ConnectorRepository.normalizeLegacyMapping(legacy);
+
+    assertThat(normalized.hasSource()).isFalse();
+    assertThat(normalized.hasDestination()).isFalse();
+    assertThat(normalized.getMappingsCount()).isEqualTo(1);
+    SourceMapping mapping = normalized.getMappings(0);
+    assertThat(mapping.getSource().getNamespace().getSegmentsList()).containsExactly("db");
+    assertThat(mapping.getSource().getTable()).isEqualTo("orders");
+    assertThat(mapping.getSource().getColumnsList()).containsExactly("order_id");
+    assertThat(mapping.getDestination().getCatalogId().getId()).isEqualTo("cat-1");
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void legacySourceOnlyConnectorIsNormalizedIntoSingleMapping() {
+    Connector legacy =
+        Connector.newBuilder()
+            .setSource(
+                SourceSelector.newBuilder()
+                    .setNamespace(NamespacePath.newBuilder().addSegments("db"))
+                    .setTable("orders"))
+            .build();
+
+    Connector normalized = ConnectorRepository.normalizeLegacyMapping(legacy);
+
+    assertThat(normalized.hasSource()).isFalse();
+    assertThat(normalized.hasDestination()).isFalse();
+    assertThat(normalized.getMappingsCount()).isEqualTo(1);
+    SourceMapping mapping = normalized.getMappings(0);
+    assertThat(mapping.getSource().getNamespace().getSegmentsList()).containsExactly("db");
+    assertThat(mapping.getSource().getTable()).isEqualTo("orders");
+    assertThat(mapping.getDestination()).isEqualTo(DestinationTarget.getDefaultInstance());
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void legacyDestinationOnlyConnectorIsNormalizedIntoSingleMapping() {
+    Connector legacy =
+        Connector.newBuilder()
+            .setDestination(
+                DestinationTarget.newBuilder().setCatalogId(ResourceId.newBuilder().setId("cat-1")))
+            .build();
+
+    Connector normalized = ConnectorRepository.normalizeLegacyMapping(legacy);
+
+    assertThat(normalized.hasSource()).isFalse();
+    assertThat(normalized.hasDestination()).isFalse();
+    assertThat(normalized.getMappingsCount()).isEqualTo(1);
+    SourceMapping mapping = normalized.getMappings(0);
+    assertThat(mapping.getSource()).isEqualTo(SourceSelector.getDefaultInstance());
+    assertThat(mapping.getDestination().getCatalogId().getId()).isEqualTo("cat-1");
+  }
+
+  @Test
+  void mappingsConnectorPassesThroughUnchanged() {
+    Connector connector =
+        Connector.newBuilder()
+            .addMappings(
+                SourceMapping.newBuilder()
+                    .setSource(
+                        SourceSelector.newBuilder()
+                            .setNamespace(NamespacePath.newBuilder().addSegments("db"))))
+            .build();
+
+    assertThat(ConnectorRepository.normalizeLegacyMapping(connector)).isSameAs(connector);
+  }
+
+  @Test
+  void shellConnectorWithoutSourceOrMappingsPassesThrough() {
+    Connector shell = Connector.newBuilder().setDisplayName("shell").build();
+
+    assertThat(ConnectorRepository.normalizeLegacyMapping(shell)).isSameAs(shell);
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
@@ -983,8 +983,10 @@ class TransactionsServiceImplTest {
     assertEquals("s3://warehouse/db/orders", connector.getUri());
     assertEquals("register:pref:db.orders", connector.getDisplayName());
     assertEquals("Filesystem connector", connector.getDescription());
-    assertEquals(List.of("db"), connector.getSource().getNamespace().getSegmentsList());
-    assertEquals("orders", connector.getSource().getTable());
+    assertEquals(1, connector.getMappingsCount());
+    assertEquals(
+        List.of("db"), connector.getMappings(0).getSource().getNamespace().getSegmentsList());
+    assertEquals("orders", connector.getMappings(0).getSource().getTable());
     assertEquals("filesystem", connector.getPropertiesOrThrow("iceberg.source"));
     assertEquals("us-east-1", connector.getPropertiesOrThrow("s3.region"));
     assertNotNull(connector.getResourceId());


### PR DESCRIPTION
## Summary

Update the connector configuration to support a list of source/destination pairs, enabling multiple namespace/table mappings to be configured from a single connector, as required by the web application. The existing source and destination fields are retained for backward compatibility with existing tools.

This change also allows connectors to be created without an initial source or destination. In this case, the connector is created in the CS_CREATING state and should not be reconciled until its configuration is complete.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [ ] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

