### PR TITLE
fix: recompute parent state before advancing the reconcile projection generation

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -2115,85 +2115,11 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
           Long.valueOf(previousProjection.appliedGeneration()));
       return;
     }
-    if (previousProjection != null
-        && projectionAggregateMatchesCanonical(parent, previousProjection)
-        && requestedGeneration > Math.max(0L, previousProjection.appliedGeneration())
-        && canPublishCanonicalProjectionPatch(parent, previousProjection)) {
-      var nextProjection =
-          projectionWithCanonicalFields(parent, previousProjection, requestedGeneration);
-      projections().upsert(nextProjection);
-      LOG.infof(
-          "reconcile projection generation patch accountId=%s jobId=%s kind=%s parentJobId=%s"
-              + " requestedGeneration=%d previousAppliedGeneration=%d projectionGeneration=%d"
-              + " state=%s tables=%d/%d stats=%d indexes=%d fileGroups=%d/%d files=%d/%d",
-          accountId,
-          parentJobId,
-          parent.jobKind(),
-          blankToEmpty(parent.parentJobId),
-          Long.valueOf(requestedGeneration),
-          Long.valueOf(previousAppliedGeneration),
-          Long.valueOf(nextProjection.appliedGeneration()),
-          nextProjection.state(),
-          Long.valueOf(nextProjection.tablesChanged()),
-          Long.valueOf(nextProjection.tablesScanned()),
-          Long.valueOf(nextProjection.statsProcessed()),
-          Long.valueOf(nextProjection.indexesProcessed()),
-          Long.valueOf(nextProjection.completedFileGroups()),
-          Long.valueOf(nextProjection.plannedFileGroups()),
-          Long.valueOf(nextProjection.completedFiles()),
-          Long.valueOf(nextProjection.plannedFiles()));
-      if (blankToEmpty(parent.parentJobId).isBlank()) {
-        rootSummaries().upsert(toRootListSummary(parent, nextProjection));
-      }
-      enqueueSnapshotFinalizationForPlanSnapshotIfEligible(
-          projector().toPublicJob(parent, nextProjection, true), snapshotTaskFromStored(parent));
-      advanceAppliedProjectionGeneration(accountId, parentJobId, requestedGeneration);
-      if (propagateDirtyParent && requestedGeneration > previousAppliedGeneration) {
-        markDirtyParent(parent.accountId, parent.parentJobId);
-      }
-      return;
-    }
-    if (canPublishCanonicalAggregatePatch(parent, previousProjection)) {
-      var nextProjection =
-          projectionWithCanonicalFields(parent, previousProjection, requestedGeneration);
-      boolean projectionChanged = !Objects.equals(previousProjection, nextProjection);
-      if (projectionChanged) {
-        if (!commitProjectionAggregateChange(parent, previousProjection, nextProjection)) {
-          throw new IllegalStateException(
-              "Failed to apply reconcile projection aggregate patch to parent job "
-                  + blankToEmpty(parent.parentJobId));
-        }
-      }
-      LOG.infof(
-          "reconcile projection aggregate patch accountId=%s jobId=%s kind=%s parentJobId=%s"
-              + " requestedGeneration=%d previousAppliedGeneration=%d projectionGeneration=%d"
-              + " state=%s stats=%d indexes=%d fileGroups=%d/%d files=%d/%d",
-          accountId,
-          parentJobId,
-          parent.jobKind(),
-          blankToEmpty(parent.parentJobId),
-          Long.valueOf(requestedGeneration),
-          Long.valueOf(previousAppliedGeneration),
-          Long.valueOf(nextProjection.appliedGeneration()),
-          nextProjection.state(),
-          Long.valueOf(nextProjection.statsProcessed()),
-          Long.valueOf(nextProjection.indexesProcessed()),
-          Long.valueOf(nextProjection.completedFileGroups()),
-          Long.valueOf(nextProjection.plannedFileGroups()),
-          Long.valueOf(nextProjection.completedFiles()),
-          Long.valueOf(nextProjection.plannedFiles()));
-      if (blankToEmpty(parent.parentJobId).isBlank()) {
-        rootSummaries().upsert(toRootListSummary(parent, nextProjection));
-      }
-      enqueueSnapshotFinalizationForPlanSnapshotIfEligible(
-          projector().toPublicJob(parent, nextProjection, true), snapshotTaskFromStored(parent));
-      advanceAppliedProjectionGeneration(accountId, parentJobId, requestedGeneration);
-      if (propagateDirtyParent
-          && (requestedGeneration > previousAppliedGeneration || projectionChanged)) {
-        markDirtyParent(parent.accountId, parent.parentJobId);
-      }
-      return;
-    }
+    // Every remaining path must recompute the state from the children before it advances the
+    // applied generation. A counters-only patch that consumed the generation would leave a stale
+    // non-terminal state published forever: nothing else re-derives it (the maintenance sweep is
+    // dirty-marker-driven and the marker is deleted after this call, the read paths never
+    // recompute, and the canonical cascade only runs on a lease outcome).
     List<StoredReconcileJob> directChildren = listAllStoredChildJobs(accountId, parentJobId);
     var nextProjection = recomputeSummaryProjection(parent, directChildren, false, true);
     if (nextProjection == null) {
@@ -3207,56 +3133,6 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     long requestedGeneration = Math.max(0L, record.projectionRequestedGeneration);
     long appliedGeneration = Math.max(0L, projection.appliedGeneration());
     return appliedGeneration >= requestedGeneration;
-  }
-
-  private boolean canPublishCanonicalAggregatePatch(
-      StoredReconcileJob record, StoredReconcileJobProjection projection) {
-    return canPublishCanonicalProjectionPatch(record, projection)
-        && !projectionAggregateMatchesCanonical(record, projection);
-  }
-
-  private boolean canPublishCanonicalProjectionPatch(
-      StoredReconcileJob record, StoredReconcileJobProjection projection) {
-    if (record == null || projection == null || !isParentCapable(record.jobKind())) {
-      return false;
-    }
-    String canonicalState = blankToEmpty(record.state);
-    String projectionState = blankToEmpty(projection.state());
-    if (canonicalState.isBlank()
-        || isTerminalState(canonicalState)
-        || isTerminalState(projectionState)
-        || isCancellationState(canonicalState)) {
-      return false;
-    }
-    return true;
-  }
-
-  private StoredReconcileJobProjection projectionWithCanonicalFields(
-      StoredReconcileJob record, StoredReconcileJobProjection previous, long appliedGeneration) {
-    return new StoredReconcileJobProjection(
-        previous.accountId(),
-        previous.jobId(),
-        Math.max(Math.max(0L, appliedGeneration), Math.max(0L, previous.appliedGeneration())),
-        previous.state(),
-        previous.message(),
-        previous.startedAtMs(),
-        previous.finishedAtMs(),
-        Math.max(0L, record.tablesScanned),
-        Math.max(0L, record.tablesChanged),
-        Math.max(0L, record.viewsScanned),
-        Math.max(0L, record.viewsChanged),
-        Math.max(0L, record.errors),
-        Math.max(0L, record.snapshotsProcessed),
-        Math.max(0L, record.statsProcessed),
-        Math.max(0L, record.indexesProcessed),
-        Math.max(0L, record.plannedFileGroups),
-        Math.max(0L, record.plannedFiles),
-        Math.max(0L, record.completedFileGroups),
-        Math.max(0L, record.failedFileGroups),
-        Math.max(0L, record.completedFiles),
-        Math.max(0L, record.failedFiles),
-        previous.executorId(),
-        previous.aggregateSummaryPresent());
   }
 
   private boolean commitProjectionAggregateChange(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -2169,6 +2169,12 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         && (requestedGeneration > previousAppliedGeneration || projectionChanged)) {
       markDirtyParent(parent.accountId, parent.parentJobId);
     }
