### PR TITLE
GetUserObjects: add fast-path identity-only resolution

### DIFF
--- a/core/proto/src/main/proto/floecat/catalog/table_root.proto
+++ b/core/proto/src/main/proto/floecat/catalog/table_root.proto
@@ -87,6 +87,18 @@ message SnapshotManifestEntry {
 
   /** Upstream commit time; drives AS_OF resolution and current-advance order. */
   google.protobuf.Timestamp upstream_created_at = 5;
+
+  /**
+   * Content fingerprint of this snapshot's READ SCHEMA: sha256 of the snapshot's schema_json, or a
+   * constant sentinel when schema_json is blank (the served schema is then the table definition's
+   * default, already covered by the root's definition ref). Two snapshots with identical read
+   * schemas share a fingerprint, so a data-only ingest does not move it — this is what lets a
+   * caching client's schema stay warm across ingests while a snapshot-backed schema CHANGE still
+   * moves the possession token (see RelationPinIdentity.table_blob_version). Empty on entries
+   * written before this field existed; readers fall back to snapshot_ref.version (correct, but
+   * cold on every ingest).
+   */
+  string schema_fingerprint = 6;
 }
 
 /**

--- a/core/proto/src/main/proto/floecat/query/pinning.proto
+++ b/core/proto/src/main/proto/floecat/query/pinning.proto
@@ -179,35 +179,46 @@ message RelationPinIdentity {
   PinKind pin_kind = 2;
 
   /**
-   * Opaque cache key for the SERVED PAYLOAD of a resolved relation. A caching client keys the
-   * relation by this value and serves it warm across queries; the slim identity-only reply is gated
-   * on it (GetUserObjectsRequest.known_table_blob_versions). Treat it as an opaque token: the server
-   * mints it and the client only stores and echoes it, so the derivation may change without a wire
-   * break.
+   * Cache/provenance token whose MEANING depends on the emitting path:
    *
-   * The payload is (column schema + any engine-specific column decoration), so the token is scoped
-   * accordingly. When the server emits engine-specific decoration it folds the requesting engine
-   * (kind, version) and a decorator epoch into the token; otherwise the token is exactly the table
-   * DEFINITION blob version (root.definition_ref). This is what keeps identity-only reuse sound when
-   * a client shares one cache across engines or spans an engine/decorator upgrade — a version
-   * decorated for engine A cannot be reused, identity-only, under engine B.
+   *   - On a GetUserObjects bundle (RelationInfo.pin_identity) it is the opaque, payload-scoped
+   *     POSSESSION TOKEN: a caching client keys the relation by it and serves it warm across
+   *     queries, and the slim identity-only reply is gated on it
+   *     (GetUserObjectsRequest.known_table_blob_versions). The server mints it and the client only
+   *     stores and echoes it, so the derivation may change without a wire break — treat it as
+   *     opaque. Derivation and contracts below.
+   *   - On the query-pin paths (BeginQueryResponse.relation_pins, GetQuerySchema) it is the RAW
+   *     table DEFINITION blob version (TablePin.table_blob_version) — real per-touch provenance,
+   *     NOT a minted cache key. A value read from these paths MUST NOT be fed into
+   *     known_table_blob_versions: the bundle path recomputes a hashed token, so the raw value can
+   *     never match (a silent, permanent cache miss — fail-safe, but the optimization is dead).
+   *
+   * Possession-token derivation (bundle path only): the served payload is the column schema (read
+   * schema-on-read from the pinned snapshot) plus any engine-specific column decoration, so the
+   * token folds in the table definition blob version AND the pinned SNAPSHOT blob version, plus —
+   * when the server emits engine-specific decoration — the requesting engine (kind, version) and a
+   * decorator epoch. When there is nothing to fold (no snapshot pin — views/system relations — AND
+   * no decoration) the token is exactly the definition blob version. Folding the engine keeps reuse
+   * sound across engines/decorator upgrades: a version decorated for engine A cannot be reused,
+   * identity-only, under engine B.
    *
    * Soundness rests on three contracts:
-   *   1. Any change to the served column schema moves this version. Columns are read from the
-   *      snapshot blob (schema-on-read), so schema-affecting changes (DDL, connector resync) bump
-   *      the definition ref; a benign change that leaves the read schema untouched need not, and
-   *      deliberately does not (see pin_fingerprint) — that is what lets the schema stay warm
-   *      across ingests, stats publishes, and constraint writes.
-   *   2. Any change to the engine decoration of the served columns moves this version — via the
-   *      engine identity and decorator epoch folded in above.
-   *   3. A version denotes the FULL column set. The server stamps pin_identity only on
-   *      full-schema (wants_all_columns) responses, so "I hold version V" means "I hold V's
-   *      complete schema"; projection is a client-local operation over that cached full schema.
+   *   1. Any change to the served column schema moves the token. The schema is read from the
+   *      snapshot blob, and a snapshot schema change (CreateSnapshot/UpdateSnapshot) need NOT move
+   *      the definition ref — so the token folds in the snapshot blob version, which moves whenever
+   *      the snapshot does. That is a superset of schema changes (a data-only ingest also moves it),
+   *      so it is never stale but coarser than the schema; it does NOT move on stats-generation or
+   *      constraints writes (separate manifest refs), so the schema stays warm across those.
+   *   2. Any change to the engine decoration of the served columns moves the token — via the engine
+   *      identity and decorator epoch folded in above.
+   *   3. A non-blank token denotes the FULL column set. The server stamps a non-blank token only on
+   *      full-schema (wants_all_columns) responses; a projected or decoration-incomplete reply still
+   *      carries pin_identity for provenance but with this field blank, so "I hold version V" means
+   *      "I hold V's complete schema" and projection stays a client-local operation.
    *
-   * Note this is a distinct concern from the pin's DATA identity: pin_fingerprint deliberately
-   * excludes table_blob_version, and the internal TablePin.table_blob_version stays the raw
-   * definition version for pin equality and validation — only this client-facing cache key is
-   * payload-scoped.
+   * Distinct from the pin's DATA identity: pin_fingerprint deliberately excludes table_blob_version,
+   * and the internal TablePin.table_blob_version stays the raw definition version for pin equality
+   * and validation — only the bundle-path cache key is payload-scoped.
    */
   string table_blob_version = 3;
 

