### PR TITLE
fix: remove stale paused cancellation cleanup markers

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -488,7 +488,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       cancellationMaintenanceService = new ReconcileCancellationMaintenanceService();
     }
     cancellationMaintenanceService.bind(
-        pointerStore, this::cleanupCancellationRoot, readyScanLimit);
+        pointerStore,
+        this::cleanupCancellationRoot,
+        this::isObsoleteCancellationCleanupRoot,
+        readyScanLimit);
     return cancellationMaintenanceService;
   }
 
@@ -2219,6 +2222,20 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       throw ReconcileCancellationMaintenanceService.obsoleteMarker();
     }
     return propagateDirectChildCancellation(loaded.record, request, childPageSize);
+  }
+
+  private boolean isObsoleteCancellationCleanupRoot(
+      ReconcileCancellationMaintenanceService.CancellationCleanupRequest request) {
+    if (request == null) {
+      return true;
+    }
+    String accountId = blankToEmpty(request.accountId());
+    String rootJobId = blankToEmpty(request.rootJobId());
+    StoredEnvelope loaded = loadByAnyAccount(rootJobId).orElse(null);
+    return loaded == null
+        || loaded.record == null
+        || !accountId.equals(blankToEmpty(loaded.record.accountId))
+        || !isCancellationState(loaded.record.state);
   }
 
   private ReconcileCancellationMaintenanceService.CancellationCleanupResult

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -2246,7 +2246,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     return root != null
         && "JS_CANCELLED".equals(blankToEmpty(root.state))
         && root.finishedAtMs > 0L
-        && root.childrenFinalized;
+        && root.childrenFinalized
+        && !needsAbandonedFullRescanStatsCleanup(root);
   }
 
   private ReconcileCancellationMaintenanceService.CancellationCleanupResult

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -2212,30 +2212,41 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       return new ReconcileCancellationMaintenanceService.CancellationCleanupResult(
           true, "", false, false, false);
     }
+    StoredReconcileJob root = activeCancellationCleanupRoot(request);
+    if (root == null) {
+      throw ReconcileCancellationMaintenanceService.obsoleteMarker();
+    }
+    return propagateDirectChildCancellation(root, request, childPageSize);
+  }
+
+  private boolean isObsoleteCancellationCleanupRoot(
+      ReconcileCancellationMaintenanceService.CancellationCleanupRequest request) {
+    return activeCancellationCleanupRoot(request) == null;
+  }
+
+  private StoredReconcileJob activeCancellationCleanupRoot(
+      ReconcileCancellationMaintenanceService.CancellationCleanupRequest request) {
+    if (request == null) {
+      return null;
+    }
     String accountId = blankToEmpty(request.accountId());
     String rootJobId = blankToEmpty(request.rootJobId());
     StoredEnvelope loaded = loadByAnyAccount(rootJobId).orElse(null);
     if (loaded == null
         || loaded.record == null
         || !accountId.equals(blankToEmpty(loaded.record.accountId))
-        || !isCancellationState(loaded.record.state)) {
-      throw ReconcileCancellationMaintenanceService.obsoleteMarker();
+        || !isCancellationState(loaded.record.state)
+        || cancellationCleanupRootComplete(loaded.record)) {
+      return null;
     }
-    return propagateDirectChildCancellation(loaded.record, request, childPageSize);
+    return loaded.record;
   }
 
