### PR TITLE
FM3: Add per-account snapshot sequence number

### DIFF
--- a/core/proto/src/main/proto/floecat/catalog/snapshot.proto
+++ b/core/proto/src/main/proto/floecat/catalog/snapshot.proto
@@ -64,6 +64,11 @@ message GetSnapshotResponse {
   Snapshot snapshot = 1;
 }
 
+message GetSnapshotCreateSequenceRequest {}
+message GetSnapshotCreateSequenceResponse {
+  int64 current_account_create_sequence = 1;
+}
+
 message GetCurrentSnapshotPointerRequest {
   ai.floedb.floecat.common.ResourceId table_id = 1;
 }
@@ -119,6 +124,8 @@ message UpdateSnapshotResponse {
 service SnapshotService {
   rpc ListSnapshots(ListSnapshotsRequest) returns (ListSnapshotsResponse);
   rpc GetSnapshot(GetSnapshotRequest) returns (GetSnapshotResponse);
+  rpc GetSnapshotCreateSequence(GetSnapshotCreateSequenceRequest)
+      returns (GetSnapshotCreateSequenceResponse);
   rpc GetCurrentSnapshotPointer(GetCurrentSnapshotPointerRequest)
       returns (GetCurrentSnapshotPointerResponse);
   rpc CreateSnapshot(CreateSnapshotRequest) returns (CreateSnapshotResponse);

--- a/core/proto/src/main/proto/floecat/catalog/snapshot.proto
+++ b/core/proto/src/main/proto/floecat/catalog/snapshot.proto
@@ -64,9 +64,11 @@ message GetSnapshotResponse {
   Snapshot snapshot = 1;
 }
 
-message GetSnapshotCreateSequenceRequest {}
-message GetSnapshotCreateSequenceResponse {
-  int64 current_account_create_sequence = 1;
+message GetSnapshotCreateCounterRequest {}
+message GetSnapshotCreateCounterResponse {
+  // Account-scoped high-water counter for committed snapshot creates.
+  // This is not stored on snapshot blobs and is not a per-snapshot field.
+  int64 current_account_snapshot_create_counter = 1;
 }
 
 message GetCurrentSnapshotPointerRequest {
@@ -124,8 +126,8 @@ message UpdateSnapshotResponse {
 service SnapshotService {
   rpc ListSnapshots(ListSnapshotsRequest) returns (ListSnapshotsResponse);
   rpc GetSnapshot(GetSnapshotRequest) returns (GetSnapshotResponse);
-  rpc GetSnapshotCreateSequence(GetSnapshotCreateSequenceRequest)
-      returns (GetSnapshotCreateSequenceResponse);
+  rpc GetSnapshotCreateCounter(GetSnapshotCreateCounterRequest)
+      returns (GetSnapshotCreateCounterResponse);
   rpc GetCurrentSnapshotPointer(GetCurrentSnapshotPointerRequest)
       returns (GetCurrentSnapshotPointerResponse);
   rpc CreateSnapshot(CreateSnapshotRequest) returns (CreateSnapshotResponse);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
@@ -24,8 +24,8 @@ import ai.floedb.floecat.catalog.rpc.DeleteSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.DeleteSnapshotResponse;
 import ai.floedb.floecat.catalog.rpc.GetCurrentSnapshotPointerRequest;
 import ai.floedb.floecat.catalog.rpc.GetCurrentSnapshotPointerResponse;
-import ai.floedb.floecat.catalog.rpc.GetSnapshotCreateSequenceRequest;
-import ai.floedb.floecat.catalog.rpc.GetSnapshotCreateSequenceResponse;
+import ai.floedb.floecat.catalog.rpc.GetSnapshotCreateCounterRequest;
+import ai.floedb.floecat.catalog.rpc.GetSnapshotCreateCounterResponse;
 import ai.floedb.floecat.catalog.rpc.GetSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.GetSnapshotResponse;
 import ai.floedb.floecat.catalog.rpc.ListSnapshotsRequest;
@@ -184,9 +184,9 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
   }
 
   @Override
-  public Uni<GetSnapshotCreateSequenceResponse> getSnapshotCreateSequence(
-      GetSnapshotCreateSequenceRequest request) {
-    var L = LogHelper.start(LOG, "GetSnapshotCreateSequence");
+  public Uni<GetSnapshotCreateCounterResponse> getSnapshotCreateCounter(
+      GetSnapshotCreateCounterRequest request) {
+    var L = LogHelper.start(LOG, "GetSnapshotCreateCounter");
 
     return mapFailures(
             run(
@@ -195,9 +195,9 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
                   authz.require(principalContext, "table.read");
 
                   String accountId = principalContext.getAccountId();
-                  return GetSnapshotCreateSequenceResponse.newBuilder()
-                      .setCurrentAccountCreateSequence(
-                          snapshotRepo.currentCreateSequence(accountId))
+                  return GetSnapshotCreateCounterResponse.newBuilder()
+                      .setCurrentAccountSnapshotCreateCounter(
+                          snapshotRepo.currentSnapshotCreateCounter(accountId))
                       .build();
                 }),
             correlationId())

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
@@ -24,6 +24,8 @@ import ai.floedb.floecat.catalog.rpc.DeleteSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.DeleteSnapshotResponse;
 import ai.floedb.floecat.catalog.rpc.GetCurrentSnapshotPointerRequest;
 import ai.floedb.floecat.catalog.rpc.GetCurrentSnapshotPointerResponse;
+import ai.floedb.floecat.catalog.rpc.GetSnapshotCreateSequenceRequest;
+import ai.floedb.floecat.catalog.rpc.GetSnapshotCreateSequenceResponse;
 import ai.floedb.floecat.catalog.rpc.GetSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.GetSnapshotResponse;
 import ai.floedb.floecat.catalog.rpc.ListSnapshotsRequest;
@@ -172,6 +174,30 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
                   return ListSnapshotsResponse.newBuilder()
                       .addAllSnapshots(snaps)
                       .setPage(page)
+                      .build();
+                }),
+            correlationId())
+        .onFailure()
+        .invoke(L::fail)
+        .onItem()
+        .invoke(L::ok);
+  }
+
+  @Override
+  public Uni<GetSnapshotCreateSequenceResponse> getSnapshotCreateSequence(
+      GetSnapshotCreateSequenceRequest request) {
+    var L = LogHelper.start(LOG, "GetSnapshotCreateSequence");
+
+    return mapFailures(
+            run(
+                () -> {
+                  var principalContext = principal.get();
+                  authz.require(principalContext, "table.read");
+
+                  String accountId = principalContext.getAccountId();
+                  return GetSnapshotCreateSequenceResponse.newBuilder()
+                      .setCurrentAccountCreateSequence(
+                          snapshotRepo.currentCreateSequence(accountId))
                       .build();
                 }),
             correlationId())

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotCreateCounterStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotCreateCounterStore.java
@@ -30,29 +30,29 @@ import java.util.Map;
 import java.util.Objects;
 
 @ApplicationScoped
-public class SnapshotCreateSequenceStore {
-  private static final String STATE_PREFIX = "seq:";
+public class SnapshotCreateCounterStore {
+  private static final String STATE_PREFIX = "counter:";
 
   private final PointerStore pointerStore;
 
   @Inject
-  public SnapshotCreateSequenceStore(PointerStore pointerStore) {
+  public SnapshotCreateCounterStore(PointerStore pointerStore) {
     this.pointerStore = Objects.requireNonNull(pointerStore, "pointerStore");
   }
 
-  public record CreateTarget(String accountId) {}
+  public record CreateIncrement(String accountId) {}
 
-  public List<PointerStore.CasOp> planCreateOps(List<CreateTarget> targets) {
-    if (targets == null || targets.isEmpty()) {
+  public List<PointerStore.CasOp> planIncrementOps(List<CreateIncrement> increments) {
+    if (increments == null || increments.isEmpty()) {
       return List.of();
     }
 
     Map<String, Integer> createsByAccount = new LinkedHashMap<>();
-    for (CreateTarget target : targets) {
-      if (target == null) {
+    for (CreateIncrement increment : increments) {
+      if (increment == null) {
         continue;
       }
-      createsByAccount.merge(target.accountId(), 1, Integer::sum);
+      createsByAccount.merge(increment.accountId(), 1, Integer::sum);
     }
 
     List<PointerStore.CasOp> ops = new ArrayList<>();
@@ -63,45 +63,45 @@ public class SnapshotCreateSequenceStore {
         continue;
       }
 
-      String stateKey = Keys.snapshotCreateSequenceStatePointer(accountId);
+      String stateKey = Keys.snapshotCreateCounterStatePointer(accountId);
       Pointer state = pointerStore.get(stateKey).orElse(null);
       long expectedVersion = state == null ? 0L : state.getVersion();
-      long lastSequence = state == null ? 0L : parseStateSequence(state, stateKey);
-      long nextLastSequence = lastSequence + createCount;
+      long currentCounter = state == null ? 0L : parseStateCounter(state, stateKey);
+      long nextCounter = currentCounter + createCount;
 
       ops.add(
           new PointerStore.CasUpsert(
               stateKey,
               expectedVersion,
               PointerReferences.opaqueMarkerPointer(
-                  stateKey, STATE_PREFIX + nextLastSequence, expectedVersion + 1L)));
+                  stateKey, STATE_PREFIX + nextCounter, expectedVersion + 1L)));
     }
     return ops;
   }
 
-  public long currentSequence(String accountId) {
-    String stateKey = Keys.snapshotCreateSequenceStatePointer(accountId);
+  public long currentCounter(String accountId) {
+    String stateKey = Keys.snapshotCreateCounterStatePointer(accountId);
     return pointerStore
         .get(stateKey)
-        .map(pointer -> parseStateSequence(pointer, stateKey))
+        .map(pointer -> parseStateCounter(pointer, stateKey))
         .orElse(0L);
   }
 
-  private static long parseStateSequence(Pointer pointer, String stateKey) {
+  private static long parseStateCounter(Pointer pointer, String stateKey) {
     if (!PointerReferences.isOpaqueMarkerPointer(pointer)) {
       throw new BaseResourceRepository.CorruptionException(
-          "snapshot create sequence state has wrong pointer kind: " + stateKey);
+          "snapshot create counter state has wrong pointer kind: " + stateKey);
     }
     String payload = pointer.getBlobUri();
     if (payload == null || !payload.startsWith(STATE_PREFIX)) {
       throw new BaseResourceRepository.CorruptionException(
-          "snapshot create sequence state has invalid payload: " + stateKey);
+          "snapshot create counter state has invalid payload: " + stateKey);
     }
     try {
       return Long.parseLong(payload.substring(STATE_PREFIX.length()));
     } catch (NumberFormatException e) {
       throw new BaseResourceRepository.CorruptionException(
-          "snapshot create sequence state is not numeric: " + stateKey, e);
+          "snapshot create counter state is not numeric: " + stateKey, e);
     }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotCreateSequenceStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotCreateSequenceStore.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@ApplicationScoped
+public class SnapshotCreateSequenceStore {
+  private static final String STATE_PREFIX = "seq:";
+
+  private final PointerStore pointerStore;
+
+  @Inject
+  public SnapshotCreateSequenceStore(PointerStore pointerStore) {
+    this.pointerStore = Objects.requireNonNull(pointerStore, "pointerStore");
+  }
+
+  public record CreateTarget(String accountId) {}
+
+  public List<PointerStore.CasOp> planCreateOps(List<CreateTarget> targets) {
+    if (targets == null || targets.isEmpty()) {
+      return List.of();
+    }
+
+    Map<String, Integer> createsByAccount = new LinkedHashMap<>();
+    for (CreateTarget target : targets) {
+      if (target == null) {
+        continue;
+      }
+      createsByAccount.merge(target.accountId(), 1, Integer::sum);
+    }
+
+    List<PointerStore.CasOp> ops = new ArrayList<>();
+    for (Map.Entry<String, Integer> entry : createsByAccount.entrySet()) {
+      String accountId = entry.getKey();
+      int createCount = entry.getValue();
+      if (createCount <= 0) {
+        continue;
+      }
+
+      String stateKey = Keys.snapshotCreateSequenceStatePointer(accountId);
+      Pointer state = pointerStore.get(stateKey).orElse(null);
+      long expectedVersion = state == null ? 0L : state.getVersion();
+      long lastSequence = state == null ? 0L : parseStateSequence(state, stateKey);
+      long nextLastSequence = lastSequence + createCount;
+
+      ops.add(
+          new PointerStore.CasUpsert(
+              stateKey,
+              expectedVersion,
+              PointerReferences.opaqueMarkerPointer(
+                  stateKey, STATE_PREFIX + nextLastSequence, expectedVersion + 1L)));
+    }
+    return ops;
+  }
+
+  public long currentSequence(String accountId) {
+    String stateKey = Keys.snapshotCreateSequenceStatePointer(accountId);
+    return pointerStore
+        .get(stateKey)
+        .map(pointer -> parseStateSequence(pointer, stateKey))
+        .orElse(0L);
+  }
+
+  private static long parseStateSequence(Pointer pointer, String stateKey) {
+    if (!PointerReferences.isOpaqueMarkerPointer(pointer)) {
+      throw new BaseResourceRepository.CorruptionException(
+          "snapshot create sequence state has wrong pointer kind: " + stateKey);
+    }
+    String payload = pointer.getBlobUri();
+    if (payload == null || !payload.startsWith(STATE_PREFIX)) {
+      throw new BaseResourceRepository.CorruptionException(
+          "snapshot create sequence state has invalid payload: " + stateKey);
+    }
+    try {
+      return Long.parseLong(payload.substring(STATE_PREFIX.length()));
+    } catch (NumberFormatException e) {
+      throw new BaseResourceRepository.CorruptionException(
+          "snapshot create sequence state is not numeric: " + stateKey, e);
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
@@ -19,8 +19,10 @@ package ai.floedb.floecat.service.repo.impl;
 import ai.floedb.floecat.catalog.rpc.CurrentSnapshotPointer;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.model.SnapshotKey;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
@@ -28,11 +30,14 @@ import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import ai.floedb.floecat.telemetry.StoreOperationSummary;
+import ai.floedb.floecat.types.Hashing;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Clock;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -51,6 +56,8 @@ public class SnapshotRepository {
   }
 
   private final GenericResourceRepository<Snapshot, SnapshotKey> repo;
+  private final PointerStore pointerStore;
+  private final SnapshotCreateSequenceStore createSequences;
   private final TableRepository tableRepo;
   private final CurrentSnapshotPointerRepository currentPointerRepo;
   private final Clock clock;
@@ -69,6 +76,8 @@ public class SnapshotRepository {
             Snapshot::parseFrom,
             Snapshot::toByteArray,
             "application/x-protobuf");
+    this.pointerStore = pointerStore;
+    this.createSequences = new SnapshotCreateSequenceStore(pointerStore);
     this.tableRepo = tableRepo;
     this.currentPointerRepo = currentPointerRepo;
     this.clock = Clock.systemUTC();
@@ -97,13 +106,49 @@ public class SnapshotRepository {
             Snapshot::parseFrom,
             Snapshot::toByteArray,
             "application/x-protobuf");
+    this.pointerStore = pointerStore;
+    this.createSequences = new SnapshotCreateSequenceStore(pointerStore);
     this.tableRepo = tableRepo;
     this.currentPointerRepo = currentPointerRepo;
     this.clock = clock;
   }
 
   public void create(Snapshot snapshot) {
-    repo.create(snapshot);
+    String blobUri = snapshotBlobUri(snapshot);
+    repo.putBlob(blobUri, snapshot);
+
+    List<String> snapshotPointerKeys = snapshotPointerKeys(snapshot);
+    for (int attempt = 0; attempt < BaseResourceRepository.CAS_MAX; attempt++) {
+      List<PointerStore.CasOp> ops = new ArrayList<>(snapshotPointerKeys.size() + 1);
+      for (String pointerKey : snapshotPointerKeys) {
+        ops.add(new PointerStore.CasUpsert(pointerKey, 0L, snapshotPointer(pointerKey, blobUri)));
+      }
+      ops.addAll(
+          createSequences.planCreateOps(
+              List.of(
+                  new SnapshotCreateSequenceStore.CreateTarget(
+                      snapshot.getTableId().getAccountId()))));
+
+      if (pointerStore.compareAndSetBatch(ops)) {
+        return;
+      }
+      try {
+        classifySnapshotCreateConflict(blobUri, snapshotPointerKeys);
+      } catch (BaseResourceRepository.AbortRetryableException e) {
+        if (attempt + 1 >= BaseResourceRepository.CAS_MAX) {
+          throw e;
+        }
+        backoffCurrentPointerAdvance(attempt);
+        continue;
+      }
+      return;
+    }
+    throw new BaseResourceRepository.AbortRetryableException(
+        "snapshot create sequence conflict for: "
+            + Keys.snapshotPointerById(
+                snapshot.getTableId().getAccountId(),
+                snapshot.getTableId().getId(),
+                snapshot.getSnapshotId()));
   }
 
   public boolean update(Snapshot snapshot, long expectedPointerVersion) {
@@ -340,6 +385,10 @@ public class SnapshotRepository {
     return repo.listByPrefix(prefix, limit, pageToken, nextOut);
   }
 
+  public long currentCreateSequence(String accountId) {
+    return createSequences.currentSequence(accountId);
+  }
+
   public int count(ResourceId tableId) {
     String prefix = Keys.snapshotPointerByIdPrefix(tableId.getAccountId(), tableId.getId());
     return repo.countByPrefix(prefix);
@@ -386,5 +435,67 @@ public class SnapshotRepository {
     } while (!token.isEmpty());
 
     return Optional.ofNullable(best);
+  }
+
+  private static String snapshotBlobUri(Snapshot snapshot) {
+    byte[] bytes = snapshot.toByteArray();
+    return Keys.snapshotBlobUri(
+        snapshot.getTableId().getAccountId(),
+        snapshot.getTableId().getId(),
+        snapshot.getSnapshotId(),
+        Hashing.sha256Hex(bytes));
+  }
+
+  private static Pointer snapshotPointer(String pointerKey, String blobUri) {
+    return PointerReferences.blobPointer(pointerKey, blobUri, 1L);
+  }
+
+  private static List<String> snapshotPointerKeys(Snapshot snapshot) {
+    long upstreamCreatedAtMs =
+        snapshot.hasUpstreamCreatedAt() ? Timestamps.toMillis(snapshot.getUpstreamCreatedAt()) : 0L;
+    LinkedHashSet<String> keys = new LinkedHashSet<>();
+    keys.add(
+        Keys.snapshotPointerById(
+            snapshot.getTableId().getAccountId(),
+            snapshot.getTableId().getId(),
+            snapshot.getSnapshotId()));
+    keys.add(
+        Keys.snapshotPointerByTime(
+            snapshot.getTableId().getAccountId(),
+            snapshot.getTableId().getId(),
+            snapshot.getSnapshotId(),
+            upstreamCreatedAtMs));
+    return List.copyOf(keys);
+  }
+
+  private void classifySnapshotCreateConflict(String blobUri, List<String> pointerKeys) {
+    int present = 0;
+    int absent = 0;
+    for (String pointerKey : pointerKeys) {
+      Pointer pointer = pointerStore.get(pointerKey).orElse(null);
+      if (pointer == null) {
+        absent++;
+        continue;
+      }
+      if (!blobUri.equals(pointer.getBlobUri())) {
+        throw new BaseResourceRepository.NameConflictException(
+            "pointer bound to different blob: " + pointerKey);
+      }
+      present++;
+    }
+    if (absent == 0) {
+      return;
+    }
+    if (present == 0) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "snapshot create conflict, no snapshot pointer present: " + pointerKeys.get(0));
+    }
+    throw new BaseResourceRepository.CorruptionException(
+        "partial snapshot create state ("
+            + present
+            + " present, "
+            + absent
+            + " absent) for: "
+            + pointerKeys);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
@@ -57,7 +57,7 @@ public class SnapshotRepository {
 
   private final GenericResourceRepository<Snapshot, SnapshotKey> repo;
   private final PointerStore pointerStore;
-  private final SnapshotCreateSequenceStore createSequences;
+  private final SnapshotCreateCounterStore createCounters;
   private final TableRepository tableRepo;
   private final CurrentSnapshotPointerRepository currentPointerRepo;
   private final Clock clock;
@@ -77,7 +77,7 @@ public class SnapshotRepository {
             Snapshot::toByteArray,
             "application/x-protobuf");
     this.pointerStore = pointerStore;
-    this.createSequences = new SnapshotCreateSequenceStore(pointerStore);
+    this.createCounters = new SnapshotCreateCounterStore(pointerStore);
     this.tableRepo = tableRepo;
     this.currentPointerRepo = currentPointerRepo;
     this.clock = Clock.systemUTC();
@@ -107,7 +107,7 @@ public class SnapshotRepository {
             Snapshot::toByteArray,
             "application/x-protobuf");
     this.pointerStore = pointerStore;
-    this.createSequences = new SnapshotCreateSequenceStore(pointerStore);
+    this.createCounters = new SnapshotCreateCounterStore(pointerStore);
     this.tableRepo = tableRepo;
     this.currentPointerRepo = currentPointerRepo;
     this.clock = clock;
@@ -124,9 +124,9 @@ public class SnapshotRepository {
         ops.add(new PointerStore.CasUpsert(pointerKey, 0L, snapshotPointer(pointerKey, blobUri)));
       }
       ops.addAll(
-          createSequences.planCreateOps(
+          createCounters.planIncrementOps(
               List.of(
-                  new SnapshotCreateSequenceStore.CreateTarget(
+                  new SnapshotCreateCounterStore.CreateIncrement(
                       snapshot.getTableId().getAccountId()))));
 
       if (pointerStore.compareAndSetBatch(ops)) {
@@ -144,7 +144,7 @@ public class SnapshotRepository {
       return;
     }
     throw new BaseResourceRepository.AbortRetryableException(
-        "snapshot create sequence conflict for: "
+        "snapshot create counter conflict for: "
             + Keys.snapshotPointerById(
                 snapshot.getTableId().getAccountId(),
                 snapshot.getTableId().getId(),
@@ -385,8 +385,8 @@ public class SnapshotRepository {
     return repo.listByPrefix(prefix, limit, pageToken, nextOut);
   }
 
-  public long currentCreateSequence(String accountId) {
-    return createSequences.currentSequence(accountId);
+  public long currentSnapshotCreateCounter(String accountId) {
+    return createCounters.currentCounter(accountId);
   }
 
   public int count(ResourceId tableId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -485,7 +485,7 @@ public final class Keys {
     return String.format("/accounts/%s/tables/%s/snapshots/by-time/", encode(tid), encode(tbid));
   }
 
-  public static String snapshotCreateSequenceStatePointer(String accountId) {
+  public static String snapshotCreateCounterStatePointer(String accountId) {
     String tid = req("account_id", accountId);
     return String.format("/accounts/%s/snapshots/creates/state", encode(tid));
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -485,6 +485,11 @@ public final class Keys {
     return String.format("/accounts/%s/tables/%s/snapshots/by-time/", encode(tid), encode(tbid));
   }
 
+  public static String snapshotCreateSequenceStatePointer(String accountId) {
+    String tid = req("account_id", accountId);
+    return String.format("/accounts/%s/snapshots/creates/state", encode(tid));
+  }
+
   public static String snapshotBlobUri(
       String accountId, String tableId, long snapshotId, String sha256) {
     String tid = req("account_id", accountId);

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
@@ -23,7 +23,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.service.catalog.impl.surface.CatalogSurfaceWritePolicy;
-import ai.floedb.floecat.service.repo.impl.SnapshotCreateSequenceStore;
+import ai.floedb.floecat.service.repo.impl.SnapshotCreateCounterStore;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
@@ -89,7 +89,7 @@ public class TransactionIntentApplierSupport {
   @Inject PointerStore pointerStore;
   @Inject BlobStore blobStore;
   @Inject CatalogOverlay overlay;
-  @Inject SnapshotCreateSequenceStore snapshotCreateSequenceStore;
+  @Inject SnapshotCreateCounterStore snapshotCreateCounterStore;
 
   public boolean isTableByIdPointer(String pointerKey) {
     return pointerKey != null && pointerKey.contains("/tables/by-id/");
@@ -281,9 +281,9 @@ public class TransactionIntentApplierSupport {
       }
     }
 
-    ApplyOutcome sequenceOutcome = appendSnapshotCreateSequenceOps(intents, touchedKeys, ops);
-    if (sequenceOutcome.status != ApplyStatus.APPLIED) {
-      return sequenceOutcome;
+    ApplyOutcome counterOutcome = appendSnapshotCreateCounterOps(intents, touchedKeys, ops);
+    if (counterOutcome.status != ApplyStatus.APPLIED) {
+      return counterOutcome;
     }
     if (ops.size() > MAX_POINTER_TXN_OPS) {
       return ApplyOutcome.conflict(
@@ -342,9 +342,9 @@ public class TransactionIntentApplierSupport {
       }
     }
 
-    ApplyOutcome sequenceOutcome = appendSnapshotCreateSequenceOps(intents, touchedKeys, ops);
-    if (sequenceOutcome.status != ApplyStatus.APPLIED) {
-      return sequenceOutcome;
+    ApplyOutcome counterOutcome = appendSnapshotCreateCounterOps(intents, touchedKeys, ops);
+    if (counterOutcome.status != ApplyStatus.APPLIED) {
+      return counterOutcome;
     }
     if (ops.size() > MAX_POINTER_TXN_OPS - 1) {
       return ApplyOutcome.conflict(
@@ -1021,9 +1021,9 @@ public class TransactionIntentApplierSupport {
     return null;
   }
 
-  private ApplyOutcome appendSnapshotCreateSequenceOps(
+  private ApplyOutcome appendSnapshotCreateCounterOps(
       List<TransactionIntent> intents, Set<String> touchedKeys, List<PointerStore.CasOp> ops) {
-    List<SnapshotCreateSequenceStore.CreateTarget> targets = new ArrayList<>();
+    List<SnapshotCreateCounterStore.CreateIncrement> increments = new ArrayList<>();
     Set<String> seenSnapshotPointers = new HashSet<>();
     for (TransactionIntent intent : intents) {
       if (intent == null || !isSnapshotByIdPointer(intent.getTargetPointerKey())) {
@@ -1057,14 +1057,14 @@ public class TransactionIntentApplierSupport {
       if (!seenSnapshotPointers.add(expectedPointerKey)) {
         continue;
       }
-      targets.add(
-          new SnapshotCreateSequenceStore.CreateTarget(snapshot.getTableId().getAccountId()));
+      increments.add(
+          new SnapshotCreateCounterStore.CreateIncrement(snapshot.getTableId().getAccountId()));
     }
-    if (targets.isEmpty()) {
+    if (increments.isEmpty()) {
       return ApplyOutcome.applied();
     }
 
-    for (PointerStore.CasOp op : snapshotCreateSequences().planCreateOps(targets)) {
+    for (PointerStore.CasOp op : snapshotCreateCounters().planIncrementOps(increments)) {
       ApplyOutcome outcome = addOp(op, casOpKey(op), touchedKeys, ops);
       if (outcome.status != ApplyStatus.APPLIED) {
         return outcome;
@@ -1073,10 +1073,10 @@ public class TransactionIntentApplierSupport {
     return ApplyOutcome.applied();
   }
 
-  private SnapshotCreateSequenceStore snapshotCreateSequences() {
-    return snapshotCreateSequenceStore != null
-        ? snapshotCreateSequenceStore
-        : new SnapshotCreateSequenceStore(pointerStore);
+  private SnapshotCreateCounterStore snapshotCreateCounters() {
+    return snapshotCreateCounterStore != null
+        ? snapshotCreateCounterStore
+        : new SnapshotCreateCounterStore(pointerStore);
   }
 
   private boolean isSnapshotByIdPointer(String pointerKey) {

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
@@ -16,12 +16,14 @@
 
 package ai.floedb.floecat.service.transaction.impl;
 
+import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.service.catalog.impl.surface.CatalogSurfaceWritePolicy;
+import ai.floedb.floecat.service.repo.impl.SnapshotCreateSequenceStore;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
@@ -87,6 +89,7 @@ public class TransactionIntentApplierSupport {
   @Inject PointerStore pointerStore;
   @Inject BlobStore blobStore;
   @Inject CatalogOverlay overlay;
+  @Inject SnapshotCreateSequenceStore snapshotCreateSequenceStore;
 
   public boolean isTableByIdPointer(String pointerKey) {
     return pointerKey != null && pointerKey.contains("/tables/by-id/");
@@ -106,6 +109,20 @@ public class TransactionIntentApplierSupport {
       return Table.parseFrom(bytes);
     } catch (Exception e) {
       LOG.debugf("table blob parse failed: %s", blobUri, e);
+      return null;
+    }
+  }
+
+  public Snapshot readSnapshot(String blobUri) {
+    try {
+      byte[] bytes = blobStore.get(blobUri);
+      if (bytes == null) {
+        LOG.debugf("snapshot blob missing: %s", blobUri);
+        return null;
+      }
+      return Snapshot.parseFrom(bytes);
+    } catch (Exception e) {
+      LOG.debugf("snapshot blob parse failed: %s", blobUri, e);
       return null;
     }
   }
@@ -264,6 +281,19 @@ public class TransactionIntentApplierSupport {
       }
     }
 
+    ApplyOutcome sequenceOutcome = appendSnapshotCreateSequenceOps(intents, touchedKeys, ops);
+    if (sequenceOutcome.status != ApplyStatus.APPLIED) {
+      return sequenceOutcome;
+    }
+    if (ops.size() > MAX_POINTER_TXN_OPS) {
+      return ApplyOutcome.conflict(
+          "POINTER_TXN_TOO_LARGE",
+          "transaction requires more than " + MAX_POINTER_TXN_OPS + " pointer operations",
+          null,
+          null,
+          null);
+    }
+
     if (!ops.isEmpty() && !pointerStore.compareAndSetBatch(ops)) {
       ApplyOutcome conflictOutcome = findExpectedVersionConflict(intents);
       if (conflictOutcome != null) {
@@ -310,6 +340,19 @@ public class TransactionIntentApplierSupport {
             null,
             null);
       }
+    }
+
+    ApplyOutcome sequenceOutcome = appendSnapshotCreateSequenceOps(intents, touchedKeys, ops);
+    if (sequenceOutcome.status != ApplyStatus.APPLIED) {
+      return sequenceOutcome;
+    }
+    if (ops.size() > MAX_POINTER_TXN_OPS - 1) {
+      return ApplyOutcome.conflict(
+          "POINTER_TXN_TOO_LARGE",
+          "transaction requires more than " + MAX_POINTER_TXN_OPS + " pointer operations",
+          null,
+          null,
+          null);
     }
 
     ApplyOutcome txOutcome =
@@ -976,6 +1019,84 @@ public class TransactionIntentApplierSupport {
       }
     }
     return null;
+  }
+
+  private ApplyOutcome appendSnapshotCreateSequenceOps(
+      List<TransactionIntent> intents, Set<String> touchedKeys, List<PointerStore.CasOp> ops) {
+    List<SnapshotCreateSequenceStore.CreateTarget> targets = new ArrayList<>();
+    Set<String> seenSnapshotPointers = new HashSet<>();
+    for (TransactionIntent intent : intents) {
+      if (intent == null || !isSnapshotByIdPointer(intent.getTargetPointerKey())) {
+        continue;
+      }
+      if (isDeleteSentinel(intent)) {
+        continue;
+      }
+      Pointer current = pointerStore.get(intent.getTargetPointerKey()).orElse(null);
+      if (current != null) {
+        continue;
+      }
+      Snapshot snapshot = readSnapshot(intent.getBlobUri());
+      if (snapshot == null || !snapshot.hasTableId()) {
+        return ApplyOutcome.retryable(
+            "SNAPSHOT_BLOB_MISSING", "snapshot create payload is missing or unreadable");
+      }
+      String expectedPointerKey =
+          Keys.snapshotPointerById(
+              snapshot.getTableId().getAccountId(),
+              snapshot.getTableId().getId(),
+              snapshot.getSnapshotId());
+      if (!expectedPointerKey.equals(intent.getTargetPointerKey())) {
+        return ApplyOutcome.conflict(
+            "SNAPSHOT_INTENT_TARGET_MISMATCH",
+            "snapshot payload does not match target pointer",
+            null,
+            null,
+            null);
+      }
+      if (!seenSnapshotPointers.add(expectedPointerKey)) {
+        continue;
+      }
+      targets.add(
+          new SnapshotCreateSequenceStore.CreateTarget(snapshot.getTableId().getAccountId()));
+    }
+    if (targets.isEmpty()) {
+      return ApplyOutcome.applied();
+    }
+
+    for (PointerStore.CasOp op : snapshotCreateSequences().planCreateOps(targets)) {
+      ApplyOutcome outcome = addOp(op, casOpKey(op), touchedKeys, ops);
+      if (outcome.status != ApplyStatus.APPLIED) {
+        return outcome;
+      }
+    }
+    return ApplyOutcome.applied();
+  }
+
+  private SnapshotCreateSequenceStore snapshotCreateSequences() {
+    return snapshotCreateSequenceStore != null
+        ? snapshotCreateSequenceStore
+        : new SnapshotCreateSequenceStore(pointerStore);
+  }
+
+  private boolean isSnapshotByIdPointer(String pointerKey) {
+    return pointerKey != null && pointerKey.contains("/snapshots/by-id/");
+  }
+
+  private static String casOpKey(PointerStore.CasOp op) {
+    if (op instanceof PointerStore.CasUpsert upsert) {
+      return upsert.key();
+    }
+    if (op instanceof PointerStore.CasDelete delete) {
+      return delete.key();
+    }
+    if (op instanceof PointerStore.CasCheck check) {
+      return check.key();
+    }
+    if (op instanceof PointerStore.CasCheckAbsent check) {
+      return check.key();
+    }
+    throw new IllegalArgumentException("unknown pointer CAS op: " + op);
   }
 
   private ApplyOutcome appendIntentCleanupOps(

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImplTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.*;
 
 import ai.floedb.floecat.catalog.rpc.CreateSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.DeleteSnapshotRequest;
-import ai.floedb.floecat.catalog.rpc.GetSnapshotCreateSequenceRequest;
+import ai.floedb.floecat.catalog.rpc.GetSnapshotCreateCounterRequest;
 import ai.floedb.floecat.catalog.rpc.GetSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotSpec;
@@ -692,7 +692,7 @@ class SnapshotServiceImplTest {
   }
 
   @Test
-  void getSnapshotCreateSequenceReturnsPointerStoreSequence() {
+  void getSnapshotCreateCounterReturnsPointerStoreCounter() {
     var svc = new SnapshotServiceImpl();
 
     svc.snapshotRepo = mock(SnapshotRepository.class);
@@ -709,14 +709,14 @@ class SnapshotServiceImplTest {
     when(pc.getAccountId()).thenReturn("acct");
     doNothing().when(svc.authz).require(any(), anyString());
 
-    when(svc.snapshotRepo.currentCreateSequence("acct")).thenReturn(12L);
+    when(svc.snapshotRepo.currentSnapshotCreateCounter("acct")).thenReturn(12L);
 
     var resp =
-        svc.getSnapshotCreateSequence(GetSnapshotCreateSequenceRequest.newBuilder().build())
+        svc.getSnapshotCreateCounter(GetSnapshotCreateCounterRequest.newBuilder().build())
             .await()
             .indefinitely();
 
-    assertEquals(12L, resp.getCurrentAccountCreateSequence());
+    assertEquals(12L, resp.getCurrentAccountSnapshotCreateCounter());
     verify(svc.authz).require(eq(pc), eq("table.read"));
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import ai.floedb.floecat.catalog.rpc.CreateSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.DeleteSnapshotRequest;
+import ai.floedb.floecat.catalog.rpc.GetSnapshotCreateSequenceRequest;
 import ai.floedb.floecat.catalog.rpc.GetSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotSpec;
@@ -688,6 +689,35 @@ class SnapshotServiceImplTest {
     svc.updateSnapshot(req).await().indefinitely();
 
     verify(svc.tableRepo, never()).update(any(Table.class), anyLong());
+  }
+
+  @Test
+  void getSnapshotCreateSequenceReturnsPointerStoreSequence() {
+    var svc = new SnapshotServiceImpl();
+
+    svc.snapshotRepo = mock(SnapshotRepository.class);
+    svc.statsStore = mock(StatsStore.class);
+    svc.principal = mock(PrincipalProvider.class);
+    svc.authz = mock(Authorizer.class);
+    svc.idempotencyStore = mock(IdempotencyRepository.class);
+    svc.overlay = mock(CatalogOverlay.class);
+    svc.currentSnapshotPointerService = mock(CurrentSnapshotPointerService.class);
+
+    var pc = mock(PrincipalContext.class);
+    when(svc.principal.get()).thenReturn(pc);
+    when(pc.getCorrelationId()).thenReturn("corr");
+    when(pc.getAccountId()).thenReturn("acct");
+    doNothing().when(svc.authz).require(any(), anyString());
+
+    when(svc.snapshotRepo.currentCreateSequence("acct")).thenReturn(12L);
+
+    var resp =
+        svc.getSnapshotCreateSequence(GetSnapshotCreateSequenceRequest.newBuilder().build())
+            .await()
+            .indefinitely();
+
+    assertEquals(12L, resp.getCurrentAccountCreateSequence());
+    verify(svc.authz).require(eq(pc), eq("table.read"));
   }
 
   private static SnapshotServiceImpl serviceWithVisibleTable(ResourceId tableId, TableNode node) {

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotRepositoryTest.java
@@ -158,6 +158,51 @@ class SnapshotRepositoryTest {
   }
 
   @Test
+  void createAdvancesAccountSnapshotCreateSequenceInPointerStore() {
+    String account = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT).getId();
+    var firstTable =
+        ResourceId.newBuilder()
+            .setAccountId(account)
+            .setId(UUID.randomUUID().toString())
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    var secondTable =
+        ResourceId.newBuilder()
+            .setAccountId(account)
+            .setId(UUID.randomUUID().toString())
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+
+    seedSnapshot(snapshotRepo, account, firstTable, 10, clock.millis(), clock.millis() - 20_000);
+    seedSnapshot(snapshotRepo, account, secondTable, 20, clock.millis(), clock.millis() - 10_000);
+
+    assertEquals(2L, snapshotRepo.currentCreateSequence(account));
+  }
+
+  @Test
+  void duplicateIdenticalSnapshotCreateDoesNotAllocateNewCreateSequence() {
+    String account = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT).getId();
+    var tableRid =
+        ResourceId.newBuilder()
+            .setAccountId(account)
+            .setId(UUID.randomUUID().toString())
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    Snapshot snapshot =
+        Snapshot.newBuilder()
+            .setTableId(tableRid)
+            .setSnapshotId(10L)
+            .setIngestedAt(Timestamps.fromMillis(clock.millis()))
+            .setUpstreamCreatedAt(Timestamps.fromMillis(clock.millis() - 10_000))
+            .build();
+
+    snapshotRepo.create(snapshot);
+    snapshotRepo.create(snapshot);
+
+    assertEquals(1L, snapshotRepo.currentCreateSequence(account));
+  }
+
+  @Test
   void maybeAdvanceCurrentSnapshotPointerCreatesPointerWithoutMutatingTable() {
     String account = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT).getId();
     var tableRid =

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotRepositoryTest.java
@@ -158,7 +158,7 @@ class SnapshotRepositoryTest {
   }
 
   @Test
-  void createAdvancesAccountSnapshotCreateSequenceInPointerStore() {
+  void createAdvancesAccountSnapshotCreateCounterInPointerStore() {
     String account = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT).getId();
     var firstTable =
         ResourceId.newBuilder()
@@ -176,11 +176,11 @@ class SnapshotRepositoryTest {
     seedSnapshot(snapshotRepo, account, firstTable, 10, clock.millis(), clock.millis() - 20_000);
     seedSnapshot(snapshotRepo, account, secondTable, 20, clock.millis(), clock.millis() - 10_000);
 
-    assertEquals(2L, snapshotRepo.currentCreateSequence(account));
+    assertEquals(2L, snapshotRepo.currentSnapshotCreateCounter(account));
   }
 
   @Test
-  void duplicateIdenticalSnapshotCreateDoesNotAllocateNewCreateSequence() {
+  void duplicateIdenticalSnapshotCreateDoesNotAdvanceCreateCounter() {
     String account = TestSupport.createAccountId(TestSupport.DEFAULT_SEED_ACCOUNT).getId();
     var tableRid =
         ResourceId.newBuilder()
@@ -199,7 +199,7 @@ class SnapshotRepositoryTest {
     snapshotRepo.create(snapshot);
     snapshotRepo.create(snapshot);
 
-    assertEquals(1L, snapshotRepo.currentCreateSequence(account));
+    assertEquals(1L, snapshotRepo.currentSnapshotCreateCounter(account));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
@@ -19,9 +19,11 @@ package ai.floedb.floecat.service.transaction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.impl.SnapshotCreateSequenceStore;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
@@ -135,6 +137,64 @@ class TransactionIntentApplierSupportTest {
         intentRepo.getByTarget("acct", "/accounts/acct/custom/key-1").isPresent(),
         "intent entry should remain until transaction state is durably updated");
     assertEquals(1, intentRepo.listByTx("acct", "tx-1").size());
+  }
+
+  @Test
+  void applyTransactionBestEffortAdvancesSnapshotCreateSequenceForNewSnapshot() throws Exception {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var intentRepo = new TransactionIntentRepository(pointers, blobs);
+
+    var support = new TransactionIntentApplierSupport();
+    inject(support, "pointerStore", pointers);
+    inject(support, "blobStore", blobs);
+    inject(support, "overlay", permissiveOverlay());
+
+    String accountId = "acct";
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId(accountId)
+            .setId("table-1")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    long upstreamCreatedMs = 1234L;
+    Snapshot snapshot =
+        Snapshot.newBuilder()
+            .setTableId(tableId)
+            .setSnapshotId(42L)
+            .setUpstreamCreatedAt(Timestamps.fromMillis(upstreamCreatedMs))
+            .build();
+    String blobUri =
+        Keys.snapshotBlobUri(
+            accountId,
+            tableId.getId(),
+            snapshot.getSnapshotId(),
+            ai.floedb.floecat.types.Hashing.sha256Hex(snapshot.toByteArray()));
+    blobs.put(blobUri, snapshot.toByteArray(), "application/x-protobuf");
+
+    TransactionIntent byId =
+        TransactionIntent.newBuilder()
+            .setAccountId(accountId)
+            .setTxId("tx-1")
+            .setTargetPointerKey(Keys.snapshotPointerById(accountId, tableId.getId(), 42L))
+            .setBlobUri(blobUri)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+    TransactionIntent byTime =
+        TransactionIntent.newBuilder()
+            .setAccountId(accountId)
+            .setTxId("tx-1")
+            .setTargetPointerKey(
+                Keys.snapshotPointerByTime(accountId, tableId.getId(), 42L, upstreamCreatedMs))
+            .setBlobUri(blobUri)
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    var outcome = support.applyTransactionBestEffort(List.of(byId, byTime), intentRepo);
+
+    assertEquals(TransactionIntentApplierSupport.ApplyStatus.APPLIED, outcome.status());
+    var createSequences = new SnapshotCreateSequenceStore(pointers);
+    assertEquals(1L, createSequences.currentSequence(accountId));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
@@ -23,7 +23,7 @@ import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
-import ai.floedb.floecat.service.repo.impl.SnapshotCreateSequenceStore;
+import ai.floedb.floecat.service.repo.impl.SnapshotCreateCounterStore;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
@@ -140,7 +140,7 @@ class TransactionIntentApplierSupportTest {
   }
 
   @Test
-  void applyTransactionBestEffortAdvancesSnapshotCreateSequenceForNewSnapshot() throws Exception {
+  void applyTransactionBestEffortAdvancesSnapshotCreateCounterForNewSnapshot() throws Exception {
     var pointers = new InMemoryPointerStore();
     var blobs = new InMemoryBlobStore();
     var intentRepo = new TransactionIntentRepository(pointers, blobs);
@@ -193,8 +193,8 @@ class TransactionIntentApplierSupportTest {
     var outcome = support.applyTransactionBestEffort(List.of(byId, byTime), intentRepo);
 
     assertEquals(TransactionIntentApplierSupport.ApplyStatus.APPLIED, outcome.status());
-    var createSequences = new SnapshotCreateSequenceStore(pointers);
-    assertEquals(1L, createSequences.currentSequence(accountId));
+    var createCounters = new SnapshotCreateCounterStore(pointers);
+    assertEquals(1L, createCounters.currentCounter(accountId));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds an atomically updated sequence number that increments each time a snapshot is created in an account.

## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

