### PR TITLE
feat: add tag-based account filter to reconcile planner (M5)

### DIFF
--- a/core/proto/src/main/proto/floecat/account/account.proto
+++ b/core/proto/src/main/proto/floecat/account/account.proto
@@ -30,11 +30,15 @@ message Account {
   string display_name = 2;
   optional string description = 3;
   google.protobuf.Timestamp created_at = 10;
+  // Free-form key/value tags used to scope which floecat instance manages the
+  // account (e.g. a CI run stamps `ci-run=<run-id>`; see the planner tag filter).
+  map<string, string> tags = 99;
 }
 
 message AccountSpec {
   optional string display_name = 1;
   optional string description = 2;
+  map<string, string> tags = 99;
 }
 
 // ====== Requests / Responses ======

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -87,7 +87,8 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
   @Inject PointerStore pointerStore;
   @Inject DefaultCredentialResolver credentialResolver;
 
-  private static final Set<String> ACCOUNT_MUTABLE_PATHS = Set.of("display_name", "description");
+  private static final Set<String> ACCOUNT_MUTABLE_PATHS =
+      Set.of("display_name", "description", "tags");
 
   private static final Logger LOG = Logger.getLogger(AccountService.class);
   private static final Logger CLEANUP_LOG = Logger.getLogger(AccountServiceImpl.class);
@@ -192,6 +193,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                           .setDisplayName(normName)
                           .setDescription(spec.getDescription())
                           .setCreatedAt(tsNow)
+                          .putAllTags(spec.getTagsMap())
                           .build();
 
                   if (idempotencyKey == null) {
@@ -657,6 +659,10 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
       }
     }
 
+    if (maskTargets(mask, "tags")) {
+      b.clearTags().putAllTags(spec.getTagsMap());
+    }
+
     return b.build();
   }
 
@@ -681,6 +687,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     return new Canonicalizer()
         .scalar("name", normalizeName(s.getDisplayName()))
         .scalar("description", s.getDescription())
+        .map("tags", s.getTagsMap())
         .bytes();
   }
 
@@ -688,6 +695,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     return AccountSpec.newBuilder()
         .setDisplayName(normalizeName(account.getDisplayName()))
         .setDescription(account.getDescription())