-  private boolean isObsoleteCancellationCleanupRoot(
-      ReconcileCancellationMaintenanceService.CancellationCleanupRequest request) {
-    if (request == null) {
-      return true;
-    }
-    String accountId = blankToEmpty(request.accountId());
-    String rootJobId = blankToEmpty(request.rootJobId());
-    StoredEnvelope loaded = loadByAnyAccount(rootJobId).orElse(null);
-    return loaded == null
-        || loaded.record == null
-        || !accountId.equals(blankToEmpty(loaded.record.accountId))
-        || !isCancellationState(loaded.record.state);
+  private boolean cancellationCleanupRootComplete(StoredReconcileJob root) {
+    return root != null
+        && "JS_CANCELLED".equals(blankToEmpty(root.state))
+        && root.finishedAtMs > 0L
+        && root.childrenFinalized;
   }
 
   private ReconcileCancellationMaintenanceService.CancellationCleanupResult

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcileJobCancellationMaintenanceScheduler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcileJobCancellationMaintenanceScheduler.java
@@ -31,7 +31,7 @@ public class ReconcileJobCancellationMaintenanceScheduler {
   @Inject DurableReconcileJobStore jobs;
 
   @Scheduled(
-      every = "{floecat.reconciler.job-store.cancellation-maintenance.tick-every:1s}",
+      every = "{floecat.reconciler.job-store.cancellation-maintenance.tick-every:5s}",
       concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
       skipExecutionIf = ReconcileJobGcScheduler.DisabledOrStopping.class)
   void tick() {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileCancellationMaintenanceService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileCancellationMaintenanceService.java
@@ -132,12 +132,15 @@ public class ReconcileCancellationMaintenanceService {
           continue;
         }
         if (marker.request().paused()) {
-          paused++;
           if (isObsoleteCancellationRoot(marker.request())) {
             if (pointerStore.compareAndDelete(pointer.getKey(), pointer.getVersion())) {
               obsoleteDeleted++;
               deleted++;
+            } else {
+              paused++;
             }
+          } else {
+            paused++;
           }
           continue;
         }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileCancellationMaintenanceService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileCancellationMaintenanceService.java
@@ -33,17 +33,25 @@ public class ReconcileCancellationMaintenanceService {
     CancellationCleanupResult accept(CancellationCleanupRequest request, int childPageSize);
   }
 
+  @FunctionalInterface
+  public interface IsObsoleteCancellationRoot {
+    boolean test(CancellationCleanupRequest request);
+  }
+
   private PointerStore pointerStore;
   private CleanupCancellationRoot cleanupCancellationRoot;
+  private IsObsoleteCancellationRoot isObsoleteCancellationRoot;
   private int readyScanLimit;
   private volatile String cancellationScanToken = "";
 
   public void bind(
       PointerStore pointerStore,
       CleanupCancellationRoot cleanupCancellationRoot,
+      IsObsoleteCancellationRoot isObsoleteCancellationRoot,
       int readyScanLimit) {
     this.pointerStore = pointerStore;
     this.cleanupCancellationRoot = cleanupCancellationRoot;
+    this.isObsoleteCancellationRoot = isObsoleteCancellationRoot;
     this.readyScanLimit = readyScanLimit;
   }
 
@@ -66,10 +74,19 @@ public class ReconcileCancellationMaintenanceService {
     int invalidDeleted = 0;
     int obsoleteDeleted = 0;
     int failures = 0;
+    int paused = 0;
     while (true) {
       if (System.currentTimeMillis() > deadlineMs) {
         return new CancellationStats(
-            false, pages, scanned, cleaned, invalidDeleted, obsoleteDeleted, deleted, failures);
+            false,
+            pages,
+            scanned,
+            cleaned,
+            paused,
+            invalidDeleted,
+            obsoleteDeleted,
+            deleted,
+            failures);
       }
       StringBuilder next = new StringBuilder();
       List<Pointer> pointers =
@@ -78,13 +95,29 @@ public class ReconcileCancellationMaintenanceService {
       if (pointers.isEmpty()) {
         cancellationScanToken = "";
         return new CancellationStats(
-            true, pages, scanned, cleaned, invalidDeleted, obsoleteDeleted, deleted, failures);
+            true,
+            pages,
+            scanned,
+            cleaned,
+            paused,
+            invalidDeleted,
+            obsoleteDeleted,
+            deleted,
+            failures);
       }
       String nextToken = blankToEmpty(next.toString());
       for (Pointer pointer : pointers) {
         if (System.currentTimeMillis() > deadlineMs) {
           return new CancellationStats(
-              false, pages, scanned, cleaned, invalidDeleted, obsoleteDeleted, deleted, failures);
+              false,
+              pages,
+              scanned,
+              cleaned,
+              paused,
+              invalidDeleted,
+              obsoleteDeleted,
+              deleted,
+              failures);
         }
         if (pointer == null || pointer.getKey().isBlank()) {
           continue;
@@ -99,6 +132,13 @@ public class ReconcileCancellationMaintenanceService {
           continue;
         }
         if (marker.request().paused()) {
+          paused++;
+          if (isObsoleteCancellationRoot(marker.request())) {
+            if (pointerStore.compareAndDelete(pointer.getKey(), pointer.getVersion())) {
+              obsoleteDeleted++;
+              deleted++;
+            }
+          }
           continue;
         }
         try {
@@ -129,7 +169,15 @@ public class ReconcileCancellationMaintenanceService {
       if (nextToken.isBlank()) {
         cancellationScanToken = "";
         return new CancellationStats(
-            true, pages + 1, scanned, cleaned, invalidDeleted, obsoleteDeleted, deleted, failures);
+            true,
+            pages + 1,
+            scanned,
+            cleaned,
+            paused,
+            invalidDeleted,
+            obsoleteDeleted,
+            deleted,
+            failures);
       }
       if (nextToken.equals(token)) {
         LOG.warn(
@@ -137,7 +185,15 @@ public class ReconcileCancellationMaintenanceService {
                 + " avoid livelock");
         cancellationScanToken = "";
         return new CancellationStats(
-            true, pages + 1, scanned, cleaned, invalidDeleted, obsoleteDeleted, deleted, failures);
+            true,
+            pages + 1,
+            scanned,
+            cleaned,
+            paused,
+            invalidDeleted,
+            obsoleteDeleted,
+            deleted,
+            failures);
       }
       cancellationScanToken = nextToken;
       token = nextToken;
@@ -146,8 +202,32 @@ public class ReconcileCancellationMaintenanceService {
         LOG.warn("Reconcile cancellation cleanup pagination hit safety page cap; aborting scan");
         cancellationScanToken = "";
         return new CancellationStats(
-            true, pages, scanned, cleaned, invalidDeleted, obsoleteDeleted, deleted, failures);
+            true,
+            pages,
+            scanned,
+            cleaned,
+            paused,
+            invalidDeleted,
+            obsoleteDeleted,
+            deleted,
+            failures);
       }
+    }
+  }
+
+  private boolean isObsoleteCancellationRoot(CancellationCleanupRequest request) {
+    if (isObsoleteCancellationRoot == null) {
+      return false;
+    }
+    try {
+      return isObsoleteCancellationRoot.test(request);
+    } catch (RuntimeException e) {
+      LOG.warnf(
+          e,
+          "Failed to validate paused reconcile cancellation cleanup marker accountId=%s rootJobId=%s",
+          request == null ? "" : request.accountId(),
+          request == null ? "" : request.rootJobId());
+      return false;
     }
   }
 
@@ -178,20 +258,26 @@ public class ReconcileCancellationMaintenanceService {
 
   private void logMaintenanceSummary(long startedAtMs, CancellationStats stats) {
     long elapsedMs = System.currentTimeMillis() - startedAtMs;
-    if (!stats.active() && elapsedMs <= 500L) {
+    if (stats.infoQuiet() && elapsedMs <= 500L) {
       LOG.debugf(
-          "runCancellationMaintenanceOnce total_ms=%d completed=%s",
-          Long.valueOf(elapsedMs), Boolean.valueOf(stats.completed()));
+          "runCancellationMaintenanceOnce total_ms=%d completed=%s pages=%d scanned=%d"
+              + " paused=%d",
+          Long.valueOf(elapsedMs),
+          Boolean.valueOf(stats.completed()),
+          Integer.valueOf(stats.pages()),
+          Integer.valueOf(stats.scanned()),
+          Integer.valueOf(stats.paused()));
       return;
     }
     LOG.infof(
         "runCancellationMaintenanceOnce total_ms=%d completed=%s pages=%d scanned=%d cleaned=%d"
-            + " invalid_deleted=%d obsolete_deleted=%d deleted=%d failures=%d",
+            + " paused=%d invalid_deleted=%d obsolete_deleted=%d deleted=%d failures=%d",
         Long.valueOf(elapsedMs),
         Boolean.valueOf(stats.completed()),
         Integer.valueOf(stats.pages()),
         Integer.valueOf(stats.scanned()),
         Integer.valueOf(stats.cleaned()),
+        Integer.valueOf(stats.paused()),
         Integer.valueOf(stats.invalidDeleted()),
         Integer.valueOf(stats.obsoleteDeleted()),
         Integer.valueOf(stats.deleted()),
@@ -284,22 +370,22 @@ public class ReconcileCancellationMaintenanceService {
       int pages,
       int scanned,
       int cleaned,
+      int paused,
       int invalidDeleted,
       int obsoleteDeleted,
       int deleted,
       int failures) {
     static CancellationStats empty() {
-      return new CancellationStats(true, 0, 0, 0, 0, 0, 0, 0);
+      return new CancellationStats(true, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
-    boolean active() {
-      return !completed
-          || scanned > 0
-          || cleaned > 0
-          || invalidDeleted > 0
-          || obsoleteDeleted > 0
-          || deleted > 0
-          || failures > 0;
+    boolean infoQuiet() {
+      return completed
+          && cleaned == 0
+          && invalidDeleted == 0
+          && obsoleteDeleted == 0
+          && deleted == 0
+          && failures == 0;
     }
   }
 

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -127,7 +127,7 @@ floecat.reconciler.job-store.projection-maintenance.enabled=${FLOECAT_RECONCILER
 floecat.reconciler.job-store.projection-maintenance.tick-every=${FLOECAT_RECONCILER_JOB_STORE_PROJECTION_MAINTENANCE_TICK_EVERY:5s}
 floecat.reconciler.job-store.projection-maintenance.max-tick-millis=${FLOECAT_RECONCILER_JOB_STORE_PROJECTION_MAINTENANCE_MAX_TICK_MILLIS:30000}
 floecat.reconciler.job-store.cancellation-maintenance.enabled=${FLOECAT_RECONCILER_JOB_STORE_CANCELLATION_MAINTENANCE_ENABLED:true}
-floecat.reconciler.job-store.cancellation-maintenance.tick-every=${FLOECAT_RECONCILER_JOB_STORE_CANCELLATION_MAINTENANCE_TICK_EVERY:1s}
+floecat.reconciler.job-store.cancellation-maintenance.tick-every=${FLOECAT_RECONCILER_JOB_STORE_CANCELLATION_MAINTENANCE_TICK_EVERY:5s}
 floecat.reconciler.job-store.cancellation-maintenance.max-tick-millis=${FLOECAT_RECONCILER_JOB_STORE_CANCELLATION_MAINTENANCE_MAX_TICK_MILLIS:30000}
 # Reconciler gRPC auth for worker/backend calls.
 floecat.reconciler.authorization.header=${FLOECAT_RECONCILER_AUTHORIZATION_HEADER:authorization}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -4491,6 +4491,47 @@ class DurableReconcileJobStoreTest {
   }
 
   @Test
+  void cancellationMaintenanceDeletesPausedMarkerForCompletedCancelledRoot() {
+    String connectorJobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.empty());
+    assertDoesNotThrow(
+        () ->
+            invokePrivateMethod(
+                store,
+                "mutateByCanonicalPointerReturningRecord",
+                new Class<?>[] {String.class, UnaryOperator.class},
+                Keys.reconcileJobPointerById(ACCOUNT_ID, connectorJobId),
+                (UnaryOperator<StoredReconcileJob>)
+                    current -> {
+                      current.state = "JS_CANCELLED";
+                      current.message = "Cancelled";
+                      current.startedAtMs = Math.max(current.startedAtMs, 50L);
+                      current.finishedAtMs = Math.max(current.finishedAtMs, 100L);
+                      current.childrenFinalized = true;
+                      current.readyPointerKey = null;
+                      current.nextAttemptAtMs = 0L;
+                      return current;
+                    }));
+    String key = Keys.reconcileCancellationCleanupPointer(ACCOUNT_ID, connectorJobId);
+    String payload =
+        ReconcileCancellationMaintenanceService.cancellationCleanupPayload(
+            new ReconcileCancellationMaintenanceService.CancellationCleanupRequest(
+                ACCOUNT_ID, connectorJobId, "", true, false, true));
+    assertTrue(
+        store.pointerStore.compareAndSet(
+            key, 0L, PointerReferences.opaqueMarkerPointer(key, payload, 1L)));
+
+    runCancellationMaintenance();
+
+    assertTrue(store.pointerStore.get(key).isEmpty());
+  }
+
+  @Test
   void repeatedSnapshotFinalizationResetsFinalizedStatusUntilNewFinalizerSucceeds() {
     ReconcileSnapshotTask snapshotTask =
         ReconcileSnapshotTask.of("table-1", 55L, "db", "orders", List.of(), true);

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
@@ -326,6 +326,7 @@ class ReconcileMaintenanceServicesTest {
           return new ReconcileCancellationMaintenanceService.CancellationCleanupResult(
               true, "", false, false, false);
         },
+        request -> false,
         10);
 
     service.runCancellationMaintenanceOnce(200L);
@@ -361,12 +362,41 @@ class ReconcileMaintenanceServicesTest {
           return new ReconcileCancellationMaintenanceService.CancellationCleanupResult(
               true, "", false, false, false);
         },
+        request -> false,
         10);
 
     service.runCancellationMaintenanceOnce(200L);
 
     assertEquals(0, calls.get());
     assertTrue(pointerStore.get(key).isPresent());
+  }
+
+  @Test
+  void cancellationCleanupDeletesObsoletePausedMarker() {
+    PointerStore pointerStore = new TestPointerStore();
+    ReconcileCancellationMaintenanceService service = new ReconcileCancellationMaintenanceService();
+    AtomicInteger calls = new AtomicInteger();
+    String key = Keys.reconcileCancellationCleanupPointer("acct", "missing-root");
+    String payload =
+        ReconcileCancellationMaintenanceService.cancellationCleanupPayload(
+            new ReconcileCancellationMaintenanceService.CancellationCleanupRequest(
+                "acct", "missing-root", "", true, false, true));
+    pointerStore.compareAndSet(key, 0L, PointerReferences.opaqueMarkerPointer(key, payload, 1L));
+
+    service.bind(
+        pointerStore,
+        (request, childPageSize) -> {
+          calls.incrementAndGet();
+          return new ReconcileCancellationMaintenanceService.CancellationCleanupResult(
+              true, "", false, false, false);
+        },
+        request -> true,
+        10);
+
+    service.runCancellationMaintenanceOnce(200L);
+
+    assertEquals(0, calls.get());
+    assertTrue(pointerStore.get(key).isEmpty());
   }
 
   private static void putDirtyMarker(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
@@ -40,6 +40,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQue
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.spi.PointerStore;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -372,7 +373,7 @@ class ReconcileMaintenanceServicesTest {
   }
 
   @Test
-  void cancellationCleanupDeletesObsoletePausedMarker() {
+  void cancellationCleanupDeletesObsoletePausedMarker() throws Exception {
     PointerStore pointerStore = new TestPointerStore();
     ReconcileCancellationMaintenanceService service = new ReconcileCancellationMaintenanceService();
     AtomicInteger calls = new AtomicInteger();
@@ -393,9 +394,12 @@ class ReconcileMaintenanceServicesTest {
         request -> true,
         10);
 
-    service.runCancellationMaintenanceOnce(200L);
+    Object stats = cleanupCancellationMarkers(service, System.currentTimeMillis() + 200L);
 
     assertEquals(0, calls.get());
+    assertEquals(0, cancellationStat(stats, "paused"));
+    assertEquals(1, cancellationStat(stats, "obsoleteDeleted"));
+    assertEquals(1, cancellationStat(stats, "deleted"));
     assertTrue(pointerStore.get(key).isEmpty());
   }
 
@@ -424,6 +428,21 @@ class ReconcileMaintenanceServicesTest {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
+  }
+
+  private static Object cleanupCancellationMarkers(
+      ReconcileCancellationMaintenanceService service, long deadlineMs) throws Exception {
+    Method method =
+        ReconcileCancellationMaintenanceService.class.getDeclaredMethod(
+            "cleanupCancellationMarkers", long.class);
+    method.setAccessible(true);
+    return method.invoke(service, deadlineMs);
+  }
+
+  private static int cancellationStat(Object stats, String name) throws Exception {
+    Method method = stats.getClass().getDeclaredMethod(name);
+    method.setAccessible(true);
+    return (Integer) method.invoke(stats);
   }
 
   private static void putMarker(


### PR DESCRIPTION
## Summary

This updates reconcile cancellation maintenance to validate paused cleanup markers before skipping them. If a paused marker points to a missing, mismatched, or no-longer-cancelling root job, it is now deleted as obsolete instead of being scanned forever.

Also changes cancellation maintenance’s default tick interval from 1s to 5s and moves no-op/paused-only maintenance summaries to DEBUG, while keeping real cleanup/deletes/failures at INFO.

Test coverage added for obsolete paused marker cleanup via ReconcileMaintenanceServicesTest.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

