### PR TITLE
Fix: Separate renewable catalog credentials from storage credentials

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorFactory.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorFactory.java
@@ -44,6 +44,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
 final class DeltaConnectorFactory {
+  private static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
+  private static final String CLIENT_CREDENTIALS_PROVIDER_PREFIX =
+      CLIENT_CREDENTIALS_PROVIDER + ".";
 
   private DeltaConnectorFactory() {}
 
@@ -104,7 +107,8 @@ final class DeltaConnectorFactory {
             tableName);
       }
       case GLUE -> {
-        var glue = AwsGlueClientFactory.createRefreshing(effectiveOptions, effectiveAuthProps);
+        Map<String, String> catalogOptions = buildGlueCatalogOptions(effectiveOptions);
+        var glue = AwsGlueClientFactory.createRefreshing(catalogOptions, effectiveAuthProps);
         yield new DeltaGlueConnector(
             "delta-glue",
             new GlueDeltaCatalog(glue),
@@ -134,6 +138,48 @@ final class DeltaConnectorFactory {
             ndvMaxFiles);
       }
     };
+  }
+
+  static Map<String, String> buildGlueCatalogOptions(Map<String, String> options) {
+    Map<String, String> catalogOptions =
+        options == null ? new LinkedHashMap<>() : new LinkedHashMap<>(options);
+    copyIfAbsent(catalogOptions, "s3.access-key-id", "rest.access-key-id");
+    copyIfAbsent(catalogOptions, "s3.secret-access-key", "rest.secret-access-key");
+    copyIfAbsent(catalogOptions, "s3.session-token", "rest.session-token");
+
+    String catalogProviderId =
+        resolveOption(
+            catalogOptions,
+            RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID,
+            null);
+    if (catalogProviderId == null) {
+      catalogProviderId =
+          resolveOption(
+              catalogOptions, RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID, null);
+      if (catalogProviderId != null) {
+        catalogOptions.put(
+            RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID, catalogProviderId);
+      }
+    }
+
+    catalogOptions.remove(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID);
+    catalogOptions.remove(RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID);
+    catalogOptions.remove("s3.access-key-id");
+    catalogOptions.remove("s3.secret-access-key");
+    catalogOptions.remove("s3.session-token");
+    catalogOptions.remove(CLIENT_CREDENTIALS_PROVIDER);
+    catalogOptions
+        .keySet()
+        .removeIf(key -> key != null && key.startsWith(CLIENT_CREDENTIALS_PROVIDER_PREFIX));
+    return Map.copyOf(catalogOptions);
+  }
+
+  private static void copyIfAbsent(
+      Map<String, String> properties, String sourceKey, String targetKey) {
+    String value = properties.get(sourceKey);
+    if (value != null && !value.isBlank()) {
+      properties.putIfAbsent(targetKey, value);
+    }
   }
 
   static DeltaSource selectSource(Map<String, String> options) {

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorFactoryTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorFactoryTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.connector.delta.uc.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -100,5 +101,53 @@ class DeltaConnectorFactoryTest {
     assertNotSame(first, second);
     assertInstanceOf(RegistryBackedAwsCredentialsProvider.class, first);
     assertInstanceOf(RegistryBackedAwsCredentialsProvider.class, second);
+  }
+
+  @Test
+  void glueCatalogOptionsKeepCatalogProviderSeparateFromStorageProvider() {
+    Map<String, String> catalogOptions =
+        DeltaConnectorFactory.buildGlueCatalogOptions(
+            Map.of(
+                "delta.source",
+                "glue",
+                RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID,
+                "catalog-provider",
+                RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+                "storage-provider",
+                "rest.access-key-id",
+                "catalog-access",
+                "rest.secret-access-key",
+                "catalog-secret",
+                "s3.access-key-id",
+                "storage-access",
+                "s3.secret-access-key",
+                "storage-secret"));
+
+    assertEquals(
+        "catalog-provider",
+        catalogOptions.get(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID));
+    assertEquals("catalog-access", catalogOptions.get("rest.access-key-id"));
+    assertEquals("catalog-secret", catalogOptions.get("rest.secret-access-key"));
+    assertFalse(
+        catalogOptions.containsKey(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID));
+    assertFalse(catalogOptions.containsKey("s3.access-key-id"));
+    assertFalse(catalogOptions.containsKey("s3.secret-access-key"));
+  }
+
+  @Test
+  void glueCatalogOptionsUseConnectorProviderWhenStorageAuthorityWasNotApplied() {
+    Map<String, String> catalogOptions =
+        DeltaConnectorFactory.buildGlueCatalogOptions(
+            Map.of(
+                "delta.source",
+                "glue",
+                RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+                "connector-provider"));
+
+    assertEquals(
+        "connector-provider",
+        catalogOptions.get(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID));
+    assertFalse(
+        catalogOptions.containsKey(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID));
   }
 }

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/CatalogSigV4AuthManager.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/CatalogSigV4AuthManager.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.connector.iceberg.impl;
+
+import ai.floedb.floecat.connector.common.auth.RefreshingAwsCredentialsProviderRegistry;
+import ai.floedb.floecat.connector.common.auth.RegistryBackedAwsCredentialsProvider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.RESTSigV4AuthSession;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTUtil;
+import org.apache.iceberg.rest.auth.AuthManager;
+import org.apache.iceberg.rest.auth.AuthManagers;
+import org.apache.iceberg.rest.auth.AuthProperties;
+import org.apache.iceberg.rest.auth.AuthSession;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+
+/** Uses catalog-scoped AWS credentials for REST signing without changing FileIO credentials. */
+public final class CatalogSigV4AuthManager implements AuthManager {
+  private static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
+  private static final String CLIENT_CREDENTIALS_PROVIDER_PREFIX =
+      CLIENT_CREDENTIALS_PROVIDER + ".";
+
+  private final Aws4Signer signer = Aws4Signer.create();
+  private final String name;
+  private volatile AuthManager delegate;
+  private Map<String, String> catalogProperties = Map.of();
+
+  public CatalogSigV4AuthManager(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public AuthSession initSession(RESTClient initClient, Map<String, String> properties) {
+    Map<String, String> authProperties = catalogAuthProperties(properties);
+    return new RESTSigV4AuthSession(
+        signer,
+        delegate(properties).initSession(initClient, authProperties),
+        new AwsProperties(authProperties));
+  }
+
+  @Override
+  public AuthSession catalogSession(RESTClient sharedClient, Map<String, String> properties) {
+    catalogProperties = properties;
+    Map<String, String> authProperties = catalogAuthProperties(properties);
+    return new RESTSigV4AuthSession(
+        signer,
+        delegate(properties).catalogSession(sharedClient, authProperties),
+        new AwsProperties(authProperties));
+  }
+
+  @Override
+  public AuthSession contextualSession(SessionCatalog.SessionContext context, AuthSession parent) {
+    RESTSigV4AuthSession sigV4Parent = requireSigV4Parent(parent);
+    Map<String, String> contextProperties =
+        RESTUtil.merge(
+            catalogProperties,
+            RESTUtil.merge(
+                Optional.ofNullable(context.properties()).orElseGet(Map::of),
+                Optional.ofNullable(context.credentials()).orElseGet(Map::of)));
+    Map<String, String> authProperties = catalogAuthProperties(contextProperties);
+    return new RESTSigV4AuthSession(
+        signer,
+        delegate().contextualSession(context, sigV4Parent.delegate()),
+        new AwsProperties(authProperties));
+  }
+
+  @Override
+  public AuthSession tableSession(
+      TableIdentifier table, Map<String, String> properties, AuthSession parent) {
+    RESTSigV4AuthSession sigV4Parent = requireSigV4Parent(parent);
+    Map<String, String> authProperties =
+        catalogAuthProperties(RESTUtil.merge(catalogProperties, properties));
+    return new RESTSigV4AuthSession(
+        signer,
+        delegate().tableSession(table, properties, sigV4Parent.delegate()),
+        new AwsProperties(authProperties));
+  }
+
+  @Override
+  public void close() {
+    AuthManager current = delegate;
+    if (current != null) {
+      current.close();
+    }
+  }
+
+  private AuthManager delegate(Map<String, String> properties) {
+    AuthManager current = delegate;
+    if (current != null) {
+      return current;
+    }
+    synchronized (this) {
+      current = delegate;
+      if (current == null) {
+        String delegateType =
+            properties.getOrDefault(
+                AuthProperties.SIGV4_DELEGATE_AUTH_TYPE,
+                AuthProperties.SIGV4_DELEGATE_AUTH_TYPE_DEFAULT);
+        if (AuthProperties.AUTH_TYPE_SIGV4.equals(delegateType)
+            || CatalogSigV4AuthManager.class.getName().equals(delegateType)) {
+          throw new IllegalArgumentException(
+              "Catalog SigV4 auth cannot delegate to " + delegateType);
+        }
+        Map<String, String> delegateProperties = new HashMap<>(properties);
+        delegateProperties.put(AuthProperties.AUTH_TYPE, delegateType);
+        current = AuthManagers.loadAuthManager(name, delegateProperties);
+        delegate = current;
+      }
+    }
+    return current;
+  }
+
+  private AuthManager delegate() {
+    AuthManager current = delegate;
+    if (current == null) {
+      throw new IllegalStateException("Catalog SigV4 auth manager is not initialized");
+    }
+    return current;
+  }
+
+  static Map<String, String> catalogAuthProperties(Map<String, String> properties) {
+    Map<String, String> authProperties = new HashMap<>(properties);
+    String providerId =
+        authProperties.get(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID);
+    if (providerId == null || providerId.isBlank()) {
+      return Map.copyOf(authProperties);
+    }
+    authProperties.keySet().removeIf(key -> key.startsWith(CLIENT_CREDENTIALS_PROVIDER_PREFIX));
+    authProperties.put(
+        CLIENT_CREDENTIALS_PROVIDER, RegistryBackedAwsCredentialsProvider.class.getName());
+    authProperties.put(
+        CLIENT_CREDENTIALS_PROVIDER_PREFIX
+            + RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID,
+        providerId);
+    authProperties.remove("rest.access-key-id");
+    authProperties.remove("rest.secret-access-key");
+    authProperties.remove("rest.session-token");
+    return Map.copyOf(authProperties);
+  }
+
+  private static RESTSigV4AuthSession requireSigV4Parent(AuthSession parent) {
+    if (!(parent instanceof RESTSigV4AuthSession sigV4Parent)) {
+      throw new IllegalStateException("Parent session is not SigV4: " + parent);
+    }
+    return sigV4Parent;
+  }
+}

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/CatalogSigV4AuthManager.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/CatalogSigV4AuthManager.java
@@ -150,6 +150,10 @@ public final class CatalogSigV4AuthManager implements AuthManager {
         CLIENT_CREDENTIALS_PROVIDER_PREFIX
             + RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID,
         providerId);
+    authProperties.put(
+        CLIENT_CREDENTIALS_PROVIDER_PREFIX
+            + RefreshingAwsCredentialsProviderRegistry.PROPERTY_CREDENTIAL_SCOPE,
+        "catalog");
     authProperties.remove("rest.access-key-id");
     authProperties.remove("rest.secret-access-key");
     authProperties.remove("rest.session-token");

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactory.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactory.java
@@ -21,33 +21,31 @@ import ai.floedb.floecat.connector.common.auth.AwsProfileSupport;
 import ai.floedb.floecat.connector.common.auth.RefreshingAwsCredentialsProviderRegistry;
 import ai.floedb.floecat.connector.common.auth.RegistryBackedAwsCredentialsProvider;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.HTTPClient;
+import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.apache.iceberg.rest.RESTUtil;
 import org.jboss.logging.Logger;
 
 final class IcebergConnectorFactory {
   private static final Logger LOG = Logger.getLogger(IcebergConnectorFactory.class);
-  private static final long REST_CATALOG_TTL_MS = Duration.ofMinutes(5).toMillis();
-  private static final ConcurrentMap<CatalogCacheKey, CatalogCacheEntry> REST_CATALOG_CACHE =
-      new ConcurrentHashMap<>();
   private static final String DEFAULT_S3_FILE_IO = "org.apache.iceberg.aws.s3.S3FileIO";
   private static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
   private static final String CLIENT_CREDENTIALS_PROVIDER_PREFIX =
       CLIENT_CREDENTIALS_PROVIDER + ".";
-  private static final Set<String> ICEBERG_HEADER_KEYS =
-      Set.of("header.x-iceberg-access-delegation");
 
   private IcebergConnectorFactory() {}
 
@@ -113,110 +111,80 @@ final class IcebergConnectorFactory {
             fileIO);
       }
       case GLUE, REST -> {
-        Map<String, String> props = buildCatalogProperties(uri, baseProps);
-        applyCatalogAuth(props, authScheme, authProps);
-        applyStorageAuth(props, authScheme, authProps);
-
+        Map<String, String> catalogProps = buildCatalogProperties(uri, baseProps);
+        Map<String, String> storageProps = buildStorageProperties(baseProps, authScheme, authProps);
+        applyStorageProperties(catalogProps, storageProps);
+        applyCatalogAuth(catalogProps, authScheme, authProps);
         if (headerHints != null) {
-          headerHints.forEach((k, v) -> props.put("header." + k, v));
+          headerHints.forEach((k, v) -> catalogProps.put("header." + k, v));
         }
 
-        props.putIfAbsent("rest.client.user-agent", "floecat-connector-iceberg");
+        catalogProps.putIfAbsent("rest.client.user-agent", "floecat-connector-iceberg");
 
-        CatalogLease catalogLease = acquireRestCatalog(props);
-        RESTCatalog rawCatalog = catalogLease.rawCatalog();
-        Catalog tableCatalog = catalogLease.tableCatalog();
+        RESTSessionCatalog rawCatalog = createRestCatalog(catalogProps);
+        Runnable closeCatalog = closeOnce(rawCatalog);
         try {
+          SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+          Catalog catalog = rawCatalog.asCatalog(context);
+          SupportsNamespaces namespaceCatalog = (SupportsNamespaces) catalog;
+          ViewCatalog viewCatalog = rawCatalog.asViewCatalog(context);
           if (source == IcebergSource.GLUE) {
-            var glue = AwsGlueClientFactory.createRefreshing(props, authProps);
+            var glue = AwsGlueClientFactory.createRefreshing(catalogProps, authProps);
             var glueFilter = new GlueIcebergFilter(glue);
             yield new IcebergGlueConnector(
                 "iceberg-glue",
-                rawCatalog,
-                tableCatalog,
+                catalog,
+                namespaceCatalog,
+                viewCatalog,
+                catalog,
                 glueFilter,
                 ndvEnabled,
                 ndvSampleFraction,
                 ndvMaxFiles,
-                false,
-                catalogLease::release);
+                closeCatalog);
           }
           yield new IcebergRestConnector(
               "iceberg-rest",
-              rawCatalog,
-              tableCatalog,
+              catalog,
+              namespaceCatalog,
+              viewCatalog,
+              catalog,
               ndvEnabled,
               ndvSampleFraction,
               ndvMaxFiles,
-              false,
-              catalogLease::release);
-        } catch (RuntimeException e) {
-          catalogLease.release();
+              closeCatalog);
+        } catch (RuntimeException | Error e) {
+          closeCatalog.run();
           throw e;
         }
       }
     };
   }
 
