### PR TITLE
gc: harden CAS sweep against the wider reachability-gap class 

### DIFF
--- a/docker/localstack-init.sh
+++ b/docker/localstack-init.sh
@@ -10,6 +10,14 @@ awslocal s3api create-bucket --bucket "${BUCKET}" --region "${REGION}" >/dev/nul
 # version-targeted deletes are what let a delete race a concurrent re-reference safely.
 awslocal s3api put-bucket-versioning --bucket "${BUCKET}" \
   --versioning-configuration Status=Enabled >/dev/null 2>&1 || true
+# Every content-addressed re-reference is deliberately a fresh PUT so a concurrent CAS GC cannot
+# delete it. Versioning turns those PUTs into noncurrent versions; expire old history so hot keys do
+# not grow without bound. Keep a small, time-bounded recovery window, matching the production
+# prerequisite documented in docs/storage-aws.md.
+awslocal s3api put-bucket-lifecycle-configuration --bucket "${BUCKET}" \
+  --lifecycle-configuration \
+  '{"Rules":[{"ID":"floecat-expire-noncurrent-cas-versions","Status":"Enabled","Filter":{"Prefix":""},"NoncurrentVersionExpiration":{"NoncurrentDays":30,"NewerNoncurrentVersions":3}}]}' \
+  >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "bucket" --region "${REGION}" >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "warehouse" --region "${REGION}" >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "yb-iceberg-tpcds" --region "${REGION}" >/dev/null 2>&1 || true

--- a/docs/storage-aws.md
+++ b/docs/storage-aws.md
@@ -59,6 +59,64 @@ Extensibility:
 - Wrap additional S3 options (encryption, storage classes) inside `S3BlobStore` by extending metadata
   tags.
 