+        .putAllTags(account.getTagsMap())
         .build();
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/AccountTagFilter.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/AccountTagFilter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.jobs;
+
+import java.util.Map;
+
+/**
+ * Startup tag rule deciding whether the reconcile planner manages a given account.
+ *
+ * <p>The rule is chosen once at startup and never changes as accounts come and go — accounts are
+ * created already carrying (or not carrying) the tag the rule keys on. Two selection modes, plus a
+ * pass-all default:
+ *
+ * <ul>
+ *   <li>{@code ignore-key:<key>} — skip any account carrying {@code <key>}, whatever its value.
+ *       Used by the steady-state floecat to ignore every CI account, past or present, without a
+ *       restart as runs come and go.
+ *   <li>{@code own-value:<key>=<value>} — manage only the account whose {@code <key>} tag equals
+ *       {@code <value>}. Used by an overlay floecat to own exactly this run's account and never
+ *       grab a prior run's torn-down account.
+ * </ul>
+ *
+ * <p>An unset/blank spec yields {@link PassAll}, preserving the account-blind steady-state
+ * behavior.
+ */
+public sealed interface AccountTagFilter {
+
+  String IGNORE_KEY_PREFIX = "ignore-key:";
+  String OWN_VALUE_PREFIX = "own-value:";
+
+  /** Whether the planner should manage an account carrying {@code tags}. */
+  boolean accountPasses(Map<String, String> tags);
+
+  /** Manage every account (no filtering). */
+  record PassAll() implements AccountTagFilter {
+    @Override
+    public boolean accountPasses(Map<String, String> tags) {
+      return true;
+    }
+  }
+
+  /** Skip any account carrying {@code key}, regardless of value. */
+  record IgnoreKey(String key) implements AccountTagFilter {
+    @Override
+    public boolean accountPasses(Map<String, String> tags) {
+      return !tags.containsKey(key);
+    }
+  }
+
+  /** Manage only the account whose {@code key} tag equals {@code value}. */
+  record OwnValue(String key, String value) implements AccountTagFilter {
+    @Override
+    public boolean accountPasses(Map<String, String> tags) {
+      return value.equals(tags.get(key));
+    }
+  }
+
+  /**
+   * Parse a filter spec into a rule. A blank or {@code null} spec yields {@link PassAll}; otherwise
+   * the spec must be {@code ignore-key:<key>} or {@code own-value:<key>=<value>}.
+   *
+   * @throws IllegalArgumentException if the spec is non-blank but not a recognised, well-formed
+   *     rule
+   */
+  static AccountTagFilter parse(String spec) {
+    if (spec == null || spec.isBlank()) {
+      return new PassAll();
+    }
+    String s = spec.strip();
+    if (s.startsWith(IGNORE_KEY_PREFIX)) {
+      String key = s.substring(IGNORE_KEY_PREFIX.length()).strip();
+      if (key.isEmpty()) {
+        throw new IllegalArgumentException(
+            "account-tag-filter '" + spec + "' must be " + IGNORE_KEY_PREFIX + "<key>");
+      }
+      return new IgnoreKey(key);
+    }
+    if (s.startsWith(OWN_VALUE_PREFIX)) {
+      String kv = s.substring(OWN_VALUE_PREFIX.length());
+      int eq = kv.indexOf('=');
+      String key = eq < 0 ? "" : kv.substring(0, eq).strip();
+      String value = eq < 0 ? "" : kv.substring(eq + 1).strip();
+      if (key.isEmpty() || value.isEmpty()) {
+        throw new IllegalArgumentException(
+            "account-tag-filter '" + spec + "' must be " + OWN_VALUE_PREFIX + "<key>=<value>");
+      }
+      return new OwnValue(key, value);
+    }
+    throw new IllegalArgumentException(
+        "account-tag-filter '"
+            + spec
+            + "' must be blank, "
+            + IGNORE_KEY_PREFIX
+            + "<key>, or "
+            + OWN_VALUE_PREFIX
+            + "<key>=<value>");
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
@@ -124,6 +124,7 @@ public class ReconcilePlannerScheduler {
       int connectorsPageSize,
       long defaultIntervalMs,
       ReconcileMode defaultMode) {
+    AccountTagFilter tagFilter = accountTagFilter();
     String accountToken = plannerCursor.accountToken();
     while (nowMs() < deadlineMs) {
       StringBuilder accountNext = new StringBuilder();
@@ -146,6 +147,9 @@ public class ReconcilePlannerScheduler {
         if (nowMs() >= deadlineMs) {
           plannerCursor = new PlannerCursor(accountToken);
           return;
+        }
+        if (!tagFilter.accountPasses(account.getTagsMap())) {
+          continue;
         }
         String accountId = account.getResourceId().getId();
         processAccount(accountId, deadlineMs, connectorsPageSize, defaultIntervalMs, defaultMode);
@@ -209,6 +213,10 @@ public class ReconcilePlannerScheduler {
 
   PlannerCursor plannerCursor() {
     return plannerCursor;
+  }
+
+  AccountTagFilter accountTagFilter() {
+    return settings.accountTagFilter();
   }
 
   ReconcileExecutionPolicy autoExecutionPolicy() {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilerSettingsStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilerSettingsStore.java
@@ -28,12 +28,17 @@ public class ReconcilerSettingsStore {
   private volatile long defaultIntervalMs = Duration.ofMinutes(10).toMillis();
   private volatile ReconcileMode defaultMode = ReconcileMode.RM_INCREMENTAL;
   private volatile long finishedJobRetentionMs = Duration.ofDays(7).toMillis();
+  private volatile AccountTagFilter accountTagFilter = new AccountTagFilter.PassAll();
 
   @PostConstruct
   void init() {
     var cfg = ConfigProvider.getConfig();
     autoEnabled =
         cfg.getOptionalValue("floecat.reconciler.auto.enabled", Boolean.class).orElse(true);
+    accountTagFilter =
+        AccountTagFilter.parse(
+            cfg.getOptionalValue("floecat.reconciler.auto.account-tag-filter", String.class)
+                .orElse(""));
     defaultIntervalMs =
         cfg.getOptionalValue("floecat.reconciler.default-interval", Duration.class)
             .map(Duration::toMillis)
@@ -70,6 +75,10 @@ public class ReconcilerSettingsStore {
 
   public ReconcileMode defaultMode() {
     return defaultMode;
+  }
+
+  public AccountTagFilter accountTagFilter() {
+    return accountTagFilter;
   }
 
   public long finishedJobRetentionMs() {

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -155,6 +155,11 @@ floecat.reconciler.auto.tick-every=${FLOECAT_RECONCILER_AUTO_TICK_EVERY:500ms}
 floecat.reconciler.auto.max-tick-millis=${FLOECAT_RECONCILER_AUTO_MAX_TICK_MILLIS:4000}
 floecat.reconciler.auto.accounts-page-size=${FLOECAT_RECONCILER_AUTO_ACCOUNTS_PAGE_SIZE:50}
 floecat.reconciler.auto.connectors-page-size=${FLOECAT_RECONCILER_AUTO_CONNECTORS_PAGE_SIZE:200}
+# Startup tag filter scoping which accounts the planner manages. Blank manages every
+# account; `ignore-key:<key>` skips accounts carrying <key> (steady-state ignoring CI
+# accounts); `own-value:<key>=<value>` manages only the matching account (overlay owning
+# one CI run).
+floecat.reconciler.auto.account-tag-filter=${FLOECAT_RECONCILER_AUTO_ACCOUNT_TAG_FILTER:}
 # Routing policy for planner-enqueued jobs.
 floecat.reconciler.auto.execution-class=${FLOECAT_RECONCILER_AUTO_EXECUTION_CLASS:DEFAULT}
 floecat.reconciler.auto.execution-lane=${FLOECAT_RECONCILER_AUTO_EXECUTION_LANE:}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/AccountTagFilterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/AccountTagFilterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AccountTagFilterTest {
+
+  private static final Map<String, String> UNTAGGED = Map.of();
+  private static final Map<String, String> THIS_RUN = Map.of("ci-run", "run-1");
+  private static final Map<String, String> OTHER_RUN = Map.of("ci-run", "run-2");
+
+  // ----- ignore-by-key (steady-state floecat) -----
+
+  @Test
+  void ignoreKeySkipsAnyAccountCarryingTheKeyRegardlessOfValue() {
+    var filter = new AccountTagFilter.IgnoreKey("ci-run");
+    assertFalse(filter.accountPasses(THIS_RUN));
+    assertFalse(filter.accountPasses(OTHER_RUN));
+  }
+
+  @Test
+  void ignoreKeyOwnsUntaggedAccounts() {
+    var filter = new AccountTagFilter.IgnoreKey("ci-run");
+    assertTrue(filter.accountPasses(UNTAGGED));
+    assertTrue(filter.accountPasses(Map.of("other-key", "v")));
+  }
+
+  // ----- own-by-exact-value (overlay floecat) -----
+
+  @Test
+  void ownValueManagesOnlyTheAccountWithTheExactValue() {
+    var filter = new AccountTagFilter.OwnValue("ci-run", "run-1");
+    assertTrue(filter.accountPasses(THIS_RUN));
+  }
+
+  @Test
+  void ownValueRejectsAnotherRunsAccount() {
+    var filter = new AccountTagFilter.OwnValue("ci-run", "run-1");
+    assertFalse(filter.accountPasses(OTHER_RUN));
+  }
+
+  @Test
+  void ownValueIgnoresUntaggedAccounts() {
+    var filter = new AccountTagFilter.OwnValue("ci-run", "run-1");
+    assertFalse(filter.accountPasses(UNTAGGED));
+  }
+
+  // ----- pass-all (no filter configured) -----
+
+  @Test
+  void passAllManagesEveryAccount() {
+    var filter = new AccountTagFilter.PassAll();
+    assertTrue(filter.accountPasses(UNTAGGED));
+    assertTrue(filter.accountPasses(THIS_RUN));
+    assertTrue(filter.accountPasses(OTHER_RUN));
+  }
+
+  // ----- parse -----
+
+  @Test
+  void parseBlankOrNullYieldsPassAll() {
+    assertEquals(new AccountTagFilter.PassAll(), AccountTagFilter.parse(""));
+    assertEquals(new AccountTagFilter.PassAll(), AccountTagFilter.parse("   "));
+    assertEquals(new AccountTagFilter.PassAll(), AccountTagFilter.parse(null));
+  }
+
+  @Test
+  void parseIgnoreKey() {
+    assertEquals(
+        new AccountTagFilter.IgnoreKey("ci-run"), AccountTagFilter.parse("ignore-key:ci-run"));
+    assertEquals(
+        new AccountTagFilter.IgnoreKey("ci-run"), AccountTagFilter.parse("  ignore-key:ci-run  "));
+  }
+
+  @Test
+  void parseOwnValue() {
+    assertEquals(
+        new AccountTagFilter.OwnValue("ci-run", "run-1"),
+        AccountTagFilter.parse("own-value:ci-run=run-1"));
+  }
+
+  @Test
+  void parseRejectsMalformedSpecs() {
+    assertThrows(IllegalArgumentException.class, () -> AccountTagFilter.parse("nonsense"));
+    assertThrows(IllegalArgumentException.class, () -> AccountTagFilter.parse("ignore-key:"));
+    assertThrows(IllegalArgumentException.class, () -> AccountTagFilter.parse("own-value:ci-run"));
+    assertThrows(IllegalArgumentException.class, () -> AccountTagFilter.parse("own-value:=run-1"));
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
@@ -48,6 +48,7 @@ import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ReconcilePlannerSchedulerTest {
@@ -493,12 +494,102 @@ class ReconcilePlannerSchedulerTest {
         .enqueuePlan(anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString());
   }
 
+  @Test
+  void runPlannerPassSkipsAccountsRejectedByTagFilter() {
+    TestScheduler scheduler = new TestScheduler();
+    scheduler.accounts = mock(AccountRepository.class);
+    scheduler.connectors = mock(ConnectorRepository.class);
+    scheduler.jobs = mock(ReconcileJobStore.class);
+    scheduler.executorRegistry = mock(ReconcileExecutorRegistry.class);
+    // Steady-state floecat: ignore any account carrying the ci-run key.
+    scheduler.accountTagFilter = new AccountTagFilter.IgnoreKey("ci-run");
+    when(scheduler.executorRegistry.hasExecutorForJobKind(any())).thenReturn(true);
+    stubNoActiveRootJobs(scheduler.jobs);
+
+    List<String> enqueued = new ArrayList<>();
+    when(scheduler.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              enqueued.add(invocation.getArgument(1, String.class));
+              return "job-" + enqueued.size();
+            });
+
+    when(scheduler.accounts.list(anyInt(), anyString(), any()))
+        .thenReturn(
+            List.of(
+                account("acct-real", "real"),
+                taggedAccount("acct-ci", "ci", Map.of("ci-run", "run-1"))));
+    when(scheduler.connectors.list(anyString(), anyInt(), anyString(), any()))
+        .thenAnswer(
+            invocation -> {
+              String accountId = invocation.getArgument(0, String.class);
+              if ("acct-real".equals(accountId)) {
+                return List.of(connector("acct-real", "conn-real", "real-1"));
+              }
+              return List.of(connector("acct-ci", "conn-ci", "ci-1"));
+            });
+    stubConnectorLookup(
+        scheduler.connectors,
+        connector("acct-real", "conn-real", "real-1"),
+        connector("acct-ci", "conn-ci", "ci-1"));
+
+    scheduler.runPlannerPass(100L, 10, 10, 1L, ReconcileMode.RM_INCREMENTAL);
+
+    // The tagged CI account is skipped entirely; its connectors are never scanned.
+    assertEquals(List.of("conn-real"), enqueued);
+    verify(scheduler.connectors, never()).list(eq("acct-ci"), anyInt(), anyString(), any());
+  }
+
+  @Test
+  void runPlannerPassOwnValueManagesOnlyTheMatchingAccount() {
+    TestScheduler scheduler = new TestScheduler();
+    scheduler.accounts = mock(AccountRepository.class);
+    scheduler.connectors = mock(ConnectorRepository.class);
+    scheduler.jobs = mock(ReconcileJobStore.class);
+    scheduler.executorRegistry = mock(ReconcileExecutorRegistry.class);
+    // Overlay floecat: own only this run's account, ignore untagged and prior runs.
+    scheduler.accountTagFilter = new AccountTagFilter.OwnValue("ci-run", "run-1");
+    when(scheduler.executorRegistry.hasExecutorForJobKind(any())).thenReturn(true);
+    stubNoActiveRootJobs(scheduler.jobs);
+
+    List<String> enqueued = new ArrayList<>();
+    when(scheduler.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              enqueued.add(invocation.getArgument(1, String.class));
+              return "job-" + enqueued.size();
+            });
+
+    when(scheduler.accounts.list(anyInt(), anyString(), any()))
+        .thenReturn(
+            List.of(
+                account("acct-real", "real"),
+                taggedAccount("acct-prior", "prior", Map.of("ci-run", "run-0")),
+                taggedAccount("acct-mine", "mine", Map.of("ci-run", "run-1"))));
+    when(scheduler.connectors.list(anyString(), anyInt(), anyString(), any()))
+        .thenReturn(List.of(connector("acct-mine", "conn-mine", "mine-1")));
+    stubConnectorLookup(scheduler.connectors, connector("acct-mine", "conn-mine", "mine-1"));
+
+    scheduler.runPlannerPass(100L, 10, 10, 1L, ReconcileMode.RM_INCREMENTAL);
+
+    assertEquals(List.of("conn-mine"), enqueued);
+    verify(scheduler.connectors, never()).list(eq("acct-real"), anyInt(), anyString(), any());
+    verify(scheduler.connectors, never()).list(eq("acct-prior"), anyInt(), anyString(), any());
+  }
+
   private static Account account(String accountId, String displayName) {
     return Account.newBuilder()
         .setResourceId(
             ResourceId.newBuilder().setId(accountId).setKind(ResourceKind.RK_ACCOUNT).build())
         .setDisplayName(displayName)
         .build();
+  }
+
+  private static Account taggedAccount(
+      String accountId, String displayName, java.util.Map<String, String> tags) {
+    return account(accountId, displayName).toBuilder().putAllTags(tags).build();
   }
 
   private static Connector connector(String accountId, String id, String displayName) {
@@ -524,6 +615,7 @@ class ReconcilePlannerSchedulerTest {
     private long nowMs;
     private ReconcileExecutionPolicy autoExecutionPolicy =
         ReconcileExecutionPolicy.of(ReconcileExecutionClass.DEFAULT, "", java.util.Map.of());
+    private AccountTagFilter accountTagFilter = new AccountTagFilter.PassAll();
 
     @Override
     long nowMs() {
@@ -533,6 +625,11 @@ class ReconcilePlannerSchedulerTest {
     @Override
     ReconcileExecutionPolicy autoExecutionPolicy() {
       return autoExecutionPolicy;
+    }
+
+    @Override
+    AccountTagFilter accountTagFilter() {
+      return accountTagFilter;
     }
   }
 }


### PR DESCRIPTION
floecat is account-blind: the reconcile planner pages every account each tick with no filter. To isolate an ephemeral CI account from the shared reconcile path, give the account model a `tags` field and the planner a startup tag filter so an instance manages only the accounts a tag rule selects.

- account proto: `map<string,string> tags` on `Account` and `AccountSpec`; threaded through `AccountServiceImpl` (create, update-mask, idempotency fingerprint, spec projection). The repository round-trips the whole proto blob, so tags persist and project to the planner with no repo change.
- `AccountTagFilter`: a pure sealed rule with two modes — `ignore-key:<key>` (steady-state floecat skips any account carrying the key, whatever its value) and `own-value:<key>=<value>` (overlay floecat owns only the exact match) — plus a pass-all default that preserves account-blind behavior.
- config `floecat.reconciler.auto.account-tag-filter`, parsed once in `ReconcilerSettingsStore` and applied in the `runPlannerPass` per-account loop.
