### PR TITLE
Set index generation on by default

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
@@ -57,7 +57,8 @@ public class ReconcilePlannerScheduler {
           java.util.Set.of(
               ReconcileCapturePolicy.Output.TABLE_STATS,
               ReconcileCapturePolicy.Output.FILE_STATS,
-              ReconcileCapturePolicy.Output.COLUMN_STATS));
+              ReconcileCapturePolicy.Output.COLUMN_STATS,
+              ReconcileCapturePolicy.Output.PARQUET_PAGE_INDEX));
   private static final Set<String> ACTIVE_ROOT_STATES =
       Set.of("JS_QUEUED", "JS_WAITING", "JS_RUNNING", "JS_CANCELLING");
 

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerSchedulerTest.java
@@ -376,7 +376,8 @@ class ReconcilePlannerSchedulerTest {
         java.util.Set.of(
             ReconcileCapturePolicy.Output.TABLE_STATS,
             ReconcileCapturePolicy.Output.FILE_STATS,
-            ReconcileCapturePolicy.Output.COLUMN_STATS),
+            ReconcileCapturePolicy.Output.COLUMN_STATS,
+            ReconcileCapturePolicy.Output.PARQUET_PAGE_INDEX),
         enqueuedScopes.getFirst().capturePolicy().outputs());
   }
 


### PR DESCRIPTION
## Summary

Sets the default connector reconcile policy to include statistics and indexes.

## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
