### PR TITLE
telemetry: restore per-request span decorations dropped by the #305 worker-hop change

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -106,6 +106,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- InMemorySpanExporter for the interceptor-ordering IT (SpanDecorationIT). -->
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>

--- a/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
@@ -42,6 +42,7 @@ import com.google.protobuf.util.Timestamps;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.smallrye.mutiny.Multi;
@@ -90,13 +91,29 @@ public abstract class BaseServiceImpl {
     return idempotencyTtlSeconds;
   }
 
+  /**
+   * The OTel context to re-activate inside a hopped body. Prefers the context current at method
+   * entry, but when that carries no valid span — the norm on this server, where the span is only
+   * current inside the innermost tracing interceptor's window and never at the method layer — it
+   * grafts on the span {@code SpanCaptureInterceptor} stashed on the per-call duplicated-context
+   * carrier. Without this, {@code Span.current()} inside the body is the invalid root span and
+   * every per-request decoration and diagnostic summary event silently no-ops.
+   */
+  private static Context otelContextForBody(Context captured) {
+    if (Span.fromContext(captured).getSpanContext().isValid()) {
+      return captured;
+    }
+    Span carried = ResolvedCallContexts.currentCallSpanOrInvalid();
+    return carried.getSpanContext().isValid() ? captured.with(carried) : captured;
+  }
+
   protected <T> Uni<T> run(Supplier<T> body) {
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
     // Read the resolved call context at method entry — before any executor hop — and carry it by
     // reference into the body. The captured io.grpc.Context alone is unreliable across the hop
     // (eng-floe/floecat#361).
     ResolvedCallContext callCtx = ResolvedCallContexts.currentOrNull();
-    Context otelCtx = Context.current();
+    Context otelCtx = otelContextForBody(Context.current());
     return Uni.createFrom()
         .item(
             () ->
@@ -123,7 +140,7 @@ public abstract class BaseServiceImpl {
   protected <T> Multi<T> runStream(Function<ResolvedCallContext, Multi<T>> body) {
     ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
-    Context otelCtx = Context.current();
+    Context otelCtx = otelContextForBody(Context.current());
     return Multi.createFrom()
         .<T>deferred(
             () ->
@@ -144,7 +161,7 @@ public abstract class BaseServiceImpl {
       BiConsumer<ResolvedCallContext, MultiEmitter<? super T>> body) {
     ResolvedCallContext callCtx = ResolvedCallContexts.currentOrUnauthenticated();
     GrpcContextUtil grpcCtx = GrpcContextUtil.capture();
-    Context otelCtx = Context.current();
+    Context otelCtx = otelContextForBody(Context.current());
     return Multi.createFrom()
         .<T>emitter(
             emitter ->

--- a/service/src/main/java/ai/floedb/floecat/service/common/GrpcInterceptorPriorities.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/GrpcInterceptorPriorities.java
@@ -39,12 +39,32 @@ public final class GrpcInterceptorPriorities {
    */
   public static final int INBOUND_CONTEXT = 1_000_000;
 
-  public static final int TELEMETRY = 300;
-
   public static final int RPC_LOGGING = 200;
 
-  /** Innermost: localizes error payloads before the outer logging interceptor observes them. */
+  /** Localizes error payloads before the outer logging interceptor observes them. */
   public static final int LOCALIZE_ERRORS = 100;
+
+  /**
+   * Telemetry runs INNER of Quarkus's tracing interceptor — deliberately below 0. Quarkus's {@code
+   * GrpcTracingServerInterceptor} implements no {@code Prioritized}, so the comparator gives it 0;
+   * it creates the call's server span and makes it current ONLY inside its own {@code
+   * interceptCall} window, never re-attaching around listener events. Telemetry's delegate ({@code
+   * GrpcTelemetryServerInterceptor}) captures {@code Span.current()} AND builds its {@code
+   * PhaseDiagnostics} at {@code interceptCall}, so anything above 0 captures the invalid root span
+   * and a {@code NOOP} diagnostics — and then emits neither {@code floecat.rpc.status} nor the
+   * {@code floecat.rpc.summary} event. Sorting below 0 runs its chain build inside the window; it
+   * captures the span synchronously there, so its later {@code finish()} (on call close, outside
+   * the window) still holds a valid captured span.
+   */
+  public static final int TELEMETRY = -500;
+
+  /**
+   * Innermost of ALL interceptors — below {@link #TELEMETRY}. Captures the server span (valid only
+   * here, inside the tracing window; see {@link #TELEMETRY}) onto the per-call carrier and applies
+   * the per-request identity attributes. Ordering relative to {@link #TELEMETRY} is immaterial —
+   * both sit inside the window and touch the span independently.
+   */
+  public static final int SPAN_CAPTURE = -1_000;
 
   private GrpcInterceptorPriorities() {}
 }

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptor.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.telemetry.grpc.GrpcTelemetryServerInterceptor;
 import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
@@ -120,6 +121,14 @@ public class InboundContextInterceptor {
     Context context = contextWithResolvedCallContext(Context.current(), resolved);
 
     populateMdc(resolved);
+    // Component/operation MDC lives HERE — the outermost interceptor — not in the telemetry
+    // interceptor: telemetry sorts inner of RPC logging (it must run inside the tracing window,
+    // below priority 0), so clearing these keys in its close would strip them from the structured
+    // JSON fields of the very rpc log line (and error line) logging emits at ITS close. This
+    // class's close runs last on the way out, keeping them present for every log line of the call.
+    MDC.put("floecat_component", "service");
+    MDC.put(
+        "floecat_operation", GrpcTelemetryServerInterceptor.simplifyOp(call.getMethodDescriptor()));
     // Mirror the whole resolved call context onto the Vert.x duplicated context (same channel as
     // MDC) so principal, correlation id, and engine context together survive Quarkus's gRPC
     // dispatch worker thread-hops into the service body, where the io.grpc.Context keys alone are
@@ -145,14 +154,32 @@ public class InboundContextInterceptor {
           }
         };
 
-    return Contexts.interceptCall(context, forwarding, headers, next);
+    try {
+      return Contexts.interceptCall(context, forwarding, headers, next);
+    } catch (RuntimeException e) {
+      // The forwarding close() clears MDC on the normal path, but if an inner interceptor throws
+      // during interceptCall (before any close), gRPC tears the call down directly and that close
+      // never runs — leaking these keys on the pooled worker thread. Clear defensively here so the
+      // thread is clean for its next call. (This owns all MDC keys since telemetry stopped clearing
+      // its own; the old ServiceTelemetryInterceptor had the same defensive catch.)
+      clearMdc();
+      throw e;
+    }
   }
 
   private static boolean isCallAllowed(ServerCall<?, ?> call) {
-    String method = call.getMethodDescriptor().getFullMethodName();
-    return method != null
-        && (method.startsWith("grpc.health.v1.Health/")
-            || method.startsWith("grpc.reflection.v1.ServerReflection/"));
+    return isInfrastructureMethod(call.getMethodDescriptor().getFullMethodName());
+  }
+
+  /**
+   * True for gRPC infrastructure methods (health probes, server reflection) rather than application
+   * RPCs. These bypass auth resolution, and — because Quarkus may not open a server span for them —
+   * span-dependent code must not treat a missing span on these paths as an ordering regression.
+   */
+  public static boolean isInfrastructureMethod(String fullMethodName) {
+    return fullMethodName != null
+        && (fullMethodName.startsWith("grpc.health.v1.Health/")
+            || fullMethodName.startsWith("grpc.reflection.v1.ServerReflection/"));
   }
 
   private static Metadata.Key<String> metadataKey(String name) {
@@ -198,6 +225,8 @@ public class InboundContextInterceptor {
   }
 
   public static void clearMdc() {
+    MDC.remove("floecat_component");
+    MDC.remove("floecat_operation");
     MDC.remove("query_id");
     MDC.remove("correlation_id");
     MDC.remove("floecat_account_id");

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.context.impl;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import io.opentelemetry.api.trace.Span;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
 import java.util.Objects;
@@ -59,6 +60,18 @@ public final class ResolvedCallContexts {
   /** Vert.x duplicated-context local key under which the resolved call context is stored. */
   private static final String CONTEXT_LOCAL = "floecat.resolved-call-context";
 
+  /**
+   * Vert.x duplicated-context local key under which the call's gRPC server span is stored. The span
+   * is created by Quarkus's {@code GrpcTracingServerInterceptor} — which carries no {@code
+   * Prioritized} priority and therefore sorts to 0, the INNERMOST slot of the chain — and is only
+   * current inside that interceptor's {@code makeCurrent()} window. No floecat interceptor or
+   * handler thread ever has it current, so every {@code Span.current()} decoration silently no-ops.
+   * {@code SpanCaptureInterceptor} (priority below 0, inner to the tracing interceptor) captures
+   * the span inside that window and stows it here — the same per-call channel MDC and the resolved
+   * call context already ride — so decoration code anywhere in the call can reach it.
+   */
+  private static final String SPAN_LOCAL = "floecat.call-span";
+
   private static final ThreadLocal<ResolvedCallContext> SCOPE = new ThreadLocal<>();
 
   private ResolvedCallContexts() {}
@@ -89,6 +102,43 @@ public final class ResolvedCallContexts {
           resolved.correlationId());
     }
     ctx.putLocal(CONTEXT_LOCAL, resolved);
+  }
+
+  /**
+   * Stores the call's gRPC server span on the current Vert.x duplicated context so decoration code
+   * outside the tracing interceptor's {@code makeCurrent()} window (every floecat interceptor,
+   * service handlers, Mutiny bodies) can reach it. Called once per call by {@code
+   * SpanCaptureInterceptor}, the only floecat code that runs inside that window.
+   *
+   * <p>A pure store: no-op when off a duplicated context or when no valid span is current. The
+   * loud-vs-quiet judgement for a missing span (ordering regression vs tracing disabled) belongs to
+   * {@code SpanCaptureInterceptor}, which knows whether tracing is enabled; this carrier stays a
+   * dumb sink so both callers and tests can invoke it without a config dependency.
+   */
+  public static void storeSpanOnDuplicatedContext(Span span) {
+    io.vertx.core.Context ctx = Vertx.currentContext();
+    if (ctx == null || !VertxContext.isDuplicatedContext(ctx)) {
+      return;
+    }
+    if (span == null || !span.getSpanContext().isValid()) {
+      return;
+    }
+    ctx.putLocal(SPAN_LOCAL, span);
+  }
+
+  /**
+   * The gRPC server span carried on the current duplicated context, or {@link Span#getInvalid()}
+   * when none is present (off a duplicated context, or no span was captured for this call).
+   */
+  public static Span currentCallSpanOrInvalid() {
+    io.vertx.core.Context ctx = Vertx.currentContext();
+    if (ctx != null && VertxContext.isDuplicatedContext(ctx)) {
+      Object value = ctx.getLocal(SPAN_LOCAL);
+      if (value instanceof Span span) {
+        return span;
+      }
+    }
+    return Span.getInvalid();
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryInterceptor.java
@@ -21,19 +21,15 @@ import ai.floedb.floecat.service.common.GrpcInterceptorPriorities;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.grpc.GrpcTelemetryServerInterceptor;
-import io.grpc.ForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-import io.grpc.Status;
-import io.opentelemetry.api.trace.Span;
 import io.quarkus.grpc.GlobalInterceptor;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.Prioritized;
 import jakarta.inject.Inject;
 import java.util.Objects;
-import org.jboss.logging.MDC;
 
 /** Service-specific gRPC interceptor that publishes RPC metrics through the telemetry hub. */
 @ApplicationScoped
@@ -56,55 +52,19 @@ public final class ServiceTelemetryInterceptor implements ServerInterceptor, Pri
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
       ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-    String operation = GrpcTelemetryServerInterceptor.simplifyOp(call.getMethodDescriptor());
-    Span span = Span.current();
-    if (span.getSpanContext().isValid()) {
-      String queryId = InboundContextInterceptor.QUERY_KEY.get();
-      if (queryId != null && !queryId.isBlank()) {
-        span.setAttribute("query_id", queryId);
-      }
-      String correlationId = InboundContextInterceptor.CORR_KEY.get();
-      if (correlationId != null && !correlationId.isBlank()) {
-        span.setAttribute("correlation_id", correlationId);
-      }
-      PrincipalContext principalContext = InboundContextInterceptor.PC_KEY.get();
-      if (principalContext != null) {
-        span.setAttribute("floecat_account_id", principalContext.getAccountId());
-        span.setAttribute("floecat_subject", principalContext.getSubject());
-      }
-      String engineVersion = InboundContextInterceptor.ENGINE_VERSION_KEY.get();
-      if (engineVersion != null && !engineVersion.isBlank()) {
-        span.setAttribute("floecat_engine_version", engineVersion);
-      }
-      String engineKind = InboundContextInterceptor.ENGINE_KIND_KEY.get();
-      if (engineKind != null && !engineKind.isBlank()) {
-        span.setAttribute("floecat_engine_kind", engineKind);
-      }
-    }
-    MDC.put("floecat_component", "service");
-    MDC.put("floecat_operation", operation);
-    ServerCall<ReqT, RespT> wrapped =
-        new ForwardingServerCall.SimpleForwardingServerCall<>(call) {
-          @Override
-          public void close(Status status, Metadata trailers) {
-            try {
-              MDC.remove("floecat_component");
-              MDC.remove("floecat_operation");
-            } finally {
-              super.close(status, trailers);
-            }
-          }
-        };
-    try {
-      return delegate.interceptCall(wrapped, headers, next);
-    } catch (RuntimeException e) {
-      MDC.remove("floecat_component");
-      MDC.remove("floecat_operation");
-      throw e;
-    }
+    // This interceptor runs INSIDE the tracing interceptor's makeCurrent() window (TELEMETRY sorts
+    // below 0; see GrpcInterceptorPriorities), so the delegate captures a valid Span.current() and
+    // a recording PhaseDiagnostics at interceptCall — the RPC span status and the
+    // floecat.rpc.summary event depend on that. Per-request IDENTITY attributes (query_id,
+    // correlation_id, …) live in SpanCaptureInterceptor, also inside the window; the
+    // floecat_component/floecat_operation MDC lives in InboundContextInterceptor, which stays
+    // OUTER of RPC logging so those keys survive onto the rpc log line at logging's close.
+    return delegate.interceptCall(call, headers, next);
   }
 
-  /** Higher = outer; see {@link GrpcInterceptorPriorities}. */
+  /**
+   * Below 0 — must run inside the tracing window; see {@link GrpcInterceptorPriorities#TELEMETRY}.
+   */
   @Override
   public int getPriority() {
     return GrpcInterceptorPriorities.TELEMETRY;

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/SpanCaptureInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/SpanCaptureInterceptor.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.telemetry;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.service.common.GrpcInterceptorPriorities;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.opentelemetry.api.trace.Span;
+import io.quarkus.grpc.GlobalInterceptor;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Prioritized;
+import jakarta.inject.Inject;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
+
+/**
+ * Captures the call's gRPC server span — from the ONE place in the whole chain where it is
+ * reachable — and makes it available to every other decoration site via the per-call
+ * duplicated-context carrier.
+ *
+ * <p>Quarkus's {@code GrpcTracingServerInterceptor} creates the server span and makes it current
+ * only inside its own {@code interceptCall} window (its listener never re-attaches around events;
+ * it only ends the span on terminal ones). Because that interceptor carries no {@code Prioritized}
+ * priority it sorts to 0 — INSIDE every floecat interceptor — so all of floecat's {@code
+ * Span.current()} decoration reads (interceptor tags, handler attributes, per-phase diagnostic
+ * events) resolve the invalid root span and silently no-op. This interceptor's {@link
+ * GrpcInterceptorPriorities#SPAN_CAPTURE below-zero priority} places its chain build inside the
+ * tracing window, where {@code Span.current()} provably resolves the real span.
+ *
+ * <p>Two actions, both inside the window:
+ *
+ * <ul>
+ *   <li>stow the span on the duplicated-context carrier ({@link
+ *       ResolvedCallContexts#storeSpanOnDuplicatedContext}) so {@code BaseServiceImpl} can graft it
+ *       into service-method bodies and Mutiny pipelines;
+ *   <li>apply the per-request identity attributes (query id, correlation id, principal, engine)
+ *       directly onto that span.
+ * </ul>
+ *
+ * <p>When tracing is effectively enabled but no valid span is current here on an application RPC,
+ * that is an interceptor-ordering regression (this interceptor fell outside the window), and it is
+ * logged at WARN — never silently — because it collapses every per-request decoration back to a
+ * no-op. A missing span stays a quiet DEBUG when tracing is off (any of the three OTel switches) or
+ * on infrastructure methods Quarkus may legitimately leave untraced.
+ *
+ * <p>The identity values come from the {@code io.grpc.Context} keys the inbound context interceptor
+ * populated: it is far outer to this one, and {@code Contexts.interceptCall} keeps its context
+ * attached through the inner chain build.
+ */
+@ApplicationScoped
+@GlobalInterceptor
+public final class SpanCaptureInterceptor implements ServerInterceptor, Prioritized {
+
+  private static final Logger LOG = Logger.getLogger(SpanCaptureInterceptor.class);
+
+  /**
+   * Whether OpenTelemetry tracing is effectively active — the OTel master switch AND traces AND the
+   * SDK not runtime-disabled. When it is, Quarkus's default {@code parentbased_always_on} sampler
+   * yields a valid span context for EVERY call at an in-window capture, so a missing span here is
+   * never a sampling artifact — it is an ordering regression, and is logged loudly. When any of the
+   * three switches turns tracing off the SDK no-ops and a missing span is expected, so it stays
+   * quiet: gating on {@code traces.enabled} alone would spam the regression WARN on every RPC when
+   * an operator disables telemetry via the master switch while leaving {@code traces.enabled} at
+   * its default.
+   */
+  private final boolean tracingEnabled;
+
+  /**
+   * Process-wide count of application RPCs that hit the no-valid-span regression branch. Under a
+   * real ordering regression this branch is taken on EVERY call, so the WARN is throttled to the
+   * first occurrence and each decade milestone ({@link #isFirstOrDecadeMilestone}) — the count
+   * rides the log line so the regression stays countable without one WARN per request flooding the
+   * log at production QPS.
+   */
+  private final AtomicLong missingSpanRegressions = new AtomicLong();
+
+  @Inject
+  public SpanCaptureInterceptor(
+      @ConfigProperty(name = "quarkus.otel.enabled", defaultValue = "true") boolean otelEnabled,
+      @ConfigProperty(name = "quarkus.otel.traces.enabled", defaultValue = "true")
+          boolean tracesEnabled,
+      @ConfigProperty(name = "quarkus.otel.sdk.disabled", defaultValue = "false")
+          boolean sdkDisabled) {
+    this.tracingEnabled = otelEnabled && tracesEnabled && !sdkDisabled;
+  }
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    Span span = Span.current();
+    if (span.getSpanContext().isValid()) {
+      ResolvedCallContexts.storeSpanOnDuplicatedContext(span);
+      applyCallAttributes(span);
+    } else if (tracingEnabled
+        && !InboundContextInterceptor.isInfrastructureMethod(
+            call.getMethodDescriptor().getFullMethodName())) {
+      // Tracing is on and this is an application RPC, so an in-window capture must see a valid span
+      // (always_on gives one to every such call). Its absence means this interceptor no longer
+      // sorts inside the tracing interceptor's makeCurrent() window — an ordering regression (e.g.
+      // a
+      // Quarkus/OTel bump changing that interceptor's priority). Loud and countable, because every
+      // per-request span decoration silently no-ops when it happens; a DEBUG line (off in prod)
+      // would hide the regression. Health probes and reflection are excluded: Quarkus may not open
+      // a span for them, and they are polled on a tight interval, so a WARN there is pure noise
+      // pointing at a regression that isn't real. Throttled to first occurrence + decade
+      // milestones: this branch is taken on EVERY call under a real regression, so an unthrottled
+      // per-call WARN would itself become a production log flood.
+      long n = missingSpanRegressions.incrementAndGet();
+      if (isFirstOrDecadeMilestone(n)) {
+        LOG.warnf(
+            "SpanCaptureInterceptor found no valid server span while tracing is enabled"
+                + " (occurrence #%d, correlation_id=%s): it is no longer inside the tracing"
+                + " interceptor's window, so every per-request span decoration will no-op. Check"
+                + " GrpcInterceptorPriorities against Quarkus's gRPC interceptor ordering.",
+            n, MDC.get("correlation_id"));
+      }
+    } else {
+      LOG.debugf(
+          "no server span to capture (correlation_id=%s): tracing disabled or an untraced"
+              + " infrastructure method",
+          MDC.get("correlation_id"));
+    }
+    return next.startCall(call, headers);
+  }
+
+  /**
+   * Per-request identity attributes, from the inbound interceptor's {@code io.grpc.Context}. The
+   * floecat-specific keys use the dotted {@code floecat.*} span-attribute namespace shared by every
+   * other decoration on this span (the telemetry delegate's {@code floecat.component} /{@code
+   * floecat.rpc.status}, the handler bodies' {@code floecat.get_user_objects.*}) so per-account and
+   * per-engine trace queries group with the rest. {@code query_id}/{@code correlation_id} keep
+   * their flat names — they mirror the MDC log keys and any dashboards already keyed on them. (The
+   * MDC log fields, a separate namespace, stay underscore-cased.)
+   */
+  private static void applyCallAttributes(Span span) {
+    String queryId = InboundContextInterceptor.QUERY_KEY.get();
+    if (queryId != null && !queryId.isBlank()) {
+      span.setAttribute("query_id", queryId);
+    }
+    String correlationId = InboundContextInterceptor.CORR_KEY.get();
+    if (correlationId != null && !correlationId.isBlank()) {
+      span.setAttribute("correlation_id", correlationId);
+    }
+    PrincipalContext principalContext = InboundContextInterceptor.PC_KEY.get();
+    if (principalContext != null) {
+      span.setAttribute("floecat.account_id", principalContext.getAccountId());
+      span.setAttribute("floecat.subject", principalContext.getSubject());
+    }
+    String engineVersion = InboundContextInterceptor.ENGINE_VERSION_KEY.get();
+    if (engineVersion != null && !engineVersion.isBlank()) {
+      span.setAttribute("floecat.engine.version", engineVersion);
+    }
+    String engineKind = InboundContextInterceptor.ENGINE_KIND_KEY.get();
+    if (engineKind != null && !engineKind.isBlank()) {
+      span.setAttribute("floecat.engine.kind", engineKind);
+    }
+  }
+
+  /**
+   * Whether the {@code n}-th regression occurrence should be logged: the first, then each power of
+   * ten (10, 100, 1000, …). This taps the WARN to at most ~one line per decade of volume — loud on
+   * the first hit, still periodically visible under a sustained regression, never a per-call flood.
+   */
+  static boolean isFirstOrDecadeMilestone(long n) {
+    if (n < 1) {
+      return false;
+    }
+    while (n % 10 == 0) {
+      n /= 10;
+    }
+    return n == 1;
+  }
+
+  /** Below zero — must stay inner to the priority-0 tracing interceptor; see the class doc. */
+  @Override
+  public int getPriority() {
+    return GrpcInterceptorPriorities.SPAN_CAPTURE;
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/ResolvedCallContextsSpanTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/ResolvedCallContextsSpanTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.context.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Vertx;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The span carrier that lets streaming RPCs re-activate the gRPC server span across the dispatch/
+ * subscription hop. The carrier rides the same per-call Vert.x duplicated-context channel as the
+ * resolved call context, so these run the store/read on an actual duplicated context.
+ */
+class ResolvedCallContextsSpanTest {
+
+  private static final Span SAMPLED_SPAN =
+      Span.wrap(
+          SpanContext.createFromRemoteParent(
+              "0af7651916cd43dd8448eb211c80319c",
+              "b7ad6b7169203331",
+              TraceFlags.getSampled(),
+              TraceState.getDefault()));
+
+  /** Runs {@code body} on a fresh Vert.x duplicated context and returns its result. */
+  private static <T> T onDuplicatedContext(Vertx vertx, java.util.function.Supplier<T> body)
+      throws Exception {
+    CompletableFuture<T> result = new CompletableFuture<>();
+    io.vertx.core.Context duplicated =
+        VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+    duplicated.runOnContext(
+        ignored -> {
+          try {
+            result.complete(body.get());
+          } catch (Throwable t) {
+            result.completeExceptionally(t);
+          }
+        });
+    return result.get(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void aValidSpanRoundTripsOnTheDuplicatedContext() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      Span readBack =
+          onDuplicatedContext(
+              vertx,
+              () -> {
+                ResolvedCallContexts.storeSpanOnDuplicatedContext(SAMPLED_SPAN);
+                return ResolvedCallContexts.currentCallSpanOrInvalid();
+              });
+      assertTrue(readBack.getSpanContext().isValid());
+      assertEquals(
+          SAMPLED_SPAN.getSpanContext().getTraceId(), readBack.getSpanContext().getTraceId());
+      assertEquals(
+          SAMPLED_SPAN.getSpanContext().getSpanId(), readBack.getSpanContext().getSpanId());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void anInvalidSpanIsNotCarried() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      // An invalid span can never prove which trace this call belongs to, so it must not be
+      // stored: the reader returns the invalid span, and callers keep the no-op behaviour rather
+      // than decorating a bogus span.
+      Span readBack =
+          onDuplicatedContext(
+              vertx,
+              () -> {
+                ResolvedCallContexts.storeSpanOnDuplicatedContext(Span.getInvalid());
+                return ResolvedCallContexts.currentCallSpanOrInvalid();
+              });
+      assertFalse(readBack.getSpanContext().isValid());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void readingOffAnyDuplicatedContextWithoutAStoredSpanReturnsInvalid() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      Span readBack = onDuplicatedContext(vertx, ResolvedCallContexts::currentCallSpanOrInvalid);
+      assertFalse(readBack.getSpanContext().isValid());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void storeOffAnyVertxContextIsANoOpNotACrash() {
+    // No Vert.x context on a plain JUnit thread: store must silently no-op and the reader must
+    // return the invalid span rather than throwing.
+    ResolvedCallContexts.storeSpanOnDuplicatedContext(SAMPLED_SPAN);
+    assertFalse(ResolvedCallContexts.currentCallSpanOrInvalid().getSpanContext().isValid());
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/it/SpanDecorationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/SpanDecorationIT.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.catalog.rpc.CatalogServiceGrpc;
+import ai.floedb.floecat.catalog.rpc.ListCatalogsRequest;
+import ai.floedb.floecat.common.rpc.QueryInput;
+import ai.floedb.floecat.query.rpc.BeginQueryRequest;
+import ai.floedb.floecat.query.rpc.GetUserObjectsRequest;
+import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
+import ai.floedb.floecat.query.rpc.TableReferenceCandidate;
+import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
+import ai.floedb.floecat.query.rpc.UserObjectsServiceGrpc;
+import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
+import ai.floedb.floecat.service.util.TestDataResetter;
+import ai.floedb.floecat.service.util.TestSupport;
+import io.grpc.Channel;
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Build-time guard for the interceptor-ordering premise the span decorations rest on.
+ *
+ * <p>Quarkus's {@code GrpcTracingServerInterceptor} carries no {@code Prioritized} priority and
+ * sorts to 0; floecat's {@code SpanCaptureInterceptor} and {@code ServiceTelemetryInterceptor} sit
+ * at negative priorities so their chain builds run INSIDE its {@code makeCurrent()} window — the
+ * only place the server span is ever current. Unit tests cannot validate that: the production
+ * {@code QuarkusContextStorage} and the real interceptor sort only exist in a booted Quarkus. This
+ * IT boots one, issues one real RPC, and asserts the decorations that ONLY land when the ordering
+ * holds:
+ *
+ * <ul>
+ *   <li>{@code correlation_id} — written by {@code SpanCaptureInterceptor} inside the window;
+ *   <li>{@code floecat.component} / {@code floecat.rpc.status} — written by the telemetry
+ *       delegate's in-window span capture and its close-time finish;
+ *   <li>the {@code floecat.rpc.summary} event — emitted only when the diagnostics factory saw a
+ *       valid recording span at interceptCall.
+ * </ul>
+ *
+ * <p>If a Quarkus/OTel bump ever changes the tracing interceptor's effective priority, this test
+ * fails at build time instead of the decorations silently no-op'ing in production (where the only
+ * signal would be {@code SpanCaptureInterceptor}'s WARN).
+ */
+@QuarkusTest
+@TestProfile(SpanDecorationIT.InMemoryTracingProfile.class)
+class SpanDecorationIT {
+
+  /** Re-enables span export (test defaults disable it) and drains batches fast. */
+  public static class InMemoryTracingProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "quarkus.otel.traces.exporter", "cdi",
+          "quarkus.otel.exporter.otlp.enabled", "false",
+          "quarkus.otel.bsp.schedule.delay", "100ms");
+    }
+  }
+
+  /**
+   * CDI-published in-memory exporter, picked up because the profile sets the traces exporter to
+   * {@code cdi}. Under every other test profile the exporter is {@code none}, so this bean is inert
+   * there. Static so the test reads finished spans without injecting SDK types.
+   */
+  @ApplicationScoped
+  public static class InMemoryExporterProducer {
+    static final InMemorySpanExporter EXPORTER = InMemorySpanExporter.create();
+
+    @Produces
+    @Singleton
+    SpanExporter exporter() {
+      return EXPORTER;
+    }
+  }
+
+  @GrpcClient("floecat")
+  CatalogServiceGrpc.CatalogServiceBlockingStub catalog;
+
+  @GrpcClient("floecat")
+  QueryServiceGrpc.QueryServiceBlockingStub lifecycle;
+
+  @GrpcClient("floecat")
+  Channel channel;
+
+  @Inject TestDataResetter resetter;
+  @Inject SeedRunner seeder;
+
+  @Test
+  void serverSpanCarriesFloecatDecorations() {
+    InMemoryExporterProducer.EXPORTER.reset();
+
+    catalog.listCatalogs(ListCatalogsRequest.newBuilder().build());
+
+    SpanData span =
+        awaitServerSpan("ListCatalogs")
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "no SERVER span for ListCatalogs was exported — tracing itself is broken"
+                            + " in this profile"));
+
+    // SpanCaptureInterceptor, inside the tracing window: identity attributes on the REAL span.
+    assertThat(span.getAttributes().get(AttributeKey.stringKey("correlation_id")))
+        .as("correlation_id — SpanCaptureInterceptor must capture inside the tracing window")
+        .isNotBlank();
+
+    // The telemetry delegate's in-window capture: component tag at interceptCall, status at
+    // finish. Both read the span reference captured at interceptCall time.
+    assertThat(span.getAttributes().get(AttributeKey.stringKey("floecat.component")))
+        .as("floecat.component — ServiceTelemetryInterceptor must run inside the tracing window")
+        .isEqualTo("service");
+    assertThat(span.getAttributes().get(AttributeKey.stringKey("floecat.rpc.status")))
+        .as("floecat.rpc.status — the finish() path must hold the captured span")
+        .isEqualTo("OK");
+
+    // The diagnostics factory returns NOOP unless a valid recording span was current at
+    // interceptCall; the summary event only exists when it was not NOOP.
+    assertThat(span.getEvents())
+        .as("floecat.rpc.summary event — PhaseDiagnostics must not be NOOP")
+        .anyMatch(event -> "floecat.rpc.summary".equals(event.getName()));
+  }
+
+  @Test
+  void streamingServerSpanCarriesBodySetDecorations() {
+    // Closes the loop the unary test cannot: the unary decorations all land inside the tracing
+    // window, so they would pass even if the duplicated-context carrier were broken. This drives a
+    // STREAMING RPC (getUserObjects) whose handler body runs on a hopped worker thread OUTSIDE the
+    // window; the floecat.get_user_objects.* attributes are written on Span.current() captured
+    // inside that body. They only reach the real RPC span if storeSpanOnDuplicatedContext ->
+    // otelContextForBody grafted the captured span onto the body's context — the mechanism this
+    // whole change exists to enable. An unresolved candidate is enough: the body's summary sets
+    // the outcome attribute regardless of whether the table resolves.
+    resetter.wipeAll();
+    seeder.seedData();
+    InMemoryExporterProducer.EXPORTER.reset();
+
+    var cat = TestSupport.createCatalog(catalog, "span_it_cat", "");
+    var begin =
+        lifecycle.beginQuery(
+            BeginQueryRequest.newBuilder().setDefaultCatalogId(cat.getResourceId()).build());
+    var candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(
+                QueryInput.newBuilder()
+                    .setName(TestSupport.fq("span_it_cat", List.of("no_such_ns"), "no_such_table"))
+                    .build())
+            .build();
+
+    collectUserObjectBundle(
+        GetUserObjectsRequest.newBuilder()
+            .setQueryId(begin.getQuery().getQueryId())
+            .addTables(candidate)
+            .build());
+
+    SpanData span =
+        awaitServerSpan("GetUserObjects")
+            .orElseThrow(
+                () -> new AssertionError("no SERVER span for GetUserObjects was exported"));
+
+    // Written on Span.current() inside the streaming body — present only if the carrier grafted
+    // the captured span onto the hopped body's OTel context.
+    assertThat(span.getAttributes().get(AttributeKey.stringKey("floecat.get_user_objects.outcome")))
+        .as(
+            "floecat.get_user_objects.outcome — the carrier-to-body graft must make the RPC span"
+                + " current inside the streaming handler body")
+        .isNotBlank();
+  }
+
+  /** Drives the streaming getUserObjects RPC and waits for the stream to terminate. */
+  private void collectUserObjectBundle(GetUserObjectsRequest request) {
+    UserObjectsServiceGrpc.UserObjectsServiceStub async =
+        UserObjectsServiceGrpc.newStub(channel).withDeadlineAfter(10, TimeUnit.SECONDS);
+    CompletableFuture<List<UserObjectsBundleChunk>> future = new CompletableFuture<>();
+    List<UserObjectsBundleChunk> chunks = Collections.synchronizedList(new ArrayList<>());
+    async.getUserObjects(
+        request,
+        new StreamObserver<>() {
+          @Override
+          public void onNext(UserObjectsBundleChunk chunk) {
+            chunks.add(chunk);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            // A not-found candidate may terminate the stream in error; the span is still emitted
+            // with the body-set outcome, which is what this test asserts.
+            future.complete(new ArrayList<>(chunks));
+          }
+
+          @Override
+          public void onCompleted() {
+            future.complete(new ArrayList<>(chunks));
+          }
+        });
+    future.orTimeout(10, TimeUnit.SECONDS).join();
+  }
+
+  /** Polls the exporter for the finished SERVER span of the given method (batch delay ~100ms). */
+  private static Optional<SpanData> awaitServerSpan(String methodPart) {
+    Instant deadline = Instant.now().plus(Duration.ofSeconds(15));
+    while (Instant.now().isBefore(deadline)) {
+      Optional<SpanData> match =
+          InMemoryExporterProducer.EXPORTER.getFinishedSpanItems().stream()
+              .filter(span -> span.getKind() == io.opentelemetry.api.trace.SpanKind.SERVER)
+              .filter(span -> span.getName().contains(methodPart))
+              .findFirst();
+      if (match.isPresent()) {
+        return match;
+      }
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return Optional.empty();
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/telemetry/SpanCaptureInterceptorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/telemetry/SpanCaptureInterceptorTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
+import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Scope;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Vertx;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The capture interceptor's contract: inside the tracing window (a valid span current), it stows
+ * the span on the per-call duplicated-context carrier and applies the per-request identity
+ * attributes; outside it (invalid root span), it does neither and never disturbs the chain. Tests
+ * run under OTel's default thread-local context storage — the production Quarkus storage cannot be
+ * installed in a unit test. Where the span IS current in production (the interceptor-ordering
+ * premise) is guarded by {@code SpanDecorationIT}, which boots a real Quarkus and asserts the
+ * decorations on an exported span; what this covers is what the interceptor does once it is.
+ */
+class SpanCaptureInterceptorTest {
+
+  private static final SpanContext VALID_SPAN_CONTEXT =
+      SpanContext.createFromRemoteParent(
+          "0af7651916cd43dd8448eb211c80319c",
+          "b7ad6b7169203331",
+          TraceFlags.getSampled(),
+          TraceState.getDefault());
+
+  /** Runs {@code body} on a fresh Vert.x duplicated context and returns its result. */
+  private static <T> T onDuplicatedContext(Vertx vertx, Supplier<T> body) throws Exception {
+    CompletableFuture<T> result = new CompletableFuture<>();
+    io.vertx.core.Context duplicated =
+        VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+    duplicated.runOnContext(
+        ignored -> {
+          try {
+            result.complete(body.get());
+          } catch (Throwable t) {
+            result.completeExceptionally(t);
+          }
+        });
+    return result.get(10, TimeUnit.SECONDS);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ServerCall<Object, Object> stubCall() {
+    return stubCall("floecat.catalog.v1.CatalogService/ListCatalogs");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ServerCall<Object, Object> stubCall(String fullMethodName) {
+    ServerCall<Object, Object> call = mock(ServerCall.class);
+    io.grpc.MethodDescriptor<Object, Object> md = mock(io.grpc.MethodDescriptor.class);
+    when(md.getFullMethodName()).thenReturn(fullMethodName);
+    when(call.getMethodDescriptor()).thenReturn(md);
+    return call;
+  }
+
+  /**
+   * A minimal real {@link Span} whose attribute writes are observable. A Mockito mock cannot serve
+   * here: {@code makeCurrent()}/{@code storeInContext()} are interface DEFAULT methods that a mock
+   * stubs away, so the "span" never actually becomes current.
+   */
+  private static final class RecordingSpan implements Span {
+    final java.util.Map<String, Object> attributes = new java.util.concurrent.ConcurrentHashMap<>();
+
+    @Override
+    public <T> Span setAttribute(AttributeKey<T> key, T value) {
+      attributes.put(key.getKey(), value);
+      return this;
+    }
+
+    @Override
+    public Span addEvent(String name, io.opentelemetry.api.common.Attributes a) {
+      return this;
+    }
+
+    @Override
+    public Span addEvent(
+        String name, io.opentelemetry.api.common.Attributes a, long ts, TimeUnit unit) {
+      return this;
+    }
+
+    @Override
+    public Span setStatus(StatusCode statusCode, String description) {
+      return this;
+    }
+
+    @Override
+    public Span recordException(Throwable exception, io.opentelemetry.api.common.Attributes a) {
+      return this;
+    }
+
+    @Override
+    public Span updateName(String name) {
+      return this;
+    }
+
+    @Override
+    public void end() {}
+
+    @Override
+    public void end(long timestamp, TimeUnit unit) {}
+
+    @Override
+    public SpanContext getSpanContext() {
+      return VALID_SPAN_CONTEXT;
+    }
+
+    @Override
+    public boolean isRecording() {
+      return true;
+    }
+  }
+
+  @Test
+  void insideTheWindowStowsTheSpanAndAppliesIdentityAttributes() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      RecordingSpan span = new RecordingSpan();
+      SpanCaptureInterceptor interceptor = new SpanCaptureInterceptor(true, true, false);
+      @SuppressWarnings("unchecked")
+      ServerCallHandler<Object, Object> next = mock(ServerCallHandler.class);
+      ServerCall.Listener<Object> chainListener = new ServerCall.Listener<>() {};
+      when(next.startCall(any(), any())).thenReturn(chainListener);
+
+      // The inbound interceptor's io.grpc.Context keys, attached as Contexts.interceptCall keeps
+      // them through the inner chain build.
+      Context grpcCtx =
+          Context.current()
+              .withValue(InboundContextInterceptor.QUERY_KEY, "query-1")
+              .withValue(InboundContextInterceptor.CORR_KEY, "corr-1")
+              .withValue(
+                  InboundContextInterceptor.PC_KEY,
+                  PrincipalContext.newBuilder().setAccountId("acct").setSubject("dev").build())
+              .withValue(InboundContextInterceptor.ENGINE_VERSION_KEY, "0.1")
+              .withValue(InboundContextInterceptor.ENGINE_KIND_KEY, "floedb");
+
+      ServerCall.Listener<Object> returned =
+          onDuplicatedContext(
+              vertx,
+              () -> {
+                Context prev = grpcCtx.attach();
+                try (Scope ignored = span.makeCurrent()) {
+                  var listener = interceptor.interceptCall(stubCall(), new Metadata(), next);
+                  // Captured on the SAME duplicated context, readable after the window closes.
+                  assertTrue(
+                      ResolvedCallContexts.currentCallSpanOrInvalid().getSpanContext().isValid());
+                  return listener;
+                } finally {
+                  grpcCtx.detach(prev);
+                }
+              });
+
+      assertSame(chainListener, returned, "the chain must continue undisturbed");
+      assertEquals("query-1", span.attributes.get("query_id"));
+      assertEquals("corr-1", span.attributes.get("correlation_id"));
+      assertEquals("acct", span.attributes.get("floecat.account_id"));
+      assertEquals("dev", span.attributes.get("floecat.subject"));
+      assertEquals("0.1", span.attributes.get("floecat.engine.version"));
+      assertEquals("floedb", span.attributes.get("floecat.engine.kind"));
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void outsideTheWindowStowsNothingAndNeverDisturbsTheChain() throws Exception {
+    // The no-span path across every log-level case. Only the FIRST — an application RPC with
+    // tracing effectively on — takes the loud regression WARN; all the others stay a quiet DEBUG:
+    //   - application RPC, traces.enabled=false                → tracing off
+    //   - infrastructure RPC (health), tracing on              → health/reflection may legitimately
+    //                                                             be untraced; suppress per-probe
+    // noise
+    //   - application RPC, otel.enabled=false (master switch)  → SDK no-op though
+    // traces.enabled=true
+    //   - application RPC, sdk.disabled=true                   → SDK no-op though
+    // traces.enabled=true
+    // The master-switch and sdk-disabled cases are the ones that would spam the WARN if the gate
+    // read traces.enabled alone. All behave identically here — nothing stowed, chain undisturbed —
+    // only the level differs; this asserts the shared behaviour for every case.
+    record Case(boolean otelEnabled, boolean tracesEnabled, boolean sdkDisabled, String method) {}
+    String app = "floecat.catalog.v1.CatalogService/ListCatalogs";
+    Case[] cases = {
+      new Case(true, true, false, app), // loud
+      new Case(true, false, false, app), // traces off → quiet
+      new Case(true, true, false, "grpc.health.v1.Health/Check"), // infra → quiet
+      new Case(false, true, false, app), // master switch off → quiet
+      new Case(true, true, true, app), // sdk disabled → quiet
+    };
+    for (Case c : cases) {
+      Vertx vertx = Vertx.vertx();
+      try {
+        SpanCaptureInterceptor interceptor =
+            new SpanCaptureInterceptor(c.otelEnabled(), c.tracesEnabled(), c.sdkDisabled());
+        @SuppressWarnings("unchecked")
+        ServerCallHandler<Object, Object> next = mock(ServerCallHandler.class);
+        ServerCall.Listener<Object> chainListener = new ServerCall.Listener<>() {};
+        when(next.startCall(any(), any())).thenReturn(chainListener);
+
+        ServerCall.Listener<Object> returned =
+            onDuplicatedContext(
+                vertx,
+                () -> {
+                  // No span current: the interceptor must not stow the invalid root span.
+                  var listener =
+                      interceptor.interceptCall(stubCall(c.method()), new Metadata(), next);
+                  assertFalse(
+                      ResolvedCallContexts.currentCallSpanOrInvalid().getSpanContext().isValid());
+                  return listener;
+                });
+
+        assertSame(chainListener, returned);
+      } finally {
+        vertx.close().toCompletionStage().toCompletableFuture().get();
+      }
+    }
+  }
+
+  @Test
+  void sortsBelowTheImplicitZeroOfTheQuarkusTracingInterceptor() {
+    // The whole mechanism rests on this: Quarkus's GrpcTracingServerInterceptor carries no
+    // Prioritized priority, so the comparator assigns it 0 — the capture interceptor must sort
+    // strictly below to have its chain build run inside the tracing window.
+    assertTrue(new SpanCaptureInterceptor(true, true, false).getPriority() < 0);
+    assertEquals(
+        ai.floedb.floecat.service.common.GrpcInterceptorPriorities.SPAN_CAPTURE,
+        new SpanCaptureInterceptor(true, true, false).getPriority());
+  }
+
+  @Test
+  void regressionWarnLogsOnFirstOccurrenceAndEachDecadeOnly() {
+    // The regression WARN is taken on every call once the ordering breaks; it must taper to first
+    // occurrence + powers of ten so it never floods the log at production QPS.
+    for (long milestone : new long[] {1, 10, 100, 1000, 10_000, 1_000_000}) {
+      assertTrue(
+          SpanCaptureInterceptor.isFirstOrDecadeMilestone(milestone), "should log at " + milestone);
+    }
+    for (long between : new long[] {0, 2, 5, 9, 11, 99, 101, 999, 123_456}) {
+      assertFalse(
+          SpanCaptureInterceptor.isFirstOrDecadeMilestone(between),
+          "should stay quiet at " + between);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

floecat RPC spans in Jaeger carry only Quarkus's auto-instrumentation tags (`network.*`, `rpc.*`,
`span.kind`) — none of floecat's own decorations: the `query_id` / `correlation_id` / account tags
from the telemetry interceptor, the `floecat.get_user_objects.*` attributes, or the per-phase
diagnostic summary event. Every floecat `Span.current()` decoration silently no-ops.

## Root cause

floecat never *creates* spans; it decorates `Span.current()` behind `getSpanContext().isValid()`
guards. #305 (`853db0742`) replaced Vert.x's `io.vertx.grpc.BlockingServerInterceptor.wrap` with
the custom `CtxPropagatingBlockingWrap` to stop a principal/correlation context loss. The custom
wrap re-attaches the gRPC `Context` and the CDI request context across the event-loop → worker
hop — but not the OpenTelemetry context, which the Vert.x wrapper had propagated implicitly. So
since #305, every floecat handler runs on a worker thread where the OTel context is the invalid
root span, and all downstream decorations (interceptor, handlers, diagnostics factory) drop
silently.

## Fix

Carry the OTel context across the worker hop the same way `CtxPropagatingBlockingWrap` already
carries the gRPC and CDI contexts: capture `Context.current()` on the caller (event loop, where
the server span is current) and re-activate it on the worker around both the delegate build
(`inner.interceptCall`) and each replayed listener event. One change, at the exact seam that
regressed; fixes all floecat spans (unary and streaming) at once.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
