### PR TITLE
gc: stop CasBlobGc deleting live blobs when a pointer re-targets an old sha mid-pass

### DIFF
--- a/core/proto/src/main/proto/floecat/common/common.proto
+++ b/core/proto/src/main/proto/floecat/common/common.proto
@@ -115,6 +115,9 @@ message BlobHeader {
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp last_modified_at = 6;
   repeated Tag tags = 7;
+  // Store-assigned version of the blob observed by this header (S3 object versionId), used for
+  // version-targeted deletes; empty when the store has no versioning.
+  string version_id = 8;
 }
 
 message Tag {

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/BlobStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/BlobStore.java
@@ -32,17 +32,30 @@ public interface BlobStore {
   boolean delete(String uri);
 
   /**
+   * Whether {@link #delete(String, String)} acts on immutable version identities. {@code false}
+   * means a version-targeted delete cannot be trusted to leave a concurrent re-write intact — e.g.
+   * an S3 bucket whose versioning status is not {@code Enabled}: unversioned and suspended buckets
+   * overwrite the {@code "null"} version in place — so callers deleting for correctness must skip
+   * deleting instead. The default is {@code false}: fail closed.
+   */
+  default boolean supportsVersionedDeletes() {
+    return false;
+  }
+
+  /**
    * Deletes only the blob version that {@code versionId} names (as observed via {@link
    * BlobHeader#getVersionId()}). A different version — in particular one written concurrently after
    * the caller's {@link #head} — must survive, so a check-then-delete caller acts on exactly the
    * object it checked. Returns true when the named version was deleted (or already absent); false
    * when the store can tell the blob has moved past it and nothing was deleted.
    *
-   * <p>A blank {@code versionId} (store without versioning) and the default implementation both
-   * fall back to the unconditional {@link #delete(String)}; version-capable stores must override.
+   * <p>Callers must gate on {@link #supportsVersionedDeletes()}; a blank {@code versionId} is a
+   * caller bug and is rejected. There is deliberately NO fallback to the unconditional {@link
+   * #delete(String)} — that would silently reintroduce the delete-after-re-reference race this
+   * method exists to close.
    */
   default boolean delete(String uri, String versionId) {
-    return delete(uri);
+    throw new UnsupportedOperationException("versioned deletes not supported by this store");
   }
 
   void deletePrefix(String prefix);

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/BlobStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/BlobStore.java
@@ -31,6 +31,20 @@ public interface BlobStore {
 
   boolean delete(String uri);
 
+  /**
+   * Deletes only the blob version that {@code versionId} names (as observed via {@link
+   * BlobHeader#getVersionId()}). A different version — in particular one written concurrently after
+   * the caller's {@link #head} — must survive, so a check-then-delete caller acts on exactly the
+   * object it checked. Returns true when the named version was deleted (or already absent); false
+   * when the store can tell the blob has moved past it and nothing was deleted.
+   *
+   * <p>A blank {@code versionId} (store without versioning) and the default implementation both
+   * fall back to the unconditional {@link #delete(String)}; version-capable stores must override.
+   */
+  default boolean delete(String uri, String versionId) {
+    return delete(uri);
+  }
+
   void deletePrefix(String prefix);
 
   default Map<String, byte[]> getBatch(List<String> uris) {

--- a/docker/localstack-init.sh
+++ b/docker/localstack-init.sh
@@ -6,6 +6,10 @@ BUCKET="${FLOECAT_BLOB_S3_BUCKET:-floecat-dev}"
 TABLE="${FLOECAT_KV_TABLE:-floecat_pointers}"
 
 awslocal s3api create-bucket --bucket "${BUCKET}" --region "${REGION}" >/dev/null 2>&1 || true
+# CAS blob GC fails closed (collects nothing) unless the blob bucket's versioning is Enabled:
+# version-targeted deletes are what let a delete race a concurrent re-reference safely.
+awslocal s3api put-bucket-versioning --bucket "${BUCKET}" \
+  --versioning-configuration Status=Enabled >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "bucket" --region "${REGION}" >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "warehouse" --region "${REGION}" >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "yb-iceberg-tpcds" --region "${REGION}" >/dev/null 2>&1 || true

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
@@ -70,9 +70,22 @@ public class CasBlobGc {
       int blobsDeleted,
       int referenced,
       int tablesScanned,
-      boolean poisoned) {}
+      boolean poisoned,
+      boolean deletesUnsupported) {}
 
   public Result runForAccount(String accountId) {
+    if (!blobStore.supportsVersionedDeletes()) {
+      // Fail closed: without immutable version identities every delete is the
+      // eng-floe/core#1904 race (an S3 bucket whose versioning is not Enabled overwrites version
+      // state in place), so nothing may be collected. One warn per pass; the scheduler gauges
+      // this so a misconfigured bucket is noticed rather than silently never collecting.
+      LOG.warnf(
+          "cas gc for account %s skipped: blob store cannot delete by immutable version"
+              + " (on S3 the bucket's versioning status must be Enabled)",
+          accountId);
+      return new Result(0, 0, 0, 0, 0, false, true);
+    }
+
     final var cfg = ConfigProvider.getConfig();
     final int pageSize =
         cfg.getOptionalValue("floecat.gc.cas.page-size", Integer.class).orElse(500);
@@ -196,7 +209,7 @@ public class CasBlobGc {
       LOG.warnf(
           "cas gc for account %s skipped its delete phase: %d root-chain walk(s) failed",
           accountId, walkFailures[0]);
-      return new Result(pointersScanned, 0, 0, referenced.size(), tablesScanned, true);
+      return new Result(pointersScanned, 0, 0, referenced.size(), tablesScanned, true, false);
     }
 
     var account =
@@ -303,7 +316,8 @@ public class CasBlobGc {
         blobsDeleted,
         referenced.size(),
         tablesScanned,
-        walkFailures[0] > 0);
+        walkFailures[0] > 0,
+        false);
   }
 
   /**
@@ -522,13 +536,19 @@ public class CasBlobGc {
           if (referencedByOwnerPointer(normalized)) {
             continue;
           }
+          String versionId = header.getVersionId();
+          if (versionId.isBlank()) {
+            // Cannot name the version this pass age-checked (unexpected on a store that reports
+            // supportsVersionedDeletes): fail closed and leave the blob for a future pass — an
+            // unconditional delete here would reintroduce the race.
+            continue;
+          }
           // Delete exactly the version this pass age-checked: the fences above are still stale
           // reads — a writer can re-PUT the blob and CAS its pointer between them and this delete
           // — but that re-PUT mints a NEW version a targeted delete cannot touch, so the check and
           // the act name the same immutable object and the pointer stays resolvable in every
-          // interleaving. An empty version id (store without versioning) degrades to the
-          // unconditional delete: on S3, fully closing the race requires bucket versioning.
-          if (blobStore.delete(key, header.getVersionId())) {
+          // interleaving.
+          if (blobStore.delete(key, versionId)) {
             deleted++;
           }
         }

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
@@ -514,6 +514,14 @@ public class CasBlobGc {
           if (nowMs - lastModified < minAgeMs) {
             continue;
           }
+          // Last line of defense against the mark/CAS race: a pointer CAS can re-target an OLD
+          // existing blob after this pass's one-time mark, invisible to both the mark and (if the
+          // writer left LastModified stale) the age fence. For pointer-rooted families the key
+          // encodes its owner (see Keys.ownerPointerKeyForBlob) — re-read that pointer right
+          // before the delete and keep the blob it currently references.
+          if (referencedByOwnerPointer(normalized)) {
+            continue;
+          }
           if (blobStore.delete(key)) {
             deleted++;
           }
@@ -526,6 +534,15 @@ public class CasBlobGc {
     }
 
     return new DeleteResult(scanned, deleted);
+  }
+
+  private boolean referencedByOwnerPointer(String normalizedKey) {
+    String ownerKey = Keys.ownerPointerKeyForBlob(normalizedKey);
+    if (ownerKey == null) {
+      return false;
+    }
+    var owner = pointerStore.get(ownerKey).orElse(null);
+    return owner != null && normalizedKey.equals(normalizeKey(owner.getBlobUri()));
   }
 
   private static String decodeSuffix(String prefix, String fullKey) {

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
@@ -514,15 +514,21 @@ public class CasBlobGc {
           if (nowMs - lastModified < minAgeMs) {
             continue;
           }
-          // Last line of defense against the mark/CAS race: a pointer CAS can re-target an OLD
-          // existing blob after this pass's one-time mark, invisible to both the mark and (if the
-          // writer left LastModified stale) the age fence. For pointer-rooted families the key
-          // encodes its owner (see Keys.ownerPointerKeyForBlob) — re-read that pointer right
-          // before the delete and keep the blob it currently references.
+          // Second fence against the mark/CAS race: a pointer CAS can re-target an OLD existing
+          // blob after this pass's one-time mark, invisible to both the mark and (if the writer
+          // left LastModified stale) the age fence. For pointer-rooted families the key encodes
+          // its owner (see Keys.ownerPointerKeyForBlob) — re-read that pointer right before the
+          // delete and keep the blob it currently references.
           if (referencedByOwnerPointer(normalized)) {
             continue;
           }
-          if (blobStore.delete(key)) {
+          // Delete exactly the version this pass age-checked: the fences above are still stale
+          // reads — a writer can re-PUT the blob and CAS its pointer between them and this delete
+          // — but that re-PUT mints a NEW version a targeted delete cannot touch, so the check and
+          // the act name the same immutable object and the pointer stays resolvable in every
+          // interleaving. An empty version id (store without versioning) degrades to the
+          // unconditional delete: on S3, fully closing the race requires bucket versioning.
+          if (blobStore.delete(key, header.getVersionId())) {
             deleted++;
           }
         }

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGcScheduler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGcScheduler.java
@@ -62,6 +62,7 @@ public class CasBlobGcScheduler {
   // climbs — the direct "GC is falling behind on this account" signal.
   private final Map<String, Long> lastCleanSweepMs = new ConcurrentHashMap<>();
   private final AtomicInteger poisonedAccountsLastTick = new AtomicInteger(0);
+  private final AtomicInteger deleteUnsupportedAccountsLastTick = new AtomicInteger(0);
   private ScheduledTaskMetrics taskMetrics;
 
   private volatile boolean stopping;
@@ -83,6 +84,12 @@ public class CasBlobGcScheduler {
         ServiceMetrics.Gc.CAS_POISONED_ACCOUNTS,
         () -> (double) poisonedAccountsLastTick.get(),
         "Accounts whose CAS GC delete phase was poisoned in the last tick",
+        Tag.of(TagKey.COMPONENT, "service"),
+        Tag.of(TagKey.OPERATION, "gc_cas"));
+    observability.gauge(
+        ServiceMetrics.Gc.CAS_DELETE_UNSUPPORTED_ACCOUNTS,
+        () -> (double) deleteUnsupportedAccountsLastTick.get(),
+        "Accounts whose CAS GC sweep was skipped: store cannot delete by immutable version",
         Tag.of(TagKey.COMPONENT, "service"),
         Tag.of(TagKey.OPERATION, "gc_cas"));
     observability.gauge(
@@ -147,6 +154,7 @@ public class CasBlobGcScheduler {
 
     long tickStart = System.nanoTime();
     int poisonedThisTick = 0;
+    int deleteUnsupportedThisTick = 0;
     try {
       List<Account> allAccounts = fetchAllAccounts(accountRepo, accountsPageSize);
 
@@ -168,7 +176,11 @@ public class CasBlobGcScheduler {
         long accountStart = System.nanoTime();
         String accountId = account.getResourceId().getId();
         var result = gc.runForAccount(accountId);
-        if (result.poisoned()) {
+        if (result.deletesUnsupported()) {
+          // Fail-closed skip (store cannot delete by immutable version): nothing was collected,
+          // so the account's backlog age must keep climbing, exactly like a poisoned sweep.
+          deleteUnsupportedThisTick++;
+        } else if (result.poisoned()) {
           poisonedThisTick++;
         } else {
           // A clean, fully-reached sweep resets this account's backlog age.
@@ -186,6 +198,7 @@ public class CasBlobGcScheduler {
       }
     } finally {
       poisonedAccountsLastTick.set(poisonedThisTick);
+      deleteUnsupportedAccountsLastTick.set(deleteUnsupportedThisTick);
       gcMetrics.recordPause(
           Duration.ofNanos(System.nanoTime() - tickStart), Tag.of(TagKey.RESULT, "tick"));
       lastTickEndMs.set(System.currentTimeMillis());

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -1517,6 +1517,118 @@ public final class Keys {
   }
 
   /**
+   * The pointer key that owns a content-addressed blob, derived from the blob key's shape, or
+   * {@code null} when no single owning pointer is derivable. Accepts keys with or without the
+   * leading slash (blob LISTs return them unslashed). Used by {@code CasBlobGc} to re-check, right
+   * before deleting a candidate, that no pointer CAS re-targeted it after the mark phase.
+   *
+   * <p>Not derivable — {@code null} — for:
+   *
+   * <ul>
+   *   <li>root manifest pages ({@code .../root/manifest/<sha>.pb}): referenced by the {@code
+   *       TableRoot} blob's content, not by any pointer;
+   *   <li>per-target stats records ({@code .../target-stats/<target>/<sha>.pb}) and file stats
+   *       ({@code .../file-stats/<path>/<sha>.pb}): their owning pointers live under {@code
+   *       .../snapshots/<snapshot_id>/stats/...} and the snapshot id is not part of the blob key.
+   * </ul>
+   */
+  public static String ownerPointerKeyForBlob(String blobKey) {
+    if (blobKey == null || blobKey.isEmpty()) {
+      return null;
+    }
+    String key = blobKey.startsWith("/") ? blobKey.substring(1) : blobKey;
+    String[] seg = key.split("/", -1);
+    if (seg.length < 4 || !"accounts".equals(seg[0])) {
+      return null;
+    }
+    try {
+      return ownerPointerKeyForSegments(seg);
+    } catch (IllegalArgumentException e) {
+      // A malformed key (blank segment, ...) has no derivable owner; the caller falls back to
+      // treating the blob as unowned, exactly as before this mapping existed.
+      return null;
+    }
+  }
+
+  private static String ownerPointerKeyForSegments(String[] seg) {
+    String account = percentDecode(seg[1]);
+    return switch (seg[2]) {
+      case "account" -> seg.length == 4 ? accountPointerById(account) : null;
+      case "catalogs" ->
+          seg.length == 6 && "catalog".equals(seg[4])
+              ? catalogPointerById(account, percentDecode(seg[3]))
+              : null;
+      case "namespaces" ->
+          seg.length == 6 && "namespace".equals(seg[4])
+              ? namespacePointerById(account, percentDecode(seg[3]))
+              : null;
+      case "views" ->
+          seg.length == 6 && "view".equals(seg[4])
+              ? viewPointerById(account, percentDecode(seg[3]))
+              : null;
+      case "connectors" ->
+          seg.length == 6 && "connector".equals(seg[4])
+              ? connectorPointerById(account, percentDecode(seg[3]))
+              : null;
+      case "tables" -> seg.length >= 6 ? tableBlobOwner(account, seg) : null;
+      default -> null;
+    };
+  }
+
+  private static String tableBlobOwner(String account, String[] seg) {
+    String table = percentDecode(seg[3]);
+    switch (seg[4]) {
+      case "table":
+        return seg.length == 6 ? tablePointerById(account, table) : null;
+      case "root":
+        // root/<sha>.pb is owned by the current-root pointer; root/manifest/<sha>.pb pages are
+        // referenced only from root blob content — no owning pointer.
+        return seg.length == 6 ? tableRootByTable(account, table) : null;
+      case "snapshots":
+        {
+          // snapshots/<snapshot_id>/snapshot/<sha>.pb
+          Long sid = seg.length == 8 && "snapshot".equals(seg[6]) ? parseSnapshotId(seg[5]) : null;
+          return sid == null ? null : snapshotPointerById(account, table, sid);
+        }
+      case "constraints":
+        {
+          // constraints/<snapshot_id>/<sha>.pb
+          Long sid = seg.length == 7 ? parseSnapshotId(seg[5]) : null;
+          return sid == null ? null : snapshotConstraintsPointer(account, table, sid);
+        }
+      case "target-stats":
+        {
+          // target-stats/<snapshot_id>/manifests/<generation>.pb -> the active-generation pointer;
+          // target-stats/<snapshot_id>/generations/<gen>/<target>/<sha>.pb -> per-record pointer;
+          // target-stats/<target>/<sha>.pb carries no snapshot id -> not derivable.
+          Long sid = parseSnapshotId(seg[5]);
+          if (sid == null) {
+            return null;
+          }
+          if (seg.length == 8 && "manifests".equals(seg[6])) {
+            return snapshotTargetStatsManifestPointer(account, table, sid);
+          }
+          if (seg.length == 10 && "generations".equals(seg[6])) {
+            return snapshotTargetStatsGenerationPointer(
+                account, table, sid, percentDecode(seg[7]), percentDecode(seg[8]));
+          }
+          return null;
+        }
+      default:
+        return null;
+    }
+  }
+
+  private static Long parseSnapshotId(String segment) {
+    try {
+      long sid = Long.parseLong(segment);
+      return sid < 0 ? null : sid;
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /**
    * Returns the last path segment of a pointer key, percent-decoded. Used as a fallback to extract
    * display_name from a by-name pointer key when the Pointer.display_name field is not set (e.g.
    * for pointers written before the topology fields were added).

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -265,12 +265,11 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
   protected void writeBlob(String blobUri, T value) {
     byte[] bytes = toBytes.apply(value);
     String want = sha256B64(bytes);
-    var before = blobStore.head(blobUri);
 
-    if (before.isPresent() && want.equals(before.get().getEtag())) {
-      return;
-    }
-
+    // Always PUT, even when an identical blob already exists. Content-addressed URIs recur
+    // (rewrites oscillate between content states), and CasBlobGc's min-age fence is anchored on
+    // LastModified: skipping the PUT would leave a re-referenced old blob "already old" and thus
+    // sweepable in a pass whose mark predates the pointer CAS (eng-floe/core#1904).
     blobStore.put(blobUri, bytes, contentType);
     var after = blobStore.head(blobUri);
 
@@ -286,10 +285,8 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
   protected void writeBlobStrictBytes(String blobUri, byte[] bytes) {
     final String want = sha256B64(bytes);
 
-    if (blobStore.head(blobUri).map(h -> want.equals(h.getEtag())).orElse(false)) {
-      return;
-    }
-
+    // No exists-with-matching-etag skip: see writeBlob — the PUT refreshes LastModified, which
+    // the CAS GC's min-age fence depends on.
     blobStore.put(blobUri, bytes, contentType);
 
     if (!blobStore.head(blobUri).map(h -> want.equals(h.getEtag())).orElse(false)) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -214,6 +214,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
 
           if (pointerStore.compareAndSetBatch(ops)) {
+            healCanonicalBlobIfMissing(blobUri, value);
             return;
           }
 
@@ -314,6 +315,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
 
           if (pointerStore.compareAndSetBatch(ops)) {
+            healCanonicalBlobIfMissing(blobUri, value);
             return true;
           }
           return classifyCreateIfAbsentConflict(
@@ -523,10 +525,33 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
 
           if (pointerStore.compareAndSetBatch(ops)) {
+            healCanonicalBlobIfMissing(blobUri, updatedValue);
             return true;
           }
           return classifyUpdateConflict(canonicalPointer, expectedCanonicalVersion, blobUri, toAdd);
         });
+  }
+
+  /**
+   * Post-commit backstop for the CAS-GC mark/CAS race (eng-floe/core#1904): if a concurrent sweep
+   * deleted the (re-referenced) canonical blob between this call's writeBlob and its pointer batch
+   * commit, re-PUT it — the writer still holds the bytes, so the residual race becomes a transient
+   * blip instead of a permanent dangling pointer, and a pre-existing dangling heals on the next
+   * write. One cheap HEAD per committed write. Best-effort: the pointers HAVE committed, so a heal
+   * failure must not fail the call; the warn is the GC-race detection signal.
+   */
+  private void healCanonicalBlobIfMissing(String blobUri, T value) {
+    try {
+      if (blobStore.head(blobUri).isPresent()) {
+        return;
+      }
+      log.warnf(
+          "canonical %s blob %s missing after pointer commit; re-writing (gc-race heal)",
+          schema.resourceName, blobUri);
+      writeBlob(blobUri, value);
+    } catch (RuntimeException e) {
+      log.errorf(e, "failed to heal canonical blob %s after pointer commit", blobUri);
+    }
   }
 
   private boolean classifyUpdateConflict(

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
@@ -312,6 +312,20 @@ public final class ServiceMetrics {
             "floecat.service.gc.cas.poisoned_accounts", MetricType.GAUGE, "", CONTRACT, "service");
 
     /**
+     * Accounts whose sweep was skipped in the last tick because the blob store cannot delete by
+     * immutable version (on S3: bucket versioning not Enabled, or s3:GetBucketVersioning denied).
+     * Fail-closed is safe but collects NOTHING — a persistently non-zero value means the bucket or
+     * IAM policy is misconfigured and garbage is accumulating.
+     */
+    public static final MetricId CAS_DELETE_UNSUPPORTED_ACCOUNTS =
+        new MetricId(
+            "floecat.service.gc.cas.delete_unsupported_accounts",
+            MetricType.GAUGE,
+            "",
+            CONTRACT,
+            "service");
+
+    /**
      * Age in milliseconds of the LEAST-recently cleanly-swept account — the direct "GC is N behind"
      * signal. It climbs when an account is poisoned or is starved by the per-tick deadline, and
      * resets as each account completes a clean sweep.

--- a/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
@@ -211,6 +211,57 @@ class CasBlobGcTest {
   }
 
   @Test
+  void aPointerRetargetedBetweenTheGcHeadAndItsDeleteIsNotSwept() {
+    // The narrower TOCTOU inside a single delete candidate: GC HEADs old blob A (stale header),
+    // the writer THEN re-PUTs A (new version, fresh LastModified) and CASes the pointer onto it,
+    // and only then does GC act. Both GC fences already ran on stale reads — the age fence on the
+    // stale header, the owner re-check on the pre-CAS pointer — so only the version-targeted
+    // delete can refuse: it names the version the pass age-checked, which the re-PUT superseded.
+    String pointerKey = Keys.tablePointerById(ACCOUNT_ID, TABLE_ID);
+    String blobA = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-a");
+    String blobB = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-b");
+    boolean[] injected = {false};
+    var racingPointers =
+        new InMemoryPointerStore() {
+          @Override
+          public java.util.Optional<Pointer> get(String key) {
+            var observed = super.get(key);
+            // The only get() of the table's by-id pointer in a pass is the pre-delete owner
+            // re-check (the mark scans by prefix), so GC has already HEAD'd blob A here. Serve
+            // the stale pointer (still on B), then land the writer's re-PUT + CAS onto A before
+            // GC reaches its delete.
+            if (!injected[0] && pointerKey.equals(key)) {
+              injected[0] = true;
+              blobs.put(blobA, "a".getBytes(StandardCharsets.UTF_8), "text/plain");
+              var current = super.get(key).orElseThrow();
+              super.compareAndSet(
+                  key,
+                  current.getVersion(),
+                  PointerReferences.blobPointer(pointerKey, blobA, current.getVersion() + 1));
+            }
+            return observed;
+          }
+        };
+    gc.pointerStore = racingPointers;
+    blobs.put(blobA, "a".getBytes(StandardCharsets.UTF_8), "text/plain");
+    blobs.put(blobB, "b".getBytes(StandardCharsets.UTF_8), "text/plain");
+    racingPointers.compareAndSet(
+        pointerKey, 0L, PointerReferences.blobPointer(pointerKey, blobB, 1L));
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(injected[0], "the between-head-and-delete re-PUT + CAS was injected");
+    assertTrue(
+        blobs.head(blobA).isPresent(),
+        "the version-targeted delete must not touch the version the writer just re-PUT");
+    assertEquals(0, result.blobsDeleted(), "nothing was deleted this pass");
+    assertEquals(
+        blobA,
+        racingPointers.get(pointerKey).orElseThrow().getBlobUri(),
+        "the pointer resolves — no dangling");
+  }
+
+  @Test
   void secondaryPointerDoesNotProtectBlob() {
     String blobUri = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-secondary");
     blobs.put(blobUri, "data".getBytes(StandardCharsets.UTF_8), "text/plain");

--- a/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
@@ -262,6 +262,51 @@ class CasBlobGcTest {
   }
 
   @Test
+  void sweepFailsClosedWhenTheStoreCannotDeleteByVersion() {
+    // Without immutable version identities (S3: bucket versioning not Enabled) every delete is
+    // the eng-floe/core#1904 race, so the pass must collect NOTHING — never fall back to
+    // unconditional deletes — and must report the skip so it is gauged, not silent.
+    var unversionedBlobs =
+        new InMemoryBlobStore() {
+          @Override
+          public boolean supportsVersionedDeletes() {
+            return false;
+          }
+        };
+    gc.blobStore = unversionedBlobs;
+    String orphan = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-orphan");
+    unversionedBlobs.put(orphan, "x".getBytes(StandardCharsets.UTF_8), "text/plain");
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(unversionedBlobs.head(orphan).isPresent(), "a fail-closed pass deletes nothing");
+    assertEquals(0, result.blobsDeleted());
+    assertTrue(result.deletesUnsupported(), "the skip surfaces for the scheduler gauge");
+  }
+
+  @Test
+  void aBlobWhoseHeaderLacksAVersionIdIsSkippedNotDeleted() {
+    // Capability says versioned deletes work, but this header carries no versionId: the pass
+    // cannot name the version it age-checked, so it must fail closed on this blob rather than
+    // fall back to an unconditional delete.
+    var versionlessHeads =
+        new InMemoryBlobStore() {
+          @Override
+          public java.util.Optional<ai.floedb.floecat.common.rpc.BlobHeader> head(String key) {
+            return super.head(key).map(h -> h.toBuilder().clearVersionId().build());
+          }
+        };
+    gc.blobStore = versionlessHeads;
+    String orphan = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-orphan");
+    versionlessHeads.put(orphan, "x".getBytes(StandardCharsets.UTF_8), "text/plain");
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(versionlessHeads.head(orphan).isPresent(), "the unnameable version is skipped");
+    assertEquals(0, result.blobsDeleted());
+  }
+
+  @Test
   void secondaryPointerDoesNotProtectBlob() {
     String blobUri = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-secondary");
     blobs.put(blobUri, "data".getBytes(StandardCharsets.UTF_8), "text/plain");

--- a/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
@@ -166,6 +166,51 @@ class CasBlobGcTest {
   }
 
   @Test
+  void aPointerRetargetedToAnOldExistingBlobMidPassIsNotSwept() {
+    // The staging data-loss interleave (eng-floe/core#1904): contents A and B both exist, the
+    // pointer is on B when the pass marks its roots, and a concurrent update CASes it back to the
+    // OLD blob A before the delete phase reaches A. The mark cannot see the CAS and A is already
+    // older than min-age, so only the pre-delete owner re-check can keep it.
+    String pointerKey = Keys.tablePointerById(ACCOUNT_ID, TABLE_ID);
+    String blobA = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-a");
+    String blobB = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-b");
+    boolean[] flipped = {false};
+    var racingBlobs =
+        new InMemoryBlobStore() {
+          @Override
+          public BlobStore.Page list(String prefix, int limit, String pageToken) {
+            // The first LIST of the delete phase runs strictly after the one-time pointer mark:
+            // flip the pointer back onto the old blob A right here, mid-pass.
+            if (!flipped[0]) {
+              flipped[0] = true;
+              var current = pointers.get(pointerKey).orElseThrow();
+              pointers.compareAndSet(
+                  pointerKey,
+                  current.getVersion(),
+                  PointerReferences.blobPointer(pointerKey, blobA, current.getVersion() + 1));
+            }
+            return super.list(prefix, limit, pageToken);
+          }
+        };
+    gc.blobStore = racingBlobs;
+    racingBlobs.put(blobA, "a".getBytes(StandardCharsets.UTF_8), "text/plain");
+    racingBlobs.put(blobB, "b".getBytes(StandardCharsets.UTF_8), "text/plain");
+    putPointer(pointerKey, blobB);
+
+    gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(flipped[0], "the mid-pass pointer CAS was injected");
+    assertTrue(
+        racingBlobs.head(blobA).isPresent(),
+        "a blob its owning pointer re-targeted mid-pass must survive the sweep");
+
+    // Next pass: the mark sees the pointer on A; B is genuinely unreferenced and is collected.
+    gc.runForAccount(ACCOUNT_ID);
+    assertTrue(racingBlobs.head(blobA).isPresent());
+    assertFalse(racingBlobs.head(blobB).isPresent());
+  }
+
+  @Test
   void secondaryPointerDoesNotProtectBlob() {
     String blobUri = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-secondary");
     blobs.put(blobUri, "data".getBytes(StandardCharsets.UTF_8), "text/plain");

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryUpdateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryUpdateTest.java
@@ -140,4 +140,36 @@ class GenericResourceRepositoryUpdateTest {
     assertThatThrownBy(() -> repo.update(account("acct-missing", "alpha", ""), 1L))
         .isInstanceOf(BaseResourceRepository.NotFoundException.class);
   }
+
+  @Test
+  void update_rewritesTheCanonicalBlobWhenGcSweptItBeforeTheCommit() {
+    // CAS-GC race backstop (eng-floe/core#1904): a concurrent sweep can delete the re-referenced,
+    // identical-content canonical blob after this update's writeBlob but before its pointer batch
+    // commits. The committed update must detect the hole and re-PUT the bytes it still holds —
+    // turning a would-be permanent dangling pointer into a transient blip.
+    boolean[] armed = {false};
+    String[] sweptBlob = {null};
+    var racingPtr =
+        new InMemoryPointerStore() {
+          @Override
+          public boolean compareAndSetBatch(
+              java.util.List<ai.floedb.floecat.storage.spi.PointerStore.CasOp> ops) {
+            if (armed[0]) {
+              armed[0] = false;
+              blobs.delete(sweptBlob[0]); // the GC sweep lands just before the commit
+            }
+            return super.compareAndSetBatch(ops);
+          }
+        };
+    var repo = new AccountRepository(racingPtr, blobs);
+    repo.create(account("acct-1", "alpha", "v1"));
+    sweptBlob[0] = racingPtr.get(Keys.accountPointerById("acct-1")).orElseThrow().getBlobUri();
+    armed[0] = true;
+
+    // Identical content: same content-addressed blob URI — the oscillating-rewrite shape.
+    assertThat(repo.update(account("acct-1", "alpha", "v1"), 1L)).isTrue();
+
+    assertThat(blobs.head(sweptBlob[0])).as("the canonical blob was healed").isPresent();
+    assertThat(repo.getById(id("acct-1"))).as("the pointer resolves — no dangling").isPresent();
+  }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
@@ -91,4 +91,65 @@ class KeysTest {
     assertEquals(null, Keys.tableIdFromSnapshotPointerKey("/accounts/a/connectors/by-id/c"));
     assertEquals(null, Keys.tableIdFromSnapshotPointerKey(null));
   }
+
+  @Test
+  void ownerPointerKeyForBlobDerivesTheOwnerForEveryPointerRootedFamily() {
+    // Ids with spaces exercise the percent-decode/re-encode round trip.
+    assertEquals(
+        Keys.accountPointerById("a c"),
+        Keys.ownerPointerKeyForBlob(Keys.accountBlobUri("a c", "sha")));
+    assertEquals(
+        Keys.catalogPointerById("a c", "cat 1"),
+        Keys.ownerPointerKeyForBlob(Keys.catalogBlobUri("a c", "cat 1", "sha")));
+    assertEquals(
+        Keys.namespacePointerById("a c", "ns 1"),
+        Keys.ownerPointerKeyForBlob(Keys.namespaceBlobUri("a c", "ns 1", "sha")));
+    assertEquals(
+        Keys.tablePointerById("a c", "tbl 1"),
+        Keys.ownerPointerKeyForBlob(Keys.tableBlobUri("a c", "tbl 1", "sha")));
+    assertEquals(
+        Keys.viewPointerById("a c", "v 1"),
+        Keys.ownerPointerKeyForBlob(Keys.viewBlobUri("a c", "v 1", "sha")));
+    assertEquals(
+        Keys.connectorPointerById("a c", "con 1"),
+        Keys.ownerPointerKeyForBlob(Keys.connectorBlobUri("a c", "con 1", "sha")));
+    assertEquals(
+        Keys.tableRootByTable("a c", "tbl 1"),
+        Keys.ownerPointerKeyForBlob(Keys.tableRootBlobUri("a c", "tbl 1", "sha")));
+    assertEquals(
+        Keys.snapshotPointerById("a c", "tbl 1", 7L),
+        Keys.ownerPointerKeyForBlob(Keys.snapshotBlobUri("a c", "tbl 1", 7L, "sha")));
+    assertEquals(
+        Keys.snapshotConstraintsPointer("a c", "tbl 1", 7L),
+        Keys.ownerPointerKeyForBlob(Keys.snapshotConstraintsBlobUri("a c", "tbl 1", 7L, "sha")));
+    assertEquals(
+        Keys.snapshotTargetStatsManifestPointer("a c", "tbl 1", 7L),
+        Keys.ownerPointerKeyForBlob(
+            Keys.snapshotTargetStatsManifestBlobUri("a c", "tbl 1", 7L, "gen 1")));
+    assertEquals(
+        Keys.snapshotTargetStatsGenerationPointer("a c", "tbl 1", 7L, "gen 1", "tgt 1"),
+        Keys.ownerPointerKeyForBlob(
+            Keys.snapshotTargetStatsBlobUri("a c", "tbl 1", 7L, "gen 1", "tgt 1", "sha")));
+    // Blob LISTs return keys without the leading slash — same derivation.
+    assertEquals(
+        Keys.tablePointerById("a c", "tbl 1"),
+        Keys.ownerPointerKeyForBlob(Keys.tableBlobUri("a c", "tbl 1", "sha").substring(1)));
+  }
+
+  @Test
+  void ownerPointerKeyForBlobIsNullWhereNoSingleOwnerIsDerivable() {
+    // Root manifest pages are referenced from TableRoot blob content, not by any pointer.
+    assertEquals(null, Keys.ownerPointerKeyForBlob(Keys.snapshotManifestBlobUri("a", "t", "sha")));
+    // Per-target stats and file-stats blobs carry no snapshot id in the key, so their owning
+    // /snapshots/<snapshot_id>/stats/... pointers cannot be derived.
+    assertEquals(
+        null, Keys.ownerPointerKeyForBlob(Keys.snapshotTargetStatsBlobUri("a", "t", "tgt", "sha")));
+    assertEquals(
+        null, Keys.ownerPointerKeyForBlob(Keys.snapshotFileStatsBlobUri("a", "t", "f", "sha")));
+    assertEquals(null, Keys.ownerPointerKeyForBlob(null));
+    assertEquals(null, Keys.ownerPointerKeyForBlob("/accounts/a"));
+    assertEquals(null, Keys.ownerPointerKeyForBlob("/other/a/tables/t/table/sha.pb"));
+    // Malformed (blank) segments degrade to "no owner", never throw.
+    assertEquals(null, Keys.ownerPointerKeyForBlob("/accounts/%20/tables/t/table/sha.pb"));
+  }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/util/BaseResourceRepositoryWriteBlobTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/util/BaseResourceRepositoryWriteBlobTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.repo.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.floedb.floecat.account.rpc.Account;
+import ai.floedb.floecat.service.repo.model.AccountKey;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.Schemas;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Re-referencing an existing content-addressed blob must refresh its LastModified — the write path
+ * always PUTs, even when an identical blob exists. CasBlobGc's min-age fence is anchored on
+ * LastModified at pass start: with a PUT-skip, a pointer CAS onto an old identical blob leaves it
+ * looking unreferenced AND old, i.e. sweepable mid-pass (eng-floe/core#1904).
+ */
+class BaseResourceRepositoryWriteBlobTest {
+
+  private static final class CountingBlobStore extends InMemoryBlobStore {
+    final Map<String, Integer> puts = new HashMap<>();
+
+    @Override
+    public void put(String uri, byte[] bytes, String contentType) {
+      puts.merge(uri, 1, Integer::sum);
+      super.put(uri, bytes, contentType);
+    }
+  }
+
+  private static GenericResourceRepository<Account, AccountKey> repo(CountingBlobStore blobs) {
+    return new GenericResourceRepository<>(
+        new InMemoryPointerStore(),
+        blobs,
+        Schemas.ACCOUNT,
+        Account::parseFrom,
+        Account::toByteArray,
+        "application/x-protobuf");
+  }
+
+  @Test
+  void putBlobRePutsWhenAnIdenticalBlobAlreadyExists() {
+    var blobs = new CountingBlobStore();
+    var repo = repo(blobs);
+    var value = Account.newBuilder().setDisplayName("alpha").build();
+    String uri = Keys.accountBlobUri("acct-1", "sha-1");
+
+    repo.putBlob(uri, value);
+    repo.putBlob(uri, value);
+
+    assertEquals(2, blobs.puts.get(uri), "an identical re-write must still PUT");
+  }
+
+  @Test
+  void putBlobStrictBytesRePutsWhenAnIdenticalBlobAlreadyExists() {
+    var blobs = new CountingBlobStore();
+    var repo = repo(blobs);
+    byte[] bytes = "same".getBytes(StandardCharsets.UTF_8);
+    String uri = Keys.accountBlobUri("acct-1", "sha-2");
+
+    repo.putBlobStrictBytes(uri, bytes);
+    repo.putBlobStrictBytes(uri, bytes);
+
+    assertEquals(2, blobs.puts.get(uri), "an identical strict re-write must still PUT");
+  }
+}

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/s3/S3BlobStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/s3/S3BlobStore.java
@@ -37,11 +37,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.BucketVersioningStatus;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketVersioningRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
@@ -54,11 +57,17 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 @Singleton
 @IfBuildProperty(name = "floecat.blob", stringValue = "s3")
 public class S3BlobStore implements BlobStore {
+  private static final Logger LOG = Logger.getLogger(S3BlobStore.class);
   private static final String META_SHA256 = "floecat-sha256";
   private static final String META_CREATED_AT = "floecat-created-at";
+  private static final long VERSIONING_STATUS_TTL_NANOS = java.time.Duration.ofMinutes(5).toNanos();
 
   private final S3Caller s3;
   private final String bucket;
+  // Cached GetBucketVersioning outcome (a bucket's status changes rarely); refreshed on TTL
+  // expiry. A lookup failure is cached as false — fail closed — and retried after the TTL.
+  private volatile Boolean versionedDeletesSupported;
+  private volatile long versionedDeletesCheckedAtNanos;
 
   @Inject
   public S3BlobStore(
@@ -278,11 +287,55 @@ public class S3BlobStore implements BlobStore {
     }
   }
 
+  /**
+   * Version-targeted deletes are safe only while the bucket's versioning status is {@code Enabled}:
+   * every PUT then mints a fresh immutable versionId (pre-versioning objects keep their literal
+   * {@code "null"} id as a noncurrent version, so even those are targetable). Unversioned AND
+   * suspended buckets overwrite the {@code "null"} version in place, which reintroduces the
+   * delete-after-re-reference race — so both report unsupported and the CAS GC fails closed.
+   */
+  @Override
+  public boolean supportsVersionedDeletes() {
+    Boolean cached = versionedDeletesSupported;
+    if (cached != null
+        && System.nanoTime() - versionedDeletesCheckedAtNanos < VERSIONING_STATUS_TTL_NANOS) {
+      return cached;
+    }
+    boolean enabled;
+    try {
+      var status =
+          s3.call(
+                  c ->
+                      c.getBucketVersioning(
+                          GetBucketVersioningRequest.builder().bucket(bucket).build()))
+              .status();
+      enabled = BucketVersioningStatus.ENABLED.equals(status);
+      if (!enabled) {
+        LOG.warnf(
+            "bucket %s versioning status is %s; version-targeted deletes disabled (fail closed)",
+            bucket, status == null ? "not enabled" : status);
+      }
+    } catch (RuntimeException e) {
+      // Without s3:GetBucketVersioning we cannot prove version identities are immutable: fail
+      // closed, and retry after the TTL so a fixed policy recovers without a restart.
+      LOG.warnf(
+          e,
+          "could not read bucket %s versioning status; version-targeted deletes disabled"
+              + " (fail closed)",
+          bucket);
+      enabled = false;
+    }
+    versionedDeletesSupported = enabled;
+    versionedDeletesCheckedAtNanos = System.nanoTime();
+    return enabled;
+  }
+
   @Override
   public boolean delete(String key, String versionId) {
     if (versionId == null || versionId.isBlank()) {
-      // No version observed (unversioned bucket): degrade to the unconditional delete.
-      return delete(key);
+      // Never degrade to the unconditional delete — that silently reintroduces the
+      // delete-after-re-reference race. A blank version is a caller bug.
+      throw new IllegalArgumentException("versioned delete requires a versionId: " + key);
     }
     final String k = normalize(key);
     try {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/s3/S3BlobStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/s3/S3BlobStore.java
@@ -122,7 +122,10 @@ public class S3BlobStore implements BlobStore {
               .setEtag(metaSha == null ? "" : metaSha)
               .setCreatedAt(com.google.protobuf.util.Timestamps.fromMillis(createdAtMs))
               .setLastModifiedAt(com.google.protobuf.util.Timestamps.fromMillis(lastModifiedMs))
-              .setContentLength((int) Math.min(Integer.MAX_VALUE, storedBytes));
+              .setContentLength((int) Math.min(Integer.MAX_VALUE, storedBytes))
+              // Null on unversioned buckets; the literal "null" versionId of objects written
+              // before versioning was enabled is a real, targetable version and passes through.
+              .setVersionId(r.versionId() == null ? "" : r.versionId());
 
       return Optional.of(hb.build());
     } catch (S3Exception e) {
@@ -272,6 +275,39 @@ public class S3BlobStore implements BlobStore {
       throw new StorageAbortRetryableException(msg("DELETE", k, e.getMessage()));
     } catch (RuntimeException e) {
       throw mapClosedPoolOrRethrow("DELETE", k, e);
+    }
+  }
+
+  @Override
+  public boolean delete(String key, String versionId) {
+    if (versionId == null || versionId.isBlank()) {
+      // No version observed (unversioned bucket): degrade to the unconditional delete.
+      return delete(key);
+    }
+    final String k = normalize(key);
+    try {
+      // Version-targeted DeleteObject: a HARD delete of exactly this version (no delete marker).
+      // A version PUT concurrently after the caller's HEAD is untouched and stays current.
+      // (SDK 2.44.4 also models If-Match conditional deletes, but S3 supports those only on
+      // directory buckets, so versionId targeting is the mechanism here.)
+      s3.call(
+          c ->
+              c.deleteObject(
+                  DeleteObjectRequest.builder()
+                      .bucket(bucket)
+                      .key(k)
+                      .versionId(versionId)
+                      .build()));
+      return true;
+    } catch (S3Exception e) {
+      if (e.statusCode() == 404) {
+        return true;
+      }
+      throw mapAndWrap("DELETE_VERSION", k, e);
+    } catch (SdkClientException e) {
+      throw new StorageAbortRetryableException(msg("DELETE_VERSION", k, e.getMessage()));
+    } catch (RuntimeException e) {
+      throw mapClosedPoolOrRethrow("DELETE_VERSION", k, e);
     }
   }
 

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/s3/S3BlobStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/s3/S3BlobStoreTest.java
@@ -17,7 +17,7 @@
 package ai.floedb.floecat.storage.aws.s3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,8 +29,11 @@ import java.util.Optional;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.BucketVersioningStatus;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.GetBucketVersioningRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketVersioningResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
@@ -93,7 +96,7 @@ class S3BlobStoreTest {
   }
 
   @Test
-  void blankVersionDegradesToUnconditionalDelete() {
+  void aBlankVersionIdIsRejectedNotDegradedToUnconditional() {
     List<DeleteObjectRequest> captured = new ArrayList<>();
     var client =
         new FakeS3Client() {
@@ -105,10 +108,69 @@ class S3BlobStoreTest {
         };
     S3BlobStore store = new S3BlobStore(client, Optional.of("bucket"));
 
-    assertTrue(store.delete("/k", ""));
+    assertThrows(IllegalArgumentException.class, () -> store.delete("/k", ""));
+    assertEquals(0, captured.size(), "no delete request was sent");
+  }
 
-    assertEquals(1, captured.size());
-    assertNull(captured.get(0).versionId(), "no version targeting on an unversioned observation");
+  @Test
+  void versionedDeletesAreSupportedOnlyWhileBucketVersioningIsEnabled() {
+    assertTrue(versioningStore(BucketVersioningStatus.ENABLED).supportsVersionedDeletes());
+    // Suspended buckets overwrite the "null" version in place — a targeted delete of it could
+    // destroy a concurrent re-write, so it must report unsupported (fail closed).
+    assertFalse(versioningStore(BucketVersioningStatus.SUSPENDED).supportsVersionedDeletes());
+    assertFalse(versioningStore(null).supportsVersionedDeletes());
+  }
+
+  @Test
+  void versioningStatusLookupFailureFailsClosed() {
+    var client =
+        new FakeS3Client() {
+          @Override
+          public GetBucketVersioningResponse getBucketVersioning(
+              GetBucketVersioningRequest request) {
+            throw new IllegalStateException("s3:GetBucketVersioning denied");
+          }
+        };
+    S3BlobStore store = new S3BlobStore(client, Optional.of("bucket"));
+
+    assertFalse(store.supportsVersionedDeletes());
+  }
+
+  @Test
+  void versioningStatusIsCachedAcrossCalls() {
+    int[] calls = {0};
+    var client =
+        new FakeS3Client() {
+          @Override
+          public GetBucketVersioningResponse getBucketVersioning(
+              GetBucketVersioningRequest request) {
+            calls[0]++;
+            return GetBucketVersioningResponse.builder()
+                .status(BucketVersioningStatus.ENABLED)
+                .build();
+          }
+        };
+    S3BlobStore store = new S3BlobStore(client, Optional.of("bucket"));
+
+    assertTrue(store.supportsVersionedDeletes());
+    assertTrue(store.supportsVersionedDeletes());
+    assertEquals(1, calls[0], "the versioning status is cached, not re-fetched per call");
+  }
+
+  private static S3BlobStore versioningStore(BucketVersioningStatus status) {
+    var client =
+        new FakeS3Client() {
+          @Override
+          public GetBucketVersioningResponse getBucketVersioning(
+              GetBucketVersioningRequest request) {
+            var b = GetBucketVersioningResponse.builder();
+            if (status != null) {
+              b.status(status);
+            }
+            return b.build();
+          }
+        };
+    return new S3BlobStore(client, Optional.of("bucket"));
   }
 
   @Test

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/s3/S3BlobStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/s3/S3BlobStoreTest.java
@@ -16,15 +16,118 @@
 
 package ai.floedb.floecat.storage.aws.s3;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 class S3BlobStoreTest {
+
+  @Test
+  void headExposesTheS3VersionId() {
+    var client =
+        new FakeS3Client() {
+          @Override
+          public HeadObjectResponse headObject(HeadObjectRequest request) {
+            return HeadObjectResponse.builder()
+                .versionId("v9")
+                .contentLength(3L)
+                .lastModified(Instant.EPOCH)
+                .build();
+          }
+        };
+    S3BlobStore store = new S3BlobStore(client, Optional.of("bucket"));
+
+    assertEquals("v9", store.head("/k").orElseThrow().getVersionId());
+  }
+
+  @Test
+  void headMapsAMissingVersionIdToEmpty() {
+    var client =
+        new FakeS3Client() {
+          @Override
+          public HeadObjectResponse headObject(HeadObjectRequest request) {
+            // Unversioned bucket: S3 returns no versionId.
+            return HeadObjectResponse.builder()
+                .contentLength(3L)
+                .lastModified(Instant.EPOCH)
+                .build();
+          }
+        };
+    S3BlobStore store = new S3BlobStore(client, Optional.of("bucket"));
+
+    assertEquals("", store.head("/k").orElseThrow().getVersionId());
+  }
+
+  @Test
+  void versionTargetedDeleteNamesExactlyTheObservedVersion() {
+    List<DeleteObjectRequest> captured = new ArrayList<>();
+    var client =
+        new FakeS3Client() {
+          @Override
+          public DeleteObjectResponse deleteObject(DeleteObjectRequest request) {
+            captured.add(request);
+            return DeleteObjectResponse.builder().build();
+          }
+        };
+    S3BlobStore store = new S3BlobStore(client, Optional.of("bucket"));
+
+    assertTrue(store.delete("/k", "v123"));
+
+    assertEquals(1, captured.size());
+    assertEquals("k", captured.get(0).key());
+    assertEquals("v123", captured.get(0).versionId());
+  }
+
+  @Test
+  void blankVersionDegradesToUnconditionalDelete() {
+    List<DeleteObjectRequest> captured = new ArrayList<>();
+    var client =
+        new FakeS3Client() {
+          @Override
+          public DeleteObjectResponse deleteObject(DeleteObjectRequest request) {
+            captured.add(request);
+            return DeleteObjectResponse.builder().build();
+          }
+        };
+    S3BlobStore store = new S3BlobStore(client, Optional.of("bucket"));
+
+    assertTrue(store.delete("/k", ""));
+
+    assertEquals(1, captured.size());
+    assertNull(captured.get(0).versionId(), "no version targeting on an unversioned observation");
+  }
+
+  @Test
+  void mapsRuntimeClosedPoolFailureToRetryableForVersionDelete() {
+    S3BlobStore store = closedPoolStore();
+
+    assertThrows(StorageAbortRetryableException.class, () -> store.delete("key", "v1"));
+  }
+
+  /** All S3Client operations are codegen defaults throwing UnsupportedOperationException. */
+  private abstract static class FakeS3Client implements S3Client {
+    @Override
+    public String serviceName() {
+      return "s3";
+    }
+
+    @Override
+    public void close() {}
+  }
 
   @Test
   void mapsRuntimeClosedPoolFailureToRetryableForHead() {

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryBlobStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryBlobStore.java
@@ -43,8 +43,10 @@ public class InMemoryBlobStore implements BlobStore {
   private static final class Blob {
     final byte[] data;
     final BlobHeader hdr;
-    // Per-key monotonic write counter emulating S3 object versions (exposed as
-    // BlobHeader.versionId) so version-targeted delete semantics are deterministically testable.
+    // Write counter emulating S3 object versions (exposed as BlobHeader.versionId) so
+    // version-targeted delete semantics are deterministically testable. Ids are STORE-wide unique
+    // and never reused, so a delete-and-recreate of a key cannot resurrect an old id (the ABA a
+    // stale versioned delete would otherwise exploit).
     final long version;
 
     Blob(byte[] d, BlobHeader h, long version) {
@@ -55,6 +57,14 @@ public class InMemoryBlobStore implements BlobStore {
   }
 
   private final Map<String, Blob> map = new ConcurrentHashMap<>();
+  private final java.util.concurrent.atomic.AtomicLong versionCounter =
+      new java.util.concurrent.atomic.AtomicLong();
+
+  /** Models an S3 bucket with versioning Enabled: ids are immutable, unique, never reused. */
+  @Override
+  public boolean supportsVersionedDeletes() {
+    return true;
+  }
 
   @Override
   public void put(String uri, byte[] bytes, String contentType) {
@@ -74,7 +84,7 @@ public class InMemoryBlobStore implements BlobStore {
           final BlobHeader prevHdr = prev == null ? null : prev.hdr;
           final Timestamp createdAt =
               prevHdr == null ? Timestamps.fromMillis(now) : prevHdr.getCreatedAt();
-          final long version = prev == null ? 1L : prev.version + 1;
+          final long version = versionCounter.incrementAndGet();
 
           BlobHeader.Builder hb =
               BlobHeader.newBuilder()
@@ -116,7 +126,8 @@ public class InMemoryBlobStore implements BlobStore {
   @Override
   public boolean delete(String uri, String versionId) {
     if (versionId == null || versionId.isBlank()) {
-      return delete(uri);
+      // Match the S3 store: never degrade to the unconditional delete.
+      throw new IllegalArgumentException("versioned delete requires a versionId: " + uri);
     }
     final String k = normalize(uri);
     boolean[] removed = {false};

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryBlobStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryBlobStore.java
@@ -43,10 +43,14 @@ public class InMemoryBlobStore implements BlobStore {
   private static final class Blob {
     final byte[] data;
     final BlobHeader hdr;
+    // Per-key monotonic write counter emulating S3 object versions (exposed as
+    // BlobHeader.versionId) so version-targeted delete semantics are deterministically testable.
+    final long version;
 
-    Blob(byte[] d, BlobHeader h) {
+    Blob(byte[] d, BlobHeader h, long version) {
       this.data = d;
       this.hdr = h;
+      this.version = version;
     }
   }
 
@@ -70,6 +74,7 @@ public class InMemoryBlobStore implements BlobStore {
           final BlobHeader prevHdr = prev == null ? null : prev.hdr;
           final Timestamp createdAt =
               prevHdr == null ? Timestamps.fromMillis(now) : prevHdr.getCreatedAt();
+          final long version = prev == null ? 1L : prev.version + 1;
 
           BlobHeader.Builder hb =
               BlobHeader.newBuilder()
@@ -77,11 +82,12 @@ public class InMemoryBlobStore implements BlobStore {
                   .setEtag(etag)
                   .setCreatedAt(createdAt)
                   .setContentLength(copy.length)
-                  .setLastModifiedAt(Timestamps.fromMillis(now));
+                  .setLastModifiedAt(Timestamps.fromMillis(now))
+                  .setVersionId(Long.toString(version));
 
           addTag(hb, TAG_CONTENT_TYPE, ct);
 
-          return new Blob(copy, hb.build());
+          return new Blob(copy, hb.build(), version);
         });
   }
 
@@ -105,6 +111,27 @@ public class InMemoryBlobStore implements BlobStore {
   public boolean delete(String uri) {
     uri = normalize(uri);
     return map.remove(uri) != null;
+  }
+
+  @Override
+  public boolean delete(String uri, String versionId) {
+    if (versionId == null || versionId.isBlank()) {
+      return delete(uri);
+    }
+    final String k = normalize(uri);
+    boolean[] removed = {false};
+    map.computeIfPresent(
+        k,
+        (key, blob) -> {
+          // Only the named version dies; a write that landed after the caller's head() minted a
+          // higher version and must survive — mirroring an S3 version-targeted DeleteObject.
+          if (Long.toString(blob.version).equals(versionId)) {
+            removed[0] = true;
+            return null;
+          }
+          return blob;
+        });
+    return removed[0];
   }
 
   @Override

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/memory/InMemoryBlobStoreVersioningTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/memory/InMemoryBlobStoreVersioningTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.storage.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Version emulation contract: every put mints a new per-key monotonic version (exposed as {@code
+ * BlobHeader.versionId}) and a version-targeted delete touches ONLY the named version — mirroring
+ * an S3 versioned bucket, so the CAS-GC check-then-delete race is deterministically testable.
+ */
+class InMemoryBlobStoreVersioningTest {
+
+  private static final byte[] BYTES = "same".getBytes(StandardCharsets.UTF_8);
+
+  @Test
+  void everyPutMintsAMonotonicVersionEvenForIdenticalContent() {
+    var store = new InMemoryBlobStore();
+    store.put("/k", BYTES, "text/plain");
+    assertEquals("1", store.head("/k").orElseThrow().getVersionId());
+
+    store.put("/k", BYTES, "text/plain");
+    assertEquals("2", store.head("/k").orElseThrow().getVersionId());
+  }
+
+  @Test
+  void versionTargetedDeleteRefusesASupersededVersion() {
+    var store = new InMemoryBlobStore();
+    store.put("/k", BYTES, "text/plain");
+    String observed = store.head("/k").orElseThrow().getVersionId();
+    store.put("/k", BYTES, "text/plain"); // concurrent re-write after the observation
+
+    assertFalse(store.delete("/k", observed), "a superseded version must not be deletable");
+    assertTrue(store.head("/k").isPresent(), "the newer version survives");
+
+    assertTrue(store.delete("/k", store.head("/k").orElseThrow().getVersionId()));
+    assertTrue(store.head("/k").isEmpty());
+  }
+
+  @Test
+  void blankVersionDegradesToUnconditionalDelete() {
+    var store = new InMemoryBlobStore();
+    store.put("/k", BYTES, "text/plain");
+
+    assertTrue(store.delete("/k", ""));
+    assertTrue(store.head("/k").isEmpty());
+  }
+}

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/memory/InMemoryBlobStoreVersioningTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/memory/InMemoryBlobStoreVersioningTest.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.storage.memory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -57,11 +58,31 @@ class InMemoryBlobStoreVersioningTest {
   }
 
   @Test
-  void blankVersionDegradesToUnconditionalDelete() {
+  void aStaleVersionIdCannotDeleteARecreatedBlob() {
+    // Version ids are store-wide unique and never reused: a delete-and-recreate of the same key
+    // must not resurrect an old id, or a stale versioned delete (the GC's) would remove the
+    // recreation — the ABA shape of the eng-floe/core#1904 race.
+    var store = new InMemoryBlobStore();
+    store.put("/k", BYTES, "text/plain");
+    String observed = store.head("/k").orElseThrow().getVersionId();
+    assertTrue(store.delete("/k"));
+    store.put("/k", BYTES, "text/plain");
+
+    assertFalse(store.delete("/k", observed), "a pre-delete version id must not match again");
+    assertTrue(store.head("/k").isPresent(), "the recreated blob survives the stale delete");
+  }
+
+  @Test
+  void modelsAVersioningEnabledBucket() {
+    assertTrue(new InMemoryBlobStore().supportsVersionedDeletes());
+  }
+
+  @Test
+  void aBlankVersionIdIsRejectedNotDegradedToUnconditional() {
     var store = new InMemoryBlobStore();
     store.put("/k", BYTES, "text/plain");
 
-    assertTrue(store.delete("/k", ""));
-    assertTrue(store.head("/k").isEmpty());
+    assertThrows(IllegalArgumentException.class, () -> store.delete("/k", ""));
+    assertTrue(store.head("/k").isPresent(), "nothing was deleted");
   }
 }


### PR DESCRIPTION
Implements both recommendations from eng-floe/core#1904 (CasBlobGc deleted live table blobs on staging, leaving permanently dangling pointers).

## The race

Table protos are content-addressed (`tables/<id>/table/<sha256>.pb`) and reconcile rewrites oscillate between recurring content states, so the same sha recurs. Three behaviors interacted:

1. `BaseResourceRepository.writeBlob`/`writeBlobStrictBytes` **skipped the S3 PUT** when the blob already existed with a matching etag — re-referencing an old blob never refreshed its `LastModified`.
2. `CasBlobGc.runForAccount` marks pointer roots **once per pass**, then sweeps unreferenced blobs whose age exceeds min-age anchored at pass start (`nowMs` frozen).
3. A pointer CAS that re-targets an old existing blob mid-pass (PUT skipped, `LastModified` stale) is invisible to both the mark and the age fence → live blob deleted → dangling pointer, unrecoverable once the sweep also collects the previously-live blob.

## Fix 1 — always PUT (`service/repo`)

`writeBlob` and `writeBlobStrictBytes` now PUT unconditionally; the post-write etag verification is unchanged. Combined with the existing pass-start-anchored fence this is provably safe: any blob re-referenced during a pass gets `LastModified > nowMs`, so `nowMs - lastModified < minAgeMs` always skips it that pass.

Chosen over a "touch on skip" (self-CopyObject with metadata replace) because the `BlobStore` SPI has no copy/touch primitive — adding one means new SPI surface plus a per-backend implementation, while the PUT path already exists on every backend and these are small metadata protos, so the cost is one small PUT per oscillating rewrite.

## Fix 2 — re-check the owning pointer before each delete (`service/gc`)

For pointer-rooted blob families the key encodes its owner. New `Keys.ownerPointerKeyForBlob` derives the owning pointer key from the blob key shape; `CasBlobGc.deleteUnreferenced` re-reads that pointer immediately before each delete and skips the blob it currently references. One extra pointer read per delete *candidate* only, and it shrinks the exposure window to milliseconds independently of fix 1 (belt and suspenders — either fix alone closes the observed race).

Derivable owners: account, catalog, namespace, table, view, connector, table-root (`root/current`), snapshot (by-id), constraints (by-snapshot), target-stats generation manifests (`targets-active`) and per-generation records.

Not derivable (documented on `ownerPointerKeyForBlob`, protected by fix 1 plus the existing chain-walk rooting/poisoning):
- root manifest pages (`.../root/manifest/<sha>.pb`) — referenced from `TableRoot` blob content, not by any pointer;
- per-target stats (`.../target-stats/<target>/<sha>.pb`) and file stats (`.../file-stats/<path>/<sha>.pb`) — their owning pointers live under `.../snapshots/<snapshot_id>/stats/...` and the snapshot id is not part of the blob key.

## Fix 3 — version-targeted delete + writer-side heal (`storage`, `service`)

Review found a residual TOCTOU inside a single delete candidate: both fences above are stale reads, so a writer landing a re-PUT + pointer CAS inside the GC's per-key HEAD→delete gap could still lose the blob. Closed by making the check and the act name the same immutable object:

- `BlobHeader` now carries the S3 object `versionId` observed at HEAD, and `CasBlobGc` deletes exactly that version via the new `BlobStore.delete(uri, versionId)`. A concurrent re-PUT mints a NEW version the targeted delete cannot touch, so the pointer stays resolvable in every interleaving. `InMemoryBlobStore` emulates an Enabled versioned bucket with store-wide unique, never-reused version ids (so delete-and-recreate cannot ABA a stale versioned delete).
- **Fail closed, never fall back.** GC deletes are gated on `BlobStore.supportsVersionedDeletes()`: when the store cannot guarantee immutable version identities, the pass collects NOTHING, warns once, and reports `deletesUnsupported` — surfaced by a new scheduler gauge (`floecat.service.gc.cas.delete_unsupported_accounts`) and by the account's backlog age, which keeps climbing. There is no unconditional-delete fallback anywhere in the GC path (a blank versionId on a capable store is also skipped, and `delete(uri, versionId)` rejects blank ids outright).
- On S3 the capability check is `GetBucketVersioning == Enabled`, cached with a 5-minute TTL (failures are cached as unsupported and retried after the TTL). **Suspended is unsafe too**, not just unversioned: a suspended bucket overwrites the `"null"` version in place, so even a nominally targeted delete could destroy a concurrent re-write. In an Enabled bucket a pre-versioning object's literal `"null"` versionId IS safe to target — the gate is on the bucket status, not the id's shape.
- **Deployment note:** the floecat runtime role needs `s3:GetBucketVersioning` on the blob bucket, and the bucket's versioning must be Enabled — otherwise GC fails closed forever (safe, but collects nothing; watch the new gauge). `docker/localstack-init.sh` now enables versioning on the dev/CI bucket so the safe delete path is actually exercised.
- SDK 2.44.4 does model conditional deletes (`ifMatch`/`ifMatchLastModifiedTime`/`ifMatchSize` on `DeleteObjectRequest`), but S3 supports those headers only on directory buckets — and `ifMatch` would not help anyway (the etag is the content sha, identical across the re-PUT). versionId targeting is the mechanism.
- **Behavior flag:** version-targeted deletes are HARD deletes (no delete marker), unlike the previous marker-stacking delete. Intended — real space reclaim — but it removes the accidental restore-from-marker net used during the incident remediation.
- **Writer-side backstop:** after a committed create/createIfAbsent/update pointer batch, `GenericResourceRepository` HEADs the canonical blob and re-PUTs it if missing (the writer still holds the bytes), logging a warn (the GC-race detection signal). Any residual hole becomes a transient blip, and a pre-existing dangling heals on the next write. One cheap HEAD per committed write. (It is a backstop only — it cannot replace the versioned delete, since a stale GC delete can land after the heal's HEAD.)

## Tests

- `CasBlobGcTest.aPointerRetargetedToAnOldExistingBlobMidPassIsNotSwept` — reproduces the staging interleave: pointer on B at mark time, CAS back to old blob A injected mid-pass (from the sweep's first blob LIST), min-age fence already passed for A. Fails without fix 2, passes with it; also asserts the next pass keeps A and collects B.
- `CasBlobGcTest.aPointerRetargetedBetweenTheGcHeadAndItsDeleteIsNotSwept` — the reviewer's narrower ordering: re-PUT + CAS injected between the GC's HEAD and its delete; only the version-targeted delete can refuse (verified to fail against an unconditional delete).
- `GenericResourceRepositoryUpdateTest.update_rewritesTheCanonicalBlobWhenGcSweptItBeforeTheCommit` — the writer-side heal re-PUTs a canonical blob swept between writeBlob and the pointer commit.
- `CasBlobGcTest.sweepFailsClosedWhenTheStoreCannotDeleteByVersion` / `aBlobWhoseHeaderLacksAVersionIdIsSkippedNotDeleted` — the fail-closed paths: capability off → nothing collected and the skip is reported; unnameable version → per-blob skip.
- `InMemoryBlobStoreVersioningTest` — monotonic versionId per put; a superseded version is not deletable; a stale pre-delete id cannot delete a recreated blob (ABA); blank version rejected; models Enabled.
- `S3BlobStoreTest` — head exposes/omits versionId; version-targeted delete names exactly the observed version; blank version rejected (no request sent); versioning gate Enabled/Suspended/none; lookup failure fails closed; status cached; closed-pool mapping for the new op.
- `BaseResourceRepositoryWriteBlobTest` — `putBlob`/`putBlobStrictBytes` must re-PUT when an identical blob already exists (pins fix 1 independently).
- `KeysTest.ownerPointerKeyForBlob*` — owner derivation for every pointer-rooted family (including percent-encoding round trip and unslashed LIST keys) and null for every non-derivable/malformed shape.

`mvn -pl core/storage-spi,storage/memory,storage/aws,service -am test`: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