-  private static CatalogLease acquireRestCatalog(Map<String, String> props) {
-    long now = System.currentTimeMillis();
-    evictExpiredCatalogs(now);
-    CatalogCacheKey key = CatalogCacheKey.of(props);
-    CatalogCacheEntry cached = REST_CATALOG_CACHE.get(key);
-    if (cached != null && !cached.isExpired(now)) {
-      CatalogLease lease = cached.tryAcquire(now + REST_CATALOG_TTL_MS);
-      if (lease != null) {
-        return lease;
-      }
-    }
-    while (true) {
-      CatalogCacheEntry entry =
-          REST_CATALOG_CACHE.compute(
-              key,
-              (ignored, existing) -> {
-                long refreshNow = System.currentTimeMillis();
-                if (existing != null && !existing.isExpired(refreshNow)) {
-                  existing.touch(refreshNow + REST_CATALOG_TTL_MS);
-                  return existing;
-                }
-                if (existing != null) {
-                  existing.retire();
-                }
-                RESTCatalog created = new RESTCatalog();
-                Map<String, String> catalogProps =
-                    Collections.unmodifiableMap(new HashMap<>(props));
-                created.initialize("floecat-iceberg", catalogProps);
-                LOG.infof(
-                    "created iceberg rest catalog uri=%s warehouse=%s accessDelegationHeader=%s"
-                        + " headerKeys=%s storageKeyPresent=%s cacheSize=%d",
-                    catalogProps.get("uri"),
-                    catalogProps.get("warehouse"),
-                    catalogProps.get("header.X-Iceberg-Access-Delegation"),
-                    headerKeys(catalogProps),
-                    catalogProps.containsKey("s3.access-key-id"),
-                    REST_CATALOG_CACHE.size() + 1);
-                return new CatalogCacheEntry(created, created, refreshNow + REST_CATALOG_TTL_MS);
-              });
-      CatalogLease lease = entry.tryAcquire(System.currentTimeMillis() + REST_CATALOG_TTL_MS);
-      if (lease != null) {
-        return lease;
-      }
-    }
+  private static RESTSessionCatalog createRestCatalog(Map<String, String> catalogProperties) {
+    Map<String, String> catalogProps =
+        Collections.unmodifiableMap(new HashMap<>(catalogProperties));
+    RESTSessionCatalog catalog =
+        new RESTSessionCatalog(
+            config ->
+                HTTPClient.builder(config)
+                    .uri(config.get(CatalogProperties.URI))
+                    .withHeaders(RESTUtil.configHeaders(config))
+                    .build(),
+            null);
+    catalog.initialize("floecat-iceberg", catalogProps);
+    LOG.infof(
+        "created iceberg rest catalog uri=%s warehouse=%s accessDelegationHeader=%s"
+            + " headerKeys=%s storageKeyPresent=%s",
+        catalogProps.get("uri"),
+        catalogProps.get("warehouse"),
+        catalogProps.get("header.X-Iceberg-Access-Delegation"),
+        headerKeys(catalogProps),
+        catalogProps.containsKey("s3.access-key-id"));
+    return catalog;
   }
 
-  private static void evictExpiredCatalogs(long now) {
-    for (Map.Entry<CatalogCacheKey, CatalogCacheEntry> entry : REST_CATALOG_CACHE.entrySet()) {
-      CatalogCacheEntry cached = entry.getValue();
-      if (!cached.isExpired(now)) {
-        continue;
-      }
-      if (REST_CATALOG_CACHE.remove(entry.getKey(), cached)) {
-        cached.retire();
-      }
-    }
-  }
-
-  private static void closeQuietly(RESTCatalog catalog) {
+  private static void closeQuietly(RESTSessionCatalog catalog) {
     if (catalog == null) {
       return;
     }
@@ -224,6 +192,15 @@ final class IcebergConnectorFactory {
       catalog.close();
     } catch (Exception ignore) {
     }
+  }
+
+  private static Runnable closeOnce(RESTSessionCatalog catalog) {
+    AtomicBoolean closed = new AtomicBoolean(false);
+    return () -> {
+      if (closed.compareAndSet(false, true)) {
+        closeQuietly(catalog);
+      }
+    };
   }
 
   private static Set<String> headerKeys(Map<String, String> props) {
@@ -248,7 +225,41 @@ final class IcebergConnectorFactory {
     if (baseProps != null && !baseProps.isEmpty()) {
       props.putAll(baseProps);
     }
+    copyIfAbsent(props, "s3.access-key-id", "rest.access-key-id");
+    copyIfAbsent(props, "s3.secret-access-key", "rest.secret-access-key");
+    copyIfAbsent(props, "s3.session-token", "rest.session-token");
+    String catalogProviderId =
+        props.get(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID);
+    if (isBlank(catalogProviderId)) {
+      catalogProviderId = props.get(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID);
+      if (!isBlank(catalogProviderId)) {
+        props.put(
+            RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID, catalogProviderId);
+      }
+    }
+    props.remove(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID);
+    props.remove(RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID);
+    props.remove("s3.access-key-id");
+    props.remove("s3.secret-access-key");
+    props.remove("s3.session-token");
+    props.remove(CLIENT_CREDENTIALS_PROVIDER);
+    props
+        .keySet()
+        .removeIf(key -> key != null && key.startsWith(CLIENT_CREDENTIALS_PROVIDER_PREFIX));
+    if (!isBlank(catalogProviderId)) {
+      props.remove("rest.access-key-id");
+      props.remove("rest.secret-access-key");
+      props.remove("rest.session-token");
+    }
     return props;
+  }
+
+  private static void copyIfAbsent(
+      Map<String, String> properties, String sourceKey, String targetKey) {
+    String value = properties.get(sourceKey);
+    if (!isBlank(value)) {
+      properties.putIfAbsent(targetKey, value);
+    }
   }
 
   static Map<String, String> buildStorageProperties(
@@ -257,8 +268,19 @@ final class IcebergConnectorFactory {
     if (baseProps != null && !baseProps.isEmpty()) {
       props.putAll(baseProps);
     }
+    props.remove(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID);
+    props.remove("rest.access-key-id");
+    props.remove("rest.secret-access-key");
+    props.remove("rest.session-token");
     applyStorageAuth(props, authScheme, authProps);
     return props;
+  }
+
+  static void applyStorageProperties(
+      Map<String, String> catalogProperties, Map<String, String> storageProperties) {
+    if (storageProperties != null && !storageProperties.isEmpty()) {
+      catalogProperties.putAll(storageProperties);
+    }
   }
 
   static void applyCatalogAuth(
@@ -267,13 +289,18 @@ final class IcebergConnectorFactory {
     String scheme = (authScheme == null ? "none" : authScheme.trim().toLowerCase(Locale.ROOT));
     switch (scheme) {
       case "aws-sigv4" -> {
+        props.remove("rest.sigv4-enabled");
         String signingName = safeAuthProps.getOrDefault("signing-name", "glue");
         String signingRegion =
             safeAuthProps.getOrDefault(
                 "signing-region",
                 props.getOrDefault(
                     "rest.signing-region", props.getOrDefault("s3.region", "us-east-1")));
-        props.put("rest.auth.type", "sigv4");
+        props.put(
+            "rest.auth.type",
+            isBlank(props.get(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID))
+                ? "sigv4"
+                : CatalogSigV4AuthManager.class.getName());
         props.put("rest.signing-name", signingName);
         props.put("rest.signing-region", signingRegion);
       }
@@ -409,201 +436,5 @@ final class IcebergConnectorFactory {
 
   private static boolean isBlank(String value) {
     return value == null || value.isBlank();
-  }
-
-  private record CatalogCacheKey(
-      String uri,
-      String warehouse,
-      String restFlavor,
-      String restAuthType,
-      String restSigningName,
-      String restSigningRegion,
-      String restClientUserAgent,
-      String ioImpl,
-      String s3Endpoint,
-      String s3PathStyleAccess,
-      String s3Region,
-      String clientRegion,
-      String awsRegion,
-      String s3RemoteSigningEnabled,
-      String awsProfile,
-      String awsProfilePath,
-      String storageAuthMode,
-      String staticAccessKeyFingerprint,
-      Map<String, String> icebergHeaders) {
-    static CatalogCacheKey of(Map<String, String> props) {
-      Map<String, String> safe = props == null ? Map.of() : props;
-      return new CatalogCacheKey(
-          normalizedValue(safe.get("uri")),
-          normalizedValue(safe.get("warehouse")),
-          normalizedValue(safe.get("rest.flavor")),
-          normalizedValue(safe.get("rest.auth.type")),
-          normalizedValue(safe.get("rest.signing-name")),
-          normalizedValue(safe.get("rest.signing-region")),
-          normalizedValue(safe.get("rest.client.user-agent")),
-          normalizedValue(safe.get("io-impl")),
-          normalizedValue(safe.get("s3.endpoint")),
-          normalizedValue(safe.get("s3.path-style-access")),
-          normalizedValue(safe.get("s3.region")),
-          normalizedValue(safe.get("client.region")),
-          normalizedValue(safe.get("aws.region")),
-          normalizedValue(safe.get("s3.remote-signing-enabled")),
-          normalizedValue(safe.get("aws.profile")),
-          normalizedValue(safe.get("aws.profile_path")),
-          catalogStorageAuthMode(safe),
-          catalogStaticAccessKeyFingerprint(safe),
-          stableIcebergHeaders(safe));
-    }
-  }
-
-  private static String catalogStorageAuthMode(Map<String, String> props) {
-    if (props == null || props.isEmpty()) {
-      return "none";
-    }
-    if (!isBlank(props.get(CLIENT_CREDENTIALS_PROVIDER))) {
-      return "provider";
-    }
-    if (!isBlank(props.get("s3.access-key-id")) || !isBlank(props.get("s3.secret-access-key"))) {
-      return "static-keys";
-    }
-    if (!isBlank(props.get("aws.profile"))) {
-      return "profile";
-    }
-    return "none";
-  }
-
-  private static String catalogStaticAccessKeyFingerprint(Map<String, String> props) {
-    if (props == null || props.isEmpty()) {
-      return null;
-    }
-    String accessKeyId = normalizedValue(props.get("s3.access-key-id"));
-    return accessKeyId == null ? null : fingerprintValue(accessKeyId);
-  }
-
-  private static Map<String, String> stableIcebergHeaders(Map<String, String> props) {
-    if (props == null || props.isEmpty()) {
-      return Map.of();
-    }
-    Map<String, String> headers = new HashMap<>();
-    props.forEach(
-        (key, value) -> {
-          String normalizedKey = normalizedValue(key);
-          String normalizedValue = normalizedValue(value);
-          if (normalizedKey == null
-              || normalizedValue == null
-              || !ICEBERG_HEADER_KEYS.contains(normalizedKey.toLowerCase(Locale.ROOT))) {
-            return;
-          }
-          headers.put(normalizedKey.toLowerCase(Locale.ROOT), normalizedValue);
-        });
-    return headers.isEmpty() ? Map.of() : Map.copyOf(headers);
-  }
-
-  private static String normalizedValue(String value) {
-    if (value == null || value.isBlank()) {
-      return null;
-    }
-    return value.trim();
-  }
-
-  private static String fingerprintValue(String value) {
-    String safe = value == null ? "" : value;
-    return "sha256:"
-        + ai.floedb.floecat.types.Hashing.sha256Hex(
-            safe.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-  }
-
-  private static final class CatalogCacheEntry {
-    private final RESTCatalog rawCatalog;
-    private final Catalog catalog;
-    private volatile long expiresAtMs;
-    private int activeLeases;
-    private boolean retired;
-    private boolean closed;
-
-    private CatalogCacheEntry(RESTCatalog rawCatalog, Catalog catalog, long expiresAtMs) {
-      this.rawCatalog = rawCatalog;
-      this.catalog = catalog;
-      this.expiresAtMs = expiresAtMs;
-    }
-
-    private RESTCatalog rawCatalog() {
-      return rawCatalog;
-    }
-
-    private Catalog tableCatalog() {
-      return catalog;
-    }
-
-    private boolean isExpired(long now) {
-      return now >= expiresAtMs;
-    }
-
-    private void touch(long nextExpiryMs) {
-      this.expiresAtMs = nextExpiryMs;
-    }
-
-    private CatalogLease tryAcquire(long nextExpiryMs) {
-      synchronized (this) {
-        if (retired || closed) {
-          return null;
-        }
-        this.expiresAtMs = nextExpiryMs;
-        activeLeases++;
-      }
-      return new CatalogLease(this);
-    }
-
-    private void release() {
-      RESTCatalog toClose = null;
-      synchronized (this) {
-        if (activeLeases > 0) {
-          activeLeases--;
-        }
-        if (retired && activeLeases == 0 && !closed) {
-          closed = true;
-          toClose = rawCatalog;
-        }
-      }
-      closeQuietly(toClose);
-    }
-
-    private void retire() {
-      RESTCatalog toClose = null;
-      synchronized (this) {
-        if (retired) {
-          return;
-        }
-        retired = true;
-        if (activeLeases == 0 && !closed) {
-          closed = true;
-          toClose = rawCatalog;
-        }
-      }
-      closeQuietly(toClose);
-    }
-  }
-
-  private static final class CatalogLease {
-    private final CatalogCacheEntry entry;
-    private final AtomicBoolean released = new AtomicBoolean(false);
-
-    private CatalogLease(CatalogCacheEntry entry) {
-      this.entry = entry;
-    }
-
-    private RESTCatalog rawCatalog() {
-      return entry.rawCatalog();
-    }
-
-    private Catalog tableCatalog() {
-      return entry.tableCatalog();
-    }
-
-    private void release() {
-      if (released.compareAndSet(false, true)) {
-        entry.release();
-      }
-    }
   }
 }

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactory.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactory.java
@@ -334,6 +334,10 @@ final class IcebergConnectorFactory {
           CLIENT_CREDENTIALS_PROVIDER_PREFIX
               + RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID,
           refreshProviderId);
+      props.put(
+          CLIENT_CREDENTIALS_PROVIDER_PREFIX
+              + RefreshingAwsCredentialsProviderRegistry.PROPERTY_CREDENTIAL_SCOPE,
+          "storage");
       props.remove("s3.access-key-id");
       props.remove("s3.secret-access-key");
       props.remove("s3.session-token");

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergGlueConnector.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergGlueConnector.java
@@ -22,72 +22,35 @@ import java.util.Optional;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.catalog.ViewCatalog;
 
 final class IcebergGlueConnector extends IcebergConnector {
   private final GlueIcebergFilter glueFilter;
-  private final RESTCatalog catalog;
+  private final Catalog catalog;
+  private final SupportsNamespaces namespaceCatalog;
+  private final ViewCatalog viewCatalog;
   private final Catalog tableCatalog;
-  private final boolean closeCatalogOnClose;
   private final Runnable closeHook;
 
   IcebergGlueConnector(
       String connectorId,
-      RESTCatalog catalog,
-      Catalog tableCatalog,
-      GlueIcebergFilter glueFilter,
-      boolean ndvEnabled,
-      double ndvSampleFraction,
-      long ndvMaxFiles) {
-    this(
-        connectorId,
-        catalog,
-        tableCatalog,
-        glueFilter,
-        ndvEnabled,
-        ndvSampleFraction,
-        ndvMaxFiles,
-        true,
-        null);
-  }
-
-  IcebergGlueConnector(
-      String connectorId,
-      RESTCatalog catalog,
+      Catalog catalog,
+      SupportsNamespaces namespaceCatalog,
+      ViewCatalog viewCatalog,
       Catalog tableCatalog,
       GlueIcebergFilter glueFilter,
       boolean ndvEnabled,
       double ndvSampleFraction,
       long ndvMaxFiles,
-      boolean closeCatalogOnClose) {
-    this(
-        connectorId,
-        catalog,
-        tableCatalog,
-        glueFilter,
-        ndvEnabled,
-        ndvSampleFraction,
-        ndvMaxFiles,
-        closeCatalogOnClose,
-        null);
-  }
-
-  IcebergGlueConnector(
-      String connectorId,
-      RESTCatalog catalog,
-      Catalog tableCatalog,
-      GlueIcebergFilter glueFilter,
-      boolean ndvEnabled,
-      double ndvSampleFraction,
-      long ndvMaxFiles,
-      boolean closeCatalogOnClose,
       Runnable closeHook) {
     super(connectorId, null, null, null, ndvEnabled, ndvSampleFraction, ndvMaxFiles, null);
     this.glueFilter = Objects.requireNonNull(glueFilter, "glueFilter");
     this.catalog = Objects.requireNonNull(catalog, "catalog");
+    this.namespaceCatalog = Objects.requireNonNull(namespaceCatalog, "namespaceCatalog");
+    this.viewCatalog = Objects.requireNonNull(viewCatalog, "viewCatalog");
     this.tableCatalog = Objects.requireNonNull(tableCatalog, "tableCatalog");
-    this.closeCatalogOnClose = closeCatalogOnClose;
     this.closeHook = closeHook;
   }
 
@@ -96,7 +59,7 @@ final class IcebergGlueConnector extends IcebergConnector {
     if (isSingleTableMode()) {
       return listNamespacesSingle();
     }
-    return catalog.listNamespaces().stream()
+    return namespaceCatalog.listNamespaces().stream()
         .map(Namespace::toString)
         .filter(glueFilter::databaseHasIceberg)
         .sorted()
@@ -113,17 +76,17 @@ final class IcebergGlueConnector extends IcebergConnector {
 
   @Override
   public List<String> listViews(String namespaceFq) {
-    return listViewsFromCatalog(catalog, namespaceFq);
+    return listViewsFromCatalog(viewCatalog, namespaceFq);
   }
 
   @Override
   public List<ViewDescriptor> listViewDescriptors(String namespaceFq) {
-    return listViewDescriptorsFromCatalog(catalog, namespaceFq);
+    return listViewDescriptorsFromCatalog(viewCatalog, namespaceFq);
   }
 
   @Override
   public Optional<ViewDescriptor> describeView(String namespaceFq, String viewName) {
-    return describeViewFromCatalog(catalog, namespaceFq, viewName);
+    return describeViewFromCatalog(viewCatalog, namespaceFq, viewName);
   }
 
   @Override
@@ -141,17 +104,10 @@ final class IcebergGlueConnector extends IcebergConnector {
 
   @Override
   protected void closeCatalog() {
-    try {
-      if (closeCatalogOnClose) {
-        catalog.close();
-      }
-    } catch (Exception ignore) {
-    } finally {
-      if (closeHook != null) {
-        try {
-          closeHook.run();
-        } catch (RuntimeException ignore) {
-        }
+    if (closeHook != null) {
+      try {
+        closeHook.run();
+      } catch (RuntimeException ignore) {
       }
     }
   }

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergRestConnector.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergRestConnector.java
@@ -22,67 +22,32 @@ import java.util.Optional;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.catalog.ViewCatalog;
 
 final class IcebergRestConnector extends IcebergConnector {
-  private final RESTCatalog catalog;
+  private final Catalog catalog;
+  private final SupportsNamespaces namespaceCatalog;
+  private final ViewCatalog viewCatalog;
   private final Catalog tableCatalog;
-  private final boolean closeCatalogOnClose;
   private final Runnable closeHook;
 
   IcebergRestConnector(
       String connectorId,
-      RESTCatalog catalog,
-      boolean ndvEnabled,
-      double ndvSampleFraction,
-      long ndvMaxFiles) {
-    this(connectorId, catalog, catalog, ndvEnabled, ndvSampleFraction, ndvMaxFiles, true, null);
-  }
-
-  IcebergRestConnector(
-      String connectorId,
-      RESTCatalog catalog,
-      Catalog tableCatalog,
-      boolean ndvEnabled,
-      double ndvSampleFraction,
-      long ndvMaxFiles) {
-    this(
-        connectorId, catalog, tableCatalog, ndvEnabled, ndvSampleFraction, ndvMaxFiles, true, null);
-  }
-
-  IcebergRestConnector(
-      String connectorId,
-      RESTCatalog catalog,
+      Catalog catalog,
+      SupportsNamespaces namespaceCatalog,
+      ViewCatalog viewCatalog,
       Catalog tableCatalog,
       boolean ndvEnabled,
       double ndvSampleFraction,
       long ndvMaxFiles,
-      boolean closeCatalogOnClose) {
-    this(
-        connectorId,
-        catalog,
-        tableCatalog,
-        ndvEnabled,
-        ndvSampleFraction,
-        ndvMaxFiles,
-        closeCatalogOnClose,
-        null);
-  }
-
-  IcebergRestConnector(
-      String connectorId,
-      RESTCatalog catalog,
-      Catalog tableCatalog,
-      boolean ndvEnabled,
-      double ndvSampleFraction,
-      long ndvMaxFiles,
-      boolean closeCatalogOnClose,
       Runnable closeHook) {
     super(connectorId, null, null, null, ndvEnabled, ndvSampleFraction, ndvMaxFiles, null);
     this.catalog = Objects.requireNonNull(catalog, "catalog");
+    this.namespaceCatalog = Objects.requireNonNull(namespaceCatalog, "namespaceCatalog");
+    this.viewCatalog = Objects.requireNonNull(viewCatalog, "viewCatalog");
     this.tableCatalog = Objects.requireNonNull(tableCatalog, "tableCatalog");
-    this.closeCatalogOnClose = closeCatalogOnClose;
     this.closeHook = closeHook;
   }
 
@@ -91,7 +56,7 @@ final class IcebergRestConnector extends IcebergConnector {
     if (isSingleTableMode()) {
       return listNamespacesSingle();
     }
-    return catalog.listNamespaces().stream().map(Namespace::toString).sorted().toList();
+    return namespaceCatalog.listNamespaces().stream().map(Namespace::toString).sorted().toList();
   }
 
   @Override
@@ -108,17 +73,17 @@ final class IcebergRestConnector extends IcebergConnector {
 
   @Override
   public List<String> listViews(String namespaceFq) {
-    return listViewsFromCatalog(catalog, namespaceFq);
+    return listViewsFromCatalog(viewCatalog, namespaceFq);
   }
 
   @Override
   public List<ViewDescriptor> listViewDescriptors(String namespaceFq) {
-    return listViewDescriptorsFromCatalog(catalog, namespaceFq);
+    return listViewDescriptorsFromCatalog(viewCatalog, namespaceFq);
   }
 
   @Override
   public Optional<ViewDescriptor> describeView(String namespaceFq, String viewName) {
-    return describeViewFromCatalog(catalog, namespaceFq, viewName);
+    return describeViewFromCatalog(viewCatalog, namespaceFq, viewName);
   }
 
   @Override
@@ -136,17 +101,10 @@ final class IcebergRestConnector extends IcebergConnector {
 
   @Override
   protected void closeCatalog() {
-    try {
-      if (closeCatalogOnClose) {
-        catalog.close();
-      }
-    } catch (Exception ignore) {
-    } finally {
-      if (closeHook != null) {
-        try {
-          closeHook.run();
-        } catch (RuntimeException ignore) {
-        }
+    if (closeHook != null) {
+      try {
+        closeHook.run();
+      } catch (RuntimeException ignore) {
       }
     }
   }

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactoryTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactoryTest.java
@@ -348,6 +348,12 @@ class IcebergConnectorFactoryTest {
             .get(
                 "client.credentials-provider."
                     + RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID));
+    assertEquals(
+        "catalog",
+        CatalogSigV4AuthManager.catalogAuthProperties(catalogProps)
+            .get(
+                "client.credentials-provider."
+                    + RefreshingAwsCredentialsProviderRegistry.PROPERTY_CREDENTIAL_SCOPE));
 
     assertEquals(
         RegistryBackedAwsCredentialsProvider.class.getName(),
@@ -357,6 +363,11 @@ class IcebergConnectorFactoryTest {
         storageProps.get(
             "client.credentials-provider."
                 + RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID));
+    assertEquals(
+        "storage",
+        storageProps.get(
+            "client.credentials-provider."
+                + RefreshingAwsCredentialsProviderRegistry.PROPERTY_CREDENTIAL_SCOPE));
     assertFalse(storageProps.containsKey("rest.access-key-id"));
     assertFalse(
         storageProps.containsKey(

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactoryTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorFactoryTest.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.connector.iceberg.impl;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,6 +34,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.iceberg.rest.RESTUtil;
+import org.apache.iceberg.rest.auth.AuthManager;
+import org.apache.iceberg.rest.auth.AuthManagers;
 import org.junit.jupiter.api.Test;
 
 class IcebergConnectorFactoryTest {
@@ -258,28 +262,31 @@ class IcebergConnectorFactoryTest {
 
   @Test
   void restCatalogPropsUseRefreshingProviderWhenPresent() {
+    Map<String, String> baseProps =
+        IcebergConnectorFactory.buildBaseIcebergProperties(
+            Map.of(
+                "iceberg.source",
+                "glue",
+                "s3.region",
+                "us-east-1",
+                RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+                "provider-1",
+                "s3.access-key-id",
+                "akid",
+                "s3.secret-access-key",
+                "secret",
+                "s3.session-token",
+                "session"));
     Map<String, String> props =
         IcebergConnectorFactory.buildCatalogProperties(
-            "https://glue.us-east-1.amazonaws.com/iceberg/",
-            IcebergConnectorFactory.buildBaseIcebergProperties(
-                Map.of(
-                    "iceberg.source",
-                    "glue",
-                    "s3.region",
-                    "us-east-1",
-                    RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
-                    "provider-1",
-                    "s3.access-key-id",
-                    "akid",
-                    "s3.secret-access-key",
-                    "secret",
-                    "s3.session-token",
-                    "session")));
+            "https://glue.us-east-1.amazonaws.com/iceberg/", baseProps);
+    Map<String, String> storageProps =
+        IcebergConnectorFactory.buildStorageProperties(baseProps, "aws-sigv4", Map.of());
 
+    IcebergConnectorFactory.applyStorageProperties(props, storageProps);
     IcebergConnectorFactory.applyCatalogAuth(props, "aws-sigv4", Map.of());
-    IcebergConnectorFactory.applyStorageAuth(props, "aws-sigv4", Map.of());
 
-    assertEquals("sigv4", props.get("rest.auth.type"));
+    assertEquals(CatalogSigV4AuthManager.class.getName(), props.get("rest.auth.type"));
     assertEquals(
         RegistryBackedAwsCredentialsProvider.class.getName(),
         props.get("client.credentials-provider"));
@@ -294,95 +301,121 @@ class IcebergConnectorFactoryTest {
   }
 
   @Test
-  void restCatalogCacheKeyIgnoresTransientProviderIdentityAndOauthToken() throws Exception {
-    Map<String, String> props1 =
+  void catalogAndLeaseScopedStorageUseDifferentCredentialProviders() {
+    Map<String, String> baseProps =
+        IcebergConnectorFactory.buildBaseIcebergProperties(
+            Map.of(
+                "iceberg.source",
+                "glue",
+                "s3.region",
+                "us-east-1",
+                RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID,
+                "catalog-provider",
+                RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+                "storage-provider",
+                "rest.access-key-id",
+                "catalog-access",
+                "rest.secret-access-key",
+                "catalog-secret",
+                "s3.access-key-id",
+                "storage-access",
+                "s3.secret-access-key",
+                "storage-secret"));
+
+    Map<String, String> catalogProps =
         IcebergConnectorFactory.buildCatalogProperties(
-            "http://polaris:8181/api/catalog",
-            IcebergConnectorFactory.buildBaseIcebergProperties(
-                Map.of(
-                    "iceberg.source",
-                    "rest",
-                    "warehouse",
-                    "quickstart_catalog",
-                    "s3.region",
-                    "us-east-1",
-                    RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
-                    "provider-1")));
-    IcebergConnectorFactory.applyCatalogAuth(props1, "oauth2", Map.of("token", "token-1"));
-    IcebergConnectorFactory.applyStorageAuth(props1, "none", Map.of());
+            "https://glue.us-east-1.amazonaws.com/iceberg/", baseProps);
+    Map<String, String> storageProps =
+        IcebergConnectorFactory.buildStorageProperties(baseProps, "aws-sigv4", Map.of());
+    IcebergConnectorFactory.applyStorageProperties(catalogProps, storageProps);
+    IcebergConnectorFactory.applyCatalogAuth(catalogProps, "aws-sigv4", Map.of());
 
-    Map<String, String> props2 = new HashMap<>(props1);
-    props2.put("token", "token-2");
-    props2.put(
-        "client.credentials-provider."
-            + RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID,
-        "provider-2");
+    assertEquals(
+        RegistryBackedAwsCredentialsProvider.class.getName(),
+        catalogProps.get("client.credentials-provider"));
+    assertEquals(
+        "storage-provider",
+        catalogProps.get(
+            "client.credentials-provider."
+                + RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID));
+    assertEquals(CatalogSigV4AuthManager.class.getName(), catalogProps.get("rest.auth.type"));
+    assertFalse(catalogProps.containsKey("rest.access-key-id"));
+    assertFalse(catalogProps.containsKey("rest.secret-access-key"));
+    assertFalse(catalogProps.containsKey("s3.access-key-id"));
+    assertEquals(
+        "catalog-provider",
+        CatalogSigV4AuthManager.catalogAuthProperties(catalogProps)
+            .get(
+                "client.credentials-provider."
+                    + RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID));
 
-    Object key1 = catalogCacheKey(props1);
-    Object key2 = catalogCacheKey(props2);
-
-    assertEquals(key1, key2);
-    assertEquals(key1.hashCode(), key2.hashCode());
+    assertEquals(
+        RegistryBackedAwsCredentialsProvider.class.getName(),
+        storageProps.get("client.credentials-provider"));
+    assertEquals(
+        "storage-provider",
+        storageProps.get(
+            "client.credentials-provider."
+                + RefreshingAwsCredentialsProviderRegistry.PROPERTY_PROVIDER_ID));
+    assertFalse(storageProps.containsKey("rest.access-key-id"));
+    assertFalse(
+        storageProps.containsKey(
+            RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID));
   }
 
   @Test
-  void restCatalogCacheKeyTracksStableIcebergHeaders() throws Exception {
-    Map<String, String> props1 =
-        IcebergConnectorFactory.buildCatalogProperties(
-            "http://polaris:8181/api/catalog",
-            IcebergConnectorFactory.buildBaseIcebergProperties(
-                Map.of(
-                    "iceberg.source", "rest",
-                    "warehouse", "quickstart_catalog",
-                    "header.X-Iceberg-Access-Delegation", "remote-signing")));
-    Map<String, String> props2 = new HashMap<>(props1);
-    props2.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
+  void restTableConfigOverridesConfiguredStorageFallback() {
+    Map<String, String> fallback =
+        Map.of(
+            "s3.access-key-id", "fallback-access",
+            "s3.secret-access-key", "fallback-secret",
+            "s3.endpoint", "https://fallback.example");
+    Map<String, String> tableConfig =
+        Map.of(
+            "s3.access-key-id", "vended-access",
+            "s3.secret-access-key", "vended-secret",
+            "s3.endpoint", "https://vended.example");
 
-    Object key1 = catalogCacheKey(props1);
-    Object key2 = catalogCacheKey(props2);
+    Map<String, String> merged = RESTUtil.merge(fallback, tableConfig);
 
-    assertFalse(key1.equals(key2));
+    assertEquals("vended-access", merged.get("s3.access-key-id"));
+    assertEquals("vended-secret", merged.get("s3.secret-access-key"));
+    assertEquals("https://vended.example", merged.get("s3.endpoint"));
   }
 
   @Test
-  void restCatalogCacheKeyDistinguishesStorageAuthModes() throws Exception {
-    Map<String, String> noStorageAuth =
-        IcebergConnectorFactory.buildCatalogProperties(
-            "http://polaris:8181/api/catalog",
-            IcebergConnectorFactory.buildBaseIcebergProperties(
-                Map.of(
-                    "iceberg.source", "rest",
-                    "warehouse", "quickstart_catalog",
-                    "s3.region", "us-east-1")));
+  void catalogSigV4AuthManagerCanBeLoadedByIceberg() {
+    AuthManager manager =
+        AuthManagers.loadAuthManager(
+            "test-catalog", Map.of("rest.auth.type", CatalogSigV4AuthManager.class.getName()));
 
-    Map<String, String> staticStorageAuth =
-        IcebergConnectorFactory.buildCatalogProperties(
-            "http://polaris:8181/api/catalog",
-            IcebergConnectorFactory.buildBaseIcebergProperties(
-                Map.of(
-                    "iceberg.source", "rest",
-                    "warehouse", "quickstart_catalog",
-                    "s3.region", "us-east-1",
-                    "s3.access-key-id", "akid",
-                    "s3.secret-access-key", "secret")));
+    try {
+      assertInstanceOf(CatalogSigV4AuthManager.class, manager);
+    } finally {
+      manager.close();
+    }
+  }
 
-    Map<String, String> profileStorageAuth =
-        IcebergConnectorFactory.buildCatalogProperties(
-            "http://polaris:8181/api/catalog",
-            IcebergConnectorFactory.buildBaseIcebergProperties(
-                Map.of(
-                    "iceberg.source", "rest",
-                    "warehouse", "quickstart_catalog",
-                    "s3.region", "us-east-1",
-                    "aws.profile", "dev-profile")));
+  @Test
+  void deprecatedSigV4FlagCannotBypassCatalogAuthManager() {
+    Map<String, String> props =
+        new HashMap<>(
+            Map.of(
+                "rest.sigv4-enabled",
+                "true",
+                RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID,
+                "catalog-provider"));
 
-    Object noStorageKey = catalogCacheKey(noStorageAuth);
-    Object staticStorageKey = catalogCacheKey(staticStorageAuth);
-    Object profileStorageKey = catalogCacheKey(profileStorageAuth);
+    IcebergConnectorFactory.applyCatalogAuth(props, "aws-sigv4", Map.of());
 
-    assertFalse(noStorageKey.equals(staticStorageKey));
-    assertFalse(noStorageKey.equals(profileStorageKey));
-    assertFalse(staticStorageKey.equals(profileStorageKey));
+    assertFalse(props.containsKey("rest.sigv4-enabled"));
+    assertEquals(CatalogSigV4AuthManager.class.getName(), props.get("rest.auth.type"));
+    AuthManager manager = AuthManagers.loadAuthManager("test-catalog", props);
+    try {
+      assertInstanceOf(CatalogSigV4AuthManager.class, manager);
+    } finally {
+      manager.close();
+    }
   }
 
   @Test
@@ -454,14 +487,5 @@ class IcebergConnectorFactoryTest {
     assertEquals("oauth2", props.get("rest.auth.type"));
     assertEquals("oauth-token", props.get("token"));
     assertEquals("http://polaris:8181/api/catalog/v1/oauth/tokens", props.get("oauth2-server-uri"));
-  }
-
-  private static Object catalogCacheKey(Map<String, String> props) throws Exception {
-    Class<?> keyClass =
-        Class.forName(
-            "ai.floedb.floecat.connector.iceberg.impl.IcebergConnectorFactory$CatalogCacheKey");
-    Method ofMethod = keyClass.getDeclaredMethod("of", Map.class);
-    ofMethod.setAccessible(true);
-    return ofMethod.invoke(null, props);
   }
 }

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergViewConnectorTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergViewConnectorTest.java
@@ -48,7 +48,9 @@ class IcebergViewConnectorTest {
     catalog.addView(namespace, "v_b", fakeView("v_b", "SELECT 2", "trino", namespace));
     catalog.addView(namespace, "v_a", fakeView("v_a", "SELECT 1", "spark", namespace));
 
-    var connector = new IcebergRestConnector("iceberg-rest", catalog, false, 0.1d, 0L);
+    var connector =
+        new IcebergRestConnector(
+            "iceberg-rest", catalog, catalog, catalog, catalog, false, 0.1d, 0L, null);
 
     List<FloecatConnector.ViewDescriptor> views = connector.listViewDescriptors("ns1.ns2");
 
@@ -71,7 +73,9 @@ class IcebergViewConnectorTest {
         "v_only",
         fakeViewWithoutSpark("v_only", "SELECT current_date", "trino", namespace));
 
-    var connector = new IcebergRestConnector("iceberg-rest", catalog, false, 0.1d, 0L);
+    var connector =
+        new IcebergRestConnector(
+            "iceberg-rest", catalog, catalog, catalog, catalog, false, 0.1d, 0L, null);
 
     Optional<FloecatConnector.ViewDescriptor> described = connector.describeView("db", "v_only");
 

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/AwsGlueClientFactory.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/AwsGlueClientFactory.java
@@ -85,7 +85,7 @@ public final class AwsGlueClientFactory {
     String providerId =
         option(options, RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID);
     if (providerId != null) {
-      return new RegistryBackedAwsCredentialsProvider(providerId);
+      return new RegistryBackedAwsCredentialsProvider(providerId, "catalog");
     }
     String access = option(options, "rest.access-key-id");
     String secret = option(options, "rest.secret-access-key");

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/AwsGlueClientFactory.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/AwsGlueClientFactory.java
@@ -83,13 +83,13 @@ public final class AwsGlueClientFactory {
   private static AwsCredentialsProvider resolveCredentials(
       Map<String, String> options, Map<String, String> authProps) {
     String providerId =
-        option(options, RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID);
+        option(options, RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID);
     if (providerId != null) {
       return new RegistryBackedAwsCredentialsProvider(providerId);
     }
-    String access = option(options, "s3.access-key-id");
-    String secret = option(options, "s3.secret-access-key");
-    String token = option(options, "s3.session-token");
+    String access = option(options, "rest.access-key-id");
+    String secret = option(options, "rest.secret-access-key");
+    String token = option(options, "rest.session-token");
     if (access != null && secret != null) {
       AwsCredentials credentials =
           token == null

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/RefreshingAwsCredentialsProviderRegistry.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/RefreshingAwsCredentialsProviderRegistry.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -37,6 +38,7 @@ public final class RefreshingAwsCredentialsProviderRegistry {
   public static final String CATALOG_OPTION_PROVIDER_ID =
       "floecat.catalog.aws.credentials-provider-id";
   public static final String PROPERTY_PROVIDER_ID = "floecat-provider-id";
+  public static final String PROPERTY_CREDENTIAL_SCOPE = "floecat-credential-scope";
   public static final String CLIENT_PROVIDER_CLASS =
       RegistryBackedAwsCredentialsProvider.class.getName();
   public static final String ICEBERG_CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
@@ -67,7 +69,12 @@ public final class RefreshingAwsCredentialsProviderRegistry {
         computeRefreshSkew(
             initialCredentials,
             refreshSkew == null || refreshSkew.isNegative() ? DEFAULT_REFRESH_SKEW : refreshSkew);
-    REGISTRY.put(normalizedProviderId, new Entry(initialCredentials, refresher, effectiveSkew));
+    Entry entry = new Entry(normalizedProviderId, initialCredentials, refresher, effectiveSkew);
+    REGISTRY.put(normalizedProviderId, entry);
+    LOG.log(
+        Level.INFO,
+        "Registered AWS credentials provider; providerRef={0}, expiresAt={1}, refreshSkewMs={2}",
+        new Object[] {entry.providerRef, initialCredentials.expiresAt(), effectiveSkew.toMillis()});
     return normalizedProviderId;
   }
 
@@ -75,15 +82,25 @@ public final class RefreshingAwsCredentialsProviderRegistry {
     if (providerId == null || providerId.isBlank()) {
       return;
     }
-    REGISTRY.remove(providerId.trim());
+    Entry removed = REGISTRY.remove(providerId.trim());
+    if (removed != null) {
+      LOG.log(
+          Level.INFO,
+          "Unregistered AWS credentials provider; providerRef={0}, observedScopes={1}",
+          new Object[] {removed.providerRef, removed.observedScopes});
+    }
   }
 
   public static AwsCredentials resolve(String providerId) {
+    return resolve(providerId, "direct");
+  }
+
+  public static AwsCredentials resolve(String providerId, String credentialScope) {
     Entry entry = REGISTRY.get(requireNonBlank(providerId, "providerId"));
     if (entry == null) {
       throw new IllegalStateException("Unknown AWS credentials provider id: " + providerId);
     }
-    return entry.resolveCredentials();
+    return entry.resolveCredentials(normalizeScope(credentialScope));
   }
 
   public static Map<String, String> propertiesFor(String providerId) {
@@ -148,22 +165,42 @@ public final class RefreshingAwsCredentialsProviderRegistry {
     return value == null || value.isBlank();
   }
 
+  private static String normalizeScope(String credentialScope) {
+    return isBlank(credentialScope) ? "unspecified" : credentialScope.trim().toLowerCase();
+  }
+
+  private static String providerRef(String providerId) {
+    return Integer.toUnsignedString(providerId.hashCode(), 16);
+  }
+
   private static final class Entry {
+    private final String providerRef;
     private final Supplier<ResolvedStorageCredentials> refresher;
     private final Duration refreshSkew;
+    private final Set<String> observedScopes = ConcurrentHashMap.newKeySet();
     private volatile ResolvedStorageCredentials current;
     private volatile TerminalCredentialRefreshException terminalFailure;
 
     private Entry(
+        String providerId,
         ResolvedStorageCredentials initialCredentials,
         Supplier<ResolvedStorageCredentials> refresher,
         Duration refreshSkew) {
+      this.providerRef = providerRef(providerId);
       this.current = initialCredentials;
       this.refresher = refresher;
       this.refreshSkew = refreshSkew;
     }
 
-    private AwsCredentials resolveCredentials() {
+    private AwsCredentials resolveCredentials(String credentialScope) {
+      if (observedScopes.add(credentialScope)) {
+        LOG.log(
+            Level.INFO,
+            "Resolved AWS credentials provider scope; providerRef={0}, scope={1}, expiresAt={2}",
+            new Object[] {
+              providerRef, credentialScope, current == null ? null : current.expiresAt()
+            });
+      }
       TerminalCredentialRefreshException terminal = terminalFailure;
       if (terminal != null) {
         throw terminal;
@@ -188,9 +225,13 @@ public final class RefreshingAwsCredentialsProviderRegistry {
               current = refreshed;
               LOG.log(
                   Level.INFO,
-                  "Refreshed AWS storage credentials; previousExpiresAt={0}, newExpiresAt={1}",
+                  "Refreshed AWS credentials; providerRef={0}, scope={1}, previousExpiresAt={2},"
+                      + " newExpiresAt={3}",
                   new Object[] {
-                    snapshot == null ? null : snapshot.expiresAt(), refreshed.expiresAt()
+                    providerRef,
+                    credentialScope,
+                    snapshot == null ? null : snapshot.expiresAt(),
+                    refreshed.expiresAt()
                   });
             } catch (RuntimeException e) {
               if (e instanceof TerminalCredentialRefreshException terminalRefresh) {

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/RefreshingAwsCredentialsProviderRegistry.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/RefreshingAwsCredentialsProviderRegistry.java
@@ -34,6 +34,8 @@ public final class RefreshingAwsCredentialsProviderRegistry {
   private static final Logger LOG =
       Logger.getLogger(RefreshingAwsCredentialsProviderRegistry.class.getName());
   public static final String OPTION_PROVIDER_ID = "floecat.aws.credentials-provider-id";
+  public static final String CATALOG_OPTION_PROVIDER_ID =
+      "floecat.catalog.aws.credentials-provider-id";
   public static final String PROPERTY_PROVIDER_ID = "floecat-provider-id";
   public static final String CLIENT_PROVIDER_CLASS =
       RegistryBackedAwsCredentialsProvider.class.getName();

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/RegistryBackedAwsCredentialsProvider.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/RegistryBackedAwsCredentialsProvider.java
@@ -22,12 +22,21 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 public final class RegistryBackedAwsCredentialsProvider implements AwsCredentialsProvider {
   private final String providerId;
+  private final String credentialScope;
 
   public RegistryBackedAwsCredentialsProvider(String providerId) {
+    this(providerId, "storage");
+  }
+
+  public RegistryBackedAwsCredentialsProvider(String providerId, String credentialScope) {
     if (providerId == null || providerId.isBlank()) {
       throw new IllegalArgumentException("providerId must be non-blank");
     }
     this.providerId = providerId.trim();
+    this.credentialScope =
+        credentialScope == null || credentialScope.isBlank()
+            ? "unspecified"
+            : credentialScope.trim();
   }
 
   public static AwsCredentialsProvider create(Map<String, String> properties) {
@@ -39,11 +48,13 @@ public final class RegistryBackedAwsCredentialsProvider implements AwsCredential
     if (providerId == null || providerId.isBlank()) {
       providerId = properties.get(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID);
     }
-    return new RegistryBackedAwsCredentialsProvider(providerId);
+    return new RegistryBackedAwsCredentialsProvider(
+        providerId,
+        properties.get(RefreshingAwsCredentialsProviderRegistry.PROPERTY_CREDENTIAL_SCOPE));
   }
 
   @Override
   public AwsCredentials resolveCredentials() {
-    return RefreshingAwsCredentialsProviderRegistry.resolve(providerId);
+    return RefreshingAwsCredentialsProviderRegistry.resolve(providerId, credentialScope);
   }
 }

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/auth/AwsGlueClientFactoryTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/auth/AwsGlueClientFactoryTest.java
@@ -17,11 +17,14 @@
 package ai.floedb.floecat.connector.common.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 class AwsGlueClientFactoryTest {
 
@@ -64,15 +67,45 @@ class AwsGlueClientFactoryTest {
   }
 
   @Test
-  void credentialsProviderFactoryBuildsFreshRegistryProviderForEachClientRefresh() {
+  void credentialsProviderFactoryDoesNotUseStorageRegistryProviderForGlue() {
     var factory =
         AwsGlueClientFactory.credentialsProviderFactory(
             Map.of(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID, "provider-1"),
             Map.of());
 
     AwsCredentialsProvider first = factory.get();
-    AwsCredentialsProvider second = factory.get();
 
-    assertNotSame(first, second);
+    assertInstanceOf(DefaultCredentialsProvider.class, first);
+  }
+
+  @Test
+  void credentialsProviderFactoryUsesCatalogRegistryProviderForGlue() {
+    var factory =
+        AwsGlueClientFactory.credentialsProviderFactory(
+            Map.of(
+                RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID, "provider-1"),
+            Map.of());
+
+    AwsCredentialsProvider provider = factory.get();
+
+    assertInstanceOf(RegistryBackedAwsCredentialsProvider.class, provider);
+  }
+
+  @Test
+  void credentialsProviderFactoryUsesCatalogStaticCredentialsForGlue() {
+    var factory =
+        AwsGlueClientFactory.credentialsProviderFactory(
+            Map.of(
+                "rest.access-key-id", "catalog-access",
+                "rest.secret-access-key", "catalog-secret",
+                "rest.session-token", "catalog-session",
+                "s3.access-key-id", "storage-access",
+                "s3.secret-access-key", "storage-secret"),
+            Map.of());
+
+    AwsCredentialsProvider provider = factory.get();
+
+    assertInstanceOf(StaticCredentialsProvider.class, provider);
+    assertEquals("catalog-access", provider.resolveCredentials().accessKeyId());
   }
 }

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/auth/AwsGlueClientFactoryTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/auth/AwsGlueClientFactoryTest.java
@@ -20,7 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import java.time.Instant;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -107,5 +109,39 @@ class AwsGlueClientFactoryTest {
 
     assertInstanceOf(StaticCredentialsProvider.class, provider);
     assertEquals("catalog-access", provider.resolveCredentials().accessKeyId());
+  }
+
+  @Test
+  void catalogRegistryProviderRenewsExpiredCredentials() {
+    AtomicInteger refreshes = new AtomicInteger();
+    String providerId =
+        RefreshingAwsCredentialsProviderRegistry.register(
+            new ResolvedStorageCredentials(
+                "expired-access",
+                "expired-secret",
+                "expired-session",
+                Instant.now().minusSeconds(1)),
+            () -> {
+              refreshes.incrementAndGet();
+              return new ResolvedStorageCredentials(
+                  "renewed-access",
+                  "renewed-secret",
+                  "renewed-session",
+                  Instant.now().plusSeconds(900));
+            });
+    try {
+      AwsCredentialsProvider provider =
+          AwsGlueClientFactory.credentialsProviderFactory(
+                  Map.of(
+                      RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID,
+                      providerId),
+                  Map.of())
+              .get();
+
+      assertEquals("renewed-access", provider.resolveCredentials().accessKeyId());
+      assertEquals(1, refreshes.get());
+    } finally {
+      RefreshingAwsCredentialsProviderRegistry.unregister(providerId);
+    }
   }
 }

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/auth/RefreshingAwsCredentialsProviderRegistryTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/auth/RefreshingAwsCredentialsProviderRegistryTest.java
@@ -77,7 +77,7 @@ class RefreshingAwsCredentialsProviderRegistryTest {
           public void publish(LogRecord record) {
             if (record != null
                 && record.getMessage() != null
-                && record.getMessage().startsWith("Refreshed AWS storage credentials")) {
+                && record.getMessage().startsWith("Refreshed AWS credentials")) {
               refreshLog.set(record);
             }
           }
@@ -96,13 +96,15 @@ class RefreshingAwsCredentialsProviderRegistryTest {
           () -> credentials("new", refreshedExpiry),
           Duration.ZERO);
 
-      RefreshingAwsCredentialsProviderRegistry.resolve(providerId);
+      RefreshingAwsCredentialsProviderRegistry.resolve(providerId, "catalog");
 
       LogRecord record = refreshLog.get();
       assertNotNull(record);
       assertEquals(Level.INFO, record.getLevel());
-      assertEquals(previousExpiry, record.getParameters()[0]);
-      assertEquals(refreshedExpiry, record.getParameters()[1]);
+      assertNotNull(record.getParameters()[0]);
+      assertEquals("catalog", record.getParameters()[1]);
+      assertEquals(previousExpiry, record.getParameters()[2]);
+      assertEquals(refreshedExpiry, record.getParameters()[3]);
     } finally {
       RefreshingAwsCredentialsProviderRegistry.unregister(providerId);
       logger.removeHandler(handler);

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -1083,7 +1083,7 @@ public class ReconcilerService {
     }
     DestinationTableMetadata metadata = requiredTableMetadata(ctx, tableId);
     ServerSideStorageConfigResolver.ResolvedConnectorConfig resolved =
-        resolveManagedServerSideStorage(
+        resolveManagedTableScopedStorage(
             ctx,
             active.connector(),
             active.resolvedConfig(),
@@ -1097,6 +1097,25 @@ public class ReconcilerService {
       resolved.close();
       throw e;
     }
+  }
+
+  private ServerSideStorageConfigResolver.ResolvedConnectorConfig resolveManagedTableScopedStorage(
+      ReconcileContext ctx,
+      Connector connector,
+      ConnectorConfig config,
+      Optional<String> storageLocation,
+      Optional<ResourceId> tableId) {
+    if (serverSideStorageConfigResolver == null) {
+      return new ServerSideStorageConfigResolver.ResolvedConnectorConfig(config, () -> {});
+    }
+    return serverSideStorageConfigResolver.resolveManagedBorrowingInputProvidersWithAuthorization(
+        ctx.authorizationToken(),
+        ctx.executionJobId(),
+        ctx.executionLeaseEpoch(),
+        storageLocation,
+        tableId,
+        connector,
+        config);
   }
 
   private ConnectorConfig withCommittedMetadataLocation(

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
@@ -45,6 +45,11 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
 public class ServerSideStorageConfigResolver {
+  private enum InputProviderOwnership {
+    TAKE,
+    BORROW
+  }
+
   public record ResolvedConnectorConfig(ConnectorConfig config, Runnable closeAction)
       implements AutoCloseable {
     public ResolvedConnectorConfig {
@@ -130,7 +135,28 @@ public class ServerSideStorageConfigResolver {
         storageLocation,
         tableId,
         connector,
-        config);
+        config,
+        InputProviderOwnership.TAKE);
+  }
+
+  public ResolvedConnectorConfig resolveManagedBorrowingInputProvidersWithAuthorization(
+      Optional<String> authorizationToken,
+      Optional<String> executionJobId,
+      Optional<String> executionLeaseEpoch,
+      Optional<String> storageLocation,
+      Optional<ResourceId> tableId,
+      Connector connector,
+      ConnectorConfig config) {
+    return resolveManaged(
+        Optional.empty(),
+        authorizationToken,
+        executionJobId,
+        executionLeaseEpoch,
+        storageLocation,
+        tableId,
+        connector,
+        config,
+        InputProviderOwnership.BORROW);
   }
 
   private ResolvedConnectorConfig resolveManaged(
@@ -141,7 +167,14 @@ public class ServerSideStorageConfigResolver {
       Optional<String> storageLocation,
       Optional<ResourceId> tableId,
       Connector connector,
-      ConnectorConfig config) {
+      ConnectorConfig config,
+      InputProviderOwnership inputProviderOwnership) {
+    java.util.LinkedHashSet<String> inputProviderIds = new java.util.LinkedHashSet<>();
+    addProviderIds(inputProviderIds, config);
+    java.util.LinkedHashSet<String> providerIds = new java.util.LinkedHashSet<>();
+    if (inputProviderOwnership == InputProviderOwnership.TAKE) {
+      providerIds.addAll(inputProviderIds);
+    }
     ConnectorConfig resolved =
         resolve(
             correlationId,
@@ -153,16 +186,31 @@ public class ServerSideStorageConfigResolver {
             connector,
             config,
             true);
-    String providerId =
-        resolved == null
-            ? null
-            : resolved.options().get(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID);
-    if (!isNonBlank(providerId)) {
+    addProviderIds(providerIds, resolved);
+    if (inputProviderOwnership == InputProviderOwnership.BORROW) {
+      providerIds.removeAll(inputProviderIds);
+    }
+    if (providerIds.isEmpty()) {
       return new ResolvedConnectorConfig(resolved, () -> {});
     }
-    String capturedProviderId = providerId;
     return new ResolvedConnectorConfig(
-        resolved, () -> RefreshingAwsCredentialsProviderRegistry.unregister(capturedProviderId));
+        resolved, () -> providerIds.forEach(RefreshingAwsCredentialsProviderRegistry::unregister));
+  }
+
+  private static void addProviderIds(java.util.Set<String> providerIds, ConnectorConfig config) {
+    if (config == null || config.options() == null) {
+      return;
+    }
+    String storageProviderId =
+        config.options().get(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID);
+    if (isNonBlank(storageProviderId)) {
+      providerIds.add(storageProviderId);
+    }
+    String catalogProviderId =
+        config.options().get(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID);
+    if (isNonBlank(catalogProviderId)) {
+      providerIds.add(catalogProviderId);
+    }
   }
 
   private ConnectorConfig resolve(
@@ -221,9 +269,10 @@ public class ServerSideStorageConfigResolver {
     if (response == null) {
       return config;
     }
+    Map<String, String> baseOptions = preserveCatalogCredentials(config);
     Map<String, String> merged =
         mergeResolvedStorageConfig(
-            config.options(),
+            baseOptions,
             response,
             true,
             refreshableExecutionCredentials
@@ -242,6 +291,38 @@ public class ServerSideStorageConfigResolver {
         ? config
         : new ConnectorConfig(
             config.kind(), config.displayName(), config.uri(), merged, config.auth());
+  }
+
+  static Map<String, String> preserveCatalogCredentials(ConnectorConfig config) {
+    if (config == null || config.options() == null) {
+      return config == null ? Map.of() : config.options();
+    }
+    boolean icebergCatalog =
+        config.kind() == ConnectorConfig.Kind.ICEBERG
+            && !"filesystem".equals(normalize(config.options().get("iceberg.source")));
+    boolean deltaGlue =
+        config.kind() == ConnectorConfig.Kind.DELTA
+            && "glue".equals(normalize(config.options().get("delta.source")));
+    if (!icebergCatalog && !deltaGlue) {
+      return config.options();
+    }
+    LinkedHashMap<String, String> preserved = new LinkedHashMap<>(config.options());
+    copyIfPresent(preserved, "s3.access-key-id", "rest.access-key-id");
+    copyIfPresent(preserved, "s3.secret-access-key", "rest.secret-access-key");
+    copyIfPresent(preserved, "s3.session-token", "rest.session-token");
+    copyIfPresent(
+        preserved,
+        RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+        RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID);
+    return Map.copyOf(preserved);
+  }
+
+  private static void copyIfPresent(
+      Map<String, String> properties, String sourceKey, String targetKey) {
+    String value = properties.get(sourceKey);
+    if (isNonBlank(value)) {
+      properties.putIfAbsent(targetKey, value);
+    }
   }
 
   private static VendStorageCredentialsRequest resolveRequest(

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.common.auth.RefreshingAwsCredentialsProviderRegistry;
+import ai.floedb.floecat.connector.common.auth.ResolvedStorageCredentials;
 import ai.floedb.floecat.connector.common.auth.TerminalCredentialRefreshException;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorKind;
@@ -48,6 +49,263 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class ServerSideStorageConfigResolverTest {
+
+  @Test
+  void preservesIcebergCatalogCredentialsBeforeStorageAuthorityReplacement() {
+    ConnectorConfig config =
+        new ConnectorConfig(
+            ConnectorConfig.Kind.ICEBERG,
+            "glue",
+            "https://glue.us-east-1.amazonaws.com/iceberg/",
+            Map.of(
+                "iceberg.source",
+                "glue",
+                "s3.access-key-id",
+                "catalog-access",
+                "s3.secret-access-key",
+                "catalog-secret",
+                "s3.session-token",
+                "catalog-session",
+                RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+                "catalog-provider"),
+            new ConnectorConfig.Auth("aws-sigv4", Map.of(), Map.of()));
+
+    Map<String, String> preserved =
+        ServerSideStorageConfigResolver.preserveCatalogCredentials(config);
+
+    assertEquals("catalog-access", preserved.get("rest.access-key-id"));
+    assertEquals("catalog-secret", preserved.get("rest.secret-access-key"));
+    assertEquals("catalog-session", preserved.get("rest.session-token"));
+    assertEquals(
+        "catalog-provider",
+        preserved.get(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID));
+  }
+
+  @Test
+  void preservesDeltaGlueCatalogCredentialsBeforeStorageAuthorityReplacement() {
+    ConnectorConfig config =
+        new ConnectorConfig(
+            ConnectorConfig.Kind.DELTA,
+            "glue",
+            "https://glue.us-east-1.amazonaws.com",
+            Map.of(
+                "delta.source",
+                "glue",
+                "s3.access-key-id",
+                "catalog-access",
+                "s3.secret-access-key",
+                "catalog-secret",
+                "s3.session-token",
+                "catalog-session",
+                RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+                "catalog-provider"),
+            new ConnectorConfig.Auth("aws-sigv4", Map.of(), Map.of()));
+
+    Map<String, String> preserved =
+        ServerSideStorageConfigResolver.preserveCatalogCredentials(config);
+
+    assertEquals("catalog-access", preserved.get("rest.access-key-id"));
+    assertEquals("catalog-secret", preserved.get("rest.secret-access-key"));
+    assertEquals("catalog-session", preserved.get("rest.session-token"));
+    assertEquals(
+        "catalog-provider",
+        preserved.get(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID));
+  }
+
+  @Test
+  void doesNotCreateCatalogCredentialScopeForDeltaUnity() {
+    ConnectorConfig config =
+        new ConnectorConfig(
+            ConnectorConfig.Kind.DELTA,
+            "unity",
+            "https://workspace.example.com",
+            Map.of(
+                "delta.source",
+                "unity",
+                RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+                "storage-provider"),
+            new ConnectorConfig.Auth("oauth2", Map.of(), Map.of()));
+
+    Map<String, String> preserved =
+        ServerSideStorageConfigResolver.preserveCatalogCredentials(config);
+
+    assertFalse(
+        preserved.containsKey(RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID));
+  }
+
+  @Test
+  void managedConfigCleansUpCatalogAndStorageProviderRegistrations() {
+    String catalogProvider =
+        RefreshingAwsCredentialsProviderRegistry.register(
+            new ResolvedStorageCredentials(
+                "catalog-access",
+                "catalog-secret",
+                "catalog-session",
+                Instant.now().plusSeconds(900)),
+            () ->
+                new ResolvedStorageCredentials(
+                    "catalog-access",
+                    "catalog-secret",
+                    "catalog-session",
+                    Instant.now().plusSeconds(900)));
+    String storageProvider =
+        RefreshingAwsCredentialsProviderRegistry.register(
+            new ResolvedStorageCredentials(
+                "storage-access",
+                "storage-secret",
+                "storage-session",
+                Instant.now().plusSeconds(900)),
+            () ->
+                new ResolvedStorageCredentials(
+                    "storage-access",
+                    "storage-secret",
+                    "storage-session",
+                    Instant.now().plusSeconds(900)));
+    ConnectorConfig config =
+        new ConnectorConfig(
+            ConnectorConfig.Kind.ICEBERG,
+            "glue",
+            "https://glue.us-east-1.amazonaws.com/iceberg/",
+            Map.of(
+                "iceberg.source",
+                "glue",
+                RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID,
+                catalogProvider,
+                RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+                storageProvider),
+            new ConnectorConfig.Auth("aws-sigv4", Map.of(), Map.of()));
+    Connector connector =
+        Connector.newBuilder()
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setResourceId(
+                ResourceId.newBuilder()
+                    .setAccountId("acct")
+                    .setId("conn")
+                    .setKind(ResourceKind.RK_CONNECTOR))
+            .build();
+    ServerSideStorageConfigResolver resolver =
+        new ServerSideStorageConfigResolver(java.util.Optional.empty(), java.util.Optional.empty());
+
+    try (var ignored =
+        resolver.resolveManagedWithAuthorization(
+            java.util.Optional.empty(),
+            java.util.Optional.empty(),
+            java.util.Optional.empty(),
+            java.util.Optional.empty(),
+            java.util.Optional.empty(),
+            connector,
+            config)) {}
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> RefreshingAwsCredentialsProviderRegistry.resolve(catalogProvider));
+    assertThrows(
+        IllegalStateException.class,
+        () -> RefreshingAwsCredentialsProviderRegistry.resolve(storageProvider));
+  }
+
+  @Test
+  void borrowedManagedConfigCleansUpOnlyItsNewStorageProvider() {
+    String catalogProvider =
+        RefreshingAwsCredentialsProviderRegistry.register(
+            new ResolvedStorageCredentials(
+                "catalog-access",
+                "catalog-secret",
+                "catalog-session",
+                Instant.now().plusSeconds(900)),
+            () ->
+                new ResolvedStorageCredentials(
+                    "catalog-access",
+                    "catalog-secret",
+                    "catalog-session",
+                    Instant.now().plusSeconds(900)));
+    String parentStorageProvider =
+        RefreshingAwsCredentialsProviderRegistry.register(
+            new ResolvedStorageCredentials(
+                "parent-access", "parent-secret", "parent-session", Instant.now().plusSeconds(900)),
+            () ->
+                new ResolvedStorageCredentials(
+                    "parent-access",
+                    "parent-secret",
+                    "parent-session",
+                    Instant.now().plusSeconds(900)));
+    String tableStorageProvider = null;
+    try {
+      ServerSideStorageConfigResolver resolver =
+          new ServerSideStorageConfigResolver(
+              java.util.Optional.empty(), java.util.Optional.empty());
+      resolver.storageAuthorities =
+          mock(StorageAuthoritiesGrpc.StorageAuthoritiesBlockingStub.class);
+      when(resolver.storageAuthorities.withInterceptors(any()))
+          .thenReturn(resolver.storageAuthorities);
+      when(resolver.storageAuthorities.vendStorageCredentials(any()))
+          .thenReturn(
+              ResolveStorageAuthorityResponse.newBuilder()
+                  .addStorageCredentials(
+                      VendedStorageCredential.newBuilder()
+                          .putConfig("s3.access-key-id", "table-access")
+                          .putConfig("s3.secret-access-key", "table-secret")
+                          .putConfig("s3.session-token", "table-session")
+                          .setExpiresAt(
+                              com.google.protobuf.util.Timestamps.fromMillis(
+                                  Instant.now().plusSeconds(900).toEpochMilli())))
+                  .build());
+      Connector connector =
+          Connector.newBuilder()
+              .setKind(ConnectorKind.CK_ICEBERG)
+              .setResourceId(
+                  ResourceId.newBuilder()
+                      .setAccountId("acct")
+                      .setId("conn")
+                      .setKind(ResourceKind.RK_CONNECTOR))
+              .build();
+      ConnectorConfig parentConfig =
+          new ConnectorConfig(
+              ConnectorConfig.Kind.ICEBERG,
+              "glue",
+              "https://glue.us-east-1.amazonaws.com/iceberg/",
+              Map.of(
+                  "iceberg.source",
+                  "glue",
+                  RefreshingAwsCredentialsProviderRegistry.CATALOG_OPTION_PROVIDER_ID,
+                  catalogProvider,
+                  RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID,
+                  parentStorageProvider),
+              new ConnectorConfig.Auth("aws-sigv4", Map.of(), Map.of()));
+
+      try (var tableScoped =
+          resolver.resolveManagedBorrowingInputProvidersWithAuthorization(
+              java.util.Optional.of("token"),
+              java.util.Optional.of("job-1"),
+              java.util.Optional.of("lease-1"),
+              java.util.Optional.of("s3://bucket/table"),
+              java.util.Optional.empty(),
+              connector,
+              parentConfig)) {
+        tableStorageProvider =
+            tableScoped
+                .config()
+                .options()
+                .get(RefreshingAwsCredentialsProviderRegistry.OPTION_PROVIDER_ID);
+        assertFalse(parentStorageProvider.equals(tableStorageProvider));
+      }
+
+      assertEquals(
+          "catalog-access",
+          RefreshingAwsCredentialsProviderRegistry.resolve(catalogProvider).accessKeyId());
+      assertEquals(
+          "parent-access",
+          RefreshingAwsCredentialsProviderRegistry.resolve(parentStorageProvider).accessKeyId());
+      String closedTableStorageProvider = tableStorageProvider;
+      assertThrows(
+          IllegalStateException.class,
+          () -> RefreshingAwsCredentialsProviderRegistry.resolve(closedTableStorageProvider));
+    } finally {
+      RefreshingAwsCredentialsProviderRegistry.unregister(catalogProvider);
+      RefreshingAwsCredentialsProviderRegistry.unregister(parentStorageProvider);
+      RefreshingAwsCredentialsProviderRegistry.unregister(tableStorageProvider);
+    }
+  }
 
   @Test
   void onlyStructuredLeaseFailedPreconditionIsTerminalForCredentialRefresh() {


### PR DESCRIPTION
## Summary

- Isolates Glue/Iceberg REST catalog authentication from S3 storage authentication.
- Adds catalog-scoped renewable AWS credential providers and SigV4 signing without overriding FileIO credentials.
- Preserves catalog credentials when table-scoped storage credentials are vended.
- Correctly manages borrowed versus owned credential-provider lifecycles.
- Updates Delta Glue authentication to use catalog-specific credentials.
- Moves Iceberg REST connectors to session-aware catalogs with explicit lifecycle handling.
- Retains configured storage credentials as a fallback while allowing table-vended credentials to override them.
- Adds regression coverage for credential separation, renewal, ownership, and deprecated SigV4 configuration.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