--- a/core/proto/src/main/proto/floecat/query/pinning.proto
+++ b/core/proto/src/main/proto/floecat/query/pinning.proto
@@ -179,19 +179,35 @@ message RelationPinIdentity {
   PinKind pin_kind = 2;
 
   /**
-   * Immutable version of the pinned table DEFINITION blob (root.definition_ref). A caching client
-   * keys a resolved relation's SCHEMA by this value and serves it warm across queries; the slim
-   * identity-only reply is gated on it (GetUserObjectsRequest.known_table_blob_versions).
+   * Opaque cache key for the SERVED PAYLOAD of a resolved relation. A caching client keys the
+   * relation by this value and serves it warm across queries; the slim identity-only reply is gated
+   * on it (GetUserObjectsRequest.known_table_blob_versions). Treat it as an opaque token: the server
+   * mints it and the client only stores and echoes it, so the derivation may change without a wire
+   * break.
    *
-   * Soundness rests on two contracts:
+   * The payload is (column schema + any engine-specific column decoration), so the token is scoped
+   * accordingly. When the server emits engine-specific decoration it folds the requesting engine
+   * (kind, version) and a decorator epoch into the token; otherwise the token is exactly the table
+   * DEFINITION blob version (root.definition_ref). This is what keeps identity-only reuse sound when
+   * a client shares one cache across engines or spans an engine/decorator upgrade — a version
+   * decorated for engine A cannot be reused, identity-only, under engine B.
+   *
+   * Soundness rests on three contracts:
    *   1. Any change to the served column schema moves this version. Columns are read from the
    *      snapshot blob (schema-on-read), so schema-affecting changes (DDL, connector resync) bump
    *      the definition ref; a benign change that leaves the read schema untouched need not, and
    *      deliberately does not (see pin_fingerprint) — that is what lets the schema stay warm
    *      across ingests, stats publishes, and constraint writes.
-   *   2. A version denotes the FULL column set. The server stamps pin_identity only on
+   *   2. Any change to the engine decoration of the served columns moves this version — via the
+   *      engine identity and decorator epoch folded in above.
+   *   3. A version denotes the FULL column set. The server stamps pin_identity only on
    *      full-schema (wants_all_columns) responses, so "I hold version V" means "I hold V's
    *      complete schema"; projection is a client-local operation over that cached full schema.
+   *
+   * Note this is a distinct concern from the pin's DATA identity: pin_fingerprint deliberately
+   * excludes table_blob_version, and the internal TablePin.table_blob_version stays the raw
+   * definition version for pin equality and validation — only this client-facing cache key is
+   * payload-scoped.
    */
   string table_blob_version = 3;
 

--- a/core/proto/src/main/proto/floecat/query/pinning.proto
+++ b/core/proto/src/main/proto/floecat/query/pinning.proto
@@ -133,6 +133,15 @@ message TablePin {
    * stores that do not track generations (the scan then serves live state). Server-side only.
    */
   string stats_generation_ref_uri = 16;
+
+  /**
+   * Read-schema fingerprint copied from the pinned root's manifest entry at construction (see
+   * SnapshotManifestEntry.schema_fingerprint). Feeds the possession token so a data-only ingest
+   * (new snapshot, unchanged read schema) keeps a caching client's schema warm while a
+   * snapshot-backed schema change still moves the token. Empty for pins built from pre-fingerprint
+   * manifest entries; the token then falls back to snapshot_blob_version. Server-side only.
+   */
+  string schema_fingerprint = 17;
 }
 
 /**
@@ -195,20 +204,24 @@ message RelationPinIdentity {
    *
    * Possession-token derivation (bundle path only): the served payload is the column schema (read
    * schema-on-read from the pinned snapshot) plus any engine-specific column decoration, so the
-   * token folds in the table definition blob version AND the pinned SNAPSHOT blob version, plus —
-   * when the server emits engine-specific decoration — the requesting engine (kind, version) and a
-   * decorator epoch. When there is nothing to fold (no snapshot pin — views/system relations — AND
-   * no decoration) the token is exactly the definition blob version. Folding the engine keeps reuse
-   * sound across engines/decorator upgrades: a version decorated for engine A cannot be reused,
-   * identity-only, under engine B.
+   * token folds in the table definition blob version AND the pinned read-schema fingerprint
+   * (SnapshotManifestEntry.schema_fingerprint; pre-fingerprint entries fall back to the snapshot
+   * blob version), plus — when the server emits engine-specific decoration — the requesting engine
+   * (kind, version) and a decorator epoch. When there is nothing to fold (no snapshot pin —
+   * views/system relations — AND no decoration) the token is exactly the definition blob version.
+   * Folding the engine keeps reuse sound across engines/decorator upgrades: a version decorated for
+   * engine A cannot be reused, identity-only, under engine B.
    *
    * Soundness rests on three contracts:
    *   1. Any change to the served column schema moves the token. The schema is read from the
    *      snapshot blob, and a snapshot schema change (CreateSnapshot/UpdateSnapshot) need NOT move
-   *      the definition ref — so the token folds in the snapshot blob version, which moves whenever
-   *      the snapshot does. That is a superset of schema changes (a data-only ingest also moves it),
-   *      so it is never stale but coarser than the schema; it does NOT move on stats-generation or
-   *      constraints writes (separate manifest refs), so the schema stays warm across those.
+   *      the definition ref — so the token folds in the read-schema fingerprint, which moves
+   *      exactly when the snapshot's schema_json does. A data-only ingest (new snapshot, unchanged
+   *      read schema) therefore keeps the token — and a caching client's schema — warm; so do
+   *      stats-generation and constraints writes (separate manifest refs). Pins from
+   *      pre-fingerprint manifest entries fall back to the snapshot blob version: a superset of
+   *      schema changes — never stale, just cold on every ingest until the table's next snapshot
+   *      write stamps a fingerprint.
    *   2. Any change to the engine decoration of the served columns moves the token — via the engine
    *      identity and decorator epoch folded in above.
    *   3. A non-blank token denotes the FULL column set. The server stamps a non-blank token only on

--- a/core/proto/src/main/proto/floecat/query/pinning.proto
+++ b/core/proto/src/main/proto/floecat/query/pinning.proto
@@ -178,7 +178,21 @@ message RelationPinIdentity {
   /** Kind of the pin this identity describes. */
   PinKind pin_kind = 2;
 
-  /** Immutable version of the pinned table metadata blob. */
+  /**
+   * Immutable version of the pinned table DEFINITION blob (root.definition_ref). A caching client
+   * keys a resolved relation's SCHEMA by this value and serves it warm across queries; the slim
+   * identity-only reply is gated on it (GetUserObjectsRequest.known_table_blob_versions).
+   *
+   * Soundness rests on two contracts:
+   *   1. Any change to the served column schema moves this version. Columns are read from the
+   *      snapshot blob (schema-on-read), so schema-affecting changes (DDL, connector resync) bump
+   *      the definition ref; a benign change that leaves the read schema untouched need not, and
+   *      deliberately does not (see pin_fingerprint) — that is what lets the schema stay warm
+   *      across ingests, stats publishes, and constraint writes.
+   *   2. A version denotes the FULL column set. The server stamps pin_identity only on
+   *      full-schema (wants_all_columns) responses, so "I hold version V" means "I hold V's
+   *      complete schema"; projection is a client-local operation over that cached full schema.
+   */
   string table_blob_version = 3;
 
   /** The resolved concrete snapshot id. */

--- a/core/proto/src/main/proto/floecat/query/user_objects_bundle.proto
+++ b/core/proto/src/main/proto/floecat/query/user_objects_bundle.proto
@@ -73,6 +73,18 @@ message GetUserObjectsRequest {
 
   /** Planner references expressed as ordered candidates; responses include `input_index`. */
   repeated TableReferenceCandidate tables = 2;
+
+  /**
+   * Content-hash relation versions the caller already holds (the values of
+   * RelationPinIdentity.table_blob_version from earlier responses). When a
+   * resolved relation's identity is in this list, the server MAY omit the
+   * relation payload (schema, columns, view definition) and return only the
+   * identity plus the lightweight stats — the omitted bytes are provably
+   * identical to what the caller holds. A generic conditional-request
+   * feature: servers are free to ignore the hint, and callers must treat a
+   * full payload as equally correct.
+   */
+  repeated string known_table_blob_versions = 3;
 }
 
 /**
@@ -424,11 +436,16 @@ message ColumnResult {
  * Optional relation statistics returned from a cached snapshot.
  */
 message RelationStats {
-  /** Estimated row count for the relation. */
-  int64 row_count = 1;
+  /**
+   * Estimated row count for the relation. Presence-tracked: a caching client refreshes its warm
+   * row count from an identity-only reply, so it MUST distinguish "count unknown this reply"
+   * (field absent — leave the cached estimate) from a genuine zero. A bare int64 would report both
+   * as 0 and let a size-only reply clobber a valid cached cardinality with 0.
+   */
+  optional int64 row_count = 1;
 
-  /** Estimated total size in bytes for the relation. */
-  int64 total_size_bytes = 2;
+  /** Estimated total size in bytes for the relation. Presence-tracked for the same reason. */
+  optional int64 total_size_bytes = 2;
 }
 
 /**

--- a/core/types/src/main/java/ai/floedb/floecat/types/Hashing.java
+++ b/core/types/src/main/java/ai/floedb/floecat/types/Hashing.java
@@ -16,11 +16,17 @@
 
 package ai.floedb.floecat.types;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 /** Shared hashing helpers for cross-module stable digest generation. */
 public final class Hashing {
   private Hashing() {}
+
+  /** Stable hex SHA-256 of a string's UTF-8 bytes. */
+  public static String sha256Hex(String value) {
+    return sha256Hex(value.getBytes(StandardCharsets.UTF_8));
+  }
 
   public static String sha256Hex(byte[] bytes) {
     try {

--- a/core/types/src/main/java/ai/floedb/floecat/types/Hashing.java
+++ b/core/types/src/main/java/ai/floedb/floecat/types/Hashing.java
@@ -18,13 +18,19 @@ package ai.floedb.floecat.types;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Objects;
 
 /** Shared hashing helpers for cross-module stable digest generation. */
 public final class Hashing {
   private Hashing() {}
 
-  /** Stable hex SHA-256 of a string's UTF-8 bytes. */
+  /**
+   * Stable hex SHA-256 of a string's UTF-8 bytes. The argument must be non-null: this hashes cache
+   * keys and identity tokens, where coercing null to "" would silently collide a "missing" input
+   * with a genuinely-empty one. Callers that mean "empty" must pass "".
+   */
   public static String sha256Hex(String value) {
+    Objects.requireNonNull(value, "sha256Hex value must not be null");
     return sha256Hex(value.getBytes(StandardCharsets.UTF_8));
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootMutations.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootMutations.java
@@ -405,6 +405,13 @@ public final class TableRootMutations {
     if (!incoming.hasUpstreamCreatedAt() && existing.hasUpstreamCreatedAt()) {
       merged.setUpstreamCreatedAt(existing.getUpstreamCreatedAt());
     }
+    // schema_fingerprint has the same survive-a-partial-rewrite property: an incoming candidate
+    // without one must not downgrade a fingerprinted entry to the coarse snapshot_blob_version
+    // fallback (cold-on-ingest). Every candidate builder stamps it today, so this only guards a
+    // future/legacy minimal candidate — cheap insurance, consistent with the refs above.
+    if (incoming.getSchemaFingerprint().isEmpty() && !existing.getSchemaFingerprint().isEmpty()) {
+      merged.setSchemaFingerprint(existing.getSchemaFingerprint());
+    }
     return merged.build();
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootSynthesizer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootSynthesizer.java
@@ -172,7 +172,9 @@ public class TableRootSynthesizer {
     SnapshotManifestEntry.Builder entry =
         SnapshotManifestEntry.newBuilder()
             .setSnapshotId(snapshot.getSnapshotId())
-            .setSnapshotRef(BlobRefs.refFrom(snapMeta));
+            .setSnapshotRef(BlobRefs.refFrom(snapMeta))
+            .setSchemaFingerprint(
+                ai.floedb.floecat.service.repo.impl.SnapshotManifests.schemaFingerprint(snapshot));
     if (snapshot.hasUpstreamCreatedAt()) {
       entry.setUpstreamCreatedAt(snapshot.getUpstreamCreatedAt());
     }

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
@@ -86,7 +86,9 @@ public class TableRootWriter {
     SnapshotManifestEntry.Builder entry =
         SnapshotManifestEntry.newBuilder()
             .setSnapshotId(candidate.getSnapshotId())
-            .setSnapshotRef(snapshotRef);
+            .setSnapshotRef(snapshotRef)
+            .setSchemaFingerprint(
+                ai.floedb.floecat.service.repo.impl.SnapshotManifests.schemaFingerprint(candidate));
     if (candidate.hasUpstreamCreatedAt()) {
       entry.setUpstreamCreatedAt(candidate.getUpstreamCreatedAt());
     }
@@ -280,8 +282,14 @@ public class TableRootWriter {
         SnapshotManifestEntry.newBuilder().setSnapshotId(snapshotId).setSnapshotRef(snapshotRef);
     snapshots
         .getById(tableId, snapshotId)
-        .filter(Snapshot::hasUpstreamCreatedAt)
-        .ifPresent(s -> builder.setUpstreamCreatedAt(s.getUpstreamCreatedAt()));
+        .ifPresent(
+            s -> {
+              if (s.hasUpstreamCreatedAt()) {
+                builder.setUpstreamCreatedAt(s.getUpstreamCreatedAt());
+              }
+              builder.setSchemaFingerprint(
+                  ai.floedb.floecat.service.repo.impl.SnapshotManifests.schemaFingerprint(s));
+            });
     // Attach the finalized aux refs the same way TableRootSynthesizer.entryFor does. A resync
     // creates a fresh entry (no prior entry for preserveAuxRefs to copy from), so without this a
     // finalized snapshot would land WITHOUT its stats_generation_ref — invisible under the gate —

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
@@ -321,7 +321,10 @@ public class SnapshotHelper {
             .setTableBlobUri(root.getDefinitionRef().getUri())
             .setTableBlobVersion(root.getDefinitionRef().getVersion())
             .setSnapshotBlobUri(entry.getSnapshotRef().getUri())
-            .setSnapshotBlobVersion(entry.getSnapshotRef().getVersion());
+            .setSnapshotBlobVersion(entry.getSnapshotRef().getVersion())
+            // Read-schema fingerprint for the possession token; empty on pre-fingerprint manifest
+            // entries (the token then falls back to snapshot_blob_version — correct, cold on ingest).
+            .setSchemaFingerprint(entry.getSchemaFingerprint());
     if (entry.hasConstraintsRef()) {
       pin.setConstraintsRefUri(entry.getConstraintsRef().getUri())
           .setConstraintsRefVersion(entry.getConstraintsRef().getVersion());

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
@@ -323,7 +323,8 @@ public class SnapshotHelper {
             .setSnapshotBlobUri(entry.getSnapshotRef().getUri())
             .setSnapshotBlobVersion(entry.getSnapshotRef().getVersion())
             // Read-schema fingerprint for the possession token; empty on pre-fingerprint manifest
-            // entries (the token then falls back to snapshot_blob_version — correct, cold on ingest).
+            // entries (the token then falls back to snapshot_blob_version — correct, cold on
+            // ingest).
             .setSchemaFingerprint(entry.getSchemaFingerprint());
     if (entry.hasConstraintsRef()) {
       pin.setConstraintsRefUri(entry.getConstraintsRef().getUri())

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -586,11 +586,16 @@ public class UserObjectBundleService {
    */
   private record SystemExecution(String backendKind, FlightEndpointRef flightEndpoint, String storagePath) {
     String tokenMaterial() {
-      return backendKind
-          + '\0'
-          + (flightEndpoint != null ? flightEndpoint.toString() : "")
-          + '\0'
-          + storagePath;
+      // Build from the endpoint's explicit, contractual fields (host/port/tls) rather than
+      // FlightEndpointRef.toString(): protobuf documents Message.toString() as non-contractual and
+      // subject to change, and this token is persisted by clients and matched across queries. The
+      // reserved `ticket` field is deliberately excluded — workers must not inspect it, and it is
+      // not routing identity. The token then moves exactly when the routing it covers moves.
+      String endpoint =
+          flightEndpoint != null
+              ? flightEndpoint.getHost() + ':' + flightEndpoint.getPort() + ':' + flightEndpoint.getTls()
+              : "";
+      return backendKind + '\0' + endpoint + '\0' + storagePath;
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -551,24 +551,67 @@ public class UserObjectBundleService {
     // cacheIdentity alone would collide across all system tables — a client that cached one would
     // be served another identity-only under the shared token and reuse the wrong schema. Mixing the
     // id in makes the token unique per relation while still moving with engine content (the version
-    // changes on catalog upgrade). Note it does NOT cover a system table's service-resolved
-    // Flight/storage endpoint (configuredEndpointForKey), which is static Quarkus deployment config
-    // — a change to it requires a redeploy, which resets client caches, so a caller cannot route to
-    // a stale endpoint across the change. If endpoint config ever becomes hot-reloadable, fold it
-    // in.
+    // changes on catalog upgrade). It also folds in a system table's resolved EXECUTION metadata
+    // (backend kind + the resolved Flight/storage endpoint) — an identity-only reply omits that
+    // metadata, and a config-resolved endpoint (configuredEndpointForKey) can change without moving
+    // cacheIdentity. A floecat redeploy does NOT reset an external caching client, so without this
+    // the client would match the token, get no endpoint, and route to the stale one. The exact
+    // value served is resolved once in resolveSystemExecution and reused here, so the token can
+    // never drift from what buildRelation stamps.
     ResourceId relId = relation.relationId();
-    String keyMaterial =
-        relId.getAccountId()
-            + '\0'
-            + relId.getId()
-            + '\0'
-            + relId.getKindValue()
-            + '\0'
-            + cacheIdentity;
+    StringBuilder keyMaterial =
+        new StringBuilder()
+            .append(relId.getAccountId())
+            .append('\0')
+            .append(relId.getId())
+            .append('\0')
+            .append(relId.getKindValue())
+            .append('\0')
+            .append(cacheIdentity);
+    if (relation.node() instanceof SystemTableNode systemTableNode) {
+      keyMaterial.append('\0').append(resolveSystemExecution(systemTableNode).tokenMaterial());
+    }
     return Optional.of(
         RelationPinIdentity.newBuilder()
-            .setTableBlobVersion(Hashing.sha256Hex(keyMaterial))
+            .setTableBlobVersion(Hashing.sha256Hex(keyMaterial.toString()))
             .build());
+  }
+
+  /**
+   * A system table's resolved execution metadata: the backend kind plus the concrete endpoint the
+   * bundle serves (a Flight endpoint, whether built-in, node-declared, or config-resolved, or a
+   * storage-path fallback). Resolved in ONE place so buildRelation (which stamps these fields) and
+   * pinIdentityFor (which folds them into the possession token) can never disagree — the token must
+   * cover exactly the routing an identity-only reply omits.
+   */
+  private record SystemExecution(String backendKind, FlightEndpointRef flightEndpoint, String storagePath) {
+    String tokenMaterial() {
+      return backendKind
+          + '\0'
+          + (flightEndpoint != null ? flightEndpoint.toString() : "")
+          + '\0'
+          + storagePath;
+    }
+  }
+
+  private SystemExecution resolveSystemExecution(SystemTableNode node) {
+    String backendKind = String.valueOf(node.backendKind());
+    if (node instanceof SystemTableNode.FloeCatSystemTableNode) {
+      return new SystemExecution(backendKind, floecatFlightEndpoint, "");
+    }
+    if (node instanceof SystemTableNode.StorageSystemTableNode storage) {
+      if (storage.flightEndpoint() != null) {
+        return new SystemExecution(backendKind, storage.flightEndpoint(), "");
+      }
+      Optional<FlightEndpointRef> configured = configuredEndpointForKey(storage.storageEndpointKey());
+      if (configured.isPresent()) {
+        return new SystemExecution(backendKind, configured.get(), "");
+      }
+      if (!storage.storagePath().isBlank()) {
+        return new SystemExecution(backendKind, null, storage.storagePath());
+      }
+    }
+    return new SystemExecution(backendKind, null, "");
   }
 
   /**
@@ -583,11 +626,7 @@ public class UserObjectBundleService {
       QueryContext queryContext,
       EngineContext ctx) {
     return pinIdentityFor(correlationId, relation, queryContext)
-        .map(
-            id ->
-                id.toBuilder()
-                    .setTableBlobVersion(possessionToken(id.getTableBlobVersion(), ctx))
-                    .build());
+        .map(id -> id.toBuilder().setTableBlobVersion(possessionToken(id, ctx)).build());
   }
 
   /**
@@ -602,25 +641,45 @@ public class UserObjectBundleService {
    * mint sites; the client stays engine-agnostic and correctness no longer depends on it keying its
    * own cache by engine.
    *
-   * <p>When decoration is not in play ({@code !decorationRequired}) the payload is fully determined
-   * by the content version, so the token IS the content version — byte-identical to the unscoped
-   * behavior, so no cache fragmentation and no change for single-engine or decoration-off
-   * deployments. {@code decorationEpoch} additionally invalidates cached decoration when the
-   * decorator's behavior changes without moving the engine version.
+   * <p>The token folds in the pinned SNAPSHOT blob version, because the served column schema is
+   * read from the snapshot (schema-on-read) and CreateSnapshot/UpdateSnapshot can change that
+   * schema WITHOUT moving the definition ref (table_blob_version). A definition-only token would
+   * therefore let a client that holds an old schema be served identity-only for a NEW schema and
+   * reuse stale columns/types. snapshot_blob_version moves whenever the snapshot does — a strict
+   * superset of schema changes, so never stale — but it is coarser than the schema: it also moves
+   * on data-only ingests (a new snapshot with an unchanged schema), so a hot-ingest table refetches
+   * its full (unchanged) schema each query instead of a slim identity-only reply. It does NOT move
+   * on stats-generation or constraints writes (separate manifest refs), so the schema stays warm
+   * across those. Recovering warmth across ingests needs a schema-scoped ref on the snapshot
+   * manifest entry (follow-up); until then this is correct and never serves a stale schema. Views
+   * and system relations have no snapshot pin, so their token is unaffected by this scope.
+   *
+   * <p>{@code decorationEpoch} additionally invalidates cached decoration when the decorator's
+   * behavior changes without moving the engine version. When there is nothing to fold in — no
+   * snapshot scope (views/system) AND no engine decoration — the token IS the content version,
+   * byte-identical to the unscoped behavior.
    */
-  private String possessionToken(String contentVersion, EngineContext ctx) {
-    if (contentVersion == null || contentVersion.isBlank() || !decorationRequired(ctx)) {
+  private String possessionToken(RelationPinIdentity id, EngineContext ctx) {
+    String contentVersion = id.getTableBlobVersion();
+    if (contentVersion == null || contentVersion.isBlank()) {
       return contentVersion;
     }
-    String material =
-        contentVersion
-            + '\0'
-            + safe(ctx.normalizedKind())
-            + '\0'
-            + safe(ctx.normalizedVersion())
-            + '\0'
-            + decorationEpoch;
-    return Hashing.sha256Hex(material);
+    String snapshotScope = safe(id.getSnapshotBlobVersion());
+    boolean decorate = decorationRequired(ctx);
+    if (snapshotScope.isBlank() && !decorate) {
+      return contentVersion;
+    }
+    StringBuilder material = new StringBuilder(contentVersion).append('\0').append(snapshotScope);
+    if (decorate) {
+      material
+          .append('\0')
+          .append(safe(ctx.normalizedKind()))
+          .append('\0')
+          .append(safe(ctx.normalizedVersion()))
+          .append('\0')
+          .append(decorationEpoch);
+    }
+    return Hashing.sha256Hex(material.toString());
   }
 
   /*
@@ -726,21 +785,14 @@ public class UserObjectBundleService {
      * path fallback. ENGINE tables never set an endpoint.
      */
     if (relation.node() instanceof SystemTableNode systemTableNode) {
+      // Resolve once through the shared helper so the served routing and the token that covers it
+      // (pinIdentityFor) are computed from the same logic and cannot drift.
+      SystemExecution exec = resolveSystemExecution(systemTableNode);
       builder.setBackendKind(systemTableNode.backendKind());
-      if (systemTableNode instanceof SystemTableNode.FloeCatSystemTableNode) {
-        builder.setFlightEndpoint(floecatFlightEndpoint);
-      } else if (systemTableNode instanceof SystemTableNode.StorageSystemTableNode storage) {
-        if (storage.flightEndpoint() != null) {
-          builder.setFlightEndpoint(storage.flightEndpoint());
-        } else {
-          Optional<FlightEndpointRef> configuredEndpoint =
-              configuredEndpointForKey(storage.storageEndpointKey());
-          if (configuredEndpoint.isPresent()) {
-            builder.setFlightEndpoint(configuredEndpoint.get());
-          } else if (!storage.storagePath().isBlank()) {
-            builder.setStoragePath(storage.storagePath());
-          }
-        }
+      if (exec.flightEndpoint() != null) {
+        builder.setFlightEndpoint(exec.flightEndpoint());
+      } else if (!exec.storagePath().isBlank()) {
+        builder.setStoragePath(exec.storagePath());
       }
     }
 
@@ -763,6 +815,13 @@ public class UserObjectBundleService {
     Optional<EngineMetadataDecorator> decorator = currentDecorator(ctx);
     RelationDecoration relationDecoration = null;
     boolean relationDecorationSucceeded = true;
+    // Per-phase payload-decoration success, tracked separately from
+    // relationDecorationSucceeded (which gates hint commits below). The possession-token stamp
+    // needs EVERY payload phase to have succeeded — a view or completion failure leaves the served
+    // payload incomplete, and stamping a token for it would lock that incomplete payload into a
+    // caching client until it happened to re-miss, instead of self-healing on the next query.
+    boolean viewDecorationSucceeded = true;
+    boolean completeRelationSucceeded = true;
     long relationDecorationBeforeNanos = timings.decorationTotalNanos();
 
     if (decorationRequired && decorator.isPresent()) {
@@ -808,6 +867,7 @@ public class UserObjectBundleService {
             timings.addDecorateViewNanos(System.nanoTime() - decorateViewStartNs);
           }
         } catch (RuntimeException e) {
+          viewDecorationSucceeded = false;
           LOG.debugf(
               e,
               "Decorator threw while decorating view %s (engine=%s)",
@@ -860,6 +920,7 @@ public class UserObjectBundleService {
               decorationTimingNanos(relationDecoration, COLUMN_HINT_PERSIST_NANOS_KEY));
         }
       } catch (RuntimeException e) {
+        completeRelationSucceeded = false;
         LOG.debugf(
             e,
             "Decorator threw while completing relation %s (engine=%s)",
@@ -884,35 +945,38 @@ public class UserObjectBundleService {
           relationDecorationNanos / 1_000_000.0);
     }
 
-    // Stamp the opaque payload cache token — AFTER decoration, so it reflects the payload actually
-    // served. A caching client that holds this token is later served identity-only and reuses its
-    // cached payload verbatim, so only stamp when that payload is complete and cacheable:
-    //   - full schema: a projected subset must never advertise "I hold every column", or a later
-    //     request would be starved of columns it never received;
-    //   - decoration fully succeeded: no column ended up FAILED and the relation decoration did not
-    //     throw. FAILED columns still ride the wire (name/type present, engine payload missing), so
-    //     the client legitimately holds them and would advertise the token — locking a transient
-    //     decoration failure into its cache for the whole lifetime instead of self-healing on the
-    //     next query. This is the same caution commitColumnHints applies to persisting hints;
-    //   - non-blank token: a blank version can never prove possession (the match path rejects it),
-    //     and every blank-etag relation would otherwise collide on the empty key.
+    // Stamp the pin identity. Two distinct concerns share the message and must NOT share a gate:
+    //
+    //   - The DATA identity (pin_fingerprint, snapshot id, AS-OF provenance, constraints_ref_version)
+    //     is a property of the pinned relation, not of the served payload shape. Callers rely on it
+    //     to tell a current pin from a historical one and to skip the constraints RPC, so it is
+    //     stamped UNCONDITIONALLY whenever the relation is pinned — including on projected or
+    //     decoration-incomplete replies, which previously lost it entirely.
+    //
+    //   - The possession token (table_blob_version) is payload-scoped: a client that advertises it
+    //     is later served identity-only and reuses its cached payload verbatim. It is kept only when
+    //     the served payload is complete and cacheable, and blanked otherwise:
+    //       * full schema — a projected subset must never advertise "I hold every column", or a
+    //         later request would be starved of columns it never received;
+    //       * every payload-decoration phase succeeded (relation, view, completion) and no column
+    //         ended up FAILED — else a transient decoration failure would lock into a caching
+    //         client instead of self-healing next query;
+    //       * non-blank — a blank version can never prove possession (the match path rejects it).
     //
     // scopedIdentity is computed once by the caller and threaded into both the identity-only match
     // and this stamp, so a cache miss under a populated hint set does not hash the relation twice.
-    //
-    // Caveat for system tables: a slim reply omits the endpoint metadata, and for a config-resolved
-    // endpoint (configuredEndpointForKey) that value is NOT covered by the token — see
-    // pinIdentityFor.
-    // Identity-only reuse of such a table therefore assumes its Flight endpoint config is
-    // deploy-time
-    // fixed; if it ever becomes hot-reloadable, fold the resolved endpoint into the token there.
-    if (servesFullSchema(relation.candidate())
-        && relationDecorationSucceeded
-        && countColumnsWithStatus(columnResults, ColumnStatus.COLUMN_STATUS_FAILED) == 0) {
-      scopedIdentity
-          .filter(id -> !id.getTableBlobVersion().isBlank())
-          .ifPresent(builder::setPinIdentity);
-    }
+    boolean payloadCacheable =
+        servesFullSchema(relation.candidate())
+            && relationDecorationSucceeded
+            && viewDecorationSucceeded
+            && completeRelationSucceeded
+            && countColumnsWithStatus(columnResults, ColumnStatus.COLUMN_STATUS_FAILED) == 0;
+    scopedIdentity.ifPresent(
+        id ->
+            builder.setPinIdentity(
+                payloadCacheable && !id.getTableBlobVersion().isBlank()
+                    ? id
+                    : id.toBuilder().clearTableBlobVersion().build()));
 
     builder.addAllColumns(columnResults);
     return builder.build();
@@ -1772,15 +1836,15 @@ public class UserObjectBundleService {
         if (liveCtx == null) {
           liveCtx = queryStore.get(ctx.getQueryId()).orElse(ctx);
         }
-        // Compute the engine-scoped payload token at most once per relation: the identity-only
-        // match consults it when the client sent hints, and the full-payload stamp reuses it — so a
-        // cache miss under a populated hint set does not hash the relation twice. Skip it only when
-        // neither consumer can use it (no hints AND a projected response, which never stamps).
+        // Compute the pin identity at most once per relation: the identity-only match consults it
+        // when the client sent hints, and the stamp reuses it — so a cache miss under a populated
+        // hint set does not hash the relation twice. Computed for EVERY pinned relation (not only
+        // full-schema ones), because the stamp now preserves the data identity even on a projected
+        // reply — it merely blanks the possession token there. The extra work for a projected,
+        // hint-less reply is one pin read plus a hash, off the warm path.
         Optional<RelationPinIdentity> scopedIdentity =
-            (!knownBlobVersions.isEmpty() || servesFullSchema(found.relation().candidate()))
-                ? scopedPinIdentity(
-                    correlationId, found.relation(), liveCtx, resolutionContext.engineContext())
-                : Optional.empty();
+            scopedPinIdentity(
+                correlationId, found.relation(), liveCtx, resolutionContext.engineContext());
         /* Identity-only fast path: never cached — the info cache must only
          * ever hold full payloads, or a later request that did NOT prove
          * possession would be served a payload-less relation. */

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1030,7 +1030,13 @@ public class UserObjectBundleService {
     return builder.build();
   }
 
-  private static long decorationTimingNanos(
+  /**
+   * A non-negative {@code long} decoration attribute ({@code 0} when absent, non-numeric, or
+   * negative). The extraction/clamping lives here once; {@link #decorationTimingNanos} and {@link
+   * #decorationCounter} are named wrappers that keep the intent (a nanos timing vs. a warm-hit
+   * count) legible at their call sites.
+   */
+  private static long nonNegativeLongAttribute(
       RelationDecoration relationDecoration, String attributeKey) {
     if (relationDecoration == null || attributeKey == null || attributeKey.isBlank()) {
       return 0L;
@@ -1042,16 +1048,13 @@ public class UserObjectBundleService {
     return Math.max(0L, number.longValue());
   }
 
-  private static long decorationCounter(
+  private static long decorationTimingNanos(
       RelationDecoration relationDecoration, String attributeKey) {
-    if (relationDecoration == null || attributeKey == null || attributeKey.isBlank()) {
-      return 0L;
-    }
-    Object value = relationDecoration.attribute(attributeKey);
-    if (!(value instanceof Number number)) {
-      return 0L;
-    }
-    return Math.max(0L, number.longValue());
+    return nonNegativeLongAttribute(relationDecoration, attributeKey);
+  }
+
+  private static long decorationCounter(RelationDecoration relationDecoration, String attributeKey) {
+    return nonNegativeLongAttribute(relationDecoration, attributeKey);
   }
 
   private Optional<FlightEndpointRef> configuredEndpointForKey(String endpointKey) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -555,9 +555,9 @@ public class UserObjectBundleService {
     // (backend kind + the resolved Flight/storage endpoint) — an identity-only reply omits that
     // metadata, and a config-resolved endpoint (configuredEndpointForKey) can change without moving
     // cacheIdentity. A floecat redeploy does NOT reset an external caching client, so without this
-    // the client would match the token, get no endpoint, and route to the stale one. The exact
-    // value served is resolved once in resolveSystemExecution and reused here, so the token can
-    // never drift from what buildRelation stamps.
+    // the client would match the token, get no endpoint, and route to the stale one. The endpoint is
+    // resolved through resolveSystemExecution — the same helper buildRelation uses to stamp it — so
+    // the token cannot drift from the served routing.
     ResourceId relId = relation.relationId();
     StringBuilder keyMaterial =
         new StringBuilder()
@@ -571,6 +571,13 @@ public class UserObjectBundleService {
     if (relation.node() instanceof SystemTableNode systemTableNode) {
       keyMaterial.append('\0').append(resolveSystemExecution(systemTableNode).tokenMaterial());
     }
+    // A CONTENT-derived identity: only table_blob_version is meaningful. A view or system relation
+    // has no query snapshot pin, so snapshot_id, pin_kind, pin_fingerprint, and constraints_ref
+    // stay unset (0 / UNSPECIFIED / empty) — deliberately, not as a placeholder. Consumers must key
+    // such a relation on table_blob_version alone and MUST NOT read the snapshot-pin fields off it
+    // (there is no snapshot to describe). The in-repo planner does exactly this — it reads only
+    // table_blob_version, constraints_ref_version, and snapshot_id off pin_identity and never
+    // branches on pin_kind (see RPC_parsing.cpp) — so the present-but-defaulted fields are inert.
     return Optional.of(
         RelationPinIdentity.newBuilder()
             .setTableBlobVersion(Hashing.sha256Hex(keyMaterial.toString()))
@@ -701,7 +708,8 @@ public class UserObjectBundleService {
       ResolvedRelation relation,
       Optional<RelationPinIdentity> scopedIdentity,
       StatsProvider statsProvider,
-      Set<String> knownBlobVersions) {
+      Set<String> knownBlobVersions,
+      TimingAccumulator timings) {
     // The token is the engine-scoped payload token (scopedIdentity), not the bare content version,
     // so a client that proved possession under a different engine cannot be served identity-only.
     // A blank version can never prove possession: a user table whose definition blob had no etag
@@ -715,7 +723,13 @@ public class UserObjectBundleService {
       return null;
     }
     RelationInfo.Builder slim = baseRelationInfo(relation).setPinIdentity(scopedIdentity.get());
+    // Time the stats lookup exactly as the full path does (buildRelation): the slim path still hits
+    // the stats provider, which can block on its latency budget. Without this, once the
+    // conditional-request feature is doing its job a large fraction of resolutions would contribute
+    // zero to statsLookup telemetry and the slow-RPC threshold.
+    long statsLookupStartNs = System.nanoTime();
     attachTableStats(slim, relation.relationId(), statsProvider);
+    timings.addStatsLookupNanos(System.nanoTime() - statsLookupStartNs);
     return slim.build();
   }
 
@@ -790,8 +804,10 @@ public class UserObjectBundleService {
      * path fallback. ENGINE tables never set an endpoint.
      */
     if (relation.node() instanceof SystemTableNode systemTableNode) {
-      // Resolve once through the shared helper so the served routing and the token that covers it
-      // (pinIdentityFor) are computed from the same logic and cannot drift.
+      // Resolve through the shared helper — the SAME implementation pinIdentityFor uses to fold
+      // routing into the token — so the served routing and the token that covers it cannot drift.
+      // It is invoked independently at each site (a cheap in-memory config lookup), not memoized
+      // across them; both resolve deterministically from the same node, so they always agree.
       SystemExecution exec = resolveSystemExecution(systemTableNode);
       builder.setBackendKind(systemTableNode.backendKind());
       if (exec.flightEndpoint() != null) {
@@ -1854,8 +1870,15 @@ public class UserObjectBundleService {
          * ever hold full payloads, or a later request that did NOT prove
          * possession would be served a payload-less relation. */
         RelationInfo slim =
-            identityOnlyOrNull(found.relation(), scopedIdentity, statsProvider, knownBlobVersions);
+            identityOnlyOrNull(
+                found.relation(), scopedIdentity, statsProvider, knownBlobVersions, timings);
         if (slim != null) {
+          // Account the slim path symmetric with the full path below: its stats time already landed
+          // in timings via identityOnlyOrNull; fold the remaining (identity-build) time into
+          // relationBuildNanos so identity-only resolutions are not invisible to the summary event.
+          long buildNanos = System.nanoTime() - buildStartNs;
+          long statsDeltaNanos = timings.statsLookupNanos() - statsBeforeNanos;
+          relationBuildNanos += Math.max(0L, buildNanos - statsDeltaNanos);
           resolutions.add(
               RelationResolution.newBuilder()
                   .setInputIndex(found.inputIndex())

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -82,7 +82,6 @@ import io.opentelemetry.api.trace.Span;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -121,6 +120,9 @@ public class UserObjectBundleService {
   private final EngineMetadataDecoratorProvider decoratorProvider;
   private final EngineContextProvider engineContext;
   private final boolean engineSpecificEnabled;
+  // Bumped when the engine decorator's behavior changes WITHOUT moving the engine version; folded
+  // into the identity-only possession token so a decorator change invalidates cached decoration.
+  private final String decorationEpoch;
   private final StatsProviderFactory statsFactory;
   private final PinValidator pinValidator;
   private final long slowRpcMs;
@@ -168,6 +170,8 @@ public class UserObjectBundleService {
       PinValidator pinValidator,
       @ConfigProperty(name = "floecat.catalog.bundle.emit_engine_specific", defaultValue = "true")
           boolean engineSpecificEnabled,
+      @ConfigProperty(name = "floecat.catalog.bundle.decoration_epoch", defaultValue = "1")
+          String decorationEpoch,
       @ConfigProperty(name = "floecat.flight.advertised-host", defaultValue = "localhost")
           String flightHost,
       @ConfigProperty(name = "floecat.flight.advertised-port", defaultValue = "80") int flightPort,
@@ -183,6 +187,7 @@ public class UserObjectBundleService {
     this.engineContext = engineContext;
     this.pinValidator = pinValidator;
     this.engineSpecificEnabled = engineSpecificEnabled;
+    this.decorationEpoch = safe(decorationEpoch);
     this.slowRpcMs = Math.max(0L, slowRpcMs);
     this.floecatFlightEndpoint =
         FlightEndpointRef.newBuilder()
@@ -223,6 +228,7 @@ public class UserObjectBundleService {
           }
         },
         engineSpecificEnabled,
+        "1",
         flightHost,
         flightPort,
         grpcPlainText,
@@ -554,8 +560,56 @@ public class UserObjectBundleService {
         relId.getAccountId() + '\0' + relId.getId() + '\0' + relId.getKindValue() + '\0' + cacheIdentity;
     return Optional.of(
         RelationPinIdentity.newBuilder()
-            .setTableBlobVersion(Hashing.sha256Hex(keyMaterial.getBytes(StandardCharsets.UTF_8)))
+            .setTableBlobVersion(Hashing.sha256Hex(keyMaterial))
             .build());
+  }
+
+  /**
+   * The pin identity as stamped on the wire, with its {@code table_blob_version} scoped to the
+   * SERVED PAYLOAD rather than the bare content version (see {@link #possessionToken}). Both the
+   * full-response stamp and the identity-only match go through here, so the token a client
+   * advertises and the token the gate compares can never drift.
+   */
+  private Optional<RelationPinIdentity> scopedPinIdentity(
+      String correlationId, ResolvedRelation relation, QueryContext queryContext, EngineContext ctx) {
+    return pinIdentityFor(correlationId, relation, queryContext)
+        .map(
+            id ->
+                id.toBuilder()
+                    .setTableBlobVersion(possessionToken(id.getTableBlobVersion(), ctx))
+                    .build());
+  }
+
+  /**
+   * The possession token a caching client advertises (GetUserObjectsRequest.known_table_blob_versions)
+   * and the identity-only gate matches on. It must identify the WITHHELD PAYLOAD, not merely the
+   * content version: withheld columns carry engine-keyed payload (decorateColumns /
+   * hasRequiredEnginePayload), so a bare content version would let a client that shares one catalog
+   * cache across engines — or that spans an engine-version or decorator upgrade — advertise a
+   * version decorated for engine A, be served identity-only under engine B, and reuse engine-A
+   * decoration for an engine-B query. The requesting engine is already on the wire (EngineContext),
+   * so we fold it in server-side at both mint sites; the client stays engine-agnostic and
+   * correctness no longer depends on it keying its own cache by engine.
+   *
+   * <p>When decoration is not in play ({@code !decorationRequired}) the payload is fully determined
+   * by the content version, so the token IS the content version — byte-identical to the unscoped
+   * behavior, so no cache fragmentation and no change for single-engine or decoration-off
+   * deployments. {@code decorationEpoch} additionally invalidates cached decoration when the
+   * decorator's behavior changes without moving the engine version.
+   */
+  private String possessionToken(String contentVersion, EngineContext ctx) {
+    if (contentVersion == null || contentVersion.isBlank() || !decorationRequired(ctx)) {
+      return contentVersion;
+    }
+    String material =
+        contentVersion
+            + '\0'
+            + safe(ctx.normalizedKind())
+            + '\0'
+            + safe(ctx.normalizedVersion())
+            + '\0'
+            + decorationEpoch;
+    return Hashing.sha256Hex(material);
   }
 
   /*
@@ -572,12 +626,16 @@ public class UserObjectBundleService {
       String correlationId,
       ResolvedRelation relation,
       QueryContext queryContext,
+      EngineContext engineCtx,
       StatsProvider statsProvider,
       Set<String> knownBlobVersions) {
     if (knownBlobVersions.isEmpty()) {
       return null;
     }
-    Optional<RelationPinIdentity> identity = pinIdentityFor(correlationId, relation, queryContext);
+    // Match on the engine-scoped payload token, not the bare content version, so a client that
+    // proved possession under a different engine cannot be served identity-only here.
+    Optional<RelationPinIdentity> identity =
+        scopedPinIdentity(correlationId, relation, queryContext, engineCtx);
     // A blank version can never prove possession: a user table whose definition blob had no etag
     // resolves to table_blob_version="" (the repository defaults a missing etag to empty), and
     // every such table would otherwise share that key — one cached, the rest served the wrong
@@ -695,7 +753,8 @@ public class UserObjectBundleService {
     // version ⟹ holding its full schema", so the server may serve any later request for that
     // version identity-only and the client projects locally from its cached full schema.
     if (servesFullSchema(relation.candidate())) {
-      pinIdentityFor(correlationId, relation, queryContext).ifPresent(builder::setPinIdentity);
+      scopedPinIdentity(correlationId, relation, queryContext, resolutionContext.engineContext())
+          .ifPresent(builder::setPinIdentity);
     }
 
     // If this is a view, keep a mutable builder around for decoration.
@@ -1697,7 +1756,12 @@ public class UserObjectBundleService {
          * possession would be served a payload-less relation. */
         RelationInfo slim =
             identityOnlyOrNull(
-                correlationId, found.relation(), liveCtx, statsProvider, knownBlobVersions);
+                correlationId,
+                found.relation(),
+                liveCtx,
+                resolutionContext.engineContext(),
+                statsProvider,
+                knownBlobVersions);
         if (slim != null) {
           resolutions.add(
               RelationResolution.newBuilder()

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -742,21 +742,6 @@ public class UserObjectBundleService {
     attachTableStats(builder, relation.relationId(), statsProvider);
     timings.addStatsLookupNanos(System.nanoTime() - statsLookupStartNs);
 
-    // Attach the opaque pin identity so a caching client can key this relation by its immutable
-    // content version. Tables use the query pin's identity (frozen at first touch); views and
-    // system relations carry a derived content token (see pinIdentityFor).
-    //
-    // ONLY on a full-schema response: the version token means "I hold this relation's complete
-    // column set." A projected payload is a subset, so stamping it would let a client cache a
-    // partial schema under the version, advertise it, and then be starved of columns it never
-    // received. Withholding the token on projected responses keeps the contract "advertising a
-    // version ⟹ holding its full schema", so the server may serve any later request for that
-    // version identity-only and the client projects locally from its cached full schema.
-    if (servesFullSchema(relation.candidate())) {
-      scopedPinIdentity(correlationId, relation, queryContext, resolutionContext.engineContext())
-          .ifPresent(builder::setPinIdentity);
-    }
-
     // If this is a view, keep a mutable builder around for decoration.
     ViewDefinition.Builder viewBuilder = null;
     if (relation.node() instanceof ViewNode view) {
@@ -891,6 +876,26 @@ public class UserObjectBundleService {
           relationWarmHitCount,
           relationColdMissCount,
           relationDecorationNanos / 1_000_000.0);
+    }
+
+    // Stamp the opaque payload cache token — AFTER decoration, so it reflects the payload actually
+    // served. A caching client that holds this token is later served identity-only and reuses its
+    // cached payload verbatim, so only stamp when that payload is complete and cacheable:
+    //   - full schema: a projected subset must never advertise "I hold every column", or a later
+    //     request would be starved of columns it never received;
+    //   - decoration fully succeeded: no column ended up FAILED and the relation decoration did not
+    //     throw. FAILED columns still ride the wire (name/type present, engine payload missing), so
+    //     the client legitimately holds them and would advertise the token — locking a transient
+    //     decoration failure into its cache for the whole lifetime instead of self-healing on the
+    //     next query. This is the same caution commitColumnHints applies to persisting hints;
+    //   - non-blank token: a blank version can never prove possession (the match path rejects it),
+    //     and every blank-etag relation would otherwise collide on the empty key.
+    if (servesFullSchema(relation.candidate())
+        && relationDecorationSucceeded
+        && countColumnsWithStatus(columnResults, ColumnStatus.COLUMN_STATUS_FAILED) == 0) {
+      scopedPinIdentity(correlationId, relation, queryContext, ctx)
+          .filter(id -> !id.getTableBlobVersion().isBlank())
+          .ifPresent(builder::setPinIdentity);
     }
 
     builder.addAllColumns(columnResults);

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -554,10 +554,17 @@ public class UserObjectBundleService {
     // changes on catalog upgrade). Note it does NOT cover a system table's service-resolved
     // Flight/storage endpoint (configuredEndpointForKey), which is static Quarkus deployment config
     // — a change to it requires a redeploy, which resets client caches, so a caller cannot route to
-    // a stale endpoint across the change. If endpoint config ever becomes hot-reloadable, fold it in.
+    // a stale endpoint across the change. If endpoint config ever becomes hot-reloadable, fold it
+    // in.
     ResourceId relId = relation.relationId();
     String keyMaterial =
-        relId.getAccountId() + '\0' + relId.getId() + '\0' + relId.getKindValue() + '\0' + cacheIdentity;
+        relId.getAccountId()
+            + '\0'
+            + relId.getId()
+            + '\0'
+            + relId.getKindValue()
+            + '\0'
+            + cacheIdentity;
     return Optional.of(
         RelationPinIdentity.newBuilder()
             .setTableBlobVersion(Hashing.sha256Hex(keyMaterial))
@@ -571,7 +578,10 @@ public class UserObjectBundleService {
    * advertises and the token the gate compares can never drift.
    */
   private Optional<RelationPinIdentity> scopedPinIdentity(
-      String correlationId, ResolvedRelation relation, QueryContext queryContext, EngineContext ctx) {
+      String correlationId,
+      ResolvedRelation relation,
+      QueryContext queryContext,
+      EngineContext ctx) {
     return pinIdentityFor(correlationId, relation, queryContext)
         .map(
             id ->
@@ -581,15 +591,16 @@ public class UserObjectBundleService {
   }
 
   /**
-   * The possession token a caching client advertises (GetUserObjectsRequest.known_table_blob_versions)
-   * and the identity-only gate matches on. It must identify the WITHHELD PAYLOAD, not merely the
-   * content version: withheld columns carry engine-keyed payload (decorateColumns /
-   * hasRequiredEnginePayload), so a bare content version would let a client that shares one catalog
-   * cache across engines — or that spans an engine-version or decorator upgrade — advertise a
-   * version decorated for engine A, be served identity-only under engine B, and reuse engine-A
-   * decoration for an engine-B query. The requesting engine is already on the wire (EngineContext),
-   * so we fold it in server-side at both mint sites; the client stays engine-agnostic and
-   * correctness no longer depends on it keying its own cache by engine.
+   * The possession token a caching client advertises
+   * (GetUserObjectsRequest.known_table_blob_versions) and the identity-only gate matches on. It
+   * must identify the WITHHELD PAYLOAD, not merely the content version: withheld columns carry
+   * engine-keyed payload (decorateColumns / hasRequiredEnginePayload), so a bare content version
+   * would let a client that shares one catalog cache across engines — or that spans an
+   * engine-version or decorator upgrade — advertise a version decorated for engine A, be served
+   * identity-only under engine B, and reuse engine-A decoration for an engine-B query. The
+   * requesting engine is already on the wire (EngineContext), so we fold it in server-side at both
+   * mint sites; the client stays engine-agnostic and correctness no longer depends on it keying its
+   * own cache by engine.
    *
    * <p>When decoration is not in play ({@code !decorationRequired}) the payload is fully determined
    * by the content version, so the token IS the content version — byte-identical to the unscoped
@@ -890,8 +901,10 @@ public class UserObjectBundleService {
     // and this stamp, so a cache miss under a populated hint set does not hash the relation twice.
     //
     // Caveat for system tables: a slim reply omits the endpoint metadata, and for a config-resolved
-    // endpoint (configuredEndpointForKey) that value is NOT covered by the token — see pinIdentityFor.
-    // Identity-only reuse of such a table therefore assumes its Flight endpoint config is deploy-time
+    // endpoint (configuredEndpointForKey) that value is NOT covered by the token — see
+    // pinIdentityFor.
+    // Identity-only reuse of such a table therefore assumes its Flight endpoint config is
+    // deploy-time
     // fixed; if it ever becomes hot-reloadable, fold the resolved endpoint into the token there.
     if (servesFullSchema(relation.candidate())
         && relationDecorationSucceeded

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -21,7 +21,6 @@ import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.Messag
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
-import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
 import ai.floedb.floecat.connector.common.resolver.LogicalSchemaMapper;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
@@ -41,6 +40,7 @@ import ai.floedb.floecat.query.rpc.FlightEndpointRef;
 import ai.floedb.floecat.query.rpc.Origin;
 import ai.floedb.floecat.query.rpc.RelationInfo;
 import ai.floedb.floecat.query.rpc.RelationKind;
+import ai.floedb.floecat.query.rpc.RelationPinIdentity;
 import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.RelationResolution;
 import ai.floedb.floecat.query.rpc.RelationResolutions;
@@ -75,12 +75,14 @@ import ai.floedb.floecat.systemcatalog.spi.decorator.RelationDecoration;
 import ai.floedb.floecat.systemcatalog.spi.decorator.ViewDecoration;
 import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
+import ai.floedb.floecat.types.Hashing;
 import ai.floedb.floecat.types.LogicalType;
 import ai.floedb.floecat.types.LogicalTypeFormat;
 import io.opentelemetry.api.trace.Span;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -228,8 +230,17 @@ public class UserObjectBundleService {
         250L);
   }
 
+  /** {@link #stream(String, QueryContext, List, Set)} with no possession hint. */
   public Multi<UserObjectsBundleChunk> stream(
       String correlationId, QueryContext ctx, List<TableReferenceCandidate> tables) {
+    return stream(correlationId, ctx, tables, Set.of());
+  }
+
+  public Multi<UserObjectsBundleChunk> stream(
+      String correlationId,
+      QueryContext ctx,
+      List<TableReferenceCandidate> tables,
+      Set<String> knownBlobVersions) {
     List<TableReferenceCandidate> candidates = List.copyOf(tables);
     if (LOG.isDebugEnabled()) {
       LOG.debugf(
@@ -244,7 +255,7 @@ public class UserObjectBundleService {
         .<UserObjectsBundleChunk>deferred(
             () -> {
               UserObjectBundleIterator iterator =
-                  new UserObjectBundleIterator(correlationId, ctx, candidates);
+                  new UserObjectBundleIterator(correlationId, ctx, candidates, knownBlobVersions);
               return Multi.createFrom()
                   .iterable(() -> iterator)
                   .onFailure()
@@ -490,6 +501,123 @@ public class UserObjectBundleService {
     }
   }
 
+  /**
+   * True when the payload built for this candidate carries the relation's complete column set (no
+   * projection). Mirrors {@link UserObjectBundleUtils#pruneSchema} exactly: a candidate that wants
+   * all columns, or names none, is served the full schema. The pin-identity token is only stamped
+   * for such responses (see buildRelation), so a cached version always denotes the full schema.
+   */
+  private static boolean servesFullSchema(TableReferenceCandidate candidate) {
+    return candidate.getWantsAllColumns() || candidate.getInitialColumnsCount() == 0;
+  }
+
+  /*
+   * The opaque pin identity for a resolved relation. Tables carry the query
+   * pin's identity, frozen at first touch. Views and system relations have no
+   * query pin in V1; they carry a derived content token — the SHA-256 of the
+   * relation id and the node's cache identity (see below for why the id is
+   * required) — which is immutable per content version, leaks no URI or
+   * storage authority, and (with an empty constraints ref) states the
+   * deterministic truth that no constraints bundle exists for them.
+   */
+  private Optional<RelationPinIdentity> pinIdentityFor(
+      String correlationId, ResolvedRelation relation, QueryContext queryContext) {
+    // Only a USER table carries a per-query snapshot pin; route it through the pin's identity.
+    // Views AND system tables have no query pin, so they take the derived content token below —
+    // previously system tables fell into the pin branch and emitted no identity at all, so
+    // clients could never cache them despite that being the whole point of the content token.
+    // Discriminate on kind+origin (a system table is also a TABLE node, and a view may be USER
+    // origin) rather than the concrete node class, so the routing holds for every node backing.
+    if (relation.node().kind() == GraphNodeKind.TABLE
+        && relation.node().origin() == GraphNodeOrigin.USER) {
+      return queryContext
+          .findTablePin(relation.relationId(), correlationId)
+          .map(QueryPins::identity);
+    }
+    String cacheIdentity = relation.node().cacheIdentity();
+    if (cacheIdentity == null || cacheIdentity.isBlank()) {
+      return Optional.empty();
+    }
+    // Derived content token for views and system relations: a hash of the relation id plus the
+    // node's registry cacheIdentity. The relation id is ESSENTIAL, not decoration: SystemTableNode
+    // does not override GraphNode.cacheIdentity(), which returns the bare catalog-fingerprint
+    // version (SystemNodeRegistry hands every system table in a catalog the same value), so hashing
+    // cacheIdentity alone would collide across all system tables — a client that cached one would
+    // be served another identity-only under the shared token and reuse the wrong schema. Mixing the
+    // id in makes the token unique per relation while still moving with engine content (the version
+    // changes on catalog upgrade). Note it does NOT cover a system table's service-resolved
+    // Flight/storage endpoint (configuredEndpointForKey), which is static Quarkus deployment config
+    // — a change to it requires a redeploy, which resets client caches, so a caller cannot route to
+    // a stale endpoint across the change. If endpoint config ever becomes hot-reloadable, fold it in.
+    ResourceId relId = relation.relationId();
+    String keyMaterial =
+        relId.getAccountId() + '\0' + relId.getId() + '\0' + relId.getKindValue() + '\0' + cacheIdentity;
+    return Optional.of(
+        RelationPinIdentity.newBuilder()
+            .setTableBlobVersion(Hashing.sha256Hex(keyMaterial.getBytes(StandardCharsets.UTF_8)))
+            .build());
+  }
+
+  /*
+   * Identity-only response when the request proved possession of the exact
+   * content version this resolution serves: the payload (schema, columns,
+   * view definition, decoration) is omitted — the identity plus the
+   * lightweight stats are all a caching client needs, and the omitted bytes
+   * are provably identical to what it holds. A generic conditional-request
+   * feature, never client-special-casing: servers MAY ignore the hint and
+   * clients MUST treat a full payload as equally correct. Returns null when
+   * the relation must be built in full.
+   */
+  private RelationInfo identityOnlyOrNull(
+      String correlationId,
+      ResolvedRelation relation,
+      QueryContext queryContext,
+      StatsProvider statsProvider,
+      Set<String> knownBlobVersions) {
+    if (knownBlobVersions.isEmpty()) {
+      return null;
+    }
+    Optional<RelationPinIdentity> identity = pinIdentityFor(correlationId, relation, queryContext);
+    // A blank version can never prove possession: a user table whose definition blob had no etag
+    // resolves to table_blob_version="" (the repository defaults a missing etag to empty), and
+    // every such table would otherwise share that key — one cached, the rest served the wrong
+    // schema identity-only. Force the full payload rather than match on the empty string.
+    if (identity.isEmpty()
+        || identity.get().getTableBlobVersion().isBlank()
+        || !knownBlobVersions.contains(identity.get().getTableBlobVersion())) {
+      return null;
+    }
+    RelationInfo.Builder slim = baseRelationInfo(relation).setPinIdentity(identity.get());
+    attachTableStats(slim, relation.relationId(), statsProvider);
+    return slim.build();
+  }
+
+  /**
+   * A {@link RelationInfo} builder carrying the identity fields every response sets — id, canonical
+   * name, kind, and origin. Both the slim identity-only reply and the full payload start here, so
+   * the two can never disagree on a relation's identity.
+   */
+  private RelationInfo.Builder baseRelationInfo(ResolvedRelation relation) {
+    return RelationInfo.newBuilder()
+        .setRelationId(relation.relationId())
+        .setName(canonicalName(relation.relationId(), relation.node()))
+        .setKind(mapKind(relation.node().kind(), relation.node().origin()))
+        .setOrigin(mapOrigin(relation.node().origin()));
+  }
+
+  /**
+   * Attach the relation's live snapshot-scoped estimates (row count, size) when the stats provider
+   * has them. Both response paths keep these on the wire: they move with every ingest, so a caching
+   * client relies on the reply to refresh them even when the schema payload is omitted.
+   */
+  private static void attachTableStats(
+      RelationInfo.Builder builder, ResourceId relationId, StatsProvider statsProvider) {
+    statsProvider
+        .tableStats(relationId)
+        .map(StatsProviderFactory::toRelationStats)
+        .ifPresent(builder::setStats);
+  }
+
   private RelationInfo buildRelation(
       String correlationId,
       ResolvedRelation relation,
@@ -506,9 +634,8 @@ public class UserObjectBundleService {
           relation.node().origin());
     }
 
-    RelationKind kind = mapKind(relation.node().kind(), relation.node().origin());
+    // origin is needed below for columnsFor; kind and name are set via baseRelationInfo.
     Origin origin = mapOrigin(relation.node().origin());
-    NameRef name = canonicalName(relation.relationId(), relation.node());
 
     List<SchemaColumn> schemaColumns =
         relation.node() instanceof ViewNode view
@@ -526,12 +653,7 @@ public class UserObjectBundleService {
     List<ColumnInfo> columns =
         UserObjectBundleUtils.columnsFor(schemaColumns, pruned, origin, correlationId);
 
-    RelationInfo.Builder builder =
-        RelationInfo.newBuilder()
-            .setRelationId(relation.relationId())
-            .setName(name)
-            .setKind(kind)
-            .setOrigin(origin);
+    RelationInfo.Builder builder = baseRelationInfo(relation);
 
     /*
      * Populate the bundled endpoint metadata so workers know how to reach the table. FLOECAT
@@ -559,20 +681,21 @@ public class UserObjectBundleService {
     }
 
     long statsLookupStartNs = System.nanoTime();
-    statsProvider
-        .tableStats(relation.relationId())
-        .map(StatsProviderFactory::toRelationStats)
-        .ifPresent(builder::setStats);
+    attachTableStats(builder, relation.relationId(), statsProvider);
     timings.addStatsLookupNanos(System.nanoTime() - statsLookupStartNs);
 
-    // Attach the opaque pin identity so the planner's catalog cache can distinguish the same table
-    // across different query pins. Only tables are pinned (views pin their base tables); relations
-    // that have not been pinned leave the field unset.
-    if (relation.relationId().getKind() == ResourceKind.RK_TABLE) {
-      queryContext
-          .findTablePin(relation.relationId(), correlationId)
-          .map(QueryPins::identity)
-          .ifPresent(builder::setPinIdentity);
+    // Attach the opaque pin identity so a caching client can key this relation by its immutable
+    // content version. Tables use the query pin's identity (frozen at first touch); views and
+    // system relations carry a derived content token (see pinIdentityFor).
+    //
+    // ONLY on a full-schema response: the version token means "I hold this relation's complete
+    // column set." A projected payload is a subset, so stamping it would let a client cache a
+    // partial schema under the version, advertise it, and then be starved of columns it never
+    // received. Withholding the token on projected responses keeps the contract "advertising a
+    // version ⟹ holding its full schema", so the server may serve any later request for that
+    // version identity-only and the client projects locally from its cached full schema.
+    if (servesFullSchema(relation.candidate())) {
+      pinIdentityFor(correlationId, relation, queryContext).ifPresent(builder::setPinIdentity);
     }
 
     // If this is a view, keep a mutable builder around for decoration.
@@ -1251,6 +1374,9 @@ public class UserObjectBundleService {
     private final MetadataResolutionContext resolutionContext;
     private final String engineKind;
     private final String engineVersion;
+    /* Content versions the request proved it holds; relations resolving to
+     * one of these get an identity-only response (see identityOnlyOrNull). */
+    private final Set<String> knownBlobVersions;
 
     // Maintains the order inputs were resolved so the emitted chunk mirrors the request order.
     private final List<PendingItem> pending = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
@@ -1295,10 +1421,14 @@ public class UserObjectBundleService {
     private long nodeResolutionCacheMisses = 0L;
 
     UserObjectBundleIterator(
-        String correlationId, QueryContext ctx, List<TableReferenceCandidate> tables) {
+        String correlationId,
+        QueryContext ctx,
+        List<TableReferenceCandidate> tables,
+        Set<String> knownBlobVersions) {
       this.correlationId = correlationId;
       this.ctx = ctx;
       this.tables = tables;
+      this.knownBlobVersions = knownBlobVersions;
       this.resolutionCount = tables.size();
       this.defaultCatalogId = ctx.getQueryDefaultCatalogId();
       this.statsProvider = statsFactory.forQuery(ctx, correlationId);
@@ -1561,6 +1691,21 @@ public class UserObjectBundleService {
         long buildStartNs = System.nanoTime();
         if (liveCtx == null) {
           liveCtx = queryStore.get(ctx.getQueryId()).orElse(ctx);
+        }
+        /* Identity-only fast path: never cached — the info cache must only
+         * ever hold full payloads, or a later request that did NOT prove
+         * possession would be served a payload-less relation. */
+        RelationInfo slim =
+            identityOnlyOrNull(
+                correlationId, found.relation(), liveCtx, statsProvider, knownBlobVersions);
+        if (slim != null) {
+          resolutions.add(
+              RelationResolution.newBuilder()
+                  .setInputIndex(found.inputIndex())
+                  .setStatus(ResolutionStatus.RESOLUTION_STATUS_FOUND)
+                  .setRelation(slim)
+                  .build());
+          continue;
         }
         RelationInfo info =
             buildRelation(

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -526,7 +526,7 @@ public class UserObjectBundleService {
    * storage authority, and (with an empty constraints ref) states the
    * deterministic truth that no constraints bundle exists for them.
    */
-  private Optional<RelationPinIdentity> pinIdentityFor(
+  private Optional<PinIdentitySource> pinIdentityFor(
       String correlationId, ResolvedRelation relation, QueryContext queryContext) {
     // Only a USER table carries a per-query snapshot pin; route it through the pin's identity.
     // Views AND system tables have no query pin, so they take the derived content token below —
@@ -538,7 +538,7 @@ public class UserObjectBundleService {
         && relation.node().origin() == GraphNodeOrigin.USER) {
       return queryContext
           .findTablePin(relation.relationId(), correlationId)
-          .map(QueryPins::identity);
+          .map(pin -> new PinIdentitySource(QueryPins.identity(pin), schemaScope(pin)));
     }
     String cacheIdentity = relation.node().cacheIdentity();
     if (cacheIdentity == null || cacheIdentity.isBlank()) {
@@ -578,10 +578,33 @@ public class UserObjectBundleService {
     // (there is no snapshot to describe). The in-repo planner does exactly this — it reads only
     // table_blob_version, constraints_ref_version, and snapshot_id off pin_identity and never
     // branches on pin_kind (see RPC_parsing.cpp) — so the present-but-defaulted fields are inert.
+    // No schema scope either: the content hash above IS the schema identity.
     return Optional.of(
-        RelationPinIdentity.newBuilder()
-            .setTableBlobVersion(Hashing.sha256Hex(keyMaterial.toString()))
-            .build());
+        new PinIdentitySource(
+            RelationPinIdentity.newBuilder()
+                .setTableBlobVersion(Hashing.sha256Hex(keyMaterial.toString()))
+                .build(),
+            ""));
+  }
+
+  /**
+   * A wire-facing pin identity plus the server-side schema-scope material its possession token
+   * folds in. The scope stays OFF the identity (RelationPinIdentity is planner-facing; the
+   * fingerprint is internal pin state) — this pair is how it travels from pinIdentityFor to
+   * possessionToken without widening the wire message.
+   */
+  private record PinIdentitySource(RelationPinIdentity identity, String schemaScope) {}
+
+  /**
+   * The schema-scope material a table pin contributes to the possession token: the read-schema
+   * fingerprint stamped on the pinned manifest entry, or — for pins built from pre-fingerprint
+   * entries — the snapshot blob version (correct but coarser: it also moves on data-only ingests,
+   * so legacy entries run cold on ingest until their next snapshot write stamps a fingerprint).
+   */
+  private static String schemaScope(ai.floedb.floecat.query.rpc.TablePin pin) {
+    return pin.getSchemaFingerprint().isBlank()
+        ? pin.getSnapshotBlobVersion()
+        : pin.getSchemaFingerprint();
   }
 
   /**
@@ -638,7 +661,13 @@ public class UserObjectBundleService {
       QueryContext queryContext,
       EngineContext ctx) {
     return pinIdentityFor(correlationId, relation, queryContext)
-        .map(id -> id.toBuilder().setTableBlobVersion(possessionToken(id, ctx)).build());
+        .map(
+            src ->
+                src.identity().toBuilder()
+                    .setTableBlobVersion(
+                        possessionToken(
+                            src.identity().getTableBlobVersion(), src.schemaScope(), ctx))
+                    .build());
   }
 
   /**
@@ -653,35 +682,33 @@ public class UserObjectBundleService {
    * mint sites; the client stays engine-agnostic and correctness no longer depends on it keying its
    * own cache by engine.
    *
-   * <p>The token folds in the pinned SNAPSHOT blob version, because the served column schema is
-   * read from the snapshot (schema-on-read) and CreateSnapshot/UpdateSnapshot can change that
-   * schema WITHOUT moving the definition ref (table_blob_version). A definition-only token would
-   * therefore let a client that holds an old schema be served identity-only for a NEW schema and
-   * reuse stale columns/types. snapshot_blob_version moves whenever the snapshot does — a strict
-   * superset of schema changes, so never stale — but it is coarser than the schema: it also moves
-   * on data-only ingests (a new snapshot with an unchanged schema), so a hot-ingest table refetches
-   * its full (unchanged) schema each query instead of a slim identity-only reply. It does NOT move
-   * on stats-generation or constraints writes (separate manifest refs), so the schema stays warm
-   * across those. Recovering warmth across ingests needs a schema-scoped ref on the snapshot
-   * manifest entry (follow-up); until then this is correct and never serves a stale schema. Views
-   * and system relations have no snapshot pin, so their token is unaffected by this scope.
+   * <p>The token folds in a SCHEMA scope ({@code schemaScope}), because the served column schema is
+   * read from the pinned snapshot (schema-on-read) and CreateSnapshot/UpdateSnapshot can change
+   * that schema WITHOUT moving the definition ref (table_blob_version). A definition-only token
+   * would therefore let a client that holds an old schema be served identity-only for a NEW schema
+   * and reuse stale columns/types. The scope is the read-schema fingerprint stamped on the pinned
+   * manifest entry (SnapshotManifestEntry.schema_fingerprint): identical read schemas share it, so
+   * a data-only ingest keeps the token — and the client's schema — warm, while a snapshot-backed
+   * schema change moves it. Pins built from pre-fingerprint manifest entries fall back to the
+   * snapshot blob version (see {@link #schemaScope}): still never stale, just cold on every ingest
+   * until the table's next snapshot write stamps a fingerprint. Views and system relations pass an
+   * empty scope — their content hash is already the schema identity.
    *
    * <p>{@code decorationEpoch} additionally invalidates cached decoration when the decorator's
    * behavior changes without moving the engine version. When there is nothing to fold in — no
-   * snapshot scope (views/system) AND no engine decoration — the token IS the content version,
+   * schema scope (views/system) AND no engine decoration — the token IS the content version,
    * byte-identical to the unscoped behavior.
    */
-  private String possessionToken(RelationPinIdentity id, EngineContext ctx) {
-    String contentVersion = id.getTableBlobVersion();
+  private String possessionToken(String contentVersion, String schemaScope, EngineContext ctx) {
     if (contentVersion == null || contentVersion.isBlank()) {
       return contentVersion;
     }
-    String snapshotScope = safe(id.getSnapshotBlobVersion());
+    String scope = safe(schemaScope);
     boolean decorate = decorationRequired(ctx);
-    if (snapshotScope.isBlank() && !decorate) {
+    if (scope.isBlank() && !decorate) {
       return contentVersion;
     }
-    StringBuilder material = new StringBuilder(contentVersion).append('\0').append(snapshotScope);
+    StringBuilder material = new StringBuilder(contentVersion).append('\0').append(scope);
     if (decorate) {
       material
           .append('\0')

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -623,29 +623,23 @@ public class UserObjectBundleService {
    * the relation must be built in full.
    */
   private RelationInfo identityOnlyOrNull(
-      String correlationId,
       ResolvedRelation relation,
-      QueryContext queryContext,
-      EngineContext engineCtx,
+      Optional<RelationPinIdentity> scopedIdentity,
       StatsProvider statsProvider,
       Set<String> knownBlobVersions) {
-    if (knownBlobVersions.isEmpty()) {
-      return null;
-    }
-    // Match on the engine-scoped payload token, not the bare content version, so a client that
-    // proved possession under a different engine cannot be served identity-only here.
-    Optional<RelationPinIdentity> identity =
-        scopedPinIdentity(correlationId, relation, queryContext, engineCtx);
+    // The token is the engine-scoped payload token (scopedIdentity), not the bare content version,
+    // so a client that proved possession under a different engine cannot be served identity-only.
     // A blank version can never prove possession: a user table whose definition blob had no etag
     // resolves to table_blob_version="" (the repository defaults a missing etag to empty), and
     // every such table would otherwise share that key — one cached, the rest served the wrong
     // schema identity-only. Force the full payload rather than match on the empty string.
-    if (identity.isEmpty()
-        || identity.get().getTableBlobVersion().isBlank()
-        || !knownBlobVersions.contains(identity.get().getTableBlobVersion())) {
+    if (knownBlobVersions.isEmpty()
+        || scopedIdentity.isEmpty()
+        || scopedIdentity.get().getTableBlobVersion().isBlank()
+        || !knownBlobVersions.contains(scopedIdentity.get().getTableBlobVersion())) {
       return null;
     }
-    RelationInfo.Builder slim = baseRelationInfo(relation).setPinIdentity(identity.get());
+    RelationInfo.Builder slim = baseRelationInfo(relation).setPinIdentity(scopedIdentity.get());
     attachTableStats(slim, relation.relationId(), statsProvider);
     return slim.build();
   }
@@ -682,7 +676,8 @@ public class UserObjectBundleService {
       QueryContext queryContext,
       MetadataResolutionContext resolutionContext,
       StatsProvider statsProvider,
-      TimingAccumulator timings) {
+      TimingAccumulator timings,
+      Optional<RelationPinIdentity> scopedIdentity) {
     if (LOG.isTraceEnabled()) {
       LOG.tracef(
           "Building relation bundle query_id=%s relation=%s kind=%s origin=%s",
@@ -890,10 +885,18 @@ public class UserObjectBundleService {
     //     next query. This is the same caution commitColumnHints applies to persisting hints;
     //   - non-blank token: a blank version can never prove possession (the match path rejects it),
     //     and every blank-etag relation would otherwise collide on the empty key.
+    //
+    // scopedIdentity is computed once by the caller and threaded into both the identity-only match
+    // and this stamp, so a cache miss under a populated hint set does not hash the relation twice.
+    //
+    // Caveat for system tables: a slim reply omits the endpoint metadata, and for a config-resolved
+    // endpoint (configuredEndpointForKey) that value is NOT covered by the token — see pinIdentityFor.
+    // Identity-only reuse of such a table therefore assumes its Flight endpoint config is deploy-time
+    // fixed; if it ever becomes hot-reloadable, fold the resolved endpoint into the token there.
     if (servesFullSchema(relation.candidate())
         && relationDecorationSucceeded
         && countColumnsWithStatus(columnResults, ColumnStatus.COLUMN_STATUS_FAILED) == 0) {
-      scopedPinIdentity(correlationId, relation, queryContext, ctx)
+      scopedIdentity
           .filter(id -> !id.getTableBlobVersion().isBlank())
           .ifPresent(builder::setPinIdentity);
     }
@@ -1756,17 +1759,20 @@ public class UserObjectBundleService {
         if (liveCtx == null) {
           liveCtx = queryStore.get(ctx.getQueryId()).orElse(ctx);
         }
+        // Compute the engine-scoped payload token at most once per relation: the identity-only
+        // match consults it when the client sent hints, and the full-payload stamp reuses it — so a
+        // cache miss under a populated hint set does not hash the relation twice. Skip it only when
+        // neither consumer can use it (no hints AND a projected response, which never stamps).
+        Optional<RelationPinIdentity> scopedIdentity =
+            (!knownBlobVersions.isEmpty() || servesFullSchema(found.relation().candidate()))
+                ? scopedPinIdentity(
+                    correlationId, found.relation(), liveCtx, resolutionContext.engineContext())
+                : Optional.empty();
         /* Identity-only fast path: never cached — the info cache must only
          * ever hold full payloads, or a later request that did NOT prove
          * possession would be served a payload-less relation. */
         RelationInfo slim =
-            identityOnlyOrNull(
-                correlationId,
-                found.relation(),
-                liveCtx,
-                resolutionContext.engineContext(),
-                statsProvider,
-                knownBlobVersions);
+            identityOnlyOrNull(found.relation(), scopedIdentity, statsProvider, knownBlobVersions);
         if (slim != null) {
           resolutions.add(
               RelationResolution.newBuilder()
@@ -1783,7 +1789,8 @@ public class UserObjectBundleService {
                 liveCtx,
                 resolutionContext,
                 statsProvider,
-                timings);
+                timings,
+                scopedIdentity);
         long buildNanos = System.nanoTime() - buildStartNs;
         long statsDeltaNanos = timings.statsLookupNanos() - statsBeforeNanos;
         long decorationDeltaNanos = timings.decorationTotalNanos() - decorationBeforeNanos;

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -555,7 +555,8 @@ public class UserObjectBundleService {
     // (backend kind + the resolved Flight/storage endpoint) — an identity-only reply omits that
     // metadata, and a config-resolved endpoint (configuredEndpointForKey) can change without moving
     // cacheIdentity. A floecat redeploy does NOT reset an external caching client, so without this
-    // the client would match the token, get no endpoint, and route to the stale one. The endpoint is
+    // the client would match the token, get no endpoint, and route to the stale one. The endpoint
+    // is
     // resolved through resolveSystemExecution — the same helper buildRelation uses to stamp it — so
     // the token cannot drift from the served routing.
     ResourceId relId = relation.relationId();
@@ -614,7 +615,8 @@ public class UserObjectBundleService {
    * pinIdentityFor (which folds them into the possession token) can never disagree — the token must
    * cover exactly the routing an identity-only reply omits.
    */
-  private record SystemExecution(String backendKind, FlightEndpointRef flightEndpoint, String storagePath) {
+  private record SystemExecution(
+      String backendKind, FlightEndpointRef flightEndpoint, String storagePath) {
     String tokenMaterial() {
       // Build from the endpoint's explicit, contractual fields (host/port/tls) rather than
       // FlightEndpointRef.toString(): protobuf documents Message.toString() as non-contractual and
@@ -623,7 +625,11 @@ public class UserObjectBundleService {
       // not routing identity. The token then moves exactly when the routing it covers moves.
       String endpoint =
           flightEndpoint != null
-              ? flightEndpoint.getHost() + ':' + flightEndpoint.getPort() + ':' + flightEndpoint.getTls()
+              ? flightEndpoint.getHost()
+                  + ':'
+                  + flightEndpoint.getPort()
+                  + ':'
+                  + flightEndpoint.getTls()
               : "";
       return backendKind + '\0' + endpoint + '\0' + storagePath;
     }
@@ -638,7 +644,8 @@ public class UserObjectBundleService {
       if (storage.flightEndpoint() != null) {
         return new SystemExecution(backendKind, storage.flightEndpoint(), "");
       }
-      Optional<FlightEndpointRef> configured = configuredEndpointForKey(storage.storageEndpointKey());
+      Optional<FlightEndpointRef> configured =
+          configuredEndpointForKey(storage.storageEndpointKey());
       if (configured.isPresent()) {
         return new SystemExecution(backendKind, configured.get(), "");
       }
@@ -995,14 +1002,16 @@ public class UserObjectBundleService {
 
     // Stamp the pin identity. Two distinct concerns share the message and must NOT share a gate:
     //
-    //   - The DATA identity (pin_fingerprint, snapshot id, AS-OF provenance, constraints_ref_version)
+    //   - The DATA identity (pin_fingerprint, snapshot id, AS-OF provenance,
+    // constraints_ref_version)
     //     is a property of the pinned relation, not of the served payload shape. Callers rely on it
     //     to tell a current pin from a historical one and to skip the constraints RPC, so it is
     //     stamped UNCONDITIONALLY whenever the relation is pinned — including on projected or
     //     decoration-incomplete replies, which previously lost it entirely.
     //
     //   - The possession token (table_blob_version) is payload-scoped: a client that advertises it
-    //     is later served identity-only and reuses its cached payload verbatim. It is kept only when
+    //     is later served identity-only and reuses its cached payload verbatim. It is kept only
+    // when
     //     the served payload is complete and cacheable, and blanked otherwise:
     //       * full schema — a projected subset must never advertise "I hold every column", or a
     //         later request would be starved of columns it never received;
@@ -1053,7 +1062,8 @@ public class UserObjectBundleService {
     return nonNegativeLongAttribute(relationDecoration, attributeKey);
   }
 
-  private static long decorationCounter(RelationDecoration relationDecoration, String attributeKey) {
+  private static long decorationCounter(
+      RelationDecoration relationDecoration, String attributeKey) {
     return nonNegativeLongAttribute(relationDecoration, attributeKey);
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImpl.java
@@ -33,6 +33,7 @@ import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -93,7 +94,11 @@ public class UserObjectsServiceImpl extends BaseServiceImpl implements UserObjec
               }
 
               var subscription =
-                  bundles.stream(correlationId, ctx, request.getTablesList())
+                  bundles.stream(
+                          correlationId,
+                          ctx,
+                          request.getTablesList(),
+                          Set.copyOf(request.getKnownTableBlobVersionsList()))
                       .subscribe()
                       .with(emitter::emit, emitter::fail, emitter::complete);
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotManifests.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotManifests.java
@@ -21,11 +21,17 @@ import ai.floedb.floecat.catalog.rpc.SnapshotManifestEntry;
 import ai.floedb.floecat.catalog.rpc.SnapshotManifestPage;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 
 /**
@@ -56,19 +62,62 @@ public final class SnapshotManifests {
 
   private SnapshotManifests() {}
 
+  private static final ObjectMapper FINGERPRINT_JSON = new ObjectMapper();
+
   /**
    * Content fingerprint of a snapshot's READ SCHEMA, stamped on its manifest entry at write time
-   * (see {@code SnapshotManifestEntry.schema_fingerprint}). Two snapshots with byte-identical
-   * schema_json share a fingerprint, so a data-only ingest does not move it; a snapshot-backed
-   * schema change does. Formatting-only churn in schema_json moves the fingerprint too — that
-   * degrades to a cold (full-payload) resolution, never a stale schema.
+   * (see {@code SnapshotManifestEntry.schema_fingerprint}). Two snapshots with the same logical
+   * read schema share a fingerprint, so a data-only ingest does not move it; a snapshot-backed
+   * schema change does.
+   *
+   * <p>The fingerprint is over a CANONICALIZED form of schema_json, not the raw bytes: the value is
+   * stored verbatim as the ingesting client supplied it, and a client that re-serializes an
+   * unchanged schema with different object-key order or whitespace on each ingest would otherwise
+   * churn the fingerprint every ingest — silently degrading the warm path to cold-on-every-ingest
+   * (never stale, just never warm). Canonicalization sorts object keys and drops insignificant
+   * whitespace while PRESERVING array order (column order is semantic). schema_json that does not
+   * parse as JSON falls back to the raw string — still never stale, just not churn-resilient for
+   * that input.
    */
   public static String schemaFingerprint(ai.floedb.floecat.catalog.rpc.Snapshot snapshot) {
     String schemaJson = snapshot.getSchemaJson();
     if (schemaJson.isBlank()) {
       return SCHEMA_FINGERPRINT_DEFINITION_DEFAULT;
     }
-    return ai.floedb.floecat.types.Hashing.sha256Hex(schemaJson);
+    return ai.floedb.floecat.types.Hashing.sha256Hex(canonicalizeSchemaJson(schemaJson));
+  }
+
+  /**
+   * Re-serialize JSON with object keys sorted and array order preserved, so a logically-identical
+   * schema hashes the same regardless of the producer's key ordering or whitespace. Scalars are
+   * left exactly as parsed (no number/string reformatting). Non-JSON input returns unchanged.
+   */
+  private static String canonicalizeSchemaJson(String json) {
+    try {
+      return FINGERPRINT_JSON.writeValueAsString(canonicalize(FINGERPRINT_JSON.readTree(json)));
+    } catch (JacksonException e) {
+      return json;
+    }
+  }
+
+  private static JsonNode canonicalize(JsonNode node) {
+    if (node.isObject()) {
+      ObjectNode sorted = FINGERPRINT_JSON.createObjectNode();
+      TreeSet<String> names = new TreeSet<>();
+      node.fieldNames().forEachRemaining(names::add);
+      for (String name : names) {
+        sorted.set(name, canonicalize(node.get(name)));
+      }
+      return sorted;
+    }
+    if (node.isArray()) {
+      ArrayNode ordered = FINGERPRINT_JSON.createArrayNode();
+      for (JsonNode element : node) {
+        ordered.add(canonicalize(element)); // preserve order: column position is semantic
+      }
+      return ordered;
+    }
+    return node;
   }
 
   /** One walk context over a fixed head, with a content-addressed page cache. */

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotManifests.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotManifests.java
@@ -46,7 +46,30 @@ public final class SnapshotManifests {
   /** Bounds a page so the common reads (current, recent AS_OF) touch one blob. */
   public static final int PAGE_ENTRY_BOUND = 256;
 
+  /**
+   * Sentinel fingerprint for a snapshot whose schema_json is blank: the read schema is then the
+   * table definition's default, already covered by the root's definition ref, so every such
+   * snapshot shares one constant fingerprint. Distinct from "" (a legacy entry written before the
+   * field existed), which readers treat as unknown and fall back on.
+   */
+  public static final String SCHEMA_FINGERPRINT_DEFINITION_DEFAULT = "definition-default";
+
   private SnapshotManifests() {}
+
+  /**
+   * Content fingerprint of a snapshot's READ SCHEMA, stamped on its manifest entry at write time
+   * (see {@code SnapshotManifestEntry.schema_fingerprint}). Two snapshots with byte-identical
+   * schema_json share a fingerprint, so a data-only ingest does not move it; a snapshot-backed
+   * schema change does. Formatting-only churn in schema_json moves the fingerprint too — that
+   * degrades to a cold (full-payload) resolution, never a stale schema.
+   */
+  public static String schemaFingerprint(ai.floedb.floecat.catalog.rpc.Snapshot snapshot) {
+    String schemaJson = snapshot.getSchemaJson();
+    if (schemaJson.isBlank()) {
+      return SCHEMA_FINGERPRINT_DEFINITION_DEFAULT;
+    }
+    return ai.floedb.floecat.types.Hashing.sha256Hex(schemaJson);
+  }
 
   /** One walk context over a fixed head, with a content-addressed page cache. */
   public static Chain chain(TableRootRepository roots, ResourceId tableId, BlobRef head) {

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootMutationsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootMutationsTest.java
@@ -112,11 +112,16 @@ class TableRootMutationsTest {
   void inPlaceUpdatePreservesAuxRefsAndKeepsCurrency() {
     commit(
         TableRootMutations.upsertSnapshot(
-            roots, TABLE, entry(7, 1_000), ref("s3://t/def.pb"), true));
+            roots,
+            TABLE,
+            entry(7, 1_000).toBuilder().setSchemaFingerprint("fp-7").build(),
+            ref("s3://t/def.pb"),
+            true));
     commit(TableRootMutations.setStatsGeneration(roots, TABLE, 7, ref("s3://t/gen-1.pb"), 7L));
     commit(TableRootMutations.setConstraints(roots, TABLE, 7, ref("s3://t/constraints-1.pb")));
 
-    // The in-place snapshot update carries a new snapshot blob but no aux refs of its own.
+    // The in-place snapshot update carries a new snapshot blob but no aux refs (and no schema
+    // fingerprint) of its own — none may be dropped by the partial rewrite.
     TableRoot updated =
         commit(
             TableRootMutations.upsertSnapshot(
@@ -131,6 +136,7 @@ class TableRootMutationsTest {
     assertEquals("s3://t/gen-1.pb", e.getStatsGenerationRef().getUri(), "stats ref preserved");
     assertEquals(
         "s3://t/constraints-1.pb", e.getConstraintsRef().getUri(), "constraints ref preserved");
+    assertEquals("fp-7", e.getSchemaFingerprint(), "schema fingerprint preserved");
     assertEquals(7L, updated.getCurrentSnapshotId(), "same-id update keeps currency");
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -309,6 +309,75 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void identityOnlyPossessionIsScopedToTheRequestingEngine() {
+    // With engine-specific decoration in play the withheld columns are engine-keyed, so a version
+    // proved under one engine must NOT be honored identity-only under another — otherwise a client
+    // sharing one cache across engines would reuse engine-A decoration for an engine-B query.
+    AtomicInteger decorations = new AtomicInteger();
+    EngineMetadataDecoratorProvider provider =
+        c -> Optional.of(new CountingDecorator(decorations, true, false));
+    UserObjectBundleService decorated =
+        new UserObjectBundleService(
+            overlay,
+            resolver,
+            queryStore,
+            statsFactory,
+            provider,
+            engineContextProvider,
+            true,
+            "localhost",
+            47470,
+            false,
+            "test");
+
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_B))
+            .build();
+    EngineContext engineA = EngineContext.of("pg", "16.0");
+    EngineContext engineB = EngineContext.of("pg", "17.0");
+
+    // Full payload under engine A; capture the possession token it mints.
+    RelationInfo fullA = firstRelationUnderEngine(decorated, candidate, Set.of(), engineA);
+    String tokenA = fullA.getPinIdentity().getTableBlobVersion();
+    assertThat(fullA.getColumnsCount()).isPositive();
+    assertThat(tokenA).isNotEmpty();
+
+    // Same engine, advertising tokenA: served identity-only (control — the token still works).
+    RelationInfo slimSame = firstRelationUnderEngine(decorated, candidate, Set.of(tokenA), engineA);
+    assertThat(slimSame.getColumnsCount()).isZero();
+    assertThat(slimSame.getPinIdentity().getTableBlobVersion()).isEqualTo(tokenA);
+
+    // Different engine, advertising engine-A's token: NOT honored — full payload, distinct token.
+    RelationInfo fullB = firstRelationUnderEngine(decorated, candidate, Set.of(tokenA), engineB);
+    assertThat(fullB.getColumnsCount()).isPositive();
+    assertThat(fullB.getPinIdentity().getTableBlobVersion()).isNotEqualTo(tokenA);
+  }
+
+  private RelationInfo firstRelationUnderEngine(
+      UserObjectBundleService svc,
+      TableReferenceCandidate candidate,
+      Set<String> known,
+      EngineContext engine) {
+    Context context =
+        Context.current().withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, engine);
+    Context previous = context.attach();
+    try {
+      return svc.stream("cid", ctx, List.of(candidate), known)
+          .collect()
+          .asList()
+          .await()
+          .indefinitely()
+          .get(1)
+          .getResolutions()
+          .getItems(0)
+          .getRelation();
+    } finally {
+      context.detach(previous);
+    }
+  }
+
+  @Test
   void projectedResponseCarriesNoPinIdentitySoItIsNotCacheable() {
     // A two-column table so a single-column projection is a genuine strict subset.
     overlay.registerTable(

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -309,6 +309,69 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void snapshotSchemaChangeMovesThePossessionToken() {
+    // Same table, same definition ref (blobBackedPin fixes table_blob_version), but two different
+    // pinned snapshots (etag-s123 vs etag-s456): the shape of a CreateSnapshot/UpdateSnapshot that
+    // changes the read schema (schema-on-read from the snapshot) without moving the definition ref.
+    // The possession token must move with the snapshot, or a client holding the old snapshot's
+    // token would be served identity-only for the new schema and reuse stale columns/types.
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    String token123 = firstRelation(ctx, candidate, Set.of()).getPinIdentity().getTableBlobVersion();
+    assertThat(token123).isNotEmpty();
+
+    QueryContext ctx456 = pinnedAt(TABLE_A, 456L);
+    queryStore.seed(ctx456);
+    RelationInfo full456 = firstRelation(ctx456, candidate, Set.of());
+    assertThat(full456.getColumnsCount()).isPositive();
+    assertThat(full456.getPinIdentity().getTableBlobVersion())
+        .as("a new snapshot (new read schema, same definition ref) must move the possession token")
+        .isNotEqualTo(token123);
+
+    // Advertising the OLD snapshot's token under the new pin must NOT be honored identity-only.
+    RelationInfo underStaleToken = firstRelation(ctx456, candidate, Set.of(token123));
+    assertThat(underStaleToken.getColumnsCount())
+        .as("a stale possession token must not gate an identity-only reply for the new schema")
+        .isPositive();
+  }
+
+  private QueryContext pinnedAt(ResourceId table, long snapshotId) {
+    return QueryContext.builder()
+        .queryId("q-" + snapshotId)
+        .principal(
+            PrincipalContext.newBuilder()
+                .setAccountId("acct")
+                .setSubject("tester")
+                .setCorrelationId("cid")
+                .build())
+        .relationPins(
+            SnapshotTestSupport.relationPins(SnapshotTestSupport.blobBackedPin(table, snapshotId))
+                .toByteArray())
+        .createdAtMs(1)
+        .expiresAtMs(1000)
+        .state(QueryContext.State.ACTIVE)
+        .version(1)
+        .queryDefaultCatalogId(DEFAULT_CATALOG)
+        .build();
+  }
+
+  private RelationInfo firstRelation(
+      QueryContext context, TableReferenceCandidate candidate, Set<String> known) {
+    return service.stream("cid", context, List.of(candidate), known)
+        .collect()
+        .asList()
+        .await()
+        .indefinitely()
+        .get(1)
+        .getResolutions()
+        .getItems(0)
+        .getRelation();
+  }
+
+  @Test
   void identityOnlyPossessionIsScopedToTheRequestingEngine() {
     // With engine-specific decoration in play the withheld columns are engine-keyed, so a version
     // proved under one engine must NOT be honored identity-only under another — otherwise a client
@@ -407,7 +470,11 @@ class UserObjectBundleServiceTest {
     RelationInfo failed = firstRelationUnderEngine(failing, candidate, Set.of(), engine);
     assertThat(failed.getColumnsList())
         .allMatch(c -> c.getStatus() == ColumnStatus.COLUMN_STATUS_FAILED);
-    assertThat(failed.hasPinIdentity()).isFalse();
+    // The data identity survives; only the possession token is withheld, so the incomplete payload
+    // is never cacheable while provenance is still reported.
+    assertThat(failed.hasPinIdentity()).isTrue();
+    assertThat(failed.getPinIdentity().getPinFingerprint()).isNotEmpty();
+    assertThat(failed.getPinIdentity().getTableBlobVersion()).isEmpty();
 
     // Control: when decoration succeeds, the same full response IS stamped and cacheable.
     EngineMetadataDecoratorProvider okPayload =
@@ -428,10 +495,13 @@ class UserObjectBundleServiceTest {
     RelationInfo ok = firstRelationUnderEngine(succeeding, candidate, Set.of(), engine);
     assertThat(ok.getColumnsList()).allMatch(c -> c.getStatus() == ColumnStatus.COLUMN_STATUS_OK);
     assertThat(ok.hasPinIdentity()).isTrue();
+    assertThat(ok.getPinIdentity().getTableBlobVersion())
+        .as("a fully-decorated full payload carries the possession token")
+        .isNotEmpty();
   }
 
   @Test
-  void projectedResponseCarriesNoPinIdentitySoItIsNotCacheable() {
+  void projectedResponsePreservesIdentityButBlanksThePossessionToken() {
     // A two-column table so a single-column projection is a genuine strict subset.
     overlay.registerTable(
         TABLE_A,
@@ -478,9 +548,17 @@ class UserObjectBundleServiceTest {
             .getItems(0)
             .getRelation();
     assertThat(projRel.getColumnsCount()).isLessThan(fullRel.getColumnsCount());
+    // The DATA identity survives — callers rely on pin_fingerprint / snapshot id / provenance even
+    // for a projected relation, and dropping it conflated two concerns.
     assertThat(projRel.hasPinIdentity())
-        .as("a projected (partial) payload must not be cacheable as the full-schema version")
-        .isFalse();
+        .as("the pin identity (data provenance) is preserved on a projected relation")
+        .isTrue();
+    assertThat(projRel.getPinIdentity().getPinFingerprint()).isNotEmpty();
+    // Only the possession token is payload-scoped: blanked, so a projected (partial) payload can
+    // never advertise "I hold every column".
+    assertThat(projRel.getPinIdentity().getTableBlobVersion())
+        .as("a projected payload is not cacheable as the full-schema version")
+        .isEmpty();
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -270,6 +270,119 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void knownVersionGetsIdentityOnlyResponse() {
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    // First resolution: full payload, and the identity to prove possession of.
+    RelationInfo full =
+        service.stream("cid", ctx, List.of(candidate))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely()
+            .get(1)
+            .getResolutions()
+            .getItems(0)
+            .getRelation();
+    assertThat(full.getColumnsCount()).isPositive();
+    String version = full.getPinIdentity().getTableBlobVersion();
+    assertThat(version).isNotEmpty();
+
+    // Proving possession omits the payload: identity returns, columns do not.
+    RelationInfo slim =
+        service.stream("cid", ctx, List.of(candidate), Set.of(version))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely()
+            .get(1)
+            .getResolutions()
+            .getItems(0)
+            .getRelation();
+    assertThat(slim.hasPinIdentity()).isTrue();
+    assertThat(slim.getPinIdentity().getTableBlobVersion()).isEqualTo(version);
+    assertThat(slim.getColumnsCount()).isZero();
+    assertThat(slim.getName().getName()).isEqualTo(full.getName().getName());
+  }
+
+  @Test
+  void projectedResponseCarriesNoPinIdentitySoItIsNotCacheable() {
+    // A two-column table so a single-column projection is a genuine strict subset.
+    overlay.registerTable(
+        TABLE_A,
+        List.of(
+            SchemaColumn.newBuilder().setName("id_a").setNullable(true).build(),
+            SchemaColumn.newBuilder().setName("payload_a").setNullable(true).build()),
+        NameRef.newBuilder().setCatalog("cat").setName("a").build());
+
+    // A full request first: it carries the version token and the complete column set.
+    TableReferenceCandidate full =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+    RelationInfo fullRel =
+        service.stream("cid", ctx, List.of(full))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely()
+            .get(1)
+            .getResolutions()
+            .getItems(0)
+            .getRelation();
+    assertThat(fullRel.hasPinIdentity()).isTrue();
+    assertThat(fullRel.getColumnsCount()).isGreaterThan(1);
+    String oneColumn = fullRel.getColumns(0).getColumnName();
+
+    // A projected request for a single column: the payload is a subset, so it must NOT carry a
+    // version token — caching it under the version would let a later request be starved of the
+    // columns this response omitted.
+    TableReferenceCandidate projected =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .addInitialColumns(oneColumn)
+            .build();
+    RelationInfo projRel =
+        service.stream("cid", ctx, List.of(projected))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely()
+            .get(1)
+            .getResolutions()
+            .getItems(0)
+            .getRelation();
+    assertThat(projRel.getColumnsCount()).isLessThan(fullRel.getColumnsCount());
+    assertThat(projRel.hasPinIdentity())
+        .as("a projected (partial) payload must not be cacheable as the full-schema version")
+        .isFalse();
+  }
+
+  @Test
+  void unknownVersionStillGetsTheFullPayload() {
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    // A stale hint (DDL happened since) must never suppress the payload.
+    RelationInfo relation =
+        service.stream("cid", ctx, List.of(candidate), Set.of("some-superseded-version"))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely()
+            .get(1)
+            .getResolutions()
+            .getItems(0)
+            .getRelation();
+    assertThat(relation.getColumnsCount()).isPositive();
+  }
+
+  @Test
   void statsAvailableWhenPinAddedDuringBundle() {
     QueryContext noPinCtx =
         QueryContext.builder()
@@ -765,6 +878,58 @@ class UserObjectBundleServiceTest {
     } finally {
       restoreProperties(previousValues);
     }
+  }
+
+  @Test
+  void systemTablesSharingACatalogVersionGetDistinctPinIdentities() {
+    // SystemNodeRegistry hands every system table in a catalog the same
+    // fingerprint-derived version, and SystemTableNode does not override
+    // GraphNode.cacheIdentity() — so two system tables share their cacheIdentity
+    // ("1" here, from the fixture's version=1L). The derived pin-identity token
+    // must still be unique per relation, or a client that cached one would be
+    // served the other's schema identity-only under the shared version.
+    ResourceId sysA =
+        ResourceId.newBuilder().setAccountId("sys").setId("SYS_A").setKind(ResourceKind.RK_TABLE).build();
+    ResourceId sysB =
+        ResourceId.newBuilder().setAccountId("sys").setId("SYS_B").setKind(ResourceKind.RK_TABLE).build();
+    overlay.registerRelation(
+        sysA,
+        storageSystemTableNode(sysA, "sys://a", "k"),
+        UserObjectBundleTestSupport.schemaFor("a"),
+        NameRef.newBuilder().setCatalog("sys").setName("sys_a").build());
+    overlay.registerRelation(
+        sysB,
+        storageSystemTableNode(sysB, "sys://b", "k"),
+        UserObjectBundleTestSupport.schemaFor("b"),
+        NameRef.newBuilder().setCatalog("sys").setName("sys_b").build());
+
+    List<UserObjectsBundleChunk> chunks =
+        service
+            .stream(
+                "cid",
+                ctx,
+                List.of(
+                    TableReferenceCandidate.newBuilder()
+                        .addCandidates(QueryInput.newBuilder().setTableId(sysA))
+                        .build(),
+                    TableReferenceCandidate.newBuilder()
+                        .addCandidates(QueryInput.newBuilder().setTableId(sysB))
+                        .build()))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely();
+
+    Map<ResourceId, String> tokenById = new java.util.HashMap<>();
+    chunks.get(1).getResolutions().getItemsList().stream()
+        .map(RelationResolution::getRelation)
+        .forEach(r -> tokenById.put(r.getRelationId(), r.getPinIdentity().getTableBlobVersion()));
+
+    assertThat(tokenById.get(sysA)).isNotBlank();
+    assertThat(tokenById.get(sysB)).isNotBlank();
+    assertThat(tokenById.get(sysA))
+        .as("two system tables sharing a catalog version must not collide on table_blob_version")
+        .isNotEqualTo(tokenById.get(sysB));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -1011,9 +1011,17 @@ class UserObjectBundleServiceTest {
     // must still be unique per relation, or a client that cached one would be
     // served the other's schema identity-only under the shared version.
     ResourceId sysA =
-        ResourceId.newBuilder().setAccountId("sys").setId("SYS_A").setKind(ResourceKind.RK_TABLE).build();
+        ResourceId.newBuilder()
+            .setAccountId("sys")
+            .setId("SYS_A")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
     ResourceId sysB =
-        ResourceId.newBuilder().setAccountId("sys").setId("SYS_B").setKind(ResourceKind.RK_TABLE).build();
+        ResourceId.newBuilder()
+            .setAccountId("sys")
+            .setId("SYS_B")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
     overlay.registerRelation(
         sysA,
         storageSystemTableNode(sysA, "sys://a", "k"),
@@ -1026,8 +1034,7 @@ class UserObjectBundleServiceTest {
         NameRef.newBuilder().setCatalog("sys").setName("sys_b").build());
 
     List<UserObjectsBundleChunk> chunks =
-        service
-            .stream(
+        service.stream(
                 "cid",
                 ctx,
                 List.of(

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -339,6 +339,16 @@ class UserObjectBundleServiceTest {
   }
 
   private QueryContext pinnedAt(ResourceId table, long snapshotId) {
+    return pinnedWith(SnapshotTestSupport.blobBackedPin(table, snapshotId), snapshotId);
+  }
+
+  private QueryContext pinnedAt(ResourceId table, long snapshotId, String schemaFingerprint) {
+    return pinnedWith(
+        SnapshotTestSupport.blobBackedPin(table, snapshotId, schemaFingerprint), snapshotId);
+  }
+
+  private QueryContext pinnedWith(
+      ai.floedb.floecat.query.rpc.TablePin pin, long snapshotId) {
     return QueryContext.builder()
         .queryId("q-" + snapshotId)
         .principal(
@@ -347,15 +357,51 @@ class UserObjectBundleServiceTest {
                 .setSubject("tester")
                 .setCorrelationId("cid")
                 .build())
-        .relationPins(
-            SnapshotTestSupport.relationPins(SnapshotTestSupport.blobBackedPin(table, snapshotId))
-                .toByteArray())
+        .relationPins(SnapshotTestSupport.relationPins(pin).toByteArray())
         .createdAtMs(1)
         .expiresAtMs(1000)
         .state(QueryContext.State.ACTIVE)
         .version(1)
         .queryDefaultCatalogId(DEFAULT_CATALOG)
         .build();
+  }
+
+  @Test
+  void dataOnlyIngestKeepsThePossessionTokenAndSchemaWarm() {
+    // Two pins at DIFFERENT snapshots (an ingest moved the snapshot) whose manifest entries carry
+    // the SAME read-schema fingerprint: the served schema is unchanged, so the possession token
+    // must be stable — this is what keeps a hot-ingest table's schema warm across ingests.
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    QueryContext ctx1 = pinnedAt(TABLE_A, 123L, "schema-v1");
+    queryStore.seed(ctx1);
+    String token1 = firstRelation(ctx1, candidate, Set.of()).getPinIdentity().getTableBlobVersion();
+    assertThat(token1).isNotEmpty();
+
+    QueryContext ctx2 = pinnedAt(TABLE_A, 456L, "schema-v1");
+    queryStore.seed(ctx2);
+    RelationInfo warm = firstRelation(ctx2, candidate, Set.of(token1));
+    assertThat(warm.getPinIdentity().getTableBlobVersion())
+        .as("a data-only ingest (same read schema) keeps the possession token stable")
+        .isEqualTo(token1);
+    assertThat(warm.getColumnsCount())
+        .as("the client's proof of possession is honored identity-only across the ingest")
+        .isZero();
+    assertThat(warm.getPinIdentity().getSnapshotId())
+        .as("the slim reply still carries the NEW pin's data identity")
+        .isEqualTo(456L);
+
+    // A snapshot that CHANGED the read schema moves the fingerprint and with it the token.
+    QueryContext ctx3 = pinnedAt(TABLE_A, 789L, "schema-v2");
+    queryStore.seed(ctx3);
+    RelationInfo changed = firstRelation(ctx3, candidate, Set.of(token1));
+    assertThat(changed.getPinIdentity().getTableBlobVersion()).isNotEqualTo(token1);
+    assertThat(changed.getColumnsCount())
+        .as("a schema-changing snapshot must not be served identity-only under the old token")
+        .isPositive();
   }
 
   private RelationInfo firstRelation(

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -320,7 +320,8 @@ class UserObjectBundleServiceTest {
             .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
             .build();
 
-    String token123 = firstRelation(ctx, candidate, Set.of()).getPinIdentity().getTableBlobVersion();
+    String token123 =
+        firstRelation(ctx, candidate, Set.of()).getPinIdentity().getTableBlobVersion();
     assertThat(token123).isNotEmpty();
 
     QueryContext ctx456 = pinnedAt(TABLE_A, 456L);
@@ -347,8 +348,7 @@ class UserObjectBundleServiceTest {
         SnapshotTestSupport.blobBackedPin(table, snapshotId, schemaFingerprint), snapshotId);
   }
 
-  private QueryContext pinnedWith(
-      ai.floedb.floecat.query.rpc.TablePin pin, long snapshotId) {
+  private QueryContext pinnedWith(ai.floedb.floecat.query.rpc.TablePin pin, long snapshotId) {
     return QueryContext.builder()
         .queryId("q-" + snapshotId)
         .principal(

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -378,6 +378,59 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void failedColumnDecorationIsNotStampedAsCacheable() {
+    // A full payload whose columns FAILED decoration (engine payload missing) is incomplete, so it
+    // must not carry the possession token — otherwise a client caches it, is served identity-only
+    // later, and reuses the incomplete payload, locking in a transient failure instead of
+    // re-fetching until decoration succeeds.
+    EngineMetadataDecoratorProvider missingPayload =
+        c -> Optional.of(new CountingDecorator(new AtomicInteger(), false, false));
+    UserObjectBundleService failing =
+        new UserObjectBundleService(
+            overlay,
+            resolver,
+            queryStore,
+            statsFactory,
+            missingPayload,
+            engineContextProvider,
+            true,
+            "localhost",
+            47470,
+            false,
+            "test");
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_B))
+            .build();
+    EngineContext engine = EngineContext.of("pg", "16.0");
+
+    RelationInfo failed = firstRelationUnderEngine(failing, candidate, Set.of(), engine);
+    assertThat(failed.getColumnsList())
+        .allMatch(c -> c.getStatus() == ColumnStatus.COLUMN_STATUS_FAILED);
+    assertThat(failed.hasPinIdentity()).isFalse();
+
+    // Control: when decoration succeeds, the same full response IS stamped and cacheable.
+    EngineMetadataDecoratorProvider okPayload =
+        c -> Optional.of(new CountingDecorator(new AtomicInteger(), true, false));
+    UserObjectBundleService succeeding =
+        new UserObjectBundleService(
+            overlay,
+            resolver,
+            queryStore,
+            statsFactory,
+            okPayload,
+            engineContextProvider,
+            true,
+            "localhost",
+            47470,
+            false,
+            "test");
+    RelationInfo ok = firstRelationUnderEngine(succeeding, candidate, Set.of(), engine);
+    assertThat(ok.getColumnsList()).allMatch(c -> c.getStatus() == ColumnStatus.COLUMN_STATUS_OK);
+    assertThat(ok.hasPinIdentity()).isTrue();
+  }
+
+  @Test
   void projectedResponseCarriesNoPinIdentitySoItIsNotCacheable() {
     // A two-column table so a single-column projection is a genuine strict subset.
     overlay.registerTable(

--- a/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/impl/UserObjectsServiceImplTest.java
@@ -62,7 +62,10 @@ class UserObjectsServiceImplTest {
     UserObjectBundleService mockBundles = Mockito.mock(UserObjectBundleService.class);
     Mockito.when(
             mockBundles.stream(
-                Mockito.anyString(), Mockito.any(QueryContext.class), Mockito.anyList()))
+                Mockito.anyString(),
+                Mockito.any(QueryContext.class),
+                Mockito.anyList(),
+                Mockito.anySet()))
         .thenAnswer(
             _ -> {
               // This runs inside grpcCtx.call/run — context should be set.
@@ -159,7 +162,10 @@ class UserObjectsServiceImplTest {
     UserObjectBundleService mockBundles = Mockito.mock(UserObjectBundleService.class);
     Mockito.when(
             mockBundles.stream(
-                Mockito.anyString(), Mockito.any(QueryContext.class), Mockito.anyList()))
+                Mockito.anyString(),
+                Mockito.any(QueryContext.class),
+                Mockito.anyList(),
+                Mockito.anySet()))
         .thenReturn(
             Multi.createFrom()
                 .<UserObjectsBundleChunk>emitter(

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotManifestsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotManifestsTest.java
@@ -244,7 +244,8 @@ class SnapshotManifestsTest {
   }
 
   private static String fingerprint(String schemaJson) {
-    return SnapshotManifests.schemaFingerprint(Snapshot.newBuilder().setSchemaJson(schemaJson).build());
+    return SnapshotManifests.schemaFingerprint(
+        Snapshot.newBuilder().setSchemaJson(schemaJson).build());
   }
 
   /* Canonicalization: a client that re-serializes an UNCHANGED schema with different object-key
@@ -253,9 +254,12 @@ class SnapshotManifestsTest {
   @Test
   void schemaFingerprintIsStableAcrossKeyOrderAndWhitespace() {
     String a = "{\"type\":\"struct\",\"fields\":[{\"id\":1,\"name\":\"x\",\"type\":\"long\"}]}";
-    String reordered = "{\"fields\":[{\"type\":\"long\",\"name\":\"x\",\"id\":1}],\"type\":\"struct\"}";
-    String spaced = "{  \"type\" : \"struct\" ,\n  \"fields\" : [ { \"id\":1, \"name\":\"x\", \"type\":\"long\" } ] }";
-    assertEquals(fingerprint(a), fingerprint(reordered), "object-key order must not move the fingerprint");
+    String reordered =
+        "{\"fields\":[{\"type\":\"long\",\"name\":\"x\",\"id\":1}],\"type\":\"struct\"}";
+    String spaced =
+        "{  \"type\" : \"struct\" ,\n  \"fields\" : [ { \"id\":1, \"name\":\"x\", \"type\":\"long\" } ] }";
+    assertEquals(
+        fingerprint(a), fingerprint(reordered), "object-key order must not move the fingerprint");
     assertEquals(fingerprint(a), fingerprint(spaced), "whitespace must not move the fingerprint");
   }
 
@@ -273,7 +277,10 @@ class SnapshotManifestsTest {
     String base = "{\"fields\":[{\"id\":1,\"name\":\"x\"}]}";
     String added = "{\"fields\":[{\"id\":1,\"name\":\"x\"},{\"id\":2,\"name\":\"y\"}]}";
     assertNotEquals(fingerprint(base), fingerprint(added));
-    assertEquals(fingerprint("not-json"), fingerprint("not-json"), "non-JSON hashes stably via the raw fallback");
+    assertEquals(
+        fingerprint("not-json"),
+        fingerprint("not-json"),
+        "non-JSON hashes stably via the raw fallback");
     assertEquals(
         SnapshotManifests.SCHEMA_FINGERPRINT_DEFINITION_DEFAULT,
         SnapshotManifests.schemaFingerprint(Snapshot.newBuilder().build()),

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotManifestsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/SnapshotManifestsTest.java
@@ -16,11 +16,13 @@
 package ai.floedb.floecat.service.repo.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.catalog.rpc.BlobRef;
+import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotManifestEntry;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
@@ -239,5 +241,42 @@ class SnapshotManifestsTest {
     var s1 = entry(1, 1_000, false);
     BlobRef head = SnapshotManifests.upsert(roots, TABLE, null, s1);
     assertTrue(SnapshotManifests.latestQueryableCurrent(roots, head, s1).isEmpty());
+  }
+
+  private static String fingerprint(String schemaJson) {
+    return SnapshotManifests.schemaFingerprint(Snapshot.newBuilder().setSchemaJson(schemaJson).build());
+  }
+
+  /* Canonicalization: a client that re-serializes an UNCHANGED schema with different object-key
+   * order or whitespace must still share the fingerprint, or a data-only ingest would churn the
+   * possession token every write and the warm path would silently die for that table. */
+  @Test
+  void schemaFingerprintIsStableAcrossKeyOrderAndWhitespace() {
+    String a = "{\"type\":\"struct\",\"fields\":[{\"id\":1,\"name\":\"x\",\"type\":\"long\"}]}";
+    String reordered = "{\"fields\":[{\"type\":\"long\",\"name\":\"x\",\"id\":1}],\"type\":\"struct\"}";
+    String spaced = "{  \"type\" : \"struct\" ,\n  \"fields\" : [ { \"id\":1, \"name\":\"x\", \"type\":\"long\" } ] }";
+    assertEquals(fingerprint(a), fingerprint(reordered), "object-key order must not move the fingerprint");
+    assertEquals(fingerprint(a), fingerprint(spaced), "whitespace must not move the fingerprint");
+  }
+
+  /* But COLUMN order is semantic — reordering the fields array is a different schema. */
+  @Test
+  void schemaFingerprintRespectsColumnOrder() {
+    String xy = "{\"fields\":[{\"id\":1,\"name\":\"x\"},{\"id\":2,\"name\":\"y\"}]}";
+    String yx = "{\"fields\":[{\"id\":2,\"name\":\"y\"},{\"id\":1,\"name\":\"x\"}]}";
+    assertNotEquals(fingerprint(xy), fingerprint(yx), "array (column) order is preserved");
+  }
+
+  /* A real schema change (a new column) moves it; non-JSON falls back to the raw string, stably. */
+  @Test
+  void schemaFingerprintMovesOnSchemaChangeAndToleratesNonJson() {
+    String base = "{\"fields\":[{\"id\":1,\"name\":\"x\"}]}";
+    String added = "{\"fields\":[{\"id\":1,\"name\":\"x\"},{\"id\":2,\"name\":\"y\"}]}";
+    assertNotEquals(fingerprint(base), fingerprint(added));
+    assertEquals(fingerprint("not-json"), fingerprint("not-json"), "non-JSON hashes stably via the raw fallback");
+    assertEquals(
+        SnapshotManifests.SCHEMA_FINGERPRINT_DEFINITION_DEFAULT,
+        SnapshotManifests.schemaFingerprint(Snapshot.newBuilder().build()),
+        "blank schema_json uses the definition-default sentinel");
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/TableRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/TableRepositoryTest.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.catalog.rpc.UpstreamRef;
 import ai.floedb.floecat.catalog.rpc.View;
+import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.repo.model.Keys;
@@ -249,6 +250,27 @@ class TableRepositoryTest {
     var claimed = tableRepo.relationNameClaim(account, catalogId, namespaceId, "invoices");
     assertTrue(claimed.isPresent(), "new name's claim must be reserved by the rename");
     assertEquals(tableId.getId(), claimed.get().getId());
+  }
+
+  @Test
+  void renameProducesANewTableBlobVersion() {
+    ResourceId tableId = createTable("sales", "us", "orders");
+    MutationMeta before = tableRepo.metaForSafe(tableId);
+
+    Table renamed =
+        tableRepo.getById(tableId).orElseThrow().toBuilder().setDisplayName("invoices").build();
+    assertTrue(tableRepo.update(renamed, before.getPointerVersion()));
+
+    /* The signal the whole warm-cache model leans on: any table change —
+     * rename included — rewrites the content-addressed table blob, so its
+     * identity (blob uri / version) moves and cached records for the old
+     * identity become unreachable. A future rename path that stopped bumping
+     * it would silently poison every content-keyed cache. */
+    MutationMeta after = tableRepo.metaForSafe(tableId);
+    assertTrue(after.getPointerVersion() > before.getPointerVersion());
+    assertTrue(
+        !after.getBlobUri().equals(before.getBlobUri()),
+        "rename must move the table blob identity");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/SnapshotTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/SnapshotTestSupport.java
@@ -63,7 +63,8 @@ public final class SnapshotTestSupport {
    * fingerprint model a data-only ingest; different fingerprints model a snapshot-backed schema
    * change. The no-fingerprint {@link #blobBackedPin} models a legacy pre-fingerprint entry.
    */
-  public static TablePin blobBackedPin(ResourceId tableId, long snapshotId, String schemaFingerprint) {
+  public static TablePin blobBackedPin(
+      ResourceId tableId, long snapshotId, String schemaFingerprint) {
     return blobBackedPin(tableId, snapshotId).toBuilder()
         .setSchemaFingerprint(schemaFingerprint)
         .build();

--- a/service/src/test/java/ai/floedb/floecat/service/testsupport/SnapshotTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/testsupport/SnapshotTestSupport.java
@@ -57,6 +57,18 @@ public final class SnapshotTestSupport {
         .build();
   }
 
+  /**
+   * A blob-backed pin whose manifest entry carried a read-schema fingerprint (see
+   * SnapshotManifestEntry.schema_fingerprint). Two pins at different snapshots with the SAME
+   * fingerprint model a data-only ingest; different fingerprints model a snapshot-backed schema
+   * change. The no-fingerprint {@link #blobBackedPin} models a legacy pre-fingerprint entry.
+   */
+  public static TablePin blobBackedPin(ResourceId tableId, long snapshotId, String schemaFingerprint) {
+    return blobBackedPin(tableId, snapshotId).toBuilder()
+        .setSchemaFingerprint(schemaFingerprint)
+        .build();
+  }
+
   /** The relation-pin set resolution stores on a query context, from blob-backed pins. */
   public static RelationPinSet relationPins(TablePin... pins) {
     RelationPinSet.Builder set = RelationPinSet.newBuilder();


### PR DESCRIPTION
## Summary

This PR adds an identity-only (conditional-request) fast path to the user-objects bundle: clients advertise known_table_blob_versions, and the server withholds the payload and returns early when it can prove the client already holds the exact served version. 

This is needed to validate objects in the planner cache still do exist while avoiding re-running the whole machinery of resolve + build + decoration.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x]  No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