+    // The read paths report the canonical state whenever it is nonblank, so a terminal rollup that
+    // only reaches the projection leaves get()/list() waiting forever. Runs last so the canonical
+    // advance sees the persisted projection and any finalizer this refresh enqueued.
+    if (isTerminalState(nextProjection.state())) {
+      advanceCanonicalSchedulingAfterRecordChange(parent);
+    }
   }
 
   private boolean hasLiveDirectChildLease(StoredReconcileJob parent) {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -2525,7 +2525,7 @@ class DurableReconcileJobStoreTest {
   }
 
   @Test
-  void parentRefreshAdvancesGenerationWithoutScanningWhenCanonicalProjectionFieldsMatch() {
+  void parentRefreshRecomputesStaleWaitingStateBeforeAdvancingGeneration() {
     String tableJobId =
         store.enqueue(
             ACCOUNT_ID,
@@ -2571,9 +2571,22 @@ class DurableReconcileJobStoreTest {
                   current.plannedFiles = 1208L;
                   current.completedFileGroups = 85L;
                   current.completedFiles = 1208L;
+                  current.childrenFinalized = true;
                   current.projectionRequestedGeneration = 796L;
                   current.projectionAppliedGeneration = 794L;
                   current.updatedAtMs = 200L;
+                  return current;
+                }));
+    assertDoesNotThrow(
+        () ->
+            store.jobIndexStore.mutateByCanonicalPointerReturningRecord(
+                Keys.reconcileJobPointerById(ACCOUNT_ID, snapshotJobId),
+                current -> {
+                  current.state = "JS_SUCCEEDED";
+                  current.message = "Succeeded";
+                  current.startedAtMs = 120L;
+                  current.finishedAtMs = 180L;
+                  current.updatedAtMs = 180L;
                   return current;
                 }));
 
@@ -2619,13 +2632,13 @@ class DurableReconcileJobStoreTest {
                 0L,
                 0L,
                 1L,
-                9999L,
-                9999L,
+                1208L,
+                1208L,
+                85L,
+                1208L,
+                85L,
                 0L,
-                0L,
-                0L,
-                0L,
-                0L,
+                1208L,
                 0L,
                 "",
                 true));
@@ -2641,11 +2654,158 @@ class DurableReconcileJobStoreTest {
 
     StoredReconcileJobProjection projection =
         projectionStore().load(ACCOUNT_ID, tableJobId).orElseThrow();
+    // The generation advance is only legitimate because the state was re-derived from the children.
+    // A counters-only patch used to advance it while republishing the stale JS_WAITING, which froze
+    // the projection forever: the applied generation then matched the requested one, so no later
+    // refresh or read ever recomputed the state again.
+    assertEquals("JS_SUCCEEDED", projection.state());
     assertEquals(796L, projection.appliedGeneration());
     assertEquals(86L, projection.tablesScanned());
     assertEquals(86L, projection.tablesChanged());
     assertEquals(1208L, projection.statsProcessed());
     assertEquals(1208L, projection.indexesProcessed());
+  }
+
+  @Test
+  void rootRefreshRecomputesStaleWaitingStateWhenCanonicalCountersRunAhead() {
+    String connectorJobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.empty());
+    String tableJobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.of(List.of(), "orders-id"),
+            ReconcileJobKind.PLAN_TABLE,
+            ReconcileTableTask.of("src.ns", "orders", "orders-id", "orders"),
+            ReconcileExecutionPolicy.defaults(),
+            connectorJobId,
+            "");
+
+    // Shape observed in CI: the root's canonical counters have caught up with the finished work
+    // (fileGroups 4/4, files 4/4) while its projection still carries the JS_WAITING state computed
+    // before the last child went terminal, and lagging counters. Because the counters differ the
+    // refresh used to take a counters-only patch, republish JS_WAITING, and mark generation 42
+    // applied - freezing the root as JS_WAITING for good.
+    assertDoesNotThrow(
+        () ->
+            store.jobIndexStore.mutateByCanonicalPointerReturningRecord(
+                Keys.reconcileJobPointerById(ACCOUNT_ID, connectorJobId),
+                current -> {
+                  current.state = "JS_WAITING";
+                  current.message = "Waiting on child work";
+                  current.startedAtMs = 10L;
+                  current.tablesScanned = 1L;
+                  current.tablesChanged = 1L;
+                  current.snapshotsProcessed = 4L;
+                  current.statsProcessed = 4L;
+                  current.indexesProcessed = 4L;
+                  current.plannedFileGroups = 4L;
+                  current.plannedFiles = 4L;
+                  current.completedFileGroups = 4L;
+                  current.completedFiles = 4L;
+                  current.childrenFinalized = true;
+                  current.projectionRequestedGeneration = 42L;
+                  current.projectionAppliedGeneration = 39L;
+                  current.updatedAtMs = 40L;
+                  return current;
+                }));
+    assertDoesNotThrow(
+        () ->
+            store.jobIndexStore.mutateByCanonicalPointerReturningRecord(
+                Keys.reconcileJobPointerById(ACCOUNT_ID, tableJobId),
+                current -> {
+                  current.state = "JS_SUCCEEDED";
+                  current.message = "Succeeded";
+                  current.tablesScanned = 1L;
+                  current.tablesChanged = 1L;
+                  current.snapshotsProcessed = 4L;
+                  current.statsProcessed = 4L;
+                  current.indexesProcessed = 4L;
+                  current.plannedFileGroups = 4L;
+                  current.plannedFiles = 4L;
+                  current.completedFileGroups = 4L;
+                  current.completedFiles = 4L;
+                  current.startedAtMs = 20L;
+                  current.finishedAtMs = 30L;
+                  current.updatedAtMs = 30L;
+                  return current;
+                }));
+
+    projectionStore()
+        .upsert(
+            new StoredReconcileJobProjection(
+                ACCOUNT_ID,
+                connectorJobId,
+                39L,
+                "JS_WAITING",
+                "Waiting on child work",
+                10L,
+                0L,
+                1L,
+                1L,
+                0L,
+                0L,
+                0L,
+                3L,
+                3L,
+                3L,
+                4L,
+                4L,
+                3L,
+                0L,
+                3L,
+                0L,
+                "",
+                true));
+    projectionStore()
+        .upsert(
+            new StoredReconcileJobProjection(
+                ACCOUNT_ID,
+                tableJobId,
+                39L,
+                "JS_SUCCEEDED",
+                "Succeeded",
+                20L,
+                30L,
+                1L,
+                1L,
+                0L,
+                0L,
+                0L,
+                4L,
+                4L,
+                4L,
+                4L,
+                4L,
+                4L,
+                0L,
+                4L,
+                0L,
+                "",
+                true));
+
+    assertDoesNotThrow(
+        () ->
+            invokePrivateMethod(
+                store,
+                "refreshProjectedParent",
+                new Class<?>[] {String.class, String.class},
+                ACCOUNT_ID,
+                connectorJobId));
+
+    StoredReconcileJobProjection projection =
+        projectionStore().load(ACCOUNT_ID, connectorJobId).orElseThrow();
+    assertEquals("JS_SUCCEEDED", projection.state());
+    assertEquals(42L, projection.appliedGeneration());
+    assertEquals(4L, projection.completedFileGroups());
+    assertEquals(4L, projection.completedFiles());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -2664,6 +2664,9 @@ class DurableReconcileJobStoreTest {
     assertEquals(86L, projection.tablesChanged());
     assertEquals(1208L, projection.statsProcessed());
     assertEquals(1208L, projection.indexesProcessed());
+    // The recomputed state has to reach the public read path, not just the projection record:
+    // GetReconcileJob is what clients poll to completion.
+    assertEquals("JS_SUCCEEDED", store.get(ACCOUNT_ID, tableJobId).orElseThrow().state);
   }
 
   @Test