+### Required S3 versioning and lifecycle policy
+
+An S3-backed deployment **must** provision both of the following on the bucket configured by
+`floecat.blob.s3.bucket`:
+
+1. Bucket versioning with status `Enabled`. CAS blob GC fails closed when versioning is disabled or
+   suspended because it cannot safely race a blob re-reference without immutable version IDs. The
+   service role needs `s3:GetBucketVersioning` to verify this prerequisite, and — because CAS GC
+   deletes a specific version id (`DeleteObject` with `versionId`), not the current version —
+   `s3:DeleteObjectVersion`. Plain `s3:DeleteObject` is insufficient: without
+   `s3:DeleteObjectVersion` every version-targeted GC delete fails with `AccessDenied` and aborts
+   the tick.
+2. A `NoncurrentVersionExpiration` lifecycle rule. Repository writes deliberately PUT recurring
+   content-addressed keys again on every re-reference. Each PUT refreshes the current version for GC
+   safety and makes the previous version noncurrent. CAS GC only lists and deletes current versions;
+   without a bucket lifecycle rule, noncurrent versions of hot keys accumulate indefinitely. See
+   [Deleting object versions from a versioning-enabled bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html)
+   for AWS's lifecycle and billing behavior.
+
+Choose the expiration window and retained-version count to match the deployment's recovery policy.
+For example, the following rule keeps at least three newer noncurrent versions and does not expire a
+noncurrent version until it has been noncurrent for 30 days:
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "floecat-expire-noncurrent-cas-versions",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "" },
+      "NoncurrentVersionExpiration": {
+        "NoncurrentDays": 30,
+        "NewerNoncurrentVersions": 3
+      }
+    }
+  ]
+}
+```
+
+Apply the rule through the deployment's bucket IaC. For a newly provisioned bucket, the equivalent
+AWS CLI operations are:
+
+```bash
+aws s3api put-bucket-versioning \
+  --bucket "$FLOECAT_BLOB_S3_BUCKET" \
+  --versioning-configuration Status=Enabled
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket "$FLOECAT_BLOB_S3_BUCKET" \
+  --lifecycle-configuration file://floecat-blob-lifecycle.json
+```
+
+`put-bucket-lifecycle-configuration` replaces the bucket's complete lifecycle configuration. When a
+bucket already has lifecycle rules, merge the Floecat rule into the existing `Rules` array instead of
+overwriting it. The provisioning identity needs `s3:PutLifecycleConfiguration`; the Floecat runtime
+identity does not. Expiration permanently removes noncurrent versions, so shortening the example
+window trades recovery history for lower storage cost. The bundled LocalStack initializer provisions
+this example policy automatically.
+
 ## Examples & Scenarios
 - **Production deployment** – Set `floecat.kv=dynamodb`, `floecat.blob=s3`, supply the DynamoDB table
   name and S3 bucket. On startup, `AwsClients` initialises AWS SDK clients and repositories begin

--- a/docs/telemetry/contract.json
+++ b/docs/telemetry/contract.json
@@ -460,6 +460,16 @@
     "allowedTags": ["component", "operation", "reason", "resource", "status"]
   },
   {
+    "name": "floecat.service.gc.cas.delete_unsupported_accounts",
+    "type": "GAUGE",
+    "unit": "",
+    "since": "v1",
+    "origin": "service",
+    "description": "Accounts whose CAS GC sweep was skipped because immutable version deletes are unsupported.",
+    "requiredTags": ["component", "operation"],
+    "allowedTags": ["component", "operation"]
+  },
+  {
     "name": "floecat.service.gc.cas.oldest_sweep_age",
     "type": "GAUGE",
     "unit": "ms",
@@ -868,6 +878,16 @@
     "description": "Stats engine batch capture calls.",
     "requiredTags": ["component", "operation"],
     "allowedTags": ["component", "mode", "operation", "reason", "resource", "result", "scope", "trigger"]
+  },
+  {
+    "name": "floecat.service.stats.planner_lookup_outcomes.total",
+    "type": "COUNTER",
+    "unit": "",
+    "since": "v1",
+    "origin": "service",
+    "description": "Planner stats lookup outcomes by the ladder rung that served or failed each target.",
+    "requiredTags": ["component", "operation", "result"],
+    "allowedTags": ["component", "operation", "result"]
   },
   {
     "name": "floecat.service.stats.store_hits.total",

--- a/docs/telemetry/contract.md
+++ b/docs/telemetry/contract.md
@@ -68,6 +68,7 @@ This lists all metrics currently available in the repository:
 | floecat.service.flight.inflight | GAUGE |  | v1 | Current number of in-flight Flight streams. | component, operation | component, operation, resource |
 | floecat.service.flight.latency | TIMER | ms | v1 | Flight request latency by operation, table, and terminal status. | component, operation, status | component, operation, reason, resource, status |
 | floecat.service.flight.requests.total | COUNTER |  | v1 | Total Flight requests by operation, table, and terminal status. | component, operation, status | component, operation, reason, resource, status |
+| floecat.service.gc.cas.delete_unsupported_accounts | GAUGE |  | v1 | Accounts whose CAS GC sweep was skipped because immutable version deletes are unsupported. | component, operation | component, operation |
 | floecat.service.gc.cas.oldest_sweep_age | GAUGE | ms | v1 | Age in milliseconds of the least-recently cleanly-swept CAS GC account. | component, operation | component, operation |
 | floecat.service.gc.cas.poisoned_accounts | GAUGE |  | v1 | Accounts whose CAS GC delete phase was poisoned in the last tick. | component, operation | component, operation |
 | floecat.service.gc.reconcile_jobs.account_page.index | GAUGE | count | v1 | Current reconcile job GC index within the cached account page. | component, operation | component, operation |
@@ -109,6 +110,7 @@ This lists all metrics currently available in the repository:
 | floecat.service.stats.batch_groups.total | COUNTER |  | v1 | Stats batch request groups processed. | component, operation | component, mode, operation, reason, resource, result, scope, trigger |
 | floecat.service.stats.batch_items.total | COUNTER |  | v1 | Stats batch item counters (untagged series tracks submitted items; tagged series with result=* tracks per-outcome items; query with result tag filters to avoid double-counting). | component, operation | component, mode, operation, reason, resource, result, scope, trigger |
 | floecat.service.stats.engine_batch_calls.total | COUNTER |  | v1 | Stats engine batch capture calls. | component, operation | component, mode, operation, reason, resource, result, scope, trigger |
+| floecat.service.stats.planner_lookup_outcomes.total | COUNTER |  | v1 | Planner stats lookup outcomes by the ladder rung that served or failed each target. | component, operation, result | component, operation, result |
 | floecat.service.stats.store_hits.total | COUNTER |  | v1 | Stats store hit count for batch resolution. | component, operation | component, mode, operation, reason, resource, result, scope, trigger |
 | floecat.service.stats.store_misses.total | COUNTER |  | v1 | Stats store miss count for batch resolution. | component, operation | component, mode, operation, reason, resource, result, scope, trigger |
 | floecat.service.stats.sync.latency | TIMER | ms | v1 | End-to-end latency of a single sync-first resolution attempt including store reads. | component, operation | component, mode, operation, reason, resource, result, scope, trigger |

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
@@ -31,6 +31,7 @@ import jakarta.inject.Inject;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -51,6 +52,36 @@ import org.jboss.logging.Logger;
  * sweep on nodes serving queries ({@code floecat.gc.cas.enabled=false}) or share pin roots across
  * nodes first; the in-process context store already makes queries node-sticky, so this constraint
  * travels with the existing query-routing one.
+ *
+ * <p>Defense in depth: independent of how the referenced set was computed, the delete phase
+ * re-reads each candidate's OWNING pointer ({@link Keys#ownerPointerKeyForBlob}) immediately before
+ * deleting, and refuses — loudly — to delete a blob a live pointer still references. Such a rescue
+ * keeps the blob, counts {@code blobs-rescued}, and WARNs, then CONTINUES the pass — it does NOT
+ * poison the sweep. A stale referenced set can only cause false KEEPS here, never false deletes,
+ * because every owner-derivable candidate self-rechecks and every no-owner candidate is deferred
+ * and re-proven per table; poisoning the sweep on a rescue would instead let one table's persistent
+ * flip-flop starve the whole account's no-owner collection. A miss here is catalog data loss with
+ * no self-heal (reads fail with "dangling pointer, missing blob" and a reconcile re-references the
+ * dead URI). Deletes are version-targeted (the exact version the pass age-checked), and the sweep
+ * fails closed unless the store reports immutable version ids (S3 bucket versioning Enabled), so a
+ * concurrent re-PUT always survives as a new version the targeted delete cannot touch. Families
+ * with no owner pointer derivable from the key (manifest pages, per-target and file stats records)
+ * cannot be rescued individually, and lexicographic listing puts some of them before any blob whose
+ * rescue could reveal the stale set — so their deletion is DEFERRED, and the flush independently
+ * re-proves liveness per owning table against the settled store (root-chain re-walk plus
+ * constraints/stats pointer re-scan) before deleting. Superseded-but-pinned blobs are outside the
+ * recheck's reach (their owner pointer has moved on) and remain guarded by pin roots and
+ * walk-failure poisoning alone.
+ *
+ * <p><b>Versioned-bucket operations note.</b> This sweep only ever deletes the CURRENT version it
+ * age-checked; it never visits noncurrent versions. With the always-PUT write path, an oscillating
+ * live URI accrues a version per rewrite, and a garbage blob with N versions needs N sweep ticks to
+ * disappear (each targeted delete promotes the previous version to current). Neither is reclaimed
+ * fully by this GC: versioned deployments REQUIRE a bucket lifecycle rule expiring noncurrent
+ * versions (which also finishes off delete markers left by the unversioned {@code delete(key)}
+ * fallback, which reclaims nothing physically on a versioned bucket). This is the deliberate trade:
+ * versioning is what makes the delete race closable at all, and it doubles as the
+ * corruption-recovery mechanism (staging was healed by restoring deleted versions).
  */
 @ApplicationScoped
 public class CasBlobGc {
@@ -64,10 +95,17 @@ public class CasBlobGc {
   @Inject TableRootRepository tableRootRepo;
   @Inject StatsRepository statsRepository;
 
+  /**
+   * One sweep's tallies. On a versioned store {@code blobsDeleted} counts VERSION deletes, not
+   * whole-blob removals: deleting the current version of an N-version blob leaves it readable with
+   * N-1 versions, so this metric must not be read as "garbage fully reclaimed" (see the class note
+   * on lifecycle rules).
+   */
   public record Result(
       int pointersScanned,
       int blobsScanned,
       int blobsDeleted,
+      int blobsRescued,
       int referenced,
       int tablesScanned,
       boolean poisoned,
@@ -83,7 +121,7 @@ public class CasBlobGc {
           "cas gc for account %s skipped: blob store cannot delete by immutable version"
               + " (on S3 the bucket's versioning status must be Enabled)",
           accountId);
-      return new Result(0, 0, 0, 0, 0, false, true);
+      return new Result(0, 0, 0, 0, 0, 0, false, true);
     }
 
     final var cfg = ConfigProvider.getConfig();
@@ -201,6 +239,7 @@ public class CasBlobGc {
 
     int blobsScanned = 0;
     int blobsDeleted = 0;
+    int blobsRescued = 0;
 
     if (walkFailures[0] > 0) {
       // A chain walk failed: manifest pages and every ref inside them are reachable only through
@@ -209,7 +248,7 @@ public class CasBlobGc {
       LOG.warnf(
           "cas gc for account %s skipped its delete phase: %d root-chain walk(s) failed",
           accountId, walkFailures[0]);
-      return new Result(pointersScanned, 0, 0, referenced.size(), tablesScanned, true, false);
+      return new Result(pointersScanned, 0, 0, 0, referenced.size(), tablesScanned, true, false);
     }
 
     var account =
@@ -219,11 +258,13 @@ public class CasBlobGc {
             walkedPinRoots,
             walkFailures,
             key -> key.contains(Keys.SEG_ACCOUNT),
+            null,
             pageSize,
             nowMs,
             minAgeMs);
     blobsScanned += account.scanned();
     blobsDeleted += account.deleted();
+    blobsRescued += account.rescued();
 
     var catalogs =
         deleteUnreferenced(
@@ -232,11 +273,13 @@ public class CasBlobGc {
             walkedPinRoots,
             walkFailures,
             key -> key.contains(Keys.SEG_CATALOG),
+            null,
             pageSize,
             nowMs,
             minAgeMs);
     blobsScanned += catalogs.scanned();
     blobsDeleted += catalogs.deleted();
+    blobsRescued += catalogs.rescued();
 
     var namespaces =
         deleteUnreferenced(
@@ -245,15 +288,20 @@ public class CasBlobGc {
             walkedPinRoots,
             walkFailures,
             key -> key.contains(Keys.SEG_NAMESPACE),
+            null,
             pageSize,
             nowMs,
             minAgeMs);
     blobsScanned += namespaces.scanned();
     blobsDeleted += namespaces.deleted();
+    blobsRescued += namespaces.rescued();
 
     // One LIST over the table subtree covers all five blob families that live under it — the
     // segment filters are mutually exclusive key shapes, so a combined pass deletes exactly what
-    // five per-family passes would, at a fifth of the listing cost.
+    // five per-family passes would, at a fifth of the listing cost. Chain-walked families with no
+    // owner pointer are only COLLECTED here; they are flushed after every pass finished clean
+    // (see the flush below).
+    var deferredNoOwner = new ArrayList<DeferredCandidate>();
     var tableTree =
         deleteUnreferenced(
             Keys.tableRootPrefix(accountId),
@@ -274,11 +322,13 @@ public class CasBlobGc {
                     || key.contains(Keys.SEG_FILE_STATS)
                     || key.contains(Keys.SEG_CONSTRAINTS)
                     || key.contains(Keys.SEG_TABLE_ROOT),
+            deferredNoOwner,
             pageSize,
             nowMs,
             minAgeMs);
     blobsScanned += tableTree.scanned();
     blobsDeleted += tableTree.deleted();
+    blobsRescued += tableTree.rescued();
 
     var views =
         deleteUnreferenced(
@@ -287,11 +337,13 @@ public class CasBlobGc {
             walkedPinRoots,
             walkFailures,
             key -> key.contains(Keys.SEG_VIEW),
+            null,
             pageSize,
             nowMs,
             minAgeMs);
     blobsScanned += views.scanned();
     blobsDeleted += views.deleted();
+    blobsRescued += views.rescued();
 
     var connectors =
         deleteUnreferenced(
@@ -300,11 +352,109 @@ public class CasBlobGc {
             walkedPinRoots,
             walkFailures,
             key -> key.contains(Keys.SEG_CONNECTOR),
+            null,
             pageSize,
             nowMs,
             minAgeMs);
     blobsScanned += connectors.scanned();
     blobsDeleted += connectors.deleted();
+    blobsRescued += connectors.rescued();
+
+    // Flush the chain-walked candidates LAST, and never on the sweep-long stale set alone. These
+    // families cannot rescue themselves: manifest pages have no pointer at all, and the
+    // per-target/file stats records are referenced by per-snapshot pointers not reconstructible
+    // from the blob key — a flip-flop or scan miss on those produces no inline rescue anywhere
+    // (and the head/min-age skip paths can swallow a top-level rescue signal). So the flush
+    // proves liveness for itself: for each table that owns deferred candidates, it re-reads that
+    // table's root chain and re-scans its constraints and stats pointer prefixes against the
+    // SETTLED store, and only deletes candidates this fresh, scoped re-mark still leaves
+    // unreferenced. The zero-rescue/zero-poison gate remains as a cheap early out — any rescue
+    // already means the whole set is suspect — but correctness rests on the re-mark, not on
+    // rescue-signal completeness. Cost is proportional to actual garbage (tables with deferred
+    // candidates), not to steady-state traffic.
+    int remarkFailures = 0;
+    // Gated on walkFailures only, NOT on blobsRescued: a rescue means the referenced set is
+    // stale, but the flush re-proves liveness per table against the SETTLED store (it does not
+    // trust the stale set for the delete decision), so a rescue on one table must not starve every
+    // table's no-owner garbage collection. A pin-chain or root-chain walk FAILURE does block it.
+    if (walkFailures[0] == 0 && !deferredNoOwner.isEmpty()) {
+      var deferredByTable = new HashMap<String, List<DeferredCandidate>>();
+      for (DeferredCandidate candidate : deferredNoOwner) {
+        String key = candidate.key();
+        String tableId = Keys.extractResourceIdFromBlobUri(key.startsWith("/") ? key : "/" + key);
+        deferredByTable.computeIfAbsent(tableId, k -> new ArrayList<>()).add(candidate);
+      }
+      for (var entry : deferredByTable.entrySet()) {
+        String tableId = entry.getKey();
+        if (tableId.isEmpty()) {
+          continue; // unparseable key shape: fail safe, leave it for a future pass
+        }
+        // Snapshot the live pins before re-marking this table so remarkTable runs against a
+        // pin-aware referenced set; the per-CANDIDATE re-snapshot below is what actually closes
+        // the late-pin window before each delete. A PIN-chain walk failure is global — the
+        // referenced set itself is unprovable — so it aborts the whole flush, unlike a per-table
+        // re-mark failure below.
+        rootLivePinChains(referenced, walkedPinRoots, walkFailures);
+        if (walkFailures[0] > 0) {
+          break;
+        }
+        var fresh = new HashSet<String>();
+        if (!remarkTable(accountId, tableId, fresh, pageSize)) {
+          // This table's chain is unprovable: keep ITS candidates and move on. Each table's
+          // deletion is gated on its own re-mark, so one transiently unreadable root must not
+          // starve every other table's independently-proven flush — but the failure still reaches
+          // the poisoned gauge (below), because unprovable garbage was left behind.
+          remarkFailures++;
+          continue;
+        }
+        var deleted = new ArrayList<String>();
+        boolean pinWalkFailed = false;
+        for (DeferredCandidate candidate : entry.getValue()) {
+          String normalized = normalizeKey(candidate.key());
+          if (referenced.contains(normalized) || fresh.contains(normalized)) {
+            continue; // rooted by a late pin walk, or live per the settled re-mark
+          }
+          // Final guard: re-snapshot pins immediately before THIS delete, not just once per table.
+          // A query pinning a superseded root after the per-table snapshot would otherwise lose a
+          // manifest page reachable only through it (pin publication is read-only, so version
+          // targeting cannot catch it). A pin-chain walk failure aborts the flush.
+          if (keepForLatePin(normalized, referenced, walkedPinRoots, walkFailures)) {
+            if (walkFailures[0] > 0) {
+              pinWalkFailed = true;
+              break;
+            }
+            continue; // a pin published since the per-table snapshot now protects it
+          }
+          // Version-targeted like the inline path: a concurrent re-PUT mints a new version this
+          // delete cannot touch, so on a versioned store the re-referenced blob survives.
+          if (blobStore.delete(candidate.key(), candidate.versionId())) {
+            blobsDeleted++;
+            deleted.add(normalized);
+          }
+        }
+        if (pinWalkFailed) {
+          break; // reachability unprovable mid-flush: stop, the next tick retries
+        }
+        // Residual-race detector for UNVERSIONED stores, mirroring the inline path's post-delete
+        // probe: a second re-mark sees the settled state; a candidate it now references AND whose
+        // key is actually gone was destroyed by a delete that degraded to unconditional — name it
+        // at ERROR so the operator knows exactly what to repair.
+        if (!deleted.isEmpty()) {
+          var after = new HashSet<String>();
+          if (remarkTable(accountId, tableId, after, pageSize)) {
+            for (String normalized : deleted) {
+              if (after.contains(normalized) && blobStore.head(normalized).isEmpty()) {
+                LOG.errorf(
+                    "cas gc deleted deferred blob %s of table %s that a concurrent commit"
+                        + " re-referenced during the flush: the resource is corrupted — repair"
+                        + " (re-create/re-sync) required",
+                    normalized, tableId);
+              }
+            }
+          }
+        }
+      }
+    }
 
     // Report the FINAL poison state, not a static false: the delete passes re-run rootLivePinChains
     // per page, so a pin registered mid-sweep whose chain walk fails raises walkFailures[0] and
@@ -314,9 +464,10 @@ public class CasBlobGc {
         pointersScanned,
         blobsScanned,
         blobsDeleted,
+        blobsRescued,
         referenced.size(),
         tablesScanned,
-        walkFailures[0] > 0,
+        walkFailures[0] > 0 || remarkFailures > 0,
         false);
   }
 
@@ -473,7 +624,10 @@ public class CasBlobGc {
     }
   }
 
-  private record DeleteResult(int scanned, int deleted) {}
+  private record DeleteResult(int scanned, int deleted, int rescued) {}
+
+  /** A deferred no-owner candidate: the key plus the exact version the sweep age-checked. */
+  private record DeferredCandidate(String key, String versionId) {}
 
   private DeleteResult deleteUnreferenced(
       String prefix,
@@ -481,12 +635,14 @@ public class CasBlobGc {
       Set<String> walkedPinRoots,
       int[] walkFailures,
       Predicate<String> isCandidate,
+      List<DeferredCandidate> deferNoOwnerTo,
       int pageSize,
       long nowMs,
       long minAgeMs) {
     String token = "";
     int scanned = 0;
     int deleted = 0;
+    int rescued = 0;
 
     while (true) {
       BlobStore.Page page = blobStore.list(prefix, pageSize, token);
@@ -496,9 +652,11 @@ public class CasBlobGc {
       // node-local memory and chains walk at most once per pin root, so this stays cheap.
       rootLivePinChains(referenced, walkedPinRoots, walkFailures);
       if (walkFailures[0] > 0) {
-        // A pin-chain walk failed mid-phase: stop deleting immediately (see the pass-level gate).
-        LOG.warnf("cas gc delete pass over %s aborted: pin-chain walk failed mid-sweep", prefix);
-        return new DeleteResult(scanned, deleted);
+        // A pin-chain walk failed mid-phase (reachability is now unknowable): stop deleting
+        // immediately (see the pass-level gate). A rescue does NOT reach here — it keeps the blob
+        // and continues without raising walkFailures.
+        LOG.warnf("cas gc delete pass over %s aborted: pin-chain walk failed mid-phase", prefix);
+        return new DeleteResult(scanned, deleted, rescued);
       }
       for (String key : page.keys()) {
         scanned++;
@@ -532,15 +690,67 @@ public class CasBlobGc {
           // blob after this pass's one-time mark, invisible to both the mark and (if the writer
           // left LastModified stale) the age fence. For pointer-rooted families the key encodes
           // its owner (see Keys.ownerPointerKeyForBlob) — re-read that pointer right before the
-          // delete and keep the blob it currently references.
-          if (referencedByOwnerPointer(normalized)) {
-            continue;
-          }
+          // delete. The recheck runs on every owner-derivable delete candidate — and those are
+          // NOT rare: every commit supersedes its table/root/snapshot blobs, so each such
+          // deletion pays up to two extra pointer reads (this recheck + the post-delete probe).
+          // That is the deliberate price of never deleting a live blob.
+          String ownerPointerKey = Keys.ownerPointerKeyForBlob(normalized);
           String versionId = header.getVersionId();
           if (versionId.isBlank()) {
             // Cannot name the version this pass age-checked (unexpected on a store that reports
             // supportsVersionedDeletes): fail closed and leave the blob for a future pass — an
             // unconditional delete here would reintroduce the race.
+            continue;
+          }
+          if (ownerPointerKey == null && deferNoOwnerTo != null) {
+            // No owner pointer derivable from the key (chain-walked manifest pages, and the
+            // per-target/file stats records whose per-snapshot pointers are not reconstructible
+            // from the blob key alone) — and blob listing is lexicographic, so these often sort
+            // BEFORE any blob whose rescue could reveal a stale referenced set. Deleting them
+            // inline would destroy a missed table's chain before anything can object. Defer them
+            // (with the version this pass age-checked): the flush below re-proves liveness per
+            // table against the settled store before deleting (see the flush comment for why the
+            // rescue signal alone is not sufficient proof).
+            deferNoOwnerTo.add(new DeferredCandidate(key, versionId));
+            continue;
+          }
+          if (ownerPointerKey != null && ownedBy(ownerPointerKey, normalized)) {
+            // The owner pointer still references this blob: the referenced set missed a live
+            // reference (canonically the content-addressed pointer flip-flop A -> B -> A across the
+            // sweep, the revert skipping the blob write so min-age is blind). Keep it and count the
+            // rescue — but do NOT poison or abort the pass. A stale referenced set can only cause
+            // false KEEPS here, never false deletes: every owner-derivable candidate self-rechecks
+            // (this branch), every no-owner candidate is deferred and re-proven per-table against
+            // the settled store, so continuing is safe and lets the pass finish collecting
+            // deferrals. Poisoning on rescue would let one table's persistent flip-flop starve the
+            // whole account's no-owner garbage collection. blobs-rescued is the operator signal.
+            rescued++;
+            LOG.warnf(
+                "cas gc rescued live blob %s: owner pointer %s still references it but the"
+                    + " referenced set missed it (stale mark, e.g. a pointer flip during the sweep)"
+                    + " — keeping it; the referenced set is stale but the recheck protects each"
+                    + " delete independently",
+                key, ownerPointerKey);
+            continue;
+          }
+          if (ownerPointerKey == null) {
+            // Reached only for a candidate with no derivable owner in a pass that does NOT defer
+            // (account/catalog/namespace/view/connector families are all owner-derivable for
+            // well-formed keys, so this is an unexpected/malformed shape). Fail safe: never take
+            // the unconditional-delete path below, which would skip the owner-recheck invariant.
+            // Leave it for investigation rather than risk deleting live data.
+            LOG.debugf(
+                "cas gc skipped %s: no derivable owner pointer and no deferral in this pass", key);
+            continue;
+          }
+          // Final guard before the irreversible delete: a query may have published a pin to a
+          // superseded root since this page's pin snapshot. Re-read the live pins and keep the blob
+          // if it is now pin-reachable; a pin-chain walk failure aborts the pass (reachability
+          // unprovable).
+          if (keepForLatePin(normalized, referenced, walkedPinRoots, walkFailures)) {
+            if (walkFailures[0] > 0) {
+              return new DeleteResult(scanned, deleted, rescued);
+            }
             continue;
           }
           // Delete exactly the version this pass age-checked: the fences above are still stale
@@ -550,6 +760,21 @@ public class CasBlobGc {
           // interleaving.
           if (blobStore.delete(key, versionId)) {
             deleted++;
+            // Defensive post-delete corruption detector. The sweep only reaches here on a
+            // versioned store (unversioned/blank-version blobs fail closed above), where a
+            // version-targeted delete keeps any concurrent re-PUT as a new version — so this should
+            // never fire. If it does (owner pointer now references this key AND the key is actually
+            // gone), a live blob was destroyed: log at ERROR with both keys so the operator knows
+            // exactly what to repair.
+            if (ownerPointerKey != null
+                && ownedBy(ownerPointerKey, normalized)
+                && blobStore.head(key).isEmpty()) {
+              LOG.errorf(
+                  "cas gc deleted blob %s while owner pointer %s concurrently flipped to it:"
+                      + " the pointer now dangles and the resource is corrupted — repair"
+                      + " (re-create/re-sync) required",
+                  key, ownerPointerKey);
+            }
           }
         }
       }
@@ -559,16 +784,66 @@ public class CasBlobGc {
       }
     }
 
-    return new DeleteResult(scanned, deleted);
+    return new DeleteResult(scanned, deleted, rescued);
   }
 
-  private boolean referencedByOwnerPointer(String normalizedKey) {
-    String ownerKey = Keys.ownerPointerKeyForBlob(normalizedKey);
-    if (ownerKey == null) {
-      return false;
-    }
-    var owner = pointerStore.get(ownerKey).orElse(null);
+  /**
+   * Re-snapshots the live query pins immediately before an irreversible delete and reports whether
+   * the blob must be kept. A query can publish a pin to a SUPERSEDED root at any instant — the
+   * root's manifest pages and chain blobs are then absent from the sweep-time referenced set and
+   * from the current-root re-mark, yet must survive. Pin publication is read-only (no re-PUT), so
+   * the version fence cannot catch it either. Re-reading the (node-local, cheap) pin set here and
+   * expanding any newly-pinned root's chain narrows the exposure to the microseconds between this
+   * read and the delete — the same residual the owner recheck accepts. A pin-chain walk failure
+   * makes reachability unprovable, so it too returns "keep" (and the caller aborts). Fully closing
+   * the window needs atomic pin/GC coordination (see the node-local-pin constraint in the class
+   * header).
+   */
+  private boolean keepForLatePin(
+      String normalizedKey,
+      Set<String> referenced,
+      Set<String> walkedPinRoots,
+      int[] walkFailures) {
+    rootLivePinChains(referenced, walkedPinRoots, walkFailures);
+    return walkFailures[0] > 0 || referenced.contains(normalizedKey);
+  }
+
+  /** Whether the given owner pointer currently references exactly this normalized blob key. */
+  private boolean ownedBy(String ownerPointerKey, String normalizedKey) {
+    var owner = pointerStore.get(ownerPointerKey).orElse(null);
     return owner != null && normalizedKey.equals(normalizeKey(owner.getBlobUri()));
+  }
+
+  /**
+   * Re-proves one table's chain-referenced liveness against the SETTLED store: re-reads the
+   * table-root pointer and re-walks its chain, then re-scans the table's stats and constraints
+   * pointer prefixes, accumulating every referenced URI into {@code fresh}. Returns false when the
+   * chain walk could not complete — the caller must then treat the table's candidates as unprovable
+   * and keep them.
+   *
+   * <p>Honesty about the guarantee: only the chain walk carries a completeness signal. The
+   * stats/constraints re-scans rely on {@code listPointersByPrefix} either returning the full
+   * settled listing or THROWING (which aborts the whole sweep) — a silently partial, non-throwing
+   * listing is undetectable at this layer and would leave {@code fresh} incomplete. The flush
+   * therefore still requires a candidate to be absent from BOTH the sweep's original referenced set
+   * and this re-mark before deleting; that is two independent scans, not a proof.
+   */
+  private boolean remarkTable(String accountId, String tableId, Set<String> fresh, int pageSize) {
+    var rootPtr = pointerStore.get(Keys.tableRootByTable(accountId, tableId)).orElse(null);
+    if (rootPtr != null && !rootPtr.getBlobUri().isBlank()) {
+      if (!rootTableRootChain(rootPtr.getBlobUri(), fresh)) {
+        return false;
+      }
+    }
+    collectPointers(
+        Keys.snapshotRootPrefix(accountId, tableId),
+        fresh,
+        null,
+        pageSize,
+        ptr -> ptr.getKey() != null && ptr.getKey().contains(Keys.SEG_STATS));
+    collectPointers(
+        Keys.snapshotConstraintsPointerPrefix(accountId, tableId), fresh, null, pageSize);
+    return true;
   }
 
   private static String decodeSuffix(String prefix, String fullKey) {

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
@@ -438,10 +438,12 @@ public class CasBlobGc {
         if (pinWalkFailed) {
           break; // reachability unprovable mid-flush: stop, the next tick retries
         }
-        // Residual-race detector for UNVERSIONED stores, mirroring the inline path's post-delete
-        // probe: a second re-mark sees the settled state; a candidate it now references AND whose
-        // key is actually gone was destroyed by a delete that degraded to unconditional — name it
-        // at ERROR so the operator knows exactly what to repair.
+        // Defensive post-delete corruption detector, mirroring the inline path's probe. The flush
+        // is only reached on a versioned store (unversioned/blank-version blobs fail closed at the
+        // top of runForAccount), where a version-targeted delete keeps any concurrent re-PUT as a
+        // new version — so this should never fire. If it does (a second re-mark now references a
+        // candidate AND its key is actually gone), a live blob was destroyed: name it at ERROR so
+        // the operator knows exactly what to repair.
         if (!deleted.isEmpty()) {
           var after = new HashSet<String>();
           if (remarkTable(accountId, tableId, after, pageSize)) {

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
@@ -96,10 +96,13 @@ public class CasBlobGc {
   @Inject StatsRepository statsRepository;
 
   /**
-   * One sweep's tallies. On a versioned store {@code blobsDeleted} counts VERSION deletes, not
-   * whole-blob removals: deleting the current version of an N-version blob leaves it readable with
-   * N-1 versions, so this metric must not be read as "garbage fully reclaimed" (see the class note
-   * on lifecycle rules).
+   * One sweep's tallies. {@code blobsDeleted} counts successful version-delete CALLS, not blobs
+   * physically removed: (a) on a versioned store, deleting the current version of an N-version blob
+   * leaves it readable with N-1 versions, so it is not "garbage fully reclaimed" (see the class
+   * note on lifecycle rules); and (b) a version-targeted delete returns success — and is counted —
+   * even for an already-absent blob (another actor removed it between this pass's head() and the
+   * delete, or a 404). So the count can read slightly high; treat it as a delete-throughput signal,
+   * not a reclaimed-bytes measure.
    */
   public record Result(
       int pointersScanned,

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGcScheduler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGcScheduler.java
@@ -44,9 +44,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class CasBlobGcScheduler {
+
+  private static final Logger LOG = Logger.getLogger(CasBlobGcScheduler.class);
 
   @Inject Provider<AccountRepository> accounts;
   @Inject Provider<CasBlobGc> casBlobGc;
@@ -175,7 +178,23 @@ public class CasBlobGcScheduler {
         }
         long accountStart = System.nanoTime();
         String accountId = account.getResourceId().getId();
-        var result = gc.runForAccount(accountId);
+        CasBlobGc.Result result;
+        try {
+          result = gc.runForAccount(accountId);
+        } catch (RuntimeException e) {
+          // Isolate one account's failure from the rest of the tick. A version-targeted delete
+          // throws StorageAbortRetryableException on a transient SDK fault and maps non-404 S3
+          // errors (e.g. 403 AccessDenied when the role lacks s3:DeleteObjectVersion) — unguarded,
+          // one such fault would skip every remaining shuffled account. Treat it like a poisoned
+          // sweep (backlog age keeps climbing) and move on.
+          LOG.warnf(
+              e, "cas gc for account %s failed; skipping to next account this tick", accountId);
+          poisonedThisTick++;
+          gcMetrics.recordPause(
+              Duration.ofNanos(System.nanoTime() - accountStart),
+              Tag.of(TagKey.RESULT, "account-error"));
+          continue;
+        }
         if (result.deletesUnsupported()) {
           // Fail-closed skip (store cannot delete by immutable version): nothing was collected,
           // so the account's backlog age must keep climbing, exactly like a poisoned sweep.
@@ -190,6 +209,7 @@ public class CasBlobGcScheduler {
             result.pointersScanned(), Tag.of(TagKey.RESULT, "pointers-scanned"));
         gcMetrics.recordCollection(result.blobsScanned(), Tag.of(TagKey.RESULT, "blobs-scanned"));
         gcMetrics.recordCollection(result.blobsDeleted(), Tag.of(TagKey.RESULT, "blobs-deleted"));
+        gcMetrics.recordCollection(result.blobsRescued(), Tag.of(TagKey.RESULT, "blobs-rescued"));
         gcMetrics.recordCollection(result.referenced(), Tag.of(TagKey.RESULT, "referenced"));
         gcMetrics.recordCollection(result.tablesScanned(), Tag.of(TagKey.RESULT, "tables-scanned"));
         gcMetrics.recordPause(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -1527,9 +1527,14 @@ public final class Keys {
    * <ul>
    *   <li>root manifest pages ({@code .../root/manifest/<sha>.pb}): referenced by the {@code
    *       TableRoot} blob's content, not by any pointer;
-   *   <li>per-target stats records ({@code .../target-stats/<target>/<sha>.pb}) and file stats
-   *       ({@code .../file-stats/<path>/<sha>.pb}): their owning pointers live under {@code
+   *   <li>the snapshot-id-less per-target stats records ({@code
+   *       .../target-stats/<target>/<sha>.pb}) and file stats ({@code
+   *       .../file-stats/<path>/<sha>.pb}): their owning pointers live under {@code
    *       .../snapshots/<snapshot_id>/stats/...} and the snapshot id is not part of the blob key.
+   *       Note the generation-scoped target-stats shape ({@code
+   *       .../target-stats/<snapshot_id>/generations/<gen>/<target>/<sha>.pb}) DOES carry the
+   *       snapshot id and IS derivable — it takes the inline recheck path below, not this null
+   *       branch.
    * </ul>
    */
   public static String ownerPointerKeyForBlob(String blobKey) {

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributor.java
@@ -313,6 +313,12 @@ public final class ServiceTelemetryContributor implements TelemetryContributor {
         "Accounts whose CAS GC delete phase was poisoned in the last tick.");
     add(
         defs,
+        ServiceMetrics.Gc.CAS_DELETE_UNSUPPORTED_ACCOUNTS,
+        gcRequired,
+        gcAllowed,
+        "Accounts whose CAS GC sweep was skipped because immutable version deletes are unsupported.");
+    add(
+        defs,
         ServiceMetrics.Gc.CAS_OLDEST_SWEEP_AGE,
         gcRequired,
         gcAllowed,

--- a/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcSchedulerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcSchedulerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.gc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.account.rpc.Account;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.impl.AccountRepository;
+import ai.floedb.floecat.telemetry.TestObservability;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CasBlobGcSchedulerTest {
+
+  /**
+   * One account's sweep throwing (e.g. a transient S3 fault, or 403 AccessDenied when the role
+   * lacks the now-required {@code s3:DeleteObjectVersion}) must not starve the rest of the tick.
+   * {@code runForAccount} is called inside the per-account loop; without a guard, one exception
+   * would end the tick and skip every remaining shuffled account.
+   */
+  @Test
+  void tickAdvancesPastAnAccountWhoseSweepThrows() {
+    AccountRepository accounts = mock(AccountRepository.class);
+    when(accounts.list(anyInt(), anyString(), any()))
+        .thenReturn(List.of(account("acct-a"), account("acct-b")));
+
+    RecordingGc gc = new RecordingGc();
+    gc.failAccountId = "acct-a";
+
+    CasBlobGcScheduler scheduler = new CasBlobGcScheduler();
+    scheduler.accounts = () -> accounts;
+    scheduler.casBlobGc = () -> gc;
+    scheduler.observability = new TestObservability();
+    scheduler.initMeters();
+
+    // Test config disables CAS GC; a system property (higher config ordinal) re-enables it for the
+    // direct tick() invocation.
+    System.setProperty("floecat.gc.cas.enabled", "true");
+    try {
+      scheduler.tick();
+    } finally {
+      System.clearProperty("floecat.gc.cas.enabled");
+    }
+
+    // Both accounts were attempted; the throw on acct-a did not abort the tick before acct-b.
+    assertEquals(2, gc.accountIds.size());
+    assertTrue(gc.accountIds.contains("acct-a"));
+    assertTrue(gc.accountIds.contains("acct-b"));
+  }
+
+  private static Account account(String accountId) {
+    return Account.newBuilder()
+        .setResourceId(
+            ResourceId.newBuilder().setId(accountId).setKind(ResourceKind.RK_ACCOUNT).build())
+        .setDisplayName(accountId)
+        .build();
+  }
+
+  private static final class RecordingGc extends CasBlobGc {
+    private final List<String> accountIds = new ArrayList<>();
+    private String failAccountId;
+
+    @Override
+    public Result runForAccount(String accountId) {
+      accountIds.add(accountId);
+      if (accountId.equals(failAccountId)) {
+        throw new RuntimeException("simulated storage fault");
+      }
+      return new Result(0, 0, 0, 0, 0, 0, false, false);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
@@ -32,6 +32,7 @@ import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,6 +79,58 @@ class CasBlobGcTest {
     gc.runForAccount(ACCOUNT_ID);
 
     assertTrue(blobs.head(blobUri).isPresent());
+  }
+
+  @Test
+  void keyWithoutADerivableOwnerIsNeverDeletedInANonDeferringPass() {
+    // A candidate that passes a family's segment filter but whose key shape yields no owner
+    // pointer (malformed/blank rid) must NOT take the unconditional-delete path in the
+    // account/catalog/namespace/view/connector passes (which do not defer). Fail safe: leave it.
+    String malformed = "/accounts/" + ACCOUNT_ID + "/catalogs//catalog/sha-x.pb";
+    blobs.put(malformed, "x".getBytes(StandardCharsets.UTF_8), "text/plain");
+    assertEquals(null, Keys.ownerPointerKeyForBlob(malformed), "precondition: no derivable owner");
+
+    gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(
+        blobs.head(malformed).isPresent(),
+        "an owner-underivable candidate must be kept, not blind-deleted");
+  }
+
+  @Test
+  void aLatePinPublishedDuringTheFlushProtectsADeferredBlob() {
+    // P1 regression: the flush snapshots pins once per table, then deletes each deferred candidate.
+    // A query pinning a superseded root AFTER that snapshot would lose a blob reachable only
+    // through
+    // it — pin publication is read-only, so version-targeting cannot catch it. The per-candidate
+    // pin re-read closes this. No by-id pointer is seeded, so the mark phase never reads this
+    // table's root; the ONLY tableRootByTable read is remarkTable's, strictly after the flush's
+    // per-table pin snapshot — so the pin the flag then reveals is invisible to that snapshot and
+    // only the per-candidate re-read can catch it.
+    String fileStatsBlob = Keys.snapshotFileStatsBlobUri(ACCOUNT_ID, TABLE_ID, "f1", "sha-fs");
+    blobs.put(
+        fileStatsBlob, "fs".getBytes(StandardCharsets.UTF_8), "text/plain"); // deferred garbage
+    String rootKey = Keys.tableRootByTable(ACCOUNT_ID, TABLE_ID);
+    java.util.concurrent.atomic.AtomicBoolean remarkStarted =
+        new java.util.concurrent.atomic.AtomicBoolean();
+    gc.pointerStore =
+        new ScanHidingPointerStore(pointers, Set.of()) {
+          @Override
+          public java.util.Optional<Pointer> get(String key) {
+            if (rootKey.equals(key)) {
+              remarkStarted.set(true); // remarkTable reached this table -> after the pin snapshot
+            }
+            return super.get(key);
+          }
+        };
+    when(queryContextStore.referencedPinBlobUris())
+        .thenAnswer(inv -> remarkStarted.get() ? Set.of(fileStatsBlob) : Set.of());
+
+    gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(
+        blobs.head(fileStatsBlob).isPresent(),
+        "a pin published after the per-table snapshot must still protect the deferred blob");
   }
 
   @Test
@@ -760,5 +813,297 @@ class CasBlobGcTest {
                 .setVersion("v-t")
                 .build(),
             true));
+  }
+
+  // ===== Delete-time owner-liveness recheck (last line of defense) =====
+
+  /**
+   * Delegates to the real in-memory store but HIDES chosen keys from {@code listPointersByPrefix}
+   * while still serving them from {@code get}. This reproduces the signature of a reachability gap
+   * — the referenced-set computation (built from prefix scans) misses a pointer that is very much
+   * alive — regardless of which upstream race caused it.
+   */
+  private static class ScanHidingPointerStore implements PointerStore {
+    private final PointerStore delegate;
+    private final Set<String> hiddenFromScans;
+
+    ScanHidingPointerStore(PointerStore delegate, Set<String> hiddenFromScans) {
+      this.delegate = delegate;
+      this.hiddenFromScans = hiddenFromScans;
+    }
+
+    @Override
+    public java.util.Optional<Pointer> get(String key) {
+      return delegate.get(key);
+    }
+
+    @Override
+    public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
+      return delegate.compareAndSet(key, expectedVersion, next);
+    }
+
+    @Override
+    public boolean delete(String key) {
+      return delegate.delete(key);
+    }
+
+    @Override
+    public boolean compareAndDelete(String key, long expectedVersion) {
+      return delegate.compareAndDelete(key, expectedVersion);
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<PointerStore.CasOp> ops) {
+      return delegate.compareAndSetBatch(ops);
+    }
+
+    @Override
+    public List<Pointer> listPointersByPrefix(
+        String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+      List<Pointer> page = delegate.listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
+      return page.stream().filter(ptr -> !hiddenFromScans.contains(ptr.getKey())).toList();
+    }
+
+    @Override
+    public int deleteByPrefix(String prefix) {
+      return delegate.deleteByPrefix(prefix);
+    }
+
+    @Override
+    public int countByPrefix(String prefix) {
+      return delegate.countByPrefix(prefix);
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return delegate.isEmpty();
+    }
+  }
+
+  @Test
+  void rescuesLiveDefinitionBlobWhenThePointerScanMissedIt() {
+    // The CI-observed data-loss shape: the CurrentTableState pointer references the table
+    // definition blob, but the referenced-set missed that pointer. Without the delete-time
+    // recheck the sweep deletes the blob and every read of the table fails forever with
+    // "dangling pointer, missing blob". With it, the blob survives and the rescue is counted.
+    String pointerKey = Keys.tablePointerById(ACCOUNT_ID, TABLE_ID);
+    String blobUri = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-live");
+    blobs.put(blobUri, "live".getBytes(StandardCharsets.UTF_8), "text/plain");
+    putPointer(pointerKey, blobUri);
+    gc.pointerStore = new ScanHidingPointerStore(pointers, Set.of(pointerKey));
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(blobs.head(blobUri).isPresent(), "live definition blob must never be deleted");
+    assertEquals(1, result.blobsRescued(), "the rescue must be counted (reachability-bug signal)");
+    assertFalse(
+        result.poisoned(),
+        "a rescue keeps the blob but does NOT poison — the recheck protects each delete");
+  }
+
+  @Test
+  void rescuesLiveRootBlobWhenThePointerScanMissedIt() {
+    // Same defense for the table-root family: the root pointer's blob is owner-derivable from
+    // the key shape, so a scan miss must not destroy the root chain's anchor.
+    String rootPointerKey = Keys.tableRootByTable(ACCOUNT_ID, TABLE_ID);
+    String rootBlobUri = Keys.tableRootBlobUri(ACCOUNT_ID, TABLE_ID, "sha-root");
+    blobs.put(rootBlobUri, "root".getBytes(StandardCharsets.UTF_8), "application/octet-stream");
+    putPointer(rootPointerKey, rootBlobUri);
+    gc.pointerStore = new ScanHidingPointerStore(pointers, Set.of(rootPointerKey));
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(blobs.head(rootBlobUri).isPresent(), "live root blob must never be deleted");
+    assertEquals(1, result.blobsRescued());
+    assertFalse(result.poisoned());
+  }
+
+  @Test
+  void rescuesContentAddressedBlobTheScanSawUnderItsSupersededTarget() {
+    // The root-cause interleave behind the staging "dangling pointer, missing blob" corruption
+    // (Jul 2026), reproduced red/green against the pre-fix sweep: a table definition flip-flops
+    // A -> B -> A across a sweep. The pointer scan runs while the pointer is at B, so A is
+    // unreferenced in the captured set. The mutation then reverts to content A: the
+    // content-addressed write path finds blob A already present and SKIPS the put — leaving A's
+    // lastModified ancient, so the min-age fence (which only protects recent WRITES) cannot save
+    // it — and CASes the pointer back to A. The delete phase, trusting the stale set, destroyed
+    // the blob the pointer references. Only the delete-time owner recheck closes this
+    // time-of-check-to-time-of-delete gap.
+    String pointerKey = Keys.tablePointerById(ACCOUNT_ID, TABLE_ID);
+    String blobA = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-a-reverted-to");
+    String blobB = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-b-superseded");
+    blobs.put(blobA, "a".getBytes(StandardCharsets.UTF_8), "text/plain");
+    blobs.put(blobB, "b".getBytes(StandardCharsets.UTF_8), "text/plain");
+    // Live truth: pointer is (back) at A ...
+    putPointer(pointerKey, blobA);
+    // ... but every SCAN sees the stale mid-flip view: pointer at B.
+    Pointer staleView = PointerReferences.blobPointer(pointerKey, blobB, 1L);
+    gc.pointerStore =
+        new ScanHidingPointerStore(pointers, Set.of()) {
+          @Override
+          public List<Pointer> listPointersByPrefix(
+              String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+            return super.listPointersByPrefix(prefix, limit, pageToken, nextTokenOut).stream()
+                .map(ptr -> pointerKey.equals(ptr.getKey()) ? staleView : ptr)
+                .toList();
+          }
+        };
+
+    // An unrelated, genuinely-unreferenced orphan LATER in the same pass's key order: a rescue
+    // must NOT poison/abort the sweep, so this real garbage is still collected in the same tick.
+    // (The rescue keeps only the live blob; every other candidate is judged independently by its
+    // own recheck, so a persistent flip-flop on one table can't starve the account's collection.)
+    String unrelatedOrphan = Keys.tableBlobUri(ACCOUNT_ID, "zz-other-table", "sha-orphan");
+    blobs.put(unrelatedOrphan, "x".getBytes(StandardCharsets.UTF_8), "text/plain");
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(
+        blobs.head(blobA).isPresent(),
+        "the blob the pointer references at delete time must survive the stale-scan race");
+    assertEquals(1, result.blobsRescued());
+    assertFalse(result.poisoned());
+    assertFalse(
+        blobs.head(unrelatedOrphan).isPresent(),
+        "a rescue must not starve collection of unrelated garbage in the same tick");
+  }
+
+  @Test
+  void aLiveNoOwnerBlobSurvivesARescueElsewhereViaTheFlushRemark() {
+    // A LIVE no-owner family (file-stats, with its own live pointer) sorts BEFORE the table's
+    // definition blob. When the scan misses the table's by-id pointer, the definition is only
+    // rescued AFTER the file-stats was already reached. Deferral keeps the file-stats out of the
+    // inline delete path; the flush then re-proves it against the settled store (its live stats
+    // pointer) and keeps it — and the rescue does NOT poison the flush, so this works even under a
+    // concurrent rescue.
+    String tablePtr = Keys.tablePointerById(ACCOUNT_ID, TABLE_ID);
+    String definitionBlob = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-def");
+    String fileStatsPtr = Keys.snapshotFileStatsPointer(ACCOUNT_ID, TABLE_ID, 7L, "f1");
+    String fileStatsBlob = Keys.snapshotFileStatsBlobUri(ACCOUNT_ID, TABLE_ID, "f1", "sha-fs");
+    blobs.put(definitionBlob, "def".getBytes(StandardCharsets.UTF_8), "text/plain");
+    blobs.put(fileStatsBlob, "fs".getBytes(StandardCharsets.UTF_8), "text/plain");
+    putPointer(tablePtr, definitionBlob); // live definition (its by-id pointer)
+    putPointer(fileStatsPtr, fileStatsBlob); // live file-stats
+    // The scan misses only the table's by-id pointer, so the table is absent from tableIds and its
+    // mark-phase stats/root scans never run — the definition and file-stats are both unreferenced
+    // in the stale set. The file-stats pointer itself stays visible for the flush re-mark.
+    gc.pointerStore = new ScanHidingPointerStore(pointers, Set.of(tablePtr));
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(blobs.head(definitionBlob).isPresent(), "definition rescued by the owner recheck");
+    assertTrue(
+        blobs.head(fileStatsBlob).isPresent(),
+        "a live no-owner blob is deferred, then kept by the flush re-mark despite the rescue");
+    assertEquals(1, result.blobsRescued());
+    assertFalse(result.poisoned());
+  }
+
+  @Test
+  void constraintsBlobsRescueThemselvesInlineViaTheirDerivablePointer() {
+    // Constraints blob keys embed the snapshot id, so their per-snapshot pointer is derivable
+    // from the key shape: a live constraints blob whose pointer the scan missed rescues ITSELF
+    // inline — no reliance on the definition rescue or the deferred flush.
+    String tablePtr = Keys.tablePointerById(ACCOUNT_ID, TABLE_ID);
+    String constraintsPtr = Keys.snapshotConstraintsPointer(ACCOUNT_ID, TABLE_ID, 7L);
+    String definitionBlob = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-def");
+    String constraintsBlob = Keys.snapshotConstraintsBlobUri(ACCOUNT_ID, TABLE_ID, 7L, "sha-con");
+    blobs.put(definitionBlob, "def".getBytes(StandardCharsets.UTF_8), "text/plain");
+    blobs.put(constraintsBlob, "con".getBytes(StandardCharsets.UTF_8), "text/plain");
+    putPointer(tablePtr, definitionBlob);
+    putPointer(constraintsPtr, constraintsBlob);
+    // Both pointers invisible to prefix scans (the deep visibility race), alive on get().
+    gc.pointerStore = new ScanHidingPointerStore(pointers, Set.of(tablePtr, constraintsPtr));
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(
+        blobs.head(constraintsBlob).isPresent(),
+        "the constraints blob's own inline recheck must rescue it");
+    assertTrue(blobs.head(definitionBlob).isPresent());
+    assertTrue(result.blobsRescued() >= 1);
+    assertFalse(result.poisoned());
+  }
+
+  @Test
+  void flushReprovesLivenessAgainstTheSettledStoreBeforeDeletingSideResources() {
+    // Constraints/stats records are referenced by their OWN per-snapshot pointers, which have no
+    // inline rescue path (the pointer key is not reconstructible from the blob key). A transient
+    // visibility miss on that pointer during the mark scan therefore produces NO rescue signal
+    // anywhere — the table itself is fully live and referenced. The flush must not trust the
+    // sweep's stale set: it re-scans the owning table's constraints/stats pointer prefixes
+    // against the settled store and keeps anything they reference.
+    seedCurrentTable();
+    String statsPtr = Keys.snapshotFileStatsPointer(ACCOUNT_ID, TABLE_ID, 7L, "f1");
+    String statsBlob = Keys.snapshotFileStatsBlobUri(ACCOUNT_ID, TABLE_ID, "f1", "sha-live");
+    blobs.put(statsBlob, "live".getBytes(StandardCharsets.UTF_8), "text/plain");
+    putPointer(statsPtr, statsBlob);
+    // The pointer is invisible to the FIRST prefix scan that would return it (the mark scan) and
+    // visible afterwards (the flush re-mark) — a transient list-visibility race.
+    java.util.concurrent.atomic.AtomicBoolean missConsumed =
+        new java.util.concurrent.atomic.AtomicBoolean();
+    gc.pointerStore =
+        new ScanHidingPointerStore(pointers, Set.of()) {
+          @Override
+          public List<Pointer> listPointersByPrefix(
+              String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+            List<Pointer> page = super.listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
+            if (!missConsumed.get()
+                && page.stream().anyMatch(ptr -> statsPtr.equals(ptr.getKey()))) {
+              missConsumed.set(true);
+              return page.stream().filter(ptr -> !statsPtr.equals(ptr.getKey())).toList();
+            }
+            return page;
+          }
+        };
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(
+        blobs.head(statsBlob).isPresent(),
+        "a live side-resource blob must survive a transient mark-scan miss via the flush re-mark");
+    assertEquals(0, result.blobsRescued(), "no rescue fires here: the re-mark alone must save it");
+    assertFalse(result.poisoned());
+  }
+
+  @Test
+  void oneTablesUnprovableRemarkDoesNotStarveAnotherTablesFlush() {
+    // A re-mark failure is per-table: table A's root pointer references a missing root blob, so
+    // A's chain is unprovable and its deferred candidates must be kept — but table B's deferred
+    // garbage has its own independent re-mark proof and must still be reclaimed in the same
+    // flush. The failure still surfaces on the poisoned gauge (unprovable garbage was left).
+    String rootPtrA = Keys.tableRootByTable(ACCOUNT_ID, "tbl-a");
+    putPointer(rootPtrA, Keys.tableRootBlobUri(ACCOUNT_ID, "tbl-a", "sha-missing"));
+    String deferredA = Keys.snapshotFileStatsBlobUri(ACCOUNT_ID, "tbl-a", "f", "sha-a");
+    String deferredB = Keys.snapshotFileStatsBlobUri(ACCOUNT_ID, "tbl-b", "f", "sha-b");
+    blobs.put(deferredA, "a".getBytes(StandardCharsets.UTF_8), "text/plain");
+    blobs.put(deferredB, "b".getBytes(StandardCharsets.UTF_8), "text/plain");
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(
+        blobs.head(deferredA).isPresent(), "candidates of the unprovable table must be kept");
+    assertFalse(
+        blobs.head(deferredB).isPresent(),
+        "the other table's independently-proven garbage must still be reclaimed");
+    assertTrue(result.poisoned(), "an unprovable re-mark must still reach the poisoned gauge");
+  }
+
+  @Test
+  void stillDeletesSupersededBlobWhosePointerMovedOn() {
+    // The recheck must not resurrect garbage: when the owner pointer references a NEWER blob,
+    // the superseded one is genuinely unreferenced and the sweep reclaims it as before.
+    String pointerKey = Keys.tablePointerById(ACCOUNT_ID, TABLE_ID);
+    String oldBlob = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-old");
+    String newBlob = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-new");
+    blobs.put(oldBlob, "old".getBytes(StandardCharsets.UTF_8), "text/plain");
+    blobs.put(newBlob, "new".getBytes(StandardCharsets.UTF_8), "text/plain");
+    putPointer(pointerKey, newBlob);
+
+    var result = gc.runForAccount(ACCOUNT_ID);
+
+    assertFalse(blobs.head(oldBlob).isPresent(), "superseded blob is still reclaimed");
+    assertTrue(blobs.head(newBlob).isPresent());
+    assertEquals(0, result.blobsRescued());
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/telemetry/ServiceTelemetryContributorTest.java
@@ -54,6 +54,8 @@ class ServiceTelemetryContributorTest {
         registry.metric(ServiceMetrics.Reconcile.PLANNER_TICK_LATENCY.name());
     MetricDef plannerEnqueue = registry.metric(ServiceMetrics.Reconcile.PLANNER_ENQUEUE.name());
     MetricDef casPoisonedAccounts = registry.metric(ServiceMetrics.Gc.CAS_POISONED_ACCOUNTS.name());
+    MetricDef casDeleteUnsupportedAccounts =
+        registry.metric(ServiceMetrics.Gc.CAS_DELETE_UNSUPPORTED_ACCOUNTS.name());
     MetricDef casOldestSweepAge = registry.metric(ServiceMetrics.Gc.CAS_OLDEST_SWEEP_AGE.name());
     MetricDef reconcileGcAccounts =
         registry.metric(ServiceMetrics.Gc.RECONCILE_JOB_ACCOUNTS_LAST_TICK.name());
@@ -147,6 +149,11 @@ class ServiceTelemetryContributorTest {
         .containsExactlyInAnyOrder(TagKey.COMPONENT, TagKey.OPERATION);
     assertThat(casPoisonedAccounts.allowedTags())
         .containsExactlyInAnyOrder(TagKey.COMPONENT, TagKey.OPERATION);
+    assertThat(casDeleteUnsupportedAccounts).isNotNull();
+    assertThat(casDeleteUnsupportedAccounts.requiredTags())
+        .isEqualTo(casPoisonedAccounts.requiredTags());
+    assertThat(casDeleteUnsupportedAccounts.allowedTags())
+        .isEqualTo(casPoisonedAccounts.allowedTags());
     assertThat(casOldestSweepAge).isNotNull();
     assertThat(casOldestSweepAge.requiredTags()).isEqualTo(casPoisonedAccounts.requiredTags());
     assertThat(casOldestSweepAge.allowedTags()).isEqualTo(casPoisonedAccounts.allowedTags());
@@ -191,6 +198,7 @@ class ServiceTelemetryContributorTest {
                 ServiceMetrics.Reconcile.PLANNER_TICK_LATENCY.name(),
                 ServiceMetrics.Reconcile.PLANNER_ENQUEUE.name(),
                 ServiceMetrics.Gc.CAS_POISONED_ACCOUNTS.name(),
+                ServiceMetrics.Gc.CAS_DELETE_UNSUPPORTED_ACCOUNTS.name(),
                 ServiceMetrics.Gc.CAS_OLDEST_SWEEP_AGE.name(),
                 ServiceMetrics.Gc.RECONCILE_JOB_ACCOUNTS_LAST_TICK.name(),
                 ServiceMetrics.Gc.RECONCILE_JOB_ACCOUNT_PAGE_INDEX.name(),

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryBlobStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryBlobStore.java
@@ -130,6 +130,11 @@ public class InMemoryBlobStore implements BlobStore {
       throw new IllegalArgumentException("versioned delete requires a versionId: " + uri);
     }
     final String k = normalize(uri);
+    if (!map.containsKey(k)) {
+      // Contract (and S3 behavior, which maps the 404 to true): the named version being already
+      // absent counts as deleted — the caller's goal state holds.
+      return true;
+    }
     boolean[] removed = {false};
     map.computeIfPresent(
         k,

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryBlobStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryBlobStore.java
@@ -129,18 +129,25 @@ public class InMemoryBlobStore implements BlobStore {
       // Match the S3 store: never degrade to the unconditional delete.
       throw new IllegalArgumentException("versioned delete requires a versionId: " + uri);
     }
+    // The SPI contract distinguishes two outcomes, and this single-version model maps both:
+    //   - key WHOLLY absent  -> true  ("the named version is gone; the caller's goal state holds",
+    //                                   matching S3's 404 -> true);
+    //   - key present but the CURRENT version differs -> false ("the store can tell the blob has
+    //                                   moved past the caller's head(): nothing was deleted").
+    // The two returns look opposite for what is, in both, "the named version is not current", but
+    // they answer different questions the contract asks: "is that version gone?" (yes for absent)
+    // vs "did I delete something / did the current copy survive?" (nothing deleted, survived).
     final String k = normalize(uri);
     if (!map.containsKey(k)) {
-      // Contract (and S3 behavior, which maps the 404 to true): the named version being already
-      // absent counts as deleted — the caller's goal state holds.
       return true;
     }
     boolean[] removed = {false};
     map.computeIfPresent(
         k,
         (key, blob) -> {
-          // Only the named version dies; a write that landed after the caller's head() minted a
-          // higher version and must survive — mirroring an S3 version-targeted DeleteObject.
+          // This store keeps only the CURRENT version. Delete it iff it IS the named one; a newer
+          // version (higher counter) means a write landed after the caller's head() and must
+          // survive — mirroring an S3 version-targeted DeleteObject that leaves other versions.
           if (Long.toString(blob.version).equals(versionId)) {
             removed[0] = true;
             return null;

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/memory/InMemoryBlobStoreVersioningTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/memory/InMemoryBlobStoreVersioningTest.java
@@ -85,4 +85,12 @@ class InMemoryBlobStoreVersioningTest {
     assertThrows(IllegalArgumentException.class, () -> store.delete("/k", ""));
     assertTrue(store.head("/k").isPresent(), "nothing was deleted");
   }
+
+  @Test
+  void versionTargetedDeleteOfAnAbsentKeyCountsAsDeleted() {
+    // SPI contract (and S3, which maps the 404 to true): the named version being already absent
+    // means the caller's goal state holds.
+    var store = new InMemoryBlobStore();
+    assertTrue(store.delete("/accounts/a/tables/t/table/never-existed.pb", "42"));
+  }
 }


### PR DESCRIPTION
## Summary 

#390 closes the observed corruption (eng-floe/core#1904) — the content-addressed pointer flip-flop that let `CasBlobGc` delete a live table blob — via always-PUT (min-age fence works again), the per-candidate owner recheck, version-targeted deletes, and a fail-closed gate on non-versioned buckets. This follow-up hardens the sweep against the **broader class**: any gap between the referenced set and the truth (scan-visibility races, swallowed signals), where a wrong delete is permanent catalog corruption with no self-heal.

### What's here

- **`gc: harden the owner recheck — defer no-owner families, re-prove, isolate account failures`**
  - **Rescue, don't poison.** When a candidate's owner pointer still references it, the referenced set missed a live reference — keep the blob and count the rescue (`blobs-rescued` gauge, WARN), but do **not** poison or abort. A stale set can only cause false *keeps*: every owner-derivable candidate self-rechecks, every no-owner candidate is deferred and re-proven, so continuing is safe and lets the pass finish. (Poisoning on rescue let one table's persistent flip-flop starve the whole account's no-owner collection — the bug this replaces.)
  - **Deferred flush with per-table re-mark.** Families with no derivable owner (root manifest pages, per-target/file stats) are deferred (carrying the age-checked version) and deleted only after re-proving liveness per owning table against the **settled** store (root-chain re-walk + stats/constraints re-scan). Gated on `walkFailures` only; a per-table re-mark failure keeps that table's candidates without starving others.
  - **Fail-safe** on an underivable owner in a non-deferring pass (skip, never blind-delete).
  - **Scheduler isolates account failures.** `runForAccount` is wrapped so one account's storage fault — a transient SDK error, or 403 AccessDenied when the role lacks the now-required `s3:DeleteObjectVersion` — is logged, counted poisoned, and the tick advances instead of aborting.

- **`telemetry: register unsupported CAS delete accounts`** — surfaces #390's fail-closed gate (versioning disabled → GC skips) so a misconfigured bucket is observable, not silently never-collecting.

- **`storage/aws: require noncurrent version expiration`** — documents and locally provisions the deployment contract #390's always-PUT + versioning creates: versioning `Enabled` **and** a `NoncurrentVersionExpiration` lifecycle rule (else noncurrent versions of hot keys grow unbounded — the lifecycle rule, not GC code, is the right tool). Adds the missing `s3:DeleteObjectVersion` IAM prerequisite.

- **`docs: clarify Keys.ownerPointerKeyForBlob`** — the generation-scoped target-stats shape carries the snapshot id and *is* owner-derivable (inline recheck), unlike the snapshot-id-less shape (deferred). Doc-only.

## Type of Change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
