### PR TITLE
Planner stats: pinned-generation reads, verbatim sketch propagation, and broken-root self-healing

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/SystemSchemaMapper.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/util/SystemSchemaMapper.java
@@ -35,9 +35,7 @@ public final class SystemSchemaMapper {
             .setLogicalType(column.type().getName())
             .setNullable(column.nullable())
             .setOrdinal(column.ordinal());
-    if (column.hasId()) {
-      builder.setId(column.id());
-    }
+    builder.setId(column.hasId() ? column.id() : column.ordinal());
     return builder.build();
   }
 
@@ -45,7 +43,23 @@ public final class SystemSchemaMapper {
     if (columns == null || columns.isEmpty()) {
       return List.of();
     }
-    return columns.stream().map(SystemSchemaMapper::toSchemaColumn).toList();
+    List<SchemaColumn> mapped = columns.stream().map(SystemSchemaMapper::toSchemaColumn).toList();
+    // Explicit ids and ordinal-derived fallback ids share one positive integer space, so a
+    // relation mixing id-bearing and id-less columns could mint two columns with the same target
+    // id — and the planner keys stats targets on this id, so a collision silently serves one
+    // column's stats for another. Fail at registry build instead.
+    java.util.Set<Long> seen = new java.util.HashSet<>(mapped.size());
+    for (SchemaColumn column : mapped) {
+      if (!seen.add(column.getId())) {
+        throw new IllegalStateException(
+            "duplicate column id "
+                + column.getId()
+                + " in system relation schema (column '"
+                + column.getName()
+                + "'): explicit ids must not overlap ordinal-derived fallback ids");
+      }
+    }
+    return mapped;
   }
 
   private static SystemColumnDef fromSchemaColumn(SchemaColumn column, int ordinal) {

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/util/SystemSchemaMapperTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/util/SystemSchemaMapperTest.java
@@ -16,13 +16,65 @@
 
 package ai.floedb.floecat.systemcatalog.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
+import ai.floedb.floecat.systemcatalog.def.SystemColumnDef;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class SystemSchemaMapperTest {
+
+  @Test
+  void toSchemaColumn_defaultsMissingIdToOrdinal() {
+    SystemColumnDef column =
+        new SystemColumnDef("table_name", name("VARCHAR"), false, 3, null, List.of());
+
+    SchemaColumn schemaColumn = SystemSchemaMapper.toSchemaColumn(column);
+
+    assertThat(schemaColumn.getId()).isEqualTo(3);
+    assertThat(schemaColumn.getOrdinal()).isEqualTo(3);
+  }
+
+  @Test
+  void toSchemaColumn_preservesExplicitId() {
+    SystemColumnDef column =
+        new SystemColumnDef("table_name", name("VARCHAR"), false, 3, 42L, List.of());
+
+    SchemaColumn schemaColumn = SystemSchemaMapper.toSchemaColumn(column);
+
+    assertThat(schemaColumn.getId()).isEqualTo(42);
+    assertThat(schemaColumn.getOrdinal()).isEqualTo(3);
+  }
+
+  @Test
+  void toSchemaColumns_rejectsExplicitIdCollidingWithAFallbackOrdinalId() {
+    // Explicit ids and ordinal-derived fallback ids share one positive integer space: column 1
+    // has no id (falls back to ordinal 1) while column 2 explicitly claims id 1. Serving would
+    // key both columns' stats on the same target id, so the mix must fail at build time.
+    List<SystemColumnDef> mixed =
+        List.of(
+            new SystemColumnDef("a", name("VARCHAR"), false, 1, null, List.of()),
+            new SystemColumnDef("b", name("VARCHAR"), false, 2, 1L, List.of()));
+
+    assertThatThrownBy(() -> SystemSchemaMapper.toSchemaColumns(mixed))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("duplicate column id 1");
+  }
+
+  @Test
+  void toSchemaColumns_acceptsDisjointExplicitAndFallbackIds() {
+    List<SystemColumnDef> mixed =
+        List.of(
+            new SystemColumnDef("a", name("VARCHAR"), false, 1, null, List.of()),
+            new SystemColumnDef("b", name("VARCHAR"), false, 2, 42L, List.of()));
+
+    assertThat(SystemSchemaMapper.toSchemaColumns(mixed))
+        .extracting(SchemaColumn::getId)
+        .containsExactly(1L, 42L);
+  }
 
   @Test
   void fromSchemaColumns_rejectsBlankLogicalType() {
@@ -37,5 +89,9 @@ class SystemSchemaMapperTest {
     assertThatThrownBy(() -> SystemSchemaMapper.fromSchemaColumns(List.of(column)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("logicalType");
+  }
+
+  private static NameRef name(String name) {
+    return NameRef.newBuilder().setName(name).build();
   }
 }

--- a/core/proto/src/main/proto/floecat/catalog/stats.proto
+++ b/core/proto/src/main/proto/floecat/catalog/stats.proto
@@ -33,6 +33,11 @@ message UpstreamStamp {
 }
 
 // Number-of-distinct-values payload supporting exact and approximate representations.
+// CONTRACT: the mode oneof MAY be unset while sketches are present. Stored records legitimately
+// carry payload-only envelopes (e.g. a sketch carried forward across a stats-generation republish
+// whose new capture produced no estimate). Consumers MUST gate estimate reads on the mode
+// (exact/approx presence), never on the envelope's own presence — reading approx from a mode-less
+// envelope yields a bogus zero estimate.
 message Ndv {
   oneof mode {
     int64 exact = 1;

--- a/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsStore.java
+++ b/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsStore.java
@@ -43,6 +43,21 @@ public interface StatsStore {
     RETRYABLE_IN_PROGRESS
   }
 
+  /**
+   * Signals that a frozen generation token cannot be resolved before any target-specific read.
+   * Callers may handle this once for the whole generation-scoped batch rather than isolating
+   * individual targets. Retryable storage failures must retain their retryable exception type.
+   */
+  final class GenerationUnavailableException extends RuntimeException {
+    public GenerationUnavailableException(String message) {
+      super(message);
+    }
+
+    public GenerationUnavailableException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
   /** Upserts a target stats record. */
   void putTargetStats(TargetStatsRecord value);
 

--- a/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsStore.java
+++ b/core/stats/src/main/java/ai/floedb/floecat/stats/spi/StatsStore.java
@@ -148,6 +148,34 @@ public interface StatsStore {
     return Collections.unmodifiableMap(out);
   }
 
+  /**
+   * Returns the target stats record for the exact table/snapshot/target key within the frozen stats
+   * generation named by {@code generationToken}. Stores that do not track generations serve the
+   * live exact-snapshot record.
+   */
+  default Optional<TargetStatsRecord> getTargetStatsInGeneration(
+      ResourceId tableId, long snapshotId, String generationToken, StatsTarget target) {
+    return getTargetStats(tableId, snapshotId, target);
+  }
+
+  /**
+   * Batch variant of {@link #getTargetStatsInGeneration}. Tracking stores must read the immutable
+   * keyspace named by {@code generationToken}, not the live active generation for the snapshot.
+   */
+  default Map<String, Optional<TargetStatsRecord>> getTargetStatsBatchInGeneration(
+      ResourceId tableId, long snapshotId, String generationToken, List<StatsTarget> targets) {
+    if (targets == null || targets.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, Optional<TargetStatsRecord>> out = new LinkedHashMap<>(targets.size());
+    for (StatsTarget target : targets) {
+      out.put(
+          StatsTargetIdentity.storageId(target),
+          getTargetStatsInGeneration(tableId, snapshotId, generationToken, target));
+    }
+    return Collections.unmodifiableMap(out);
+  }
+
   /** Deletes the exact table/snapshot/target record and returns true iff a record was deleted. */
   boolean deleteTargetStats(ResourceId tableId, long snapshotId, StatsTarget target);
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/FileGroupTargetStatsRollup.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/FileGroupTargetStatsRollup.java
@@ -292,6 +292,22 @@ public final class FileGroupTargetStatsRollup {
     private String displayName = "";
     private String logicalType = "";
 
+    /** Total sources folded into this column (files or partials), sketch-bearing or not. */
+    private int contributors = 0;
+
+    /**
+     * The contributing source's stats, held verbatim while it remains the ONLY contributor; {@code
+     * null} once a second source folds in.
+     *
+     * <p>This is the single sole-source rule of the rollup: producer-owned sketch payloads are
+     * never merged, re-encoded, or synthesized here — a payload from one of several sources
+     * describes only that source's rows and must not be advertised as the column's distribution.
+     * But when exactly one source contributed the whole column, its payloads ARE the column's
+     * distribution, so {@link #toScalar} propagates its scalar sketches and {@link #aggregateNdv}
+     * its entire NDV envelope untouched.
+     */
+    private ScalarStats soleSource;
+
     /** Cached decoded form of logicalType — decoding is not free, so cache after first decode. */
     private LogicalType decodedLogicalType = null;
 
@@ -301,8 +317,6 @@ public final class FileGroupTargetStatsRollup {
     private String min;
     private String max;
     private final ColumnNdv ndv = new ColumnNdv();
-    private Ndv singleSourceNdv;
-    private int ndvContributors = 0;
     private final Set<String> droppedNonThetaNdvTypes = new java.util.LinkedHashSet<>();
     private Double fallbackNdvEstimate;
     private long ndvRowsSeen = 0L;
@@ -312,6 +326,10 @@ public final class FileGroupTargetStatsRollup {
     private long totalRowsForWidth = 0L;
 
     void add(TargetStatsRecord source, ScalarStats scalar) {
+      contributors++;
+      // Exactly one contributor means its stats describe the whole column (see soleSource); a
+      // second contributor voids that claim for good.
+      soleSource = contributors == 1 ? scalar : null;
       if (source != null && metadataSource == null && source.hasMetadata()) {
         metadataSource = source;
       }
@@ -380,6 +398,10 @@ public final class FileGroupTargetStatsRollup {
       if (aggregatedNdv != null) {
         builder.setNdv(aggregatedNdv);
       }
+      if (soleSource != null) {
+        // Sole-source rule: propagated verbatim — never re-encoded, never merged.
+        builder.addAllSketches(soleSource.getSketchesList());
+      }
       if (totalRowsForWidth > 0) {
         builder.setAvgWidthBytes(
             Math.max(1L, (totalWidthBytes + totalRowsForWidth - 1) / totalRowsForWidth));
@@ -393,13 +415,7 @@ public final class FileGroupTargetStatsRollup {
         return;
       }
       Ndv currentNdv = scalar.getNdv();
-      ndvContributors++;
       collectNdvFallback(currentNdv);
-      if (ndvContributors == 1) {
-        singleSourceNdv = currentNdv;
-      } else {
-        singleSourceNdv = null;
-      }
       for (var sketch : currentNdv.getSketchesList()) {
         String type =
             sketch.getSketchType() == null ? "" : sketch.getSketchType().toLowerCase(Locale.ROOT);
@@ -410,7 +426,7 @@ public final class FileGroupTargetStatsRollup {
           // Only theta sketches can be unioned here; HLL/tuple NDV sketches from a multi-file group
           // are not mergeable, so they are not folded in. Record the type so aggregateNdv can flag
           // that the emitted estimate is a floor for mixed-format inputs rather than dropping it
-          // silently.
+          // silently. (Irrelevant for a sole source, whose envelope is returned verbatim.)
           droppedNonThetaNdvTypes.add(sketch.getSketchType());
         }
       }
@@ -441,14 +457,19 @@ public final class FileGroupTargetStatsRollup {
     }
 
     private Ndv aggregateNdv() {
+      if (soleSource != null) {
+        // Sole-source rule: the one contributor's envelope IS the column's — estimate, theta, and
+        // producer-owned payloads (tuple, HLL, …) propagate verbatim, never re-encoded or merged.
+        return soleSource.hasNdv() ? soleSource.getNdv() : null;
+      }
       ndv.finalizeTheta();
-      if (!droppedNonThetaNdvTypes.isEmpty() && ndvContributors > 1) {
+      if (!droppedNonThetaNdvTypes.isEmpty()) {
         // Non-theta NDV sketches across multiple files could not be merged, so the aggregate
         // estimate reflects only the theta-bearing (or rollup-max) subset — a floor, not exact.
         LOG.warnf(
-            "NDV rollup could not merge non-theta sketch type(s) %s across %d files; "
+            "NDV rollup could not merge non-theta sketch type(s) %s across %d sources; "
                 + "aggregate NDV estimate is a floor for this column",
-            droppedNonThetaNdvTypes, ndvContributors);
+            droppedNonThetaNdvTypes, contributors);
       }
       if (ndv.approx != null || (ndv.sketches != null && !ndv.sketches.isEmpty())) {
         Ndv.Builder builder = Ndv.newBuilder();
@@ -491,9 +512,6 @@ public final class FileGroupTargetStatsRollup {
           }
         }
         return builder.build();
-      }
-      if (ndvContributors == 1 && singleSourceNdv != null) {
-        return singleSourceNdv;
       }
       if (fallbackNdvEstimate != null) {
         NdvApprox.Builder approx =

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FileGroupTargetStatsRollupSketchTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FileGroupTargetStatsRollupSketchTest.java
@@ -172,6 +172,108 @@ class FileGroupTargetStatsRollupSketchTest {
   }
 
   @Test
+  void fileRecordRollup_soleSourceKeepsTupleSketchThroughTheThetaRebuild() {
+    SketchPayload theta =
+        ndvPayload("apache-datasketches-theta-v1", SketchRole.SKETCH_ROLE_NDV, thetaBytes("a"));
+    SketchPayload tuple =
+        ndvPayload("floedb-tuple-v2", SketchRole.SKETCH_ROLE_TUPLE_NDV, new byte[] {7, 8, 9});
+    ScalarStats sole =
+        ScalarStats.newBuilder()
+            .setDisplayName("col")
+            .setLogicalType("LONG")
+            .setRowCount(120)
+            .setNdv(
+                Ndv.newBuilder()
+                    .setApprox(NdvApprox.newBuilder().setEstimate(50).setMethod("test"))
+                    .addSketches(theta)
+                    .addSketches(tuple))
+            .build();
+
+    List<TargetStatsRecord> result =
+        FileGroupTargetStatsRollup.completeSnapshotFromFileRecords(
+            TABLE,
+            1L,
+            Set.of(FloecatConnector.StatsTargetKind.COLUMN),
+            List.of(fileRecord(1L, sole)));
+
+    // The theta rebuild reconstructs the NDV envelope from merged theta; a sole source's
+    // producer-owned tuple sketch must ride along verbatim instead of being silently dropped —
+    // this is the join-key sketch the planner consumes for fanout/skew estimation.
+    ScalarStats merged = onlyScalar(result);
+    assertTrue(
+        merged.getNdv().getSketchesList().stream()
+            .anyMatch(s -> s.getSketchType().equals("apache-datasketches-theta-v1")));
+    assertTrue(merged.getNdv().getSketchesList().stream().anyMatch(s -> s.equals(tuple)));
+  }
+
+  @Test
+  void fileRecordRollup_propagatesScalarSketchesFromASoleSourceUntouched() {
+    SketchPayload tdigest =
+        scalarPayload("apache-datasketches-tdigest-v1", SketchRole.SKETCH_ROLE_QUANTILES);
+    SketchPayload mcv =
+        scalarPayload("apache-datasketches-frequencies-utf8-v1", SketchRole.SKETCH_ROLE_MCV);
+    ScalarStats sole =
+        scalarWithSketches(
+                120,
+                ndvPayload(
+                    "apache-datasketches-theta-v1", SketchRole.SKETCH_ROLE_NDV, thetaBytes("a")),
+                tdigest)
+            .toBuilder()
+            .addSketches(mcv)
+            .build();
+
+    List<TargetStatsRecord> result =
+        FileGroupTargetStatsRollup.completeSnapshotFromFileRecords(
+            TABLE,
+            1L,
+            Set.of(FloecatConnector.StatsTargetKind.COLUMN),
+            List.of(fileRecord(1L, sole)));
+
+    // One source contributed the entire column, so its producer-owned payloads ARE the column's
+    // distribution: propagated byte-for-byte, never re-encoded. This is the payload the planner
+    // consumes for range/MCV selectivity — dropping it was the missing_quantile_sketch downgrade.
+    ScalarStats merged = onlyScalar(result);
+    assertEquals(List.of(tdigest, mcv), merged.getSketchesList());
+  }
+
+  @Test
+  void partialMerge_propagatesScalarSketchesFromASolePartialUntouched() {
+    SketchPayload tdigest =
+        scalarPayload("apache-datasketches-tdigest-v1", SketchRole.SKETCH_ROLE_QUANTILES);
+    TargetStatsRecord solePartial =
+        TargetStatsRecords.columnRecord(
+            TABLE, 1L, 1L, scalarWithSketches(120, null, tdigest), null);
+
+    List<TargetStatsRecord> result =
+        FileGroupTargetStatsRollup.mergeSnapshotAggregatePartials(
+            TABLE, 1L, Set.of(FloecatConnector.StatsTargetKind.COLUMN), List.of(solePartial));
+
+    // The full-rescan final stage merges per-group partials; a single group must not lose the
+    // sketches its file rollup carried.
+    ScalarStats merged = onlyScalar(result);
+    assertEquals(List.of(tdigest), merged.getSketchesList());
+  }
+
+  @Test
+  void partialMerge_dropsScalarSketchesAcrossMultiplePartials() {
+    SketchPayload tdigest =
+        scalarPayload("apache-datasketches-tdigest-v1", SketchRole.SKETCH_ROLE_QUANTILES);
+    TargetStatsRecord p1 =
+        TargetStatsRecords.columnRecord(TABLE, 1L, 1L, scalarWithSketches(50, null, tdigest), null);
+    TargetStatsRecord p2 =
+        TargetStatsRecords.columnRecord(TABLE, 1L, 1L, scalarWithSketches(70, null, null), null);
+
+    List<TargetStatsRecord> result =
+        FileGroupTargetStatsRollup.mergeSnapshotAggregatePartials(
+            TABLE, 1L, Set.of(FloecatConnector.StatsTargetKind.COLUMN), List.of(p1, p2));
+
+    // Two groups contributed the column: one group's sketch describes only its rows and must not
+    // be advertised as the column's distribution.
+    ScalarStats merged = onlyScalar(result);
+    assertTrue(merged.getSketchesList().isEmpty());
+  }
+
+  @Test
   void complete_preservesFinalColumnRecordWithOpaqueSketchPayloads() {
     ScalarStats finalColumnStats =
         scalarWithSketches(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/RootRepairRequests.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/RootRepairRequests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.catalog.impl;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import org.jboss.logging.Logger;
+
+/**
+ * Query-path reporting of broken table-root state into the {@link RootResyncQueue}, so the periodic
+ * re-drive converges tables whose roots a read found missing or internally inconsistent — instead
+ * of every query failing the same way forever with nothing scheduled to repair it.
+ *
+ * <p>The queue's marker was originally only written by the transactional resync path; a root broken
+ * by anything else (a swept blob under a live pointer, a migration that landed on legacy data, a
+ * manifest missing its currency) had no writer to converge it. Reads reporting here extend the same
+ * durable re-drive to any observed breakage: {@code resyncFromCommittedState} re-derives the root —
+ * definition ref, snapshot manifest, currency — from committed state, so it heals every shape of
+ * breakage whose underlying data still exists, and converges to a deleted root when it does not.
+ *
+ * <p>Two properties keep this safe on the query path:
+ *
+ * <ul>
+ *   <li><b>Rate-limited per table.</b> A broken table fails every query against it (incidents show
+ *       dozens of identical failures per second), while one durable marker is all the re-drive
+ *       needs. The first observer in each window enqueues; the rest are suppressed.
+ *   <li><b>Best-effort, never throws.</b> Repair bookkeeping must not mask or replace the query's
+ *       own diagnostic error; an enqueue failure is logged and the suppression released so a later
+ *       query retries the report.
+ * </ul>
+ *
+ * <p>The suppression map keeps one {@code (account/table) -> timestamp} entry per table ever
+ * reported broken — a handful of tiny entries in practice, never per-query growth.
+ */
+@ApplicationScoped
+public class RootRepairRequests {
+
+  private static final Logger LOG = Logger.getLogger(RootRepairRequests.class);
+
+  /**
+   * One report per table per window. Well above any query rate, well below the re-drive cadence: a
+   * marker the GC pass could not clear stays durable regardless, so re-reporting sooner buys
+   * nothing.
+   */
+  private static final long SUPPRESSION_WINDOW_NANOS = TimeUnit.MINUTES.toNanos(5);
+
+  /** Null when disabled: reports become no-ops (graphs wired without a pointer store, in tests). */
+  private final RootResyncQueue resyncQueue;
+
+  private final LongSupplier nanoClock;
+  private final ConcurrentHashMap<String, Long> lastReported = new ConcurrentHashMap<>();
+
+  @Inject
+  public RootRepairRequests(RootResyncQueue resyncQueue) {
+    this(resyncQueue, System::nanoTime);
+  }
+
+  RootRepairRequests(RootResyncQueue resyncQueue, LongSupplier nanoClock) {
+    this.resyncQueue = resyncQueue;
+    this.nanoClock = nanoClock;
+  }
+
+  /** A no-op instance for object graphs wired without a pointer store (test-only constructors). */
+  public static RootRepairRequests disabled() {
+    return new RootRepairRequests(null, System::nanoTime);
+  }
+
+  /**
+   * Reports the table's root as observed-broken, durably enqueueing it for the periodic resync
+   * re-drive. Fire-and-forget: rate-limited per table and swallowing enqueue failures, so callers
+   * on the query path invoke it right before raising their own error without changing what the
+   * client sees.
+   */
+  public void request(ResourceId tableId) {
+    if (resyncQueue == null) {
+      return;
+    }
+    String key = tableId.getAccountId() + "/" + tableId.getId();
+    long now = nanoClock.getAsLong();
+    boolean[] firstInWindow = {false};
+    // Atomic claim of the window so concurrent failing queries elect exactly one reporter.
+    // Comparison by difference: nanoTime is only meaningful subtractively (it may be negative).
+    lastReported.compute(
+        key,
+        (k, prev) -> {
+          if (prev != null && now - prev < SUPPRESSION_WINDOW_NANOS) {
+            return prev;
+          }
+          firstInWindow[0] = true;
+          return now;
+        });
+    if (!firstInWindow[0]) {
+      return;
+    }
+    try {
+      resyncQueue.enqueue(tableId);
+    } catch (RuntimeException e) {
+      // Release the claimed window (only if still ours) so the next failing query retries the
+      // report instead of the table sitting unrepaired for the full window.
+      lastReported.remove(key, now);
+      LOG.warnf(e, "failed to enqueue root repair for table %s", tableId.getId());
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueue.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueue.java
@@ -25,9 +25,10 @@ import jakarta.inject.Inject;
 import java.util.function.LongConsumer;
 
 /**
- * The durable queue of tables whose post-transaction root resync failed and awaits re-drive by the
- * periodic transaction GC. A table only ever written through REST transactions has no other writer
- * to converge its root, so an absorbed resync failure must leave a durable trace.
+ * The durable queue of tables whose root needs a re-driven resync by the periodic transaction GC.
+ * Two kinds of writer enqueue: the post-transaction resync path when its attempt was absorbed (a
+ * table only ever written through REST transactions has no other writer to converge its root), and
+ * query-path reads that observed a broken root ({@link RootRepairRequests}).
  *
  * <p>Enqueueing when a marker already exists TOUCHES it (bumps the pointer version): the GC pass
  * clears markers with a versioned delete taken against the version it listed, so a failure recorded
@@ -37,7 +38,7 @@ import java.util.function.LongConsumer;
 @ApplicationScoped
 public class RootResyncQueue {
 
-  private static final int ENQUEUE_ATTEMPTS = 4;
+  static final int ENQUEUE_ATTEMPTS = 4;
   private static final long[] RETRY_BACKOFF_MS = {10L, 25L, 50L};
 
   private final PointerStore pointerStore;

--- a/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/execution/impl/ScanBundleService.java
@@ -71,17 +71,20 @@ public class ScanBundleService {
   private final SnapshotRepository snapshots;
   private final StatsStore statsStore;
   private final ServerSideFileIoPropertiesResolver fileIoPropertiesResolver;
+  private final PinValidator pinValidator;
 
   @Inject
   public ScanBundleService(
       TableRepository tables,
       SnapshotRepository snapshots,
       StatsStore statsStore,
-      ServerSideFileIoPropertiesResolver fileIoPropertiesResolver) {
+      ServerSideFileIoPropertiesResolver fileIoPropertiesResolver,
+      PinValidator pinValidator) {
     this.tables = tables;
     this.snapshots = snapshots;
     this.statsStore = statsStore;
     this.fileIoPropertiesResolver = fileIoPropertiesResolver;
+    this.pinValidator = pinValidator;
   }
 
   /**
@@ -104,13 +107,13 @@ public class ScanBundleService {
     // fails as catalog-integrity corruption — a still-resident decode must not mask a swept blob,
     // so these reads' emptiness has to reflect the store. Once per scan session, not per page.
     Table table =
-        PinValidator.requirePinnedTableBlob(
+        pinValidator.requirePinnedTableBlob(
             tables.getByBlobUriLive(pin.getTableBlobUri()), correlationId, tableId);
     StoreOperationSummary.nanos("table_load", System.nanoTime() - tableStartedNanos);
 
     long snapshotStartedNanos = System.nanoTime();
     Snapshot snapshot =
-        PinValidator.requirePinnedSnapshotBlob(
+        pinValidator.requirePinnedSnapshotBlob(
             snapshots.getByBlobUriLive(pin.getSnapshotBlobUri()),
             correlationId,
             tableId,

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.metagraph.model.*;
 import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.service.catalog.impl.RootRepairRequests;
 import ai.floedb.floecat.service.catalog.impl.TableRootCommitter;
 import ai.floedb.floecat.service.error.impl.GeneratedErrorMessages;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
@@ -75,6 +76,7 @@ public final class UserGraph {
   private final SnapshotHelper snapshots;
   private final EngineHintManager hints;
   private final PrincipalProvider principal;
+  private final PinValidator pinValidator;
 
   // ----------------------------------------------------------------------
   // Constructor
@@ -113,7 +115,8 @@ public final class UserGraph {
           long metaCacheTtlSeconds,
       EngineHintManager engineHints,
       ai.floedb.floecat.stats.spi.StatsStore statsStore,
-      ImmutableBlobCache blobCache) {
+      ImmutableBlobCache blobCache,
+      PinValidator pinValidator) {
     this.cache =
         new GraphCacheManager(
             cacheMaxSize > 0, cacheMaxSize, Math.max(0L, metaCacheTtlSeconds), observability);
@@ -123,7 +126,9 @@ public final class UserGraph {
     this.nodes = new NodeLoader(catalogRepo, nsRepo, tableRepo, viewRepo);
     this.names = new NameResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
     this.fq = new FullyQualifiedResolver(catalogRepo, nsRepo, tableRepo, viewRepo);
-    this.snapshots = new SnapshotHelper(snapshotRepo, tableRootRepo, rootCommitter, statsStore);
+    this.pinValidator = pinValidator;
+    this.snapshots =
+        new SnapshotHelper(snapshotRepo, tableRootRepo, rootCommitter, statsStore, pinValidator);
     this.hints = engineHints;
     this.principal = principal;
   }
@@ -157,7 +162,9 @@ public final class UserGraph {
         // Mirror the pre-fold node-cache knob: a positive max size enables node caching.
         cacheMaxSize > 0
             ? new ImmutableBlobCache(true, 64L * 1024 * 1024, Duration.ofMinutes(15))
-            : null);
+            : null,
+        // No pointer store in this wiring, so broken-root repair reporting is disabled.
+        new PinValidator(tableRootRepo, RootRepairRequests.disabled()));
   }
 
   /** TEST-ONLY constructor; no legacy-root synthesis. */
@@ -188,7 +195,9 @@ public final class UserGraph {
         2L,
         null,
         null,
-        new ImmutableBlobCache(true, 64L * 1024 * 1024, Duration.ofMinutes(15)));
+        new ImmutableBlobCache(true, 64L * 1024 * 1024, Duration.ofMinutes(15)),
+        // No pointer store in this wiring, so broken-root repair reporting is disabled.
+        new PinValidator(tableRootRepo, RootRepairRequests.disabled()));
   }
 
   // No writer-refresh here, deliberately (unlike the root-pointer cache): resolve() always
@@ -514,7 +523,7 @@ public final class UserGraph {
                             cid,
                             GeneratedErrorMessages.MessageKey.TABLE,
                             Map.of("id", tblId.getId())))
-            : PinValidator.requirePinnedTableBlob(
+            : pinValidator.requirePinnedTableBlob(
                 nodes.tableFromBlob(tblId, tableBlobUri), cid, tblId);
     return new SchemaResolution(tbl, schemaJsonFor(cid, tbl, snapshot, snapshotBlobUri));
   }

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
@@ -56,22 +56,26 @@ public class SnapshotHelper {
   private final TableRootRepository roots;
   private final TableRootCommitter rootCommitter;
   private final StatsStore statsStore;
+  private final PinValidator pins;
 
   /**
    * {@code rootCommitter} materializes a legacy table's root at first touch ({@code ensureRoot}),
    * so a pre-existing deployment migrates lazily as its tables are queried. Pins are built from a
    * just-read root blob and validated by every consumption through the {@link PinValidator}
-   * contract, so construction performs no extra validation round-trip.
+   * contract, so construction performs no extra validation round-trip — {@code pins} here serves
+   * the pinned schema read and reports broken roots observed during pin construction for repair.
    */
   public SnapshotHelper(
       SnapshotRepository snapshots,
       TableRootRepository roots,
       TableRootCommitter rootCommitter,
-      StatsStore statsStore) {
+      StatsStore statsStore,
+      PinValidator pins) {
     this.snapshots = snapshots;
     this.roots = roots;
     this.rootCommitter = rootCommitter;
     this.statsStore = statsStore;
+    this.pins = pins;
   }
 
   /**
@@ -141,6 +145,13 @@ public class SnapshotHelper {
       // pathological second race): fall through to the per-pin-kind not-found handling below.
       rootMeta = roots.metaForSafeLive(tableId);
       root = loadRoot(rootMeta);
+      if (root == null && rootMeta != null && !rootMeta.getBlobUri().isEmpty()) {
+        // The re-read pointer still names an unreadable blob (a vanished pointer would be a
+        // legitimate drop): every future query fails here the same way until the root is
+        // re-derived, so enqueue the table for the resync re-drive (fire-and-forget) before the
+        // per-pin-kind not-found handling below rejects this query.
+        pins.requestRootRepair(tableId);
+      }
     }
 
     if (override != null && override.hasSnapshotId()) {
@@ -198,14 +209,17 @@ public class SnapshotHelper {
         SnapshotManifests.findEntry(roots, manifestHead(root), currentId)
             .orElseThrow(
                 // Currency pointing at a snapshot the manifest does not carry is a broken root
-                // invariant (removal clears currency in the same commit), never a client state.
-                () ->
-                    GrpcErrors.internal(
-                        cid,
-                        QUERY_PINNED_SNAPSHOT_BLOB_MISSING,
-                        Map.of(
-                            "table_id", tableId.getId(),
-                            "snapshot_id", Long.toString(currentId))));
+                // invariant (removal clears currency in the same commit), never a client state —
+                // report the table for the resync re-drive to re-derive its root.
+                () -> {
+                  pins.requestRootRepair(tableId);
+                  return GrpcErrors.internal(
+                      cid,
+                      QUERY_PINNED_SNAPSHOT_BLOB_MISSING,
+                      Map.of(
+                          "table_id", tableId.getId(),
+                          "snapshot_id", Long.toString(currentId)));
+                });
     if (gateOnFinalize() && !entry.hasStatsGenerationRef()) {
       // Committed currency can move before the generation publishes. Rather than reporting no
       // current for the whole append->finalize window, pin the newest FINALIZED snapshot at or
@@ -278,13 +292,18 @@ public class SnapshotHelper {
       MutationMeta rootMeta,
       Timestamp originalAsOf) {
     if (!root.hasDefinitionRef() || root.getDefinitionRef().getUri().isEmpty()) {
+      // A root without a definition ref is a broken invariant every query trips over: report the
+      // table for the resync re-drive (which re-derives the definition ref from committed state).
+      pins.requestRootRepair(tableId);
       throw GrpcErrors.internal(
           cid, QUERY_PINNED_TABLE_BLOB_MISSING, Map.of("table_id", tableId.getId()));
     }
     if (!entry.hasSnapshotRef() || entry.getSnapshotRef().getUri().isEmpty()) {
       // Every writer records a snapshot ref with the entry; its absence is a broken root
       // invariant. Failing here names the real problem instead of pinning an empty URI that a
-      // downstream requirePinnedSnapshotBlob would report as a generic internal error.
+      // downstream requirePinnedSnapshotBlob would report as a generic internal error — and the
+      // repair report gives the re-drive a chance to rebuild the manifest entry.
+      pins.requestRootRepair(tableId);
       throw GrpcErrors.internal(
           cid,
           QUERY_PINNED_SNAPSHOT_BLOB_MISSING,
@@ -357,7 +376,7 @@ public class SnapshotHelper {
 
     if (snapshotBlobUri != null && !snapshotBlobUri.isEmpty()) {
       Snapshot snap =
-          PinValidator.requirePinnedSnapshotBlob(
+          pins.requirePinnedSnapshotBlob(
               // LIVE: this read's emptiness is the pin-integrity detector (requirePinned*); a
               // still-resident decode must not mask a swept pinned blob.
               snapshots.getByBlobUriLive(snapshotBlobUri), cid, tbl.id());

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
@@ -153,7 +153,7 @@ public class SnapshotHelper {
                   () ->
                       GrpcErrors.notFound(
                           cid,
-                          SNAPSHOT,
+                          QUERY_SNAPSHOT_NOT_IN_TABLE,
                           Map.of(
                               "table_id", tableId.getId(),
                               "snapshot_id", Long.toString(snapshotId))));
@@ -190,7 +190,8 @@ public class SnapshotHelper {
     // current snapshot (freshly created with no data yet, or its current snapshot was deleted) is
     // an expected, client-reachable state — NOT_FOUND.
     if (root == null || !root.hasCurrentSnapshotId()) {
-      throw GrpcErrors.notFound(cid, SNAPSHOT, Map.of("table_id", tableId.getId()));
+      throw GrpcErrors.notFound(
+          cid, QUERY_TABLE_NO_QUERYABLE_SNAPSHOT, Map.of("table_id", tableId.getId()));
     }
     long currentId = root.getCurrentSnapshotId();
     SnapshotManifestEntry entry =
@@ -214,7 +215,11 @@ public class SnapshotHelper {
       entry =
           SnapshotManifests.latestQueryableCurrent(roots, manifestHead(root), entry)
               .orElseThrow(
-                  () -> GrpcErrors.notFound(cid, SNAPSHOT, Map.of("table_id", tableId.getId())));
+                  () ->
+                      GrpcErrors.notFound(
+                          cid,
+                          QUERY_TABLE_NO_QUERYABLE_SNAPSHOT,
+                          Map.of("table_id", tableId.getId())));
     }
     return pinFromEntry(cid, tableId, PinKind.PIN_KIND_CURRENT, entry, root, rootMeta, null);
   }
@@ -382,7 +387,7 @@ public class SnapshotHelper {
                   () ->
                       GrpcErrors.notFound(
                           cid,
-                          SNAPSHOT,
+                          QUERY_SNAPSHOT_NOT_IN_TABLE,
                           Map.of(
                               "table_id", tableId.getId(),
                               "snapshot_id", Long.toString(ref.getSnapshotId()))));
@@ -394,7 +399,7 @@ public class SnapshotHelper {
                   () ->
                       GrpcErrors.notFound(
                           cid,
-                          SNAPSHOT,
+                          QUERY_SNAPSHOT_NOT_FOUND_AT_TIME,
                           Map.of(
                               "table_id", tableId.getId(),
                               "as_of",

--- a/service/src/main/java/ai/floedb/floecat/service/query/PinValidator.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/PinValidator.java
@@ -23,6 +23,7 @@ import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.Messag
 
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.service.catalog.impl.RootRepairRequests;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -37,6 +38,11 @@ import java.util.Map;
  * loudly through {@link #requirePinnedTableBlob}/{@link #requirePinnedSnapshotBlob} if it is gone —
  * so the single root leg is the pin's integrity contract, not a per-blob re-check.
  *
+ * <p>Every integrity failure raised here also reports the table through {@link #requestRootRepair}:
+ * a missing pinned blob means the table's committed root names data a read cannot load, a state
+ * that persists across queries until the root is re-derived — so beyond failing this query loudly,
+ * the table is enqueued for the periodic resync re-drive to converge.
+ *
  * <p>A pin with an empty root URI was never legitimately constructed (construction reads the root
  * or fails) and is rejected loudly rather than waved through.
  */
@@ -44,47 +50,66 @@ import java.util.Map;
 public class PinValidator {
 
   private final TableRootRepository roots;
+  private final RootRepairRequests repairs;
 
   @Inject
-  public PinValidator(TableRootRepository roots) {
+  public PinValidator(TableRootRepository roots, RootRepairRequests repairs) {
     this.roots = roots;
+    this.repairs = repairs;
+  }
+
+  /**
+   * Reports the table's root as observed-broken so the periodic resync re-drive converges it.
+   * Fire-and-forget (rate-limited, never throws): raisers of catalog-integrity errors call this
+   * right before throwing, without changing what the failing query sees. Exposed for pin
+   * CONSTRUCTION sites ({@code SnapshotHelper}) whose breakage surfaces before any pin exists for
+   * the read-side contract here to check.
+   */
+  public void requestRootRepair(ResourceId tableId) {
+    repairs.request(tableId);
   }
 
   /**
    * Unwrap a pinned-table-blob load, failing with the same catalog-integrity error every pinned
    * read uses when the blob is gone. Keeps the error contract for "the pinned blob vanished" in one
-   * place across the schema/scan read sites.
+   * place across the schema/scan read sites, and enqueues the table for repair — the pinned root
+   * still names the vanished blob, so without a re-derived root every future query fails the same
+   * way.
    */
-  public static <T> T requirePinnedTableBlob(
+  public <T> T requirePinnedTableBlob(
       java.util.Optional<T> loaded, String correlationId, ResourceId tableId) {
     return loaded.orElseThrow(
-        () ->
-            GrpcErrors.internal(
-                correlationId,
-                QUERY_PINNED_TABLE_BLOB_MISSING,
-                Map.of("table_id", tableId.getId())));
+        () -> {
+          requestRootRepair(tableId);
+          return GrpcErrors.internal(
+              correlationId, QUERY_PINNED_TABLE_BLOB_MISSING, Map.of("table_id", tableId.getId()));
+        });
   }
 
   /** Snapshot-blob variant of {@link #requirePinnedTableBlob} for sites without the snapshot id. */
-  public static <T> T requirePinnedSnapshotBlob(
+  public <T> T requirePinnedSnapshotBlob(
       java.util.Optional<T> loaded, String correlationId, ResourceId tableId) {
     return loaded.orElseThrow(
-        () ->
-            GrpcErrors.internal(
-                correlationId,
-                QUERY_PINNED_SNAPSHOT_BLOB_MISSING,
-                Map.of("table_id", tableId.getId())));
+        () -> {
+          requestRootRepair(tableId);
+          return GrpcErrors.internal(
+              correlationId,
+              QUERY_PINNED_SNAPSHOT_BLOB_MISSING,
+              Map.of("table_id", tableId.getId()));
+        });
   }
 
   /** Snapshot-blob variant carrying the snapshot id in the error payload. */
-  public static <T> T requirePinnedSnapshotBlob(
+  public <T> T requirePinnedSnapshotBlob(
       java.util.Optional<T> loaded, String correlationId, ResourceId tableId, long snapshotId) {
     return loaded.orElseThrow(
-        () ->
-            GrpcErrors.internal(
-                correlationId,
-                QUERY_PINNED_SNAPSHOT_BLOB_MISSING,
-                Map.of("table_id", tableId.getId(), "snapshot_id", Long.toString(snapshotId))));
+        () -> {
+          requestRootRepair(tableId);
+          return GrpcErrors.internal(
+              correlationId,
+              QUERY_PINNED_SNAPSHOT_BLOB_MISSING,
+              Map.of("table_id", tableId.getId(), "snapshot_id", Long.toString(snapshotId)));
+        });
   }
 
   /** Validate the pin's root leg, throwing a catalog-integrity error when it does not hold. */
@@ -100,9 +125,16 @@ public class PinValidator {
     // pin-registration invariant it guards has broken.
     String etag = roots.blobEtag(pin.getRootUri());
     if (etag == null) {
+      // The pinned root blob is gone. Either the live pointer moved past it (this pin lost a
+      // race; the table itself is fine) or the pointer still names it (every future pin will fail
+      // too). Reporting for repair covers the second case and is a converged no-op in the first.
+      requestRootRepair(pin.getTableId());
       throw GrpcErrors.internal(
           correlationId, QUERY_PINNED_ROOT_MISSING, Map.of("table_id", pin.getTableId().getId()));
     }
+    // A version mismatch means the blob at the pinned URI was REPLACED — the table has moved on
+    // and a fresh pin would succeed, so unlike the missing-blob cases there is nothing for the
+    // resync re-drive to converge.
     if (!pin.getRootVersion().isEmpty() && !etag.equals(pin.getRootVersion())) {
       throw GrpcErrors.internal(
           correlationId,

--- a/service/src/main/java/ai/floedb/floecat/service/query/QueryPins.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/QueryPins.java
@@ -67,11 +67,17 @@ public final class QueryPins {
    * commit.
    */
   public static List<String> gcRootUris(TablePin pin) {
-    List<String> uris = new ArrayList<>(4);
+    List<String> uris = new ArrayList<>(5);
     addUriIfPresent(uris, pin.getRootUri());
     addUriIfPresent(uris, pin.getTableBlobUri());
     addUriIfPresent(uris, pin.getSnapshotBlobUri());
     addUriIfPresent(uris, pin.getConstraintsRefUri());
+    // The stats generation frozen on the pin is a DIRECT root, like every other pin ref: the
+    // planner reads the generation manifest through this URI for the query's lifetime, so it must
+    // not depend on the GC's table-root chain walk (which also references it, but is a sweep-time
+    // traversal that can be skipped on read failures) — symmetric with how live scan sessions
+    // root their frozen generation.
+    addUriIfPresent(uris, pin.getStatsGenerationRefUri());
     return uris;
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleService.java
@@ -21,6 +21,7 @@ import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.Messag
 import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
 import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.StatsTarget;
+import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.query.rpc.BundleFailure;
 import ai.floedb.floecat.query.rpc.BundleResultStatus;
@@ -337,9 +338,22 @@ public class PlannerStatsBundleService {
                 .build());
       }
 
+      /* Planner-aware completeness: a pinned record must carry every requested payload to count
+       * as a hit, or resolution falls through to the newest generation of the same snapshot.
+       * Passed as plain predicates so the orchestrator stays independent of the request model;
+       * the rule itself lives with the serving code (PlannerStatsResultMaterializer) so the two
+       * can never disagree on what "complete" means. */
+      java.util.Map<String, java.util.function.Predicate<TargetStatsRecord>> completeness =
+          new java.util.HashMap<>(targets.size());
+      for (PlannerStatsTargetNeed target : targets) {
+        completeness.put(
+            target.storageId(),
+            record -> PlannerStatsResultMaterializer.satisfiesNeed(record, target));
+      }
+
       java.util.Map<String, StatsResolutionResult> resolved =
           statsOrchestrator.resolvePlannerBatchInGeneration(
-              requests, statsGenerationRef, policy.staleOk(), deadlineNanos);
+              requests, statsGenerationRef, completeness, policy.staleOk(), deadlineNanos);
 
       Map<String, PlannerTargetStatsLookupResult> byTarget = new LinkedHashMap<>(targets.size());
       for (PlannerStatsTargetNeed target : targets) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleService.java
@@ -213,7 +213,7 @@ public class PlannerStatsBundleService {
         constraintRepository,
         RequestScopeConstraintPruner::new,
         RequestScopeConstraintPruner::forRequestedTablesOnly,
-        (tableId, snapshotId, targets, policy, deadlineNanos) -> {
+        (tableId, snapshotId, statsGenerationRef, targets, policy, deadlineNanos) -> {
           Map<String, PlannerTargetStatsLookupResult> byTarget = new LinkedHashMap<>();
           for (PlannerStatsTargetNeed target : targets) {
             PlannerTargetStatsLookupResult result =
@@ -303,6 +303,7 @@ public class PlannerStatsBundleService {
     Map<String, PlannerTargetStatsLookupResult> get(
         ResourceId tableId,
         long snapshotId,
+        Optional<String> statsGenerationRef,
         List<PlannerStatsTargetNeed> targets,
         PlannerStatsServingPolicy policy,
         long deadlineNanos);
@@ -312,7 +313,7 @@ public class PlannerStatsBundleService {
       StatsOrchestrator statsOrchestrator, TableRepository tableRepository) {
     Objects.requireNonNull(statsOrchestrator, "statsOrchestrator");
     Objects.requireNonNull(tableRepository, "tableRepository");
-    return (tableId, snapshotId, targets, policy, deadlineNanos) -> {
+    return (tableId, snapshotId, statsGenerationRef, targets, policy, deadlineNanos) -> {
       if (targets == null || targets.isEmpty()) {
         return Map.of();
       }
@@ -337,7 +338,8 @@ public class PlannerStatsBundleService {
       }
 
       java.util.Map<String, StatsResolutionResult> resolved =
-          statsOrchestrator.resolvePlannerBatch(requests, policy.staleOk(), deadlineNanos);
+          statsOrchestrator.resolvePlannerBatchInGeneration(
+              requests, statsGenerationRef, policy.staleOk(), deadlineNanos);
 
       Map<String, PlannerTargetStatsLookupResult> byTarget = new LinkedHashMap<>(targets.size());
       for (PlannerStatsTargetNeed target : targets) {
@@ -849,7 +851,11 @@ public class PlannerStatsBundleService {
           "target_batch_lookup",
           () ->
               work.ensureTargetBatchLoaded(
-                  targetStatsLookup, snapshotId, servingPolicy, requestDeadlineNanos));
+                  targetStatsLookup,
+                  snapshotId,
+                  pinLookup.pinnedStatsGenerationRef(work.tableId),
+                  servingPolicy,
+                  requestDeadlineNanos));
     }
 
     private ConstraintResolution resolveConstraintsTimed(TableWork work) {
@@ -1404,6 +1410,7 @@ public class PlannerStatsBundleService {
 
     private boolean constraintsEmitted = false;
     private OptionalLong loadedSnapshot = OptionalLong.empty();
+    private Optional<String> loadedStatsGenerationRef = Optional.empty();
     private Map<String, PlannerTargetStatsLookupResult> loadedTargetsById = Map.of();
     private RuntimeException loadFailure;
 
@@ -1459,17 +1466,32 @@ public class PlannerStatsBundleService {
     private void ensureTargetBatchLoaded(
         TargetStatsLookup lookup,
         long snapshotId,
+        Optional<String> statsGenerationRef,
         PlannerStatsServingPolicy servingPolicy,
         long deadlineNanos) {
-      if (loadedSnapshot.isPresent() && loadedSnapshot.getAsLong() == snapshotId) {
+      Optional<String> normalizedStatsGenerationRef =
+          statsGenerationRef == null
+              ? Optional.empty()
+              : statsGenerationRef.filter(token -> !token.isBlank());
+      if (loadedSnapshot.isPresent()
+          && loadedSnapshot.getAsLong() == snapshotId
+          && loadedStatsGenerationRef.equals(normalizedStatsGenerationRef)) {
         if (loadFailure != null) {
           throw loadFailure;
         }
         return;
       }
       loadedSnapshot = OptionalLong.of(snapshotId);
+      loadedStatsGenerationRef = normalizedStatsGenerationRef;
       try {
-        loadedTargetsById = lookup.get(tableId, snapshotId, targets, servingPolicy, deadlineNanos);
+        loadedTargetsById =
+            lookup.get(
+                tableId,
+                snapshotId,
+                normalizedStatsGenerationRef,
+                targets,
+                servingPolicy,
+                deadlineNanos);
         loadFailure = null;
       } catch (RuntimeException e) {
         loadedTargetsById = Map.of();

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsRequestNormalizer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsRequestNormalizer.java
@@ -20,6 +20,7 @@ import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.Messag
 
 import ai.floedb.floecat.catalog.rpc.StatsTarget;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.query.rpc.FetchTableConstraintsRequest;
 import ai.floedb.floecat.query.rpc.FetchTargetStatsRequest;
 import ai.floedb.floecat.query.rpc.RequestedStat;
@@ -72,11 +73,12 @@ final class PlannerStatsRequestNormalizer {
             PLANNER_STATS_REQUEST_TABLE_ID_MISSING,
             Map.of("table_index", Integer.toString(tableIndex)));
       }
+      ResourceId tableId = normalizePlannerTableId(table.getTableId());
       if (table.getTargetsCount() == 0) {
         throw GrpcErrors.invalidArgument(
             correlationId,
             PLANNER_STATS_REQUEST_TARGETS_MISSING,
-            Map.of("table_id", table.getTableId().getId()));
+            Map.of("table_id", tableId.getId()));
       }
 
       List<PlannerStatsTargetNeed> asTargets = new ArrayList<>(table.getTargetsCount());
@@ -102,18 +104,18 @@ final class PlannerStatsRequestNormalizer {
             new PlannerStatsTargetNeed(
                 target,
                 requestedStats,
-                validatedStorageId(correlationId, table.getTableId().getId(), target),
+                validatedStorageId(correlationId, tableId.getId(), target),
                 priority));
       }
 
       asTargets.sort(Comparator.comparingInt(PlannerStatsTargetNeed::priority));
       List<PlannerStatsTargetNeed> dedupedRaw =
-          dedupeTargets(correlationId, table.getTableId().getId(), asTargets);
+          dedupeTargets(correlationId, tableId.getId(), asTargets);
       if (dedupedRaw.isEmpty()) {
         throw GrpcErrors.invalidArgument(
             correlationId,
             PLANNER_STATS_REQUEST_TARGETS_MISSING,
-            Map.of("table_id", table.getTableId().getId()));
+            Map.of("table_id", tableId.getId()));
       }
 
       List<PlannerStatsTargetNeed> deduped = new ArrayList<>(dedupedRaw.size());
@@ -141,8 +143,7 @@ final class PlannerStatsRequestNormalizer {
         omitted = List.copyOf(deduped);
         omittedTargets += deduped.size();
         normalized.add(
-            new PlannerStatsTableRequest(
-                table.getTableId(), List.of(), omitted, snapshotOverride(table)));
+            new PlannerStatsTableRequest(tableId, List.of(), omitted, snapshotOverride(table)));
         continue;
       }
       if (deduped.size() > remaining) {
@@ -154,7 +155,7 @@ final class PlannerStatsRequestNormalizer {
       }
       normalized.add(
           new PlannerStatsTableRequest(
-              table.getTableId(), List.copyOf(deduped), omitted, snapshotOverride(table)));
+              tableId, List.copyOf(deduped), omitted, snapshotOverride(table)));
       totalTargets += deduped.size();
     }
 
@@ -173,6 +174,13 @@ final class PlannerStatsRequestNormalizer {
     }
   }
 
+  private static ResourceId normalizePlannerTableId(ResourceId tableId) {
+    if (tableId.getKind() == ResourceKind.RK_UNSPECIFIED) {
+      return tableId.toBuilder().setKind(ResourceKind.RK_TABLE).build();
+    }
+    return tableId;
+  }
+
   List<ResourceId> normalizeConstraints(
       String correlationId, FetchTableConstraintsRequest request) {
     if (request.getTableIdsCount() == 0) {
@@ -189,7 +197,9 @@ final class PlannerStatsRequestNormalizer {
             PLANNER_STATS_REQUEST_TABLE_ID_MISSING,
             Map.of("table_index", Integer.toString(tableIndex)));
       }
-      deduped.putIfAbsent(RequestScopeConstraintPruner.relationKey(tableId), tableId);
+      ResourceId normalizedTableId = normalizePlannerTableId(tableId);
+      deduped.putIfAbsent(
+          RequestScopeConstraintPruner.relationKey(normalizedTableId), normalizedTableId);
     }
     if (deduped.size() > maxTables) {
       throw GrpcErrors.invalidArgument(

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsResultMaterializer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsResultMaterializer.java
@@ -206,6 +206,43 @@ final class PlannerStatsResultMaterializer {
         .build();
   }
 
+  /**
+   * True when {@code record} can serve every stat {@code need} requests: the scalar header when
+   * {@code STAT_ROLE_SCALAR} is requested, and a payload matching each requested sketch role and
+   * type.
+   *
+   * <p>This is the planner-aware completeness rule behind generation fallback: a record that merely
+   * EXISTS in the pinned generation is not a complete hit — a scalar-only record must not satisfy a
+   * quantile need, or resolution would stop at a record the planner can only consume downgraded.
+   * Lives next to {@link #findMatchingSketch} so resolution and serving judge capability with the
+   * same rule and can never disagree.
+   *
+   * <p>Presence-only: a sketch that exists but exceeds the request's byte budget still satisfies —
+   * budget omission is a serving-policy decision, not a data gap another generation could fill.
+   */
+  static boolean satisfiesNeed(TargetStatsRecord record, PlannerStatsTargetNeed need) {
+    for (PlannerStatsStatRequest requested : need.requestedStats()) {
+      if (requested.omittedByPolicy()) {
+        // Served as OMITTED_BY_BUDGET regardless of what the record carries.
+        continue;
+      }
+      if (requested.role() == StatRole.STAT_ROLE_SCALAR) {
+        if (!record.hasScalar()) {
+          return false;
+        }
+        continue;
+      }
+      if (!requested.requestsSketchPayload()) {
+        // Unsupported role: served as ERROR; no generation can improve it.
+        continue;
+      }
+      if (findMatchingSketch(record, requested) == null) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   private static SketchPayload findMatchingSketch(
       TargetStatsRecord record, PlannerStatsStatRequest request) {
     if (!record.hasScalar()) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsResultMaterializer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/PlannerStatsResultMaterializer.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.query.catalog;
 
 import ai.floedb.floecat.catalog.rpc.Ndv;
+import ai.floedb.floecat.catalog.rpc.NdvOrBuilder;
 import ai.floedb.floecat.catalog.rpc.ScalarStats;
 import ai.floedb.floecat.catalog.rpc.SketchPayload;
 import ai.floedb.floecat.catalog.rpc.SketchRole;
@@ -105,8 +106,13 @@ final class PlannerStatsResultMaterializer {
           ndvBuilder.addSketches(sketch);
         }
       }
-      if (returnScalar || ndvBuilder.getSketchesCount() > 0) {
+      if (hasEstimate(ndvBuilder) || ndvBuilder.getSketchesCount() > 0) {
         scalarBuilder.setNdv(ndvBuilder.build());
+      } else {
+        // An enrichment-fabricated envelope (sketch carrier with no estimate) whose sketches were
+        // all filtered out carries nothing servable — drop it rather than emit hasNdv() with
+        // neither mode nor payloads (hasEstimate is the shared mode gate).
+        scalarBuilder.clearNdv();
       }
     }
     if (!returnScalar
@@ -204,6 +210,19 @@ final class PlannerStatsResultMaterializer {
     return out.setStatus(StatsResultStatus.STATS_RESULT_HIT_COMPLETE)
         .setBytes(returnedSketch.getSerializedSize())
         .build();
+  }
+
+  /**
+   * True when the NDV envelope carries an actual estimate — its exact/approx mode oneof is set.
+   *
+   * <p>The single mode gate for NDV envelopes, per the CONTRACT note on {@code Ndv} in stats.proto:
+   * the mode oneof MAY be unset while sketches are present (e.g. an envelope fabricated by
+   * stats-generation enrichment purely to carry a superseded generation's sketch forward), so
+   * {@code hasNdv()} alone must never be read as "has an estimate" — that turns "NDV absent" into a
+   * bogus zero estimate.
+   */
+  static boolean hasEstimate(NdvOrBuilder ndv) {
+    return ndv.hasExact() || ndv.hasApprox();
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/SnapshotPinLookup.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/SnapshotPinLookup.java
@@ -25,6 +25,14 @@ interface SnapshotPinLookup {
   OptionalLong pinnedSnapshotId(ResourceId tableId);
 
   /**
+   * The stats generation ref frozen on this table's pin. Empty means no pin, no stats generation at
+   * pin time, or a store that does not track stats generations.
+   */
+  default Optional<String> pinnedStatsGenerationRef(ResourceId tableId) {
+    return Optional.empty();
+  }
+
+  /**
    * The constraints ref frozen on this table's pin — the pinned root entry's immutable bundle
    * identity, copied onto the pin at construction. Empty means no bundle existed at pin time (or no
    * pin): the query deterministically serves no constraints for its lifetime, even if a bundle

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/SnapshotPinResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/SnapshotPinResolver.java
@@ -76,6 +76,17 @@ final class SnapshotPinResolver implements SnapshotPinLookup {
                     pin.getConstraintsRefUri(), pin.getConstraintsRefVersion()));
   }
 
+  @Override
+  public Optional<String> pinnedStatsGenerationRef(ResourceId tableId) {
+    QueryContext ctx = liveContext();
+    if (ctx == null) {
+      return Optional.empty();
+    }
+    return ctx.findTablePin(tableId, correlationId)
+        .map(pin -> pin.getStatsGenerationRefUri())
+        .filter(uri -> !uri.isBlank());
+  }
+
   <T> Optional<T> withPinnedSnapshot(
       ResourceId tableId, LongFunction<Optional<T>> snapshotScopedLookup) {
     QueryContext ctx = liveContext();

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
@@ -289,6 +289,10 @@ public final class StatsProviderFactory {
 
     private static StatsProvider.ColumnStatsView toColumnStatsView(TargetStatsRecord record) {
       ScalarStats scalar = record.getScalar();
+      Ndv estimatedNdv =
+          scalar.hasNdv() && (scalar.getNdv().hasExact() || scalar.getNdv().hasApprox())
+              ? scalar.getNdv()
+              : null;
       return new ColumnStatsViewImpl(
           record.getTableId(),
           record.getTarget().getColumn().getColumnId(),
@@ -299,7 +303,7 @@ public final class StatsProviderFactory {
           scalar.getLogicalType(),
           scalar.hasMin() ? Optional.of(scalar.getMin()) : Optional.empty(),
           scalar.hasMax() ? Optional.of(scalar.getMax()) : Optional.empty(),
-          scalar.hasNdv() ? scalar.getNdv() : null,
+          estimatedNdv,
           scalar.hasAvgWidthBytes()
               ? OptionalLong.of(scalar.getAvgWidthBytes())
               : OptionalLong.empty());

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
@@ -147,14 +147,13 @@ public final class StatsProviderFactory {
       this.allowUnpinnedLatestSnapshotFallback = allowUnpinnedLatestSnapshotFallback;
     }
 
-    // Pinning note (intentional, deferred): these lookups scope stats to the pin's SNAPSHOT but not
-    // its stats GENERATION — StatsRepository resolves the live active generation for that snapshot,
-    // and pin_fingerprint carries no generation discriminator. So after a same-snapshot stats
-    // recompute, the planner may read a newer generation than the scan streams. This is deliberate
-    // best-effort: the active generation is root-protected (never GC'd), and the SCAN is
-    // authoritative for results (it freezes stats_generation_ref_uri), so this affects plan-quality
-    // estimation only, never correctness. Strict generation-pinning needs a generation-scoped stats
-    // lookup + a generation etag on RelationPinIdentity threaded into every stats cache key.
+    // Generation policy: these lookups scope stats to the pin's SNAPSHOT and read the pin's frozen
+    // stats generation FIRST via resolveInGeneration — the same generation the scan uses — so plans
+    // are stable and consistent with the scan. The newest (live active) generation only fills a
+    // target the pinned generation lacks, so an incomplete pinned generation never yields
+    // NOT_FOUND; an unpinned read uses the live/newest generation directly. The SCAN stays
+    // authoritative for results (it freezes stats_generation_ref_uri); a planner/scan generation
+    // difference affects estimation only, never correctness.
     @Override
     public Optional<StatsProvider.TableStatsView> tableStats(ResourceId tableId) {
       if (allowUnpinnedLatestSnapshotFallback) {
@@ -231,7 +230,9 @@ public final class StatsProviderFactory {
                 .correlationId(correlationId)
                 .latencyBudget(syncEnabled ? Optional.of(syncLatencyBudget) : Optional.empty())
                 .build();
-        StatsResolutionResult result = statsOrchestrator.resolve(request);
+        StatsResolutionResult result =
+            statsOrchestrator.resolveInGeneration(
+                request, pinResolver.pinnedStatsGenerationRef(tableId));
         return result
             .stats()
             .filter(TargetStatsRecord::hasTable)
@@ -256,7 +257,9 @@ public final class StatsProviderFactory {
                 .correlationId(correlationId)
                 .latencyBudget(syncEnabled ? Optional.of(syncLatencyBudget) : Optional.empty())
                 .build();
-        StatsResolutionResult result = statsOrchestrator.resolve(request);
+        StatsResolutionResult result =
+            statsOrchestrator.resolveInGeneration(
+                request, pinResolver.pinnedStatsGenerationRef(tableId));
         return result
             .stats()
             .filter(TargetStatsRecord::hasScalar)

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactory.java
@@ -289,8 +289,10 @@ public final class StatsProviderFactory {
 
     private static StatsProvider.ColumnStatsView toColumnStatsView(TargetStatsRecord record) {
       ScalarStats scalar = record.getScalar();
+      // Estimate-less envelopes are sketch carriers only (see the shared
+      // PlannerStatsResultMaterializer.hasEstimate mode gate) — never a zero-NDV estimate.
       Ndv estimatedNdv =
-          scalar.hasNdv() && (scalar.getNdv().hasExact() || scalar.getNdv().hasApprox())
+          scalar.hasNdv() && PlannerStatsResultMaterializer.hasEstimate(scalar.getNdv())
               ? scalar.getNdv()
               : null;
       return new ColumnStatsViewImpl(

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -212,7 +212,8 @@ public class UserObjectBundleService {
         statsFactory,
         decoratorProvider,
         engineContext,
-        new PinValidator(null) {
+        new PinValidator(
+            null, ai.floedb.floecat.service.catalog.impl.RootRepairRequests.disabled()) {
           @Override
           public void validate(String correlationId, ai.floedb.floecat.query.rpc.TablePin pin) {
             throw new IllegalStateException(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsGenerationEnrichment.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsGenerationEnrichment.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import ai.floedb.floecat.catalog.rpc.Ndv;
+import ai.floedb.floecat.catalog.rpc.ScalarStats;
+import ai.floedb.floecat.catalog.rpc.SketchPayload;
+import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Write-side half of the "generations only enrich" contract: a new stats generation for a snapshot
+ * must not lose sketch payloads the superseded generation already held for the same target.
+ *
+ * <p>Why this exists: stats writers have unequal capabilities. A sampled ANALYZE capture publishes
+ * column records rich with sketch payloads (quantiles, MCV, tuple), while a file-group rollup can
+ * only derive scalars and merged theta NDV from file records. When the rollup republishes a
+ * snapshot's stats it would otherwise supersede a sketch-bearing generation with a scalar-only one
+ * — and since the snapshot's data has not changed, every payload of the older generation is still a
+ * valid fact for the new one. This class folds those payloads forward at publish time so the newest
+ * generation of a snapshot is capability-wise a superset of the one it replaces.
+ *
+ * <p>Boundaries (deliberate):
+ *
+ * <ul>
+ *   <li><b>Payload enrichment only, never target resurrection.</b> A target the new generation does
+ *       not publish stays absent — {@code replaceAllStatsForSnapshot} owns which targets exist (a
+ *       republish may legitimately drop a column). Readers cover absent targets through the
+ *       pinned/newest generation fallback.
+ *   <li><b>Add, never overwrite.</b> The incoming record's own fields and payloads always win; a
+ *       superseded payload is folded in only when the incoming record has no payload with the same
+ *       (role, sketch_type) identity — the same identity the serving path matches on.
+ *   <li><b>Sketches only.</b> Scalar fields (row counts, min/max, NDV estimates) come from the new
+ *       capture and are authoritative; only immutable sketch payloads are carried forward.
+ * </ul>
+ */
+final class StatsGenerationEnrichment {
+  private StatsGenerationEnrichment() {}
+
+  /**
+   * Returns {@code incoming} with every sketch payload of {@code previous} folded in whose (role,
+   * sketch_type) identity the incoming record does not already carry. Records without scalar stats
+   * on either side are returned unchanged — only column-style records carry sketch payloads.
+   */
+  static TargetStatsRecord carrySketchesForward(
+      TargetStatsRecord incoming, TargetStatsRecord previous) {
+    if (!incoming.hasScalar() || !previous.hasScalar()) {
+      return incoming;
+    }
+    ScalarStats incomingScalar = incoming.getScalar();
+    ScalarStats previousScalar = previous.getScalar();
+
+    // Identities the incoming record already serves, across BOTH payload locations: the serving
+    // path (findMatchingSketch) searches scalar.sketches and scalar.ndv.sketches alike, so a
+    // payload present in either place must suppress the carry-forward of its identity.
+    Set<String> present = new HashSet<>();
+    incomingScalar.getSketchesList().forEach(sketch -> present.add(identity(sketch)));
+    if (incomingScalar.hasNdv()) {
+      incomingScalar.getNdv().getSketchesList().forEach(sketch -> present.add(identity(sketch)));
+    }
+
+    ScalarStats.Builder enriched = null;
+    for (SketchPayload sketch : previousScalar.getSketchesList()) {
+      if (present.add(identity(sketch))) {
+        enriched = enriched == null ? incomingScalar.toBuilder() : enriched;
+        enriched.addSketches(sketch);
+      }
+    }
+    if (previousScalar.hasNdv()) {
+      Ndv.Builder ndv = null;
+      for (SketchPayload sketch : previousScalar.getNdv().getSketchesList()) {
+        if (present.add(identity(sketch))) {
+          if (ndv == null) {
+            enriched = enriched == null ? incomingScalar.toBuilder() : enriched;
+            // Carry the payload into the incoming NDV envelope (creating an estimate-less one if
+            // the incoming record has none): the new capture's NDV ESTIMATE stays authoritative,
+            // only the superseded payload rides along. A fabricated envelope has hasNdv() == true
+            // with the exact/approx mode oneof UNSET — consumers must gate estimates on the mode,
+            // never on hasNdv() alone (the serving path already does).
+            ndv = enriched.hasNdv() ? enriched.getNdv().toBuilder() : Ndv.newBuilder();
+          }
+          ndv.addSketches(sketch);
+        }
+      }
+      if (ndv != null) {
+        enriched.setNdv(ndv);
+      }
+    }
+    if (enriched == null) {
+      return incoming;
+    }
+    return incoming.toBuilder().setScalar(enriched).build();
+  }
+
+  /**
+   * Payload identity for the carry-forward decision: role + sketch_type, mirroring the serving
+   * path's match rule so "already present" here means exactly "already servable" there.
+   */
+  private static String identity(SketchPayload sketch) {
+    return sketch.getRole().getNumber() + "|" + sketch.getSketchType();
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -363,13 +363,41 @@ public class StatsRepository implements StatsStore {
   @Override
   public Map<String, Optional<TargetStatsRecord>> getTargetStatsBatch(
       ResourceId tableId, long snapshotId, List<StatsTarget> targets) {
+    return getTargetStatsBatchInResolvedGeneration(
+        tableId,
+        snapshotId,
+        targets,
+        activeGeneration(tableId, snapshotId).map(ActiveSnapshotStats::generationId));
+  }
+
+  @Override
+  public Optional<TargetStatsRecord> getTargetStatsInGeneration(
+      ResourceId tableId, long snapshotId, String generationToken, StatsTarget target) {
+    return readGenerationIdForFrozenToken(snapshotId, generationToken)
+        .flatMap(
+            generationId ->
+                targetStatsStorage.getByPointer(
+                    targetPointerKey(tableId, snapshotId, generationId, target)));
+  }
+
+  @Override
+  public Map<String, Optional<TargetStatsRecord>> getTargetStatsBatchInGeneration(
+      ResourceId tableId, long snapshotId, String generationToken, List<StatsTarget> targets) {
+    return getTargetStatsBatchInResolvedGeneration(
+        tableId, snapshotId, targets, readGenerationIdForFrozenToken(snapshotId, generationToken));
+  }
+
+  private Map<String, Optional<TargetStatsRecord>> getTargetStatsBatchInResolvedGeneration(
+      ResourceId tableId,
+      long snapshotId,
+      List<StatsTarget> targets,
+      Optional<String> generationIdOpt) {
     if (targets == null || targets.isEmpty()) {
       return Map.of();
     }
 
-    // Resolve active generation ONCE — shared manifest for all targets in this snapshot.
-    Optional<ActiveSnapshotStats> activeOpt = activeGeneration(tableId, snapshotId);
-    if (activeOpt.isEmpty()) {
+    // Resolve generation ONCE — shared manifest for all targets in this snapshot.
+    if (generationIdOpt.isEmpty()) {
       // No stats captured for this snapshot yet — all misses.
       Map<String, Optional<TargetStatsRecord>> out = new LinkedHashMap<>(targets.size());
       for (StatsTarget t : targets) {
@@ -377,7 +405,7 @@ public class StatsRepository implements StatsStore {
       }
       return Collections.unmodifiableMap(out);
     }
-    ActiveSnapshotStats active = activeOpt.get();
+    String generationId = generationIdOpt.get();
 
     // Parallel fetch: one virtual thread per target, bounded by MAX_PARALLEL_READS.
     // The semaphore is a sliding window: as any read completes its slot is immediately
@@ -391,8 +419,7 @@ public class StatsRepository implements StatsStore {
               .map(
                   target -> {
                     String key = StatsTargetIdentity.storageId(target);
-                    String pKey =
-                        targetPointerKey(tableId, snapshotId, active.generationId(), target);
+                    String pKey = targetPointerKey(tableId, snapshotId, generationId, target);
                     return CompletableFuture.runAsync(
                         () -> {
                           semaphore.acquireUninterruptibly();
@@ -415,6 +442,21 @@ public class StatsRepository implements StatsStore {
       out.put(k, parallel.getOrDefault(k, Optional.empty()));
     }
     return Collections.unmodifiableMap(out);
+  }
+
+  private Optional<String> readGenerationIdForFrozenToken(long snapshotId, String generationToken) {
+    if (generationToken == null || generationToken.isBlank()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        loadGenerationId(generationToken)
+            .orElseThrow(
+                () ->
+                    new BaseResourceRepository.NotFoundException(
+                        "frozen stats generation manifest missing for snapshot "
+                            + snapshotId
+                            + ": "
+                            + generationToken)));
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -228,6 +228,8 @@ public class StatsRepository implements StatsStore {
                 .map(this::canonicalRecord)
                 .peek(record -> requireRecordForSnapshot(tableId, snapshotId, record))
                 .toList();
+    Optional<ActiveSnapshotStats> current = activeGenerationLive(tableId, snapshotId);
+    canonicalRecords = carrySketchesFromSuperseded(tableId, snapshotId, canonicalRecords, current);
     markGenerationPublishing(tableId, snapshotId, effectiveGenerationId);
     List<TargetStatsWrite> writes = new ArrayList<>(canonicalRecords.size());
     for (TargetStatsRecord record : canonicalRecords) {
@@ -238,7 +240,6 @@ public class StatsRepository implements StatsStore {
               record));
     }
     targetStatsStorage.overwriteBatch(writes);
-    Optional<ActiveSnapshotStats> current = activeGenerationLive(tableId, snapshotId);
     publishActiveGeneration(tableId, snapshotId, effectiveGenerationId, current);
     for (TargetStatsRecord record :
         listAllInGeneration(tableId, snapshotId, effectiveGenerationId)) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -448,15 +448,19 @@ public class StatsRepository implements StatsStore {
     if (generationToken == null || generationToken.isBlank()) {
       return Optional.empty();
     }
-    return Optional.of(
-        loadGenerationId(generationToken)
-            .orElseThrow(
-                () ->
-                    new BaseResourceRepository.NotFoundException(
-                        "frozen stats generation manifest missing for snapshot "
-                            + snapshotId
-                            + ": "
-                            + generationToken)));
+    String unavailableMessage =
+        "frozen stats generation manifest unavailable for snapshot "
+            + snapshotId
+            + ": "
+            + generationToken;
+    try {
+      return Optional.of(
+          loadGenerationId(generationToken)
+              .orElseThrow(
+                  () -> new StatsStore.GenerationUnavailableException(unavailableMessage)));
+    } catch (BaseResourceRepository.CorruptionException e) {
+      throw new StatsStore.GenerationUnavailableException(unavailableMessage, e);
+    }
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -872,6 +872,11 @@ public class StatsRepository implements StatsStore {
                 .peek(record -> requireRecordForSnapshot(tableId, snapshotId, record))
                 .toList();
     Optional<ActiveSnapshotStats> current = activeGenerationLive(tableId, snapshotId);
+    // Generations only enrich: fold the superseded generation's sketch payloads into same-target
+    // records before writing, so a scalar-only republish (e.g. a file-group rollup) never loses
+    // sketches an earlier capture already published for this unchanged snapshot. See
+    // StatsGenerationEnrichment for the contract and its deliberate boundaries.
+    canonicalRecords = carrySketchesFromSuperseded(tableId, snapshotId, canonicalRecords, current);
     String generationId = newGenerationId();
 
     try {
@@ -921,6 +926,42 @@ public class StatsRepository implements StatsStore {
     TargetStatsRecord canonical = TargetStatsRecords.canonicalize(value);
     Schemas.TARGET_STATS.keyFromValue.apply(canonical);
     return canonical;
+  }
+
+  /**
+   * Folds the superseded generation's sketch payloads into the records a new generation is about to
+   * publish (see {@link StatsGenerationEnrichment} for the contract). One batched read of the
+   * superseded generation, only for the scalar-bearing (column-style) targets being republished —
+   * this runs on the finalize/republish path, never on the query hot path.
+   */
+  private List<TargetStatsRecord> carrySketchesFromSuperseded(
+      ResourceId tableId,
+      long snapshotId,
+      List<TargetStatsRecord> incoming,
+      Optional<ActiveSnapshotStats> superseded) {
+    if (superseded.isEmpty() || incoming.isEmpty()) {
+      return incoming;
+    }
+    List<StatsTarget> scalarTargets =
+        incoming.stream()
+            .filter(TargetStatsRecord::hasScalar)
+            .map(TargetStatsRecord::getTarget)
+            .toList();
+    if (scalarTargets.isEmpty()) {
+      return incoming;
+    }
+    Map<String, Optional<TargetStatsRecord>> previous =
+        getTargetStatsBatchInResolvedGeneration(
+            tableId, snapshotId, scalarTargets, superseded.map(ActiveSnapshotStats::generationId));
+    return incoming.stream()
+        .map(
+            record ->
+                previous
+                    .getOrDefault(
+                        StatsTargetIdentity.storageId(record.getTarget()), Optional.empty())
+                    .map(prior -> StatsGenerationEnrichment.carrySketchesForward(record, prior))
+                    .orElse(record))
+        .toList();
   }
 
   private void publishActiveGeneration(

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/PlannerStatsResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/PlannerStatsResolver.java
@@ -28,7 +28,6 @@ import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsSyncOutcome;
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
 import ai.floedb.floecat.telemetry.MetricId;
-import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.Tag;
 import ai.floedb.floecat.telemetry.Telemetry.TagKey;
 import com.github.benmanes.caffeine.cache.Cache;
@@ -69,9 +68,6 @@ import org.jboss.logging.Logger;
 final class PlannerStatsResolver {
 
   private static final Logger LOG = Logger.getLogger(PlannerStatsResolver.class);
-  // Same tags as StatsOrchestrator so the extraction does not move any dashboard series.
-  private static final String COMPONENT = "service";
-  private static final String OPERATION = "stats_orchestrator";
 
   /**
    * Fully-qualified cache key for a single column-stats record.
@@ -155,19 +151,36 @@ final class PlannerStatsResolver {
           .build();
 
   private final StatsStore statsStore;
-  private final Observability observability;
+  private final Function<StatsCaptureRequest, Optional<TargetStatsRecord>> storeReader;
+  private final MetricCounter counter;
   private final Consumer<StatsSyncOutcome> hitObserver;
 
   /**
+   * Counter seam into the orchestrator's telemetry: the orchestrator stays the single owner of the
+   * component/operation tags and the null-observability no-op, so the extraction defines every
+   * dashboard series exactly once.
+   */
+  @FunctionalInterface
+  interface MetricCounter {
+    void increment(MetricId metric, double amount, Tag... tags);
+  }
+
+  /**
    * @param statsStore the persisted stats store all rungs read from
-   * @param observability metric sink; may be null (tests), in which case counters no-op
+   * @param storeReader the orchestrator's counted live-generation read (STORE_HITS/MISSES stay
+   *     defined once, there), used by the single-target rungs
+   * @param counter counter seam; the orchestrator merges in its component/operation tags
    * @param hitObserver invoked once per store/cache hit so the orchestrator's sync-outcome
    *     telemetry stays the single owner of that counter
    */
   PlannerStatsResolver(
-      StatsStore statsStore, Observability observability, Consumer<StatsSyncOutcome> hitObserver) {
+      StatsStore statsStore,
+      Function<StatsCaptureRequest, Optional<TargetStatsRecord>> storeReader,
+      MetricCounter counter,
+      Consumer<StatsSyncOutcome> hitObserver) {
     this.statsStore = statsStore;
-    this.observability = observability;
+    this.storeReader = storeReader;
+    this.counter = counter;
     this.hitObserver = hitObserver;
   }
 
@@ -406,7 +419,7 @@ final class PlannerStatsResolver {
     // Primary: the pinned generation (query-consistent), or live/newest when the pin froze none.
     Optional<TargetStatsRecord> primary;
     if (pinnedGeneration.isBlank()) {
-      primary = readStore(request);
+      primary = storeReader.apply(request);
     } else {
       try {
         primary =
@@ -433,7 +446,7 @@ final class PlannerStatsResolver {
     // Newest gap-fill — only when a specific generation was pinned; the pinned generation lacks
     // this target, so the newest generation backstops it before capture.
     if (!pinnedGeneration.isBlank()) {
-      return readStore(request);
+      return storeReader.apply(request);
     }
     return Optional.empty();
   }
@@ -443,14 +456,7 @@ final class PlannerStatsResolver {
     if (tableId == null) {
       return;
     }
-    statsCache
-        .asMap()
-        .keySet()
-        .removeIf(
-            key ->
-                key.accountId().equals(tableId.getAccountId())
-                    && key.tableId().equals(tableId.getId())
-                    && key.snapshotId() == snapshotId);
+    statsCache.asMap().keySet().removeIf(key -> matchesSnapshot(key, tableId, snapshotId));
   }
 
   /** Invalidates one cached target for one table snapshot. */
@@ -463,11 +469,7 @@ final class PlannerStatsResolver {
         .asMap()
         .keySet()
         .removeIf(
-            key ->
-                key.accountId().equals(tableId.getAccountId())
-                    && key.tableId().equals(tableId.getId())
-                    && key.snapshotId() == snapshotId
-                    && key.storageId().equals(storageId));
+            key -> matchesSnapshot(key, tableId, snapshotId) && key.storageId().equals(storageId));
   }
 
   /** Invalidates cached targets represented by successfully persisted records. */
@@ -491,10 +493,17 @@ final class PlannerStatsResolver {
         .keySet()
         .removeIf(
             key ->
-                key.accountId().equals(tableId.getAccountId())
-                    && key.tableId().equals(tableId.getId())
-                    && key.snapshotId() == snapshotId
-                    && storageIds.contains(key.storageId()));
+                matchesSnapshot(key, tableId, snapshotId) && storageIds.contains(key.storageId()));
+  }
+
+  /**
+   * The (account, table, snapshot) scope shared by every invalidation variant; keep the key-shape
+   * match here so a cache-key change cannot silently under-invalidate one variant.
+   */
+  private static boolean matchesSnapshot(StatsCacheKey key, ResourceId tableId, long snapshotId) {
+    return key.accountId().equals(tableId.getAccountId())
+        && key.tableId().equals(tableId.getId())
+        && key.snapshotId() == snapshotId;
   }
 
   /** Cache key for one request under a specific served-generation token ("" = live/newest). */
@@ -556,6 +565,21 @@ final class PlannerStatsResolver {
       return java.util.Collections.unmodifiableMap(out);
     } catch (BaseResourceRepository.AbortRetryableException | StorageAbortRetryableException e) {
       throw e;
+    } catch (StatsStore.GenerationUnavailableException generationError) {
+      LOG.debugf(
+          generationError,
+          "planner stats generation unavailable table=%s snapshot=%s; skipping target isolation",
+          tableId,
+          snapshotId);
+      Map<String, StatsResolutionResult> out = new LinkedHashMap<>();
+      String message =
+          generationError.getMessage() == null
+              ? "stats generation unavailable"
+              : generationError.getMessage();
+      for (StatsCaptureRequest request : requests) {
+        out.put(storageId(request), StatsResolutionResult.failed(message));
+      }
+      return java.util.Collections.unmodifiableMap(out);
     } catch (RuntimeException batchError) {
       if (requests.size() == 1) {
         return readPlannerTargetIsolated(
@@ -609,21 +633,8 @@ final class PlannerStatsResolver {
     return requests.stream().map(StatsCaptureRequest::target).toList();
   }
 
-  private static String storageId(StatsCaptureRequest request) {
+  static String storageId(StatsCaptureRequest request) {
     return StatsTargetIdentity.storageId(request.target());
-  }
-
-  private Optional<TargetStatsRecord> readStore(StatsCaptureRequest request) {
-    // Fast path: authoritative persisted read.
-    Optional<TargetStatsRecord> out =
-        statsStore.getTargetStats(request.tableId(), request.snapshotId(), request.target());
-    incrementCounter(
-        out.isPresent()
-            ? ServiceMetrics.Stats.STORE_HITS_TOTAL
-            : ServiceMetrics.Stats.STORE_MISSES_TOTAL,
-        1,
-        Tag.of(TagKey.SCOPE, "orchestrator"));
-    return out;
   }
 
   @FunctionalInterface
@@ -678,7 +689,7 @@ final class PlannerStatsResolver {
 
     void emit(ResourceId tableId, long snapshotId, String pinnedGeneration, int requested) {
       for (Map.Entry<PlannerLookupOutcome, Integer> entry : counts.entrySet()) {
-        incrementCounter(
+        counter.increment(
             ServiceMetrics.Stats.PLANNER_LOOKUP_OUTCOMES_TOTAL,
             entry.getValue(),
             Tag.of(TagKey.RESULT, entry.getKey().name().toLowerCase(java.util.Locale.ROOT)));
@@ -693,20 +704,5 @@ final class PlannerStatsResolver {
           requested,
           counts);
     }
-  }
-
-  /**
-   * Counter with the orchestrator's component/operation tags; no-ops when observability is absent
-   * (tests).
-   */
-  private void incrementCounter(MetricId metric, double amount, Tag... tags) {
-    if (observability == null) {
-      return;
-    }
-    Tag[] baseTags = {Tag.of(TagKey.COMPONENT, COMPONENT), Tag.of(TagKey.OPERATION, OPERATION)};
-    Tag[] merged = new Tag[baseTags.length + tags.length];
-    System.arraycopy(baseTags, 0, merged, 0, baseTags.length);
-    System.arraycopy(tags, 0, merged, baseTags.length, tags.length);
-    observability.counter(metric, amount, merged);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/PlannerStatsResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/PlannerStatsResolver.java
@@ -1,0 +1,704 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.statistics;
+
+import ai.floedb.floecat.catalog.rpc.StatsTarget;
+import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.service.telemetry.ServiceMetrics;
+import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
+import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
+import ai.floedb.floecat.stats.spi.StatsResolutionResult;
+import ai.floedb.floecat.stats.spi.StatsStore;
+import ai.floedb.floecat.stats.spi.StatsSyncOutcome;
+import ai.floedb.floecat.telemetry.MetricId;
+import ai.floedb.floecat.telemetry.Observability;
+import ai.floedb.floecat.telemetry.Tag;
+import ai.floedb.floecat.telemetry.Telemetry.TagKey;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Weigher;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.jboss.logging.Logger;
+
+/**
+ * Planner-facing STORE resolution for stats: generation ordering, per-target completeness matching,
+ * the pinned → newest → stale fallback ladder, the planner stats cache with its generation-scoped
+ * keyspaces and invalidation, and the per-batch lookup diagnostics.
+ *
+ * <p>Invariants this class maintains:
+ *
+ * <ul>
+ *   <li>the pinned generation is the primary source (query-consistent); when the pin froze no
+ *       generation the live/newest generation is primary;
+ *   <li>the newest (live active) generation is consulted only as same-snapshot gap-fill — richer
+ *       stats for identical data, never weakened snapshot consistency;
+ *   <li>a partial record is still served (the planner degrades per stat) and never falls through to
+ *       stale or capture;
+ *   <li>hits are cached under the generation actually served; records are cached whole and
+ *       completeness is re-judged per read, so one query's lesser need never masks another's richer
+ *       need.
+ * </ul>
+ *
+ * <p>Capture policy (bounded sync capture, async enqueue) stays in {@link StatsOrchestrator}, which
+ * owns this resolver and runs it as the store rungs of the planner ladder.
+ */
+final class PlannerStatsResolver {
+
+  private static final Logger LOG = Logger.getLogger(PlannerStatsResolver.class);
+  // Same tags as StatsOrchestrator so the extraction does not move any dashboard series.
+  private static final String COMPONENT = "service";
+  private static final String OPERATION = "stats_orchestrator";
+
+  /**
+   * Fully-qualified cache key for a single column-stats record.
+   *
+   * <p>All four fields are required to guarantee no cross-contamination:
+   *
+   * <ul>
+   *   <li>{@code accountId} — isolates tenants.
+   *   <li>{@code tableId} — isolates tables within an account.
+   *   <li>{@code snapshotId} — isolates snapshots; new stats captures produce new snapshot IDs, so
+   *       stale entries from old snapshots are never served for new-snapshot queries.
+   *   <li>{@code storageId} — the {@link ai.floedb.floecat.stats.identity.StatsTargetIdentity}
+   *       storage key that uniquely identifies the target (column, table-level, file, etc.) within
+   *       a snapshot.
+   * </ul>
+   */
+  private record StatsCacheKey(
+      String accountId, String tableId, long snapshotId, String generationToken, String storageId) {
+    private StatsCacheKey {
+      generationToken = generationToken == null ? "" : generationToken;
+    }
+  }
+
+  /**
+   * Maximum total byte weight of the stats cache.
+   *
+   * <p>256 MB accommodates roughly:
+   *
+   * <ul>
+   *   <li>~200,000 scalar-only records at ~1 KB each (typical planner path today), or
+   *   <li>~2,500 sketch-bearing records at ~100 KB each (theta k=4096 + tuple v2).
+   * </ul>
+   *
+   * <p>Using weight rather than entry count prevents OOM when sketch-carrying {@link
+   * TargetStatsRecord}s are common — a record with k=4096 theta + tuple sketches is ~100× larger
+   * than a scalar record, so a count-only cap of 500,000 could allow ~50 GB of in-memory sketch
+   * data if every entry held full sketch payloads.
+   */
+  private static final long STATS_CACHE_MAX_WEIGHT_BYTES = 256L * 1024 * 1024; // 256 MB
+
+  /**
+   * Weigher: approximate JVM heap cost per cache entry.
+   *
+   * <p>Uses {@link com.google.protobuf.AbstractMessage#getSerializedSize()} as a proxy for the
+   * proto object's heap footprint. Proto objects typically occupy 1–2× their wire size in heap
+   * (field objects, repeated-field lists, etc.), so the true heap usage may be larger; the weight
+   * budget accounts for this by being set conservatively. A small fixed overhead (64 B) is added
+   * per entry for cache bookkeeping and the key object.
+   *
+   * <p>Caffeine requires the weight to fit in an {@code int}. Records larger than {@link
+   * Integer#MAX_VALUE} bytes are treated as maximum weight, effectively evicting them immediately —
+   * an acceptable safety valve for pathologically large records.
+   */
+  private static int cacheWeight(StatsCacheKey key, TargetStatsRecord record) {
+    long size = record.getSerializedSize() + 64L; // +64 for key object + cache overhead
+    return (int) Math.min(size, Integer.MAX_VALUE);
+  }
+
+  /**
+   * Application-scoped, snapshot-safe stats cache, bounded by byte weight.
+   *
+   * <p>Lifetime: the JVM process (survives all queries and connections).
+   *
+   * <p>Invalidation: snapshot IDs isolate normal new-snapshot captures, but full-rescan/finalize
+   * paths can replace stats for the same snapshot ID. Successful mutation paths must explicitly
+   * invalidate affected entries through this resolver; TTL is only a backstop for memory and missed
+   * invalidation bugs.
+   *
+   * <p>Only positive hits (present records) are cached. Absent results are not cached because they
+   * may be under active synchronous capture and could appear within seconds.
+   *
+   * <p>Bounded by {@link #STATS_CACHE_MAX_WEIGHT_BYTES} rather than entry count: a single
+   * sketch-bearing record can be ~100 KB while a scalar record is ~1 KB; a count-only cap would
+   * allow unbounded memory growth as sketch payloads become common.
+   */
+  private final Cache<StatsCacheKey, TargetStatsRecord> statsCache =
+      Caffeine.newBuilder()
+          .maximumWeight(STATS_CACHE_MAX_WEIGHT_BYTES)
+          .weigher((Weigher<StatsCacheKey, TargetStatsRecord>) PlannerStatsResolver::cacheWeight)
+          .expireAfterWrite(10, TimeUnit.MINUTES) // Backstop; mutation paths invalidate eagerly.
+          .build();
+
+  private final StatsStore statsStore;
+  private final Observability observability;
+  private final Consumer<StatsSyncOutcome> hitObserver;
+
+  /**
+   * @param statsStore the persisted stats store all rungs read from
+   * @param observability metric sink; may be null (tests), in which case counters no-op
+   * @param hitObserver invoked once per store/cache hit so the orchestrator's sync-outcome
+   *     telemetry stays the single owner of that counter
+   */
+  PlannerStatsResolver(
+      StatsStore statsStore, Observability observability, Consumer<StatsSyncOutcome> hitObserver) {
+    this.statsStore = statsStore;
+    this.observability = observability;
+    this.hitObserver = hitObserver;
+  }
+
+  /**
+   * Outcome of the store rungs for one planner batch: the results served so far ({@code resolved},
+   * in ladder-insertion order), the targets no store rung could serve ({@code stillMissing}, ready
+   * for the orchestrator's capture rung), the batch diagnostics the capture rung records onto and
+   * the orchestrator emits exactly once, and the normalized pinned-generation token ({@code ""}
+   * when the pin froze none).
+   */
+  record Resolution(
+      Map<String, StatsResolutionResult> resolved,
+      List<StatsCaptureRequest> stillMissing,
+      PlannerLookupDiagnostics diagnostics,
+      String pinnedGeneration) {}
+
+  /**
+   * Store rungs of the planner batch ladder — cache, pinned/primary generation, newest gap-fill,
+   * stale — leaving capture to the caller. Callers guarantee a non-empty batch sharing one
+   * table/snapshot; the full ladder contract is documented on {@link
+   * StatsOrchestrator#resolvePlannerBatchInGeneration(java.util.List, Optional, java.util.Map,
+   * boolean, long)}.
+   */
+  Resolution resolveFromStore(
+      List<StatsCaptureRequest> requests,
+      Optional<String> pinnedGenerationToken,
+      Map<String, Predicate<TargetStatsRecord>> completenessByStorageId,
+      boolean staleOk) {
+    // All requests must share the same tableId and snapshotId (grouped upstream by TableWork).
+    StatsCaptureRequest first = requests.get(0);
+    String pinnedGeneration = pinnedGenerationToken.filter(token -> !token.isBlank()).orElse("");
+    java.util.function.Function<String, java.util.function.Predicate<TargetStatsRecord>>
+        completenessFor = key -> completenessByStorageId.getOrDefault(key, record -> true);
+    PlannerLookupDiagnostics diagnostics = new PlannerLookupDiagnostics();
+    // Primary keyspace/reader: the pinned generation when the pin froze one, else the live/newest
+    // generation (empty token). A new snapshotId is always a cache miss, so stats from a different
+    // snapshot are never returned for the current query.
+    String primaryToken = pinnedGeneration;
+    TargetBatchReader primaryBatch =
+        pinnedGeneration.isBlank()
+            ? statsStore::getTargetStatsBatch
+            : (tableId, snapshotId, targets) ->
+                statsStore.getTargetStatsBatchInGeneration(
+                    tableId, snapshotId, pinnedGeneration, targets);
+    TargetReader primaryTarget =
+        pinnedGeneration.isBlank()
+            ? statsStore::getTargetStats
+            : (tableId, snapshotId, target) ->
+                statsStore.getTargetStatsInGeneration(
+                    tableId, snapshotId, pinnedGeneration, target);
+
+    // 1. Cache check in the primary keyspace. A cached record that fails its completeness
+    // predicate reads as a miss — the store may hold an enriched generation this query can use —
+    // but is NOT evicted: it still satisfies lesser needs, and records are immutable per
+    // generation so re-reads converge on the same bytes.
+    java.util.Map<String, StatsResolutionResult> out =
+        new java.util.LinkedHashMap<>(requests.size());
+    java.util.List<StatsCaptureRequest> cacheMisses = new java.util.ArrayList<>();
+    // Cached-but-incomplete records from the primary keyspace. Each is itself a valid partial hit
+    // (the planner degrades per stat), kept as a last-resort candidate so that if the store re-read
+    // for a richer record fails — an unreadable frozen manifest — or comes back empty, an
+    // incomplete
+    // PINNED record still serves rather than degrading to stale/capture, honouring the ladder's
+    // "a partial pinned record is a hit, never a stale/capture trigger" invariant.
+    java.util.Map<String, TargetStatsRecord> cachedPartial = new java.util.LinkedHashMap<>();
+    for (StatsCaptureRequest req : requests) {
+      String key = storageId(req);
+      TargetStatsRecord cached = statsCache.getIfPresent(cacheKeyFor(req, primaryToken));
+      if (cached != null && completenessFor.apply(key).test(cached)) {
+        hitObserver.accept(StatsSyncOutcome.HIT);
+        diagnostics.record(PlannerLookupOutcome.CACHE_HIT);
+        out.put(key, StatsResolutionResult.hit(cached));
+      } else {
+        if (cached != null) {
+          // Present but incomplete for THIS need: not a hit here, but a valid degraded fallback.
+          cachedPartial.put(key, cached);
+        }
+        cacheMisses.add(req);
+      }
+    }
+
+    if (cacheMisses.isEmpty()) {
+      return new Resolution(out, List.of(), diagnostics, pinnedGeneration);
+    }
+
+    // 2. Primary store read: the pinned generation (query-consistent), or live/newest if no pin.
+    java.util.Map<String, StatsResolutionResult> primaryHits =
+        readPlannerBatchIsolated(
+            first.tableId(),
+            first.snapshotId(),
+            cacheMisses,
+            primaryBatch,
+            primaryTarget,
+            StatsResolutionResult::hit);
+
+    // Pinned records that exist but fail their completeness predicate: candidates the newest
+    // gap-fill may replace, and the answer of last resort if it cannot — a partial record is
+    // still a hit (the planner degrades per stat), never a stale/capture trigger.
+    java.util.Map<String, TargetStatsRecord> partialPinned = new java.util.LinkedHashMap<>();
+    java.util.List<StatsCaptureRequest> misses = new java.util.ArrayList<>();
+    for (StatsCaptureRequest req : cacheMisses) {
+      String key = storageId(req);
+      StatsResolutionResult hit = primaryHits.get(key);
+      if (hit != null && hit.hasStats()) {
+        TargetStatsRecord record = hit.stats().get();
+        boolean satisfies = completenessFor.apply(key).test(record);
+        if (satisfies || pinnedGeneration.isBlank()) {
+          // Complete — or partial with no pin, where the primary IS the newest generation and no
+          // richer same-snapshot source exists: serve as-is, the planner degrades per stat.
+          servePlannerHit(
+              out,
+              diagnostics,
+              req,
+              key,
+              record,
+              primaryToken,
+              satisfies ? PlannerLookupOutcome.PRIMARY_HIT : PlannerLookupOutcome.PARTIAL);
+        } else {
+          partialPinned.put(key, record);
+          misses.add(req);
+        }
+      } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
+        if (pinnedGeneration.isBlank()) {
+          diagnostics.record(PlannerLookupOutcome.FAILED);
+          out.put(key, hit);
+        } else {
+          // A pinned-generation read failure (e.g. an unreadable frozen manifest) must not zero
+          // planning quality for the batch: the newest generation of the same snapshot is an
+          // independent read path with no frozen manifest involved, so fall through to the
+          // gap-fill. If that fails too, ITS failure is the terminal one.
+          misses.add(req);
+        }
+      } else {
+        misses.add(req);
+      }
+    }
+
+    // A miss whose pinned store read failed or returned nothing, but for which we hold an
+    // incomplete cached record, keeps that cached record as its partial candidate: the store
+    // yielded no (fresher) partial to prefer, so the cached one is the last-resort hit that keeps
+    // an incomplete pinned record off the stale/capture path. Store-derived partials already in
+    // partialPinned win — they are read from the same pinned generation, only fresher.
+    for (StatsCaptureRequest req : misses) {
+      String key = storageId(req);
+      if (!partialPinned.containsKey(key) && cachedPartial.containsKey(key)) {
+        partialPinned.put(key, cachedPartial.get(key));
+      }
+    }
+
+    // 3. Newest gap-fill — only when a specific generation was pinned. Serves targets the pinned
+    // generation lacks (prevents NOT_FOUND) or holds only partially (prevents a needless
+    // downgrade), from the newest generation of the SAME snapshot; cached under the empty token.
+    java.util.List<StatsCaptureRequest> afterFill = new java.util.ArrayList<>();
+    if (!pinnedGeneration.isBlank() && !misses.isEmpty()) {
+      java.util.Map<String, StatsResolutionResult> fillHits =
+          readPlannerBatchIsolated(
+              first.tableId(),
+              first.snapshotId(),
+              misses,
+              statsStore::getTargetStatsBatch,
+              statsStore::getTargetStats,
+              StatsResolutionResult::hit);
+      for (StatsCaptureRequest req : misses) {
+        String key = storageId(req);
+        StatsResolutionResult hit = fillHits.get(key);
+        TargetStatsRecord partial = partialPinned.get(key);
+        boolean newestSatisfies =
+            hit != null && hit.hasStats() && completenessFor.apply(key).test(hit.stats().get());
+        if (newestSatisfies) {
+          servePlannerHit(
+              out, diagnostics, req, key, hit.stats().get(), "", PlannerLookupOutcome.NEWEST_FILL);
+        } else if (partial != null) {
+          // Newest is no more complete than the pin: between equally incomplete records,
+          // consistency prefers the pinned generation the scan reads.
+          servePlannerHit(
+              out, diagnostics, req, key, partial, primaryToken, PlannerLookupOutcome.PARTIAL);
+        } else if (hit != null && hit.hasStats()) {
+          // Pin has nothing at all; a partial newest record beats stale or capture.
+          servePlannerHit(
+              out, diagnostics, req, key, hit.stats().get(), "", PlannerLookupOutcome.PARTIAL);
+        } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
+          diagnostics.record(PlannerLookupOutcome.FAILED);
+          out.put(key, hit);
+        } else {
+          afterFill.add(req);
+        }
+      }
+    } else {
+      afterFill.addAll(misses);
+    }
+
+    // 4. Stale fallback — BEFORE sync capture.
+    // Single batch call: finds the latest snapshot with stats once (O(1) pointer read),
+    // then fetches all missing targets from that snapshot in parallel. Replaces N×O(prefix scan).
+    java.util.List<StatsCaptureRequest> stillMissing = new java.util.ArrayList<>();
+    if (staleOk && !afterFill.isEmpty()) {
+      java.util.Map<String, StatsResolutionResult> staleBatch =
+          readPlannerBatchIsolated(
+              first.tableId(),
+              first.snapshotId(),
+              afterFill,
+              statsStore::getStaleTargetStatsBatch,
+              statsStore::getStaleTargetStats,
+              record -> StatsResolutionResult.staleHit(record, "stale_before_sync"));
+      for (StatsCaptureRequest req : afterFill) {
+        String key = storageId(req);
+        StatsResolutionResult stale = staleBatch.get(key);
+        if (stale != null && stale.hasStats()) {
+          diagnostics.record(PlannerLookupOutcome.STALE_HIT);
+          out.put(key, stale);
+        } else if (stale != null && stale.outcome() == StatsSyncOutcome.FAILED) {
+          diagnostics.record(PlannerLookupOutcome.FAILED);
+          out.put(key, stale);
+        } else {
+          stillMissing.add(req);
+        }
+      }
+    } else {
+      stillMissing.addAll(afterFill);
+    }
+
+    return new Resolution(out, stillMissing, diagnostics, pinnedGeneration);
+  }
+
+  /**
+   * Store rungs of the single-target planner lookup: the pinned generation for the pinned snapshot
+   * (query-consistent; a pinned read failure falls through rather than failing the lookup), then
+   * the newest (live active) generation only to fill a target the pinned generation lacks. Empty
+   * means no store rung could serve; the caller decides whether to capture. Does not touch the
+   * planner cache, matching the historical single-target path.
+   */
+  Optional<TargetStatsRecord> resolveSingleFromStore(
+      StatsCaptureRequest request, Optional<String> pinnedGenerationToken) {
+    String pinnedGeneration = pinnedGenerationToken.filter(token -> !token.isBlank()).orElse("");
+
+    // Primary: the pinned generation (query-consistent), or live/newest when the pin froze none.
+    Optional<TargetStatsRecord> primary;
+    if (pinnedGeneration.isBlank()) {
+      primary = readStore(request);
+    } else {
+      try {
+        primary =
+            statsStore.getTargetStatsInGeneration(
+                request.tableId(), request.snapshotId(), pinnedGeneration, request.target());
+      } catch (RuntimeException e) {
+        // A pinned-generation read failure (e.g. an unreadable frozen manifest) must not fail the
+        // lookup outright: the newest generation of the same snapshot is an independent read path
+        // with no frozen manifest involved — treat the pin as a miss and let the gap-fill below
+        // serve, matching the batch path's fallback.
+        LOG.debugf(
+            e,
+            "pinned-generation read failed for %s; falling through to newest",
+            storageId(request));
+        primary = Optional.empty();
+      }
+    }
+    if (primary.isPresent()) {
+      return primary;
+    }
+
+    // Newest gap-fill — only when a specific generation was pinned; the pinned generation lacks
+    // this target, so the newest generation backstops it before capture.
+    if (!pinnedGeneration.isBlank()) {
+      return readStore(request);
+    }
+    return Optional.empty();
+  }
+
+  /** Invalidates every cached target for one table snapshot. */
+  void invalidateStatsCache(ResourceId tableId, long snapshotId) {
+    if (tableId == null) {
+      return;
+    }
+    statsCache
+        .asMap()
+        .keySet()
+        .removeIf(
+            key ->
+                key.accountId().equals(tableId.getAccountId())
+                    && key.tableId().equals(tableId.getId())
+                    && key.snapshotId() == snapshotId);
+  }
+
+  /** Invalidates one cached target for one table snapshot. */
+  void invalidateStatsCache(ResourceId tableId, long snapshotId, StatsTarget target) {
+    if (tableId == null || target == null) {
+      return;
+    }
+    String storageId = StatsTargetIdentity.storageId(target);
+    statsCache
+        .asMap()
+        .keySet()
+        .removeIf(
+            key ->
+                key.accountId().equals(tableId.getAccountId())
+                    && key.tableId().equals(tableId.getId())
+                    && key.snapshotId() == snapshotId
+                    && key.storageId().equals(storageId));
+  }
+
+  /** Invalidates cached targets represented by successfully persisted records. */
+  void invalidateStatsCache(ResourceId tableId, long snapshotId, List<TargetStatsRecord> records) {
+    if (tableId == null || records == null || records.isEmpty()) {
+      return;
+    }
+    java.util.Set<String> storageIds = new java.util.HashSet<>();
+    for (TargetStatsRecord record : records) {
+      if (record != null && record.hasTarget()) {
+        storageIds.add(StatsTargetIdentity.storageId(record.getTarget()));
+      }
+    }
+    if (storageIds.isEmpty()) {
+      return;
+    }
+    // One O(cacheSize) pass matching any of the records' targets, not one full scan per record —
+    // a wide-table recompute (hundreds of columns) would otherwise scan the cache once per column.
+    statsCache
+        .asMap()
+        .keySet()
+        .removeIf(
+            key ->
+                key.accountId().equals(tableId.getAccountId())
+                    && key.tableId().equals(tableId.getId())
+                    && key.snapshotId() == snapshotId
+                    && storageIds.contains(key.storageId()));
+  }
+
+  /** Cache key for one request under a specific served-generation token ("" = live/newest). */
+  private StatsCacheKey cacheKeyFor(StatsCaptureRequest req, String generationToken) {
+    return new StatsCacheKey(
+        req.tableId().getAccountId(),
+        req.tableId().getId(),
+        req.snapshotId(),
+        generationToken,
+        storageId(req));
+  }
+
+  /**
+   * Serve one resolved planner target: write the record through to the cache keyspace it was served
+   * from ({@code cacheToken} — the pinned generation's token, or "" for the live/newest
+   * generation), count the ladder rung that produced it, and emit the hit. The single definition of
+   * "serve" for every rung of {@link #resolveFromStore}, so caching, telemetry, and result emission
+   * can never drift apart between rungs.
+   */
+  private void servePlannerHit(
+      java.util.Map<String, StatsResolutionResult> out,
+      PlannerLookupDiagnostics diagnostics,
+      StatsCaptureRequest req,
+      String key,
+      TargetStatsRecord record,
+      String cacheToken,
+      PlannerLookupOutcome outcome) {
+    statsCache.put(cacheKeyFor(req, cacheToken), record);
+    hitObserver.accept(StatsSyncOutcome.HIT);
+    diagnostics.record(outcome);
+    out.put(key, StatsResolutionResult.hit(record));
+  }
+
+  private Map<String, StatsResolutionResult> readPlannerBatchIsolated(
+      ResourceId tableId,
+      long snapshotId,
+      List<StatsCaptureRequest> requests,
+      TargetBatchReader batchReader,
+      TargetReader targetReader,
+      Function<TargetStatsRecord, StatsResolutionResult> hitMapper) {
+    if (requests == null || requests.isEmpty()) {
+      return Map.of();
+    }
+
+    List<StatsTarget> targets = targetsOf(requests);
+    try {
+      Map<String, Optional<TargetStatsRecord>> batchHits =
+          batchReader.read(tableId, snapshotId, targets);
+      Map<String, StatsResolutionResult> out = new LinkedHashMap<>();
+      for (StatsCaptureRequest request : requests) {
+        String key = storageId(request);
+        Optional<TargetStatsRecord> hit = batchHits == null ? Optional.empty() : batchHits.get(key);
+        out.put(
+            key,
+            hit != null && hit.isPresent()
+                ? hitMapper.apply(hit.get())
+                : StatsResolutionResult.skipped("batch_store_miss"));
+      }
+      return java.util.Collections.unmodifiableMap(out);
+    } catch (RuntimeException batchError) {
+      if (requests.size() == 1) {
+        return readPlannerTargetIsolated(
+            tableId, snapshotId, requests.get(0), targetReader, hitMapper, batchError);
+      }
+      int mid = requests.size() / 2;
+      Map<String, StatsResolutionResult> out = new LinkedHashMap<>();
+      out.putAll(
+          readPlannerBatchIsolated(
+              tableId, snapshotId, requests.subList(0, mid), batchReader, targetReader, hitMapper));
+      out.putAll(
+          readPlannerBatchIsolated(
+              tableId,
+              snapshotId,
+              requests.subList(mid, requests.size()),
+              batchReader,
+              targetReader,
+              hitMapper));
+      return java.util.Collections.unmodifiableMap(out);
+    }
+  }
+
+  private Map<String, StatsResolutionResult> readPlannerTargetIsolated(
+      ResourceId tableId,
+      long snapshotId,
+      StatsCaptureRequest request,
+      TargetReader targetReader,
+      Function<TargetStatsRecord, StatsResolutionResult> hitMapper,
+      RuntimeException batchError) {
+    String key = storageId(request);
+    try {
+      Optional<TargetStatsRecord> record = targetReader.read(tableId, snapshotId, request.target());
+      return Map.of(
+          key,
+          record.map(hitMapper).orElseGet(() -> StatsResolutionResult.skipped("batch_store_miss")));
+    } catch (RuntimeException targetError) {
+      LOG.debugf(
+          targetError,
+          "planner stats target read failed after batch isolation table=%s target=%s",
+          tableId,
+          key);
+      String message =
+          targetError.getMessage() == null ? batchError.getMessage() : targetError.getMessage();
+      return Map.of(key, StatsResolutionResult.failed(message));
+    }
+  }
+
+  private static List<StatsTarget> targetsOf(List<StatsCaptureRequest> requests) {
+    return requests.stream().map(StatsCaptureRequest::target).toList();
+  }
+
+  private static String storageId(StatsCaptureRequest request) {
+    return StatsTargetIdentity.storageId(request.target());
+  }
+
+  private Optional<TargetStatsRecord> readStore(StatsCaptureRequest request) {
+    // Fast path: authoritative persisted read.
+    Optional<TargetStatsRecord> out =
+        statsStore.getTargetStats(request.tableId(), request.snapshotId(), request.target());
+    incrementCounter(
+        out.isPresent()
+            ? ServiceMetrics.Stats.STORE_HITS_TOTAL
+            : ServiceMetrics.Stats.STORE_MISSES_TOTAL,
+        1,
+        Tag.of(TagKey.SCOPE, "orchestrator"));
+    return out;
+  }
+
+  @FunctionalInterface
+  private interface TargetBatchReader {
+    Map<String, Optional<TargetStatsRecord>> read(
+        ResourceId tableId, long snapshotId, List<StatsTarget> targets);
+  }
+
+  @FunctionalInterface
+  private interface TargetReader {
+    Optional<TargetStatsRecord> read(ResourceId tableId, long snapshotId, StatsTarget target);
+  }
+
+  /**
+   * The ladder rung that resolved (or failed) one planner target — the diagnostics vocabulary for
+   * {@link StatsOrchestrator#resolvePlannerBatchInGeneration}. Emitted per target as a {@code
+   * result}-tagged count of {@code PLANNER_LOOKUP_OUTCOMES_TOTAL} and summarized in one DEBUG line
+   * per table batch, so "which rung served this query's stats" is a metric query or a log grep, not
+   * archaeology.
+   */
+  enum PlannerLookupOutcome {
+    /** Served from the cache keyspace of the primary generation. */
+    CACHE_HIT,
+    /** The primary generation (pinned, or live when unpinned) satisfied the need. */
+    PRIMARY_HIT,
+    /** The pinned generation lacked the target or capability; the newest generation satisfied. */
+    NEWEST_FILL,
+    /** Served a record that does not satisfy the full need (planner degrades per stat). */
+    PARTIAL,
+    /** No record at the pinned snapshot; served from an earlier snapshot. */
+    STALE_HIT,
+    /** Missing everywhere; a bounded sync capture produced the record. */
+    CAPTURED,
+    /** Missing everywhere; capture is pending (async mode, budget exhausted, or in flight). */
+    CAPTURE_PENDING,
+    /** A rung failed outright (store error surfaced as FAILED). */
+    FAILED
+  }
+
+  /**
+   * Per-batch outcome accumulator for the planner ladder: counts each target's outcome, then emits
+   * them once — as {@code result}-tagged counter increments and a single DEBUG summary line. One
+   * instance per {@link #resolveFromStore} call; never shared across threads.
+   */
+  final class PlannerLookupDiagnostics {
+    private final java.util.EnumMap<PlannerLookupOutcome, Integer> counts =
+        new java.util.EnumMap<>(PlannerLookupOutcome.class);
+
+    void record(PlannerLookupOutcome outcome) {
+      counts.merge(outcome, 1, Integer::sum);
+    }
+
+    void emit(ResourceId tableId, long snapshotId, String pinnedGeneration, int requested) {
+      for (Map.Entry<PlannerLookupOutcome, Integer> entry : counts.entrySet()) {
+        incrementCounter(
+            ServiceMetrics.Stats.PLANNER_LOOKUP_OUTCOMES_TOTAL,
+            entry.getValue(),
+            Tag.of(TagKey.RESULT, entry.getKey().name().toLowerCase(java.util.Locale.ROOT)));
+      }
+      // The greppable per-batch summary: which generation the batch read and how each target
+      // resolved. "generation=live" means the pin froze none and the live generation was primary.
+      LOG.debugf(
+          "planner_stats lookup table=%s snapshot=%d generation=%s requested=%d outcomes=%s",
+          tableId.getId(),
+          snapshotId,
+          pinnedGeneration.isBlank() ? "live" : pinnedGeneration,
+          requested,
+          counts);
+    }
+  }
+
+  /**
+   * Counter with the orchestrator's component/operation tags; no-ops when observability is absent
+   * (tests).
+   */
+  private void incrementCounter(MetricId metric, double amount, Tag... tags) {
+    if (observability == null) {
+      return;
+    }
+    Tag[] baseTags = {Tag.of(TagKey.COMPONENT, COMPONENT), Tag.of(TagKey.OPERATION, OPERATION)};
+    Tag[] merged = new Tag[baseTags.length + tags.length];
+    System.arraycopy(baseTags, 0, merged, 0, baseTags.length);
+    System.arraycopy(tags, 0, merged, baseTags.length, tags.length);
+    observability.counter(metric, amount, merged);
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/PlannerStatsResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/PlannerStatsResolver.java
@@ -19,12 +19,14 @@ package ai.floedb.floecat.service.statistics;
 import ai.floedb.floecat.catalog.rpc.StatsTarget;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
 import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.telemetry.ServiceMetrics;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
 import ai.floedb.floecat.stats.spi.StatsResolutionResult;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsSyncOutcome;
+import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
 import ai.floedb.floecat.telemetry.MetricId;
 import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.Tag;
@@ -410,6 +412,8 @@ final class PlannerStatsResolver {
         primary =
             statsStore.getTargetStatsInGeneration(
                 request.tableId(), request.snapshotId(), pinnedGeneration, request.target());
+      } catch (BaseResourceRepository.AbortRetryableException | StorageAbortRetryableException e) {
+        throw e;
       } catch (RuntimeException e) {
         // A pinned-generation read failure (e.g. an unreadable frozen manifest) must not fail the
         // lookup outright: the newest generation of the same snapshot is an independent read path
@@ -550,6 +554,8 @@ final class PlannerStatsResolver {
                 : StatsResolutionResult.skipped("batch_store_miss"));
       }
       return java.util.Collections.unmodifiableMap(out);
+    } catch (BaseResourceRepository.AbortRetryableException | StorageAbortRetryableException e) {
+      throw e;
     } catch (RuntimeException batchError) {
       if (requests.size() == 1) {
         return readPlannerTargetIsolated(
@@ -585,6 +591,8 @@ final class PlannerStatsResolver {
       return Map.of(
           key,
           record.map(hitMapper).orElseGet(() -> StatsResolutionResult.skipped("batch_store_miss")));
+    } catch (BaseResourceRepository.AbortRetryableException | StorageAbortRetryableException e) {
+      throw e;
     } catch (RuntimeException targetError) {
       LOG.debugf(
           targetError,

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
@@ -475,6 +475,7 @@ public class StatsOrchestrator {
     String pinnedGeneration = pinnedGenerationToken.filter(token -> !token.isBlank()).orElse("");
     java.util.function.Function<String, java.util.function.Predicate<TargetStatsRecord>>
         completenessFor = key -> completenessByStorageId.getOrDefault(key, record -> true);
+    PlannerLookupDiagnostics diagnostics = new PlannerLookupDiagnostics();
     // Primary keyspace/reader: the pinned generation when the pin froze one, else the live/newest
     // generation (empty token). A new snapshotId is always a cache miss, so stats from a different
     // snapshot are never returned for the current query.
@@ -504,6 +505,7 @@ public class StatsOrchestrator {
       TargetStatsRecord cached = statsCache.getIfPresent(cacheKeyFor(req, primaryToken));
       if (cached != null && completenessFor.apply(key).test(cached)) {
         observeSyncOutcome(StatsSyncOutcome.HIT);
+        diagnostics.record(PlannerLookupOutcome.CACHE_HIT);
         out.put(key, StatsResolutionResult.hit(cached));
       } else {
         cacheMisses.add(req);
@@ -511,6 +513,7 @@ public class StatsOrchestrator {
     }
 
     if (cacheMisses.isEmpty()) {
+      diagnostics.emit(first.tableId(), first.snapshotId(), pinnedGeneration, requests.size());
       return java.util.Collections.unmodifiableMap(out);
     }
 
@@ -534,18 +537,24 @@ public class StatsOrchestrator {
       StatsResolutionResult hit = primaryHits.get(key);
       if (hit != null && hit.hasStats()) {
         TargetStatsRecord record = hit.stats().get();
-        if (completenessFor.apply(key).test(record) || pinnedGeneration.isBlank()) {
+        boolean satisfies = completenessFor.apply(key).test(record);
+        if (satisfies || pinnedGeneration.isBlank()) {
           // Complete — or partial with no pin, where the primary IS the newest generation and no
           // richer same-snapshot source exists: serve as-is, the planner degrades per stat.
-          // Write-through under the primary (pinned, or live when unpinned) keyspace.
-          statsCache.put(cacheKeyFor(req, primaryToken), record);
-          observeSyncOutcome(StatsSyncOutcome.HIT);
-          out.put(key, StatsResolutionResult.hit(record));
+          servePlannerHit(
+              out,
+              diagnostics,
+              req,
+              key,
+              record,
+              primaryToken,
+              satisfies ? PlannerLookupOutcome.PRIMARY_HIT : PlannerLookupOutcome.PARTIAL);
         } else {
           partialPinned.put(key, record);
           misses.add(req);
         }
       } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
+        diagnostics.record(PlannerLookupOutcome.FAILED);
         out.put(key, hit);
       } else {
         misses.add(req);
@@ -572,21 +581,19 @@ public class StatsOrchestrator {
         boolean newestSatisfies =
             hit != null && hit.hasStats() && completenessFor.apply(key).test(hit.stats().get());
         if (newestSatisfies) {
-          statsCache.put(cacheKeyFor(req, ""), hit.stats().get());
-          observeSyncOutcome(StatsSyncOutcome.HIT);
-          out.put(key, StatsResolutionResult.hit(hit.stats().get()));
+          servePlannerHit(
+              out, diagnostics, req, key, hit.stats().get(), "", PlannerLookupOutcome.NEWEST_FILL);
         } else if (partial != null) {
           // Newest is no more complete than the pin: between equally incomplete records,
           // consistency prefers the pinned generation the scan reads.
-          statsCache.put(cacheKeyFor(req, primaryToken), partial);
-          observeSyncOutcome(StatsSyncOutcome.HIT);
-          out.put(key, StatsResolutionResult.hit(partial));
+          servePlannerHit(
+              out, diagnostics, req, key, partial, primaryToken, PlannerLookupOutcome.PARTIAL);
         } else if (hit != null && hit.hasStats()) {
           // Pin has nothing at all; a partial newest record beats stale or capture.
-          statsCache.put(cacheKeyFor(req, ""), hit.stats().get());
-          observeSyncOutcome(StatsSyncOutcome.HIT);
-          out.put(key, StatsResolutionResult.hit(hit.stats().get()));
+          servePlannerHit(
+              out, diagnostics, req, key, hit.stats().get(), "", PlannerLookupOutcome.PARTIAL);
         } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
+          diagnostics.record(PlannerLookupOutcome.FAILED);
           out.put(key, hit);
         } else {
           afterFill.add(req);
@@ -613,8 +620,10 @@ public class StatsOrchestrator {
         String key = storageId(req);
         StatsResolutionResult stale = staleBatch.get(key);
         if (stale != null && stale.hasStats()) {
+          diagnostics.record(PlannerLookupOutcome.STALE_HIT);
           out.put(key, stale);
         } else if (stale != null && stale.outcome() == StatsSyncOutcome.FAILED) {
+          diagnostics.record(PlannerLookupOutcome.FAILED);
           out.put(key, stale);
         } else {
           stillMissing.add(req);
@@ -630,12 +639,14 @@ public class StatsOrchestrator {
       String key = storageId(req);
       if (!syncEnabled || req.executionMode() != StatsExecutionMode.SYNC) {
         asyncQueue.add(req);
+        diagnostics.record(PlannerLookupOutcome.CAPTURE_PENDING);
         out.put(key, StatsResolutionResult.skipped("async_mode"));
         continue;
       }
       long remainingNanos = deadlineNanos - System.nanoTime();
       if (remainingNanos <= 0) {
         asyncQueue.add(req);
+        diagnostics.record(PlannerLookupOutcome.CAPTURE_PENDING);
         out.put(key, StatsResolutionResult.timeout("latency_budget_exhausted"));
         continue;
       }
@@ -654,9 +665,11 @@ public class StatsOrchestrator {
       if (syncOutcome == StatsSyncOutcome.CAPTURED) {
         Optional<TargetStatsRecord> afterCapture = readStore(withBudget);
         if (afterCapture.isPresent()) {
+          diagnostics.record(PlannerLookupOutcome.CAPTURED);
           out.put(key, StatsResolutionResult.captured(afterCapture.get()));
         } else {
           asyncQueue.add(req);
+          diagnostics.record(PlannerLookupOutcome.CAPTURE_PENDING);
           out.put(
               key,
               StatsResolutionResult.partial(
@@ -664,6 +677,10 @@ public class StatsOrchestrator {
         }
       } else {
         asyncQueue.add(req);
+        diagnostics.record(
+            syncOutcome == StatsSyncOutcome.TIMEOUT
+                ? PlannerLookupOutcome.CAPTURE_PENDING
+                : PlannerLookupOutcome.FAILED);
         out.put(
             key,
             syncOutcome == StatsSyncOutcome.TIMEOUT
@@ -677,6 +694,7 @@ public class StatsOrchestrator {
       enqueueAsyncCaptureBatch(asyncQueue);
     }
 
+    diagnostics.emit(first.tableId(), first.snapshotId(), pinnedGeneration, requests.size());
     return java.util.Collections.unmodifiableMap(out);
   }
 
@@ -1139,6 +1157,84 @@ public class StatsOrchestrator {
         1,
         Tag.of(TagKey.RESULT, outcome.name()),
         Tag.of(TagKey.SCOPE, "orchestrator"));
+  }
+
+  /**
+   * The ladder rung that resolved (or failed) one planner target — the diagnostics vocabulary for
+   * {@link #resolvePlannerBatchInGeneration}. Emitted per target as a {@code result}-tagged count
+   * of {@code PLANNER_LOOKUP_OUTCOMES_TOTAL} and summarized in one DEBUG line per table batch, so
+   * "which rung served this query's stats" is a metric query or a log grep, not archaeology.
+   */
+  enum PlannerLookupOutcome {
+    /** Served from the cache keyspace of the primary generation. */
+    CACHE_HIT,
+    /** The primary generation (pinned, or live when unpinned) satisfied the need. */
+    PRIMARY_HIT,
+    /** The pinned generation lacked the target or capability; the newest generation satisfied. */
+    NEWEST_FILL,
+    /** Served a record that does not satisfy the full need (planner degrades per stat). */
+    PARTIAL,
+    /** No record at the pinned snapshot; served from an earlier snapshot. */
+    STALE_HIT,
+    /** Missing everywhere; a bounded sync capture produced the record. */
+    CAPTURED,
+    /** Missing everywhere; capture is pending (async mode, budget exhausted, or in flight). */
+    CAPTURE_PENDING,
+    /** A rung failed outright (store error surfaced as FAILED). */
+    FAILED
+  }
+
+  /**
+   * Per-batch outcome accumulator for the planner ladder: counts each target's outcome, then emits
+   * them once — as {@code result}-tagged counter increments and a single DEBUG summary line. One
+   * instance per {@link #resolvePlannerBatchInGeneration} call; never shared across threads.
+   */
+  private final class PlannerLookupDiagnostics {
+    private final java.util.EnumMap<PlannerLookupOutcome, Integer> counts =
+        new java.util.EnumMap<>(PlannerLookupOutcome.class);
+
+    void record(PlannerLookupOutcome outcome) {
+      counts.merge(outcome, 1, Integer::sum);
+    }
+
+    void emit(ResourceId tableId, long snapshotId, String pinnedGeneration, int requested) {
+      for (Map.Entry<PlannerLookupOutcome, Integer> entry : counts.entrySet()) {
+        incrementCounter(
+            ServiceMetrics.Stats.PLANNER_LOOKUP_OUTCOMES_TOTAL,
+            entry.getValue(),
+            Tag.of(TagKey.RESULT, entry.getKey().name().toLowerCase(java.util.Locale.ROOT)));
+      }
+      // The greppable per-batch summary: which generation the batch read and how each target
+      // resolved. "generation=live" means the pin froze none and the live generation was primary.
+      LOG.debugf(
+          "planner_stats lookup table=%s snapshot=%d generation=%s requested=%d outcomes=%s",
+          tableId.getId(),
+          snapshotId,
+          pinnedGeneration.isBlank() ? "live" : pinnedGeneration,
+          requested,
+          counts);
+    }
+  }
+
+  /**
+   * Serve one resolved planner target: write the record through to the cache keyspace it was served
+   * from ({@code cacheToken} — the pinned generation's token, or "" for the live/newest
+   * generation), count the ladder rung that produced it, and emit the hit. The single definition of
+   * "serve" for every rung of {@link #resolvePlannerBatchInGeneration}, so caching, telemetry, and
+   * result emission can never drift apart between rungs.
+   */
+  private void servePlannerHit(
+      java.util.Map<String, StatsResolutionResult> out,
+      PlannerLookupDiagnostics diagnostics,
+      StatsCaptureRequest req,
+      String key,
+      TargetStatsRecord record,
+      String cacheToken,
+      PlannerLookupOutcome outcome) {
+    statsCache.put(cacheKeyFor(req, cacheToken), record);
+    observeSyncOutcome(StatsSyncOutcome.HIT);
+    diagnostics.record(outcome);
+    out.put(key, StatsResolutionResult.hit(record));
   }
 
   private void incrementCounter(MetricId metric, double amount, Tag... tags) {

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
@@ -299,11 +299,26 @@ public class StatsOrchestrator {
     String pinnedGeneration = pinnedGenerationToken.filter(token -> !token.isBlank()).orElse("");
 
     // Primary: the pinned generation (query-consistent), or live/newest when the pin froze none.
-    Optional<TargetStatsRecord> primary =
-        pinnedGeneration.isBlank()
-            ? readStore(request)
-            : statsStore.getTargetStatsInGeneration(
+    Optional<TargetStatsRecord> primary;
+    if (pinnedGeneration.isBlank()) {
+      primary = readStore(request);
+    } else {
+      try {
+        primary =
+            statsStore.getTargetStatsInGeneration(
                 request.tableId(), request.snapshotId(), pinnedGeneration, request.target());
+      } catch (RuntimeException e) {
+        // A pinned-generation read failure (e.g. an unreadable frozen manifest) must not fail the
+        // lookup outright: the newest generation of the same snapshot is an independent read path
+        // with no frozen manifest involved — treat the pin as a miss and let the gap-fill below
+        // serve, matching the batch path's fallback.
+        LOG.debugf(
+            e,
+            "pinned-generation read failed for %s; falling through to newest",
+            storageId(request));
+        primary = Optional.empty();
+      }
+    }
     if (primary.isPresent()) {
       observeSyncOutcome(StatsSyncOutcome.HIT, startNanos);
       return StatsResolutionResult.hit(primary.get());
@@ -554,8 +569,16 @@ public class StatsOrchestrator {
           misses.add(req);
         }
       } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
-        diagnostics.record(PlannerLookupOutcome.FAILED);
-        out.put(key, hit);
+        if (pinnedGeneration.isBlank()) {
+          diagnostics.record(PlannerLookupOutcome.FAILED);
+          out.put(key, hit);
+        } else {
+          // A pinned-generation read failure (e.g. an unreadable frozen manifest) must not zero
+          // planning quality for the batch: the newest generation of the same snapshot is an
+          // independent read path with no frozen manifest involved, so fall through to the
+          // gap-fill. If that fails too, ITS failure is the terminal one.
+          misses.add(req);
+        }
       } else {
         misses.add(req);
       }

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
@@ -27,6 +27,8 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.statistics.PlannerStatsResolver.PlannerLookupDiagnostics;
+import ai.floedb.floecat.service.statistics.PlannerStatsResolver.PlannerLookupOutcome;
 import ai.floedb.floecat.service.telemetry.ServiceMetrics;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.spi.StatsCaptureBatchItemResult;
@@ -41,9 +43,6 @@ import ai.floedb.floecat.telemetry.MetricId;
 import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.Tag;
 import ai.floedb.floecat.telemetry.Telemetry.TagKey;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.Weigher;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -57,8 +56,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
@@ -75,6 +72,9 @@ import org.jboss.logging.Logger;
  * <p>Resolution is sync-first when {@code floecat.stats.sync.enabled=true} (default): on a store
  * miss the orchestrator attempts a bounded synchronous capture before falling back to async
  * enqueue. The outcome is encoded in {@link StatsResolutionResult} so callers can inspect quality.
+ *
+ * <p>Planner-facing store resolution — generation ordering, the fallback ladder, and the planner
+ * stats cache — lives in {@link PlannerStatsResolver}; capture policy stays here.
  */
 @ApplicationScoped
 public class StatsOrchestrator {
@@ -82,87 +82,6 @@ public class StatsOrchestrator {
   private static final Logger LOG = Logger.getLogger(StatsOrchestrator.class);
   private static final String COMPONENT = "service";
   private static final String OPERATION = "stats_orchestrator";
-
-  /**
-   * Fully-qualified cache key for a single column-stats record.
-   *
-   * <p>All four fields are required to guarantee no cross-contamination:
-   *
-   * <ul>
-   *   <li>{@code accountId} — isolates tenants.
-   *   <li>{@code tableId} — isolates tables within an account.
-   *   <li>{@code snapshotId} — isolates snapshots; new stats captures produce new snapshot IDs, so
-   *       stale entries from old snapshots are never served for new-snapshot queries.
-   *   <li>{@code storageId} — the {@link ai.floedb.floecat.stats.identity.StatsTargetIdentity}
-   *       storage key that uniquely identifies the target (column, table-level, file, etc.) within
-   *       a snapshot.
-   * </ul>
-   */
-  private record StatsCacheKey(
-      String accountId, String tableId, long snapshotId, String generationToken, String storageId) {
-    private StatsCacheKey {
-      generationToken = generationToken == null ? "" : generationToken;
-    }
-  }
-
-  /**
-   * Maximum total byte weight of the stats cache.
-   *
-   * <p>256 MB accommodates roughly:
-   *
-   * <ul>
-   *   <li>~200,000 scalar-only records at ~1 KB each (typical planner path today), or
-   *   <li>~2,500 sketch-bearing records at ~100 KB each (theta k=4096 + tuple v2).
-   * </ul>
-   *
-   * <p>Using weight rather than entry count prevents OOM when sketch-carrying {@link
-   * TargetStatsRecord}s are common — a record with k=4096 theta + tuple sketches is ~100× larger
-   * than a scalar record, so a count-only cap of 500,000 could allow ~50 GB of in-memory sketch
-   * data if every entry held full sketch payloads.
-   */
-  private static final long STATS_CACHE_MAX_WEIGHT_BYTES = 256L * 1024 * 1024; // 256 MB
-
-  /**
-   * Weigher: approximate JVM heap cost per cache entry.
-   *
-   * <p>Uses {@link com.google.protobuf.AbstractMessage#getSerializedSize()} as a proxy for the
-   * proto object's heap footprint. Proto objects typically occupy 1–2× their wire size in heap
-   * (field objects, repeated-field lists, etc.), so the true heap usage may be larger; the weight
-   * budget accounts for this by being set conservatively. A small fixed overhead (64 B) is added
-   * per entry for cache bookkeeping and the key object.
-   *
-   * <p>Caffeine requires the weight to fit in an {@code int}. Records larger than {@link
-   * Integer#MAX_VALUE} bytes are treated as maximum weight, effectively evicting them immediately —
-   * an acceptable safety valve for pathologically large records.
-   */
-  private static int cacheWeight(StatsCacheKey key, TargetStatsRecord record) {
-    long size = record.getSerializedSize() + 64L; // +64 for key object + cache overhead
-    return (int) Math.min(size, Integer.MAX_VALUE);
-  }
-
-  /**
-   * Application-scoped, snapshot-safe stats cache, bounded by byte weight.
-   *
-   * <p>Lifetime: the JVM process (survives all queries and connections).
-   *
-   * <p>Invalidation: snapshot IDs isolate normal new-snapshot captures, but full-rescan/finalize
-   * paths can replace stats for the same snapshot ID. Successful mutation paths must explicitly
-   * invalidate affected entries through this orchestrator; TTL is only a backstop for memory and
-   * missed invalidation bugs.
-   *
-   * <p>Only positive hits (present records) are cached. Absent results are not cached because they
-   * may be under active synchronous capture and could appear within seconds.
-   *
-   * <p>Bounded by {@link #STATS_CACHE_MAX_WEIGHT_BYTES} rather than entry count: a single
-   * sketch-bearing record can be ~100 KB while a scalar record is ~1 KB; a count-only cap would
-   * allow unbounded memory growth as sketch payloads become common.
-   */
-  private final Cache<StatsCacheKey, TargetStatsRecord> statsCache =
-      Caffeine.newBuilder()
-          .maximumWeight(STATS_CACHE_MAX_WEIGHT_BYTES)
-          .weigher((Weigher<StatsCacheKey, TargetStatsRecord>) StatsOrchestrator::cacheWeight)
-          .expireAfterWrite(10, TimeUnit.MINUTES) // Backstop; mutation paths invalidate eagerly.
-          .build();
 
   private final StatsStore statsStore;
   private final ReconcileJobStore reconcileJobStore;
@@ -172,6 +91,7 @@ public class StatsOrchestrator {
   private final boolean syncEnabled;
   private final ConcurrentMap<TableKey, String> lastEnqueuedJobByTable = new ConcurrentHashMap<>();
   private final Observability observability;
+  private final PlannerStatsResolver plannerResolver;
 
   @Inject
   public StatsOrchestrator(
@@ -191,6 +111,8 @@ public class StatsOrchestrator {
     this.syncEnabled = syncEnabled;
     this.observability =
         observability == null || observability.isUnsatisfied() ? null : observability.get();
+    this.plannerResolver =
+        new PlannerStatsResolver(statsStore, this.observability, this::observePlannerHit);
   }
 
   public StatsOrchestrator(
@@ -210,62 +132,18 @@ public class StatsOrchestrator {
 
   /** Invalidates every cached target for one table snapshot. */
   public void invalidateStatsCache(ResourceId tableId, long snapshotId) {
-    if (tableId == null) {
-      return;
-    }
-    statsCache
-        .asMap()
-        .keySet()
-        .removeIf(
-            key ->
-                key.accountId().equals(tableId.getAccountId())
-                    && key.tableId().equals(tableId.getId())
-                    && key.snapshotId() == snapshotId);
+    plannerResolver.invalidateStatsCache(tableId, snapshotId);
   }
 
   /** Invalidates one cached target for one table snapshot. */
   public void invalidateStatsCache(ResourceId tableId, long snapshotId, StatsTarget target) {
-    if (tableId == null || target == null) {
-      return;
-    }
-    String storageId = StatsTargetIdentity.storageId(target);
-    statsCache
-        .asMap()
-        .keySet()
-        .removeIf(
-            key ->
-                key.accountId().equals(tableId.getAccountId())
-                    && key.tableId().equals(tableId.getId())
-                    && key.snapshotId() == snapshotId
-                    && key.storageId().equals(storageId));
+    plannerResolver.invalidateStatsCache(tableId, snapshotId, target);
   }
 
   /** Invalidates cached targets represented by successfully persisted records. */
   public void invalidateStatsCache(
       ResourceId tableId, long snapshotId, List<TargetStatsRecord> records) {
-    if (tableId == null || records == null || records.isEmpty()) {
-      return;
-    }
-    java.util.Set<String> storageIds = new java.util.HashSet<>();
-    for (TargetStatsRecord record : records) {
-      if (record != null && record.hasTarget()) {
-        storageIds.add(StatsTargetIdentity.storageId(record.getTarget()));
-      }
-    }
-    if (storageIds.isEmpty()) {
-      return;
-    }
-    // One O(cacheSize) pass matching any of the records' targets, not one full scan per record —
-    // a wide-table recompute (hundreds of columns) would otherwise scan the cache once per column.
-    statsCache
-        .asMap()
-        .keySet()
-        .removeIf(
-            key ->
-                key.accountId().equals(tableId.getAccountId())
-                    && key.tableId().equals(tableId.getId())
-                    && key.snapshotId() == snapshotId
-                    && storageIds.contains(key.storageId()));
+    plannerResolver.invalidateStatsCache(tableId, snapshotId, records);
   }
 
   /**
@@ -296,42 +174,11 @@ public class StatsOrchestrator {
   public StatsResolutionResult resolveInGeneration(
       StatsCaptureRequest request, Optional<String> pinnedGenerationToken) {
     long startNanos = System.nanoTime();
-    String pinnedGeneration = pinnedGenerationToken.filter(token -> !token.isBlank()).orElse("");
-
-    // Primary: the pinned generation (query-consistent), or live/newest when the pin froze none.
-    Optional<TargetStatsRecord> primary;
-    if (pinnedGeneration.isBlank()) {
-      primary = readStore(request);
-    } else {
-      try {
-        primary =
-            statsStore.getTargetStatsInGeneration(
-                request.tableId(), request.snapshotId(), pinnedGeneration, request.target());
-      } catch (RuntimeException e) {
-        // A pinned-generation read failure (e.g. an unreadable frozen manifest) must not fail the
-        // lookup outright: the newest generation of the same snapshot is an independent read path
-        // with no frozen manifest involved — treat the pin as a miss and let the gap-fill below
-        // serve, matching the batch path's fallback.
-        LOG.debugf(
-            e,
-            "pinned-generation read failed for %s; falling through to newest",
-            storageId(request));
-        primary = Optional.empty();
-      }
-    }
-    if (primary.isPresent()) {
+    Optional<TargetStatsRecord> stored =
+        plannerResolver.resolveSingleFromStore(request, pinnedGenerationToken);
+    if (stored.isPresent()) {
       observeSyncOutcome(StatsSyncOutcome.HIT, startNanos);
-      return StatsResolutionResult.hit(primary.get());
-    }
-
-    // Newest gap-fill — only when a specific generation was pinned; the pinned generation lacks
-    // this target, so the newest generation backstops it before capture.
-    if (!pinnedGeneration.isBlank()) {
-      Optional<TargetStatsRecord> newest = readStore(request);
-      if (newest.isPresent()) {
-        observeSyncOutcome(StatsSyncOutcome.HIT, startNanos);
-        return StatsResolutionResult.hit(newest.get());
-      }
+      return StatsResolutionResult.hit(stored.get());
     }
     return captureAndResolve(request, startNanos);
   }
@@ -409,16 +256,6 @@ public class StatsOrchestrator {
     return resolvePlannerBatchInGeneration(requests, Optional.empty(), staleOk, deadlineNanos);
   }
 
-  /** Cache key for one request under a specific served-generation token ("" = live/newest). */
-  private StatsCacheKey cacheKeyFor(StatsCaptureRequest req, String generationToken) {
-    return new StatsCacheKey(
-        req.tableId().getAccountId(),
-        req.tableId().getId(),
-        req.snapshotId(),
-        generationToken,
-        storageId(req));
-  }
-
   /**
    * Planner batch resolution that honors the query's pinned stats generation, with presence-only
    * completeness: a target that exists in the pinned generation is a hit. Delegates to {@link
@@ -487,178 +324,18 @@ public class StatsOrchestrator {
     }
     // All requests must share the same tableId and snapshotId (grouped upstream by TableWork).
     StatsCaptureRequest first = requests.get(0);
-    String pinnedGeneration = pinnedGenerationToken.filter(token -> !token.isBlank()).orElse("");
-    java.util.function.Function<String, java.util.function.Predicate<TargetStatsRecord>>
-        completenessFor = key -> completenessByStorageId.getOrDefault(key, record -> true);
-    PlannerLookupDiagnostics diagnostics = new PlannerLookupDiagnostics();
-    // Primary keyspace/reader: the pinned generation when the pin froze one, else the live/newest
-    // generation (empty token). A new snapshotId is always a cache miss, so stats from a different
-    // snapshot are never returned for the current query.
-    String primaryToken = pinnedGeneration;
-    TargetBatchReader primaryBatch =
-        pinnedGeneration.isBlank()
-            ? statsStore::getTargetStatsBatch
-            : (tableId, snapshotId, targets) ->
-                statsStore.getTargetStatsBatchInGeneration(
-                    tableId, snapshotId, pinnedGeneration, targets);
-    TargetReader primaryTarget =
-        pinnedGeneration.isBlank()
-            ? statsStore::getTargetStats
-            : (tableId, snapshotId, target) ->
-                statsStore.getTargetStatsInGeneration(
-                    tableId, snapshotId, pinnedGeneration, target);
-
-    // 1. Cache check in the primary keyspace. A cached record that fails its completeness
-    // predicate reads as a miss — the store may hold an enriched generation this query can use —
-    // but is NOT evicted: it still satisfies lesser needs, and records are immutable per
-    // generation so re-reads converge on the same bytes.
+    // Store rungs (cache → pinned/primary → newest gap-fill → stale) live in the resolver; only
+    // capture policy remains here.
+    PlannerStatsResolver.Resolution resolution =
+        plannerResolver.resolveFromStore(
+            requests, pinnedGenerationToken, completenessByStorageId, staleOk);
+    PlannerLookupDiagnostics diagnostics = resolution.diagnostics();
     java.util.Map<String, StatsResolutionResult> out =
-        new java.util.LinkedHashMap<>(requests.size());
-    java.util.List<StatsCaptureRequest> cacheMisses = new java.util.ArrayList<>();
-    for (StatsCaptureRequest req : requests) {
-      String key = storageId(req);
-      TargetStatsRecord cached = statsCache.getIfPresent(cacheKeyFor(req, primaryToken));
-      if (cached != null && completenessFor.apply(key).test(cached)) {
-        observeSyncOutcome(StatsSyncOutcome.HIT);
-        diagnostics.record(PlannerLookupOutcome.CACHE_HIT);
-        out.put(key, StatsResolutionResult.hit(cached));
-      } else {
-        cacheMisses.add(req);
-      }
-    }
-
-    if (cacheMisses.isEmpty()) {
-      diagnostics.emit(first.tableId(), first.snapshotId(), pinnedGeneration, requests.size());
-      return java.util.Collections.unmodifiableMap(out);
-    }
-
-    // 2. Primary store read: the pinned generation (query-consistent), or live/newest if no pin.
-    java.util.Map<String, StatsResolutionResult> primaryHits =
-        readPlannerBatchIsolated(
-            first.tableId(),
-            first.snapshotId(),
-            cacheMisses,
-            primaryBatch,
-            primaryTarget,
-            StatsResolutionResult::hit);
-
-    // Pinned records that exist but fail their completeness predicate: candidates the newest
-    // gap-fill may replace, and the answer of last resort if it cannot — a partial record is
-    // still a hit (the planner degrades per stat), never a stale/capture trigger.
-    java.util.Map<String, TargetStatsRecord> partialPinned = new java.util.LinkedHashMap<>();
-    java.util.List<StatsCaptureRequest> misses = new java.util.ArrayList<>();
-    for (StatsCaptureRequest req : cacheMisses) {
-      String key = storageId(req);
-      StatsResolutionResult hit = primaryHits.get(key);
-      if (hit != null && hit.hasStats()) {
-        TargetStatsRecord record = hit.stats().get();
-        boolean satisfies = completenessFor.apply(key).test(record);
-        if (satisfies || pinnedGeneration.isBlank()) {
-          // Complete — or partial with no pin, where the primary IS the newest generation and no
-          // richer same-snapshot source exists: serve as-is, the planner degrades per stat.
-          servePlannerHit(
-              out,
-              diagnostics,
-              req,
-              key,
-              record,
-              primaryToken,
-              satisfies ? PlannerLookupOutcome.PRIMARY_HIT : PlannerLookupOutcome.PARTIAL);
-        } else {
-          partialPinned.put(key, record);
-          misses.add(req);
-        }
-      } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
-        if (pinnedGeneration.isBlank()) {
-          diagnostics.record(PlannerLookupOutcome.FAILED);
-          out.put(key, hit);
-        } else {
-          // A pinned-generation read failure (e.g. an unreadable frozen manifest) must not zero
-          // planning quality for the batch: the newest generation of the same snapshot is an
-          // independent read path with no frozen manifest involved, so fall through to the
-          // gap-fill. If that fails too, ITS failure is the terminal one.
-          misses.add(req);
-        }
-      } else {
-        misses.add(req);
-      }
-    }
-
-    // 3. Newest gap-fill — only when a specific generation was pinned. Serves targets the pinned
-    // generation lacks (prevents NOT_FOUND) or holds only partially (prevents a needless
-    // downgrade), from the newest generation of the SAME snapshot; cached under the empty token.
-    java.util.List<StatsCaptureRequest> afterFill = new java.util.ArrayList<>();
-    if (!pinnedGeneration.isBlank() && !misses.isEmpty()) {
-      java.util.Map<String, StatsResolutionResult> fillHits =
-          readPlannerBatchIsolated(
-              first.tableId(),
-              first.snapshotId(),
-              misses,
-              statsStore::getTargetStatsBatch,
-              statsStore::getTargetStats,
-              StatsResolutionResult::hit);
-      for (StatsCaptureRequest req : misses) {
-        String key = storageId(req);
-        StatsResolutionResult hit = fillHits.get(key);
-        TargetStatsRecord partial = partialPinned.get(key);
-        boolean newestSatisfies =
-            hit != null && hit.hasStats() && completenessFor.apply(key).test(hit.stats().get());
-        if (newestSatisfies) {
-          servePlannerHit(
-              out, diagnostics, req, key, hit.stats().get(), "", PlannerLookupOutcome.NEWEST_FILL);
-        } else if (partial != null) {
-          // Newest is no more complete than the pin: between equally incomplete records,
-          // consistency prefers the pinned generation the scan reads.
-          servePlannerHit(
-              out, diagnostics, req, key, partial, primaryToken, PlannerLookupOutcome.PARTIAL);
-        } else if (hit != null && hit.hasStats()) {
-          // Pin has nothing at all; a partial newest record beats stale or capture.
-          servePlannerHit(
-              out, diagnostics, req, key, hit.stats().get(), "", PlannerLookupOutcome.PARTIAL);
-        } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
-          diagnostics.record(PlannerLookupOutcome.FAILED);
-          out.put(key, hit);
-        } else {
-          afterFill.add(req);
-        }
-      }
-    } else {
-      afterFill.addAll(misses);
-    }
-
-    // 4. Stale fallback — BEFORE sync capture.
-    // Single batch call: finds the latest snapshot with stats once (O(1) pointer read),
-    // then fetches all missing targets from that snapshot in parallel. Replaces N×O(prefix scan).
-    java.util.List<StatsCaptureRequest> stillMissing = new java.util.ArrayList<>();
-    if (staleOk && !afterFill.isEmpty()) {
-      java.util.Map<String, StatsResolutionResult> staleBatch =
-          readPlannerBatchIsolated(
-              first.tableId(),
-              first.snapshotId(),
-              afterFill,
-              statsStore::getStaleTargetStatsBatch,
-              statsStore::getStaleTargetStats,
-              record -> StatsResolutionResult.staleHit(record, "stale_before_sync"));
-      for (StatsCaptureRequest req : afterFill) {
-        String key = storageId(req);
-        StatsResolutionResult stale = staleBatch.get(key);
-        if (stale != null && stale.hasStats()) {
-          diagnostics.record(PlannerLookupOutcome.STALE_HIT);
-          out.put(key, stale);
-        } else if (stale != null && stale.outcome() == StatsSyncOutcome.FAILED) {
-          diagnostics.record(PlannerLookupOutcome.FAILED);
-          out.put(key, stale);
-        } else {
-          stillMissing.add(req);
-        }
-      }
-    } else {
-      stillMissing.addAll(afterFill);
-    }
+        new java.util.LinkedHashMap<>(resolution.resolved());
 
     // 5. Sync capture for still-missing targets (per-target within deadline).
     java.util.List<StatsCaptureRequest> asyncQueue = new java.util.ArrayList<>();
-    for (StatsCaptureRequest req : stillMissing) {
+    for (StatsCaptureRequest req : resolution.stillMissing()) {
       String key = storageId(req);
       if (!syncEnabled || req.executionMode() != StatsExecutionMode.SYNC) {
         asyncQueue.add(req);
@@ -717,100 +394,13 @@ public class StatsOrchestrator {
       enqueueAsyncCaptureBatch(asyncQueue);
     }
 
-    diagnostics.emit(first.tableId(), first.snapshotId(), pinnedGeneration, requests.size());
+    diagnostics.emit(
+        first.tableId(), first.snapshotId(), resolution.pinnedGeneration(), requests.size());
     return java.util.Collections.unmodifiableMap(out);
-  }
-
-  private Map<String, StatsResolutionResult> readPlannerBatchIsolated(
-      ResourceId tableId,
-      long snapshotId,
-      List<StatsCaptureRequest> requests,
-      TargetBatchReader batchReader,
-      TargetReader targetReader,
-      Function<TargetStatsRecord, StatsResolutionResult> hitMapper) {
-    if (requests == null || requests.isEmpty()) {
-      return Map.of();
-    }
-
-    List<StatsTarget> targets = targetsOf(requests);
-    try {
-      Map<String, Optional<TargetStatsRecord>> batchHits =
-          batchReader.read(tableId, snapshotId, targets);
-      Map<String, StatsResolutionResult> out = new LinkedHashMap<>();
-      for (StatsCaptureRequest request : requests) {
-        String key = storageId(request);
-        Optional<TargetStatsRecord> hit = batchHits == null ? Optional.empty() : batchHits.get(key);
-        out.put(
-            key,
-            hit != null && hit.isPresent()
-                ? hitMapper.apply(hit.get())
-                : StatsResolutionResult.skipped("batch_store_miss"));
-      }
-      return java.util.Collections.unmodifiableMap(out);
-    } catch (RuntimeException batchError) {
-      if (requests.size() == 1) {
-        return readPlannerTargetIsolated(
-            tableId, snapshotId, requests.get(0), targetReader, hitMapper, batchError);
-      }
-      int mid = requests.size() / 2;
-      Map<String, StatsResolutionResult> out = new LinkedHashMap<>();
-      out.putAll(
-          readPlannerBatchIsolated(
-              tableId, snapshotId, requests.subList(0, mid), batchReader, targetReader, hitMapper));
-      out.putAll(
-          readPlannerBatchIsolated(
-              tableId,
-              snapshotId,
-              requests.subList(mid, requests.size()),
-              batchReader,
-              targetReader,
-              hitMapper));
-      return java.util.Collections.unmodifiableMap(out);
-    }
-  }
-
-  private Map<String, StatsResolutionResult> readPlannerTargetIsolated(
-      ResourceId tableId,
-      long snapshotId,
-      StatsCaptureRequest request,
-      TargetReader targetReader,
-      Function<TargetStatsRecord, StatsResolutionResult> hitMapper,
-      RuntimeException batchError) {
-    String key = storageId(request);
-    try {
-      Optional<TargetStatsRecord> record = targetReader.read(tableId, snapshotId, request.target());
-      return Map.of(
-          key,
-          record.map(hitMapper).orElseGet(() -> StatsResolutionResult.skipped("batch_store_miss")));
-    } catch (RuntimeException targetError) {
-      LOG.debugf(
-          targetError,
-          "planner stats target read failed after batch isolation table=%s target=%s",
-          tableId,
-          key);
-      String message =
-          targetError.getMessage() == null ? batchError.getMessage() : targetError.getMessage();
-      return Map.of(key, StatsResolutionResult.failed(message));
-    }
-  }
-
-  private static List<StatsTarget> targetsOf(List<StatsCaptureRequest> requests) {
-    return requests.stream().map(StatsCaptureRequest::target).toList();
   }
 
   private static String storageId(StatsCaptureRequest request) {
     return StatsTargetIdentity.storageId(request.target());
-  }
-
-  @FunctionalInterface
-  private interface TargetBatchReader {
-    Map<String, Optional<TargetStatsRecord>> read(
-        ResourceId tableId, long snapshotId, List<StatsTarget> targets);
-  }
-
-  @FunctionalInterface
-  private interface TargetReader {
-    Optional<TargetStatsRecord> read(ResourceId tableId, long snapshotId, StatsTarget target);
   }
 
   /**
@@ -1183,81 +773,10 @@ public class StatsOrchestrator {
   }
 
   /**
-   * The ladder rung that resolved (or failed) one planner target — the diagnostics vocabulary for
-   * {@link #resolvePlannerBatchInGeneration}. Emitted per target as a {@code result}-tagged count
-   * of {@code PLANNER_LOOKUP_OUTCOMES_TOTAL} and summarized in one DEBUG line per table batch, so
-   * "which rung served this query's stats" is a metric query or a log grep, not archaeology.
+   * Planner-hit callback for {@link PlannerStatsResolver}: counts a HIT without a latency sample.
    */
-  enum PlannerLookupOutcome {
-    /** Served from the cache keyspace of the primary generation. */
-    CACHE_HIT,
-    /** The primary generation (pinned, or live when unpinned) satisfied the need. */
-    PRIMARY_HIT,
-    /** The pinned generation lacked the target or capability; the newest generation satisfied. */
-    NEWEST_FILL,
-    /** Served a record that does not satisfy the full need (planner degrades per stat). */
-    PARTIAL,
-    /** No record at the pinned snapshot; served from an earlier snapshot. */
-    STALE_HIT,
-    /** Missing everywhere; a bounded sync capture produced the record. */
-    CAPTURED,
-    /** Missing everywhere; capture is pending (async mode, budget exhausted, or in flight). */
-    CAPTURE_PENDING,
-    /** A rung failed outright (store error surfaced as FAILED). */
-    FAILED
-  }
-
-  /**
-   * Per-batch outcome accumulator for the planner ladder: counts each target's outcome, then emits
-   * them once — as {@code result}-tagged counter increments and a single DEBUG summary line. One
-   * instance per {@link #resolvePlannerBatchInGeneration} call; never shared across threads.
-   */
-  private final class PlannerLookupDiagnostics {
-    private final java.util.EnumMap<PlannerLookupOutcome, Integer> counts =
-        new java.util.EnumMap<>(PlannerLookupOutcome.class);
-
-    void record(PlannerLookupOutcome outcome) {
-      counts.merge(outcome, 1, Integer::sum);
-    }
-
-    void emit(ResourceId tableId, long snapshotId, String pinnedGeneration, int requested) {
-      for (Map.Entry<PlannerLookupOutcome, Integer> entry : counts.entrySet()) {
-        incrementCounter(
-            ServiceMetrics.Stats.PLANNER_LOOKUP_OUTCOMES_TOTAL,
-            entry.getValue(),
-            Tag.of(TagKey.RESULT, entry.getKey().name().toLowerCase(java.util.Locale.ROOT)));
-      }
-      // The greppable per-batch summary: which generation the batch read and how each target
-      // resolved. "generation=live" means the pin froze none and the live generation was primary.
-      LOG.debugf(
-          "planner_stats lookup table=%s snapshot=%d generation=%s requested=%d outcomes=%s",
-          tableId.getId(),
-          snapshotId,
-          pinnedGeneration.isBlank() ? "live" : pinnedGeneration,
-          requested,
-          counts);
-    }
-  }
-
-  /**
-   * Serve one resolved planner target: write the record through to the cache keyspace it was served
-   * from ({@code cacheToken} — the pinned generation's token, or "" for the live/newest
-   * generation), count the ladder rung that produced it, and emit the hit. The single definition of
-   * "serve" for every rung of {@link #resolvePlannerBatchInGeneration}, so caching, telemetry, and
-   * result emission can never drift apart between rungs.
-   */
-  private void servePlannerHit(
-      java.util.Map<String, StatsResolutionResult> out,
-      PlannerLookupDiagnostics diagnostics,
-      StatsCaptureRequest req,
-      String key,
-      TargetStatsRecord record,
-      String cacheToken,
-      PlannerLookupOutcome outcome) {
-    statsCache.put(cacheKeyFor(req, cacheToken), record);
-    observeSyncOutcome(StatsSyncOutcome.HIT);
-    diagnostics.record(outcome);
-    out.put(key, StatsResolutionResult.hit(record));
+  private void observePlannerHit(StatsSyncOutcome outcome) {
+    observeSyncOutcome(outcome);
   }
 
   private void incrementCounter(MetricId metric, double amount, Tag... tags) {

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
@@ -99,7 +99,11 @@ public class StatsOrchestrator {
    * </ul>
    */
   private record StatsCacheKey(
-      String accountId, String tableId, long snapshotId, String storageId) {}
+      String accountId, String tableId, long snapshotId, String generationToken, String storageId) {
+    private StatsCacheKey {
+      generationToken = generationToken == null ? "" : generationToken;
+    }
+  }
 
   /**
    * Maximum total byte weight of the stats cache.
@@ -224,25 +228,44 @@ public class StatsOrchestrator {
     if (tableId == null || target == null) {
       return;
     }
-    statsCache.invalidate(
-        new StatsCacheKey(
-            tableId.getAccountId(),
-            tableId.getId(),
-            snapshotId,
-            StatsTargetIdentity.storageId(target)));
+    String storageId = StatsTargetIdentity.storageId(target);
+    statsCache
+        .asMap()
+        .keySet()
+        .removeIf(
+            key ->
+                key.accountId().equals(tableId.getAccountId())
+                    && key.tableId().equals(tableId.getId())
+                    && key.snapshotId() == snapshotId
+                    && key.storageId().equals(storageId));
   }
 
   /** Invalidates cached targets represented by successfully persisted records. */
   public void invalidateStatsCache(
       ResourceId tableId, long snapshotId, List<TargetStatsRecord> records) {
-    if (records == null || records.isEmpty()) {
+    if (tableId == null || records == null || records.isEmpty()) {
       return;
     }
+    java.util.Set<String> storageIds = new java.util.HashSet<>();
     for (TargetStatsRecord record : records) {
       if (record != null && record.hasTarget()) {
-        invalidateStatsCache(tableId, snapshotId, record.getTarget());
+        storageIds.add(StatsTargetIdentity.storageId(record.getTarget()));
       }
     }
+    if (storageIds.isEmpty()) {
+      return;
+    }
+    // One O(cacheSize) pass matching any of the records' targets, not one full scan per record —
+    // a wide-table recompute (hundreds of columns) would otherwise scan the cache once per column.
+    statsCache
+        .asMap()
+        .keySet()
+        .removeIf(
+            key ->
+                key.accountId().equals(tableId.getAccountId())
+                    && key.tableId().equals(tableId.getId())
+                    && key.snapshotId() == snapshotId
+                    && storageIds.contains(key.storageId()));
   }
 
   /**
@@ -259,7 +282,47 @@ public class StatsOrchestrator {
       observeSyncOutcome(StatsSyncOutcome.HIT, startNanos);
       return StatsResolutionResult.hit(stored.get());
     }
+    return captureAndResolve(request, startNanos);
+  }
 
+  /**
+   * Single-target resolution that honors the pinned stats generation, mirroring {@link
+   * #resolvePlannerBatchInGeneration}: the pinned generation for the pinned snapshot (query
+   * consistent), then the newest (live active) generation only to fill a target the pinned
+   * generation lacks (so an incomplete pinned generation never yields NOT_FOUND), then bounded
+   * capture. When the pin froze no generation the live/newest generation is the primary source.
+   * Used by the planner's per-relation stats reads.
+   */
+  public StatsResolutionResult resolveInGeneration(
+      StatsCaptureRequest request, Optional<String> pinnedGenerationToken) {
+    long startNanos = System.nanoTime();
+    String pinnedGeneration = pinnedGenerationToken.filter(token -> !token.isBlank()).orElse("");
+
+    // Primary: the pinned generation (query-consistent), or live/newest when the pin froze none.
+    Optional<TargetStatsRecord> primary =
+        pinnedGeneration.isBlank()
+            ? readStore(request)
+            : statsStore.getTargetStatsInGeneration(
+                request.tableId(), request.snapshotId(), pinnedGeneration, request.target());
+    if (primary.isPresent()) {
+      observeSyncOutcome(StatsSyncOutcome.HIT, startNanos);
+      return StatsResolutionResult.hit(primary.get());
+    }
+
+    // Newest gap-fill — only when a specific generation was pinned; the pinned generation lacks
+    // this target, so the newest generation backstops it before capture.
+    if (!pinnedGeneration.isBlank()) {
+      Optional<TargetStatsRecord> newest = readStore(request);
+      if (newest.isPresent()) {
+        observeSyncOutcome(StatsSyncOutcome.HIT, startNanos);
+        return StatsResolutionResult.hit(newest.get());
+      }
+    }
+    return captureAndResolve(request, startNanos);
+  }
+
+  /** Bounded sync capture, then async-enqueue fallback, for a store miss. */
+  private StatsResolutionResult captureAndResolve(StatsCaptureRequest request, long startNanos) {
     if (syncEnabled
         && request.executionMode() == StatsExecutionMode.SYNC
         && request.latencyBudget().isPresent()) {
@@ -328,24 +391,78 @@ public class StatsOrchestrator {
    */
   public java.util.Map<String, StatsResolutionResult> resolvePlannerBatch(
       java.util.List<StatsCaptureRequest> requests, boolean staleOk, long deadlineNanos) {
+    return resolvePlannerBatchInGeneration(requests, Optional.empty(), staleOk, deadlineNanos);
+  }
+
+  /** Cache key for one request under a specific served-generation token ("" = live/newest). */
+  private StatsCacheKey cacheKeyFor(StatsCaptureRequest req, String generationToken) {
+    return new StatsCacheKey(
+        req.tableId().getAccountId(),
+        req.tableId().getId(),
+        req.snapshotId(),
+        generationToken,
+        storageId(req));
+  }
+
+  /**
+   * Planner batch resolution that honors the query's pinned stats generation.
+   *
+   * <p>The pin freezes a stats generation for the query's lifetime (as the scan path does), so
+   * plans are stable and reproducible for a given pin. For each target the lookup order is:
+   *
+   * <ol>
+   *   <li>cache hit in the pinned generation's keyspace (the live/newest keyspace when the pin
+   *       froze no generation);
+   *   <li>the pinned generation for the pinned snapshot — the primary source;
+   *   <li>the newest (live active) generation, consulted only to fill targets the pinned generation
+   *       lacks, so an incomplete pinned generation never yields NOT_FOUND;
+   *   <li>stale stats from a snapshot &le; the pinned snapshot (when {@code staleOk});
+   *   <li>sync/async capture.
+   * </ol>
+   *
+   * <p>Hits are cached under the generation actually served — the pinned generation under its own
+   * token, newest-fill under the empty token — so the two never contaminate each other. When the
+   * pin froze no generation the primary source is the live/newest generation (empty token) and the
+   * fill step is skipped.
+   *
+   * @param pinnedGenerationToken the generation frozen on the query pin, read as the primary
+   *     source; empty when the pin froze no generation (then the live/newest generation is primary)
+   */
+  public java.util.Map<String, StatsResolutionResult> resolvePlannerBatchInGeneration(
+      java.util.List<StatsCaptureRequest> requests,
+      Optional<String> pinnedGenerationToken,
+      boolean staleOk,
+      long deadlineNanos) {
     if (requests == null || requests.isEmpty()) {
       return java.util.Map.of();
     }
     // All requests must share the same tableId and snapshotId (grouped upstream by TableWork).
     StatsCaptureRequest first = requests.get(0);
+    String pinnedGeneration = pinnedGenerationToken.filter(token -> !token.isBlank()).orElse("");
+    // Primary keyspace/reader: the pinned generation when the pin froze one, else the live/newest
+    // generation (empty token). A new snapshotId is always a cache miss, so stats from a different
+    // snapshot are never returned for the current query.
+    String primaryToken = pinnedGeneration;
+    TargetBatchReader primaryBatch =
+        pinnedGeneration.isBlank()
+            ? statsStore::getTargetStatsBatch
+            : (tableId, snapshotId, targets) ->
+                statsStore.getTargetStatsBatchInGeneration(
+                    tableId, snapshotId, pinnedGeneration, targets);
+    TargetReader primaryTarget =
+        pinnedGeneration.isBlank()
+            ? statsStore::getTargetStats
+            : (tableId, snapshotId, target) ->
+                statsStore.getTargetStatsInGeneration(
+                    tableId, snapshotId, pinnedGeneration, target);
 
-    // 1. Cache check — serve hits without touching DynamoDB.
-    // Cache key includes (accountId, tableId, snapshotId, storageId): a new snapshotId is always
-    // a cache miss, so stats from a different snapshot are never returned for the current query.
+    // 1. Cache check in the primary keyspace.
     java.util.Map<String, StatsResolutionResult> out =
         new java.util.LinkedHashMap<>(requests.size());
     java.util.List<StatsCaptureRequest> cacheMisses = new java.util.ArrayList<>();
     for (StatsCaptureRequest req : requests) {
       String key = storageId(req);
-      StatsCacheKey cacheKey =
-          new StatsCacheKey(
-              req.tableId().getAccountId(), req.tableId().getId(), req.snapshotId(), key);
-      TargetStatsRecord cached = statsCache.getIfPresent(cacheKey);
+      TargetStatsRecord cached = statsCache.getIfPresent(cacheKeyFor(req, primaryToken));
       if (cached != null) {
         observeSyncOutcome(StatsSyncOutcome.HIT);
         out.put(key, StatsResolutionResult.hit(cached));
@@ -358,26 +475,23 @@ public class StatsOrchestrator {
       return java.util.Collections.unmodifiableMap(out);
     }
 
-    // 2. Batch store read for cache misses only.
-    java.util.Map<String, StatsResolutionResult> batchHits =
+    // 2. Primary store read: the pinned generation (query-consistent), or live/newest if no pin.
+    java.util.Map<String, StatsResolutionResult> primaryHits =
         readPlannerBatchIsolated(
             first.tableId(),
             first.snapshotId(),
             cacheMisses,
-            statsStore::getTargetStatsBatch,
-            statsStore::getTargetStats,
+            primaryBatch,
+            primaryTarget,
             StatsResolutionResult::hit);
 
     java.util.List<StatsCaptureRequest> misses = new java.util.ArrayList<>();
     for (StatsCaptureRequest req : cacheMisses) {
       String key = storageId(req);
-      StatsResolutionResult hit = batchHits.get(key);
+      StatsResolutionResult hit = primaryHits.get(key);
       if (hit != null && hit.hasStats()) {
-        // Write-through: only cache positive hits; absent results may appear soon via sync capture.
-        StatsCacheKey cacheKey =
-            new StatsCacheKey(
-                req.tableId().getAccountId(), req.tableId().getId(), req.snapshotId(), key);
-        statsCache.put(cacheKey, hit.stats().get());
+        // Write-through under the primary (pinned, or live when unpinned) keyspace.
+        statsCache.put(cacheKeyFor(req, primaryToken), hit.stats().get());
         observeSyncOutcome(StatsSyncOutcome.HIT);
         out.put(key, StatsResolutionResult.hit(hit.stats().get()));
       } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
@@ -387,20 +501,50 @@ public class StatsOrchestrator {
       }
     }
 
-    // 3. Stale fallback for misses — BEFORE sync capture.
-    // Single batch call: finds the latest snapshot with stats once (O(1) pointer read),
-    // then fetches all missing targets from that snapshot in parallel. Replaces N×O(prefix scan).
-    java.util.List<StatsCaptureRequest> stillMissing = new java.util.ArrayList<>();
-    if (staleOk && !misses.isEmpty()) {
-      java.util.Map<String, StatsResolutionResult> staleBatch =
+    // 3. Newest gap-fill — only when a specific generation was pinned. Fills targets the pinned
+    // generation lacks (prevents NOT_FOUND) without disturbing the pinned reads above; served from
+    // the live/newest generation and cached under the empty token.
+    java.util.List<StatsCaptureRequest> afterFill = new java.util.ArrayList<>();
+    if (!pinnedGeneration.isBlank() && !misses.isEmpty()) {
+      java.util.Map<String, StatsResolutionResult> fillHits =
           readPlannerBatchIsolated(
               first.tableId(),
               first.snapshotId(),
               misses,
+              statsStore::getTargetStatsBatch,
+              statsStore::getTargetStats,
+              StatsResolutionResult::hit);
+      for (StatsCaptureRequest req : misses) {
+        String key = storageId(req);
+        StatsResolutionResult hit = fillHits.get(key);
+        if (hit != null && hit.hasStats()) {
+          statsCache.put(cacheKeyFor(req, ""), hit.stats().get());
+          observeSyncOutcome(StatsSyncOutcome.HIT);
+          out.put(key, StatsResolutionResult.hit(hit.stats().get()));
+        } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
+          out.put(key, hit);
+        } else {
+          afterFill.add(req);
+        }
+      }
+    } else {
+      afterFill.addAll(misses);
+    }
+
+    // 4. Stale fallback — BEFORE sync capture.
+    // Single batch call: finds the latest snapshot with stats once (O(1) pointer read),
+    // then fetches all missing targets from that snapshot in parallel. Replaces N×O(prefix scan).
+    java.util.List<StatsCaptureRequest> stillMissing = new java.util.ArrayList<>();
+    if (staleOk && !afterFill.isEmpty()) {
+      java.util.Map<String, StatsResolutionResult> staleBatch =
+          readPlannerBatchIsolated(
+              first.tableId(),
+              first.snapshotId(),
+              afterFill,
               statsStore::getStaleTargetStatsBatch,
               statsStore::getStaleTargetStats,
               record -> StatsResolutionResult.staleHit(record, "stale_before_sync"));
-      for (StatsCaptureRequest req : misses) {
+      for (StatsCaptureRequest req : afterFill) {
         String key = storageId(req);
         StatsResolutionResult stale = staleBatch.get(key);
         if (stale != null && stale.hasStats()) {
@@ -412,10 +556,10 @@ public class StatsOrchestrator {
         }
       }
     } else {
-      stillMissing.addAll(misses);
+      stillMissing.addAll(afterFill);
     }
 
-    // 4. Sync capture for still-missing targets (per-target within deadline).
+    // 5. Sync capture for still-missing targets (per-target within deadline).
     java.util.List<StatsCaptureRequest> asyncQueue = new java.util.ArrayList<>();
     for (StatsCaptureRequest req : stillMissing) {
       String key = storageId(req);
@@ -463,7 +607,7 @@ public class StatsOrchestrator {
       }
     }
 
-    // 5. Enqueue async captures for all misses that didn't sync.
+    // 6. Enqueue async captures for all misses that didn't sync.
     if (!asyncQueue.isEmpty()) {
       enqueueAsyncCaptureBatch(asyncQueue);
     }

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
@@ -30,7 +30,6 @@ import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.statistics.PlannerStatsResolver.PlannerLookupDiagnostics;
 import ai.floedb.floecat.service.statistics.PlannerStatsResolver.PlannerLookupOutcome;
 import ai.floedb.floecat.service.telemetry.ServiceMetrics;
-import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.spi.StatsCaptureBatchItemResult;
 import ai.floedb.floecat.stats.spi.StatsCaptureBatchRequest;
 import ai.floedb.floecat.stats.spi.StatsCaptureBatchResult;
@@ -112,7 +111,8 @@ public class StatsOrchestrator {
     this.observability =
         observability == null || observability.isUnsatisfied() ? null : observability.get();
     this.plannerResolver =
-        new PlannerStatsResolver(statsStore, this.observability, this::observePlannerHit);
+        new PlannerStatsResolver(
+            statsStore, this::readStore, this::incrementCounter, this::observePlannerHit);
   }
 
   public StatsOrchestrator(
@@ -336,7 +336,7 @@ public class StatsOrchestrator {
     // 5. Sync capture for still-missing targets (per-target within deadline).
     java.util.List<StatsCaptureRequest> asyncQueue = new java.util.ArrayList<>();
     for (StatsCaptureRequest req : resolution.stillMissing()) {
-      String key = storageId(req);
+      String key = PlannerStatsResolver.storageId(req);
       if (!syncEnabled || req.executionMode() != StatsExecutionMode.SYNC) {
         asyncQueue.add(req);
         diagnostics.record(PlannerLookupOutcome.CAPTURE_PENDING);
@@ -397,10 +397,6 @@ public class StatsOrchestrator {
     diagnostics.emit(
         first.tableId(), first.snapshotId(), resolution.pinnedGeneration(), requests.size());
     return java.util.Collections.unmodifiableMap(out);
-  }
-
-  private static String storageId(StatsCaptureRequest request) {
-    return StatsTargetIdentity.storageId(request.target());
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/StatsOrchestrator.java
@@ -405,32 +405,66 @@ public class StatsOrchestrator {
   }
 
   /**
-   * Planner batch resolution that honors the query's pinned stats generation.
-   *
-   * <p>The pin freezes a stats generation for the query's lifetime (as the scan path does), so
-   * plans are stable and reproducible for a given pin. For each target the lookup order is:
-   *
-   * <ol>
-   *   <li>cache hit in the pinned generation's keyspace (the live/newest keyspace when the pin
-   *       froze no generation);
-   *   <li>the pinned generation for the pinned snapshot — the primary source;
-   *   <li>the newest (live active) generation, consulted only to fill targets the pinned generation
-   *       lacks, so an incomplete pinned generation never yields NOT_FOUND;
-   *   <li>stale stats from a snapshot &le; the pinned snapshot (when {@code staleOk});
-   *   <li>sync/async capture.
-   * </ol>
-   *
-   * <p>Hits are cached under the generation actually served — the pinned generation under its own
-   * token, newest-fill under the empty token — so the two never contaminate each other. When the
-   * pin froze no generation the primary source is the live/newest generation (empty token) and the
-   * fill step is skipped.
-   *
-   * @param pinnedGenerationToken the generation frozen on the query pin, read as the primary
-   *     source; empty when the pin froze no generation (then the live/newest generation is primary)
+   * Planner batch resolution that honors the query's pinned stats generation, with presence-only
+   * completeness: a target that exists in the pinned generation is a hit. Delegates to {@link
+   * #resolvePlannerBatchInGeneration(java.util.List, Optional, java.util.Map, boolean, long)} with
+   * no per-target completeness predicates.
    */
   public java.util.Map<String, StatsResolutionResult> resolvePlannerBatchInGeneration(
       java.util.List<StatsCaptureRequest> requests,
       Optional<String> pinnedGenerationToken,
+      boolean staleOk,
+      long deadlineNanos) {
+    return resolvePlannerBatchInGeneration(
+        requests, pinnedGenerationToken, java.util.Map.of(), staleOk, deadlineNanos);
+  }
+
+  /**
+   * Planner batch resolution that honors the query's pinned stats generation and the planner's
+   * per-target completeness needs.
+   *
+   * <p>The pin freezes a stats generation for the query's lifetime (as the scan path does), so
+   * plans are stable and reproducible for a given pin. "Exists in the pinned generation" alone is
+   * too coarse a hit rule, though: generations enrich over time (a finalize can add sketch payloads
+   * to a snapshot whose earlier generation was scalar-only), so a pinned record that lacks a
+   * requested capability must not stop resolution — the planner would consume it downgraded while a
+   * richer record for the SAME snapshot exists. For each target the lookup order is:
+   *
+   * <ol>
+   *   <li>cache hit in the pinned generation's keyspace (the live/newest keyspace when the pin
+   *       froze no generation), only if the cached record satisfies the target's completeness
+   *       predicate;
+   *   <li>the pinned generation for the pinned snapshot — the primary source; a record that fails
+   *       its predicate is held as a PARTIAL candidate rather than served;
+   *   <li>the newest (live active) generation of the SAME pinned snapshot, consulted for targets
+   *       the pinned generation lacks or serves only partially. Never a newer snapshot: this is
+   *       richer stats for identical data, not weakened snapshot consistency. If newest satisfies,
+   *       it wins; if not, the pinned partial is served (consistency prefers the pin between
+   *       equally incomplete records) — partial records never fall through to stale or capture;
+   *   <li>stale stats from a snapshot &le; the pinned snapshot (when {@code staleOk}), for targets
+   *       with no record at the pinned snapshot at all;
+   *   <li>sync/async capture.
+   * </ol>
+   *
+   * <p>Hits are cached under the generation actually served — the pinned generation under its own
+   * token, newest-fill under the empty token — so the two never contaminate each other. Records are
+   * cached whole and completeness is re-evaluated per read, so one query's lesser need never masks
+   * another's richer need. When the pin froze no generation the primary source is the live/newest
+   * generation (empty token) and the fill step is skipped: a partial primary record is served
+   * as-is, because no richer same-snapshot source exists.
+   *
+   * @param pinnedGenerationToken the generation frozen on the query pin, read as the primary
+   *     source; empty when the pin froze no generation (then the live/newest generation is primary)
+   * @param completenessByStorageId per-target completeness predicate keyed by {@code
+   *     StatsTargetIdentity.storageId}; a target with no entry treats presence as complete. Kept as
+   *     plain predicates so this class stays independent of the planner request model — callers
+   *     derive them from the request's needs (see {@code PlannerStatsResultMaterializer}).
+   */
+  public java.util.Map<String, StatsResolutionResult> resolvePlannerBatchInGeneration(
+      java.util.List<StatsCaptureRequest> requests,
+      Optional<String> pinnedGenerationToken,
+      java.util.Map<String, java.util.function.Predicate<TargetStatsRecord>>
+          completenessByStorageId,
       boolean staleOk,
       long deadlineNanos) {
     if (requests == null || requests.isEmpty()) {
@@ -439,6 +473,8 @@ public class StatsOrchestrator {
     // All requests must share the same tableId and snapshotId (grouped upstream by TableWork).
     StatsCaptureRequest first = requests.get(0);
     String pinnedGeneration = pinnedGenerationToken.filter(token -> !token.isBlank()).orElse("");
+    java.util.function.Function<String, java.util.function.Predicate<TargetStatsRecord>>
+        completenessFor = key -> completenessByStorageId.getOrDefault(key, record -> true);
     // Primary keyspace/reader: the pinned generation when the pin froze one, else the live/newest
     // generation (empty token). A new snapshotId is always a cache miss, so stats from a different
     // snapshot are never returned for the current query.
@@ -456,14 +492,17 @@ public class StatsOrchestrator {
                 statsStore.getTargetStatsInGeneration(
                     tableId, snapshotId, pinnedGeneration, target);
 
-    // 1. Cache check in the primary keyspace.
+    // 1. Cache check in the primary keyspace. A cached record that fails its completeness
+    // predicate reads as a miss — the store may hold an enriched generation this query can use —
+    // but is NOT evicted: it still satisfies lesser needs, and records are immutable per
+    // generation so re-reads converge on the same bytes.
     java.util.Map<String, StatsResolutionResult> out =
         new java.util.LinkedHashMap<>(requests.size());
     java.util.List<StatsCaptureRequest> cacheMisses = new java.util.ArrayList<>();
     for (StatsCaptureRequest req : requests) {
       String key = storageId(req);
       TargetStatsRecord cached = statsCache.getIfPresent(cacheKeyFor(req, primaryToken));
-      if (cached != null) {
+      if (cached != null && completenessFor.apply(key).test(cached)) {
         observeSyncOutcome(StatsSyncOutcome.HIT);
         out.put(key, StatsResolutionResult.hit(cached));
       } else {
@@ -485,15 +524,27 @@ public class StatsOrchestrator {
             primaryTarget,
             StatsResolutionResult::hit);
 
+    // Pinned records that exist but fail their completeness predicate: candidates the newest
+    // gap-fill may replace, and the answer of last resort if it cannot — a partial record is
+    // still a hit (the planner degrades per stat), never a stale/capture trigger.
+    java.util.Map<String, TargetStatsRecord> partialPinned = new java.util.LinkedHashMap<>();
     java.util.List<StatsCaptureRequest> misses = new java.util.ArrayList<>();
     for (StatsCaptureRequest req : cacheMisses) {
       String key = storageId(req);
       StatsResolutionResult hit = primaryHits.get(key);
       if (hit != null && hit.hasStats()) {
-        // Write-through under the primary (pinned, or live when unpinned) keyspace.
-        statsCache.put(cacheKeyFor(req, primaryToken), hit.stats().get());
-        observeSyncOutcome(StatsSyncOutcome.HIT);
-        out.put(key, StatsResolutionResult.hit(hit.stats().get()));
+        TargetStatsRecord record = hit.stats().get();
+        if (completenessFor.apply(key).test(record) || pinnedGeneration.isBlank()) {
+          // Complete — or partial with no pin, where the primary IS the newest generation and no
+          // richer same-snapshot source exists: serve as-is, the planner degrades per stat.
+          // Write-through under the primary (pinned, or live when unpinned) keyspace.
+          statsCache.put(cacheKeyFor(req, primaryToken), record);
+          observeSyncOutcome(StatsSyncOutcome.HIT);
+          out.put(key, StatsResolutionResult.hit(record));
+        } else {
+          partialPinned.put(key, record);
+          misses.add(req);
+        }
       } else if (hit != null && hit.outcome() == StatsSyncOutcome.FAILED) {
         out.put(key, hit);
       } else {
@@ -501,9 +552,9 @@ public class StatsOrchestrator {
       }
     }
 
-    // 3. Newest gap-fill — only when a specific generation was pinned. Fills targets the pinned
-    // generation lacks (prevents NOT_FOUND) without disturbing the pinned reads above; served from
-    // the live/newest generation and cached under the empty token.
+    // 3. Newest gap-fill — only when a specific generation was pinned. Serves targets the pinned
+    // generation lacks (prevents NOT_FOUND) or holds only partially (prevents a needless
+    // downgrade), from the newest generation of the SAME snapshot; cached under the empty token.
     java.util.List<StatsCaptureRequest> afterFill = new java.util.ArrayList<>();
     if (!pinnedGeneration.isBlank() && !misses.isEmpty()) {
       java.util.Map<String, StatsResolutionResult> fillHits =
@@ -517,7 +568,21 @@ public class StatsOrchestrator {
       for (StatsCaptureRequest req : misses) {
         String key = storageId(req);
         StatsResolutionResult hit = fillHits.get(key);
-        if (hit != null && hit.hasStats()) {
+        TargetStatsRecord partial = partialPinned.get(key);
+        boolean newestSatisfies =
+            hit != null && hit.hasStats() && completenessFor.apply(key).test(hit.stats().get());
+        if (newestSatisfies) {
+          statsCache.put(cacheKeyFor(req, ""), hit.stats().get());
+          observeSyncOutcome(StatsSyncOutcome.HIT);
+          out.put(key, StatsResolutionResult.hit(hit.stats().get()));
+        } else if (partial != null) {
+          // Newest is no more complete than the pin: between equally incomplete records,
+          // consistency prefers the pinned generation the scan reads.
+          statsCache.put(cacheKeyFor(req, primaryToken), partial);
+          observeSyncOutcome(StatsSyncOutcome.HIT);
+          out.put(key, StatsResolutionResult.hit(partial));
+        } else if (hit != null && hit.hasStats()) {
+          // Pin has nothing at all; a partial newest record beats stale or capture.
           statsCache.put(cacheKeyFor(req, ""), hit.stats().get());
           observeSyncOutcome(StatsSyncOutcome.HIT);
           out.put(key, StatsResolutionResult.hit(hit.stats().get()));

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
@@ -283,6 +283,19 @@ public final class ServiceMetrics {
     public static final MetricId SYNC_LATENCY =
         new MetricId(
             "floecat.service.stats.sync.latency", MetricType.TIMER, "ms", CONTRACT, "service");
+
+    /**
+     * Per-target planner lookup outcomes, tagged {@code result=<outcome>} with the ladder rung that
+     * served (or failed) each target: cache/pinned/newest-fill/partial/stale/captured/
+     * pending/failed. Answers "which rung is serving planner stats" without log archaeology.
+     */
+    public static final MetricId PLANNER_LOOKUP_OUTCOMES_TOTAL =
+        new MetricId(
+            "floecat.service.stats.planner_lookup_outcomes.total",
+            MetricType.COUNTER,
+            "",
+            CONTRACT,
+            "service");
   }
 
   /** CAS blob-GC backlog health: the signals that answer "is GC falling behind?". */

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributor.java
@@ -62,6 +62,7 @@ public final class ServiceTelemetryContributor implements TelemetryContributor {
     Set<String> gcRequired = Set.of(TagKey.COMPONENT, TagKey.OPERATION);
     Set<String> gcAllowed = Set.of(TagKey.COMPONENT, TagKey.OPERATION);
     Set<String> statsRequired = Set.of(TagKey.COMPONENT, TagKey.OPERATION);
+    Set<String> plannerStatsLookupTags = Set.of(TagKey.COMPONENT, TagKey.OPERATION, TagKey.RESULT);
     Set<String> statsAllowed =
         Set.of(
             TagKey.COMPONENT,
@@ -391,6 +392,12 @@ public final class ServiceTelemetryContributor implements TelemetryContributor {
         statsAllowed,
         "Sync-first resolution outcomes by result (HIT, CAPTURED, PARTIAL, TIMEOUT, FAILED,"
             + " SKIPPED).");
+    add(
+        defs,
+        ServiceMetrics.Stats.PLANNER_LOOKUP_OUTCOMES_TOTAL,
+        plannerStatsLookupTags,
+        plannerStatsLookupTags,
+        "Planner stats lookup outcomes by the ladder rung that served or failed each target.");
     add(
         defs,
         ServiceMetrics.Stats.SYNC_LATENCY,

--- a/service/src/main/resources/errors_en.properties
+++ b/service/src/main/resources/errors_en.properties
@@ -68,6 +68,8 @@ MC_NOT_FOUND.query.not.found=Query not found: {query_id}.
 MC_NOT_FOUND.query.table.not.pinned=Table "{table_id}" is not pinned for query "{query_id}".
 MC_NOT_FOUND.query.input.unresolved=Query input could not be resolved: {name}.
 MC_NOT_FOUND.query.snapshot.not.found.at.time=No snapshot exists at or before {as_of} for table "{table_id}".
+MC_NOT_FOUND.query.snapshot.not.in.table=Snapshot "{snapshot_id}" not found for table "{table_id}".
+MC_NOT_FOUND.query.table.no.queryable.snapshot=Table "{table_id}" has no queryable snapshot.
 MC_NOT_FOUND.systemcatalog.not.found=Builtin catalog not found for engine version: {engine_version}.
 MC_NOT_FOUND.scan.handle=Scan handle not found: {handle}.
 

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/RootRepairRequestsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/RootRepairRequestsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.catalog.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class RootRepairRequestsTest {
+
+  private static final ResourceId TABLE =
+      ResourceId.newBuilder()
+          .setAccountId("acct")
+          .setId("tbl")
+          .setKind(ResourceKind.RK_TABLE)
+          .build();
+
+  private static final String MARKER = Keys.rootResyncPendingPointer("acct", "tbl");
+
+  @Test
+  void firstRequestEnqueuesTheResyncMarker() {
+    var pointers = new InMemoryPointerStore();
+    var repairs = new RootRepairRequests(new RootResyncQueue(pointers), () -> 0L);
+
+    repairs.request(TABLE);
+
+    assertTrue(pointers.get(MARKER).isPresent());
+  }
+
+  @Test
+  void repeatedRequestsWithinTheWindowAreSuppressed() {
+    var pointers = new InMemoryPointerStore();
+    var clock = new AtomicLong();
+    var repairs = new RootRepairRequests(new RootResyncQueue(pointers), clock::get);
+
+    // A broken table fails every query against it; only the first observer in the window may
+    // touch the store. The marker's version records each enqueue (touch-on-exists), so a
+    // suppressed report is visible as an unchanged version.
+    repairs.request(TABLE);
+    clock.addAndGet(TimeUnit.SECONDS.toNanos(30));
+    repairs.request(TABLE);
+    repairs.request(TABLE);
+
+    assertEquals(1L, pointers.get(MARKER).orElseThrow().getVersion());
+  }
+
+  @Test
+  void aRequestAfterTheWindowEnqueuesAgain() {
+    var pointers = new InMemoryPointerStore();
+    var clock = new AtomicLong();
+    var repairs = new RootRepairRequests(new RootResyncQueue(pointers), clock::get);
+
+    repairs.request(TABLE);
+    clock.addAndGet(TimeUnit.MINUTES.toNanos(6));
+    repairs.request(TABLE);
+
+    // The second window's report touched the still-pending marker: version bumped.
+    assertEquals(2L, pointers.get(MARKER).orElseThrow().getVersion());
+  }
+
+  @Test
+  void anEnqueueFailureIsSwallowedAndReleasesTheWindow() {
+    var failures = new AtomicInteger(RootResyncQueue.ENQUEUE_ATTEMPTS);
+    var pointers =
+        new InMemoryPointerStore() {
+          @Override
+          public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
+            if (failures.getAndDecrement() > 0) {
+              throw new IllegalStateException("pointer store down");
+            }
+            return super.compareAndSet(key, expectedVersion, next);
+          }
+        };
+    var repairs = new RootRepairRequests(new RootResyncQueue(pointers, backoffMs -> {}), () -> 0L);
+
+    // The store is down for the whole first enqueue: the query path must not see the failure.
+    assertDoesNotThrow(() -> repairs.request(TABLE));
+    // The failed report released its window claim, so the next query's report retries and lands.
+    repairs.request(TABLE);
+    assertTrue(pointers.get(MARKER).isPresent());
+  }
+
+  @Test
+  void aDisabledInstanceNoOps() {
+    assertDoesNotThrow(() -> RootRepairRequests.disabled().request(TABLE));
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/execution/impl/ScanBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/execution/impl/ScanBundleServiceTest.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.execution.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -35,12 +36,17 @@ import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.query.rpc.PinKind;
 import ai.floedb.floecat.query.rpc.TableInfo;
 import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.service.catalog.impl.RootRepairRequests;
+import ai.floedb.floecat.service.catalog.impl.RootResyncQueue;
+import ai.floedb.floecat.service.query.PinValidator;
 import ai.floedb.floecat.service.query.impl.ScanSession;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.storage.impl.ServerSideFileIoPropertiesResolver;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsStore.StatsStorePage;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +80,7 @@ class ScanBundleServiceTest {
   private ScanBundleService service;
   private ServerSideFileIoPropertiesResolver resolver;
   private StatsStore statsStore;
+  private InMemoryPointerStore repairPointers;
 
   @BeforeEach
   void setUp() {
@@ -81,7 +88,18 @@ class ScanBundleServiceTest {
     snapshotRepo = mock(SnapshotRepository.class);
     resolver = mock(ServerSideFileIoPropertiesResolver.class);
     statsStore = mock(StatsStore.class);
-    service = new ScanBundleService(tableRepo, snapshotRepo, statsStore, resolver);
+    // A real repair pipeline over an in-memory store: initScan's missing-pinned-blob failures
+    // must durably enqueue the table for the resync re-drive, and tests assert the marker.
+    repairPointers = new InMemoryPointerStore();
+    PinValidator pinValidator =
+        new PinValidator(null, new RootRepairRequests(new RootResyncQueue(repairPointers)));
+    service = new ScanBundleService(tableRepo, snapshotRepo, statsStore, resolver, pinValidator);
+  }
+
+  private boolean repairEnqueued(ResourceId tableId) {
+    return repairPointers
+        .get(Keys.rootResyncPendingPointer(tableId.getAccountId(), tableId.getId()))
+        .isPresent();
   }
 
   private void stubPinnedBlobsPresent() {
@@ -128,10 +146,23 @@ class ScanBundleServiceTest {
   }
 
   @Test
-  void initScanFailsWhenPinnedTableBlobMissing() {
+  void initScanFailsWhenPinnedTableBlobMissingAndEnqueuesRepair() {
     when(tableRepo.getByBlobUriLive(TABLE_BLOB_URI)).thenReturn(Optional.empty());
 
     assertThrows(io.grpc.StatusRuntimeException.class, () -> service.initScan("corr", PIN));
+    // The pinned root names a table blob no read can load: without a re-derived root every
+    // future scan fails the same way, so the failure durably enqueues the table for repair.
+    assertTrue(repairEnqueued(TABLE_ID));
+  }
+
+  @Test
+  void initScanFailsWhenPinnedSnapshotBlobMissingAndEnqueuesRepair() {
+    when(tableRepo.getByBlobUriLive(TABLE_BLOB_URI))
+        .thenReturn(Optional.of(Table.newBuilder().setResourceId(TABLE_ID).build()));
+    when(snapshotRepo.getByBlobUriLive(SNAPSHOT_BLOB_URI)).thenReturn(Optional.empty());
+
+    assertThrows(io.grpc.StatusRuntimeException.class, () -> service.initScan("corr", PIN));
+    assertTrue(repairEnqueued(TABLE_ID));
   }
 
   private static ScanSession session(String statsGeneration) {

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
@@ -272,9 +272,13 @@ class SnapshotHelperTest {
     assertThatThrownBy(() -> helper.tablePinFor("corr", tableId, null, Optional.empty()))
         .isInstanceOf(StatusRuntimeException.class)
         .satisfies(
-            e ->
-                assertThat(((StatusRuntimeException) e).getStatus().getCode())
-                    .isEqualTo(io.grpc.Status.Code.NOT_FOUND));
+            e -> {
+              var status = ((StatusRuntimeException) e).getStatus();
+              assertThat(status.getCode()).isEqualTo(io.grpc.Status.Code.NOT_FOUND);
+              // The rendered message must name the failing table — an operator triaging "no
+              // queryable snapshot" needs the table identity, not an unfilled "{id}" placeholder.
+              assertThat(status.getDescription()).contains(tableId.getId()).doesNotContain("{");
+            });
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
@@ -33,11 +33,15 @@ import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.query.rpc.PinKind;
 import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.service.catalog.impl.RootRepairRequests;
+import ai.floedb.floecat.service.catalog.impl.RootResyncQueue;
 import ai.floedb.floecat.service.catalog.impl.TableRootCommitter;
 import ai.floedb.floecat.service.catalog.impl.TableRootMutations;
 import ai.floedb.floecat.service.catalog.impl.TableRootSynthesizer;
+import ai.floedb.floecat.service.query.PinValidator;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.testsupport.SnapshotTestSupport;
 import ai.floedb.floecat.service.testsupport.TestNodes;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
@@ -56,6 +60,8 @@ class SnapshotHelperTest {
   private TableRepository tableRepo;
   private TableRootRepository roots;
   private TableRootCommitter committer;
+  private InMemoryPointerStore repairPointers;
+  private PinValidator validator;
 
   @BeforeEach
   void setUp() {
@@ -67,7 +73,18 @@ class SnapshotHelperTest {
     when(tableRepo.blobEtag("s3://tbl/table.pb")).thenReturn("etag-t");
     roots = new TableRootRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
     committer = new TableRootCommitter(roots);
-    helper = new SnapshotHelper(repository, roots, committer, null);
+    // A real repair pipeline over its own in-memory store, so tests can assert which broken-root
+    // observations durably enqueue the table for the resync re-drive and which do not.
+    repairPointers = new InMemoryPointerStore();
+    validator =
+        new PinValidator(roots, new RootRepairRequests(new RootResyncQueue(repairPointers)));
+    helper = new SnapshotHelper(repository, roots, committer, null, validator);
+  }
+
+  private boolean repairEnqueued(ResourceId tableId) {
+    return repairPointers
+        .get(Keys.rootResyncPendingPointer(tableId.getAccountId(), tableId.getId()))
+        .isPresent();
   }
 
   /** Seed a snapshot in the legacy fake so its blob identity resolves for validation. */
@@ -256,7 +273,8 @@ class SnapshotHelperTest {
     TableRootSynthesizer synthesizer = mock(TableRootSynthesizer.class);
     when(synthesizer.synthesize(tableId)).thenReturn(Optional.of(synthesized));
     helper =
-        new SnapshotHelper(repository, roots, new TableRootCommitter(roots, synthesizer), null);
+        new SnapshotHelper(
+            repository, roots, new TableRootCommitter(roots, synthesizer), null, validator);
 
     TablePin pin = helper.tablePinFor("corr", tableId, null, Optional.empty());
 
@@ -279,6 +297,8 @@ class SnapshotHelperTest {
               // queryable snapshot" needs the table identity, not an unfilled "{id}" placeholder.
               assertThat(status.getDescription()).contains(tableId.getId()).doesNotContain("{");
             });
+    // An expected client state (nothing broken), so nothing is enqueued for the resync re-drive.
+    assertThat(repairEnqueued(tableId)).isFalse();
   }
 
   @Test
@@ -297,6 +317,8 @@ class SnapshotHelperTest {
             e ->
                 assertThat(((StatusRuntimeException) e).getStatus().getCode())
                     .isEqualTo(io.grpc.Status.Code.NOT_FOUND));
+    // A committed root legitimately without currency is an expected client state, not breakage.
+    assertThat(repairEnqueued(tableId)).isFalse();
   }
 
   @Test
@@ -314,6 +336,9 @@ class SnapshotHelperTest {
             e ->
                 assertThat(((StatusRuntimeException) e).getStatus().getCode())
                     .isEqualTo(io.grpc.Status.Code.INTERNAL));
+    // A broken invariant fails every query against the table until its root is re-derived, so
+    // beyond the error the table is durably enqueued for the resync re-drive.
+    assertThat(repairEnqueued(tableId)).isTrue();
   }
 
   @Test
@@ -555,7 +580,7 @@ class SnapshotHelperTest {
     // Metadata surfaces (getCommittedCurrent*) still expose 12 as the committed selection.
     var tracking = mock(ai.floedb.floecat.stats.spi.StatsStore.class);
     when(tracking.tracksStatsGenerations()).thenReturn(true);
-    helper = new SnapshotHelper(repository, roots, committer, tracking);
+    helper = new SnapshotHelper(repository, roots, committer, tracking, validator);
     ResourceId tableId = tableId("tbl");
     seedSnapshot(tableId, 11, "2024-02-01T00:00:00Z");
     seedSnapshot(tableId, 12, "2024-03-01T00:00:00Z");
@@ -587,7 +612,7 @@ class SnapshotHelperTest {
     // among finalized entries only; CURRENT never points at it (currency advances at finalize).
     var tracking = mock(ai.floedb.floecat.stats.spi.StatsStore.class);
     when(tracking.tracksStatsGenerations()).thenReturn(true);
-    helper = new SnapshotHelper(repository, roots, committer, tracking);
+    helper = new SnapshotHelper(repository, roots, committer, tracking, validator);
     ResourceId tableId = tableId("tbl");
     seedSnapshot(tableId, 11, "2024-02-01T00:00:00Z");
     seedSnapshot(tableId, 12, "2024-03-01T00:00:00Z");
@@ -687,11 +712,50 @@ class SnapshotHelperTest {
                 .build(),
             BlobRef.newBuilder().setUri("s3://t/table.pb").setVersion("vt").build(),
             true));
-    var flakyHelper = new SnapshotHelper(repository, flakyRoots, flakyCommitter, null);
+    var flakyHelper = new SnapshotHelper(repository, flakyRoots, flakyCommitter, null, validator);
 
     TablePin pin = flakyHelper.tablePinFor("corr", table, null, Optional.empty());
 
     assertThat(pin.getSnapshotId()).isEqualTo(11);
+    // The one-shot re-follow recovered, so nothing was enqueued for the resync re-drive.
+    assertThat(repairEnqueued(table)).isFalse();
+  }
+
+  @Test
+  void aPersistentlyUnreadableRootBlobFailsThePinAndEnqueuesRepair() {
+    // The pointer names a blob no read can load, and the re-follow reads the same dead URI back:
+    // the table is broken for every query until its root is re-derived. The pin still fails this
+    // query, but the table must also be durably enqueued for the resync re-drive to converge.
+    var ptr = new InMemoryPointerStore();
+    var blobStore = new InMemoryBlobStore();
+    var deadRoots =
+        new TableRootRepository(ptr, blobStore) {
+          @Override
+          public java.util.Optional<ai.floedb.floecat.catalog.rpc.TableRoot> getByBlobUri(
+              String blobUri) {
+            return java.util.Optional.empty(); // swept/corrupt: never readable
+          }
+        };
+    ResourceId table = tableId("tbl-dead-root");
+    var deadCommitter = new TableRootCommitter(deadRoots);
+    deadCommitter.commit(
+        table,
+        TableRootMutations.upsertSnapshot(
+            deadRoots,
+            table,
+            SnapshotManifestEntry.newBuilder()
+                .setSnapshotId(12)
+                .setSnapshotRef(BlobRef.newBuilder().setUri("s3://t/snap-12.pb").setVersion("v12"))
+                .setStatsGenerationRef(BlobRef.newBuilder().setUri("s3://t/stats/12/gen.pb"))
+                .setUpstreamCreatedAt(com.google.protobuf.util.Timestamps.fromMillis(12_000))
+                .build(),
+            BlobRef.newBuilder().setUri("s3://t/table.pb").setVersion("vt").build(),
+            true));
+    var deadHelper = new SnapshotHelper(repository, deadRoots, deadCommitter, null, validator);
+
+    assertThatThrownBy(() -> deadHelper.tablePinFor("corr", table, null, Optional.empty()))
+        .isInstanceOf(StatusRuntimeException.class);
+    assertThat(repairEnqueued(table)).isTrue();
   }
 
   @Test
@@ -713,10 +777,12 @@ class SnapshotHelperTest {
                 .build(),
             BlobRef.newBuilder().setUri("s3://t/table.pb").setVersion("vt").build(),
             true));
-    var localHelper = new SnapshotHelper(repository, roots, localCommitter, null);
+    var localHelper = new SnapshotHelper(repository, roots, localCommitter, null, validator);
 
     assertThatThrownBy(() -> localHelper.tablePinFor("corr", table, null, Optional.empty()))
         .hasMessageContaining("INTERNAL");
+    // A broken root invariant: the table is durably enqueued for the resync re-drive.
+    assertThat(repairEnqueued(table)).isTrue();
   }
 
   @Test
@@ -726,7 +792,7 @@ class SnapshotHelperTest {
     // explicit-id (reject) and AS_OF (skip) paths — not pin a snapshot that would then scan empty.
     var tracking = mock(ai.floedb.floecat.stats.spi.StatsStore.class);
     when(tracking.tracksStatsGenerations()).thenReturn(true);
-    helper = new SnapshotHelper(repository, roots, committer, tracking);
+    helper = new SnapshotHelper(repository, roots, committer, tracking, validator);
     ResourceId tableId = tableId("tbl");
     seedSnapshot(tableId, 7, "2024-02-01T00:00:00Z");
     // Finalize 7 (generation ref present -> becomes current), then remove its generation.
@@ -749,7 +815,7 @@ class SnapshotHelperTest {
     // not be rejected. The gate keys on presence, not on the generation being non-empty.
     var tracking = mock(ai.floedb.floecat.stats.spi.StatsStore.class);
     when(tracking.tracksStatsGenerations()).thenReturn(true);
-    helper = new SnapshotHelper(repository, roots, committer, tracking);
+    helper = new SnapshotHelper(repository, roots, committer, tracking, validator);
     ResourceId tableId = tableId("tbl");
     seedSnapshot(tableId, 3, "2024-02-01T00:00:00Z");
     // The stats-generation ref points at an EMPTY generation — the snapshot is finalized, it just

--- a/service/src/test/java/ai/floedb/floecat/service/query/PinValidatorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/PinValidatorTest.java
@@ -16,7 +16,10 @@
 
 package ai.floedb.floecat.service.query;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +27,11 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.query.rpc.PinKind;
 import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.service.catalog.impl.RootRepairRequests;
+import ai.floedb.floecat.service.catalog.impl.RootResyncQueue;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +40,7 @@ class PinValidatorTest {
 
   private TableRootRepository roots;
   private PinValidator validator;
+  private InMemoryPointerStore repairPointers;
 
   private static final ResourceId TABLE =
       ResourceId.newBuilder()
@@ -44,9 +52,19 @@ class PinValidatorTest {
   @BeforeEach
   void setUp() {
     roots = mock(TableRootRepository.class);
-    validator = new PinValidator(roots);
+    // A real repair pipeline over an in-memory store, so tests can assert which integrity
+    // failures durably enqueue the table for the resync re-drive and which do not.
+    repairPointers = new InMemoryPointerStore();
+    validator =
+        new PinValidator(roots, new RootRepairRequests(new RootResyncQueue(repairPointers)));
     // The pinned root resolves at its pinned version unless a test overrides it.
     when(roots.blobEtag("s3://t/root/abc.pb")).thenReturn("etag-root");
+  }
+
+  private boolean repairEnqueued(ResourceId tableId) {
+    return repairPointers
+        .get(Keys.rootResyncPendingPointer(tableId.getAccountId(), tableId.getId()))
+        .isPresent();
   }
 
   /** A root-backed pin — the only shape construction can produce. */
@@ -76,17 +94,48 @@ class PinValidatorTest {
   }
 
   @Test
-  void aVanishedRootBlobFails() {
+  void aVanishedRootBlobFailsAndEnqueuesRepair() {
     when(roots.blobEtag("s3://t/root/abc.pb")).thenReturn(null);
     assertThrows(StatusRuntimeException.class, () -> validator.validate("corr", pin().build()));
+    // A missing pinned root may mean the live pointer still names a swept blob — every future
+    // query fails until the root is re-derived, so the table is reported for the resync re-drive.
+    assertTrue(repairEnqueued(TABLE));
   }
 
   @Test
-  void aRootVersionMismatchFails() {
+  void aRootVersionMismatchFailsWithoutRepair() {
     // The URI is content-addressed, so a different etag at the pinned URI is a broken store
     // invariant, not a benign refresh.
     when(roots.blobEtag("s3://t/root/abc.pb")).thenReturn("etag-OTHER");
     assertThrows(StatusRuntimeException.class, () -> validator.validate("corr", pin().build()));
+    // The blob was REPLACED, not lost: a fresh pin would succeed, so there is nothing for the
+    // resync re-drive to converge and no marker is written.
+    assertFalse(repairEnqueued(TABLE));
+  }
+
+  @Test
+  void aMissingPinnedTableBlobRaisesInternalAndEnqueuesRepair() {
+    assertThrows(
+        StatusRuntimeException.class,
+        () -> validator.requirePinnedTableBlob(java.util.Optional.empty(), "corr", TABLE));
+    // The committed root names a blob no read can load; without a re-derived root every future
+    // query fails identically, so the failure durably enqueues the table for repair.
+    assertTrue(repairEnqueued(TABLE));
+  }
+
+  @Test
+  void aMissingPinnedSnapshotBlobRaisesInternalAndEnqueuesRepair() {
+    assertThrows(
+        StatusRuntimeException.class,
+        () -> validator.requirePinnedSnapshotBlob(java.util.Optional.empty(), "corr", TABLE, 7L));
+    assertTrue(repairEnqueued(TABLE));
+  }
+
+  @Test
+  void aPresentPinnedBlobUnwrapsWithoutRepair() {
+    assertEquals(
+        "blob", validator.requirePinnedTableBlob(java.util.Optional.of("blob"), "corr", TABLE));
+    assertFalse(repairEnqueued(TABLE));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/query/QueryPinsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/QueryPinsTest.java
@@ -285,6 +285,7 @@ class QueryPinsTest {
             .setTableBlobUri("/accounts/a/tables/t/table/d.pb")
             .setSnapshotBlobUri("/accounts/a/tables/t/snapshots/1/snapshot/s.pb")
             .setConstraintsRefUri("/accounts/a/tables/t/constraints/1/c.pb")
+            .setStatsGenerationRefUri("/accounts/a/tables/t/snapshots/1/stats/gen-1/manifest.pb")
             .build();
 
     org.junit.jupiter.api.Assertions.assertEquals(
@@ -292,7 +293,10 @@ class QueryPinsTest {
             "/accounts/a/tables/t/root/r.pb",
             "/accounts/a/tables/t/table/d.pb",
             "/accounts/a/tables/t/snapshots/1/snapshot/s.pb",
-            "/accounts/a/tables/t/constraints/1/c.pb"),
+            "/accounts/a/tables/t/constraints/1/c.pb",
+            // The frozen stats generation manifest is a direct pin root: the planner reads it for
+            // the query's lifetime, so it must not rely on the GC's chain walk alone.
+            "/accounts/a/tables/t/snapshots/1/stats/gen-1/manifest.pb"),
         QueryPins.gcRootUris(pin));
 
     // Absent legs (no constraints, no root on a hand-built pin) are skipped, never empty strings.

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
@@ -1076,6 +1076,116 @@ class PlannerStatsBundleServiceTest extends PlannerStatsBundleServiceTestSupport
   }
 
   @Test
+  void realPlannerLookupReadsTheStatsGenerationFrozenOnThePin() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createServiceWithRealLookup(
+            repository, store, /* chunkSize= */ 5, /* maxTables= */ 5, /* maxTargets= */ 10);
+
+    long snapshotId = 482L;
+    // Pinned generation: col1 = 10.
+    repository.replaceAllStatsForSnapshot(
+        TABLE,
+        snapshotId,
+        List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE,
+                snapshotId,
+                1L,
+                ScalarStats.newBuilder().setDisplayName("col1").setRowCount(10L).build(),
+                null)));
+    String pinnedGeneration = repository.activeStatsGeneration(TABLE, snapshotId).orElseThrow();
+
+    // A newer generation for the same snapshot: col1 = 20.
+    repository.replaceAllStatsForSnapshot(
+        TABLE,
+        snapshotId,
+        List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE,
+                snapshotId,
+                1L,
+                ScalarStats.newBuilder().setDisplayName("col1").setRowCount(20L).build(),
+                null)));
+
+    QueryContext ctx =
+        queryContextWithStatsGenerationRef(
+            "real-orchestrator-pinned-generation", snapshotId, pinnedGeneration);
+    store.seed(ctx);
+
+    FetchTargetStatsRequest request = requestFor(ctx.getQueryId(), TABLE, List.of(1L));
+    List<TargetStatsBundleChunk> chunks =
+        service.streamTargets("corr", ctx, request).collect().asList().await().indefinitely();
+
+    // The plan reads the generation frozen on the pin (10), not the newer live one (20) — stable
+    // and
+    // reproducible for a given pin.
+    List<TargetStatsResult> results = flatten(chunks);
+    assertEquals(1, results.size(), "one column must produce a result");
+    assertEquals(StatsResultStatus.STATS_RESULT_HIT_COMPLETE, results.get(0).getStatus());
+    assertEquals(10L, results.get(0).getStats().getScalar().getRowCount());
+    TargetStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
+    assertEquals(1L, end.getReturnedTargets());
+    assertEquals(0L, end.getNotFoundTargets());
+  }
+
+  @Test
+  void realPlannerLookupFillsFromNewestWhenPinnedLacksTarget() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createServiceWithRealLookup(
+            repository, store, /* chunkSize= */ 5, /* maxTables= */ 5, /* maxTargets= */ 10);
+
+    long snapshotId = 482L;
+    // Pinned generation carries only col2 — it never had col1.
+    repository.replaceAllStatsForSnapshot(
+        TABLE,
+        snapshotId,
+        List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE,
+                snapshotId,
+                2L,
+                ScalarStats.newBuilder().setDisplayName("col2").setRowCount(99L).build(),
+                null)));
+    String pinnedGeneration = repository.activeStatsGeneration(TABLE, snapshotId).orElseThrow();
+
+    // The newest generation carries col1 = 20.
+    repository.replaceAllStatsForSnapshot(
+        TABLE,
+        snapshotId,
+        List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE,
+                snapshotId,
+                1L,
+                ScalarStats.newBuilder().setDisplayName("col1").setRowCount(20L).build(),
+                null)));
+
+    QueryContext ctx =
+        queryContextWithStatsGenerationRef(
+            "real-orchestrator-newest-fill", snapshotId, pinnedGeneration);
+    store.seed(ctx);
+
+    FetchTargetStatsRequest request = requestFor(ctx.getQueryId(), TABLE, List.of(1L));
+    List<TargetStatsBundleChunk> chunks =
+        service.streamTargets("corr", ctx, request).collect().asList().await().indefinitely();
+
+    // The pinned generation lacks col1, so the newest generation fills it instead of NOT_FOUND.
+    List<TargetStatsResult> results = flatten(chunks);
+    assertEquals(1, results.size(), "one column must produce a result");
+    assertEquals(StatsResultStatus.STATS_RESULT_HIT_COMPLETE, results.get(0).getStatus());
+    assertEquals(20L, results.get(0).getStats().getScalar().getRowCount());
+    TargetStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
+    assertEquals(1L, end.getReturnedTargets());
+    assertEquals(0L, end.getNotFoundTargets());
+  }
+
+  @Test
   void staleStatsAreReturnedByDefault() {
     UserObjectBundleTestSupport.TestQueryContextStore store =
         new UserObjectBundleTestSupport.TestQueryContextStore();

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
@@ -29,6 +29,8 @@ import ai.floedb.floecat.catalog.rpc.SketchPayload;
 import ai.floedb.floecat.catalog.rpc.SketchRole;
 import ai.floedb.floecat.catalog.rpc.StatsCompleteness;
 import ai.floedb.floecat.catalog.rpc.StatsTarget;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.query.rpc.FetchTargetStatsRequest;
 import ai.floedb.floecat.query.rpc.RequestedStat;
 import ai.floedb.floecat.query.rpc.ReturnedStat;
@@ -88,6 +90,64 @@ class PlannerStatsBundleServiceTest extends PlannerStatsBundleServiceTestSupport
     assertEquals(1L, end.getRequestedTargets());
     assertEquals(1L, end.getReturnedTargets());
     assertEquals(0L, end.getNotFoundTargets());
+  }
+
+  @Test
+  void legacyUnspecifiedKindRequestDefaultsToTableIdentity() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createService(
+            repository, store, /* chunkSize= */ 10, /* maxTables= */ 10, /* maxTargets= */ 10);
+    QueryContext ctx = queryContextWithPin("query-legacy-kind", 100L);
+    store.seed(ctx);
+
+    repository.putTargetStats(
+        TargetStatsRecords.columnRecord(TABLE, 100L, 1L, sampleStats(TABLE, 100L, 1L), null));
+
+    ResourceId legacyTableId = TABLE.toBuilder().setKind(ResourceKind.RK_UNSPECIFIED).build();
+    FetchTargetStatsRequest request = requestFor(ctx.getQueryId(), legacyTableId, List.of(1L));
+    List<TargetStatsBundleChunk> chunks =
+        service.streamTargets("corr", ctx, request).collect().asList().await().indefinitely();
+
+    List<TargetStatsResult> results = flatten(chunks);
+    assertEquals(1, results.size());
+    assertEquals(StatsResultStatus.STATS_RESULT_HIT_COMPLETE, results.get(0).getStatus());
+    assertEquals(ResourceKind.RK_TABLE, results.get(0).getTableId().getKind());
+
+    TargetStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
+    assertEquals(1L, end.getReturnedTargets());
+    assertEquals(0L, end.getErrorTargets());
+  }
+
+  @Test
+  void explicitViewKindDoesNotMatchTablePin() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createService(
+            repository, store, /* chunkSize= */ 10, /* maxTables= */ 10, /* maxTargets= */ 10);
+    QueryContext ctx = queryContextWithPin("query-view-kind", 100L);
+    store.seed(ctx);
+
+    repository.putTargetStats(
+        TargetStatsRecords.columnRecord(TABLE, 100L, 1L, sampleStats(TABLE, 100L, 1L), null));
+
+    ResourceId viewId = TABLE.toBuilder().setKind(ResourceKind.RK_VIEW).build();
+    FetchTargetStatsRequest request = requestFor(ctx.getQueryId(), viewId, List.of(1L));
+    List<TargetStatsBundleChunk> chunks =
+        service.streamTargets("corr", ctx, request).collect().asList().await().indefinitely();
+
+    List<TargetStatsResult> results = flatten(chunks);
+    assertEquals(1, results.size());
+    assertEquals(StatsResultStatus.STATS_RESULT_ERROR, results.get(0).getStatus());
+    assertEquals("planner_stats.pin.missing", results.get(0).getFailure().getCode());
+
+    TargetStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
+    assertEquals(0L, end.getReturnedTargets());
+    assertEquals(1L, end.getErrorTargets());
   }
 
   @Test
@@ -1086,29 +1146,19 @@ class PlannerStatsBundleServiceTest extends PlannerStatsBundleServiceTestSupport
 
     long snapshotId = 482L;
     // Pinned generation: col1 = 10.
-    repository.replaceAllStatsForSnapshot(
-        TABLE,
+    publishColumn(
+        repository,
         snapshotId,
-        List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE,
-                snapshotId,
-                1L,
-                ScalarStats.newBuilder().setDisplayName("col1").setRowCount(10L).build(),
-                null)));
+        1L,
+        ScalarStats.newBuilder().setDisplayName("col1").setRowCount(10L).build());
     String pinnedGeneration = repository.activeStatsGeneration(TABLE, snapshotId).orElseThrow();
 
     // A newer generation for the same snapshot: col1 = 20.
-    repository.replaceAllStatsForSnapshot(
-        TABLE,
+    publishColumn(
+        repository,
         snapshotId,
-        List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE,
-                snapshotId,
-                1L,
-                ScalarStats.newBuilder().setDisplayName("col1").setRowCount(20L).build(),
-                null)));
+        1L,
+        ScalarStats.newBuilder().setDisplayName("col1").setRowCount(20L).build());
 
     QueryContext ctx =
         queryContextWithStatsGenerationRef(
@@ -1142,29 +1192,19 @@ class PlannerStatsBundleServiceTest extends PlannerStatsBundleServiceTestSupport
 
     long snapshotId = 482L;
     // Pinned generation carries only col2 — it never had col1.
-    repository.replaceAllStatsForSnapshot(
-        TABLE,
+    publishColumn(
+        repository,
         snapshotId,
-        List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE,
-                snapshotId,
-                2L,
-                ScalarStats.newBuilder().setDisplayName("col2").setRowCount(99L).build(),
-                null)));
+        2L,
+        ScalarStats.newBuilder().setDisplayName("col2").setRowCount(99L).build());
     String pinnedGeneration = repository.activeStatsGeneration(TABLE, snapshotId).orElseThrow();
 
     // The newest generation carries col1 = 20.
-    repository.replaceAllStatsForSnapshot(
-        TABLE,
+    publishColumn(
+        repository,
         snapshotId,
-        List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE,
-                snapshotId,
-                1L,
-                ScalarStats.newBuilder().setDisplayName("col1").setRowCount(20L).build(),
-                null)));
+        1L,
+        ScalarStats.newBuilder().setDisplayName("col1").setRowCount(20L).build());
 
     QueryContext ctx =
         queryContextWithStatsGenerationRef(
@@ -1183,6 +1223,72 @@ class PlannerStatsBundleServiceTest extends PlannerStatsBundleServiceTestSupport
     TargetStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
     assertEquals(1L, end.getReturnedTargets());
     assertEquals(0L, end.getNotFoundTargets());
+  }
+
+  @Test
+  void realPlannerLookupFillsFromNewestWhenPinnedRecordLacksRequestedSketch() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createServiceWithRealLookup(
+            repository, store, /* chunkSize= */ 5, /* maxTables= */ 5, /* maxTargets= */ 10);
+
+    long snapshotId = 483L;
+    // Pinned generation carries col1 scalar-only: it EXISTS, but cannot serve a sketch need.
+    publishColumn(
+        repository,
+        snapshotId,
+        1L,
+        ScalarStats.newBuilder().setDisplayName("col1").setRowCount(10L).build());
+    String pinnedGeneration = repository.activeStatsGeneration(TABLE, snapshotId).orElseThrow();
+
+    // The newest generation of the SAME snapshot was enriched with the theta sketch.
+    SketchPayload sketch =
+        SketchPayload.newBuilder()
+            .setRole(SketchRole.SKETCH_ROLE_NDV)
+            .setSketchType(THETA_SKETCH_TYPE)
+            .setData(ByteString.copyFromUtf8("sketch-bytes"))
+            .setCompleteness(StatsCompleteness.SC_COMPLETE)
+            .build();
+    publishColumn(
+        repository,
+        snapshotId,
+        1L,
+        ScalarStats.newBuilder()
+            .setDisplayName("col1")
+            .setRowCount(10L)
+            .setNdv(Ndv.newBuilder().setExact(10L).addSketches(sketch))
+            .addSketches(sketch)
+            .build());
+
+    QueryContext ctx =
+        queryContextWithStatsGenerationRef(
+            "real-orchestrator-completeness-fill", snapshotId, pinnedGeneration);
+    store.seed(ctx);
+
+    FetchTargetStatsRequest request =
+        FetchTargetStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTables(
+                ai.floedb.floecat.query.rpc.TableStatsRequest.newBuilder()
+                    .setTableId(TABLE)
+                    .addTargets(sketchNeed(1L, 1)))
+            .build();
+    List<TargetStatsBundleChunk> chunks =
+        service.streamTargets("corr", ctx, request).collect().asList().await().indefinitely();
+
+    // The pinned record exists but is scalar-only: "exists" alone must not be a hit for a sketch
+    // need. Resolution falls to the newest generation and serves the sketch — complete, not
+    // downgraded.
+    List<TargetStatsResult> results = flatten(chunks);
+    assertEquals(1, results.size(), "one column must produce a result");
+    assertEquals(StatsResultStatus.STATS_RESULT_HIT_COMPLETE, results.get(0).getStatus());
+    assertEquals(1, results.get(0).getStats().getScalar().getSketchesCount());
+    TargetStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
+    assertEquals(1L, end.getReturnedTargets());
+    assertEquals(0L, end.getNotFoundTargets());
+    assertEquals(0L, end.getPartialTargets());
   }
 
   @Test
@@ -1242,6 +1348,15 @@ class PlannerStatsBundleServiceTest extends PlannerStatsBundleServiceTestSupport
     assertEquals(0L, end.getReturnedTargets());
     assertEquals(0L, end.getStaleTargets());
     assertEquals(1L, end.getNotFoundTargets());
+  }
+
+  /** Publishes one column record as a full replacement (a new live generation) of the snapshot. */
+  private static void publishColumn(
+      StatsRepository repository, long snapshotId, long columnId, ScalarStats scalar) {
+    repository.replaceAllStatsForSnapshot(
+        TABLE,
+        snapshotId,
+        List.of(TargetStatsRecords.columnRecord(TABLE, snapshotId, columnId, scalar, null)));
   }
 
   private static TargetStatsNeed sketchNeed(long columnId, int priority) {

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTest.java
@@ -29,6 +29,7 @@ import ai.floedb.floecat.catalog.rpc.SketchPayload;
 import ai.floedb.floecat.catalog.rpc.SketchRole;
 import ai.floedb.floecat.catalog.rpc.StatsCompleteness;
 import ai.floedb.floecat.catalog.rpc.StatsTarget;
+import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.query.rpc.FetchTargetStatsRequest;
@@ -1500,5 +1501,114 @@ class PlannerStatsBundleServiceTest extends PlannerStatsBundleServiceTestSupport
     assertEquals(1, results.size());
     // staleOk=true with no stale stats → NOT_FOUND (not an error)
     assertEquals(StatsResultStatus.STATS_RESULT_NOT_FOUND, results.get(0).getStatus());
+  }
+
+  /**
+   * End-to-end pipeline guard: file records with producer-owned sketches, through BOTH rollup
+   * stages exactly as a full rescan runs them, published as a generation, pinned, and served back
+   * to a planner-shaped request. Every recent stats regression (dropped quantile/tuple payloads,
+   * generation misses) crossed one of these seams while each seam's own unit tests stayed green —
+   * this test fails if any seam loses the payload again.
+   */
+  @Test
+  void fullRescanPipelineServesProducerSketchesEndToEnd() {
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsRepository repository = createRepository();
+    PlannerStatsBundleService service =
+        createServiceWithRealLookup(
+            repository, store, /* chunkSize= */ 5, /* maxTables= */ 5, /* maxTargets= */ 10);
+
+    long snapshotId = 484L;
+    ai.floedb.floecat.catalog.rpc.SketchPayload tdigest =
+        ai.floedb.floecat.catalog.rpc.SketchPayload.newBuilder()
+            .setRole(SketchRole.SKETCH_ROLE_QUANTILES)
+            .setSketchType("apache-datasketches-tdigest-v1")
+            .setData(ByteString.copyFromUtf8("pipeline-quantile-bytes"))
+            .setCompleteness(StatsCompleteness.SC_COMPLETE)
+            .build();
+    ScalarStats fileScalar =
+        ScalarStats.newBuilder()
+            .setDisplayName("l_quantity")
+            .setLogicalType("BIGINT")
+            .setRowCount(120L)
+            .setNullCount(0L)
+            .setAvgWidthBytes(8)
+            .addSketches(tdigest)
+            .build();
+    TargetStatsRecord fileRecord =
+        TargetStatsRecord.newBuilder()
+            .setTableId(TABLE)
+            .setSnapshotId(snapshotId)
+            .setFile(
+                ai.floedb.floecat.catalog.rpc.FileTargetStats.newBuilder()
+                    .setTableId(TABLE)
+                    .setSnapshotId(snapshotId)
+                    .setFilePath("s3://bucket/pipeline/file-1.parquet")
+                    .setRowCount(120L)
+                    .addColumns(
+                        ai.floedb.floecat.catalog.rpc.FileColumnStats.newBuilder()
+                            .setColumnId(5L)
+                            .setScalar(fileScalar)))
+            .build();
+
+    // The full-rescan sequence: file records → per-group partials → merged snapshot records →
+    // published generation.
+    var kinds =
+        java.util.Set.of(
+            ai.floedb.floecat.connector.spi.FloecatConnector.StatsTargetKind.TABLE,
+            ai.floedb.floecat.connector.spi.FloecatConnector.StatsTargetKind.COLUMN);
+    List<TargetStatsRecord> partials =
+        ai.floedb.floecat.reconciler.impl.FileGroupTargetStatsRollup
+            .partialAggregatesFromFileRecords(TABLE, snapshotId, kinds, List.of(fileRecord));
+    List<TargetStatsRecord> finals =
+        ai.floedb.floecat.reconciler.impl.FileGroupTargetStatsRollup.mergeSnapshotAggregatePartials(
+            TABLE, snapshotId, kinds, partials);
+    repository.replaceAllStatsForSnapshot(TABLE, snapshotId, finals);
+
+    // Serve through the pinned-generation path a real query uses.
+    String pinnedGeneration = repository.activeStatsGeneration(TABLE, snapshotId).orElseThrow();
+    QueryContext ctx =
+        queryContextWithStatsGenerationRef("query-pipeline-e2e", snapshotId, pinnedGeneration);
+    store.seed(ctx);
+
+    FetchTargetStatsRequest request =
+        FetchTargetStatsRequest.newBuilder()
+            .setQueryId(ctx.getQueryId())
+            .addTables(
+                ai.floedb.floecat.query.rpc.TableStatsRequest.newBuilder()
+                    .setTableId(TABLE)
+                    .addTargets(
+                        TargetStatsNeed.newBuilder()
+                            .setTarget(
+                                StatsTarget.newBuilder()
+                                    .setColumn(ColumnStatsTarget.newBuilder().setColumnId(5L)))
+                            .setPriority(1)
+                            .addRequestedStats(
+                                RequestedStat.newBuilder()
+                                    .setRole(StatRole.STAT_ROLE_SCALAR)
+                                    .setPriority(1))
+                            .addRequestedStats(
+                                RequestedStat.newBuilder()
+                                    .setRole(StatRole.STAT_ROLE_QUANTILES)
+                                    .setSketchType("apache-datasketches-tdigest-v1")
+                                    .setPriority(2))))
+            .build();
+    List<TargetStatsBundleChunk> chunks =
+        service.streamTargets("corr", ctx, request).collect().asList().await().indefinitely();
+
+    List<TargetStatsResult> results = flatten(chunks);
+    assertEquals(1, results.size(), "one column must produce a result");
+    assertEquals(StatsResultStatus.STATS_RESULT_HIT_COMPLETE, results.get(0).getStatus());
+    ScalarStats served = results.get(0).getStats().getScalar();
+    assertEquals(120L, served.getRowCount());
+    assertEquals(1, served.getSketchesCount());
+    // The payload must arrive byte-identical: never merged, never re-encoded, never dropped.
+    assertEquals("pipeline-quantile-bytes", served.getSketches(0).getData().toStringUtf8());
+    assertEquals(SketchRole.SKETCH_ROLE_QUANTILES, served.getSketches(0).getRole());
+    TargetStatsBundleEnd end = chunks.get(chunks.size() - 1).getEnd();
+    assertEquals(1L, end.getReturnedTargets());
+    assertEquals(0L, end.getNotFoundTargets());
+    assertEquals(0L, end.getPartialTargets());
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsBundleServiceTestSupport.java
@@ -203,6 +203,15 @@ abstract class PlannerStatsBundleServiceTestSupport {
     return queryContextWithPins(queryId, List.of(pin(TABLE, snapshotId)));
   }
 
+  protected static QueryContext queryContextWithStatsGenerationRef(
+      String queryId, long snapshotId, String statsGenerationRefUri) {
+    TablePin pin =
+        SnapshotTestSupport.blobBackedPin(TABLE, snapshotId).toBuilder()
+            .setStatsGenerationRefUri(statsGenerationRefUri)
+            .build();
+    return queryContextWithPins(queryId, List.of(pin));
+  }
+
   /** A context whose pin froze a specific constraints bundle ref (for pinned-serving tests). */
   protected static QueryContext queryContextWithConstraintRef(
       String queryId, long snapshotId, String refUri, String refVersion) {

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsResultMaterializerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/PlannerStatsResultMaterializerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.query.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.catalog.rpc.Ndv;
+import ai.floedb.floecat.catalog.rpc.ScalarStats;
+import ai.floedb.floecat.catalog.rpc.SketchPayload;
+import ai.floedb.floecat.catalog.rpc.SketchRole;
+import ai.floedb.floecat.catalog.rpc.StatsTarget;
+import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
+import ai.floedb.floecat.query.rpc.StatRole;
+import ai.floedb.floecat.query.rpc.StatsResultStatus;
+import com.google.protobuf.ByteString;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PlannerStatsResultMaterializerTest {
+
+  @Test
+  void scalarRequestDropsEstimateLessNdvEnvelope() {
+    // Generation enrichment can persist an Ndv envelope with no exact/approx estimate, existing
+    // purely to carry a superseded generation's sketch forward. Once a scalar-only request
+    // filters that sketch out, the envelope carries nothing servable and must not be emitted:
+    // hasNdv() with neither mode nor payloads would turn "NDV absent" into "NDV zero" for any
+    // consumer gating on presence alone.
+    TargetStatsRecord record = recordWithNdv(Ndv.newBuilder().addSketches(ndvSketch()).build());
+
+    TargetStatsRecord materialized = materializeScalarOnly(record);
+
+    assertTrue(materialized.hasScalar());
+    assertFalse(materialized.getScalar().hasNdv());
+  }
+
+  @Test
+  void scalarRequestKeepsNdvEstimateAndClearsSketches() {
+    TargetStatsRecord record =
+        recordWithNdv(Ndv.newBuilder().setExact(42).addSketches(ndvSketch()).build());
+
+    TargetStatsRecord materialized = materializeScalarOnly(record);
+
+    assertTrue(materialized.getScalar().hasNdv());
+    assertEquals(42, materialized.getScalar().getNdv().getExact());
+    assertEquals(0, materialized.getScalar().getNdv().getSketchesCount());
+  }
+
+  private static TargetStatsRecord materializeScalarOnly(TargetStatsRecord record) {
+    PlannerStatsTargetNeed need =
+        new PlannerStatsTargetNeed(
+            StatsTarget.getDefaultInstance(),
+            List.of(new PlannerStatsStatRequest(StatRole.STAT_ROLE_SCALAR, "", 0, 0, false, "")),
+            "target",
+            0);
+    PlannerStatsResultMaterializer.Materialized materialized =
+        PlannerStatsResultMaterializer.materialize(
+            need, PlannerTargetStatsLookupResult.hit(record));
+    assertEquals(StatsResultStatus.STATS_RESULT_HIT_COMPLETE, materialized.status());
+    return materialized.record();
+  }
+
+  private static TargetStatsRecord recordWithNdv(Ndv ndv) {
+    return TargetStatsRecord.newBuilder().setScalar(ScalarStats.newBuilder().setNdv(ndv)).build();
+  }
+
+  private static SketchPayload ndvSketch() {
+    return SketchPayload.newBuilder()
+        .setRole(SketchRole.SKETCH_ROLE_NDV)
+        .setSketchType("theta")
+        .setData(ByteString.copyFromUtf8("sketch-bytes"))
+        .build();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.catalog.rpc.Ndv;
 import ai.floedb.floecat.catalog.rpc.ScalarStats;
+import ai.floedb.floecat.catalog.rpc.SketchPayload;
+import ai.floedb.floecat.catalog.rpc.SketchRole;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.StatsTarget;
 import ai.floedb.floecat.catalog.rpc.Table;
@@ -41,12 +43,14 @@ import ai.floedb.floecat.service.repo.impl.StatsRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.statistics.StatsOrchestrator;
 import ai.floedb.floecat.service.testsupport.SnapshotTestSupport;
+import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.identity.TargetStatsRecords;
 import ai.floedb.floecat.stats.spi.StatsCaptureRequest;
 import ai.floedb.floecat.stats.spi.StatsExecutionMode;
 import ai.floedb.floecat.stats.spi.StatsResolutionResult;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import java.time.Duration;
@@ -196,6 +200,47 @@ class StatsProviderFactoryTest {
 
     var missingProvider = factory.forQuery(queryContextWithoutPin(), "corr");
     assertTrue(missingProvider.columnStats(TABLE, columnId).isEmpty());
+  }
+
+  @Test
+  void columnStatsOmitsAnEstimateLessNdvEnvelope() {
+    CountingStatsRepository repository = new CountingStatsRepository();
+    UserObjectBundleTestSupport.TestQueryContextStore store =
+        new UserObjectBundleTestSupport.TestQueryContextStore();
+    StatsProviderFactory factory = factory(repository, store);
+    long snapshotId = 23L;
+    long columnId = 2L;
+    Ndv sketchOnlyNdv =
+        Ndv.newBuilder()
+            .addSketches(
+                SketchPayload.newBuilder()
+                    .setRole(SketchRole.SKETCH_ROLE_NDV)
+                    .setSketchType("apache-datasketches-theta-v1")
+                    .setData(ByteString.copyFromUtf8("theta-bytes")))
+            .build();
+    ScalarStats stats =
+        ScalarStats.newBuilder()
+            .setDisplayName("col")
+            .setRowCount(77)
+            .setLogicalType("int64")
+            .setNdv(sketchOnlyNdv)
+            .build();
+    repository.putTargetStats(
+        TargetStatsRecords.columnRecord(TABLE, snapshotId, columnId, stats, null));
+
+    QueryContext ctx = queryContextWithPin(snapshotId);
+    store.seed(ctx);
+    var view = factory.forQuery(ctx, "corr").columnStats(TABLE, columnId).orElseThrow();
+
+    assertTrue(view.ndv().isEmpty());
+    assertEquals(
+        1,
+        repository
+            .getTargetStats(TABLE, snapshotId, StatsTargetIdentity.columnTarget(columnId))
+            .orElseThrow()
+            .getScalar()
+            .getNdv()
+            .getSketchesCount());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
@@ -265,7 +265,7 @@ class StatsProviderFactoryTest {
                             .setFormat(TableFormat.TF_ICEBERG)
                             .build())
                     .build()));
-    when(orchestrator.resolve(any()))
+    when(orchestrator.resolveInGeneration(any(), any()))
         .thenReturn(
             StatsResolutionResult.hit(
                 TargetStatsRecords.tableRecord(
@@ -279,7 +279,7 @@ class StatsProviderFactoryTest {
 
     ArgumentCaptor<StatsCaptureRequest> requestCaptor =
         ArgumentCaptor.forClass(StatsCaptureRequest.class);
-    Mockito.verify(orchestrator).resolve(requestCaptor.capture());
+    Mockito.verify(orchestrator).resolveInGeneration(requestCaptor.capture(), any());
     assertEquals("iceberg", requestCaptor.getValue().connectorType());
     assertEquals(Duration.ofSeconds(1), requestCaptor.getValue().latencyBudget().orElseThrow());
     assertEquals(StatsExecutionMode.SYNC, requestCaptor.getValue().executionMode());
@@ -327,14 +327,15 @@ class StatsProviderFactoryTest {
                             .setFormat(TableFormat.TF_ICEBERG)
                             .build())
                     .build()));
-    when(orchestrator.resolve(any())).thenReturn(StatsResolutionResult.skipped("sync_disabled"));
+    when(orchestrator.resolveInGeneration(any(), any()))
+        .thenReturn(StatsResolutionResult.skipped("sync_disabled"));
 
     var provider = factory.forQuery(ctx, "corr");
     provider.tableStats(TABLE);
 
     ArgumentCaptor<StatsCaptureRequest> requestCaptor =
         ArgumentCaptor.forClass(StatsCaptureRequest.class);
-    Mockito.verify(orchestrator).resolve(requestCaptor.capture());
+    Mockito.verify(orchestrator).resolveInGeneration(requestCaptor.capture(), any());
     assertEquals(StatsExecutionMode.ASYNC, requestCaptor.getValue().executionMode());
     assertTrue(requestCaptor.getValue().latencyBudget().isEmpty());
   }
@@ -381,14 +382,15 @@ class StatsProviderFactoryTest {
                             .setFormat(TableFormat.TF_ICEBERG)
                             .build())
                     .build()));
-    when(orchestrator.resolve(any())).thenReturn(StatsResolutionResult.skipped("sync_disabled"));
+    when(orchestrator.resolveInGeneration(any(), any()))
+        .thenReturn(StatsResolutionResult.skipped("sync_disabled"));
 
     var provider = factory.forQuery(ctx, "corr");
     provider.tableStats(TABLE);
 
     ArgumentCaptor<StatsCaptureRequest> requestCaptor =
         ArgumentCaptor.forClass(StatsCaptureRequest.class);
-    Mockito.verify(orchestrator).resolve(requestCaptor.capture());
+    Mockito.verify(orchestrator).resolveInGeneration(requestCaptor.capture(), any());
     assertEquals(Duration.ofSeconds(10), requestCaptor.getValue().latencyBudget().orElseThrow());
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -1044,6 +1044,58 @@ class StatsRepositoryTargetStorageTest {
   }
 
   @Test
+  void generationScopedBatchReadServesThePinnedGenerationAfterLiveGenerationMoves() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 4243L;
+    var target = StatsTargetIdentity.columnTarget(7L);
+    String storageId = StatsTargetIdentity.storageId(target);
+
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(1L).build(),
+                null)));
+    String pinnedManifestUri = repository.activeStatsGeneration(TABLE_ID, snapshotId).orElseThrow();
+
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build(),
+                null)));
+
+    assertThat(
+            repository
+                .getTargetStatsBatchInGeneration(
+                    TABLE_ID, snapshotId, pinnedManifestUri, java.util.List.of(target))
+                .get(storageId))
+        .isPresent()
+        .get()
+        .extracting(record -> record.getScalar().getRowCount())
+        .isEqualTo(1L);
+    assertThat(repository.getTargetStatsBatch(TABLE_ID, snapshotId, java.util.List.of(target)))
+        .containsKey(storageId);
+    assertThat(
+            repository
+                .getTargetStatsBatch(TABLE_ID, snapshotId, java.util.List.of(target))
+                .get(storageId))
+        .isPresent()
+        .get()
+        .extracting(record -> record.getScalar().getRowCount())
+        .isEqualTo(2L);
+  }
+
+  @Test
   void gcReclaimsSupersededUnprotectedGenerationsOnly() {
     InMemoryPointerStore pointerStore = new InMemoryPointerStore();
     InMemoryBlobStore blobStore = new InMemoryBlobStore();

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -1057,6 +1057,15 @@ class StatsRepositoryTargetStorageTest {
         .build();
   }
 
+  /** Publishes one column record as a full replacement (a new live generation) of the snapshot. */
+  private static void publishColumn(
+      StatsRepository repository, long snapshotId, long columnId, ScalarStats scalar) {
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        List.of(TargetStatsRecords.columnRecord(TABLE_ID, snapshotId, columnId, scalar, null)));
+  }
+
   @Test
   void replaceAllCarriesSupersededSketchesIntoTheNewGeneration() {
     StatsRepository repository =
@@ -1065,36 +1074,75 @@ class StatsRepositoryTargetStorageTest {
     var target = StatsTargetIdentity.columnTarget(7L);
 
     // First generation: a sampled capture published the column WITH a quantile sketch.
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder()
-                    .setLogicalType("BIGINT")
-                    .setRowCount(1L)
-                    .addSketches(quantileSketch("captured"))
-                    .build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder()
+            .setLogicalType("BIGINT")
+            .setRowCount(1L)
+            .addSketches(quantileSketch("captured"))
+            .build());
 
     // Second generation: a scalar-only republish (a file-group rollup cannot derive sketches).
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build());
 
     // Generations only enrich: the new generation keeps its own scalars AND the superseded
     // generation's sketch — the unchanged snapshot's earlier payloads are still valid facts.
     TargetStatsRecord live = repository.getTargetStats(TABLE_ID, snapshotId, target).orElseThrow();
+    assertThat(live.getScalar().getRowCount()).isEqualTo(2L);
+    assertThat(live.getScalar().getSketchesCount()).isEqualTo(1);
+    assertThat(live.getScalar().getSketches(0).getData().toStringUtf8()).isEqualTo("captured");
+  }
+
+  @Test
+  void publishingDraftGenerationCarriesSupersededSketchesIntoFinalAggregates() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 4249L;
+    long columnId = 7L;
+    String generationId = "full-rescan-job-1";
+    var columnTarget = StatsTargetIdentity.columnTarget(columnId);
+    String filePath = "s3://bucket/path/full-rescan.parquet";
+
+    publishColumn(
+        repository,
+        snapshotId,
+        columnId,
+        ScalarStats.newBuilder()
+            .setLogicalType("BIGINT")
+            .setRowCount(1L)
+            .addSketches(quantileSketch("captured"))
+            .build());
+
+    repository.replaceTargetStatsInGeneration(
+        TABLE_ID,
+        snapshotId,
+        generationId,
+        List.of(StatsTargetIdentity.fileTarget(filePath)),
+        List.of(
+            TargetStatsRecords.fileRecord(
+                TABLE_ID,
+                snapshotId,
+                FileTargetStats.newBuilder().setFilePath(filePath).setRowCount(2L).build())));
+    repository.publishStatsGeneration(
+        TABLE_ID,
+        snapshotId,
+        generationId,
+        List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                columnId,
+                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build(),
+                null)));
+
+    TargetStatsRecord live =
+        repository.getTargetStats(TABLE_ID, snapshotId, columnTarget).orElseThrow();
     assertThat(live.getScalar().getRowCount()).isEqualTo(2L);
     assertThat(live.getScalar().getSketchesCount()).isEqualTo(1);
     assertThat(live.getScalar().getSketches(0).getData().toStringUtf8()).isEqualTo("captured");
@@ -1107,37 +1155,27 @@ class StatsRepositoryTargetStorageTest {
     long snapshotId = 4245L;
     var target = StatsTargetIdentity.columnTarget(7L);
 
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder()
-                    .setLogicalType("BIGINT")
-                    .setRowCount(1L)
-                    .addSketches(quantileSketch("old"))
-                    .build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder()
+            .setLogicalType("BIGINT")
+            .setRowCount(1L)
+            .addSketches(quantileSketch("old"))
+            .build());
 
     // The republish carries its own payload for the same (role, sketch_type) identity: the
     // incoming record is authoritative, so the superseded payload must not ride along.
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder()
-                    .setLogicalType("BIGINT")
-                    .setRowCount(2L)
-                    .addSketches(quantileSketch("new"))
-                    .build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder()
+            .setLogicalType("BIGINT")
+            .setRowCount(2L)
+            .addSketches(quantileSketch("new"))
+            .build());
 
     TargetStatsRecord live = repository.getTargetStats(TABLE_ID, snapshotId, target).orElseThrow();
     assertThat(live.getScalar().getSketchesCount()).isEqualTo(1);
@@ -1171,16 +1209,11 @@ class StatsRepositoryTargetStorageTest {
                 ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(1L).build(),
                 null)));
 
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                2L,
-                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build(),
-                null)));
+        2L,
+        ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build());
 
     // Enrichment is payload-only: which targets EXIST is the republish's decision, so col1 stays
     // absent from the live generation (readers reach it through the pinned-generation fallback).
@@ -1206,36 +1239,26 @@ class StatsRepositoryTargetStorageTest {
             .setCompleteness(StatsCompleteness.SC_COMPLETE)
             .build();
 
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder()
-                    .setLogicalType("BIGINT")
-                    .setRowCount(1L)
-                    .setNdv(Ndv.newBuilder().setExact(5L).addSketches(theta))
-                    .build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder()
+            .setLogicalType("BIGINT")
+            .setRowCount(1L)
+            .setNdv(Ndv.newBuilder().setExact(5L).addSketches(theta))
+            .build());
 
     // The republish carries a fresher NDV ESTIMATE but no sketch payload.
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder()
-                    .setLogicalType("BIGINT")
-                    .setRowCount(2L)
-                    .setNdv(Ndv.newBuilder().setExact(6L))
-                    .build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder()
+            .setLogicalType("BIGINT")
+            .setRowCount(2L)
+            .setNdv(Ndv.newBuilder().setExact(6L))
+            .build());
 
     // The new estimate stays authoritative; the superseded payload rides along in the envelope.
     TargetStatsRecord live = repository.getTargetStats(TABLE_ID, snapshotId, target).orElseThrow();
@@ -1259,32 +1282,22 @@ class StatsRepositoryTargetStorageTest {
             .setCompleteness(StatsCompleteness.SC_COMPLETE)
             .build();
 
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder()
-                    .setLogicalType("BIGINT")
-                    .setRowCount(1L)
-                    .setNdv(Ndv.newBuilder().setExact(5L).addSketches(theta))
-                    .build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder()
+            .setLogicalType("BIGINT")
+            .setRowCount(1L)
+            .setNdv(Ndv.newBuilder().setExact(5L).addSketches(theta))
+            .build());
 
     // The republish carries NO NDV envelope at all.
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build());
 
     // The carried payload rides in a fabricated, estimate-less envelope: hasNdv() is true but the
     // exact/approx mode oneof stays UNSET — no estimate is invented for the new capture.
@@ -1305,28 +1318,18 @@ class StatsRepositoryTargetStorageTest {
     var target = StatsTargetIdentity.columnTarget(7L);
     String storageId = StatsTargetIdentity.storageId(target);
 
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(1L).build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(1L).build());
     String pinnedManifestUri = repository.activeStatsGeneration(TABLE_ID, snapshotId).orElseThrow();
 
-    repository.replaceAllStatsForSnapshot(
-        TABLE_ID,
+    publishColumn(
+        repository,
         snapshotId,
-        java.util.List.of(
-            TargetStatsRecords.columnRecord(
-                TABLE_ID,
-                snapshotId,
-                7L,
-                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build(),
-                null)));
+        7L,
+        ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build());
 
     assertThat(
             repository

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -22,7 +22,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import ai.floedb.floecat.catalog.rpc.EngineExpressionStatsTarget;
 import ai.floedb.floecat.catalog.rpc.FileColumnStats;
 import ai.floedb.floecat.catalog.rpc.FileTargetStats;
+import ai.floedb.floecat.catalog.rpc.Ndv;
 import ai.floedb.floecat.catalog.rpc.ScalarStats;
+import ai.floedb.floecat.catalog.rpc.SketchPayload;
+import ai.floedb.floecat.catalog.rpc.SketchRole;
 import ai.floedb.floecat.catalog.rpc.StatsCaptureMode;
 import ai.floedb.floecat.catalog.rpc.StatsCompleteness;
 import ai.floedb.floecat.catalog.rpc.StatsMetadata;
@@ -1041,6 +1044,256 @@ class StatsRepositoryTargetStorageTest {
     // ...but the superseded generation's manifest is retained: a query that froze it keeps
     // reading its immutable keyspace to completion (GC collects it once unreferenced).
     assertThat(blobStore.get(pinnedManifestUri)).isNotNull();
+  }
+
+  /** A quantile sketch payload as an ANALYZE-style capture would publish it. */
+  private static SketchPayload quantileSketch(String data) {
+    return SketchPayload.newBuilder()
+        .setRole(SketchRole.SKETCH_ROLE_QUANTILES)
+        .setSketchType("kll-floats-v1")
+        .setData(ByteString.copyFromUtf8(data))
+        .setCompleteness(StatsCompleteness.SC_COMPLETE)
+        .build();
+  }
+
+  @Test
+  void replaceAllCarriesSupersededSketchesIntoTheNewGeneration() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 4244L;
+    var target = StatsTargetIdentity.columnTarget(7L);
+
+    // First generation: a sampled capture published the column WITH a quantile sketch.
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder()
+                    .setLogicalType("BIGINT")
+                    .setRowCount(1L)
+                    .addSketches(quantileSketch("captured"))
+                    .build(),
+                null)));
+
+    // Second generation: a scalar-only republish (a file-group rollup cannot derive sketches).
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build(),
+                null)));
+
+    // Generations only enrich: the new generation keeps its own scalars AND the superseded
+    // generation's sketch — the unchanged snapshot's earlier payloads are still valid facts.
+    TargetStatsRecord live = repository.getTargetStats(TABLE_ID, snapshotId, target).orElseThrow();
+    assertThat(live.getScalar().getRowCount()).isEqualTo(2L);
+    assertThat(live.getScalar().getSketchesCount()).isEqualTo(1);
+    assertThat(live.getScalar().getSketches(0).getData().toStringUtf8()).isEqualTo("captured");
+  }
+
+  @Test
+  void replaceAllPrefersIncomingPayloadOverSupersededForSameIdentity() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 4245L;
+    var target = StatsTargetIdentity.columnTarget(7L);
+
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder()
+                    .setLogicalType("BIGINT")
+                    .setRowCount(1L)
+                    .addSketches(quantileSketch("old"))
+                    .build(),
+                null)));
+
+    // The republish carries its own payload for the same (role, sketch_type) identity: the
+    // incoming record is authoritative, so the superseded payload must not ride along.
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder()
+                    .setLogicalType("BIGINT")
+                    .setRowCount(2L)
+                    .addSketches(quantileSketch("new"))
+                    .build(),
+                null)));
+
+    TargetStatsRecord live = repository.getTargetStats(TABLE_ID, snapshotId, target).orElseThrow();
+    assertThat(live.getScalar().getSketchesCount()).isEqualTo(1);
+    assertThat(live.getScalar().getSketches(0).getData().toStringUtf8()).isEqualTo("new");
+  }
+
+  @Test
+  void replaceAllDoesNotResurrectTargetsAbsentFromTheNewGeneration() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 4246L;
+
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                1L,
+                ScalarStats.newBuilder()
+                    .setLogicalType("BIGINT")
+                    .setRowCount(1L)
+                    .addSketches(quantileSketch("col1"))
+                    .build(),
+                null),
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                2L,
+                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(1L).build(),
+                null)));
+
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                2L,
+                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build(),
+                null)));
+
+    // Enrichment is payload-only: which targets EXIST is the republish's decision, so col1 stays
+    // absent from the live generation (readers reach it through the pinned-generation fallback).
+    assertThat(
+            repository.getTargetStats(TABLE_ID, snapshotId, StatsTargetIdentity.columnTarget(1L)))
+        .isEmpty();
+    assertThat(
+            repository.getTargetStats(TABLE_ID, snapshotId, StatsTargetIdentity.columnTarget(2L)))
+        .isPresent();
+  }
+
+  @Test
+  void replaceAllMergesSupersededNdvEnvelopeSketches() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 4247L;
+    var target = StatsTargetIdentity.columnTarget(7L);
+    SketchPayload theta =
+        SketchPayload.newBuilder()
+            .setRole(SketchRole.SKETCH_ROLE_NDV)
+            .setSketchType("apache-datasketches-theta-v1")
+            .setData(ByteString.copyFromUtf8("theta-bytes"))
+            .setCompleteness(StatsCompleteness.SC_COMPLETE)
+            .build();
+
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder()
+                    .setLogicalType("BIGINT")
+                    .setRowCount(1L)
+                    .setNdv(Ndv.newBuilder().setExact(5L).addSketches(theta))
+                    .build(),
+                null)));
+
+    // The republish carries a fresher NDV ESTIMATE but no sketch payload.
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder()
+                    .setLogicalType("BIGINT")
+                    .setRowCount(2L)
+                    .setNdv(Ndv.newBuilder().setExact(6L))
+                    .build(),
+                null)));
+
+    // The new estimate stays authoritative; the superseded payload rides along in the envelope.
+    TargetStatsRecord live = repository.getTargetStats(TABLE_ID, snapshotId, target).orElseThrow();
+    assertThat(live.getScalar().getNdv().getExact()).isEqualTo(6L);
+    assertThat(live.getScalar().getNdv().getSketchesCount()).isEqualTo(1);
+    assertThat(live.getScalar().getNdv().getSketches(0).getData().toStringUtf8())
+        .isEqualTo("theta-bytes");
+  }
+
+  @Test
+  void replaceAllCarriesNdvSketchesIntoARecordWithoutAnNdvEnvelope() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    long snapshotId = 4248L;
+    var target = StatsTargetIdentity.columnTarget(7L);
+    SketchPayload theta =
+        SketchPayload.newBuilder()
+            .setRole(SketchRole.SKETCH_ROLE_NDV)
+            .setSketchType("apache-datasketches-theta-v1")
+            .setData(ByteString.copyFromUtf8("theta-bytes"))
+            .setCompleteness(StatsCompleteness.SC_COMPLETE)
+            .build();
+
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder()
+                    .setLogicalType("BIGINT")
+                    .setRowCount(1L)
+                    .setNdv(Ndv.newBuilder().setExact(5L).addSketches(theta))
+                    .build(),
+                null)));
+
+    // The republish carries NO NDV envelope at all.
+    repository.replaceAllStatsForSnapshot(
+        TABLE_ID,
+        snapshotId,
+        java.util.List.of(
+            TargetStatsRecords.columnRecord(
+                TABLE_ID,
+                snapshotId,
+                7L,
+                ScalarStats.newBuilder().setLogicalType("BIGINT").setRowCount(2L).build(),
+                null)));
+
+    // The carried payload rides in a fabricated, estimate-less envelope: hasNdv() is true but the
+    // exact/approx mode oneof stays UNSET — no estimate is invented for the new capture.
+    TargetStatsRecord live = repository.getTargetStats(TABLE_ID, snapshotId, target).orElseThrow();
+    assertThat(live.getScalar().hasNdv()).isTrue();
+    assertThat(live.getScalar().getNdv().hasExact()).isFalse();
+    assertThat(live.getScalar().getNdv().hasApprox()).isFalse();
+    assertThat(live.getScalar().getNdv().getSketchesCount()).isEqualTo(1);
+    assertThat(live.getScalar().getNdv().getSketches(0).getData().toStringUtf8())
+        .isEqualTo("theta-bytes");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -43,6 +43,7 @@ import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.identity.TargetStatsRecords;
+import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsStore.UnpublishedGenerationDeleteResult;
 import ai.floedb.floecat.stats.spi.StatsTargetType;
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
@@ -1821,6 +1822,22 @@ class StatsRepositoryTargetStorageTest {
     org.junit.jupiter.api.Assertions.assertTrue(
         ex.getMessage().contains("frozen stats generation manifest missing"),
         "the descriptive retention-invariant error must survive an S3-style throwing miss");
+  }
+
+  @Test
+  void targetBatchClassifiesAMissingFrozenGenerationBeforeReadingTargets() {
+    StatsRepository repository =
+        new StatsRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    var target = StatsTargetIdentity.columnTarget(7L);
+
+    var ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            StatsStore.GenerationUnavailableException.class,
+            () ->
+                repository.getTargetStatsBatchInGeneration(
+                    TABLE_ID, 5L, "s3://t/stats/5/manifest/missing.pb", java.util.List.of(target)));
+
+    assertThat(ex.getMessage()).contains("frozen stats generation manifest unavailable");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
@@ -43,6 +43,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.spi.StatsCaptureBatchRequest;
 import ai.floedb.floecat.stats.spi.StatsCaptureBatchResult;
@@ -51,6 +52,7 @@ import ai.floedb.floecat.stats.spi.StatsExecutionMode;
 import ai.floedb.floecat.stats.spi.StatsResolutionResult;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsSyncOutcome;
+import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -1311,6 +1313,56 @@ class StatsOrchestratorTest {
     // the newest generation still serves the target.
     assertThat(r.hasStats()).isTrue();
     assertThat(r.stats().get().getTable().getRowCount()).isEqualTo(10L);
+  }
+
+  @Test
+  void resolveInGeneration_propagatesRetryablePinnedReadFailure() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    BaseResourceRepository.AbortRetryableException retryable =
+        new BaseResourceRepository.AbortRetryableException("manifest read throttled");
+    when(store.getTargetStatsInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", req.target()))
+        .thenThrow(retryable);
+
+    assertThatThrownBy(() -> o.resolveInGeneration(req, Optional.of("gen-pinned")))
+        .isSameAs(retryable);
+    verify(store, never()).getTargetStats(req.tableId(), req.snapshotId(), req.target());
+  }
+
+  @Test
+  void resolvePlannerBatch_propagatesRetryablePinnedReadFailureWithoutIsolation() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    StorageAbortRetryableException retryable =
+        new StorageAbortRetryableException("manifest read throttled");
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenThrow(retryable);
+
+    assertThatThrownBy(
+            () ->
+                o.resolvePlannerBatchInGeneration(
+                    List.of(req), Optional.of("gen-pinned"), false, Long.MAX_VALUE))
+        .isSameAs(retryable);
+    verify(store, never())
+        .getTargetStatsInGeneration(req.tableId(), req.snapshotId(), "gen-pinned", req.target());
+    verify(store, never())
+        .getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target()));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
@@ -1150,6 +1150,63 @@ class StatsOrchestratorTest {
   }
 
   @Test
+  void resolvePlannerBatch_cachedPartialServesWhenPinnedRereadFailsAndNewestEmpty() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+
+    // The pinned-generation batch read succeeds the first time (priming the cache with a
+    // scalar-only record) then throws — the frozen manifest becomes unreadable between queries.
+    RuntimeException manifestGone =
+        new RuntimeException("frozen stats generation manifest missing for snapshot 42");
+    java.util.concurrent.atomic.AtomicInteger pinnedReads =
+        new java.util.concurrent.atomic.AtomicInteger();
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenAnswer(
+            inv -> {
+              if (pinnedReads.getAndIncrement() == 0) {
+                return Map.of(storageId, Optional.of(columnRecord(req, 1L)));
+              }
+              throw manifestGone;
+            });
+    when(store.getTargetStatsInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", req.target()))
+        .thenThrow(manifestGone);
+    // The newest generation of the same snapshot has nothing to gap-fill with.
+    when(store.getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.empty()));
+
+    // 1. Prime: a need with no completeness predicate caches the scalar-only pinned record.
+    o.resolvePlannerBatchInGeneration(
+        List.of(req), Optional.of("gen-pinned"), false, Long.MAX_VALUE);
+
+    // 2. A richer need the cached record cannot satisfy, staleOk=false so a fall-through would
+    // reach sync capture. The pinned re-read fails and the newest generation is empty — the only
+    // thing standing between the planner and a needless capture is the incomplete cached record,
+    // which is still a valid (degraded) hit and must be served.
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            List.of(req),
+            Optional.of("gen-pinned"),
+            completeAtRowCount(storageId, 10L),
+            false,
+            Long.MAX_VALUE);
+
+    assertThat(result.get(storageId).hasStats()).isTrue();
+    assertThat(result.get(storageId).stats().get().getTable().getRowCount()).isEqualTo(1L);
+    // The partial hit means no stale read and no capture were triggered.
+    verify(store, Mockito.never()).getStaleTargetStatsBatch(any(), anyLong(), any());
+  }
+
+  @Test
   void resolvePlannerBatch_cachedPartialDoesNotShortCircuitRicherNeed() {
     StatsStore store = Mockito.mock(StatsStore.class);
     StatsOrchestrator o =

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
@@ -1196,6 +1196,56 @@ class StatsOrchestratorTest {
   }
 
   @Test
+  void resolvePlannerBatch_countsTheLadderRungThatServedEachTarget() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    ai.floedb.floecat.telemetry.Observability obs =
+        Mockito.mock(ai.floedb.floecat.telemetry.Observability.class);
+    @SuppressWarnings("unchecked")
+    jakarta.enterprise.inject.Instance<ai.floedb.floecat.telemetry.Observability> obsInstance =
+        Mockito.mock(jakarta.enterprise.inject.Instance.class);
+    when(obsInstance.isUnsatisfied()).thenReturn(false);
+    when(obsInstance.get()).thenReturn(obs);
+    StatsOrchestrator o =
+        new StatsOrchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            connectorRepositoryWith(),
+            Mockito.mock(StatsSyncCapture.class),
+            true,
+            obsInstance);
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    // Pinned generation is partial; the newest generation satisfies → NEWEST_FILL rung.
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 1L))));
+    when(store.getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 10L))));
+
+    o.resolvePlannerBatchInGeneration(
+        List.of(req),
+        Optional.of("gen-pinned"),
+        completeAtRowCount(storageId, 10L),
+        false,
+        Long.MAX_VALUE);
+
+    // Exactly the rung that served the target is counted, tagged result=newest_fill.
+    ArgumentCaptor<ai.floedb.floecat.telemetry.Tag[]> tags =
+        ArgumentCaptor.forClass(ai.floedb.floecat.telemetry.Tag[].class);
+    verify(obs)
+        .counter(
+            Mockito.eq(
+                ai.floedb.floecat.service.telemetry.ServiceMetrics.Stats
+                    .PLANNER_LOOKUP_OUTCOMES_TOTAL),
+            Mockito.eq(1.0),
+            tags.capture());
+    assertThat(java.util.Arrays.stream(tags.getValue()))
+        .anyMatch(tag -> tag.key().equals("result") && tag.value().equals("newest_fill"));
+  }
+
+  @Test
   void invalidateStatsCacheForPersistedRecordsUsesExplicitTableSnapshot() {
     StatsStore store = Mockito.mock(StatsStore.class);
     StatsOrchestrator o =

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
@@ -1366,6 +1366,49 @@ class StatsOrchestratorTest {
   }
 
   @Test
+  void resolvePlannerBatch_generationFailureFallsThroughOnceWithoutTargetIsolation() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    List<StatsCaptureRequest> requests =
+        List.of(columnRequest(42L, 1L), columnRequest(42L, 2L), columnRequest(42L, 3L));
+    List<StatsTarget> targets = requests.stream().map(StatsCaptureRequest::target).toList();
+    Map<String, Optional<TargetStatsRecord>> newest =
+        Map.of(
+            StatsTargetIdentity.storageId(requests.get(0).target()),
+            Optional.of(columnRecord(requests.get(0))),
+            StatsTargetIdentity.storageId(requests.get(1).target()),
+            Optional.of(columnRecord(requests.get(1))),
+            StatsTargetIdentity.storageId(requests.get(2).target()),
+            Optional.of(columnRecord(requests.get(2))));
+    StatsStore.GenerationUnavailableException unavailable =
+        new StatsStore.GenerationUnavailableException("frozen manifest missing");
+    when(store.getTargetStatsBatchInGeneration(
+            requests.get(0).tableId(), requests.get(0).snapshotId(), "gen-pinned", targets))
+        .thenThrow(unavailable);
+    when(store.getTargetStatsBatch(
+            requests.get(0).tableId(), requests.get(0).snapshotId(), targets))
+        .thenReturn(newest);
+
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            requests, Optional.of("gen-pinned"), false, Long.MAX_VALUE);
+
+    assertThat(result.values()).allMatch(StatsResolutionResult::hasStats);
+    verify(store, Mockito.times(1))
+        .getTargetStatsBatchInGeneration(
+            requests.get(0).tableId(), requests.get(0).snapshotId(), "gen-pinned", targets);
+    verify(store, never()).getTargetStatsInGeneration(any(), anyLong(), anyString(), any());
+    verify(store, Mockito.times(1))
+        .getTargetStatsBatch(requests.get(0).tableId(), requests.get(0).snapshotId(), targets);
+  }
+
+  @Test
   void resolvePlannerBatch_countsTheLadderRungThatServedEachTarget() {
     StatsStore store = Mockito.mock(StatsStore.class);
     ai.floedb.floecat.telemetry.Observability obs =

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
@@ -1196,6 +1196,67 @@ class StatsOrchestratorTest {
   }
 
   @Test
+  void resolvePlannerBatch_unreadablePinnedGenerationFallsThroughToNewest() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    // The frozen manifest is unreadable: every pinned-generation read throws (batch and the
+    // per-target isolation retry alike), so the primary read resolves to FAILED.
+    RuntimeException manifestGone =
+        new RuntimeException("frozen stats generation manifest missing for snapshot 42");
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenThrow(manifestGone);
+    when(store.getTargetStatsInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", req.target()))
+        .thenThrow(manifestGone);
+    when(store.getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 10L))));
+
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            List.of(req), Optional.of("gen-pinned"), false, Long.MAX_VALUE);
+
+    // A pinned read failure must not zero the batch: the newest generation is an independent
+    // path and still serves the target.
+    assertThat(result.get(storageId).hasStats()).isTrue();
+    assertThat(result.get(storageId).stats().get().getTable().getRowCount()).isEqualTo(10L);
+  }
+
+  @Test
+  void resolveInGeneration_unreadablePinnedGenerationFallsThroughToNewest() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    when(store.getTargetStatsInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", req.target()))
+        .thenThrow(
+            new RuntimeException("frozen stats generation manifest missing for snapshot 42"));
+    when(store.getTargetStats(req.tableId(), req.snapshotId(), req.target()))
+        .thenReturn(Optional.of(columnRecord(req, 10L)));
+
+    StatsResolutionResult r = o.resolveInGeneration(req, Optional.of("gen-pinned"));
+
+    // Same contract as the batch path: a pinned read failure is a miss, not a lookup failure —
+    // the newest generation still serves the target.
+    assertThat(r.hasStats()).isTrue();
+    assertThat(r.stats().get().getTable().getRowCount()).isEqualTo(10L);
+  }
+
+  @Test
   void resolvePlannerBatch_countsTheLadderRungThatServedEachTarget() {
     StatsStore store = Mockito.mock(StatsStore.class);
     ai.floedb.floecat.telemetry.Observability obs =

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
@@ -1046,6 +1046,155 @@ class StatsOrchestratorTest {
     assertThat(r.stats().get().getTable().getRowCount()).isEqualTo(3L);
   }
 
+  /**
+   * Completeness predicate used by the planner-completeness tests: the orchestrator treats the
+   * predicate as opaque, so a simple row-count threshold stands in for "carries the requested
+   * sketch payloads" (rowCount &lt; 10 = partial record, &ge; 10 = complete).
+   */
+  private static Map<String, java.util.function.Predicate<TargetStatsRecord>> completeAtRowCount(
+      String storageId, long threshold) {
+    return Map.of(storageId, record -> record.getTable().getRowCount() >= threshold);
+  }
+
+  @Test
+  void resolvePlannerBatch_partialPinnedFallsToSatisfyingNewest() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    // Pinned generation HAS the target but only partially (fails the predicate)...
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 1L))));
+    // ...while the newest generation of the SAME snapshot satisfies it.
+    when(store.getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 10L))));
+
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            List.of(req),
+            Optional.of("gen-pinned"),
+            completeAtRowCount(storageId, 10L),
+            false,
+            Long.MAX_VALUE);
+
+    assertThat(result.get(storageId).stats().get().getTable().getRowCount()).isEqualTo(10L);
+  }
+
+  @Test
+  void resolvePlannerBatch_completePinnedRecordSkipsNewest() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 10L))));
+
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            List.of(req),
+            Optional.of("gen-pinned"),
+            completeAtRowCount(storageId, 10L),
+            false,
+            Long.MAX_VALUE);
+
+    // The pinned record satisfies the need: the hot path is one pinned read, newest untouched.
+    assertThat(result.get(storageId).stats().get().getTable().getRowCount()).isEqualTo(10L);
+    verify(store, Mockito.never()).getTargetStatsBatch(any(), anyLong(), any());
+  }
+
+  @Test
+  void resolvePlannerBatch_keepsPinnedPartialWhenNewestNoBetter() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    // Both generations hold the target, neither satisfies the predicate.
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 1L))));
+    when(store.getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 2L))));
+
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            List.of(req),
+            Optional.of("gen-pinned"),
+            completeAtRowCount(storageId, 10L),
+            /* staleOk= */ true,
+            Long.MAX_VALUE);
+
+    // Between equally incomplete records, consistency prefers the pinned generation — and a
+    // partial record is still a hit: it never falls through to the stale ladder rung.
+    assertThat(result.get(storageId).stats().get().getTable().getRowCount()).isEqualTo(1L);
+    verify(store, Mockito.never()).getStaleTargetStatsBatch(any(), anyLong(), any());
+  }
+
+  @Test
+  void resolvePlannerBatch_cachedPartialDoesNotShortCircuitRicherNeed() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 1L))));
+    when(store.getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 10L))));
+
+    // A need without a completeness predicate caches the pinned record: presence = complete.
+    assertThat(
+            o.resolvePlannerBatchInGeneration(
+                    List.of(req), Optional.of("gen-pinned"), false, Long.MAX_VALUE)
+                .get(storageId)
+                .stats()
+                .get()
+                .getTable()
+                .getRowCount())
+        .isEqualTo(1L);
+
+    // A richer need must not be short-circuited by that cached record: the cache read fails the
+    // predicate, the pinned re-read is still partial, and the newest generation serves it.
+    assertThat(
+            o.resolvePlannerBatchInGeneration(
+                    List.of(req),
+                    Optional.of("gen-pinned"),
+                    completeAtRowCount(storageId, 10L),
+                    false,
+                    Long.MAX_VALUE)
+                .get(storageId)
+                .stats()
+                .get()
+                .getTable()
+                .getRowCount())
+        .isEqualTo(10L);
+  }
+
   @Test
   void invalidateStatsCacheForPersistedRecordsUsesExplicitTableSnapshot() {
     StatsStore store = Mockito.mock(StatsStore.class);

--- a/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/statistics/StatsOrchestratorTest.java
@@ -703,6 +703,37 @@ class StatsOrchestratorTest {
   }
 
   @Test
+  void resolvePlannerBatch_differentStatsGeneration_isCacheMiss() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    TargetStatsRecord gen1Record = columnRecord(req, 1L);
+    TargetStatsRecord gen2Record = columnRecord(req, 2L);
+
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-1", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(gen1Record)));
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-2", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(gen2Record)));
+
+    o.resolvePlannerBatchInGeneration(List.of(req), Optional.of("gen-1"), false, Long.MAX_VALUE);
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            List.of(req), Optional.of("gen-2"), false, Long.MAX_VALUE);
+
+    assertThat(result.get(storageId).stats().get().getTable().getRowCount()).isEqualTo(2L);
+    verify(store, Mockito.times(2)).getTargetStatsBatchInGeneration(any(), anyLong(), any(), any());
+  }
+
+  @Test
   void resolvePlannerBatch_differentTableId_isCacheMiss() {
     StatsStore store = Mockito.mock(StatsStore.class);
     StatsOrchestrator o =
@@ -811,6 +842,208 @@ class StatsOrchestratorTest {
     assertThat(o.resolvePlannerBatch(List.of(req), false, Long.MAX_VALUE).get(storageId).stats())
         .contains(replacement);
     verify(store, Mockito.times(2)).getTargetStatsBatch(any(), anyLong(), any());
+  }
+
+  @Test
+  void invalidateStatsCacheForTargetClearsGenerationScopedEntries() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    TargetStatsRecord first = columnRecord(req, 1L);
+    TargetStatsRecord replacement = columnRecord(req, 2L);
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-1", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(first)))
+        .thenReturn(Map.of(storageId, Optional.of(replacement)));
+
+    assertThat(
+            o.resolvePlannerBatchInGeneration(
+                    List.of(req), Optional.of("gen-1"), false, Long.MAX_VALUE)
+                .get(storageId)
+                .stats())
+        .contains(first);
+
+    o.invalidateStatsCache(req.tableId(), req.snapshotId(), req.target());
+
+    assertThat(
+            o.resolvePlannerBatchInGeneration(
+                    List.of(req), Optional.of("gen-1"), false, Long.MAX_VALUE)
+                .get(storageId)
+                .stats())
+        .contains(replacement);
+    verify(store, Mockito.times(2)).getTargetStatsBatchInGeneration(any(), anyLong(), any(), any());
+  }
+
+  @Test
+  void resolvePlannerBatch_pinnedGenerationWinsWhenPresent() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    // The pinned generation has the target (3); a newer generation exists with a different value.
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 3L))));
+    when(store.getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 9L))));
+
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            List.of(req), Optional.of("gen-pinned"), false, Long.MAX_VALUE);
+
+    // The pinned generation is authoritative; newest is never consulted when the pin has the
+    // target.
+    assertThat(result.get(storageId).stats().get().getTable().getRowCount()).isEqualTo(3L);
+    verify(store, Mockito.never()).getTargetStatsBatch(any(), anyLong(), any());
+  }
+
+  @Test
+  void resolvePlannerBatch_newestFillsWhenPinnedLacksTarget() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    // Pinned generation lacks this target...
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.empty()));
+    // ...so the newest generation fills it instead of yielding NOT_FOUND.
+    when(store.getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 20L))));
+
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            List.of(req), Optional.of("gen-pinned"), false, Long.MAX_VALUE);
+
+    assertThat(result.get(storageId).hasStats()).isTrue();
+    assertThat(result.get(storageId).stats().get().getTable().getRowCount()).isEqualTo(20L);
+  }
+
+  @Test
+  void resolvePlannerBatch_staleAfterPinnedAndNewestMiss() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.empty()));
+    when(store.getTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.empty()));
+    when(store.getStaleTargetStatsBatch(req.tableId(), req.snapshotId(), List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 5L))));
+
+    Map<String, StatsResolutionResult> result =
+        o.resolvePlannerBatchInGeneration(
+            List.of(req), Optional.of("gen-pinned"), true, Long.MAX_VALUE);
+
+    assertThat(result.get(storageId).hasStats()).isTrue();
+    assertThat(result.get(storageId).stats().get().getTable().getRowCount()).isEqualTo(5L);
+  }
+
+  @Test
+  void resolvePlannerBatch_pinnedGenerationServedFromCacheOnReplay() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    String storageId = StatsTargetIdentity.storageId(req.target());
+    when(store.getTargetStatsBatchInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", List.of(req.target())))
+        .thenReturn(Map.of(storageId, Optional.of(columnRecord(req, 1L))));
+
+    // Two resolutions on the same pin: the second is served from the pinned-generation cache, so
+    // the
+    // plan is reproducible and the store is read only once.
+    for (int i = 0; i < 2; i++) {
+      assertThat(
+              o.resolvePlannerBatchInGeneration(
+                      List.of(req), Optional.of("gen-pinned"), false, Long.MAX_VALUE)
+                  .get(storageId)
+                  .stats()
+                  .get()
+                  .getTable()
+                  .getRowCount())
+          .isEqualTo(1L);
+    }
+    verify(store, Mockito.times(1)).getTargetStatsBatchInGeneration(any(), anyLong(), any(), any());
+  }
+
+  @Test
+  void resolveInGeneration_pinnedGenerationWinsWhenPresent() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    when(store.getTargetStatsInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", req.target()))
+        .thenReturn(Optional.of(columnRecord(req, 9L)));
+
+    StatsResolutionResult r = o.resolveInGeneration(req, Optional.of("gen-pinned"));
+
+    // The pinned generation is authoritative; the newest generation is never consulted.
+    assertThat(r.hasStats()).isTrue();
+    assertThat(r.stats().get().getTable().getRowCount()).isEqualTo(9L);
+    verify(store, Mockito.never()).getTargetStats(any(), anyLong(), any());
+  }
+
+  @Test
+  void resolveInGeneration_fillsFromNewestWhenPinnedMissing() {
+    StatsStore store = Mockito.mock(StatsStore.class);
+    StatsOrchestrator o =
+        orchestrator(
+            store,
+            Mockito.mock(ReconcileJobStore.class),
+            Mockito.mock(TableRepository.class),
+            Mockito.mock(StatsSyncCapture.class));
+
+    StatsCaptureRequest req = columnRequest(42L, 7L);
+    when(store.getTargetStatsInGeneration(
+            req.tableId(), req.snapshotId(), "gen-pinned", req.target()))
+        .thenReturn(Optional.empty());
+    when(store.getTargetStats(req.tableId(), req.snapshotId(), req.target()))
+        .thenReturn(Optional.of(columnRecord(req, 3L)));
+
+    StatsResolutionResult r = o.resolveInGeneration(req, Optional.of("gen-pinned"));
+
+    // Pinned generation lacks the target, so the newest generation backstops before capture.
+    assertThat(r.hasStats()).isTrue();
+    assertThat(r.stats().get().getTable().getRowCount()).isEqualTo(3L);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributorTest.java
@@ -201,6 +201,21 @@ class ServiceTelemetryContributorTest {
   }
 
   @Test
+  void registersPlannerLookupOutcomeMetricWithExpectedTags() {
+    TelemetryRegistry registry = new TelemetryRegistry();
+    registry.register(new ServiceTelemetryContributor());
+
+    MetricDef plannerLookup =
+        registry.metric(ServiceMetrics.Stats.PLANNER_LOOKUP_OUTCOMES_TOTAL.name());
+
+    assertThat(plannerLookup).isNotNull();
+    assertThat(plannerLookup.requiredTags())
+        .containsExactlyInAnyOrder(TagKey.COMPONENT, TagKey.OPERATION, TagKey.RESULT);
+    assertThat(plannerLookup.allowedTags())
+        .containsExactlyInAnyOrder(TagKey.COMPONENT, TagKey.OPERATION, TagKey.RESULT);
+  }
+
+  @Test
   void registersPartialStateAnomalyMetricWithExpectedTags() {
     TelemetryRegistry registry = new TelemetryRegistry();
     registry.register(new ServiceTelemetryContributor());


### PR DESCRIPTION
## Summary

Fixes two planner-stats regressions surfaced by the TableRoot rework (#378/#381) and closes the
operational gap that let tables with broken roots fail every query forever. Three themes:

### 1. Planner reads are pinned and reproducible

Planner stats lookups now resolve in the generation frozen by the query's pin instead of racing
the live pointer, with a pinned-first ladder: cache (pinned keyspace) → pinned generation →
same-snapshot gap-fill → stale (≤ pinned snapshot) → capture. Completeness is planner-aware
(`satisfiesNeed`): a record that exists but cannot serve every requested stat role/sketch is a
partial, not a hit — so resolution never stops at a record the planner can only consume
downgraded, and never silently drifts to a newer snapshot. Root causes of the user-visible
NOT_FOUND are fixed underneath: system column ids fall back to ordinals (with build-time
collision validation), and legacy requests with an unspecified resource kind normalize to TABLE.

### 2. Producer sketches propagate verbatim

The rollup dropped `ScalarStats.sketches` and non-theta NDV envelope payloads even when a single
source contributed — downgrading every quantile/CDF consumer. A sole source's sketch payloads and
its entire NDV envelope now propagate untouched through both rollup stages; multi-source payloads
are dropped, never merged. Generations only enrich: publishing a new generation carries a
superseded generation's sketches forward (payload-only, incoming wins per role/type, no target
resurrection), and NDV envelopes are gated on their mode oneof so an estimate-less carrier
envelope can never read as a bogus zero estimate (CONTRACT note on `Ndv` in stats.proto).

### 3. Broken roots converge instead of failing forever

A table whose root pointer named a swept blob, or whose root violated its invariants, failed
every query identically with nothing scheduled to repair it. Query-path reads now report observed
breakage into the existing `RootResyncQueue` re-drive (new `RootRepairRequests`: rate-limited per
table, fire-and-forget, never masks the query's own error); the periodic GC pass re-derives the
root from committed state. Expected client states (fresh table, no currency) and replaced-blob
version mismatches deliberately do not report. Snapshot-not-found errors now name the table
instead of rendering an unfilled `{id}` placeholder.

Also: `PlannerStatsResolver` extracted from the orchestrator (behavior-preserving), per-target
lookup-outcome diagnostics (`planner_lookup_outcomes` counter + DEBUG summary), and the pin's
frozen stats generation is GC-rooted directly.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [x] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