@@ -2806,6 +2809,9 @@ class DurableReconcileJobStoreTest {
     assertEquals(42L, projection.appliedGeneration());
     assertEquals(4L, projection.completedFileGroups());
     assertEquals(4L, projection.completedFiles());
+    // The production symptom is GetReconcileJob polling forever, and that read prefers the
+    // canonical state over the projection, so recomputing the projection alone does not clear it.
+    assertEquals("JS_SUCCEEDED", store.get(ACCOUNT_ID, connectorJobId).orElseThrow().state);
   }
 
   @Test


### PR DESCRIPTION
## Summary

A parent reconcile job can get permanently stuck reporting a stale non-terminal state after all its work has finished. Downstream this surfaces as `TimeoutError: Timed out waiting for reconcile job <id>` in any client that polls `GetReconcileJob` to completion — it took out nightly `test-sql` in floe/core three times in a week (eng-floe/core#1929). It is **not** a slow reconcile: the whole tree finishes in 3–16 s and the root `PLAN_CONNECTOR` then reports `JS_WAITING` forever.

There are two independent freezes, and both have to be fixed for the client to stop timing out:

1. **The projection freezes.** Two counters-only fast paths in `refreshProjectedParent` consumed the projection generation without ever recomputing the state from the children.
2. **The canonical state freezes.** `refreshProjectedParent` never wrote the canonical `state`, and every public read path prefers canonical over the projection — so even a correctly recomputed terminal projection stayed invisible to `GetReconcileJob`.

The first revision of this PR fixed only (1). Thanks to @mrouvroy-floe for catching that (1) alone does not change what clients see.

### Root cause 1 — the projection freeze

`refreshProjectedParent` had two counters-only fast paths — the "generation patch" and the "aggregate patch" — that both built the next projection with `projectionWithCanonicalFields`. That helper refreshes all thirteen counters from the canonical record but copies `previous.state()` verbatim. Each path then called `advanceAppliedProjectionGeneration(..., requestedGeneration)`.

That generation was bumped by `requestProjectionRefresh` *because a child changed*, and the bump carries no reason — so a path that never looked at the children consumed the token meaning "re-derive your state from your children". Once `applied == requested` with a non-terminal projection state, `projectionNeedsRefresh` returns `false` and the full recompute becomes unreachable, as do the read-path recomputes in `freshProjection` and `projectedSummaryRecord`.

Nothing ever re-dirties the job afterwards: the maintenance sweep is purely dirty-marker-driven and CAS-deletes the marker right after this call, and `advanceCanonicalSchedulingAfterRecordChange` only runs on a lease-outcome submit — and the tree has no work left to submit. Both doors are shut.

The invariant being violated: **a projection's `state` must be derived from child states observed at a generation ≥ the generation it claims to have applied.**

### Root cause 2 — the canonical freeze

`ReconcileJobProjector.effectiveParentState` is:

```java
return canonicalState.isBlank() ? projectionState : canonicalState;
```

It feeds `effectiveParentProjection`, which feeds `toPublicJob`, `toPublicTreeJob` and `toPublicJobSummary`. For parent-capable kinds, **canonical wins whenever it is nonblank** — and `ReconcileJobEnqueuer` sets `JS_QUEUED` at creation, so it is never blank. `get()`, list and tree all report canonical.

Canonical parent state is advanced only by `advanceCanonicalParentIfComplete`, reachable solely from `advanceCanonicalSchedulingAfterRecordChange`, called from exactly two lease-outcome submit sites (`bulkEnqueueAndApplyLeaseOutcome`, `applyLeaseOutcomeDirectly`). A tree with no work left to submit never reaches them again. `refreshProjectedParent`'s only canonical write is `applyCanonicalAggregateProjection` → `applyCanonicalAggregateFields`, which touches ten counters and never `state`.

So the cascade gets exactly one chance, at the last lease outcome, and in both failing runs it did not take it. Which of the six unlogged `null`-return conditions in `advanceCanonicalParentIfComplete` fired is **not determined** — the logs cannot distinguish them, which is itself the point of the observability note below. What is determined is that it never advanced either root (see Evidence), and that nothing re-triggers it afterwards.

### Evidence

Taken from the retained CI artifacts of both failing runs, not just the excerpts in the RCA.

`reconcile state transition` is the only log line that prints a **canonical** state; every `reconcile projection ...` line prints the **projection** state. A healthy root emits a canonical `PLAN_CONNECTOR JS_WAITING → JS_SUCCEEDED` line — there are **302** of them in the macOS log. Both frozen roots emit **zero** transition lines of any kind, while their children transition normally. The canonical cascade demonstrably never advanced either root.

The last write to each frozen root is an aggregate patch:

```
04:00:31,264 reconcile projection aggregate patch jobId=f0c83ca9 kind=PLAN_CONNECTOR
             requestedGeneration=42 previousAppliedGeneration=39 state=JS_WAITING fileGroups=4/4
```

That branch is gated by `canPublishCanonicalProjectionPatch`, which returns false when canonical is blank, terminal or cancelling — so the line's own emission proves canonical was non-blank and non-terminal at that instant. The client then polled `GetReconcileJob` 274 times over 275 s and timed out.

On a `PLAN_TABLE` child in the ARM run, the projection freeze itself:

```
04:00:26,604 reconcile state transition source=mutate jobId=e8c0b5b3 kind=PLAN_TABLE
             oldState=JS_WAITING newState=JS_SUCCEEDED completionHint=Succeeded
04:00:26,758 reconcile projection aggregate patch jobId=e8c0b5b3 kind=PLAN_TABLE
             requestedGeneration=14 previousAppliedGeneration=11 projectionGeneration=14
             state=JS_QUEUED stats=1 indexes=1 fileGroups=1/1 files=1/1
```

154 ms after the job succeeds its projection is rewritten with `JS_QUEUED` — a state it left 14 s earlier — with counters saying the work is complete. That is the last write.

That stale child projection did **not** propagate to the root, though. Every rollup reaches its children through `projectedSummaryRecord(child)` with `refreshStaleProjection=false`, where `shouldKeepProjectionAggregatesForTerminalCanonicalState` fires first and returns `copyProjectedAggregateSummaryRecord` — projection counters, canonical state. A child whose canonical is terminal contributes its canonical state however stale its projection is, and `e8c0b5b3` was canonically `JS_SUCCEEDED` from `04:00:26,604`.

So the root froze on its own aggregate patch copying `previous.state()`, exactly as in the macOS run — where there is no stale child at all. **Both roots froze for the same single reason.** An earlier draft of this description, and mechanism #5 of the RCA, attributed the ARM run to child-to-ancestor poisoning; that is wrong, and would require a child whose *canonical* state is also non-terminal.

### Change

**Projection freeze.** Both fast paths are removed, so every path that advances the applied generation has first recomputed the state from the children. The three helpers only they used (`projectionWithCanonicalFields`, `canPublishCanonicalProjectionPatch`, `canPublishCanonicalAggregatePatch`) go with them.

They turned out to be strictly redundant with the fallback recompute apart from skipping the child scan — the fallback already performs the same `commitProjectionAggregateChange` delta propagation and the same `enqueueSnapshotFinalizationForPlanSnapshotIfEligible`, plus canonical counter repair. The "generation patch" variant had no counter benefit at all: it only ran when the counters *already matched*, so its sole effect was consuming a refresh obligation while republishing a stale state.

**Canonical freeze.** Once the recomputed rollup is terminal, the refresh re-triggers the existing cascade:

```java
if (isTerminalState(nextProjection.state())) {
  advanceCanonicalSchedulingAfterRecordChange(parent);
}
```

Reusing `advanceCanonicalSchedulingAfterRecordChange` rather than writing canonical state inline keeps the eligibility gate (`isCanonicalParentSchedulingAdvance`), the `PLAN_SNAPSHOT` finalizer deferral and the `JS_CANCELLING`/`JS_CANCELLED` handling in one place, and inherits its ancestor walk and depth cap. It converges: the re-entry through the dirty marker finds the parent already terminal with `finishedAtMs` set, so the gate stops it on the second pass.

Rejected alternative: making the read path prefer a terminal projection over canonical. That inverts a precedence rule `shouldKeepCanonicalStateForTerminalProjection`, `shouldKeepProjectionAggregatesForTerminalCanonicalState`, `effectiveFinishedAtMs`, the root list summaries and the ancestor rollup all lean on.

Net **11 lines added, 129 deleted** in `DurableReconcileJobStore`.

Cost: the fallback passes `refreshStaleDescendants=false`, so this adds one child listing plus a projection load per child on the affected refreshes — not a recursive subtree refresh. The canonical advance runs only when the rollup is already terminal.

## Type of Change

- [x] fix (bug fix)

## Testing

- [x] `make fmt` — 513 files processed, 0 reformatted
- [ ] `make verify` — **not run** (integration tests need Keycloak); full `service` unit suite run instead: **1543 tests, 0 failures, 0 errors, 1 skipped**
- [x] Added/updated tests for changed behavior

Red-green confirmed for both halves. Reverting only the source file and keeping the tests turns both regression tests red with exactly the production symptom, `expected: <JS_SUCCEEDED> but was: <JS_WAITING>` — and keeping only the fast-path removal, without the canonical advance, leaves them red on the `store.get(...)` assertion with the same message.

Test changes:

- `parentRefreshAdvancesGenerationWithoutScanningWhenCanonicalProjectionFieldsMatch` was pinning the buggy contract — it asserted the generation advanced but never asserted the state, and used absurd child counters (`9999`) as a "did not scan children" canary. Renamed to `parentRefreshRecomputesStaleWaitingStateBeforeAdvancingGeneration`, given a consistent fixture, and now asserts the state.
- Added `rootRefreshRecomputesStaleWaitingStateWhenCanonicalCountersRunAhead` for the aggregate-patch case that actually hit the root job (`fileGroups=4/4` published alongside `JS_WAITING`).
- Both tests assert `store.get(...).state`, not just `projectionStore().load(...).state()`. Asserting only the projection is what let the first revision look complete while `GetReconcileJob` still returned `JS_WAITING`.

Both fixtures needed `childrenFinalized = true` added, since the rollup's `allSucceeded` requires it and a real `JS_WAITING` parent gets it from `SUCCEEDED_WAITING`. The old fixtures could omit it precisely because the fast path never looked at children.

## Deployment and Compatibility

- [x] No breaking changes

No schema, proto, or config change. Two `INFO` log lines disappear (`reconcile projection generation patch`, `reconcile projection aggregate patch`).

**This is a prevention fix, not a repair.** A job tree that is *already* frozen stays frozen: with `applied == requested` and the projection counters already matching canonical, `refreshProjectedParent` returns at its `projectionNeedsRefresh` early-exit without recomputing, so it never reaches the canonical advance — and in practice nothing calls it at all, since the dirty marker was CAS-deleted. Verified with a throwaway fixture. Any tree stuck before this deploys needs to be re-driven or waited out.

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed — n/a
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly

## Additional Notes

Two observability gaps found while diagnosing this, deliberately left out of scope. Both are now shown to have been load-bearing in how long the RCA took:

- `advanceCanonicalParentIfComplete` returns `null` on six distinct conditions with no logging at any level, so a stalled canonical cascade is completely silent. This is most of why the RCA was expensive — and it is the half of the bug the first revision of this PR missed.
- No log line prints a parent's canonical `state` outside a transition, so canonical-vs-projection divergence has to be inferred from which branch emitted a line. Adding a canonical-state field to the `reconcile projection ...` lines would have made this a one-grep answer.
- A projection with a non-terminal `state` but `completedFileGroups == plannedFileGroups > 0` is self-contradictory. Asserting or warning on that at write time in `commitProjectionAggregateChange` would have flagged both frozen projections immediately.

Full RCA with timelines from both failing runs: eng-floe/core#1929, with corrections in [this comment](https://github.com/eng-floe/core/issues/1929#issuecomment-5089447057) — RCA mechanism #6 has the projector precedence backwards, mechanism #5 describes poisoning that did not occur in either run, and the RCA's suggested fix (leave `appliedGeneration` alone in the patch paths) would have unfrozen the projection while leaving the client timing out on canonical.

Note for whoever bumps the pin in floe/core: the `Validate floecat submodule commit` check requires a `main`-reachable sha, so this has to merge before the pin can move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwPL4EdufMeJpQYFU72Ciz
