### PR TITLE
fix: Propagate actionable storage authority failures through reconciliation

### DIFF
--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.catalog.rpc.ViewSpec;
 import ai.floedb.floecat.catalog.rpc.ViewSqlDefinition;
+import ai.floedb.floecat.common.rpc.Error;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -48,7 +49,9 @@ import ai.floedb.floecat.reconciler.spi.ReconcilerBackend.TableSpecDescriptor;
 import ai.floedb.floecat.reconciler.spi.SnapshotHelpers;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
@@ -72,6 +75,8 @@ class QueuedReconcileWorkerSupport {
   private static final Logger LOG = Logger.getLogger(QueuedReconcileWorkerSupport.class);
   private static final BooleanSupplier NO_CANCEL = () -> false;
   private static final ProgressListener NO_PROGRESS = (ts, tc, vs, vc, e, sp, stp, m) -> {};
+  private static final String STORAGE_AUTHORITY_MISSING = "storage.authority.missing";
+  private static final String QUERY_SNAPSHOT_NOT_FINALIZED = "query.snapshot.not.finalized";
 
   @FunctionalInterface
   interface ProgressListener {
@@ -1521,6 +1526,7 @@ class QueuedReconcileWorkerSupport {
           result.statsProcessed,
           failureKindOf(result.error),
           retryDispositionOf(result.error),
+          retryClassOf(result.error),
           result.message(),
           result.error);
     }
@@ -1542,11 +1548,49 @@ class QueuedReconcileWorkerSupport {
     return ExecutionResult.FailureKind.INTERNAL;
   }
 
-  private static ExecutionResult.RetryDisposition retryDispositionOf(Exception error) {
+  static ExecutionResult.RetryDisposition retryDispositionOf(Exception error) {
     if (error instanceof ReconcileFailureException failure) {
       return failure.retryDisposition();
     }
+    StatusRuntimeException statusError = grpcStatusError(error);
+    if (statusError != null && statusError.getStatus().getCode() == Status.Code.INVALID_ARGUMENT) {
+      return ExecutionResult.RetryDisposition.TERMINAL;
+    }
+    if (statusError != null
+        && statusError.getStatus().getCode() == Status.Code.FAILED_PRECONDITION
+        && STORAGE_AUTHORITY_MISSING.equals(floecatMessageKey(statusError))) {
+      return ExecutionResult.RetryDisposition.TERMINAL;
+    }
     return ExecutionResult.RetryDisposition.RETRYABLE;
+  }
+
+  static ExecutionResult.RetryClass retryClassOf(Exception error) {
+    if (error instanceof ReconcileFailureException failure) {
+      return failure.retryClass();
+    }
+    StatusRuntimeException statusError = grpcStatusError(error);
+    if (statusError != null
+        && retryDispositionOf(error) == ExecutionResult.RetryDisposition.TERMINAL) {
+      return ExecutionResult.RetryClass.NONE;
+    }
+    if (statusError != null
+        && statusError.getStatus().getCode() == Status.Code.FAILED_PRECONDITION
+        && QUERY_SNAPSHOT_NOT_FINALIZED.equals(floecatMessageKey(statusError))) {
+      return ExecutionResult.RetryClass.DEPENDENCY_NOT_READY;
+    }
+    return ExecutionResult.RetryClass.TRANSIENT_ERROR;
+  }
+
+  private static StatusRuntimeException grpcStatusError(Throwable error) {
+    var seen = new HashSet<Throwable>();
+    Throwable current = error;
+    while (current != null && seen.add(current)) {
+      if (current instanceof StatusRuntimeException statusError) {
+        return statusError;
+      }
+      current = current.getCause();
+    }
+    return null;
   }
 
   Optional<Snapshot> buildSnapshot(
@@ -1708,7 +1752,7 @@ class QueuedReconcileWorkerSupport {
     }
   }
 
-  private static String rootCauseMessage(Throwable t) {
+  static String rootCauseMessage(Throwable t) {
     if (t == null) {
       return "unknown error";
     }
@@ -1726,7 +1770,10 @@ class QueuedReconcileWorkerSupport {
   private static String renderThrowable(Throwable t) {
     if (t instanceof StatusRuntimeException sre) {
       var status = sre.getStatus();
-      String desc = status.getDescription();
+      String desc = floecatRootMessage(sre);
+      if (desc == null || desc.isBlank()) {
+        desc = status.getDescription();
+      }
       if (desc == null || desc.isBlank()) {
         desc = sre.getMessage();
       }
@@ -1741,6 +1788,43 @@ class QueuedReconcileWorkerSupport {
       return className;
     }
     return className + ": " + message;
+  }
+
+  private static String floecatRootMessage(StatusRuntimeException error) {
+    Status.Code code = error.getStatus().getCode();
+    if (code != Status.Code.INVALID_ARGUMENT
+        && code != Status.Code.FAILED_PRECONDITION
+        && code != Status.Code.NOT_FOUND) {
+      return null;
+    }
+    Error detail = floecatError(error);
+    if (detail == null) {
+      return null;
+    }
+    String rootMessage = detail.getParamsOrDefault("root_message", "");
+    return rootMessage.isBlank() ? null : rootMessage;
+  }
+
+  private static String floecatMessageKey(StatusRuntimeException error) {
+    Error detail = floecatError(error);
+    return detail == null ? "" : detail.getMessageKey();
+  }
+
+  private static Error floecatError(StatusRuntimeException error) {
+    com.google.rpc.Status richStatus = StatusProto.fromThrowable(error);
+    if (richStatus == null) {
+      return null;
+    }
+    for (com.google.protobuf.Any detail : richStatus.getDetailsList()) {
+      if (detail.is(Error.class)) {
+        try {
+          return detail.unpack(Error.class);
+        } catch (com.google.protobuf.InvalidProtocolBufferException ignored) {
+          // Fall back to the ordinary gRPC status for malformed or foreign details.
+        }
+      }
+    }
+    return null;
   }
 
   private static final class ReconcileCancelledException extends RuntimeException {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
@@ -75,8 +75,6 @@ class QueuedReconcileWorkerSupport {
   private static final Logger LOG = Logger.getLogger(QueuedReconcileWorkerSupport.class);
   private static final BooleanSupplier NO_CANCEL = () -> false;
   private static final ProgressListener NO_PROGRESS = (ts, tc, vs, vc, e, sp, stp, m) -> {};
-  private static final String STORAGE_AUTHORITY_MISSING = "storage.authority.missing";
-  private static final String QUERY_SNAPSHOT_NOT_FINALIZED = "query.snapshot.not.finalized";
 
   @FunctionalInterface
   interface ProgressListener {
@@ -1549,48 +1547,11 @@ class QueuedReconcileWorkerSupport {
   }
 
   static ExecutionResult.RetryDisposition retryDispositionOf(Exception error) {
-    if (error instanceof ReconcileFailureException failure) {
-      return failure.retryDisposition();
-    }
-    StatusRuntimeException statusError = grpcStatusError(error);
-    if (statusError != null && statusError.getStatus().getCode() == Status.Code.INVALID_ARGUMENT) {
-      return ExecutionResult.RetryDisposition.TERMINAL;
-    }
-    if (statusError != null
-        && statusError.getStatus().getCode() == Status.Code.FAILED_PRECONDITION
-        && STORAGE_AUTHORITY_MISSING.equals(floecatMessageKey(statusError))) {
-      return ExecutionResult.RetryDisposition.TERMINAL;
-    }
-    return ExecutionResult.RetryDisposition.RETRYABLE;
+    return ReconcileFailureClassifier.retryDisposition(error);
   }
 
   static ExecutionResult.RetryClass retryClassOf(Exception error) {
-    if (error instanceof ReconcileFailureException failure) {
-      return failure.retryClass();
-    }
-    StatusRuntimeException statusError = grpcStatusError(error);
-    if (statusError != null
-        && retryDispositionOf(error) == ExecutionResult.RetryDisposition.TERMINAL) {
-      return ExecutionResult.RetryClass.NONE;
-    }
-    if (statusError != null
-        && statusError.getStatus().getCode() == Status.Code.FAILED_PRECONDITION
-        && QUERY_SNAPSHOT_NOT_FINALIZED.equals(floecatMessageKey(statusError))) {
-      return ExecutionResult.RetryClass.DEPENDENCY_NOT_READY;
-    }
-    return ExecutionResult.RetryClass.TRANSIENT_ERROR;
-  }
-
-  private static StatusRuntimeException grpcStatusError(Throwable error) {
-    var seen = new HashSet<Throwable>();
-    Throwable current = error;
-    while (current != null && seen.add(current)) {
-      if (current instanceof StatusRuntimeException statusError) {
-        return statusError;
-      }
-      current = current.getCause();
-    }
-    return null;
+    return ReconcileFailureClassifier.retryClass(error);
   }
 
   Optional<Snapshot> buildSnapshot(
@@ -1803,11 +1764,6 @@ class QueuedReconcileWorkerSupport {
     }
     String rootMessage = detail.getParamsOrDefault("root_message", "");
     return rootMessage.isBlank() ? null : rootMessage;
-  }
-
-  private static String floecatMessageKey(StatusRuntimeException error) {
-    Error detail = floecatError(error);
-    return detail == null ? "" : detail.getMessageKey();
   }
 
   private static Error floecatError(StatusRuntimeException error) {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileFailureClassifier.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileFailureClassifier.java
@@ -16,14 +16,19 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
+import ai.floedb.floecat.common.rpc.Error;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
 import java.util.LinkedHashSet;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 
 final class ReconcileFailureClassifier {
+  private static final String STORAGE_AUTHORITY_MISSING = "storage.authority.missing";
+  private static final String QUERY_SNAPSHOT_NOT_FINALIZED = "query.snapshot.not.finalized";
+
   private ReconcileFailureClassifier() {}
 
   static Exception normalize(Exception error) {
@@ -54,6 +59,82 @@ final class ReconcileFailureClassifier {
       cur = cur.getCause();
     }
     return null;
+  }
+
+  static ReconcileExecutor.ExecutionResult.RetryDisposition retryDisposition(Throwable error) {
+    ReconcileFailureException reconcileFailure = reconcileFailure(error);
+    if (reconcileFailure != null) {
+      return reconcileFailure.retryDisposition();
+    }
+    StatusRuntimeException statusError = grpcStatusError(error);
+    if (statusError != null && statusError.getStatus().getCode() == Status.Code.INVALID_ARGUMENT) {
+      return ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL;
+    }
+    if (statusError != null
+        && statusError.getStatus().getCode() == Status.Code.FAILED_PRECONDITION
+        && STORAGE_AUTHORITY_MISSING.equals(floecatMessageKey(statusError))) {
+      return ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL;
+    }
+    return ReconcileExecutor.ExecutionResult.RetryDisposition.RETRYABLE;
+  }
+
+  static ReconcileExecutor.ExecutionResult.RetryClass retryClass(Throwable error) {
+    ReconcileFailureException reconcileFailure = reconcileFailure(error);
+    if (reconcileFailure != null) {
+      return reconcileFailure.retryClass();
+    }
+    StatusRuntimeException statusError = grpcStatusError(error);
+    if (statusError != null
+        && retryDisposition(error) == ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL) {
+      return ReconcileExecutor.ExecutionResult.RetryClass.NONE;
+    }
+    if (statusError != null
+        && statusError.getStatus().getCode() == Status.Code.FAILED_PRECONDITION
+        && QUERY_SNAPSHOT_NOT_FINALIZED.equals(floecatMessageKey(statusError))) {
+      return ReconcileExecutor.ExecutionResult.RetryClass.DEPENDENCY_NOT_READY;
+    }
+    return ReconcileExecutor.ExecutionResult.RetryClass.TRANSIENT_ERROR;
+  }
+
+  private static ReconcileFailureException reconcileFailure(Throwable error) {
+    var seen = new LinkedHashSet<Throwable>();
+    Throwable current = error;
+    while (current != null && seen.add(current)) {
+      if (current instanceof ReconcileFailureException failure) {
+        return failure;
+      }
+      current = current.getCause();
+    }
+    return null;
+  }
+
+  private static StatusRuntimeException grpcStatusError(Throwable error) {
+    var seen = new LinkedHashSet<Throwable>();
+    Throwable current = error;
+    while (current != null && seen.add(current)) {
+      if (current instanceof StatusRuntimeException statusError) {
+        return statusError;
+      }
+      current = current.getCause();
+    }
+    return null;
+  }
+
+  private static String floecatMessageKey(StatusRuntimeException error) {
+    com.google.rpc.Status richStatus = StatusProto.fromThrowable(error);
+    if (richStatus == null) {
+      return "";
+    }
+    for (com.google.protobuf.Any detail : richStatus.getDetailsList()) {
+      if (detail.is(Error.class)) {
+        try {
+          return detail.unpack(Error.class).getMessageKey();
+        } catch (com.google.protobuf.InvalidProtocolBufferException ignored) {
+          return "";
+        }
+      }
+    }
+    return "";
   }
 
   private static ReconcileFailureException terminalInternal(String message, Throwable cause) {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
@@ -936,29 +936,11 @@ public class RemoteReconcileExecutorPoller {
 
   private static ReconcileExecutor.ExecutionResult.RetryDisposition retryDispositionOf(
       Throwable t) {
-    var seen = new java.util.HashSet<Throwable>();
-    Throwable cur = t;
-    while (cur != null && !seen.contains(cur)) {
-      if (cur instanceof ReconcileFailureException rfe) {
-        return rfe.retryDisposition();
-      }
-      seen.add(cur);
-      cur = cur.getCause();
-    }
-    return ReconcileExecutor.ExecutionResult.RetryDisposition.RETRYABLE;
+    return ReconcileFailureClassifier.retryDisposition(t);
   }
 
   private static ReconcileExecutor.ExecutionResult.RetryClass retryClassOf(Throwable t) {
-    var seen = new java.util.HashSet<Throwable>();
-    Throwable cur = t;
-    while (cur != null && !seen.contains(cur)) {
-      if (cur instanceof ReconcileFailureException rfe) {
-        return rfe.retryClass();
-      }
-      seen.add(cur);
-      cur = cur.getCause();
-    }
-    return ReconcileExecutor.ExecutionResult.RetryClass.TRANSIENT_ERROR;
+    return ReconcileFailureClassifier.retryClass(t);
   }
 
   private static ReconcileExecutor.ExecutionResult.JobOutcome classify(

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupportErrorTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupportErrorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.floedb.floecat.common.rpc.Error;
+import ai.floedb.floecat.common.rpc.ErrorCode;
+import com.google.protobuf.Any;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
+import org.junit.jupiter.api.Test;
+
+class QueuedReconcileWorkerSupportErrorTest {
+  private static final String MISSING_AUTHORITY =
+      "Credential vending was requested but no storage credential authority is configured for this table";
+
+  @Test
+  void safeFloecatErrorUsesStructuredRootMessageAndIsTerminal() {
+    Error detail =
+        Error.newBuilder()
+            .setCode(ErrorCode.MC_PRECONDITION_FAILED)
+            .setMessageKey("storage.authority.missing")
+            .putParams("root_message", MISSING_AUTHORITY)
+            .build();
+    StatusRuntimeException failure =
+        StatusProto.toStatusRuntimeException(
+            com.google.rpc.Status.newBuilder()
+                .setCode(Status.Code.FAILED_PRECONDITION.value())
+                .setMessage("Precondition failed.")
+                .addDetails(Any.pack(detail))
+                .build());
+
+    assertEquals(
+        "grpc=FAILED_PRECONDITION desc=" + MISSING_AUTHORITY,
+        QueuedReconcileWorkerSupport.rootCauseMessage(failure));
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL,
+        QueuedReconcileWorkerSupport.retryDispositionOf(failure));
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryClass.NONE,
+        QueuedReconcileWorkerSupport.retryClassOf(failure));
+  }
+
+  @Test
+  void foreignGrpcErrorKeepsDescriptionFallback() {
+    StatusRuntimeException failure =
+        Status.FAILED_PRECONDITION
+            .withDescription("foreign precondition detail")
+            .asRuntimeException();
+
+    assertEquals(
+        "grpc=FAILED_PRECONDITION desc=foreign precondition detail",
+        QueuedReconcileWorkerSupport.rootCauseMessage(failure));
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryDisposition.RETRYABLE,
+        QueuedReconcileWorkerSupport.retryDispositionOf(failure));
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryClass.TRANSIENT_ERROR,
+        QueuedReconcileWorkerSupport.retryClassOf(failure));
+  }
+
+  @Test
+  void snapshotNotFinalizedIsDependencyNotReady() {
+    Error detail =
+        Error.newBuilder()
+            .setCode(ErrorCode.MC_PRECONDITION_FAILED)
+            .setMessageKey("query.snapshot.not.finalized")
+            .build();
+    StatusRuntimeException failure =
+        StatusProto.toStatusRuntimeException(
+            com.google.rpc.Status.newBuilder()
+                .setCode(Status.Code.FAILED_PRECONDITION.value())
+                .setMessage("Snapshot is not finalized.")
+                .addDetails(Any.pack(detail))
+                .build());
+
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryDisposition.RETRYABLE,
+        QueuedReconcileWorkerSupport.retryDispositionOf(failure));
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryClass.DEPENDENCY_NOT_READY,
+        QueuedReconcileWorkerSupport.retryClassOf(failure));
+  }
+
+  @Test
+  void invalidArgumentPlannerFailureIsTerminal() {
+    StatusRuntimeException failure =
+        Status.INVALID_ARGUMENT.withDescription("invalid planner request").asRuntimeException();
+
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL,
+        QueuedReconcileWorkerSupport.retryDispositionOf(failure));
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryClass.NONE,
+        QueuedReconcileWorkerSupport.retryClassOf(failure));
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileFailureClassifierTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileFailureClassifierTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+class ReconcileFailureClassifierTest {
+  @Test
+  void wrappedInvalidArgumentIsTerminalForWorkerAndPollerPaths() {
+    RuntimeException failure =
+        new RuntimeException(
+            "transport wrapper",
+            Status.INVALID_ARGUMENT.withDescription("invalid request").asRuntimeException());
+
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL,
+        ReconcileFailureClassifier.retryDisposition(failure));
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryClass.NONE,
+        ReconcileFailureClassifier.retryClass(failure));
+  }
+
+  @Test
+  void unknownFailedPreconditionRemainsRetryable() {
+    RuntimeException failure =
+        Status.FAILED_PRECONDITION.withDescription("unknown precondition").asRuntimeException();
+
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryDisposition.RETRYABLE,
+        ReconcileFailureClassifier.retryDisposition(failure));
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryClass.TRANSIENT_ERROR,
+        ReconcileFailureClassifier.retryClass(failure));
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutorTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutorTest.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -39,6 +40,71 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 class RemoteDefaultReconcileExecutorTest {
+
+  @Test
+  void executeTableSubmitsTerminalFailureWithRenderedDetail() {
+    ReconcilerService reconcilerService = mock(ReconcilerService.class);
+    QueuedReconcileWorkerSupport queuedWorkerSupport = mock(QueuedReconcileWorkerSupport.class);
+    RemotePlannerWorkerClient workerClient = mock(RemotePlannerWorkerClient.class);
+    ReconcileWorkerAuthProvider authProvider = accountId -> java.util.Optional.empty();
+    var executor =
+        new RemoteDefaultReconcileExecutor(
+            reconcilerService, queuedWorkerSupport, workerClient, authProvider, true);
+    ReconcileJobStore.LeasedJob lease = tableLease("job-missing-authority", "acct-a");
+    RemoteLeasedJob remoteLease = new RemoteLeasedJob(lease);
+    String message =
+        "grpc=FAILED_PRECONDITION desc=Credential vending was requested but no storage credential authority is configured for this table";
+    ReconcileExecutor.ExecutionResult failure =
+        ReconcileExecutor.ExecutionResult.failure(
+            1,
+            0,
+            1,
+            0,
+            0,
+            ReconcileExecutor.ExecutionResult.FailureKind.INTERNAL,
+            ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL,
+            ReconcileExecutor.ExecutionResult.RetryClass.NONE,
+            message,
+            new IllegalStateException(message));
+
+    when(workerClient.getPlanTableInput(remoteLease))
+        .thenReturn(planTablePayload(lease, connectorId("acct-a")));
+    when(queuedWorkerSupport.executePlannedTable(
+            any(),
+            eq(connectorId("acct-a")),
+            eq(false),
+            any(),
+            any(),
+            eq(ReconcilerService.CaptureMode.METADATA_ONLY),
+            eq(null),
+            any(),
+            any()))
+        .thenReturn(new QueuedReconcileWorkerSupport.TableExecutionResult(failure, List.of()));
+    when(workerClient.submitPlanTableFailure(
+            remoteLease,
+            ReconcileExecutor.ExecutionResult.FailureKind.INTERNAL,
+            ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL,
+            ReconcileExecutor.ExecutionResult.RetryClass.NONE,
+            message))
+        .thenReturn(true);
+
+    ReconcileExecutor.ExecutionResult result =
+        executor.execute(
+            new ReconcileExecutor.ExecutionContext(
+                lease, () -> false, (a, b, c, d, e, f, g, h) -> {}));
+
+    assertEquals(message, result.message);
+    assertEquals(
+        ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL, result.retryDisposition);
+    assertEquals(ReconcileExecutor.ExecutionResult.RetryClass.NONE, result.retryClass);
+    verify(workerClient)
+        .submitPlanTableFailure(
+            remoteLease,
+            ReconcileExecutor.ExecutionResult.FailureKind.INTERNAL,
+            ReconcileExecutor.ExecutionResult.RetryDisposition.TERMINAL,
+            ReconcileExecutor.ExecutionResult.RetryClass.NONE,
+            message);
+  }
 
   @Test
   void executeTableDoesNotLeakWorkerAuthorizationAcrossAccounts() {

--- a/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
@@ -59,6 +59,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -73,8 +74,11 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
 public abstract class BaseServiceImpl {
+  private static final Logger LOG = Logger.getLogger(BaseServiceImpl.class);
+
   @Inject PrincipalProvider principal;
 
   protected final Clock clock = Clock.systemUTC();
@@ -190,7 +194,54 @@ public abstract class BaseServiceImpl {
   }
 
   protected <T> Uni<T> mapFailures(Uni<T> u, String corrId) {
-    return u.onFailure().transform(t -> toStatus(t, corrId));
+    return u.onFailure()
+        .transform(
+            t -> {
+              StatusRuntimeException mapped = toStatus(t, corrId);
+              if (mapped.getStatus().getCode() == Status.Code.INTERNAL) {
+                LOG.error(
+                    "Unexpected service failure correlation_id=" + safeCorrelationId(corrId),
+                    sanitizedThrowableForLogging(t));
+              }
+              return mapped;
+            });
+  }
+
+  private static String safeCorrelationId(String correlationId) {
+    return correlationId == null || correlationId.isBlank()
+        ? "-"
+        : GrpcErrors.clampDetail(correlationId);
+  }
+
+  static Throwable sanitizedThrowableForLogging(Throwable failure) {
+    return sanitizedThrowableForLogging(failure, new IdentityHashMap<>());
+  }
+
+  private static Throwable sanitizedThrowableForLogging(
+      Throwable failure, IdentityHashMap<Throwable, Throwable> seen) {
+    if (failure == null) {
+      return new LoggedFailureException("unknown failure");
+    }
+    Throwable existing = seen.get(failure);
+    if (existing != null) {
+      return existing;
+    }
+    String detail = GrpcErrors.sanitizeLogDetail(failure.getMessage());
+    String message = failure.getClass().getName() + (detail.isBlank() ? "" : ": " + detail);
+    LoggedFailureException sanitized = new LoggedFailureException(message);
+    sanitized.setStackTrace(failure.getStackTrace());
+    seen.put(failure, sanitized);
+    Throwable cause = failure.getCause();
+    if (cause != null && cause != failure) {
+      sanitized.initCause(sanitizedThrowableForLogging(cause, seen));
+    }
+    return sanitized;
+  }
+
+  private static final class LoggedFailureException extends RuntimeException {
+    private LoggedFailureException(String message) {
+      super(message);
+    }
   }
 
   protected StatusRuntimeException toStatus(Throwable t, String corrId) {

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
@@ -353,6 +353,9 @@ public final class GrpcErrors {
 
   private static final int DEFAULT_MAX_DETAIL_CHARS = 512;
   private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+  private static final Pattern SENSITIVE_LOG_VALUE =
+      Pattern.compile(
+          "(?i)(access[._-]?key(?:[._-]?id)?|secret[._-]?access[._-]?key|session[._-]?token|authorization|password|credential)(\\s*[:=]\\s*)([^,;\\s}\\]]+)");
   private static final String ELISION_PREFIX = " ...[";
   private static final String ELISION_SUFFIX = " chars elided]... ";
 
@@ -397,7 +400,7 @@ public final class GrpcErrors {
    * embedded dump, so a head-only truncation would discard it. The elision marker is counted
    * against the cap, so the returned string never exceeds {@code max}.
    */
-  static String clampDetail(String raw) {
+  public static String clampDetail(String raw) {
     if (raw == null) {
       return "";
     }
@@ -422,6 +425,14 @@ public final class GrpcErrors {
     int dropped = collapsed.length() - budget;
     String elision = ELISION_PREFIX + dropped + ELISION_SUFFIX;
     return collapsed.substring(0, head) + elision + collapsed.substring(collapsed.length() - tail);
+  }
+
+  public static String sanitizeLogDetail(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return "";
+    }
+    String redacted = SENSITIVE_LOG_VALUE.matcher(raw).replaceAll("$1$2[REDACTED]");
+    return clampDetail(redacted);
   }
 
   private static void annotateCause(Map<String, String> params, Throwable t) {

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/GrpcErrors.java
@@ -355,7 +355,7 @@ public final class GrpcErrors {
   private static final Pattern WHITESPACE = Pattern.compile("\\s+");
   private static final Pattern SENSITIVE_LOG_VALUE =
       Pattern.compile(
-          "(?i)(access[._-]?key(?:[._-]?id)?|secret[._-]?access[._-]?key|session[._-]?token|authorization|password|credential)(\\s*[:=]\\s*)([^,;\\s}\\]]+)");
+          "(?i)(access[._-]?key(?:[._-]?id)?|secret[._-]?access[._-]?key|session[._-]?token|authorization|password|credential)(\\s*[:=]\\s*)([^,;\\r\\n}\\]]+)");
   private static final String ELISION_PREFIX = " ...[";
   private static final String ELISION_SUFFIX = " chars elided]... ";
 

--- a/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/error/impl/RpcLoggingInterceptor.java
@@ -132,8 +132,9 @@ public class RpcLoggingInterceptor implements ServerInterceptor, Prioritized {
     String params =
         floecatError == null || floecatError.getParamsMap().isEmpty()
             ? ""
-            : floecatError.getParamsMap().toString();
-    String statusMessage = statusProto == null ? "" : statusProto.getMessage();
+            : GrpcErrors.sanitizeLogDetail(floecatError.getParamsMap().toString());
+    String statusMessage =
+        statusProto == null ? "" : GrpcErrors.sanitizeLogDetail(statusProto.getMessage());
 
     String logMessage =
         "rpc method="
@@ -157,7 +158,7 @@ public class RpcLoggingInterceptor implements ServerInterceptor, Prioritized {
 
     boolean floecatMessageLogged = false;
     if (!status.isOk() && floecatError != null && !floecatError.getMessage().isBlank()) {
-      logMessage += " floecat_message=" + floecatError.getMessage();
+      logMessage += " floecat_message=" + GrpcErrors.sanitizeLogDetail(floecatError.getMessage());
       floecatMessageLogged = true;
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
@@ -302,6 +302,12 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
                   StorageAuthorityResolver.resolveBest(
                           authorities, credentialScope.authorityLookupLocationPrefix())
                       .orElse(null);
+              if (authority == null) {
+                throw GrpcErrors.preconditionFailed(
+                    correlationId(),
+                    GeneratedErrorMessages.MessageKey.STORAGE_AUTHORITY_MISSING,
+                    Map.of());
+              }
               validateAuthorityCoversSessionScope(
                   authority, credentialScope.sessionScopeLocations());
               return resolver.buildResponse(

--- a/service/src/main/resources/errors_en.properties
+++ b/service/src/main/resources/errors_en.properties
@@ -80,6 +80,7 @@ MC_PRECONDITION_FAILED.query.not.active=The query is not in an active state.
 MC_PRECONDITION_FAILED.query.table.pin.conflict=Table "{table_id}" is already pinned at snapshot {pinned_snapshot} for this query; a later resolution requested incompatible snapshot {requested_snapshot}.
 MC_PRECONDITION_FAILED.etag.mismatch=ETag mismatch (expected {expected}, got {actual}).
 MC_PRECONDITION_FAILED.scan.deletes.not.complete=Delete streaming must finish before data files can be emitted.
+MC_PRECONDITION_FAILED.storage.authority.missing=Credential vending was requested but no storage credential authority is configured for this table.
 
 MC_PRECONDITION_FAILED.query.snapshot.not.finalized=Snapshot {snapshot_id} of table "{table_id}" is not yet finalized; it becomes queryable when its file list, indexes, and statistics publish.
 MC_INTERNAL.query.pinned.root.missing=Pinned table root is missing or unreadable for table "{table_id}".

--- a/service/src/test/java/ai/floedb/floecat/service/common/BaseServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/common/BaseServiceImplTest.java
@@ -60,8 +60,8 @@ class BaseServiceImplTest {
   void sanitizesUnexpectedFailureForStackTraceLogging() {
     IllegalStateException root =
         new IllegalStateException(
-            "AWS failure access_key_id=AKIA_TEST secret-access-key=super-secret "
-                + "session_token=token-value request="
+            "AWS failure access_key_id=AKIA_TEST; secret-access-key=super-secret; "
+                + "session_token=token-value; Authorization: Bearer jwt-token; request="
                 + "X".repeat(2_000));
     RuntimeException failure = new RuntimeException("outer failure", root);
 
@@ -72,8 +72,10 @@ class BaseServiceImplTest {
     assertTrue(logged.getCause().getMessage().contains("access_key_id=[REDACTED]"));
     assertTrue(logged.getCause().getMessage().contains("secret-access-key=[REDACTED]"));
     assertTrue(logged.getCause().getMessage().contains("session_token=[REDACTED]"));
+    assertTrue(logged.getCause().getMessage().contains("Authorization: [REDACTED]"));
     assertFalse(logged.getCause().getMessage().contains("AKIA_TEST"));
     assertFalse(logged.getCause().getMessage().contains("super-secret"));
+    assertFalse(logged.getCause().getMessage().contains("jwt-token"));
     assertTrue(logged.getCause().getMessage().length() < 700);
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/common/BaseServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/common/BaseServiceImplTest.java
@@ -17,6 +17,8 @@
 package ai.floedb.floecat.service.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.common.rpc.Error;
 import ai.floedb.floecat.common.rpc.ErrorCode;
@@ -52,6 +54,27 @@ class BaseServiceImplTest {
             .orElseThrow();
     assertEquals(CORRELATION_ID, err.getCorrelationId());
     assertEquals(ErrorCode.MC_NOT_FOUND, err.getCode());
+  }
+
+  @Test
+  void sanitizesUnexpectedFailureForStackTraceLogging() {
+    IllegalStateException root =
+        new IllegalStateException(
+            "AWS failure access_key_id=AKIA_TEST secret-access-key=super-secret "
+                + "session_token=token-value request="
+                + "X".repeat(2_000));
+    RuntimeException failure = new RuntimeException("outer failure", root);
+
+    Throwable logged = BaseServiceImpl.sanitizedThrowableForLogging(failure);
+
+    assertEquals(failure.getStackTrace()[0], logged.getStackTrace()[0]);
+    assertTrue(logged.getMessage().contains("java.lang.RuntimeException: outer failure"));
+    assertTrue(logged.getCause().getMessage().contains("access_key_id=[REDACTED]"));
+    assertTrue(logged.getCause().getMessage().contains("secret-access-key=[REDACTED]"));
+    assertTrue(logged.getCause().getMessage().contains("session_token=[REDACTED]"));
+    assertFalse(logged.getCause().getMessage().contains("AKIA_TEST"));
+    assertFalse(logged.getCause().getMessage().contains("super-secret"));
+    assertTrue(logged.getCause().getMessage().length() < 700);
   }
 
   private static final class TestServiceImpl extends BaseServiceImpl {

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.common.rpc.Error;
+import ai.floedb.floecat.common.rpc.ErrorCode;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -62,6 +64,7 @@ import ai.floedb.floecat.storage.secrets.SecretsManager;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.util.Timestamps;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
 import java.lang.reflect.Field;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
@@ -419,7 +422,7 @@ class StorageAuthorityServiceImplTest {
   }
 
   @Test
-  void resolveForAccountLocationFailsForNoAuthority() {
+  void resolveForAccountLocationFailsForNoAuthority() throws Exception {
     when(repo.list(eq("acct"), anyInt(), any(), any())).thenReturn(java.util.List.of());
 
     var ex =
@@ -436,7 +439,18 @@ class StorageAuthorityServiceImplTest {
                     .await()
                     .indefinitely());
 
-    assertEquals(io.grpc.Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode());
+    assertEquals(io.grpc.Status.Code.FAILED_PRECONDITION, ex.getStatus().getCode());
+    assertEquals(
+        "Credential vending was requested but no storage credential authority is configured for this table.",
+        ex.getStatus().getDescription());
+    Error detail =
+        StatusProto.fromThrowable(ex).getDetailsList().stream()
+            .filter(any -> any.is(Error.class))
+            .findFirst()
+            .orElseThrow()
+            .unpack(Error.class);
+    assertEquals(ErrorCode.MC_PRECONDITION_FAILED, detail.getCode());
+    assertEquals("storage.authority.missing", detail.getMessageKey());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Return a cataloged FAILED_PRECONDITION when credential vending lacks a storage authority.
- Decode structured Floecat errors so safe root-cause messages reach PLAN_TABLE logs and persisted failures.
- Make invalid requests and missing-authority failures terminal while preserving retryable preconditions.
- Log unexpected service failures with correlation IDs, bounded stack traces, and credential redaction.
- Add coverage for rendering, retry classification, submission, logging sanitization, and service errors.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

