### PR TITLE
catalog: map iceberg and delta list columns to variant

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaTypeMapper.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaTypeMapper.java
@@ -98,7 +98,7 @@ final class DeltaTypeMapper {
     // Delta TimestampNTZType is timezone-naive (local) → TIMESTAMP (no UTC normalisation).
     if (dt instanceof TimestampType) return LogicalType.of(LogicalKind.TIMESTAMPTZ);
     if (dt instanceof TimestampNTZType) return LogicalType.of(LogicalKind.TIMESTAMP);
-    if (dt instanceof ArrayType) return LogicalType.of(LogicalKind.ARRAY);
+    if (dt instanceof ArrayType) return LogicalType.of(LogicalKind.VARIANT);
     if (dt instanceof MapType) return LogicalType.of(LogicalKind.MAP);
     if (dt instanceof StructType) return LogicalType.of(LogicalKind.STRUCT);
     if (dt instanceof VariantType) return LogicalType.of(LogicalKind.VARIANT);

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaTypeMapperTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaTypeMapperTest.java
@@ -171,7 +171,7 @@ class DeltaTypeMapperTest {
 
   @Test
   void arrayTypeMapsToArray() {
-    assertThat(kind(new ArrayType(StringType.STRING, true))).isEqualTo(LogicalKind.ARRAY);
+    assertThat(kind(new ArrayType(StringType.STRING, true))).isEqualTo(LogicalKind.VARIANT);
   }
 
   @Test

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergTypeMapper.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergTypeMapper.java
@@ -35,7 +35,7 @@ import org.apache.iceberg.types.Type;
  * <p><b>Integer collapsing:</b> Both Iceberg {@code INTEGER} (32-bit) and {@code LONG} (64-bit)
  * collapse to canonical {@link ai.floedb.floecat.types.LogicalKind#INT} (64-bit).
  *
- * <p><b>Complex types:</b> {@code LIST} → {@link ai.floedb.floecat.types.LogicalKind#ARRAY}, {@code
+ * <p><b>Complex types:</b> {@code LIST} → {@link ai.floedb.floecat.types.LogicalKind#VARIANT} (lists surface as opaque variant columns), {@code
  * MAP} → {@link ai.floedb.floecat.types.LogicalKind#MAP}, {@code STRUCT} → {@link
  * ai.floedb.floecat.types.LogicalKind#STRUCT}. Element/value/field types are captured by child
  * {@code SchemaColumn} rows with their own paths.

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergTypeMapperTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergTypeMapperTest.java
@@ -160,8 +160,9 @@ class IcebergTypeMapperTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  void listMapsToArray() {
-    assertKind(Types.ListType.ofOptional(1, Types.StringType.get()), LogicalKind.ARRAY);
+  void listMapsToVariant() {
+    // Lists surface as opaque variant columns (docs/sql/list_as_variant.md in core).
+    assertKind(Types.ListType.ofOptional(1, Types.StringType.get()), LogicalKind.VARIANT);
   }
 
   @Test

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaMapper.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaMapper.java
@@ -122,9 +122,6 @@ final class DeltaSchemaMapper {
 
       if (dataType instanceof StructType nestedStruct) {
         walkDeltaStruct(cid_algo, sb, nestedStruct, physical, partitionKeys, ordinals);
-      } else if (dataType instanceof ArrayType arrayType
-          && arrayType.getElementType() instanceof StructType elementStruct) {
-        walkDeltaStruct(cid_algo, sb, elementStruct, physical + "[]", partitionKeys, ordinals);
       } else if (dataType instanceof MapType mapType
           && mapType.getValueType() instanceof StructType valueStruct) {
         walkDeltaStruct(cid_algo, sb, valueStruct, physical + "{}", partitionKeys, ordinals);
@@ -133,9 +130,8 @@ final class DeltaSchemaMapper {
   }
 
   private static boolean isContainerType(DataType dataType) {
-    return dataType instanceof StructType
-        || dataType instanceof ArrayType
-        || dataType instanceof MapType;
+    // Arrays are opaque variant leaves, not containers.
+    return dataType instanceof StructType || dataType instanceof MapType;
   }
 
   private static int extractFieldId(FieldMetadata metadata) {
@@ -167,7 +163,10 @@ final class DeltaSchemaMapper {
     if (dataType instanceof DateType) return LogicalType.of(LogicalKind.DATE);
     if (dataType instanceof TimestampType) return LogicalType.of(LogicalKind.TIMESTAMPTZ);
     if (dataType instanceof TimestampNTZType) return LogicalType.of(LogicalKind.TIMESTAMP);
-    if (dataType instanceof ArrayType) return LogicalType.of(LogicalKind.ARRAY);
+    // Lists surface as variant: the scan encodes list<T> rows as variant
+    // payloads regardless of table format (docs/sql/list_as_variant.md in
+    // core), so delta arrays map like iceberg lists.
+    if (dataType instanceof ArrayType) return LogicalType.of(LogicalKind.VARIANT);
     if (dataType instanceof MapType) return LogicalType.of(LogicalKind.MAP);
     if (dataType instanceof StructType) return LogicalType.of(LogicalKind.STRUCT);
     if (dataType instanceof VariantType) return LogicalType.of(LogicalKind.VARIANT);
@@ -221,11 +220,6 @@ final class DeltaSchemaMapper {
       }
       if ("struct".equals(typeNode.path("type").asText(""))) {
         walkFallbackStruct(cid_algo, sb, typeNode, physical, partitionKeys, ordinals);
-      } else if ("array".equals(typeNode.path("type").asText(""))) {
-        JsonNode elem = typeNode.get("elementType");
-        if (elem != null && elem.isObject() && "struct".equals(elem.path("type").asText(""))) {
-          walkFallbackStruct(cid_algo, sb, elem, physical + "[]", partitionKeys, ordinals);
-        }
       } else if ("map".equals(typeNode.path("type").asText(""))) {
         JsonNode value = typeNode.get("valueType");
         if (value != null && value.isObject() && "struct".equals(value.path("type").asText(""))) {
@@ -240,7 +234,7 @@ final class DeltaSchemaMapper {
       return false;
     }
     String typeTag = typeNode.path("type").asText("");
-    return "struct".equals(typeTag) || "array".equals(typeTag) || "map".equals(typeTag);
+    return "struct".equals(typeTag) || "map".equals(typeTag);
   }
 
   private static int fallbackFieldId(JsonNode field) {
@@ -268,7 +262,7 @@ final class DeltaSchemaMapper {
     if (typeNode.isObject()) {
       return switch (typeNode.path("type").asText("")) {
         case "struct" -> "STRUCT";
-        case "array" -> "ARRAY";
+        case "array" -> "VARIANT";
         case "map" -> "MAP";
         case "variant" -> "VARIANT";
         default ->

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/IcebergSchemaMapper.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/IcebergSchemaMapper.java
@@ -28,8 +28,8 @@ import org.apache.iceberg.types.Types;
 /**
  * IcebergSchemaMapper: Converts Iceberg-formatted schema JSON to logical SchemaDescriptor.
  *
- * <p>Handles Iceberg's native field IDs and nested structures (struct, list<struct>,
- * map<*,struct>).
+ * <p>Handles Iceberg's native field IDs and nested structures (struct, map<*,struct>). Lists
+ * surface as single opaque variant leaves.
  */
 public final class IcebergSchemaMapper {
 
@@ -87,11 +87,9 @@ public final class IcebergSchemaMapper {
     Type t = field.type();
 
     // Emit both container and leaf nodes. Stats will later filter to leaf=true.
-    // We treat struct/list/map as non-leaf (containers).
-    boolean isLeaf =
-        !(t instanceof Types.StructType)
-            && !(t instanceof Types.ListType)
-            && !(t instanceof Types.MapType);
+    // We treat struct/map as non-leaf (containers). Lists surface as a single
+    // opaque variant column (like iceberg VARIANT), so they are leaves.
+    boolean isLeaf = !(t instanceof Types.StructType) && !(t instanceof Types.MapType);
 
     sb.addColumns(
         ColumnIdComputer.withComputedId(
@@ -116,15 +114,8 @@ public final class IcebergSchemaMapper {
       return;
     }
 
-    // list<struct>
-    if (t instanceof Types.ListType lt && lt.elementType() instanceof Types.StructType st2) {
-      String childPrefix = physical + "[]";
-      int childOrdinal = 1;
-      for (Types.NestedField child : st2.fields()) {
-        addIcebergField(cid_algo, sb, child, childPrefix, partitionKeys, childOrdinal++);
-      }
-      return;
-    }
+    // list columns are opaque variant leaves; element fields are reachable
+    // through variant subscripting, not as expanded child columns.
 
     // map<*, struct>
     if (t instanceof Types.MapType mt && mt.valueType() instanceof Types.StructType st3) {

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/IcebergTypeMappings.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/resolver/IcebergTypeMappings.java
@@ -50,7 +50,10 @@ public final class IcebergTypeMappings {
       case STRING -> LogicalType.of(LogicalKind.STRING);
       case FIXED, BINARY -> LogicalType.of(LogicalKind.BINARY);
       case UUID -> LogicalType.of(LogicalKind.UUID);
-      case LIST -> LogicalType.of(LogicalKind.ARRAY);
+      // Lists surface as variant: the scan encodes list<T> rows as variant
+      // payloads, so the engine sees one opaque variant column regardless of
+      // element type or nesting depth (docs/sql/list_as_variant.md in core).
+      case LIST -> LogicalType.of(LogicalKind.VARIANT);
       case MAP -> LogicalType.of(LogicalKind.MAP);
       case STRUCT -> LogicalType.of(LogicalKind.STRUCT);
       case VARIANT -> LogicalType.of(LogicalKind.VARIANT);

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaMapperTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/DeltaSchemaMapperTest.java
@@ -197,7 +197,8 @@ class DeltaSchemaMapperTest {
   }
 
   @Test
-  void arrayObjectNodeMapsToArrayAndIsNotLeaf() {
+  void arrayObjectNodeMapsToVariantAndIsLeaf() {
+    // Delta arrays surface as opaque variant leaves, like iceberg lists.
     String json =
         """
         {"fields":[
@@ -206,8 +207,8 @@ class DeltaSchemaMapperTest {
         ]}
         """;
     SchemaColumn col = firstColumn(json);
-    assertThat(col.getLogicalType()).isEqualTo("ARRAY");
-    assertThat(col.getLeaf()).isFalse();
+    assertThat(col.getLogicalType()).isEqualTo("VARIANT");
+    assertThat(col.getLeaf()).isTrue();
   }
 
   @Test

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/IcebergSchemaMapperTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/IcebergSchemaMapperTest.java
@@ -166,13 +166,37 @@ class IcebergSchemaMapperTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  void listFieldMapsToArrayAndIsNotLeaf() {
+  void listFieldMapsToVariantAndIsLeaf() {
+    // Lists surface as a single opaque variant column; the scan encodes each
+    // row as a variant list payload.
     SchemaColumn col =
         singleColumn(
             Types.NestedField.optional(
                 1, "items", Types.ListType.ofOptional(2, Types.StringType.get())));
-    assertThat(col.getLogicalType()).isEqualTo("ARRAY");
-    assertThat(col.getLeaf()).isFalse();
+    assertThat(col.getLogicalType()).isEqualTo("VARIANT");
+    assertThat(col.getLeaf()).isTrue();
+  }
+
+  @Test
+  void listOfStructDoesNotExpandChildColumns() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.optional(
+                1,
+                "links",
+                Types.ListType.ofOptional(
+                    2,
+                    Types.StructType.of(
+                        Types.NestedField.optional(3, "trace_id", Types.StringType.get())))));
+    String json = SchemaParser.toJson(schema);
+    SchemaDescriptor desc = IcebergSchemaMapper.map(ColumnIdAlgorithm.CID_FIELD_ID, json, Set.of());
+
+    // Only the list column itself; element struct fields stay inside the
+    // variant payload rather than becoming separate columns.
+    assertThat(desc.getColumnsCount()).isEqualTo(1);
+    assertThat(desc.getColumns(0).getName()).isEqualTo("links");
+    assertThat(desc.getColumns(0).getLogicalType()).isEqualTo("VARIANT");
+    assertThat(desc.getColumns(0).getLeaf()).isTrue();
   }
 
   @Test

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/LogicalSchemaMapperTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/LogicalSchemaMapperTest.java
@@ -264,9 +264,9 @@ class LogicalSchemaMapperTest {
   }
 
   @Test
-  void icebergSchemaCanonicalizesElementPathsForPathOrdinal() {
-    // This test ensures that Iceberg list element paths (".element") are stable
-    // when later canonicalized by ColumnIdComputer.
+  void icebergListMapsToSingleVariantLeaf() {
+    // Lists surface as a single opaque variant column; element struct fields
+    // stay inside the variant payload rather than becoming child columns.
     String icebergJson =
         """
         {
@@ -299,36 +299,15 @@ class LogicalSchemaMapperTest {
     Table t = baseTable(icebergJson, upstream);
     SchemaDescriptor desc = mapper.map(t, icebergJson);
 
-    assertEquals(2, desc.getColumnsCount()); // arr, arr[].x (no explicit element container node)
+    assertEquals(1, desc.getColumnsCount());
     SchemaColumn arr = desc.getColumns(0);
     assertEquals("arr", arr.getPhysicalPath());
-    assertFalse(arr.getLeaf());
+    assertEquals("VARIANT", arr.getLogicalType());
+    assertTrue(arr.getLeaf());
     assertEquals(1, arr.getOrdinal());
-
-    SchemaColumn x = desc.getColumns(1);
-
-    // Depending on mapper style it may be "arr[].x" or "arr.element.x"
-    String p = x.getPhysicalPath();
-    assertTrue(p.equals("arr[].x") || p.equals("arr.element.x"), "unexpected path: " + p);
-
-    assertTrue(x.getLeaf());
-    assertEquals(1, x.getOrdinal());
 
     // Sanity: ids should be present under PATH_ORDINAL.
     assertNotEquals(0L, arr.getId());
-    assertNotEquals(0L, x.getId());
-
-    // Canonicalization should treat arr.element.x and arr[].x equivalently.
-    long canonical =
-        ColumnIdComputer.compute(ColumnIdAlgorithm.CID_PATH_ORDINAL, "x", "arr[].x", 1, 0);
-    long fromMapper =
-        ColumnIdComputer.compute(
-            ColumnIdAlgorithm.CID_PATH_ORDINAL,
-            x.getName(),
-            x.getPhysicalPath(),
-            x.getOrdinal(),
-            0);
-    assertEquals(canonical, fromMapper);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Describe what this PR changes and why.

List columns surface as the variant logical type instead of ARRAY, for both table formats — the scan-side list -> variant encoding in the engine is format-agnostic (iceberg and delta parquet files flow through the same reader chain), so the catalog mapping must be too.

IcebergTypeMappings maps LIST -> VARIANT and DeltaSchemaMapper / DeltaTypeMapper map arrays -> VARIANT. Both schema mappers emit one opaque leaf column per list; element struct fields stay inside the variant payload (reachable via variant subscripting) instead of expanding into arr[].field child columns. Stats behavior is unchanged: VARIANT, like ARRAY, is not stats-orderable.

## Type of Change

- [ x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [ ] `make fmt`
- [ ] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [ ] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [ ] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Include any follow-ups, risks, or reviewer guidance.
