### PR TITLE
fix: Prevent file-group work from starving reconcile control jobs (#399)

### DIFF
--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -29,6 +30,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -46,6 +48,7 @@ public class RemoteReconcileExecutorPoller {
   private static final long MIN_CANCEL_CHECK_MS = 500L;
   private static final long HEARTBEAT_SHUTDOWN_WAIT_MS = 1_000L;
   private static final int DEFAULT_MAX_PARALLELISM = 1;
+  private static final int DEFAULT_RESERVED_CONTROL_SLOTS = 1;
 
   enum WorkerMode {
     LOCAL,
@@ -83,6 +86,8 @@ public class RemoteReconcileExecutorPoller {
   private final AtomicInteger leaseExecutorCursor = new AtomicInteger(0);
   private volatile WorkerMode workerMode = WorkerMode.LOCAL;
   private volatile int maxParallelism = DEFAULT_MAX_PARALLELISM;
+  private volatile int reservedControlSlots;
+  private volatile Semaphore fileGroupSlots;
   private volatile ExecutorService workers;
 
   @PostConstruct
@@ -96,6 +101,18 @@ public class RemoteReconcileExecutorPoller {
       maxParallelism = 0;
       return;
     }
+    boolean hasControlExecutor =
+        executorRegistry.orderedExecutors().stream()
+            .anyMatch(RemoteReconcileExecutorPoller::supportsControlWork);
+    int configuredReservedControlSlots =
+        config
+            .getOptionalValue("reconciler.reserved-control-slots", Integer.class)
+            .orElse(DEFAULT_RESERVED_CONTROL_SLOTS);
+    reservedControlSlots =
+        !hasControlExecutor || maxParallelism <= 1
+            ? 0
+            : Math.min(maxParallelism - 1, Math.max(0, configuredReservedControlSlots));
+    fileGroupSlots = new Semaphore(maxParallelism - reservedControlSlots);
     workers = Executors.newFixedThreadPool(maxParallelism);
   }
 
@@ -160,7 +177,7 @@ public class RemoteReconcileExecutorPoller {
   }
 
   private Optional<LeaseAssignment> leaseNextAssignment() {
-    var executors = executorRegistry.orderedExecutors();
+    List<ReconcileExecutor> executors = executorRegistry.orderedExecutors();
     if (executors.isEmpty()) {
       return Optional.empty();
     }
@@ -169,12 +186,26 @@ public class RemoteReconcileExecutorPoller {
       if (requestedExecutor.isEmpty()) {
         return Optional.empty();
       }
+      boolean fileGroupSlotReserved = false;
+      if (isFileGroupOnly(requestedExecutor.get())) {
+        Semaphore slots = fileGroupSlots;
+        if (slots == null || !slots.tryAcquire()) {
+          continue;
+        }
+        fileGroupSlotReserved = true;
+      }
       ReconcileJobStore.LeaseRequest request =
           executorRegistry.leaseRequestFor(requestedExecutor.get());
       Optional<RemoteLeasedJob> lease;
       try {
         lease = client.lease(request, workerLeaseSource());
       } catch (RuntimeException e) {
+        releaseFileGroupSlot(fileGroupSlotReserved);
+        if (isLeaseScanBackpressure(e)) {
+          LOG.debugf(
+              "Skipping reconcile poll cycle due to lease scan backpressure: %s", e.getMessage());
+          return Optional.empty();
+        }
         if (shouldIgnoreStartupUnavailable(e)) {
           LOG.debugf(
               "Skipping local reconcile poll cycle until gRPC server is ready: %s", e.getMessage());
@@ -183,19 +214,22 @@ public class RemoteReconcileExecutorPoller {
         throw e;
       }
       if (lease.isEmpty()) {
+        releaseFileGroupSlot(fileGroupSlotReserved);
         continue;
       }
       if (executorCanRun(requestedExecutor.get(), lease.get().lease())) {
-        return Optional.of(new LeaseAssignment(requestedExecutor.get(), lease.get()));
+        return Optional.of(
+            new LeaseAssignment(requestedExecutor.get(), lease.get(), fileGroupSlotReserved));
       }
       Optional<ReconcileExecutor> executor = executorRegistry.executorFor(lease.get().lease());
       if (executor.isEmpty()) {
+        releaseFileGroupSlot(fileGroupSlotReserved);
         LOG.warnf(
             "Leased reconcile job jobId=%s kind=%s but no eligible executor matched locally",
             lease.get().lease().jobId, lease.get().lease().jobKind);
         continue;
       }
-      return Optional.of(new LeaseAssignment(executor.get(), lease.get()));
+      return Optional.of(new LeaseAssignment(executor.get(), lease.get(), fileGroupSlotReserved));
     }
     return Optional.empty();
   }
@@ -234,11 +268,37 @@ public class RemoteReconcileExecutorPoller {
     }
   }
 
+  private static boolean supportsControlWork(ReconcileExecutor executor) {
+    return executor != null
+        && executor.supportedJobKinds().stream()
+            .anyMatch(jobKind -> jobKind != ReconcileJobKind.EXEC_FILE_GROUP);
+  }
+
+  private static boolean isFileGroupOnly(ReconcileExecutor executor) {
+    // Capacity reservation relies on executor-scoped leases and a dedicated file-group executor.
+    // A mixed control/file-group executor must split those lease requests before it is supported.
+    return executor != null
+        && !executor.supportedJobKinds().isEmpty()
+        && executor.supportedJobKinds().stream()
+            .allMatch(jobKind -> jobKind == ReconcileJobKind.EXEC_FILE_GROUP);
+  }
+
+  private void releaseFileGroupSlot(boolean reserved) {
+    if (reserved && fileGroupSlots != null) {
+      fileGroupSlots.release();
+    }
+  }
+
   private String workerLeaseSource() {
     return switch (workerMode) {
       case LOCAL -> "local-poller";
       case REMOTE -> "remote-poller";
     };
+  }
+
+  static boolean isLeaseScanBackpressure(RuntimeException error) {
+    return error instanceof StatusRuntimeException statusError
+        && statusError.getStatus().getCode() == Status.Code.RESOURCE_EXHAUSTED;
   }
 
   private boolean shouldIgnoreStartupUnavailable(RuntimeException error) {
@@ -258,11 +318,13 @@ public class RemoteReconcileExecutorPoller {
       executor.submit(
           () -> {
             boolean ranLease = false;
+            LeaseAssignment leasedAssignment = null;
             try {
               Optional<LeaseAssignment> assignment = leaseNextAssignment();
               if (assignment.isEmpty()) {
                 return;
               }
+              leasedAssignment = assignment.get();
               ranLease = true;
               LOG.infof(
                   "Leased remote reconcile job jobId=%s kind=%s executor=%s",
@@ -273,6 +335,9 @@ public class RemoteReconcileExecutorPoller {
             } catch (RuntimeException e) {
               LOG.errorf(e, "Remote reconcile worker task failed before outcome submission");
             } finally {
+              if (leasedAssignment != null) {
+                releaseFileGroupSlot(leasedAssignment.fileGroupSlotReserved());
+              }
               releaseWorkerSlot(ranLease);
             }
           });
@@ -1032,5 +1097,10 @@ public class RemoteReconcileExecutorPoller {
     }
   }
 
-  record LeaseAssignment(ReconcileExecutor executor, RemoteLeasedJob lease) {}
+  record LeaseAssignment(
+      ReconcileExecutor executor, RemoteLeasedJob lease, boolean fileGroupSlotReserved) {
+    LeaseAssignment(ReconcileExecutor executor, RemoteLeasedJob lease) {
+      this(executor, lease, false);
+    }
+  }
 }

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPollerTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPollerTest.java
@@ -563,6 +563,90 @@ class RemoteReconcileExecutorPollerTest {
   }
 
   @Test
+  void pollOnceReservesConfiguredCapacityForControlWork() throws Exception {
+    RemoteReconcileExecutorClient client = mock(RemoteReconcileExecutorClient.class);
+    CountDownLatch fileGroupsStarted = new CountDownLatch(2);
+    CountDownLatch plannerStarted = new CountDownLatch(1);
+    CountDownLatch releaseExecutions = new CountDownLatch(1);
+    ReconcileExecutor fileGroupExecutor =
+        remoteExecutor(
+            "file-group",
+            Set.of(ReconcileJobKind.EXEC_FILE_GROUP),
+            context -> {
+              fileGroupsStarted.countDown();
+              await(releaseExecutions);
+              return ReconcileExecutor.ExecutionResult.success(0, 0, 0, 0, 0, "file-group");
+            });
+    ReconcileExecutor plannerExecutor =
+        remoteExecutor(
+            "planner",
+            Set.of(ReconcileJobKind.PLAN_CONNECTOR),
+            context -> {
+              plannerStarted.countDown();
+              await(releaseExecutions);
+              return ReconcileExecutor.ExecutionResult.success(0, 0, 0, 0, 0, "planner");
+            });
+
+    poller = new RemoteReconcileExecutorPoller();
+    poller.client = client;
+    poller.executorRegistry =
+        new ReconcileExecutorRegistry(List.of(fileGroupExecutor, plannerExecutor));
+    Config pollerConfig = mock(Config.class);
+    when(pollerConfig.getOptionalValue("reconciler.max-parallelism", Integer.class))
+        .thenReturn(java.util.Optional.of(3));
+    when(pollerConfig.getOptionalValue("reconciler.reserved-control-slots", Integer.class))
+        .thenReturn(java.util.Optional.of(1));
+    when(pollerConfig.getOptionalValue(anyString(), eq(Long.class)))
+        .thenReturn(java.util.Optional.empty());
+    poller.config = pollerConfig;
+    poller.workerModeValue = "local";
+    poller.init();
+
+    AtomicInteger fileGroupLeases = new AtomicInteger();
+    AtomicInteger plannerLeases = new AtomicInteger();
+    when(client.lease(
+            argThat(
+                request ->
+                    request != null
+                        && request.jobKinds.equals(Set.of(ReconcileJobKind.EXEC_FILE_GROUP))),
+            eq("local-poller")))
+        .thenAnswer(
+            ignored -> {
+              int leaseIndex = fileGroupLeases.getAndIncrement();
+              return leaseIndex < 2
+                  ? java.util.Optional.of(
+                      leasedJob("file-group-" + leaseIndex, ReconcileJobKind.EXEC_FILE_GROUP))
+                  : java.util.Optional.empty();
+            });
+    when(client.lease(
+            argThat(
+                request ->
+                    request != null
+                        && request.jobKinds.equals(Set.of(ReconcileJobKind.PLAN_CONNECTOR))),
+            eq("local-poller")))
+        .thenAnswer(
+            ignored ->
+                plannerLeases.getAndIncrement() == 0
+                    ? java.util.Optional.of(
+                        leasedJob("plan-connector", ReconcileJobKind.PLAN_CONNECTOR))
+                    : java.util.Optional.empty());
+    when(client.renew(any()))
+        .thenReturn(new RemoteReconcileExecutorClient.LeaseHeartbeat(true, false));
+    when(client.cancellationRequested(any())).thenReturn(false);
+    when(client.complete(
+            any(), any(), any(), any(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(),
+            anyLong(), anyLong(), any()))
+        .thenReturn(new RemoteReconcileExecutorClient.CompletionResult(true));
+
+    poller.pollOnce();
+
+    assertTrue(fileGroupsStarted.await(5, TimeUnit.SECONDS));
+    assertTrue(plannerStarted.await(5, TimeUnit.SECONDS));
+    assertEquals(2, fileGroupLeases.get());
+    releaseExecutions.countDown();
+  }
+
+  @Test
   void pollOnceUsesRemoteLeaseSourceInRemoteMode() {
     RemoteReconcileExecutorClient client = mock(RemoteReconcileExecutorClient.class);
     ReconcileExecutor executor =
@@ -699,6 +783,16 @@ class RemoteReconcileExecutorPollerTest {
     poller.pollOnce();
 
     verify(client, org.mockito.Mockito.timeout(5_000L)).lease(any(), eq("local-poller"));
+  }
+
+  @Test
+  void resourceExhaustedLeaseFailureIsBackpressure() {
+    assertTrue(
+        RemoteReconcileExecutorPoller.isLeaseScanBackpressure(
+            new io.grpc.StatusRuntimeException(io.grpc.Status.RESOURCE_EXHAUSTED)));
+    assertTrue(
+        !RemoteReconcileExecutorPoller.isLeaseScanBackpressure(
+            new io.grpc.StatusRuntimeException(io.grpc.Status.INTERNAL)));
   }
 
   @Test
@@ -1409,6 +1503,15 @@ class RemoteReconcileExecutorPollerTest {
         return fn.apply(context);
       }
     };
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(5, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
   }
 
   private static RemoteLeasedJob leasedJob(String jobId, ReconcileJobKind jobKind) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -1191,7 +1191,16 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
             totalMs, scanStats.scanCount, scanStats.candidateCount, leased.isPresent());
       }
       observeLeaseNext(startedAtMs, scanStats, outcome);
+      if (scanStats.abortedByCaller) {
+        throw new CancellationException("reconcile lease scan cancelled by caller");
+      }
+      if (scanStats.abortedByDeadline) {
+        throw new LeaseScanCapacityExceededException(
+            "reconcile lease scan deadline exceeded budget_ms=" + leaseScanBudgetMs);
+      }
       return leased;
+    } catch (CancellationException | LeaseScanCapacityExceededException e) {
+      throw e;
     } catch (RuntimeException e) {
       observeLeaseNext(startedAtMs, scanStats, "error");
       throw e;

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
@@ -328,13 +328,13 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
 
   private List<ReadyIndexSelection> readyScanSelections(LeaseRequest request) {
     LeaseRequest effective = request == null ? LeaseRequest.all() : request;
-    List<ReadyIndexSelection> selections = new java.util.ArrayList<>(2);
-    choosePinnedSelection(effective).ifPresent(selections::add);
-    chooseUnpinnedSelection(effective).ifPresent(selections::add);
+    List<ReadyIndexSelection> selections = new java.util.ArrayList<>();
+    selections.addAll(pinnedSelections(effective));
+    selections.addAll(unpinnedSelections(effective));
     return List.copyOf(selections);
   }
 
-  private Optional<ReadyIndexSelection> choosePinnedSelection(LeaseRequest request) {
+  private List<ReadyIndexSelection> pinnedSelections(LeaseRequest request) {
     List<String> executorIds =
         request.executorIds.stream()
             .map(NativeReconcileReadyQueueStore::blankToEmpty)
@@ -342,16 +342,18 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
             .sorted()
             .toList();
     if (executorIds.isEmpty()) {
-      return Optional.empty();
+      return List.of();
     }
-    String executorId = executorIds.get(nextIndex(pinnedSelectionCursor, executorIds.size()));
-    return Optional.of(
-        new ReadyIndexSelection(
-            new ReconcileReadyQueueBackend.ReadyQueueSlice(
-                ReadyIndexType.PINNED_EXECUTOR, executorId)));
+    return rotate(executorIds, pinnedSelectionCursor).stream()
+        .map(
+            executorId ->
+                new ReadyIndexSelection(
+                    new ReconcileReadyQueueBackend.ReadyQueueSlice(
+                        ReadyIndexType.PINNED_EXECUTOR, executorId)))
+        .toList();
   }
 
-  private Optional<ReadyIndexSelection> chooseUnpinnedSelection(LeaseRequest request) {
+  private List<ReadyIndexSelection> unpinnedSelections(LeaseRequest request) {
     List<String> lanes =
         request.lanes.stream()
             .map(NativeReconcileReadyQueueStore::blankToEmpty)
@@ -359,31 +361,43 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
             .sorted()
             .toList();
     if (!lanes.isEmpty()) {
-      String lane = lanes.get(nextIndex(unpinnedSelectionCursor, lanes.size()));
-      return Optional.of(
-          new ReadyIndexSelection(
-              new ReconcileReadyQueueBackend.ReadyQueueSlice(ReadyIndexType.EXECUTION_LANE, lane)));
+      return selections(ReadyIndexType.EXECUTION_LANE, rotate(lanes, unpinnedSelectionCursor));
     }
     List<String> jobKinds = request.jobKinds.stream().sorted().map(Enum::name).toList();
     if (!jobKinds.isEmpty()) {
-      String jobKind = jobKinds.get(nextIndex(unpinnedSelectionCursor, jobKinds.size()));
-      return Optional.of(
-          new ReadyIndexSelection(
-              new ReconcileReadyQueueBackend.ReadyQueueSlice(ReadyIndexType.JOB_KIND, jobKind)));
+      return selections(ReadyIndexType.JOB_KIND, rotate(jobKinds, unpinnedSelectionCursor));
     }
     List<String> executionClasses =
         request.executionClasses.stream().sorted().map(Enum::name).toList();
     if (!executionClasses.isEmpty()) {
-      String executionClass =
-          executionClasses.get(nextIndex(unpinnedSelectionCursor, executionClasses.size()));
-      return Optional.of(
-          new ReadyIndexSelection(
-              new ReconcileReadyQueueBackend.ReadyQueueSlice(
-                  ReadyIndexType.EXECUTION_CLASS, executionClass)));
+      return selections(
+          ReadyIndexType.EXECUTION_CLASS, rotate(executionClasses, unpinnedSelectionCursor));
     }
-    return Optional.of(
+    return List.of(
         new ReadyIndexSelection(
             new ReconcileReadyQueueBackend.ReadyQueueSlice(ReadyIndexType.GLOBAL, "")));
+  }
+
+  private static List<ReadyIndexSelection> selections(
+      ReadyIndexType indexType, List<String> filterValues) {
+    return filterValues.stream()
+        .map(
+            filterValue ->
+                new ReadyIndexSelection(
+                    new ReconcileReadyQueueBackend.ReadyQueueSlice(indexType, filterValue)))
+        .toList();
+  }
+
+  private static List<String> rotate(List<String> values, AtomicInteger cursor) {
+    if (values.isEmpty()) {
+      return List.of();
+    }
+    int start = nextIndex(cursor, values.size());
+    List<String> rotated = new java.util.ArrayList<>(values.size());
+    for (int offset = 0; offset < values.size(); offset++) {
+      rotated.add(values.get((start + offset) % values.size()));
+    }
+    return List.copyOf(rotated);
   }
 
   private static int nextIndex(AtomicInteger cursor, int size) {

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -157,6 +157,9 @@ floecat.reconciler.executor.snapshot-finalize.enabled=${FLOECAT_RECONCILER_SNAPS
 # `remote` runs remote-style workers; set `reconciler.max-parallelism=0` on control-plane-only nodes.
 floecat.reconciler.worker.mode=${FLOECAT_RECONCILER_WORKER_MODE:local}
 reconciler.max-parallelism=${FLOECAT_RECONCILER_MAX_PARALLELISM:1}
+# When parallelism is greater than one, keep this many local slots available for planning and
+# finalization instead of allowing file-group execution to consume the entire worker pool.
+reconciler.reserved-control-slots=${FLOECAT_RECONCILER_RESERVED_CONTROL_SLOTS:1}
 # Worker-control always uses an explicit transport path.
 floecat.reconciler.worker-control.grpc.host=${FLOECAT_RECONCILER_WORKER_GRPC_HOST:${quarkus.grpc.clients.floecat.host:${FLOECAT_GRPC_HOST:127.0.0.1}}}
 floecat.reconciler.worker-control.grpc.port=${FLOECAT_RECONCILER_WORKER_GRPC_PORT:${quarkus.grpc.clients.floecat.port:${FLOECAT_GRPC_PORT:${quarkus.http.port:9100}}}}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -58,6 +58,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndex
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexCleanupManifest;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexStore;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileLeaseStore;
+import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
@@ -1398,6 +1399,31 @@ class DurableReconcileJobStoreTest {
       assertTrue(Thread.currentThread().isInterrupted());
     } finally {
       Thread.interrupted();
+    }
+  }
+
+  @Test
+  void leaseNextReportsDeadlineAbortAsCapacityExceededInsteadOfEmpty() {
+    ReconcileReadyQueueStore original = store.readyQueueStore;
+    ReconcileReadyQueueStore readyQueue = Mockito.mock(ReconcileReadyQueueStore.class);
+    store.readyQueueStore = readyQueue;
+    try {
+      Mockito.when(readyQueue.leaseReadyDue(Mockito.anyLong(), Mockito.any(), Mockito.any()))
+          .thenAnswer(
+              invocation -> {
+                ReconcileReadyQueueStore.LeaseScanStats stats = invocation.getArgument(2);
+                stats.abortedByDeadline = true;
+                return Optional.empty();
+              });
+
+      LeaseScanCapacityExceededException error =
+          assertThrows(
+              LeaseScanCapacityExceededException.class,
+              () -> store.leaseNext(ReconcileJobStore.LeaseRequest.all()));
+
+      assertTrue(error.getMessage().contains("deadline exceeded"));
+    } finally {
+      store.readyQueueStore = original;
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.reconciler.jobs.durable.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -31,6 +32,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeaseRequest;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeasedJob;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
+import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueBackend.ReadyQueueSlice;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore.LeaseScanStats;
 import java.util.ArrayList;
 import java.util.List;
@@ -117,7 +119,7 @@ class NativeReconcileReadyQueueStoreBudgetTest {
   }
 
   @Test
-  void wildcardLaneJobKindRequestUsesOnePinnedBucketThenOneJobKindBucket() {
+  void wildcardLaneJobKindRequestUsesAllPinnedAndJobKindBuckets() {
     SliceRecordingBackend backend = new SliceRecordingBackend();
     NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
     store.bind(backend, null, null, 128, record -> true, record -> false);
@@ -134,20 +136,29 @@ class NativeReconcileReadyQueueStoreBudgetTest {
             new LeaseScanStats());
 
     assertTrue(leased.isEmpty());
-    assertEquals(2, backend.slices.size());
+    assertEquals(4, backend.slices.size());
     assertEquals(
         ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR, backend.slices.get(0).indexType());
     assertTrue(
         Set.of("remote_default_worker", "remote_planner_worker")
             .contains(backend.slices.get(0).filterValue()));
     assertEquals(
-        ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND, backend.slices.get(1).indexType());
-    assertEquals(ReconcileJobKind.PLAN_CONNECTOR.name(), backend.slices.get(1).filterValue());
-    assertEquals(List.of(16, 16), backend.pageSizes);
+        ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR, backend.slices.get(1).indexType());
+    assertTrue(
+        Set.of("remote_default_worker", "remote_planner_worker")
+            .contains(backend.slices.get(1).filterValue()));
+    assertNotEquals(backend.slices.get(0).filterValue(), backend.slices.get(1).filterValue());
+    assertEquals(
+        ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND, backend.slices.get(2).indexType());
+    assertEquals(ReconcileJobKind.PLAN_CONNECTOR.name(), backend.slices.get(2).filterValue());
+    assertEquals(
+        ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND, backend.slices.get(3).indexType());
+    assertEquals(ReconcileJobKind.PLAN_TABLE.name(), backend.slices.get(3).filterValue());
+    assertEquals(List.of(16, 16, 16, 16), backend.pageSizes);
   }
 
   @Test
-  void wildcardLaneJobKindRequestRoundRobinsUnpinnedKindBuckets() {
+  void wildcardLaneJobKindRequestScansEveryKindAndRotatesTheStartingKind() {
     SliceRecordingBackend backend = new SliceRecordingBackend();
     NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
     store.bind(backend, null, null, 128, record -> true, record -> false);
@@ -163,13 +174,101 @@ class NativeReconcileReadyQueueStoreBudgetTest {
     assertTrue(
         store.leaseReadyDue(System.currentTimeMillis(), request, new LeaseScanStats()).isEmpty());
 
-    assertEquals(2, backend.slices.size());
+    assertEquals(4, backend.slices.size());
     assertEquals(
         ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND, backend.slices.get(0).indexType());
     assertEquals(ReconcileJobKind.PLAN_CONNECTOR.name(), backend.slices.get(0).filterValue());
     assertEquals(
         ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND, backend.slices.get(1).indexType());
     assertEquals(ReconcileJobKind.PLAN_TABLE.name(), backend.slices.get(1).filterValue());
+    assertEquals(
+        ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND, backend.slices.get(2).indexType());
+    assertEquals(ReconcileJobKind.PLAN_TABLE.name(), backend.slices.get(2).filterValue());
+    assertEquals(
+        ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND, backend.slices.get(3).indexType());
+    assertEquals(ReconcileJobKind.PLAN_CONNECTOR.name(), backend.slices.get(3).filterValue());
+  }
+
+  @Test
+  void multiKindRequestLeasesFromLaterKindBeforeReturningEmpty() {
+    NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
+    ReconcileReadyQueueBackend backend = mock(ReconcileReadyQueueBackend.class);
+    ReconcileJobIndexStore jobIndexStore = mock(ReconcileJobIndexStore.class);
+    ReconcileLeaseStore leaseStore = mock(ReconcileLeaseStore.class);
+    store.bind(backend, jobIndexStore, leaseStore, 128, record -> true, record -> false);
+    long dueAtMs = System.currentTimeMillis();
+    StoredReconcileJob record = queuedRecord("job-table", dueAtMs, store);
+    record.jobKind = ReconcileJobKind.PLAN_TABLE.name();
+    String readyPointerKey =
+        store.readyPointerKeyFor(
+            record,
+            ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND,
+            dueAtMs,
+            ReconcileJobKind.PLAN_TABLE.name());
+    ReconcileReadyQueueStore.ReadyQueueEntry candidate =
+        new ReconcileReadyQueueStore.ReadyQueueEntry(
+            readyPointerKey,
+            "/canonical-table",
+            record.accountId,
+            record.jobId,
+            dueAtMs,
+            ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND,
+            ReconcileJobKind.PLAN_TABLE.name());
+    CanonicalPointerSnapshot snapshot =
+        new CanonicalPointerSnapshot("/canonical-table", "blob://job-table", 7L);
+    LeasedJob leasedJob = mock(LeasedJob.class);
+
+    when(backend.scanReadySlice(any(), eq(16), eq(""), any()))
+        .thenAnswer(
+            invocation -> {
+              ReadyQueueSlice slice = invocation.getArgument(0);
+              return new ReconcileReadyQueueStore.ReadyQueueScanPage(
+                  ReconcileJobKind.PLAN_TABLE.name().equals(slice.filterValue())
+                      ? List.of(candidate)
+                      : List.of(),
+                  "");
+            });
+    when(backend.loadCanonicalSnapshot(eq("/canonical-table"), any()))
+        .thenReturn(Optional.of(snapshot));
+    when(jobIndexStore.readRecord(snapshot)).thenReturn(Optional.of(record));
+    when(leaseStore.leaseCanonical(
+            eq("/canonical-table"),
+            eq(readyPointerKey),
+            anyLong(),
+            eq(snapshot),
+            eq(record),
+            any()))
+        .thenReturn(Optional.of(leasedJob));
+
+    Optional<LeasedJob> leased =
+        store.leaseReadyDue(
+            dueAtMs,
+            LeaseRequest.of(
+                Set.of(),
+                Set.of(LeaseRequest.anyLaneToken()),
+                Set.of(),
+                Set.of(ReconcileJobKind.PLAN_CONNECTOR, ReconcileJobKind.PLAN_TABLE)),
+            new LeaseScanStats());
+
+    assertEquals(Optional.of(leasedJob), leased);
+    verify(backend)
+        .scanReadySlice(
+            eq(
+                new ReadyQueueSlice(
+                    ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND,
+                    ReconcileJobKind.PLAN_CONNECTOR.name())),
+            eq(16),
+            eq(""),
+            any());
+    verify(backend)
+        .scanReadySlice(
+            eq(
+                new ReadyQueueSlice(
+                    ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND,
+                    ReconcileJobKind.PLAN_TABLE.name())),
+            eq(16),
+            eq(""),
+            any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

This PR improves reconcile scheduling under concurrent file-group and control-plane workloads.

Reserves configurable worker capacity for planning and finalization so file-group execution cannot saturate the worker pool.
Scans every eligible pinned-executor and job-kind bucket before reporting that no work is available.
Rotates the first scanned bucket to preserve fairness between eligible queues.
Reports lease-scan deadline exhaustion as a capacity error instead of an empty queue result.
Adds configuration for reserved control slots and unit coverage for the new scheduling and leasing behavior.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
