### PR TITLE
storage: give KV attributes a typed string/number model

### DIFF
--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AbstractEntity.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AbstractEntity.java
@@ -65,9 +65,9 @@ public abstract class AbstractEntity<M extends MessageLite> implements KvAttribu
         return null;
       }
       var m = (M) defaultInstance.getParserForType().parseFrom(data);
-      var ts = r.attrs().get(ATTR_EXPIRES_AT);
-      if (ts != null) {
-        m = setExpiresAt(m, Long.parseLong(ts));
+      long ts = AttrValue.longOr(r.attrs(), ATTR_EXPIRES_AT, 0L);
+      if (ts > 0) {
+        m = setExpiresAt(m, ts);
       }
       return m;
     } catch (InvalidProtocolBufferException e) {
@@ -84,10 +84,10 @@ public abstract class AbstractEntity<M extends MessageLite> implements KvAttribu
     return 0L;
   }
 
-  protected static Map<String, String> pointerAttrs(KvStore.Key target) {
+  protected static Map<String, AttrValue> pointerAttrs(KvStore.Key target) {
     return Map.of(
-        TARGET_PARTITION_KEY, target.partitionKey(),
-        TARGET_SORT_KEY, target.sortKey());
+        TARGET_PARTITION_KEY, AttrValue.of(target.partitionKey()),
+        TARGET_SORT_KEY, AttrValue.of(target.sortKey()));
   }
 
   protected static String normalize(String s) {
@@ -117,14 +117,16 @@ public abstract class AbstractEntity<M extends MessageLite> implements KvAttribu
    * <p>The written record.version and protobuf message version are both set to nextVersion.
    */
   protected Uni<Optional<M>> putCanonicalCas(
-      KvStore.Key key, String kind, M message, Map<String, String> attrs, long expectedVersion) {
+      KvStore.Key key, String kind, M message, Map<String, AttrValue> attrs, long expectedVersion) {
 
     long nv = nextVersion(expectedVersion);
     M withVer = versionAccessor != null ? versionAccessor.withVersion(message, nv) : message;
     long ts = getExpiresAt(withVer);
     if (ts > 0) {
       attrs = new java.util.HashMap<>(attrs);
-      attrs.put(ATTR_EXPIRES_AT, Long.toString(ts));
+      // Written as a string, not a number: an older replica's read path drops non-string attrs, and
+      // its next write of this record would then persist it without an expiry at all.
+      attrs.put(ATTR_EXPIRES_AT, AttrValue.of(Long.toString(ts)));
     }
     var rec = new KvStore.Record(key, kind, encode(withVer), attrs, nv);
     return kv.putCas(rec, expectedVersion).map(ok -> ok ? Optional.of(withVer) : Optional.empty());
@@ -141,7 +143,11 @@ public abstract class AbstractEntity<M extends MessageLite> implements KvAttribu
    * <p>Caller supplies raw value bytes; we still write a monotonically increasing version.
    */
   protected Uni<Boolean> putRawCas(
-      KvStore.Key key, String kind, byte[] value, Map<String, String> attrs, long expectedVersion) {
+      KvStore.Key key,
+      String kind,
+      byte[] value,
+      Map<String, AttrValue> attrs,
+      long expectedVersion) {
 
     long nv = nextVersion(expectedVersion);
     var rec = new KvStore.Record(key, kind, value, attrs, nv);
@@ -157,8 +163,8 @@ public abstract class AbstractEntity<M extends MessageLite> implements KvAttribu
             optPtr -> {
               if (optPtr.isEmpty()) return Uni.createFrom().item(Optional.empty());
               var ptr = optPtr.get();
-              var tpk = ptr.attrs().get(TARGET_PARTITION_KEY);
-              var tsk = ptr.attrs().get(TARGET_SORT_KEY);
+              var tpk = AttrValue.stringOr(ptr.attrs(), TARGET_PARTITION_KEY, null);
+              var tsk = AttrValue.stringOr(ptr.attrs(), TARGET_SORT_KEY, null);
               if (tpk == null || tsk == null) return Uni.createFrom().item(Optional.empty());
               return get(new KvStore.Key(tpk, tsk));
             });
@@ -190,8 +196,11 @@ public abstract class AbstractEntity<M extends MessageLite> implements KvAttribu
                   page.items().stream()
                       .map(
                           r -> {
-                            String pk = r.attrs().get(KvAttributes.TARGET_PARTITION_KEY);
-                            String sk = r.attrs().get(KvAttributes.TARGET_SORT_KEY);
+                            String pk =
+                                AttrValue.stringOr(
+                                    r.attrs(), KvAttributes.TARGET_PARTITION_KEY, null);
+                            String sk =
+                                AttrValue.stringOr(r.attrs(), KvAttributes.TARGET_SORT_KEY, null);
                             return kv.get(new KvStore.Key(pk, sk));
                           })
                       .toList();

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AbstractEntity.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AbstractEntity.java
@@ -65,9 +65,11 @@ public abstract class AbstractEntity<M extends MessageLite> implements KvAttribu
         return null;
       }
       var m = (M) defaultInstance.getParserForType().parseFrom(data);
-      long ts = AttrValue.longOr(r.attrs(), ATTR_EXPIRES_AT, 0L);
-      if (ts > 0) {
-        m = setExpiresAt(m, ts);
+      var ts = r.attrs().get(ATTR_EXPIRES_AT);
+      if (ts != null) {
+        // Accepts both the legacy string form and the native numeric one; a present but malformed
+        // stamp throws, so corrupt expiry data cannot read as "no expiry".
+        m = setExpiresAt(m, ts.asLong());
       }
       return m;
     } catch (InvalidProtocolBufferException e) {

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AbstractEntity.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AbstractEntity.java
@@ -67,8 +67,8 @@ public abstract class AbstractEntity<M extends MessageLite> implements KvAttribu
       var m = (M) defaultInstance.getParserForType().parseFrom(data);
       var ts = r.attrs().get(ATTR_EXPIRES_AT);
       if (ts != null) {
-        // Accepts both the legacy string form and the native numeric one; a present but malformed
-        // stamp throws, so corrupt expiry data cannot read as "no expiry".
+        // String or numeric form both decode; a malformed stamp throws rather than reading as
+        // "no expiry".
         m = setExpiresAt(m, ts.asLong());
       }
       return m;
@@ -126,8 +126,8 @@ public abstract class AbstractEntity<M extends MessageLite> implements KvAttribu
     long ts = getExpiresAt(withVer);
     if (ts > 0) {
       attrs = new java.util.HashMap<>(attrs);
-      // Written as a string, not a number: an older replica's read path drops non-string attrs, and
-      // its next write of this record would then persist it without an expiry at all.
+      // String, not number: an older replica drops non-string attrs on read and would then
+      // rewrite the record without its expiry (see AttrWriteRules).
       attrs.put(ATTR_EXPIRES_AT, AttrValue.of(Long.toString(ts)));
     }
     var rec = new KvStore.Record(key, kind, encode(withVer), attrs, nv);

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrValue.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrValue.java
@@ -16,7 +16,6 @@
 package ai.floedb.floecat.storage.kv;
 
 import java.util.Map;
-import java.util.OptionalLong;
 
 /**
  * A typed value of a {@link KvStore.Record} attribute.
@@ -56,22 +55,22 @@ public sealed interface AttrValue permits AttrValue.StringValue, AttrValue.Numbe
   }
 
   /**
-   * A lenient numeric view: a {@link NumberValue} yields its value, a {@link StringValue} yields
-   * its parsed decimal form when it has one, and empty otherwise.
+   * The value as a number: a {@link NumberValue} yields its value, a {@link StringValue} its parsed
+   * decimal form.
    *
-   * <p>The leniency is deliberate. Rows written before an attribute was retyped still hold it as a
-   * string, so readers of numeric metadata must accept both forms indefinitely.
+   * <p>Accepting both forms is deliberate. Rows written before an attribute was retyped still hold
+   * it as a string, so readers of numeric metadata must accept both forms indefinitely.
+   *
+   * <p>Accepting both forms is not the same as accepting garbage: a present-but-unparsable value is
+   * corrupt metadata and throws rather than reading as some default, which for a TTL stamp would
+   * quietly make the record immortal.
+   *
+   * @throws NumberFormatException if the value is a string with no decimal form
    */
-  default OptionalLong asLong() {
+  default long asLong() {
     return switch (this) {
-      case NumberValue n -> OptionalLong.of(n.value());
-      case StringValue s -> {
-        try {
-          yield OptionalLong.of(Long.parseLong(s.value()));
-        } catch (NumberFormatException e) {
-          yield OptionalLong.empty();
-        }
-      }
+      case NumberValue n -> n.value();
+      case StringValue s -> Long.parseLong(s.value());
     };
   }
 
@@ -83,10 +82,22 @@ public sealed interface AttrValue permits AttrValue.StringValue, AttrValue.Numbe
 
   /**
    * Null-safe numeric read of {@code name} from {@code attrs}, or {@code fallback} if the attribute
-   * is absent or does not have a numeric form (see {@link #asLong()}).
+   * is absent or unparsable.
+   *
+   * <p>Only for metadata that degrades gracefully when it is corrupt — cache bookkeeping, where an
+   * unreadable counter reading as 0 just makes the entry look cold. Metadata that must not be
+   * silently defaulted (a TTL stamp, whose fallback would make the record immortal) reads the
+   * attribute directly and lets {@link #asLong()} throw.
    */
   static long longOr(Map<String, AttrValue> attrs, String name, long fallback) {
     var v = attrs.get(name);
-    return v == null ? fallback : v.asLong().orElse(fallback);
+    if (v == null) {
+      return fallback;
+    }
+    try {
+      return v.asLong();
+    } catch (NumberFormatException e) {
+      return fallback;
+    }
   }
 }

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrValue.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrValue.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv;
+
+import java.util.Map;
+import java.util.OptionalLong;
+
+/**
+ * A typed value of a {@link KvStore.Record} attribute.
+ *
+ * <p>Attributes carry small bits of metadata alongside a record: pointer targets, TTL stamps, index
+ * bookkeeping. They used to be plain strings, which forced numeric metadata to travel as decimal
+ * strings and be re-parsed on every read. A {@link NumberValue} is stored natively by backends that
+ * have a numeric type (DynamoDB {@code N}), which is what makes atomic server-side increments
+ * possible — see {@link KvStore#updateMetadataAttrsIfExists}.
+ */
+public sealed interface AttrValue permits AttrValue.StringValue, AttrValue.NumberValue {
+
+  /** A string attribute. */
+  record StringValue(String value) implements AttrValue {
+    public StringValue {
+      if (value == null) throw new IllegalArgumentException("string attr value must not be null");
+    }
+  }
+
+  /** An integral numeric attribute. */
+  record NumberValue(long value) implements AttrValue {}
+
+  static AttrValue of(String value) {
+    return new StringValue(value);
+  }
+
+  static AttrValue of(long value) {
+    return new NumberValue(value);
+  }
+
+  /** The value rendered as a string; numbers render as their decimal form. */
+  default String asString() {
+    return switch (this) {
+      case StringValue s -> s.value();
+      case NumberValue n -> Long.toString(n.value());
+    };
+  }
+
+  /**
+   * A lenient numeric view: a {@link NumberValue} yields its value, a {@link StringValue} yields
+   * its parsed decimal form when it has one, and empty otherwise.
+   *
+   * <p>The leniency is deliberate. Rows written before an attribute was retyped still hold it as a
+   * string, so readers of numeric metadata must accept both forms indefinitely.
+   */
+  default OptionalLong asLong() {
+    return switch (this) {
+      case NumberValue n -> OptionalLong.of(n.value());
+      case StringValue s -> {
+        try {
+          yield OptionalLong.of(Long.parseLong(s.value()));
+        } catch (NumberFormatException e) {
+          yield OptionalLong.empty();
+        }
+      }
+    };
+  }
+
+  /** Null-safe string read of {@code name} from {@code attrs}, or {@code fallback} if absent. */
+  static String stringOr(Map<String, AttrValue> attrs, String name, String fallback) {
+    var v = attrs.get(name);
+    return v == null ? fallback : v.asString();
+  }
+
+  /**
+   * Null-safe numeric read of {@code name} from {@code attrs}, or {@code fallback} if the attribute
+   * is absent or does not have a numeric form (see {@link #asLong()}).
+   */
+  static long longOr(Map<String, AttrValue> attrs, String name, long fallback) {
+    var v = attrs.get(name);
+    return v == null ? fallback : v.asLong().orElse(fallback);
+  }
+}

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrValue.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrValue.java
@@ -20,11 +20,8 @@ import java.util.Map;
 /**
  * A typed value of a {@link KvStore.Record} attribute.
  *
- * <p>Attributes carry small bits of metadata alongside a record: pointer targets, TTL stamps, index
- * bookkeeping. They used to be plain strings, which forced numeric metadata to travel as decimal
- * strings and be re-parsed on every read. A {@link NumberValue} is stored natively by backends that
- * have a numeric type (DynamoDB {@code N}), which is what makes atomic server-side increments
- * possible — see {@link KvStore#updateMetadataAttrsIfExists}.
+ * <p>A {@link NumberValue} is stored in the backend's native numeric type (DynamoDB {@code N}),
+ * which is what makes atomic server-side increments possible.
  */
 public sealed interface AttrValue permits AttrValue.StringValue, AttrValue.NumberValue {
 
@@ -55,15 +52,9 @@ public sealed interface AttrValue permits AttrValue.StringValue, AttrValue.Numbe
   }
 
   /**
-   * The value as a number: a {@link NumberValue} yields its value, a {@link StringValue} its parsed
-   * decimal form.
-   *
-   * <p>Accepting both forms is deliberate. Rows written before an attribute was retyped still hold
-   * it as a string, so readers of numeric metadata must accept both forms indefinitely.
-   *
-   * <p>Accepting both forms is not the same as accepting garbage: a present-but-unparsable value is
-   * corrupt metadata and throws rather than reading as some default, which for a TTL stamp would
-   * quietly make the record immortal.
+   * The value as a number; a {@link StringValue} is parsed as decimal, since rows written before an
+   * attribute was retyped still hold it as a string. An unparsable value throws rather than
+   * defaulting — for a TTL stamp a default would make the record immortal.
    *
    * @throws NumberFormatException if the value is a string with no decimal form
    */
@@ -81,13 +72,10 @@ public sealed interface AttrValue permits AttrValue.StringValue, AttrValue.Numbe
   }
 
   /**
-   * Null-safe numeric read of {@code name} from {@code attrs}, or {@code fallback} if the attribute
-   * is absent or unparsable.
-   *
-   * <p>Only for metadata that degrades gracefully when it is corrupt — cache bookkeeping, where an
-   * unreadable counter reading as 0 just makes the entry look cold. Metadata that must not be
-   * silently defaulted (a TTL stamp, whose fallback would make the record immortal) reads the
-   * attribute directly and lets {@link #asLong()} throw.
+   * Null-safe numeric read of {@code name} from {@code attrs}, or {@code fallback} if absent or
+   * unparsable. Only for metadata that degrades gracefully when corrupt (cache bookkeeping);
+   * metadata that must not silently default (a TTL stamp) reads the attribute directly and lets
+   * {@link #asLong()} throw.
    */
   static long longOr(Map<String, AttrValue> attrs, String name, long fallback) {
     var v = attrs.get(name);

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrWriteRules.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrWriteRules.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv;
+
+import java.util.Map;
+
+/**
+ * Attribute-typing rules every {@link KvStore} write path enforces, so that what one store rejects
+ * the others reject identically. A laxer in-memory store would let a test pass here and fail in
+ * production.
+ */
+public final class AttrWriteRules {
+
+  private AttrWriteRules() {}
+
+  /**
+   * Rejects a numeric {@link KvAttributes#ATTR_EXPIRES_AT}, before any store issues a write.
+   *
+   * <p>A rollout constraint, not a modelling choice. A replica older than typed attributes drops
+   * every non-string attribute as it reads, so it decodes such a record as carrying no expiry at
+   * all, and its next whole-record write persists that loss permanently. Writers therefore pin the
+   * expiry stamp to a {@link AttrValue.StringValue} for as long as the fleet can still hold such a
+   * replica.
+   *
+   * <p>Reads stay lenient in both directions — {@link AttrValue#asLong()} accepts either form —
+   * because a row that some other writer typed as a number still has to be readable. The asymmetry
+   * is the point: tolerate on the way in, never produce on the way out.
+   *
+   * <p>Drop this rule once no deployed replica predates typed attributes.
+   */
+  public static void checkExpiryIsString(Map<String, AttrValue> attrs) {
+    if (attrs.get(KvAttributes.ATTR_EXPIRES_AT) instanceof AttrValue.NumberValue) {
+      throw new IllegalArgumentException(
+          "attr must be written as a string for as long as replicas that predate typed attributes"
+              + " can read it: "
+              + KvAttributes.ATTR_EXPIRES_AT);
+    }
+  }
+}

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrWriteRules.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/AttrWriteRules.java
@@ -17,29 +17,19 @@ package ai.floedb.floecat.storage.kv;
 
 import java.util.Map;
 
-/**
- * Attribute-typing rules every {@link KvStore} write path enforces, so that what one store rejects
- * the others reject identically. A laxer in-memory store would let a test pass here and fail in
- * production.
- */
+/** Attribute-typing rules enforced identically by every {@link KvStore} write path. */
 public final class AttrWriteRules {
 
   private AttrWriteRules() {}
 
   /**
-   * Rejects a numeric {@link KvAttributes#ATTR_EXPIRES_AT}, before any store issues a write.
+   * Rejects a numeric {@link KvAttributes#ATTR_EXPIRES_AT} before any store issues a write.
    *
-   * <p>A rollout constraint, not a modelling choice. A replica older than typed attributes drops
-   * every non-string attribute as it reads, so it decodes such a record as carrying no expiry at
-   * all, and its next whole-record write persists that loss permanently. Writers therefore pin the
-   * expiry stamp to a {@link AttrValue.StringValue} for as long as the fleet can still hold such a
-   * replica.
-   *
-   * <p>Reads stay lenient in both directions — {@link AttrValue#asLong()} accepts either form —
-   * because a row that some other writer typed as a number still has to be readable. The asymmetry
-   * is the point: tolerate on the way in, never produce on the way out.
-   *
-   * <p>Drop this rule once no deployed replica predates typed attributes.
+   * <p>Rollout constraint: a replica that predates typed attributes drops every non-string
+   * attribute on read, decodes such a record as having no expiry, and its next whole-record write
+   * persists that loss. Reads stay lenient ({@link AttrValue#asLong()} accepts either form) so rows
+   * typed by other writers remain readable. Drop this rule once no deployed replica predates typed
+   * attributes.
    */
   public static void checkExpiryIsString(Map<String, AttrValue> attrs) {
     if (attrs.get(KvAttributes.ATTR_EXPIRES_AT) instanceof AttrValue.NumberValue) {

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvAttributes.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvAttributes.java
@@ -15,6 +15,8 @@
  */
 package ai.floedb.floecat.storage.kv;
 
+import java.util.Set;
+
 public interface KvAttributes {
   String ATTR_PARTITION_KEY = "pk";
   String ATTR_SORT_KEY = "sk";
@@ -26,4 +28,11 @@ public interface KvAttributes {
 
   String TARGET_PARTITION_KEY = "targetPk";
   String TARGET_SORT_KEY = "targetSk";
+
+  /**
+   * Names a backend uses for the record's own structure. They are reserved: a record attribute may
+   * not use one, because storing it would collide with the structural field of the same name.
+   */
+  Set<String> STRUCTURAL_ATTRS =
+      Set.of(ATTR_PARTITION_KEY, ATTR_SORT_KEY, ATTR_KIND, ATTR_VALUE, ATTR_VERSION);
 }

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvAttributes.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvAttributes.java
@@ -30,17 +30,13 @@ public interface KvAttributes {
   String TARGET_SORT_KEY = "targetSk";
 
   /**
-   * Names a backend gives its own meaning, on a record it also stores attributes on. They are
-   * reserved: a record attribute may not use one. For {@link #ATTR_PARTITION_KEY}, {@link
-   * #ATTR_SORT_KEY}, {@link #ATTR_KIND}, {@link #ATTR_VALUE} and {@link #ATTR_VERSION} the harm is
-   * a collision with the structural field of the same name. For {@link #ATTR_TTL} it is worse and
-   * quieter: {@code DynamoDbTablesBootstrap} enables DynamoDB's TTL feature on that attribute, so
-   * an ordinary numeric attr that happens to be named {@code ttl} is read by DynamoDB as the row's
-   * expiry time and the row is deleted once it passes — no error, no trace.
+   * Names the backend gives its own meaning; a record attribute may not use one. Most would collide
+   * with the structural field of the same name. {@link #ATTR_TTL} is quieter: DynamoDB's TTL
+   * feature is enabled on that attribute, so a numeric attr named {@code ttl} silently schedules
+   * the row's deletion.
    *
-   * <p>Reserved on the way in only. A row that some other writer already put one of these names on
-   * still has to be readable, so decoders drop them rather than refusing the record (see {@code
-   * DynamoDbKvStore#avToAttrs}).
+   * <p>Reserved on writes only — rows written by others may carry these names, so decoders drop
+   * them rather than refusing the record.
    */
   Set<String> RESERVED_ATTRS =
       Set.of(ATTR_PARTITION_KEY, ATTR_SORT_KEY, ATTR_KIND, ATTR_VALUE, ATTR_VERSION, ATTR_TTL);

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvAttributes.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvAttributes.java
@@ -30,9 +30,18 @@ public interface KvAttributes {
   String TARGET_SORT_KEY = "targetSk";
 
   /**
-   * Names a backend uses for the record's own structure. They are reserved: a record attribute may
-   * not use one, because storing it would collide with the structural field of the same name.
+   * Names a backend gives its own meaning, on a record it also stores attributes on. They are
+   * reserved: a record attribute may not use one. For {@link #ATTR_PARTITION_KEY}, {@link
+   * #ATTR_SORT_KEY}, {@link #ATTR_KIND}, {@link #ATTR_VALUE} and {@link #ATTR_VERSION} the harm is
+   * a collision with the structural field of the same name. For {@link #ATTR_TTL} it is worse and
+   * quieter: {@code DynamoDbTablesBootstrap} enables DynamoDB's TTL feature on that attribute, so
+   * an ordinary numeric attr that happens to be named {@code ttl} is read by DynamoDB as the row's
+   * expiry time and the row is deleted once it passes — no error, no trace.
+   *
+   * <p>Reserved on the way in only. A row that some other writer already put one of these names on
+   * still has to be readable, so decoders drop them rather than refusing the record (see {@code
+   * DynamoDbKvStore#avToAttrs}).
    */
-  Set<String> STRUCTURAL_ATTRS =
-      Set.of(ATTR_PARTITION_KEY, ATTR_SORT_KEY, ATTR_KIND, ATTR_VALUE, ATTR_VERSION);
+  Set<String> RESERVED_ATTRS =
+      Set.of(ATTR_PARTITION_KEY, ATTR_SORT_KEY, ATTR_KIND, ATTR_VALUE, ATTR_VERSION, ATTR_TTL);
 }

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -95,47 +95,27 @@ public interface KvStore {
   Uni<Boolean> deleteCas(Key key, long expectedVersion);
 
   /**
-   * Atomically updates metadata attributes on an <em>existing</em> record and advances its
-   * optimistic-concurrency version, in a single request. This is the one write on this interface
-   * that is not a whole-record CAS: it exists so that "bump this bookkeeping metadata" costs one
-   * request instead of a read plus a conditional whole-record write, and so that concurrent bumps
-   * cannot lose each other on the version.
+   * Atomically updates metadata attributes on an <em>existing</em> record and advances its version,
+   * in a single request — the one write here that is not a whole-record CAS, so concurrent bumps
+   * cannot lose each other.
    *
    * <ul>
    *   <li>{@code sets} replaces attribute values.
-   *   <li>{@code increments} adds a delta to a numeric attribute, creating it with the delta value
-   *       if absent. Incrementing an attribute that currently holds a non-numeric string fails the
-   *       {@link Uni} with a store-specific error; it never silently overwrites.
-   *   <li>A sum outside {@code long} is not a value this SPI can carry, since {@link
-   *       AttrValue.NumberValue} is a {@code long}. Callers must not drive a counter to the
-   *       boundary. Stores differ in how they say so, and the difference is deliberately in the
-   *       strict direction: the in-memory store fails the {@link Uni} with {@link
-   *       ArithmeticException}, whereas DynamoDB's {@code ADD} is server-side arbitrary precision
-   *       and stores the true value, which {@link AttrValue#asLong()} then refuses to narrow on the
-   *       way back out. So a caller the in-memory store rejects is never one DynamoDB would have
-   *       silently mangled — the failure cannot appear first in production.
-   *   <li>The record's version is advanced by one in the same request. A record whose stored
-   *       version is missing counts as 0 and becomes 1.
+   *   <li>{@code increments} adds a delta to a numeric attribute, creating it at the delta if
+   *       absent. Incrementing a string-valued attribute, or past the range of {@code long}, fails
+   *       the {@link Uni} with a store-specific error; neither overwrites nor wraps.
+   *   <li>The version advances by one; a missing stored version counts as 0.
    *   <li>The record is never created as a side effect.
+   *   <li>A record carrying a {@code value} payload is refused, since the payload embeds its own
+   *       copy of the version and this update does not rewrite it.
    * </ul>
-   *
-   * <p><b>Restricted to attrs-only records.</b> A record carrying a {@code value} payload is
-   * refused. The reason is that canonical protobuf entities embed a copy of the version inside
-   * their serialized value and never resync it from {@code Record.version}, so advancing the
-   * version without rewriting the value would desynchronize the two. Note the check <em>excludes
-   * value-carrying records</em>; it does not by itself prove a record is attrs-only — pointer rows,
-   * for instance, are canonical entities that happen to store nothing in {@code value}. Callers
-   * must target records whose consumers treat {@code Record.version} as authoritative.
    *
    * @param sets attribute values to replace; must not name a {@link KvAttributes#RESERVED_ATTRS}
    *     attribute, nor {@link KvAttributes#ATTR_EXPIRES_AT}, which only a whole-record write may
-   *     touch (see {@link AttrWriteRules#checkExpiryIsString})
-   * @param increments deltas to add to numeric attributes; must not overlap {@code sets}, and must
-   *     not carry a counter past {@code long}
-   * @return the new version if the record existed and was updated; empty if the record was absent
-   *     or was refused for carrying a value. Never empty to report an increment that could not be
-   *     applied — that arrives as a failed {@link Uni}, because a caller reading empty as "no such
-   *     record" would swallow it.
+   *     touch
+   * @param increments deltas to add to numeric attributes; must not overlap {@code sets}
+   * @return the new version, or empty if the record was absent or refused for carrying a value. A
+   *     failed increment arrives as a failed {@link Uni}, never as empty.
    * @throws IllegalArgumentException if both maps are empty, or an attribute name is reserved, the
    *     expiry stamp, blank, or present in both maps
    */

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -49,13 +49,20 @@ public interface KvStore {
    *   <li>{@code kind} is a small discriminator (useful for debugging)
    *   <li>{@code value} is raw bytes (protobuf bytes for canonical entities; usually empty for
    *       pointer/index items)
-   *   <li>{@code attrs} are small string attributes for pointers/indexes/metadata
+   *   <li>{@code attrs} are small typed attributes for pointers/indexes/metadata (see {@link
+   *       AttrValue})
    *   <li>{@code version} is the monotonically increasing optimistic-concurrency version
    * </ul>
    */
-  record Record(Key key, String kind, byte[] value, Map<String, String> attrs, long version) {
+  record Record(Key key, String kind, byte[] value, Map<String, AttrValue> attrs, long version) {
     public Record {
       attrs = (attrs == null) ? Map.of() : Map.copyOf(attrs);
+      for (var name : attrs.keySet()) {
+        if (KvAttributes.STRUCTURAL_ATTRS.contains(name)) {
+          throw new IllegalArgumentException(
+              "attr name is reserved by the record structure: " + name);
+        }
+      }
       value = (value == null) ? new byte[0] : value;
       if (version < 0) throw new IllegalArgumentException("version must be >= 0");
     }
@@ -86,6 +93,42 @@ public interface KvStore {
    * @return true if deleted; false if the condition failed
    */
   Uni<Boolean> deleteCas(Key key, long expectedVersion);
+
+  /**
+   * Atomically updates metadata attributes on an <em>existing</em> record and advances its
+   * optimistic-concurrency version, in a single request. This is the one write on this interface
+   * that is not a whole-record CAS: it exists so that "bump this bookkeeping metadata" costs one
+   * request instead of a read plus a conditional whole-record write, and so that concurrent bumps
+   * cannot lose each other on the version.
+   *
+   * <ul>
+   *   <li>{@code sets} replaces attribute values.
+   *   <li>{@code increments} adds a delta to a numeric attribute, creating it with the delta value
+   *       if absent. Incrementing an attribute that currently holds a non-numeric string fails the
+   *       {@link Uni} with a store-specific error; it never silently overwrites.
+   *   <li>The record's version is advanced by one in the same request. A record whose stored
+   *       version is missing counts as 0 and becomes 1.
+   *   <li>The record is never created as a side effect.
+   * </ul>
+   *
+   * <p><b>Restricted to attrs-only records.</b> A record carrying a {@code value} payload is
+   * refused. The reason is that canonical protobuf entities embed a copy of the version inside
+   * their serialized value and never resync it from {@code Record.version}, so advancing the
+   * version without rewriting the value would desynchronize the two. Note the check <em>excludes
+   * value-carrying records</em>; it does not by itself prove a record is attrs-only — pointer rows,
+   * for instance, are canonical entities that happen to store nothing in {@code value}. Callers
+   * must target records whose consumers treat {@code Record.version} as authoritative.
+   *
+   * @param sets attribute values to replace; must not name a {@link KvAttributes#STRUCTURAL_ATTRS}
+   *     attribute
+   * @param increments deltas to add to numeric attributes; must not overlap {@code sets}
+   * @return the new version if the record existed and was updated; empty if the record was absent
+   *     or was refused for carrying a value
+   * @throws IllegalArgumentException if both maps are empty, or an attribute name is reserved,
+   *     blank, or present in both maps
+   */
+  Uni<Optional<Long>> updateMetadataAttrsIfExists(
+      Key key, Map<String, AttrValue> sets, Map<String, Long> increments);
 
   /**
    * Query within a partition key, ordered by sk, with a prefix constraint. This is the

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -106,6 +106,14 @@ public interface KvStore {
    *   <li>{@code increments} adds a delta to a numeric attribute, creating it with the delta value
    *       if absent. Incrementing an attribute that currently holds a non-numeric string fails the
    *       {@link Uni} with a store-specific error; it never silently overwrites.
+   *   <li>A sum outside {@code long} is not a value this SPI can carry, since {@link
+   *       AttrValue.NumberValue} is a {@code long}. Callers must not drive a counter to the
+   *       boundary. Stores differ in how they say so, and the difference is deliberately in the
+   *       strict direction: the in-memory store fails the {@link Uni} with {@link
+   *       ArithmeticException}, whereas DynamoDB's {@code ADD} is server-side arbitrary precision
+   *       and stores the true value, which {@link AttrValue#asLong()} then refuses to narrow on the
+   *       way back out. So a caller the in-memory store rejects is never one DynamoDB would have
+   *       silently mangled — the failure cannot appear first in production.
    *   <li>The record's version is advanced by one in the same request. A record whose stored
    *       version is missing counts as 0 and becomes 1.
    *   <li>The record is never created as a side effect.
@@ -122,9 +130,12 @@ public interface KvStore {
    * @param sets attribute values to replace; must not name a {@link KvAttributes#RESERVED_ATTRS}
    *     attribute, nor {@link KvAttributes#ATTR_EXPIRES_AT}, which only a whole-record write may
    *     touch (see {@link AttrWriteRules#checkExpiryIsString})
-   * @param increments deltas to add to numeric attributes; must not overlap {@code sets}
+   * @param increments deltas to add to numeric attributes; must not overlap {@code sets}, and must
+   *     not carry a counter past {@code long}
    * @return the new version if the record existed and was updated; empty if the record was absent
-   *     or was refused for carrying a value
+   *     or was refused for carrying a value. Never empty to report an increment that could not be
+   *     applied — that arrives as a failed {@link Uni}, because a caller reading empty as "no such
+   *     record" would swallow it.
    * @throws IllegalArgumentException if both maps are empty, or an attribute name is reserved, the
    *     expiry stamp, blank, or present in both maps
    */

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -84,6 +84,7 @@ public interface KvStore {
    * <p>On success, the backend should store {@code record.version} as the new ver attribute.
    *
    * @return true if write succeeded; false if the condition failed
+   * @throws IllegalArgumentException if the record's attrs break {@link AttrWriteRules}
    */
   Uni<Boolean> putCas(Record record, long expectedVersion);
 
@@ -120,12 +121,13 @@ public interface KvStore {
    * must target records whose consumers treat {@code Record.version} as authoritative.
    *
    * @param sets attribute values to replace; must not name a {@link KvAttributes#STRUCTURAL_ATTRS}
-   *     attribute
+   *     attribute, nor {@link KvAttributes#ATTR_EXPIRES_AT}, which only a whole-record write may
+   *     touch (see {@link AttrWriteRules#checkExpiryIsString})
    * @param increments deltas to add to numeric attributes; must not overlap {@code sets}
    * @return the new version if the record existed and was updated; empty if the record was absent
    *     or was refused for carrying a value
-   * @throws IllegalArgumentException if both maps are empty, or an attribute name is reserved,
-   *     blank, or present in both maps
+   * @throws IllegalArgumentException if both maps are empty, or an attribute name is reserved, the
+   *     expiry stamp, blank, or present in both maps
    */
   Uni<Optional<Long>> updateMetadataAttrsIfExists(
       Key key, Map<String, AttrValue> sets, Map<String, Long> increments);

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -58,9 +58,8 @@ public interface KvStore {
     public Record {
       attrs = (attrs == null) ? Map.of() : Map.copyOf(attrs);
       for (var name : attrs.keySet()) {
-        if (KvAttributes.STRUCTURAL_ATTRS.contains(name)) {
-          throw new IllegalArgumentException(
-              "attr name is reserved by the record structure: " + name);
+        if (KvAttributes.RESERVED_ATTRS.contains(name)) {
+          throw new IllegalArgumentException("attr name is reserved by the backend: " + name);
         }
       }
       value = (value == null) ? new byte[0] : value;
@@ -120,7 +119,7 @@ public interface KvStore {
    * for instance, are canonical entities that happen to store nothing in {@code value}. Callers
    * must target records whose consumers treat {@code Record.version} as authoritative.
    *
-   * @param sets attribute values to replace; must not name a {@link KvAttributes#STRUCTURAL_ATTRS}
+   * @param sets attribute values to replace; must not name a {@link KvAttributes#RESERVED_ATTRS}
    *     attribute, nor {@link KvAttributes#ATTR_EXPIRES_AT}, which only a whole-record write may
    *     touch (see {@link AttrWriteRules#checkExpiryIsString})
    * @param increments deltas to add to numeric attributes; must not overlap {@code sets}

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdates.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdates.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv;
+
+import java.util.Map;
+
+/**
+ * Argument validation shared by every {@link KvStore#updateMetadataAttrsIfExists} implementation,
+ * so that what one store rejects the others reject identically.
+ */
+public final class MetadataAttrUpdates {
+
+  private MetadataAttrUpdates() {}
+
+  /**
+   * Validates the arguments of {@link KvStore#updateMetadataAttrsIfExists}, throwing before any
+   * request is issued.
+   */
+  public static void validate(
+      KvStore.Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
+    if (key == null) throw new IllegalArgumentException("key must not be null");
+    if (sets == null) throw new IllegalArgumentException("sets must not be null");
+    if (increments == null) throw new IllegalArgumentException("increments must not be null");
+    if (sets.isEmpty() && increments.isEmpty()) {
+      throw new IllegalArgumentException("at least one of sets/increments must be non-empty");
+    }
+    checkNames(sets, "sets");
+    checkNames(increments, "increments");
+    for (var name : increments.keySet()) {
+      if (sets.containsKey(name)) {
+        throw new IllegalArgumentException(
+            "attr is both set and incremented, which is ambiguous: " + name);
+      }
+    }
+  }
+
+  private static void checkNames(Map<String, ?> attrs, String what) {
+    for (var e : attrs.entrySet()) {
+      var name = e.getKey();
+      if (name == null || name.isBlank()) {
+        throw new IllegalArgumentException(what + " contains a blank attr name");
+      }
+      if (KvAttributes.STRUCTURAL_ATTRS.contains(name)) {
+        throw new IllegalArgumentException(
+            "attr name is reserved by the record structure: " + name + " (in " + what + ")");
+      }
+      if (e.getValue() == null) {
+        throw new IllegalArgumentException(what + " contains a null value for attr " + name);
+      }
+    }
+  }
+}

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdates.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdates.java
@@ -57,6 +57,18 @@ public final class MetadataAttrUpdates {
         throw new IllegalArgumentException(
             "attr name is reserved by the record structure: " + name + " (in " + what + ")");
       }
+      // Rejected outright here, where whole-record writes accept the string form (see
+      // AttrWriteRules#checkExpiryIsString). An increment can only produce the numeric form this
+      // primitive must not write, and no caller needs to bump an expiry without rewriting the
+      // record that carries it — so a flat rule beats a per-form one.
+      if (KvAttributes.ATTR_EXPIRES_AT.equals(name)) {
+        throw new IllegalArgumentException(
+            "attr must not be updated by itself, only by a whole-record write: "
+                + name
+                + " (in "
+                + what
+                + ")");
+      }
       if (e.getValue() == null) {
         throw new IllegalArgumentException(what + " contains a null value for attr " + name);
       }

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdates.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdates.java
@@ -57,10 +57,9 @@ public final class MetadataAttrUpdates {
         throw new IllegalArgumentException(
             "attr name is reserved by the backend: " + name + " (in " + what + ")");
       }
-      // Rejected outright here, where whole-record writes accept the string form (see
-      // AttrWriteRules#checkExpiryIsString). An increment can only produce the numeric form this
-      // primitive must not write, and no caller needs to bump an expiry without rewriting the
-      // record that carries it — so a flat rule beats a per-form one.
+      // Rejected in both forms, though whole-record writes accept the string one: an expiry
+      // belongs to the record that carries it, and an increment could only produce the numeric
+      // form this primitive must not write.
       if (KvAttributes.ATTR_EXPIRES_AT.equals(name)) {
         throw new IllegalArgumentException(
             "attr must not be updated by itself, only by a whole-record write: "

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdates.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdates.java
@@ -53,9 +53,9 @@ public final class MetadataAttrUpdates {
       if (name == null || name.isBlank()) {
         throw new IllegalArgumentException(what + " contains a blank attr name");
       }
-      if (KvAttributes.STRUCTURAL_ATTRS.contains(name)) {
+      if (KvAttributes.RESERVED_ATTRS.contains(name)) {
         throw new IllegalArgumentException(
-            "attr name is reserved by the record structure: " + name + " (in " + what + ")");
+            "attr name is reserved by the backend: " + name + " (in " + what + ")");
       }
       // Rejected outright here, where whole-record writes accept the string form (see
       // AttrWriteRules#checkExpiryIsString). An increment can only produce the numeric form this

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/AttrWriteRulesTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/AttrWriteRulesTest.java
@@ -58,9 +58,11 @@ public class AttrWriteRulesTest {
   void accepts_numeric_values_for_every_other_attr() {
     // The rule is about one attribute's rollout constraint, not about numbers being suspect: index
     // bookkeeping is numeric precisely so it can be incremented server-side.
+    // Deliberately not ATTR_TTL: that name is reserved (DynamoDB expires rows by it), so it is no
+    // example of an ordinary attr — KvStoreRecordTest pins its rejection.
     assertDoesNotThrow(
         () ->
             AttrWriteRules.checkExpiryIsString(
-                Map.of("useCount", AttrValue.of(7L), KvAttributes.ATTR_TTL, AttrValue.of(9L))));
+                Map.of("useCount", AttrValue.of(7L), "hits", AttrValue.of(9L))));
   }
 }

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/AttrWriteRulesTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/AttrWriteRulesTest.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
- * The write-side typing rule itself. Both stores call it on every whole-record write — that each of
- * them does belongs to their {@code KvStoreContractTest} classes; this pins the rule.
+ * Pins the typing rule itself; that each store enforces it on every write belongs to the {@code
+ * KvStoreContractTest} classes.
  */
 public class AttrWriteRulesTest {
 
@@ -56,10 +56,8 @@ public class AttrWriteRulesTest {
 
   @Test
   void accepts_numeric_values_for_every_other_attr() {
-    // The rule is about one attribute's rollout constraint, not about numbers being suspect: index
-    // bookkeeping is numeric precisely so it can be incremented server-side.
-    // Deliberately not ATTR_TTL: that name is reserved (DynamoDB expires rows by it), so it is no
-    // example of an ordinary attr — KvStoreRecordTest pins its rejection.
+    // One attribute's rollout constraint, not numbers being suspect. Deliberately not ATTR_TTL,
+    // which is reserved rather than ordinary.
     assertDoesNotThrow(
         () ->
             AttrWriteRules.checkExpiryIsString(

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/AttrWriteRulesTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/AttrWriteRulesTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The write-side typing rule itself. Both stores call it on every whole-record write — that each of
+ * them does belongs to their {@code KvStoreContractTest} classes; this pins the rule.
+ */
+public class AttrWriteRulesTest {
+
+  @Test
+  void rejects_numeric_expiry_stamp() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                AttrWriteRules.checkExpiryIsString(
+                    Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of(2L))));
+    assertTrue(
+        thrown.getMessage().contains(KvAttributes.ATTR_EXPIRES_AT),
+        "expected the attr name in the message but was: " + thrown.getMessage());
+  }
+
+  @Test
+  void accepts_string_expiry_stamp() {
+    assertDoesNotThrow(
+        () ->
+            AttrWriteRules.checkExpiryIsString(
+                Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of("2"))));
+  }
+
+  @Test
+  void accepts_absent_expiry_stamp() {
+    assertDoesNotThrow(() -> AttrWriteRules.checkExpiryIsString(Map.of()));
+  }
+
+  @Test
+  void accepts_numeric_values_for_every_other_attr() {
+    // The rule is about one attribute's rollout constraint, not about numbers being suspect: index
+    // bookkeeping is numeric precisely so it can be incremented server-side.
+    assertDoesNotThrow(
+        () ->
+            AttrWriteRules.checkExpiryIsString(
+                Map.of("useCount", AttrValue.of(7L), KvAttributes.ATTR_TTL, AttrValue.of(9L))));
+  }
+}

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
@@ -154,7 +154,7 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
             .isPresent());
 
     KvStore.Record rec = kv.records.get(key("pk", "sk1"));
-    assertEquals("2", rec.attrs().get(KvAttributes.ATTR_EXPIRES_AT));
+    assertEquals(AttrValue.of("2"), rec.attrs().get(KvAttributes.ATTR_EXPIRES_AT));
   }
 
   @Test
@@ -194,7 +194,11 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
             "ptr",
             "Pointer",
             new byte[0],
-            Map.of(KvAttributes.TARGET_PARTITION_KEY, "tp", KvAttributes.TARGET_SORT_KEY, "ts"),
+            Map.of(
+                KvAttributes.TARGET_PARTITION_KEY,
+                AttrValue.of("tp"),
+                KvAttributes.TARGET_SORT_KEY,
+                AttrValue.of("ts")),
             1L));
     kv.records.put(
         targetKey, record("tp", "ts", TestEntity.KIND, pointerBytes("target"), Map.of(), 1L));
@@ -214,7 +218,10 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
             "Pointer",
             new byte[0],
             Map.of(
-                KvAttributes.TARGET_PARTITION_KEY, "tp", KvAttributes.TARGET_SORT_KEY, "missing"),
+                KvAttributes.TARGET_PARTITION_KEY,
+                AttrValue.of("tp"),
+                KvAttributes.TARGET_SORT_KEY,
+                AttrValue.of("missing")),
             1L));
 
     assertTrue(entity.getViaPointerForTest(ptrKey).await().indefinitely().isEmpty());
@@ -229,7 +236,11 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
             "p1",
             "Pointer",
             new byte[0],
-            Map.of(KvAttributes.TARGET_PARTITION_KEY, "tp", KvAttributes.TARGET_SORT_KEY, "t1"),
+            Map.of(
+                KvAttributes.TARGET_PARTITION_KEY,
+                AttrValue.of("tp"),
+                KvAttributes.TARGET_SORT_KEY,
+                AttrValue.of("t1")),
             1L));
     kv.records.put(
         key("ptr", "p2"),
@@ -238,7 +249,11 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
             "p2",
             "Pointer",
             new byte[0],
-            Map.of(KvAttributes.TARGET_PARTITION_KEY, "tp", KvAttributes.TARGET_SORT_KEY, "t2"),
+            Map.of(
+                KvAttributes.TARGET_PARTITION_KEY,
+                AttrValue.of("tp"),
+                KvAttributes.TARGET_SORT_KEY,
+                AttrValue.of("t2")),
             1L));
 
     kv.records.put(
@@ -279,7 +294,11 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
             "p1",
             "Pointer",
             new byte[0],
-            Map.of(KvAttributes.TARGET_PARTITION_KEY, "tp", KvAttributes.TARGET_SORT_KEY, "t1"),
+            Map.of(
+                KvAttributes.TARGET_PARTITION_KEY,
+                AttrValue.of("tp"),
+                KvAttributes.TARGET_SORT_KEY,
+                AttrValue.of("t1")),
             1L));
     kv.records.put(
         key("ptr", "p2"),
@@ -289,7 +308,10 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
             "Pointer",
             new byte[0],
             Map.of(
-                KvAttributes.TARGET_PARTITION_KEY, "tp", KvAttributes.TARGET_SORT_KEY, "missing"),
+                KvAttributes.TARGET_PARTITION_KEY,
+                AttrValue.of("tp"),
+                KvAttributes.TARGET_SORT_KEY,
+                AttrValue.of("missing")),
             1L));
     kv.records.put(
         key("tp", "t1"), record("tp", "t1", TestEntity.KIND, pointerBytes("t1"), Map.of(), 1L));
@@ -308,7 +330,7 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
   }
 
   private static KvStore.Record record(
-      String pk, String sk, String kind, byte[] value, Map<String, String> attrs, long version) {
+      String pk, String sk, String kind, byte[] value, Map<String, AttrValue> attrs, long version) {
     return new KvStore.Record(new KvStore.Key(pk, sk), kind, value, attrs, version);
   }
 
@@ -324,7 +346,7 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
     }
 
     private Uni<Optional<Pointer>> putCanonicalCasForTest(
-        KvStore.Key key, Pointer pointer, Map<String, String> attrs, long expectedVersion) {
+        KvStore.Key key, Pointer pointer, Map<String, AttrValue> attrs, long expectedVersion) {
       return putCanonicalCas(key, KIND, pointer, attrs, expectedVersion);
     }
 
@@ -399,6 +421,39 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
         return Uni.createFrom().item(true);
       }
       return Uni.createFrom().item(false);
+    }
+
+    @Override
+    public Uni<Optional<Long>> updateMetadataAttrsIfExists(
+        Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
+      MetadataAttrUpdates.validate(key, sets, increments);
+
+      Record existing = records.get(key);
+      if (existing == null || existing.value().length > 0) {
+        return Uni.createFrom().item(Optional.empty());
+      }
+
+      var attrs = new HashMap<>(existing.attrs());
+      attrs.putAll(sets);
+      for (var increment : increments.entrySet()) {
+        var name = increment.getKey();
+        var current = attrs.get(name);
+        if (current != null && current.asLong().isEmpty()) {
+          throw new IllegalStateException(
+              "cannot increment attr "
+                  + name
+                  + " on "
+                  + key
+                  + ": it currently holds a non-numeric string value");
+        }
+        long base = AttrValue.longOr(attrs, name, 0L);
+        attrs.put(name, AttrValue.of(base + increment.getValue()));
+      }
+
+      long newVersion = existing.version() + 1;
+      records.put(
+          key, new Record(existing.key(), existing.kind(), existing.value(), attrs, newVersion));
+      return Uni.createFrom().item(Optional.of(newVersion));
     }
 
     @Override

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
@@ -191,11 +191,8 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
 
   @Test
   void fake_kv_delivers_increment_of_string_attr_as_a_failed_uni() {
-    // Pins the fake's failure delivery rather than any entity behaviour. Both real stores surface
-    // this as a failed Uni — InMemoryKvStore from a deferred supplier, DynamoDbKvStore from ADD's
-    // ValidationException — so a fake that threw synchronously would let a contract test which
-    // awaits the Uni pass here and fail in production. Nothing else exercises this override yet,
-    // which is exactly why the divergence could return unnoticed.
+    // Both real stores surface this as a failed Uni; a fake that threw synchronously would let a
+    // test that awaits the Uni pass here and fail in production.
     KvStore.Key key = key("pk", "sk-meta");
     kv.records.put(
         key,
@@ -488,46 +485,48 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
         Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
       MetadataAttrUpdates.validate(key, sets, increments);
 
-      // Deferred (a supplier, unlike the eager item(...) used elsewhere in this fake) so that the
-      // non-numeric-increment failure below arrives as a failed Uni, the way InMemoryKvStore and
-      // DynamoDbKvStore both surface it, rather than as a synchronous throw a test awaiting the Uni
-      // would never catch. Argument validation above stays synchronous, matching them too.
-      return Uni.createFrom()
-          .item(
-              () -> {
-                Record existing = records.get(key);
-                if (existing == null || existing.value().length > 0) {
-                  return Optional.empty();
-                }
+      // Applied eagerly (a Uni can be subscribed more than once), with the failure delivered as a
+      // failed Uni rather than a synchronous throw — matching InMemoryKvStore.
+      Optional<Long> newVersion;
+      try {
+        newVersion = applyMetadataAttrUpdates(key, sets, increments);
+      } catch (RuntimeException failure) {
+        return Uni.createFrom().failure(failure);
+      }
+      return Uni.createFrom().item(newVersion);
+    }
 
-                var attrs = new HashMap<>(existing.attrs());
-                attrs.putAll(sets);
-                for (var increment : increments.entrySet()) {
-                  var name = increment.getKey();
-                  var current = attrs.get(name);
-                  // Rejected on the type, not on whether the text happens to parse — same rule as
-                  // InMemoryKvStore, because DynamoDB's ADD raises ValidationException for any
-                  // S-typed attribute, numeric-looking ones like "42" included. A laxer fake would
-                  // let an entity test pass here and fail in production.
-                  if (current != null && !(current instanceof AttrValue.NumberValue)) {
-                    throw new IllegalStateException(
-                        "cannot increment attr "
-                            + name
-                            + " on "
-                            + key
-                            + ": it currently holds a string value");
-                  }
-                  long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
-                  attrs.put(name, AttrValue.of(base + increment.getValue()));
-                }
+    private Optional<Long> applyMetadataAttrUpdates(
+        Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
+      Record existing = records.get(key);
+      if (existing == null || existing.value().length > 0) {
+        return Optional.empty();
+      }
 
-                long newVersion = existing.version() + 1;
-                records.put(
-                    key,
-                    new Record(
-                        existing.key(), existing.kind(), existing.value(), attrs, newVersion));
-                return Optional.of(newVersion);
-              });
+      var attrs = new HashMap<>(existing.attrs());
+      attrs.putAll(sets);
+      for (var increment : increments.entrySet()) {
+        var name = increment.getKey();
+        var current = attrs.get(name);
+        // Rejected on the type, not parseability: DynamoDB's ADD rejects any S-typed attribute,
+        // numeric-looking ones like "42" included.
+        if (current != null && !(current instanceof AttrValue.NumberValue)) {
+          throw new IllegalStateException(
+              "cannot increment attr "
+                  + name
+                  + " on "
+                  + key
+                  + ": it currently holds a string value");
+        }
+        long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
+        // addExact, not +: a wrapped sum would report success while storing a wildly wrong value.
+        attrs.put(name, AttrValue.of(Math.addExact(base, increment.getValue())));
+      }
+
+      long newVersion = existing.version() + 1;
+      records.put(
+          key, new Record(existing.key(), existing.kind(), existing.value(), attrs, newVersion));
+      return Optional.of(newVersion);
     }
 
     @Override

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
@@ -158,6 +158,38 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
   }
 
   @Test
+  void decode_reads_expires_at_from_either_attribute_form() {
+    // Rows written before the attribute was retyped hold the stamp as a string; both must decode.
+    for (AttrValue stamp : List.of(AttrValue.of("2"), AttrValue.of(2L))) {
+      Pointer decoded =
+          entity.decodeForTest(
+              record(
+                  "pk",
+                  "sk1",
+                  TestEntity.KIND,
+                  pointerBytes("k1"),
+                  Map.of(KvAttributes.ATTR_EXPIRES_AT, stamp),
+                  1L));
+      assertEquals(2000L, Timestamps.toMillis(decoded.getExpiresAt()));
+    }
+  }
+
+  @Test
+  void decode_throws_on_malformed_expires_at() {
+    // Fail loud: silently reading a corrupt stamp as "no expiry" would make the record immortal.
+    KvStore.Record rec =
+        record(
+            "pk",
+            "sk1",
+            TestEntity.KIND,
+            pointerBytes("k1"),
+            Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of("not-a-timestamp")),
+            1L);
+
+    assertThrows(NumberFormatException.class, () -> entity.decodeForTest(rec));
+  }
+
+  @Test
   void deleteCas_calls_kv_deleteCas_with_expectedVersion() {
     RecordingKvStore kv = new RecordingKvStore();
     TestEntity entity = new TestEntity(kv);
@@ -365,6 +397,10 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
 
     private static long nextVersionForTest(long expectedVersion) {
       return nextVersion(expectedVersion);
+    }
+
+    private Pointer decodeForTest(KvStore.Record r) {
+      return decode(r);
     }
 
     @Override

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
@@ -438,15 +438,19 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
       for (var increment : increments.entrySet()) {
         var name = increment.getKey();
         var current = attrs.get(name);
-        if (current != null && current.asLong().isEmpty()) {
+        // Rejected on the type, not on whether the text happens to parse — same rule as
+        // InMemoryKvStore, because DynamoDB's ADD raises ValidationException for any S-typed
+        // attribute, numeric-looking ones like "42" included. A laxer fake would let an entity
+        // test pass here and fail in production.
+        if (current != null && !(current instanceof AttrValue.NumberValue)) {
           throw new IllegalStateException(
               "cannot increment attr "
                   + name
                   + " on "
                   + key
-                  + ": it currently holds a non-numeric string value");
+                  + ": it currently holds a string value");
         }
-        long base = AttrValue.longOr(attrs, name, 0L);
+        long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
         attrs.put(name, AttrValue.of(base + increment.getValue()));
       }
 

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
@@ -190,6 +190,30 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
   }
 
   @Test
+  void fake_kv_delivers_increment_of_string_attr_as_a_failed_uni() {
+    // Pins the fake's failure delivery rather than any entity behaviour. Both real stores surface
+    // this as a failed Uni — InMemoryKvStore from a deferred supplier, DynamoDbKvStore from ADD's
+    // ValidationException — so a fake that threw synchronously would let a contract test which
+    // awaits the Uni pass here and fail in production. Nothing else exercises this override yet,
+    // which is exactly why the divergence could return unnoticed.
+    KvStore.Key key = key("pk", "sk-meta");
+    kv.records.put(
+        key,
+        record(
+            "pk",
+            "sk-meta",
+            TestEntity.KIND,
+            new byte[0],
+            Map.of("note", AttrValue.of("text")),
+            1L));
+
+    Uni<Optional<Long>> update =
+        assertDoesNotThrow(() -> kv.updateMetadataAttrsIfExists(key, Map.of(), Map.of("note", 1L)));
+
+    assertThrows(IllegalStateException.class, () -> update.await().indefinitely());
+  }
+
+  @Test
   void deleteCas_calls_kv_deleteCas_with_expectedVersion() {
     RecordingKvStore kv = new RecordingKvStore();
     TestEntity entity = new TestEntity(kv);
@@ -464,36 +488,46 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
         Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
       MetadataAttrUpdates.validate(key, sets, increments);
 
-      Record existing = records.get(key);
-      if (existing == null || existing.value().length > 0) {
-        return Uni.createFrom().item(Optional.empty());
-      }
+      // Deferred (a supplier, unlike the eager item(...) used elsewhere in this fake) so that the
+      // non-numeric-increment failure below arrives as a failed Uni, the way InMemoryKvStore and
+      // DynamoDbKvStore both surface it, rather than as a synchronous throw a test awaiting the Uni
+      // would never catch. Argument validation above stays synchronous, matching them too.
+      return Uni.createFrom()
+          .item(
+              () -> {
+                Record existing = records.get(key);
+                if (existing == null || existing.value().length > 0) {
+                  return Optional.empty();
+                }
 
-      var attrs = new HashMap<>(existing.attrs());
-      attrs.putAll(sets);
-      for (var increment : increments.entrySet()) {
-        var name = increment.getKey();
-        var current = attrs.get(name);
-        // Rejected on the type, not on whether the text happens to parse — same rule as
-        // InMemoryKvStore, because DynamoDB's ADD raises ValidationException for any S-typed
-        // attribute, numeric-looking ones like "42" included. A laxer fake would let an entity
-        // test pass here and fail in production.
-        if (current != null && !(current instanceof AttrValue.NumberValue)) {
-          throw new IllegalStateException(
-              "cannot increment attr "
-                  + name
-                  + " on "
-                  + key
-                  + ": it currently holds a string value");
-        }
-        long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
-        attrs.put(name, AttrValue.of(base + increment.getValue()));
-      }
+                var attrs = new HashMap<>(existing.attrs());
+                attrs.putAll(sets);
+                for (var increment : increments.entrySet()) {
+                  var name = increment.getKey();
+                  var current = attrs.get(name);
+                  // Rejected on the type, not on whether the text happens to parse — same rule as
+                  // InMemoryKvStore, because DynamoDB's ADD raises ValidationException for any
+                  // S-typed attribute, numeric-looking ones like "42" included. A laxer fake would
+                  // let an entity test pass here and fail in production.
+                  if (current != null && !(current instanceof AttrValue.NumberValue)) {
+                    throw new IllegalStateException(
+                        "cannot increment attr "
+                            + name
+                            + " on "
+                            + key
+                            + ": it currently holds a string value");
+                  }
+                  long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
+                  attrs.put(name, AttrValue.of(base + increment.getValue()));
+                }
 
-      long newVersion = existing.version() + 1;
-      records.put(
-          key, new Record(existing.key(), existing.kind(), existing.value(), attrs, newVersion));
-      return Uni.createFrom().item(Optional.of(newVersion));
+                long newVersion = existing.version() + 1;
+                records.put(
+                    key,
+                    new Record(
+                        existing.key(), existing.kind(), existing.value(), attrs, newVersion));
+                return Optional.of(newVersion);
+              });
     }
 
     @Override

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KvStoreRecordTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KvStoreRecordTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Constructor rules of {@link KvStore.Record} that every backend relies on: an attribute may not
+ * borrow a structural field's name, and a null attrs map normalizes rather than blowing up.
+ */
+public class KvStoreRecordTest {
+
+  @Test
+  void record_rejects_every_structural_attr_name() {
+    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+      Map<String, AttrValue> attrs = Map.of(name, AttrValue.of("x"));
+      IllegalArgumentException thrown =
+          assertThrows(IllegalArgumentException.class, () -> newRecord(attrs));
+      assertTrue(thrown.getMessage().contains(name), thrown.getMessage());
+    }
+  }
+
+  @Test
+  void record_rejects_structural_attr_name_mixed_in_with_ordinary_ones() {
+    Map<String, AttrValue> attrs =
+        Map.of("ordinary", AttrValue.of("x"), KvAttributes.ATTR_VERSION, AttrValue.of(7L));
+    assertThrows(IllegalArgumentException.class, () -> newRecord(attrs));
+  }
+
+  @Test
+  void record_null_attrs_becomes_empty_map() {
+    KvStore.Record rec = newRecord(null);
+    assertNotNull(rec.attrs());
+    assertEquals(Map.of(), rec.attrs());
+  }
+
+  @Test
+  void record_copies_attrs_so_later_caller_mutation_is_invisible() {
+    Map<String, AttrValue> attrs = new HashMap<>();
+    attrs.put("ordinary", AttrValue.of("x"));
+
+    KvStore.Record rec = newRecord(attrs);
+    attrs.put("added", AttrValue.of("y"));
+
+    assertEquals(Map.of("ordinary", AttrValue.of("x")), rec.attrs());
+  }
+
+  private static KvStore.Record newRecord(Map<String, AttrValue> attrs) {
+    return new KvStore.Record(new KvStore.Key("pk", "sk"), "KIND", new byte[0], attrs, 1L);
+  }
+}

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KvStoreRecordTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KvStoreRecordTest.java
@@ -26,13 +26,13 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Constructor rules of {@link KvStore.Record} that every backend relies on: an attribute may not
- * borrow a structural field's name, and a null attrs map normalizes rather than blowing up.
+ * borrow a name the backend reserves, and a null attrs map normalizes rather than blowing up.
  */
 public class KvStoreRecordTest {
 
   @Test
-  void record_rejects_every_structural_attr_name() {
-    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+  void record_rejects_every_reserved_attr_name() {
+    for (String name : KvAttributes.RESERVED_ATTRS) {
       Map<String, AttrValue> attrs = Map.of(name, AttrValue.of("x"));
       IllegalArgumentException thrown =
           assertThrows(IllegalArgumentException.class, () -> newRecord(attrs));
@@ -41,10 +41,22 @@ public class KvStoreRecordTest {
   }
 
   @Test
-  void record_rejects_structural_attr_name_mixed_in_with_ordinary_ones() {
+  void record_rejects_reserved_attr_name_mixed_in_with_ordinary_ones() {
     Map<String, AttrValue> attrs =
         Map.of("ordinary", AttrValue.of("x"), KvAttributes.ATTR_VERSION, AttrValue.of(7L));
     assertThrows(IllegalArgumentException.class, () -> newRecord(attrs));
+  }
+
+  @Test
+  void record_rejects_a_ttl_attr() {
+    // Named on its own, not left to the loop above, because its reason differs and outlives a
+    // reader who prunes the set: DynamoDB's TTL feature is enabled on this attribute, so a
+    // bookkeeping counter that happens to be called "ttl" is an epoch-second deletion schedule for
+    // the row that carries it. No error, no trace — hence a write-time rejection.
+    Map<String, AttrValue> attrs = Map.of(KvAttributes.ATTR_TTL, AttrValue.of(9L));
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> newRecord(attrs));
+    assertTrue(thrown.getMessage().contains(KvAttributes.ATTR_TTL), thrown.getMessage());
   }
 
   @Test

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KvStoreRecordTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/KvStoreRecordTest.java
@@ -49,10 +49,8 @@ public class KvStoreRecordTest {
 
   @Test
   void record_rejects_a_ttl_attr() {
-    // Named on its own, not left to the loop above, because its reason differs and outlives a
-    // reader who prunes the set: DynamoDB's TTL feature is enabled on this attribute, so a
-    // bookkeeping counter that happens to be called "ttl" is an epoch-second deletion schedule for
-    // the row that carries it. No error, no trace — hence a write-time rejection.
+    // Pinned by name: DynamoDB's TTL feature is enabled on this attribute, so a counter that
+    // happens to be called "ttl" silently schedules the row's deletion.
     Map<String, AttrValue> attrs = Map.of(KvAttributes.ATTR_TTL, AttrValue.of(9L));
     IllegalArgumentException thrown =
         assertThrows(IllegalArgumentException.class, () -> newRecord(attrs));

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdatesTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdatesTest.java
@@ -24,11 +24,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
- * Argument rules of {@link MetadataAttrUpdates#validate}, which both stores delegate to so that a
- * caller mistake is rejected identically — and synchronously, before any request is issued —
- * regardless of backend. The store-level behaviors (absent record, non-empty value, incrementing a
- * string) belong to the two {@code KvStoreContractTest} classes; this pins only the shared
- * front-door validation, including the branches no contract test reaches.
+ * Pins the shared front-door validation of {@link MetadataAttrUpdates#validate}; store-level
+ * behaviors belong to the {@code KvStoreContractTest} classes.
  */
 public class MetadataAttrUpdatesTest {
 
@@ -87,8 +84,8 @@ public class MetadataAttrUpdatesTest {
 
   @Test
   void rejects_expiry_stamp_in_sets_in_either_form() {
-    // The string form is legal in a whole-record write and still refused here: this primitive
-    // updates attrs by themselves, and an expiry belongs to the record it expires.
+    // The string form is legal in a whole-record write but refused here: an expiry belongs to the
+    // record it expires.
     for (AttrValue stamp : new AttrValue[] {AttrValue.of("2"), AttrValue.of(2L)}) {
       assertMessageContains(
           KvAttributes.ATTR_EXPIRES_AT,

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdatesTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdatesTest.java
@@ -86,6 +86,28 @@ public class MetadataAttrUpdatesTest {
   }
 
   @Test
+  void rejects_expiry_stamp_in_sets_in_either_form() {
+    // The string form is legal in a whole-record write and still refused here: this primitive
+    // updates attrs by themselves, and an expiry belongs to the record it expires.
+    for (AttrValue stamp : new AttrValue[] {AttrValue.of("2"), AttrValue.of(2L)}) {
+      assertMessageContains(
+          KvAttributes.ATTR_EXPIRES_AT,
+          () ->
+              MetadataAttrUpdates.validate(
+                  KEY, Map.of(KvAttributes.ATTR_EXPIRES_AT, stamp), Map.of()));
+    }
+  }
+
+  @Test
+  void rejects_expiry_stamp_in_increments() {
+    // An ADD would write the stamp as a native number, the one form old replicas drop on read.
+    assertMessageContains(
+        KvAttributes.ATTR_EXPIRES_AT,
+        () ->
+            MetadataAttrUpdates.validate(KEY, Map.of(), Map.of(KvAttributes.ATTR_EXPIRES_AT, 1L)));
+  }
+
+  @Test
   void rejects_same_attr_in_both_maps() {
     assertMessageContains(
         "ambiguous",

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdatesTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdatesTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.storage.kv;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Argument rules of {@link MetadataAttrUpdates#validate}, which both stores delegate to so that a
+ * caller mistake is rejected identically — and synchronously, before any request is issued —
+ * regardless of backend. The store-level behaviors (absent record, non-empty value, incrementing a
+ * string) belong to the two {@code KvStoreContractTest} classes; this pins only the shared
+ * front-door validation, including the branches no contract test reaches.
+ */
+public class MetadataAttrUpdatesTest {
+
+  private static final KvStore.Key KEY = new KvStore.Key("pk1", "sk1");
+
+  @Test
+  void accepts_sets_only() {
+    assertDoesNotThrow(
+        () -> MetadataAttrUpdates.validate(KEY, Map.of("a", AttrValue.of("x")), Map.of()));
+  }
+
+  @Test
+  void accepts_increments_only() {
+    assertDoesNotThrow(() -> MetadataAttrUpdates.validate(KEY, Map.of(), Map.of("n", 1L)));
+  }
+
+  @Test
+  void rejects_null_key() {
+    assertMessageContains(
+        "key", () -> MetadataAttrUpdates.validate(null, Map.of("a", AttrValue.of("x")), Map.of()));
+  }
+
+  @Test
+  void rejects_null_sets_map() {
+    assertMessageContains("sets", () -> MetadataAttrUpdates.validate(KEY, null, Map.of("n", 1L)));
+  }
+
+  @Test
+  void rejects_null_increments_map() {
+    assertMessageContains(
+        "increments",
+        () -> MetadataAttrUpdates.validate(KEY, Map.of("a", AttrValue.of("x")), null));
+  }
+
+  @Test
+  void rejects_both_maps_empty() {
+    // A no-op update would still advance the version, so it is a caller error rather than a no-op.
+    assertMessageContains("non-empty", () -> MetadataAttrUpdates.validate(KEY, Map.of(), Map.of()));
+  }
+
+  @Test
+  void rejects_every_structural_attr_name_in_sets() {
+    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+      assertMessageContains(
+          name, () -> MetadataAttrUpdates.validate(KEY, Map.of(name, AttrValue.of("x")), Map.of()));
+    }
+  }
+
+  @Test
+  void rejects_every_structural_attr_name_in_increments() {
+    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+      assertMessageContains(
+          name, () -> MetadataAttrUpdates.validate(KEY, Map.of(), Map.of(name, 1L)));
+    }
+  }
+
+  @Test
+  void rejects_same_attr_in_both_maps() {
+    assertMessageContains(
+        "ambiguous",
+        () ->
+            MetadataAttrUpdates.validate(KEY, Map.of("dup", AttrValue.of("x")), Map.of("dup", 1L)));
+  }
+
+  @Test
+  void rejects_blank_attr_name() {
+    for (String name : new String[] {"", " ", "\t"}) {
+      assertMessageContains(
+          "blank",
+          () -> MetadataAttrUpdates.validate(KEY, Map.of(name, AttrValue.of("x")), Map.of()));
+    }
+  }
+
+  @Test
+  void rejects_null_attr_name() {
+    // Map.of rejects null keys, so the null-name branch is only reachable via a HashMap.
+    Map<String, AttrValue> sets = new HashMap<>();
+    sets.put(null, AttrValue.of("x"));
+    assertMessageContains("blank", () -> MetadataAttrUpdates.validate(KEY, sets, Map.of()));
+  }
+
+  @Test
+  void rejects_null_attr_value_in_sets() {
+    Map<String, AttrValue> sets = new HashMap<>();
+    sets.put("a", null);
+    assertMessageContains("null value", () -> MetadataAttrUpdates.validate(KEY, sets, Map.of()));
+  }
+
+  @Test
+  void rejects_null_increment_amount() {
+    Map<String, Long> increments = new HashMap<>();
+    increments.put("n", null);
+    assertMessageContains(
+        "null value", () -> MetadataAttrUpdates.validate(KEY, Map.of(), increments));
+  }
+
+  private static void assertMessageContains(
+      String needle, org.junit.jupiter.api.function.Executable call) {
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, call);
+    assertTrue(
+        thrown.getMessage() != null && thrown.getMessage().contains(needle),
+        "expected message to contain \"" + needle + "\" but was: " + thrown.getMessage());
+  }
+}

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdatesTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/MetadataAttrUpdatesTest.java
@@ -70,16 +70,16 @@ public class MetadataAttrUpdatesTest {
   }
 
   @Test
-  void rejects_every_structural_attr_name_in_sets() {
-    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+  void rejects_every_reserved_attr_name_in_sets() {
+    for (String name : KvAttributes.RESERVED_ATTRS) {
       assertMessageContains(
           name, () -> MetadataAttrUpdates.validate(KEY, Map.of(name, AttrValue.of("x")), Map.of()));
     }
   }
 
   @Test
-  void rejects_every_structural_attr_name_in_increments() {
-    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+  void rejects_every_reserved_attr_name_in_increments() {
+    for (String name : KvAttributes.RESERVED_ATTRS) {
       assertMessageContains(
           name, () -> MetadataAttrUpdates.validate(KEY, Map.of(), Map.of(name, 1L)));
     }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -16,6 +16,7 @@
 package ai.floedb.floecat.storage.kv.dynamodb;
 
 import ai.floedb.floecat.storage.kv.AttrValue;
+import ai.floedb.floecat.storage.kv.AttrWriteRules;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.MetadataAttrUpdates;
@@ -157,6 +158,9 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   }
 
   private Map<String, AttributeValue> recordToAv(Record r) {
+    // The one place every write of a whole record passes through — putCas and txnWriteCas both
+    // serialize here, synchronously, before their request is built.
+    AttrWriteRules.checkExpiryIsString(r.attrs());
     var item = new HashMap<String, AttributeValue>();
     // Attrs first, structure second: Record's constructor already rejects structural attr names,
     // so this ordering is belt-and-braces — should that check ever gain a hole, the structural

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -110,10 +110,8 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     var out = new HashMap<String, AttrValue>();
     for (var e : item.entrySet()) {
       var k = e.getKey();
-      // Reserved names carry the backend's own meaning, so Record's constructor refuses them as
-      // attrs. Other writers do put them on rows, and skipping them here is what keeps such a read
-      // from turning into an exception. Derived from the set rather than listed out, so that a name
-      // added there — ATTR_TTL, say — cannot turn into a read that throws.
+      // Record's constructor refuses reserved names, but other writers do put them on rows;
+      // dropping them keeps such rows readable.
       if (KvAttributes.RESERVED_ATTRS.contains(k)) continue;
       var v = e.getValue();
       if (v.s() != null) {
@@ -122,12 +120,12 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
         try {
           out.put(k, AttrValue.of(Long.parseLong(v.n())));
         } catch (NumberFormatException ex) {
-          // DynamoDB's N is wider than a long and admits fractions. A foreign writer's value that
-          // does not fit degrades to its raw decimal text rather than vanishing from the record.
+          // N is wider than long and admits fractions; a value that does not fit degrades to its
+          // decimal text rather than vanishing from the record.
           out.put(k, AttrValue.of(v.n()));
         }
       }
-      // B/BOOL/M/L have no AttrValue representation and are dropped, as they always have been.
+      // B/BOOL/M/L have no AttrValue representation and are dropped.
     }
     return out;
   }
@@ -155,15 +153,12 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   }
 
   private Map<String, AttributeValue> recordToAv(Record r) {
-    // The one place every write of a whole record passes through — putCas and txnWriteCas both
-    // serialize here, synchronously, before their request is built.
+    // Every whole-record write (putCas and txnWriteCas) serializes here, before the request is
+    // built.
     AttrWriteRules.checkExpiryIsString(r.attrs());
     var item = new HashMap<String, AttributeValue>();
-    // Attrs first, structure second: Record's constructor already rejects reserved attr names, so
-    // this ordering is belt-and-braces — should that check ever gain a hole, the structural fields
-    // still win instead of being clobbered by an attr of the same name. Only the five it writes,
-    // though: ATTR_TTL is reserved too but never written here, so the constructor is its only
-    // guard.
+    // Attrs first, so the structural fields win if a reserved name ever slips past Record's
+    // constructor. ATTR_TTL is never written here, so the constructor is its only guard.
     item.putAll(attrsToAv(r.attrs()));
     item.put(ATTR_PARTITION_KEY, S(r.key().partitionKey()));
     item.put(ATTR_SORT_KEY, S(r.key().sortKey()));
@@ -332,12 +327,10 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
       addTerms.add("#a" + i + " :a" + i);
       i++;
     }
-    // ADD creates a missing attribute at the delta value, so a record with no stored version
-    // becomes version 1 — which is exactly the documented semantics.
+    // ADD creates a missing attribute at the delta, so a record with no stored version becomes 1.
     addTerms.add("#version :one");
 
-    // ADD always carries the version bump, but SET has no terms when the caller only asked for
-    // increments; a SET keyword with an empty clause is a ValidationException, so it is omitted.
+    // SET with an empty clause is a ValidationException, so it is omitted when there are no terms.
     var expr = new StringBuilder();
     if (!setTerms.isEmpty()) {
       expr.append("SET ").append(String.join(", ", setTerms)).append(' ');
@@ -359,17 +352,16 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
     return dynamo(client -> client.updateItem(req))
         .map(resp -> Optional.of(newVersionOf(resp)))
-        // Absent and refused are one and the same condition failure server-side; the SPI documents
-        // both as an empty result. Nothing else is recovered — a ValidationException (e.g. ADD on a
-        // string-typed attribute) must reach the caller.
+        // Absent and refused are the same condition failure server-side; both map to empty.
+        // Nothing else is recovered — a ValidationException (ADD on a string-typed attribute) must
+        // reach the caller.
         .onFailure(ConditionalCheckFailedException.class)
         .recoverWithItem(Optional.<Long>empty());
   }
 
   /**
-   * Reads the post-update version out of an {@code UPDATED_NEW} response. The version is always
-   * part of the update, so a missing or unparseable one is corruption, not absence, and must never
-   * be reported as an empty result.
+   * The post-update version from an {@code UPDATED_NEW} response; a missing or unparsable one is
+   * corruption, never absence.
    */
   private static long newVersionOf(UpdateItemResponse resp) {
     var v = resp.attributes() == null ? null : resp.attributes().get(ATTR_VERSION);

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -110,14 +110,11 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     var out = new HashMap<String, AttrValue>();
     for (var e : item.entrySet()) {
       var k = e.getKey();
-      // Structural names are the record's own fields, and Record's constructor now rejects them as
-      // attrs. Other writers do put them on rows, so skipping them here is what keeps such a read
-      // from turning into an exception.
-      if (k.equals(ATTR_PARTITION_KEY)
-          || k.equals(ATTR_SORT_KEY)
-          || k.equals(ATTR_KIND)
-          || k.equals(ATTR_VALUE)
-          || k.equals(ATTR_VERSION)) continue;
+      // Reserved names carry the backend's own meaning, so Record's constructor refuses them as
+      // attrs. Other writers do put them on rows, and skipping them here is what keeps such a read
+      // from turning into an exception. Derived from the set rather than listed out, so that a name
+      // added there — ATTR_TTL, say — cannot turn into a read that throws.
+      if (KvAttributes.RESERVED_ATTRS.contains(k)) continue;
       var v = e.getValue();
       if (v.s() != null) {
         out.put(k, AttrValue.of(v.s()));
@@ -162,9 +159,11 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     // serialize here, synchronously, before their request is built.
     AttrWriteRules.checkExpiryIsString(r.attrs());
     var item = new HashMap<String, AttributeValue>();
-    // Attrs first, structure second: Record's constructor already rejects structural attr names,
-    // so this ordering is belt-and-braces — should that check ever gain a hole, the structural
-    // fields still win instead of being clobbered by an attr of the same name.
+    // Attrs first, structure second: Record's constructor already rejects reserved attr names, so
+    // this ordering is belt-and-braces — should that check ever gain a hole, the structural fields
+    // still win instead of being clobbered by an attr of the same name. Only the five it writes,
+    // though: ATTR_TTL is reserved too but never written here, so the constructor is its only
+    // guard.
     item.putAll(attrsToAv(r.attrs()));
     item.put(ATTR_PARTITION_KEY, S(r.key().partitionKey()));
     item.put(ATTR_SORT_KEY, S(r.key().sortKey()));

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -15,8 +15,10 @@
  */
 package ai.floedb.floecat.storage.kv.dynamodb;
 
+import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
+import ai.floedb.floecat.storage.kv.MetadataAttrUpdates;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import java.nio.charset.StandardCharsets;
@@ -86,26 +88,48 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
     return Map.of(ATTR_PARTITION_KEY, S(k.partitionKey()), ATTR_SORT_KEY, S(k.sortKey()));
   }
 
-  private static Map<String, AttributeValue> attrsToAv(Map<String, String> attrs) {
+  /** A typed attr as its native DynamoDB type; {@code N} is what makes atomic ADD possible. */
+  private static AttributeValue attrToAv(AttrValue v) {
+    return switch (v) {
+      case AttrValue.StringValue s -> S(s.value());
+      case AttrValue.NumberValue n -> N(n.value());
+    };
+  }
+
+  private static Map<String, AttributeValue> attrsToAv(Map<String, AttrValue> attrs) {
     if (attrs == null || attrs.isEmpty()) return Map.of();
     var out = new HashMap<String, AttributeValue>(attrs.size());
     for (var e : attrs.entrySet()) {
-      out.put(e.getKey(), S(e.getValue()));
+      out.put(e.getKey(), attrToAv(e.getValue()));
     }
     return out;
   }
 
-  private static Map<String, String> avToAttrs(Map<String, AttributeValue> item) {
-    var out = new HashMap<String, String>();
+  private static Map<String, AttrValue> avToAttrs(Map<String, AttributeValue> item) {
+    var out = new HashMap<String, AttrValue>();
     for (var e : item.entrySet()) {
       var k = e.getKey();
+      // Structural names are the record's own fields, and Record's constructor now rejects them as
+      // attrs. Other writers do put them on rows, so skipping them here is what keeps such a read
+      // from turning into an exception.
       if (k.equals(ATTR_PARTITION_KEY)
           || k.equals(ATTR_SORT_KEY)
           || k.equals(ATTR_KIND)
           || k.equals(ATTR_VALUE)
           || k.equals(ATTR_VERSION)) continue;
       var v = e.getValue();
-      if (v.s() != null) out.put(k, v.s());
+      if (v.s() != null) {
+        out.put(k, AttrValue.of(v.s()));
+      } else if (v.n() != null) {
+        try {
+          out.put(k, AttrValue.of(Long.parseLong(v.n())));
+        } catch (NumberFormatException ex) {
+          // DynamoDB's N is wider than a long and admits fractions. A foreign writer's value that
+          // does not fit degrades to its raw decimal text rather than vanishing from the record.
+          out.put(k, AttrValue.of(v.n()));
+        }
+      }
+      // B/BOOL/M/L have no AttrValue representation and are dropped, as they always have been.
     }
     return out;
   }
@@ -134,6 +158,10 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
   private Map<String, AttributeValue> recordToAv(Record r) {
     var item = new HashMap<String, AttributeValue>();
+    // Attrs first, structure second: Record's constructor already rejects structural attr names,
+    // so this ordering is belt-and-braces — should that check ever gain a hole, the structural
+    // fields still win instead of being clobbered by an attr of the same name.
+    item.putAll(attrsToAv(r.attrs()));
     item.put(ATTR_PARTITION_KEY, S(r.key().partitionKey()));
     item.put(ATTR_SORT_KEY, S(r.key().sortKey()));
     item.put(ATTR_KIND, S(r.kind()));
@@ -142,7 +170,6 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
       item.put(ATTR_VALUE, B(r.value()));
     }
     item.put(ATTR_VERSION, N(r.version()));
-    item.putAll(attrsToAv(r.attrs()));
     return item;
   }
 
@@ -269,6 +296,90 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
         .replaceWith(true)
         .onFailure(ConditionalCheckFailedException.class)
         .recoverWithItem(false);
+  }
+
+  @Override
+  public Uni<Optional<Long>> updateMetadataAttrsIfExists(
+      Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
+    MetadataAttrUpdates.validate(key, sets, increments);
+
+    // Every attribute reaches the expression through a #placeholder: "value", "version" and
+    // "timestamp" are DynamoDB reserved words, and caller-supplied attr names may be too.
+    var names = new HashMap<String, String>();
+    names.put("#pk", ATTR_PARTITION_KEY);
+    names.put("#value", ATTR_VALUE);
+    names.put("#version", ATTR_VERSION);
+    var values = new HashMap<String, AttributeValue>();
+    values.put(":one", N(1L));
+
+    var setTerms = new ArrayList<String>(sets.size());
+    int i = 0;
+    for (var e : sets.entrySet()) {
+      names.put("#s" + i, e.getKey());
+      values.put(":s" + i, attrToAv(e.getValue()));
+      setTerms.add("#s" + i + " = :s" + i);
+      i++;
+    }
+
+    var addTerms = new ArrayList<String>(increments.size() + 1);
+    i = 0;
+    for (var e : increments.entrySet()) {
+      names.put("#a" + i, e.getKey());
+      values.put(":a" + i, N(e.getValue()));
+      addTerms.add("#a" + i + " :a" + i);
+      i++;
+    }
+    // ADD creates a missing attribute at the delta value, so a record with no stored version
+    // becomes version 1 — which is exactly the documented semantics.
+    addTerms.add("#version :one");
+
+    // ADD always carries the version bump, but SET has no terms when the caller only asked for
+    // increments; a SET keyword with an empty clause is a ValidationException, so it is omitted.
+    var expr = new StringBuilder();
+    if (!setTerms.isEmpty()) {
+      expr.append("SET ").append(String.join(", ", setTerms)).append(' ');
+    }
+    expr.append("ADD ").append(String.join(", ", addTerms));
+
+    var req =
+        UpdateItemRequest.builder()
+            .tableName(table)
+            .key(keyMap(key))
+            .updateExpression(expr.toString())
+            // attribute_not_exists(#value) is the attrs-only guard: a value-carrying record keeps a
+            // copy of its version inside the serialized payload, which this update cannot rewrite.
+            .conditionExpression("attribute_exists(#pk) AND attribute_not_exists(#value)")
+            .expressionAttributeNames(names)
+            .expressionAttributeValues(values)
+            .returnValues(ReturnValue.UPDATED_NEW)
+            .build();
+
+    return dynamo(client -> client.updateItem(req))
+        .map(resp -> Optional.of(newVersionOf(resp)))
+        // Absent and refused are one and the same condition failure server-side; the SPI documents
+        // both as an empty result. Nothing else is recovered — a ValidationException (e.g. ADD on a
+        // string-typed attribute) must reach the caller.
+        .onFailure(ConditionalCheckFailedException.class)
+        .recoverWithItem(Optional.<Long>empty());
+  }
+
+  /**
+   * Reads the post-update version out of an {@code UPDATED_NEW} response. The version is always
+   * part of the update, so a missing or unparseable one is corruption, not absence, and must never
+   * be reported as an empty result.
+   */
+  private static long newVersionOf(UpdateItemResponse resp) {
+    var v = resp.attributes() == null ? null : resp.attributes().get(ATTR_VERSION);
+    if (v == null || v.n() == null) {
+      throw new IllegalStateException(
+          "UpdateItem returned no numeric " + ATTR_VERSION + " attribute: " + resp.attributes());
+    }
+    try {
+      return Long.parseLong(v.n());
+    } catch (NumberFormatException e) {
+      throw new IllegalStateException(
+          "UpdateItem returned a non-integral " + ATTR_VERSION + ": " + v.n(), e);
+    }
   }
 
   // ---- Query

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -151,8 +151,8 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
     }
     var expiresAt = r.attrs().get(ATTR_EXPIRES_AT);
     if (expiresAt != null) {
-      // Accepts both the legacy string form and the native numeric one; a present but malformed
-      // stamp throws, so corrupt expiry data cannot read as "no expiry".
+      // String or numeric form both decode; a malformed stamp throws rather than reading as
+      // "no expiry".
       builder.setExpiresAt(Timestamps.fromMillis(expiresAt.asLong() * 1000L));
     }
     String rid = AttrValue.stringOr(r.attrs(), ATTR_RESOURCE_ID, null);
@@ -255,9 +255,8 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
         var attrs = attrsFor(upsert.next());
         if (upsert.next().hasExpiresAt()) {
           long ttl = Timestamps.toMillis(upsert.next().getExpiresAt()) / 1000L;
-          // Written as a string, not a number: an older replica's read path drops non-string
-          // attrs, and its next write of this record would then persist it without an expiry at
-          // all.
+          // String, not number: an older replica drops non-string attrs on read and would then
+          // rewrite the record without its expiry (see AttrWriteRules).
           attrs.put(ATTR_EXPIRES_AT, AttrValue.of(Long.toString(ttl)));
         }
         var rec =

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -20,6 +20,7 @@ import ai.floedb.floecat.common.rpc.PointerReferenceKind;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.storage.kv.AbstractEntity;
+import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.KvStore.Key;
 import ai.floedb.floecat.storage.kv.cdi.KvTable;
@@ -138,9 +139,9 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
     var builder =
         Pointer.newBuilder()
             .setKey(keyOf(r.key()))
-            .setBlobUri(r.attrs().getOrDefault(ATTR_BLOB_URI, ""))
+            .setBlobUri(AttrValue.stringOr(r.attrs(), ATTR_BLOB_URI, ""))
             .setVersion(r.version());
-    String referenceKind = r.attrs().get(ATTR_REFERENCE_KIND);
+    String referenceKind = AttrValue.stringOr(r.attrs(), ATTR_REFERENCE_KIND, null);
     if (referenceKind != null && !referenceKind.isBlank()) {
       try {
         builder.setReferenceKind(PointerReferenceKind.valueOf(referenceKind));
@@ -148,13 +149,12 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
         // Preserve legacy behavior for unknown values by leaving the kind unspecified.
       }
     }
-    var expiresAtStr = r.attrs().get(ATTR_EXPIRES_AT);
-    if (expiresAtStr != null) {
-      long ts = Long.parseLong(expiresAtStr);
+    long ts = AttrValue.longOr(r.attrs(), ATTR_EXPIRES_AT, 0L);
+    if (ts > 0) {
       builder.setExpiresAt(Timestamps.fromMillis(ts * 1000L));
     }
-    String rid = r.attrs().get(ATTR_RESOURCE_ID);
-    String rkStr = r.attrs().get(ATTR_RESOURCE_KIND);
+    String rid = AttrValue.stringOr(r.attrs(), ATTR_RESOURCE_ID, null);
+    String rkStr = AttrValue.stringOr(r.attrs(), ATTR_RESOURCE_KIND, null);
     if (rid != null && rkStr != null) {
       try {
         String pk = r.key().partitionKey();
@@ -170,7 +170,7 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
       } catch (IllegalArgumentException ignored) {
       }
     }
-    String dn = r.attrs().get(ATTR_DISPLAY_NAME);
+    String dn = AttrValue.stringOr(r.attrs(), ATTR_DISPLAY_NAME, null);
     if (dn != null && !dn.isEmpty()) {
       builder.setDisplayName(dn);
     }
@@ -253,7 +253,10 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
         var attrs = attrsFor(upsert.next());
         if (upsert.next().hasExpiresAt()) {
           long ttl = Timestamps.toMillis(upsert.next().getExpiresAt()) / 1000L;
-          attrs.put(ATTR_EXPIRES_AT, Long.toString(ttl));
+          // Written as a string, not a number: an older replica's read path drops non-string
+          // attrs, and its next write of this record would then persist it without an expiry at
+          // all.
+          attrs.put(ATTR_EXPIRES_AT, AttrValue.of(Long.toString(ttl)));
         }
         var rec =
             new KvStore.Record(
@@ -270,18 +273,18 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
     return kv.txnWriteCas(txOps);
   }
 
-  private static HashMap<String, String> attrsFor(Pointer pointer) {
-    var attrs = new HashMap<String, String>();
-    attrs.put(ATTR_BLOB_URI, pointer.getBlobUri());
+  private static HashMap<String, AttrValue> attrsFor(Pointer pointer) {
+    var attrs = new HashMap<String, AttrValue>();
+    attrs.put(ATTR_BLOB_URI, AttrValue.of(pointer.getBlobUri()));
     if (pointer.getReferenceKind() != PointerReferenceKind.PRK_UNSPECIFIED) {
-      attrs.put(ATTR_REFERENCE_KIND, pointer.getReferenceKind().name());
+      attrs.put(ATTR_REFERENCE_KIND, AttrValue.of(pointer.getReferenceKind().name()));
     }
     if (pointer.hasResourceId() && !pointer.getResourceId().getId().isEmpty()) {
-      attrs.put(ATTR_RESOURCE_ID, pointer.getResourceId().getId());
-      attrs.put(ATTR_RESOURCE_KIND, pointer.getResourceId().getKind().name());
+      attrs.put(ATTR_RESOURCE_ID, AttrValue.of(pointer.getResourceId().getId()));
+      attrs.put(ATTR_RESOURCE_KIND, AttrValue.of(pointer.getResourceId().getKind().name()));
     }
     if (!pointer.getDisplayName().isEmpty()) {
-      attrs.put(ATTR_DISPLAY_NAME, pointer.getDisplayName());
+      attrs.put(ATTR_DISPLAY_NAME, AttrValue.of(pointer.getDisplayName()));
     }
     return attrs;
   }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -149,9 +149,11 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
         // Preserve legacy behavior for unknown values by leaving the kind unspecified.
       }
     }
-    long ts = AttrValue.longOr(r.attrs(), ATTR_EXPIRES_AT, 0L);
-    if (ts > 0) {
-      builder.setExpiresAt(Timestamps.fromMillis(ts * 1000L));
+    var expiresAt = r.attrs().get(ATTR_EXPIRES_AT);
+    if (expiresAt != null) {
+      // Accepts both the legacy string form and the native numeric one; a present but malformed
+      // stamp throws, so corrupt expiry data cannot read as "no expiry".
+      builder.setExpiresAt(Timestamps.fromMillis(expiresAt.asLong() * 1000L));
     }
     String rid = AttrValue.stringOr(r.attrs(), ATTR_RESOURCE_ID, null);
     String rkStr = AttrValue.stringOr(r.attrs(), ATTR_RESOURCE_KIND, null);

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
@@ -344,10 +344,8 @@ public class DynamoDbKvStoreTest {
 
   @Test
   void reserved_attr_written_out_of_band_is_dropped_rather_than_failing_the_read() {
-    // ATTR_TTL is reserved because DynamoDB expires rows by it, and this store never writes it — so
-    // the only way a row carries one is another writer, and that row still has to be readable.
-    // Record's constructor rejects reserved names, so the decode has to drop it; letting it through
-    // would turn a foreign row into a read that throws.
+    // Only a foreign writer can put a reserved name like ttl on a row; the row must stay readable,
+    // and Record's constructor rejects reserved names, so the decode has to drop it.
     FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
     DynamoDbKvStore store = newStore(handler);
 

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
@@ -343,6 +343,37 @@ public class DynamoDbKvStoreTest {
   }
 
   @Test
+  void reserved_attr_written_out_of_band_is_dropped_rather_than_failing_the_read() {
+    // ATTR_TTL is reserved because DynamoDB expires rows by it, and this store never writes it — so
+    // the only way a row carries one is another writer, and that row still has to be readable.
+    // Record's constructor rejects reserved names, so the decode has to drop it; letting it through
+    // would turn a foreign row into a read that throws.
+    FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
+    DynamoDbKvStore store = newStore(handler);
+
+    Map<String, AttributeValue> item =
+        Map.of(
+            KvAttributes.ATTR_PARTITION_KEY,
+            AttributeValue.builder().s("pk").build(),
+            KvAttributes.ATTR_SORT_KEY,
+            AttributeValue.builder().s("sk").build(),
+            KvAttributes.ATTR_KIND,
+            AttributeValue.builder().s("K").build(),
+            KvAttributes.ATTR_VERSION,
+            AttributeValue.builder().n("4").build(),
+            KvAttributes.ATTR_TTL,
+            AttributeValue.builder().n("4321").build(),
+            "user",
+            AttributeValue.builder().s("ok").build());
+    handler.items.put(FakeDynamoDbHandler.keyFromItem(item), item);
+
+    KvStore.Record got = store.get(key("pk", "sk")).await().indefinitely().orElseThrow();
+    assertFalse(got.attrs().containsKey(KvAttributes.ATTR_TTL));
+    assertEquals(AttrValue.of("ok"), got.attrs().get("user"));
+    assertEquals(4L, got.version());
+  }
+
+  @Test
   void encodeToken_empty_returns_empty_optional() throws Exception {
     Optional<String> token = DynamoDbKvStore.encodeToken(Map.of());
     assertTrue(token.isEmpty());

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
@@ -17,6 +17,7 @@ package ai.floedb.floecat.storage.kv.dynamodb;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
 import java.lang.reflect.InvocationHandler;
@@ -131,12 +132,12 @@ public class DynamoDbKvStoreTest {
     FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
     DynamoDbKvStore store = newStore(handler);
 
-    KvStore.Record record = record("pk", "sk", "K", "v1", 3L, Map.of("foo", "bar"));
+    KvStore.Record record = record("pk", "sk", "K", "v1", 3L, Map.of("foo", AttrValue.of("bar")));
     assertTrue(store.putCas(record, 0L).await().indefinitely());
 
     KvStore.Record got = store.get(key("pk", "sk")).await().indefinitely().orElseThrow();
     assertEquals(3L, got.version());
-    assertEquals("bar", got.attrs().get("foo"));
+    assertEquals(AttrValue.of("bar"), got.attrs().get("foo"));
   }
 
   @Test
@@ -327,13 +328,13 @@ public class DynamoDbKvStoreTest {
     FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
     DynamoDbKvStore store = newStore(handler);
 
-    Map<String, String> attrs = Map.of("user", "ok");
+    Map<String, AttrValue> attrs = Map.of("user", AttrValue.of("ok"));
 
     KvStore.Record record = record("pk", "sk", "K", "v1", 1L, attrs);
     assertTrue(store.putCas(record, 0L).await().indefinitely());
 
     KvStore.Record got = store.get(key("pk", "sk")).await().indefinitely().orElseThrow();
-    assertEquals("ok", got.attrs().get("user"));
+    assertEquals(AttrValue.of("ok"), got.attrs().get("user"));
     assertFalse(got.attrs().containsKey(KvAttributes.ATTR_PARTITION_KEY));
     assertFalse(got.attrs().containsKey(KvAttributes.ATTR_SORT_KEY));
     assertFalse(got.attrs().containsKey(KvAttributes.ATTR_KIND));
@@ -763,7 +764,7 @@ public class DynamoDbKvStoreTest {
   }
 
   private static KvStore.Record record(
-      String pk, String sk, String kind, String value, long version, Map<String, String> attrs) {
+      String pk, String sk, String kind, String value, long version, Map<String, AttrValue> attrs) {
     return new KvStore.Record(
         new KvStore.Key(pk, sk), kind, value.getBytes(StandardCharsets.UTF_8), attrs, version);
   }

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.cdi.KvTable;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -285,6 +286,24 @@ public class KvStoreContractTest {
     assertEquals(AttrValue.of("new"), got.attrs().get("target"));
     assertEquals(AttrValue.of(8L), got.attrs().get("hits"));
     assertEquals(AttrValue.of("stay"), got.attrs().get("keep"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_applies_once_however_often_the_uni_is_subscribed() {
+    // The UpdateItem is already in flight by the time the Uni is returned, so subscribing twice
+    // observes one update rather than issuing a second one. Mirrored in the in-memory contract
+    // test, where the same guarantee has to be arranged by hand.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(0L))), 0L).await().indefinitely());
+
+    Uni<Optional<Long>> update = kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L));
+    assertEquals(Optional.of(2L), update.await().indefinitely());
+    assertEquals(Optional.of(2L), update.await().indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(2L, got.version());
+    assertEquals(AttrValue.of(1L), got.attrs().get("hits"));
   }
 
   @Test

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
@@ -155,8 +155,7 @@ public class KvStoreContractTest {
 
   @Test
   void putCas_rejects_numeric_expiry_stamp() {
-    // Written as N, the stamp is invisible to a replica that predates typed attributes, whose next
-    // whole-record write then drops the expiry for good. Rule and reason: AttrWriteRules.
+    // Rule and reason: AttrWriteRules.
     KvStore.Key k = key("pk1", "ttl");
     assertThrows(
         IllegalArgumentException.class,
@@ -195,9 +194,7 @@ public class KvStoreContractTest {
 
   @Test
   void numeric_expiry_stamp_written_out_of_band_stays_readable() {
-    // Writes are strict, reads are not: a foreign writer's N-typed stamp must still decode, which
-    // is
-    // the whole reason AttrValue.asLong accepts both forms.
+    // Writes are strict, reads are not: a foreign writer's N-typed stamp must still decode.
     Map<String, AttributeValue> item = rawItem("pk1", "foreign-ttl");
     item.put(KvAttributes.ATTR_VERSION, AttributeValue.fromN("1"));
     item.put(KvAttributes.ATTR_EXPIRES_AT, AttributeValue.fromN("4321"));
@@ -291,8 +288,7 @@ public class KvStoreContractTest {
   @Test
   void updateMetadataAttrsIfExists_applies_once_however_often_the_uni_is_subscribed() {
     // The UpdateItem is already in flight by the time the Uni is returned, so subscribing twice
-    // observes one update rather than issuing a second one. Mirrored in the in-memory contract
-    // test, where the same guarantee has to be arranged by hand.
+    // observes one update rather than issuing a second one.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(0L))), 0L).await().indefinitely());
@@ -325,11 +321,9 @@ public class KvStoreContractTest {
 
   @Test
   void updateMetadataAttrsIfExists_increment_past_long_max_does_not_wrap() {
-    // The counterpart to the in-memory store's ArithmeticException, and deliberately not the same
-    // outcome. ADD is server-side arbitrary precision, so DynamoDB stores the true sum instead of
-    // wrapping; the narrowing is what fails, on the way back out. The shared guarantee is only that
-    // neither store ever reports success while holding a wrapped value — the in-memory store is the
-    // stricter of the two, so a caller it rejects is never one this store would have mangled.
+    // Deliberately not the in-memory ArithmeticException: ADD is server-side arbitrary precision,
+    // so DynamoDB stores the true sum and the narrowing fails on the way back out. Neither store
+    // ever reports success while holding a wrapped value.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(Long.MAX_VALUE))), 0L)
@@ -342,8 +336,8 @@ public class KvStoreContractTest {
 
     KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
     AttrValue hits = got.attrs().get("hits");
-    // Not wrapped, and not silently narrowed: the row holds a number no long can express, so the
-    // decoder keeps it as text and asLong refuses it rather than inventing a value.
+    // The row holds a number no long can express; the decoder keeps it as text and asLong refuses
+    // it rather than inventing a value.
     assertNotEquals(AttrValue.of(Long.MIN_VALUE), hits);
     assertNotEquals(AttrValue.of(Long.MAX_VALUE), hits);
     assertThrows(NumberFormatException.class, hits::asLong);
@@ -394,7 +388,7 @@ public class KvStoreContractTest {
   @Test
   void updateMetadataAttrsIfExists_version_0_record_becomes_version_1() {
     // putCas refuses a record at version 0, so the row is planted directly. A stored 0 and a
-    // missing version attribute are the same starting point per the SPI, so both are checked.
+    // missing version attribute are the same starting point, so both are checked.
     Map<String, AttributeValue> zero = rawItem("pk1", "zero");
     zero.put(KvAttributes.ATTR_VERSION, AttributeValue.fromN("0"));
     putRawItem(zero);
@@ -421,8 +415,8 @@ public class KvStoreContractTest {
 
   @Test
   void updateMetadataAttrsIfExists_sets_only_works() {
-    // The branch where the update expression must carry SET but omit nothing else; an empty ADD
-    // or SET clause is a DynamoDB ValidationException.
+    // The branch where the update expression carries a SET clause; an empty one would be a
+    // ValidationException.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("target", AttrValue.of("old"))), 0L)
@@ -492,10 +486,9 @@ public class KvStoreContractTest {
 
   @Test
   void updateMetadataAttrsIfExists_increment_of_string_attr_fails() {
-    // DynamoDB's ADD on an S-typed attribute is a server-side ValidationException, which the SDK
-    // does not model, so it arrives as a plain DynamoDbException. The in-memory store has the
-    // stored AttrValue in hand and throws IllegalStateException instead — hence the two contract
-    // tests assert different exception types for this case by design.
+    // ADD on an S-typed attribute is a server-side ValidationException the SDK does not model, so
+    // it arrives as a plain DynamoDbException; the in-memory store throws IllegalStateException
+    // instead, so the two contract tests assert different types by design.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of("abc"))), 0L)
@@ -509,8 +502,7 @@ public class KvStoreContractTest {
                 kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L))
                     .await()
                     .indefinitely());
-    // Must not be the one failure the store recovers into an empty result: a type error is not
-    // "the record was absent".
+    // A type error is not "the record was absent" — it must not recover into an empty result.
     assertFalse(thrown instanceof ConditionalCheckFailedException);
 
     // Never silently overwritten, and the version bump in the same request did not land either.
@@ -563,8 +555,8 @@ public class KvStoreContractTest {
 
   @Test
   void number_attr_round_trips_and_stays_visible_on_read() {
-    // The read path used to drop every non-string attribute type; a NumberValue written through
-    // putCas must come back as a NumberValue, not vanish.
+    // A NumberValue written through putCas must come back as a NumberValue, not vanish or turn
+    // into a string.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
@@ -17,19 +17,29 @@ package ai.floedb.floecat.storage.kv.dynamodb;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import ai.floedb.floecat.storage.kv.AttrValue;
+import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.cdi.KvTable;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 
 @QuarkusTest
 @TestProfile(DynamoDbKvTestProfile.class)
@@ -39,6 +49,12 @@ public class KvStoreContractTest {
   @Inject
   @KvTable("floecat")
   KvStore kv;
+
+  /** Used only to plant rows the KvStore API cannot express (no version, raw attribute types). */
+  @Inject DynamoDbAsyncClient ddb;
+
+  @ConfigProperty(name = "floecat.kv.table")
+  String kvTable;
 
   @BeforeEach
   void resetTable() {
@@ -186,11 +202,315 @@ public class KvStoreContractTest {
                 .indefinitely());
   }
 
+  @Test
+  void updateMetadataAttrsIfExists_sets_and_increments_and_bumps_version() {
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(
+                attrsRecord(
+                    k,
+                    1L,
+                    Map.of(
+                        "target", AttrValue.of("old"),
+                        "hits", AttrValue.of(5L),
+                        "keep", AttrValue.of("stay"))),
+                0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of("target", AttrValue.of("new")), Map.of("hits", 3L))
+            .await()
+            .indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(2L, got.version());
+    assertEquals(AttrValue.of("new"), got.attrs().get("target"));
+    assertEquals(AttrValue.of(8L), got.attrs().get("hits"));
+    assertEquals(AttrValue.of("stay"), got.attrs().get("keep"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increment_of_absent_attr_creates_it_at_the_delta() {
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("keep", AttrValue.of("stay"))), 0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("misses", 4L)).await().indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(AttrValue.of(4L), got.attrs().get("misses"));
+    assertEquals(AttrValue.of("stay"), got.attrs().get("keep"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_absent_key_returns_empty_and_creates_nothing() {
+    KvStore.Key k = key("pk1", "ghost");
+
+    assertTrue(
+        kv.updateMetadataAttrsIfExists(k, Map.of("target", AttrValue.of("t")), Map.of("hits", 1L))
+            .await()
+            .indefinitely()
+            .isEmpty());
+
+    // No ghost row: the update must never create the record as a side effect.
+    assertTrue(kv.get(k).await().indefinitely().isEmpty());
+    assertTrue(kv.isEmpty().await().indefinitely());
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_refuses_value_carrying_record_and_leaves_it_untouched() {
+    // A value payload embeds its own copy of the version, which this update does not rewrite, so
+    // the whole record must be refused rather than partially advanced.
+    KvStore.Key k = key("pk1", "sk1");
+    KvStore.Record stored =
+        new KvStore.Record(
+            k,
+            "KIND",
+            "payload".getBytes(StandardCharsets.UTF_8),
+            Map.of("target", AttrValue.of("old"), "hits", AttrValue.of(5L)),
+            1L);
+    assertTrue(kv.putCas(stored, 0L).await().indefinitely());
+
+    assertTrue(
+        kv.updateMetadataAttrsIfExists(k, Map.of("target", AttrValue.of("new")), Map.of("hits", 1L))
+            .await()
+            .indefinitely()
+            .isEmpty());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of("old"), got.attrs().get("target"));
+    assertEquals(AttrValue.of(5L), got.attrs().get("hits"));
+    assertEquals("payload", new String(got.value(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_version_0_record_becomes_version_1() {
+    // putCas refuses a record at version 0, so the row is planted directly. A stored 0 and a
+    // missing version attribute are the same starting point per the SPI, so both are checked.
+    Map<String, AttributeValue> zero = rawItem("pk1", "zero");
+    zero.put(KvAttributes.ATTR_VERSION, AttributeValue.fromN("0"));
+    putRawItem(zero);
+
+    assertEquals(
+        Optional.of(1L),
+        kv.updateMetadataAttrsIfExists(key("pk1", "zero"), Map.of(), Map.of("hits", 1L))
+            .await()
+            .indefinitely());
+
+    KvStore.Record got = kv.get(key("pk1", "zero")).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of(1L), got.attrs().get("hits"));
+
+    putRawItem(rawItem("pk1", "noversion"));
+    assertEquals(
+        Optional.of(1L),
+        kv.updateMetadataAttrsIfExists(key("pk1", "noversion"), Map.of(), Map.of("hits", 1L))
+            .await()
+            .indefinitely());
+    assertEquals(
+        1L, kv.get(key("pk1", "noversion")).await().indefinitely().orElseThrow().version());
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_sets_only_works() {
+    // The branch where the update expression must carry SET but omit nothing else; an empty ADD
+    // or SET clause is a DynamoDB ValidationException.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("target", AttrValue.of("old"))), 0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(
+                k, Map.of("target", AttrValue.of("new"), "extra", AttrValue.of(9L)), Map.of())
+            .await()
+            .indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(2L, got.version());
+    assertEquals(AttrValue.of("new"), got.attrs().get("target"));
+    assertEquals(AttrValue.of(9L), got.attrs().get("extra"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increments_only_works() {
+    // The branch where the SET clause must be omitted entirely.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(10L))), 0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 5L, "misses", 2L))
+            .await()
+            .indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(2L, got.version());
+    assertEquals(AttrValue.of(15L), got.attrs().get("hits"));
+    assertEquals(AttrValue.of(2L), got.attrs().get("misses"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_rejects_empty_updates() {
+    // No await(): validation must throw synchronously rather than produce a failed Uni.
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> kv.updateMetadataAttrsIfExists(key("pk1", "meta"), Map.of(), Map.of()));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_rejects_structural_attr_names_in_sets() {
+    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+      Map<String, AttrValue> sets = Map.of(name, AttrValue.of("x"));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> kv.updateMetadataAttrsIfExists(key("pk1", "meta"), sets, Map.of()));
+    }
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_rejects_attr_that_is_both_set_and_incremented() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            kv.updateMetadataAttrsIfExists(
+                key("pk1", "meta"), Map.of("hits", AttrValue.of(1L)), Map.of("hits", 1L)));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increment_of_string_attr_fails() {
+    // DynamoDB's ADD on an S-typed attribute is a server-side ValidationException, which the SDK
+    // does not model, so it arrives as a plain DynamoDbException. The in-memory store has the
+    // stored AttrValue in hand and throws IllegalStateException instead — hence the two contract
+    // tests assert different exception types for this case by design.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of("abc"))), 0L)
+            .await()
+            .indefinitely());
+
+    DynamoDbException thrown =
+        assertThrows(
+            DynamoDbException.class,
+            () ->
+                kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L))
+                    .await()
+                    .indefinitely());
+    // Must not be the one failure the store recovers into an empty result: a type error is not
+    // "the record was absent".
+    assertFalse(thrown instanceof ConditionalCheckFailedException);
+
+    // Never silently overwritten, and the version bump in the same request did not land either.
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of("abc"), got.attrs().get("hits"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increment_of_numeric_looking_string_attr_fails() {
+    // "42" parses fine, but ADD rejects the S type regardless of its content.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of("42"))), 0L)
+            .await()
+            .indefinitely());
+
+    assertThrows(
+        DynamoDbException.class,
+        () ->
+            kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L)).await().indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of("42"), got.attrs().get("hits"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_version_bump_is_visible_to_putCas() {
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(1L))), 0L).await().indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L)).await().indefinitely());
+
+    // A writer that read the record before the metadata bump must be rejected...
+    assertFalse(
+        kv.putCas(attrsRecord(k, 2L, Map.of("hits", AttrValue.of(99L))), 1L)
+            .await()
+            .indefinitely());
+    // ...and one that re-read afterwards must succeed.
+    assertTrue(
+        kv.putCas(attrsRecord(k, 3L, Map.of("hits", AttrValue.of(99L))), 2L)
+            .await()
+            .indefinitely());
+    assertEquals(3L, kv.get(k).await().indefinitely().orElseThrow().version());
+  }
+
+  @Test
+  void number_attr_round_trips_and_stays_visible_on_read() {
+    // The read path used to drop every non-string attribute type; a NumberValue written through
+    // putCas must come back as a NumberValue, not vanish.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(
+                attrsRecord(k, 1L, Map.of("hits", AttrValue.of(7L), "target", AttrValue.of("t"))),
+                0L)
+            .await()
+            .indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertInstanceOf(AttrValue.NumberValue.class, got.attrs().get("hits"));
+    assertEquals(AttrValue.of(7L), got.attrs().get("hits"));
+    assertEquals(7L, got.attrs().get("hits").asLong().orElseThrow());
+    assertEquals(AttrValue.of("t"), got.attrs().get("target"));
+  }
+
+  @Test
+  void raw_numeric_and_string_attributes_read_back_with_their_native_types() {
+    // Written out-of-band so the native DynamoDB type, not this store's writer, decides the type.
+    Map<String, AttributeValue> item = rawItem("pk1", "raw");
+    item.put(KvAttributes.ATTR_VERSION, AttributeValue.fromN("3"));
+    item.put("nativeNumber", AttributeValue.fromN("42"));
+    item.put("nativeString", AttributeValue.fromS("42"));
+    putRawItem(item);
+
+    KvStore.Record got = kv.get(key("pk1", "raw")).await().indefinitely().orElseThrow();
+    assertEquals(3L, got.version());
+    assertEquals(new AttrValue.NumberValue(42L), got.attrs().get("nativeNumber"));
+    assertEquals(new AttrValue.StringValue("42"), got.attrs().get("nativeString"));
+  }
+
   private void putSeries(String pk, String skPrefix, int count) {
     for (int i = 0; i < count; i++) {
       KvStore.Record rec = record(pk, skPrefix + i, 1L, "v" + i);
       assertTrue(kv.putCas(rec, 0L).await().indefinitely());
     }
+  }
+
+  private void putRawItem(Map<String, AttributeValue> item) {
+    ddb.putItem(PutItemRequest.builder().tableName(kvTable).item(item).build()).join();
+  }
+
+  private static Map<String, AttributeValue> rawItem(String pk, String sk) {
+    Map<String, AttributeValue> item = new HashMap<>();
+    item.put(KvAttributes.ATTR_PARTITION_KEY, AttributeValue.fromS(pk));
+    item.put(KvAttributes.ATTR_SORT_KEY, AttributeValue.fromS(sk));
+    item.put(KvAttributes.ATTR_KIND, AttributeValue.fromS("META"));
+    return item;
   }
 
   private static KvStore.Key key(String pk, String sk) {
@@ -200,5 +520,10 @@ public class KvStoreContractTest {
   private static KvStore.Record record(String pk, String sk, long version, String value) {
     return new KvStore.Record(
         key(pk, sk), "KIND", value.getBytes(StandardCharsets.UTF_8), null, version);
+  }
+
+  private static KvStore.Record attrsRecord(
+      KvStore.Key key, long version, Map<String, AttrValue> attrs) {
+    return new KvStore.Record(key, "META", new byte[0], attrs, version);
   }
 }

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
@@ -305,6 +305,32 @@ public class KvStoreContractTest {
   }
 
   @Test
+  void updateMetadataAttrsIfExists_increment_past_long_max_does_not_wrap() {
+    // The counterpart to the in-memory store's ArithmeticException, and deliberately not the same
+    // outcome. ADD is server-side arbitrary precision, so DynamoDB stores the true sum instead of
+    // wrapping; the narrowing is what fails, on the way back out. The shared guarantee is only that
+    // neither store ever reports success while holding a wrapped value — the in-memory store is the
+    // stricter of the two, so a caller it rejects is never one this store would have mangled.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(Long.MAX_VALUE))), 0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L)).await().indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    AttrValue hits = got.attrs().get("hits");
+    // Not wrapped, and not silently narrowed: the row holds a number no long can express, so the
+    // decoder keeps it as text and asLong refuses it rather than inventing a value.
+    assertNotEquals(AttrValue.of(Long.MIN_VALUE), hits);
+    assertNotEquals(AttrValue.of(Long.MAX_VALUE), hits);
+    assertThrows(NumberFormatException.class, hits::asLong);
+  }
+
+  @Test
   void updateMetadataAttrsIfExists_absent_key_returns_empty_and_creates_nothing() {
     KvStore.Key k = key("pk1", "ghost");
 

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
@@ -427,8 +427,8 @@ public class KvStoreContractTest {
   }
 
   @Test
-  void updateMetadataAttrsIfExists_rejects_structural_attr_names_in_sets() {
-    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+  void updateMetadataAttrsIfExists_rejects_reserved_attr_names_in_sets() {
+    for (String name : KvAttributes.RESERVED_ATTRS) {
       Map<String, AttrValue> sets = Map.of(name, AttrValue.of("x"));
       assertThrows(
           IllegalArgumentException.class,

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 
 @QuarkusTest
@@ -149,6 +150,61 @@ public class KvStoreContractTest {
     assertFalse(kv.txnWriteCas(ops).await().indefinitely());
     assertTrue(kv.get(key("pk1", "sk1")).await().indefinitely().isPresent());
     assertTrue(kv.get(key("pk1", "sk2")).await().indefinitely().isEmpty());
+  }
+
+  @Test
+  void putCas_rejects_numeric_expiry_stamp() {
+    // Written as N, the stamp is invisible to a replica that predates typed attributes, whose next
+    // whole-record write then drops the expiry for good. Rule and reason: AttrWriteRules.
+    KvStore.Key k = key("pk1", "ttl");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            kv.putCas(
+                attrsRecord(k, 1L, Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of(2L))), 0L));
+    assertTrue(kv.get(k).await().indefinitely().isEmpty());
+  }
+
+  @Test
+  void putCas_accepts_string_expiry_stamp_and_stores_it_as_S() {
+    KvStore.Key k = key("pk1", "ttl-ok");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of("2"))), 0L)
+            .await()
+            .indefinitely());
+
+    Map<String, AttributeValue> raw = getRawItem("pk1", "ttl-ok");
+    assertEquals("2", raw.get(KvAttributes.ATTR_EXPIRES_AT).s());
+    assertNull(raw.get(KvAttributes.ATTR_EXPIRES_AT).n());
+  }
+
+  @Test
+  void txnWriteCas_rejects_numeric_expiry_stamp_before_issuing_the_transaction() {
+    var ops =
+        List.<KvStore.TxnOp>of(
+            new KvStore.TxnPut(record("pk1", "sk1", 1L, "v1"), 0L),
+            new KvStore.TxnPut(
+                attrsRecord(
+                    key("pk1", "ttl"), 1L, Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of(2L))),
+                0L));
+
+    assertThrows(IllegalArgumentException.class, () -> kv.txnWriteCas(ops).await().indefinitely());
+    assertTrue(kv.get(key("pk1", "sk1")).await().indefinitely().isEmpty());
+  }
+
+  @Test
+  void numeric_expiry_stamp_written_out_of_band_stays_readable() {
+    // Writes are strict, reads are not: a foreign writer's N-typed stamp must still decode, which
+    // is
+    // the whole reason AttrValue.asLong accepts both forms.
+    Map<String, AttributeValue> item = rawItem("pk1", "foreign-ttl");
+    item.put(KvAttributes.ATTR_VERSION, AttributeValue.fromN("1"));
+    item.put(KvAttributes.ATTR_EXPIRES_AT, AttributeValue.fromN("4321"));
+    putRawItem(item);
+
+    KvStore.Record got = kv.get(key("pk1", "foreign-ttl")).await().indefinitely().orElseThrow();
+    assertEquals(AttrValue.of(4321L), got.attrs().get(KvAttributes.ATTR_EXPIRES_AT));
+    assertEquals(4321L, got.attrs().get(KvAttributes.ATTR_EXPIRES_AT).asLong());
   }
 
   @Test
@@ -503,6 +559,24 @@ public class KvStoreContractTest {
 
   private void putRawItem(Map<String, AttributeValue> item) {
     ddb.putItem(PutItemRequest.builder().tableName(kvTable).item(item).build()).join();
+  }
+
+  /**
+   * The stored item with its native DynamoDB types, for assertions this store's reader would hide.
+   */
+  private Map<String, AttributeValue> getRawItem(String pk, String sk) {
+    return ddb.getItem(
+            GetItemRequest.builder()
+                .tableName(kvTable)
+                .key(
+                    Map.of(
+                        KvAttributes.ATTR_PARTITION_KEY,
+                        AttributeValue.fromS(pk),
+                        KvAttributes.ATTR_SORT_KEY,
+                        AttributeValue.fromS(sk)))
+                .build())
+        .join()
+        .item();
   }
 
   private static Map<String, AttributeValue> rawItem(String pk, String sk) {

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/KvStoreContractTest.java
@@ -475,7 +475,7 @@ public class KvStoreContractTest {
     KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
     assertInstanceOf(AttrValue.NumberValue.class, got.attrs().get("hits"));
     assertEquals(AttrValue.of(7L), got.attrs().get("hits"));
-    assertEquals(7L, got.attrs().get("hits").asLong().orElseThrow());
+    assertEquals(7L, got.attrs().get("hits").asLong());
     assertEquals(AttrValue.of("t"), got.attrs().get("target"));
   }
 

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/kvobject/KvObjectEntity.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/kvobject/KvObjectEntity.java
@@ -16,6 +16,7 @@
 package ai.floedb.floecat.storage.kv.dynamodb.kvobject;
 
 import ai.floedb.floecat.storage.kv.AbstractEntity;
+import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.Keys;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.cdi.KvTable;
@@ -122,7 +123,8 @@ public final class KvObjectEntity extends AbstractEntity<KvObject> {
     String id = obj.getId();
     var sKey = Keys.key(Keys.join(PK_TESTOBJ, normalize(id)), Keys.join(SK_SUB, subKey));
     var rec =
-        new KvStore.Record(sKey, KIND_SUB_OBJECT, new byte[0], Map.of(ATTR_SUBVALUE, subValue), 1);
+        new KvStore.Record(
+            sKey, KIND_SUB_OBJECT, new byte[0], Map.of(ATTR_SUBVALUE, AttrValue.of(subValue)), 1);
     return kv.txnWriteCas(List.of(new KvStore.TxnPut(rec, 0)));
   }
 

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStoreTest.java
@@ -19,9 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
+import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.KvStore;
 import io.smallrye.mutiny.Uni;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -74,6 +76,12 @@ class KvPointerStoreTest {
 
     @Override
     public Uni<Boolean> deleteCas(Key key, long expectedVersion) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uni<Optional<Long>> updateMetadataAttrsIfExists(
+        Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
       throw new UnsupportedOperationException();
     }
 

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.PointerReferenceKind;
 import ai.floedb.floecat.storage.kv.AbstractEntity;
 import ai.floedb.floecat.storage.kv.AbstractEntityTest;
+import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.dynamodb.DynamoDbKvTestProfile;
@@ -309,7 +310,7 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
             .await()
             .indefinitely()
             .orElseThrow();
-    assertEquals("1234", rec.attrs().get(KvAttributes.ATTR_EXPIRES_AT));
+    assertEquals(AttrValue.of("1234"), rec.attrs().get(KvAttributes.ATTR_EXPIRES_AT));
   }
 
   @Test
@@ -319,7 +320,7 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
             new KvStore.Key(PointerStoreEntity.GLOBAL_PK, "accounts/by-id/7/catalog/ttl"),
             PointerStoreEntity.KIND_POINTER,
             new byte[0],
-            Map.of(KvAttributes.ATTR_EXPIRES_AT, "4321"),
+            Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of("4321")),
             1L);
 
     Pointer decoded = pointers.decode(rec);
@@ -447,8 +448,8 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
                     && opt.isPresent()
                     && updated.compareAndSet(false, true)) {
                   Record current = opt.get();
-                  Map<String, String> attrs = new HashMap<>(current.attrs());
-                  attrs.put(PointerStoreEntity.ATTR_BLOB_URI, "s3://b/updated");
+                  Map<String, AttrValue> attrs = new HashMap<>(current.attrs());
+                  attrs.put(PointerStoreEntity.ATTR_BLOB_URI, AttrValue.of("s3://b/updated"));
                   Record updatedRecord =
                       new Record(
                           current.key(),
@@ -470,6 +471,12 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
     @Override
     public Uni<Boolean> deleteCas(Key key, long expectedVersion) {
       return delegate.deleteCas(key, expectedVersion);
+    }
+
+    @Override
+    public Uni<Optional<Long>> updateMetadataAttrsIfExists(
+        Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
+      return delegate.updateMetadataAttrsIfExists(key, sets, increments);
     }
 
     @Override

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
@@ -328,6 +328,35 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
   }
 
   @Test
+  void decode_sets_expiresAt_from_numeric_ATTR_EXPIRES_AT() {
+    // Same stamp in the native numeric form: retyped rows must decode like the legacy string ones.
+    KvStore.Record rec =
+        new KvStore.Record(
+            new KvStore.Key(PointerStoreEntity.GLOBAL_PK, "accounts/by-id/7/catalog/ttl"),
+            PointerStoreEntity.KIND_POINTER,
+            new byte[0],
+            Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of(4321L)),
+            1L);
+
+    Pointer decoded = pointers.decode(rec);
+    assertEquals(4321000L, Timestamps.toMillis(decoded.getExpiresAt()));
+  }
+
+  @Test
+  void decode_throws_on_malformed_ATTR_EXPIRES_AT() {
+    // Fail loud: silently reading a corrupt stamp as "no expiry" would make the pointer immortal.
+    KvStore.Record rec =
+        new KvStore.Record(
+            new KvStore.Key(PointerStoreEntity.GLOBAL_PK, "accounts/by-id/7/catalog/ttl"),
+            PointerStoreEntity.KIND_POINTER,
+            new byte[0],
+            Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of("not-a-timestamp")),
+            1L);
+
+    assertThrows(NumberFormatException.class, () -> pointers.decode(rec));
+  }
+
+  @Test
   void getExpiresAt_returns_0_when_absent() {
     Pointer p = Pointer.newBuilder().setKey("/accounts/by-id/8/catalog/ttl").build();
     assertEquals(0L, pointers.getExpiresAt(p));

--- a/storage/common/src/test/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManagerIT.java
+++ b/storage/common/src/test/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManagerIT.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.secrets.SecretsManager;
 import io.smallrye.mutiny.Uni;
@@ -156,6 +157,12 @@ class NotProdSecretsManagerIT {
                         return null;
                       })
                   == null);
+    }
+
+    @Override
+    public Uni<Optional<Long>> updateMetadataAttrsIfExists(
+        Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
+      throw new UnsupportedOperationException("updateMetadataAttrsIfExists not supported");
     }
 
     @Override

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -40,8 +40,7 @@ public final class InMemoryKvStore implements KvStore {
 
   @Override
   public Uni<Boolean> putCas(Record record, long expectedVersion) {
-    // Synchronous, like the DynamoDB store's check in recordToAv: the fake has no wire types of its
-    // own, so matching what the real store refuses is the only thing that keeps a test honest.
+    // Synchronous, matching when and what the DynamoDB store refuses.
     AttrWriteRules.checkExpiryIsString(record.attrs());
     return Uni.createFrom()
         .item(
@@ -79,11 +78,9 @@ public final class InMemoryKvStore implements KvStore {
       Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
     MetadataAttrUpdates.validate(key, sets, increments);
 
-    // Applied eagerly, like every other write in this class and like the DynamoDB store's
-    // already-in-flight UpdateItem: a Uni may be subscribed to more than once, and a mutation
-    // deferred to subscription time would increment again on every subscription. The failure is
-    // still handed back as a failed Uni rather than thrown out of a Uni-returning method, which
-    // is how the real store reports ADD on a string-typed attribute.
+    // Applied eagerly: a Uni may be subscribed more than once, and a mutation deferred to
+    // subscription time would increment on every subscription. The failure is still handed back
+    // as a failed Uni, matching how DynamoDB reports ADD on a string-typed attribute.
     Optional<Long> newVersion;
     try {
       newVersion = applyMetadataAttrUpdates(key, sets, increments);
@@ -100,17 +97,15 @@ public final class InMemoryKvStore implements KvStore {
    */
   private Optional<Long> applyMetadataAttrUpdates(
       Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
-    // A successful update always produces a version >= 1, so 0 is an unambiguous "the remap never
-    // ran, or refused". computeIfPresent's own return value cannot tell those apart from success,
-    // since a refusal also returns a non-null record.
+    // A successful update always yields version >= 1, so 0 means "never ran or refused";
+    // computeIfPresent's return value cannot tell a refusal from success.
     long[] newVersion = {0L};
     records.computeIfPresent(
         key,
         (unused, existing) -> {
           if (existing.value().length > 0) {
-            // Refused: a value-carrying record embeds a copy of the version inside its serialized
-            // payload, which this update does not rewrite. Leave it as is and leave newVersion
-            // unset.
+            // Refused: a value payload embeds its own copy of the version, which this update does
+            // not rewrite.
             return existing;
           }
 
@@ -119,11 +114,9 @@ public final class InMemoryKvStore implements KvStore {
           for (var increment : increments.entrySet()) {
             var name = increment.getKey();
             var current = attrs.get(name);
-            // Rejected on the type, not on whether the text happens to parse: DynamoDB's ADD
-            // raises ValidationException for any S-typed attribute, including a numeric-looking
-            // one like "42". Accepting those here would let a caller pass in memory and fail in
-            // production. Throwing from the remap leaves the mapping unchanged
-            // (ConcurrentHashMap's contract), so nothing is half-applied.
+            // Rejected on the type, not parseability: DynamoDB's ADD rejects any S-typed
+            // attribute, numeric-looking ones like "42" included. Throwing from the remap leaves
+            // the mapping unchanged, so nothing is half-applied.
             if (current != null && !(current instanceof AttrValue.NumberValue)) {
               throw new IllegalStateException(
                   "cannot increment attr "
@@ -133,10 +126,8 @@ public final class InMemoryKvStore implements KvStore {
                       + ": it currently holds a string value");
             }
             long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
-            // addExact, not +: a wrapped sum would report a successful update while storing a
-            // number nowhere near the one asked for. AttrValue cannot model a result outside long,
-            // so an out-of-range sum is an error, not a value. Throws from the same remap as the
-            // type check above, with the same all-or-nothing guarantee.
+            // addExact, not +: AttrValue cannot model a sum outside long, and a wrap would report
+            // success while storing a wildly wrong value.
             attrs.put(name, AttrValue.of(Math.addExact(base, increment.getValue())));
           }
 

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.storage.memory;
 
 import ai.floedb.floecat.storage.kv.AttrValue;
+import ai.floedb.floecat.storage.kv.AttrWriteRules;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.MetadataAttrUpdates;
 import io.smallrye.mutiny.Uni;
@@ -39,6 +40,9 @@ public final class InMemoryKvStore implements KvStore {
 
   @Override
   public Uni<Boolean> putCas(Record record, long expectedVersion) {
+    // Synchronous, like the DynamoDB store's check in recordToAv: the fake has no wire types of its
+    // own, so matching what the real store refuses is the only thing that keeps a test honest.
+    AttrWriteRules.checkExpiryIsString(record.attrs());
     return Uni.createFrom()
         .item(
             records.compute(
@@ -235,6 +239,7 @@ public final class InMemoryKvStore implements KvStore {
     synchronized (this) {
       for (TxnOp op : ops) {
         if (op instanceof TxnPut put) {
+          AttrWriteRules.checkExpiryIsString(put.record().attrs());
           Record existing = records.get(put.record().key());
           if (put.expectedVersion() == 0L) {
             if (existing != null) {

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -120,7 +120,12 @@ public final class InMemoryKvStore implements KvStore {
                                 + ": it currently holds a string value");
                       }
                       long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
-                      attrs.put(name, AttrValue.of(base + increment.getValue()));
+                      // addExact, not +: a wrapped sum would report a successful update while
+                      // storing a number nowhere near the one asked for. AttrValue cannot model a
+                      // result outside long, so an out-of-range sum is an error, not a value.
+                      // Throws from the same remap as the type check above, with the same
+                      // all-or-nothing guarantee.
+                      attrs.put(name, AttrValue.of(Math.addExact(base, increment.getValue())));
                     }
 
                     newVersion[0] = existing.version() + 1;

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -16,11 +16,14 @@
 
 package ai.floedb.floecat.storage.memory;
 
+import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.KvStore;
+import ai.floedb.floecat.storage.kv.MetadataAttrUpdates;
 import io.smallrye.mutiny.Uni;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -65,6 +68,63 @@ public final class InMemoryKvStore implements KvStore {
                       return null;
                     })
                 == null);
+  }
+
+  @Override
+  public Uni<Optional<Long>> updateMetadataAttrsIfExists(
+      Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
+    MetadataAttrUpdates.validate(key, sets, increments);
+
+    // Deferred (a supplier, unlike the eager item(...) used elsewhere in this class) so that the
+    // loud non-numeric-increment failure below arrives as a failed Uni instead of a synchronous
+    // throw out of a Uni-returning method. Argument validation above stays synchronous, matching
+    // deleteCas's guard.
+    return Uni.createFrom()
+        .item(
+            () -> {
+              // A successful update always produces a version >= 1, so 0 is an unambiguous "the
+              // remap never ran, or refused". computeIfPresent's own return value cannot tell
+              // those apart from success, since a refusal also returns a non-null record.
+              long[] newVersion = {0L};
+              records.computeIfPresent(
+                  key,
+                  (unused, existing) -> {
+                    if (existing.value().length > 0) {
+                      // Refused: a value-carrying record embeds a copy of the version inside its
+                      // serialized payload, which this update does not rewrite. Leave it as is and
+                      // leave newVersion unset.
+                      return existing;
+                    }
+
+                    var attrs = new HashMap<>(existing.attrs());
+                    attrs.putAll(sets);
+                    for (var increment : increments.entrySet()) {
+                      var name = increment.getKey();
+                      var current = attrs.get(name);
+                      // Rejected on the type, not on whether the text happens to parse: DynamoDB's
+                      // ADD raises ValidationException for any S-typed attribute, including a
+                      // numeric-looking one like "42". Accepting those here would let a caller pass
+                      // in memory and fail in production. Throwing from the remap leaves the
+                      // mapping
+                      // unchanged (ConcurrentHashMap's contract), so nothing is half-applied.
+                      if (current != null && !(current instanceof AttrValue.NumberValue)) {
+                        throw new IllegalStateException(
+                            "cannot increment attr "
+                                + name
+                                + " on "
+                                + key
+                                + ": it currently holds a string value");
+                      }
+                      long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
+                      attrs.put(name, AttrValue.of(base + increment.getValue()));
+                    }
+
+                    newVersion[0] = existing.version() + 1;
+                    return new Record(
+                        existing.key(), existing.kind(), existing.value(), attrs, newVersion[0]);
+                  });
+              return newVersion[0] == 0L ? Optional.<Long>empty() : Optional.of(newVersion[0]);
+            });
   }
 
   @Override

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -79,61 +79,72 @@ public final class InMemoryKvStore implements KvStore {
       Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
     MetadataAttrUpdates.validate(key, sets, increments);
 
-    // Deferred (a supplier, unlike the eager item(...) used elsewhere in this class) so that the
-    // loud non-numeric-increment failure below arrives as a failed Uni instead of a synchronous
-    // throw out of a Uni-returning method. Argument validation above stays synchronous, matching
-    // deleteCas's guard.
-    return Uni.createFrom()
-        .item(
-            () -> {
-              // A successful update always produces a version >= 1, so 0 is an unambiguous "the
-              // remap never ran, or refused". computeIfPresent's own return value cannot tell
-              // those apart from success, since a refusal also returns a non-null record.
-              long[] newVersion = {0L};
-              records.computeIfPresent(
-                  key,
-                  (unused, existing) -> {
-                    if (existing.value().length > 0) {
-                      // Refused: a value-carrying record embeds a copy of the version inside its
-                      // serialized payload, which this update does not rewrite. Leave it as is and
-                      // leave newVersion unset.
-                      return existing;
-                    }
+    // Applied eagerly, like every other write in this class and like the DynamoDB store's
+    // already-in-flight UpdateItem: a Uni may be subscribed to more than once, and a mutation
+    // deferred to subscription time would increment again on every subscription. The failure is
+    // still handed back as a failed Uni rather than thrown out of a Uni-returning method, which
+    // is how the real store reports ADD on a string-typed attribute.
+    Optional<Long> newVersion;
+    try {
+      newVersion = applyMetadataAttrUpdates(key, sets, increments);
+    } catch (RuntimeException failure) {
+      return Uni.createFrom().failure(failure);
+    }
+    return Uni.createFrom().item(newVersion);
+  }
 
-                    var attrs = new HashMap<>(existing.attrs());
-                    attrs.putAll(sets);
-                    for (var increment : increments.entrySet()) {
-                      var name = increment.getKey();
-                      var current = attrs.get(name);
-                      // Rejected on the type, not on whether the text happens to parse: DynamoDB's
-                      // ADD raises ValidationException for any S-typed attribute, including a
-                      // numeric-looking one like "42". Accepting those here would let a caller pass
-                      // in memory and fail in production. Throwing from the remap leaves the
-                      // mapping
-                      // unchanged (ConcurrentHashMap's contract), so nothing is half-applied.
-                      if (current != null && !(current instanceof AttrValue.NumberValue)) {
-                        throw new IllegalStateException(
-                            "cannot increment attr "
-                                + name
-                                + " on "
-                                + key
-                                + ": it currently holds a string value");
-                      }
-                      long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
-                      // addExact, not +: a wrapped sum would report a successful update while
-                      // storing a number nowhere near the one asked for. AttrValue cannot model a
-                      // result outside long, so an out-of-range sum is an error, not a value.
-                      // Throws from the same remap as the type check above, with the same
-                      // all-or-nothing guarantee.
-                      attrs.put(name, AttrValue.of(Math.addExact(base, increment.getValue())));
-                    }
+  /**
+   * Applies the update in place, returning the post-update version, or empty if the key is absent
+   * or the record was refused. Throws — leaving the record untouched — if an increment cannot be
+   * applied.
+   */
+  private Optional<Long> applyMetadataAttrUpdates(
+      Key key, Map<String, AttrValue> sets, Map<String, Long> increments) {
+    // A successful update always produces a version >= 1, so 0 is an unambiguous "the remap never
+    // ran, or refused". computeIfPresent's own return value cannot tell those apart from success,
+    // since a refusal also returns a non-null record.
+    long[] newVersion = {0L};
+    records.computeIfPresent(
+        key,
+        (unused, existing) -> {
+          if (existing.value().length > 0) {
+            // Refused: a value-carrying record embeds a copy of the version inside its serialized
+            // payload, which this update does not rewrite. Leave it as is and leave newVersion
+            // unset.
+            return existing;
+          }
 
-                    newVersion[0] = existing.version() + 1;
-                    return new Record(
-                        existing.key(), existing.kind(), existing.value(), attrs, newVersion[0]);
-                  });
-              return newVersion[0] == 0L ? Optional.<Long>empty() : Optional.of(newVersion[0]);
-            });
+          var attrs = new HashMap<>(existing.attrs());
+          attrs.putAll(sets);
+          for (var increment : increments.entrySet()) {
+            var name = increment.getKey();
+            var current = attrs.get(name);
+            // Rejected on the type, not on whether the text happens to parse: DynamoDB's ADD
+            // raises ValidationException for any S-typed attribute, including a numeric-looking
+            // one like "42". Accepting those here would let a caller pass in memory and fail in
+            // production. Throwing from the remap leaves the mapping unchanged
+            // (ConcurrentHashMap's contract), so nothing is half-applied.
+            if (current != null && !(current instanceof AttrValue.NumberValue)) {
+              throw new IllegalStateException(
+                  "cannot increment attr "
+                      + name
+                      + " on "
+                      + key
+                      + ": it currently holds a string value");
+            }
+            long base = current == null ? 0L : ((AttrValue.NumberValue) current).value();
+            // addExact, not +: a wrapped sum would report a successful update while storing a
+            // number nowhere near the one asked for. AttrValue cannot model a result outside long,
+            // so an out-of-range sum is an error, not a value. Throws from the same remap as the
+            // type check above, with the same all-or-nothing guarantee.
+            attrs.put(name, AttrValue.of(Math.addExact(base, increment.getValue())));
+          }
+
+          newVersion[0] = existing.version() + 1;
+          return new Record(
+              existing.key(), existing.kind(), existing.value(), attrs, newVersion[0]);
+        });
+    return newVersion[0] == 0L ? Optional.<Long>empty() : Optional.of(newVersion[0]);
   }
 
   @Override

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -20,13 +20,22 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.floedb.floecat.storage.kv.AttrValue;
+import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.memory.InMemoryKvStore;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -128,6 +137,288 @@ class KvStoreContractTest {
     assertTrue(kv.get(key("pk1", "sk2")).await().indefinitely().isEmpty());
   }
 
+  @Test
+  void updateMetadataAttrsIfExists_sets_and_increments_and_bumps_version() {
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(
+                attrsRecord(
+                    k,
+                    1L,
+                    Map.of(
+                        "target", AttrValue.of("old"),
+                        "hits", AttrValue.of(5L),
+                        "keep", AttrValue.of("stay"))),
+                0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of("target", AttrValue.of("new")), Map.of("hits", 3L))
+            .await()
+            .indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(2L, got.version());
+    assertEquals(AttrValue.of("new"), got.attrs().get("target"));
+    assertEquals(AttrValue.of(8L), got.attrs().get("hits"));
+    assertEquals(AttrValue.of("stay"), got.attrs().get("keep"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increment_of_absent_attr_creates_it_at_the_delta() {
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("keep", AttrValue.of("stay"))), 0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("misses", 4L)).await().indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(AttrValue.of(4L), got.attrs().get("misses"));
+    assertEquals(AttrValue.of("stay"), got.attrs().get("keep"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_absent_key_returns_empty_and_creates_nothing() {
+    KvStore.Key k = key("pk1", "ghost");
+
+    assertTrue(
+        kv.updateMetadataAttrsIfExists(k, Map.of("target", AttrValue.of("t")), Map.of("hits", 1L))
+            .await()
+            .indefinitely()
+            .isEmpty());
+
+    // No ghost row: the update must never create the record as a side effect.
+    assertTrue(kv.get(k).await().indefinitely().isEmpty());
+    assertTrue(kv.isEmpty().await().indefinitely());
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_refuses_value_carrying_record_and_leaves_it_untouched() {
+    // A value payload embeds its own copy of the version, which this update does not rewrite, so
+    // the whole record must be refused rather than partially advanced.
+    KvStore.Key k = key("pk1", "sk1");
+    KvStore.Record stored =
+        new KvStore.Record(
+            k,
+            "KIND",
+            "payload".getBytes(StandardCharsets.UTF_8),
+            Map.of("target", AttrValue.of("old"), "hits", AttrValue.of(5L)),
+            1L);
+    assertTrue(kv.putCas(stored, 0L).await().indefinitely());
+
+    assertTrue(
+        kv.updateMetadataAttrsIfExists(k, Map.of("target", AttrValue.of("new")), Map.of("hits", 1L))
+            .await()
+            .indefinitely()
+            .isEmpty());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of("old"), got.attrs().get("target"));
+    assertEquals(AttrValue.of(5L), got.attrs().get("hits"));
+    assertEquals("payload", new String(got.value(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_version_0_record_becomes_version_1() {
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(kv.putCas(attrsRecord(k, 0L, Map.of()), 0L).await().indefinitely());
+
+    assertEquals(
+        Optional.of(1L),
+        kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L)).await().indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of(1L), got.attrs().get("hits"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_sets_only_works() {
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("target", AttrValue.of("old"))), 0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(
+                k, Map.of("target", AttrValue.of("new"), "extra", AttrValue.of(9L)), Map.of())
+            .await()
+            .indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(2L, got.version());
+    assertEquals(AttrValue.of("new"), got.attrs().get("target"));
+    assertEquals(AttrValue.of(9L), got.attrs().get("extra"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increments_only_works() {
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(10L))), 0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 5L, "misses", 2L))
+            .await()
+            .indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(2L, got.version());
+    assertEquals(AttrValue.of(15L), got.attrs().get("hits"));
+    assertEquals(AttrValue.of(2L), got.attrs().get("misses"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_rejects_empty_updates() {
+    // No await(): validation must throw synchronously rather than produce a failed Uni.
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> kv.updateMetadataAttrsIfExists(key("pk1", "meta"), Map.of(), Map.of()));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_rejects_structural_attr_names_in_sets() {
+    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+      Map<String, AttrValue> sets = Map.of(name, AttrValue.of("x"));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> kv.updateMetadataAttrsIfExists(key("pk1", "meta"), sets, Map.of()));
+    }
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_rejects_attr_that_is_both_set_and_incremented() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            kv.updateMetadataAttrsIfExists(
+                key("pk1", "meta"), Map.of("hits", AttrValue.of(1L)), Map.of("hits", 1L)));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increment_of_string_attr_fails() {
+    // The in-memory store guards on the AttrValue type and throws IllegalStateException; the
+    // DynamoDB store has no local view of the stored type and lets the SDK's ValidationException
+    // surface instead, so the two contract tests assert different exception types here by design.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of("abc"))), 0L)
+            .await()
+            .indefinitely());
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L)).await().indefinitely());
+
+    // Never silently overwritten: the record is left exactly as it was.
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of("abc"), got.attrs().get("hits"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increment_of_numeric_looking_string_attr_fails() {
+    // "42" parses, but DynamoDB's ADD rejects an S-typed attribute regardless of its content, so
+    // the in-memory store rejects it too — otherwise a caller would pass here and fail in prod.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of("42"))), 0L)
+            .await()
+            .indefinitely());
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L)).await().indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of("42"), got.attrs().get("hits"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_version_bump_is_visible_to_putCas() {
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(1L))), 0L).await().indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L)).await().indefinitely());
+
+    // A writer that read the record before the metadata bump must be rejected...
+    assertFalse(
+        kv.putCas(attrsRecord(k, 2L, Map.of("hits", AttrValue.of(99L))), 1L)
+            .await()
+            .indefinitely());
+    // ...and one that re-read afterwards must succeed.
+    assertTrue(
+        kv.putCas(attrsRecord(k, 3L, Map.of("hits", AttrValue.of(99L))), 2L)
+            .await()
+            .indefinitely());
+    assertEquals(3L, kv.get(k).await().indefinitely().orElseThrow().version());
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_concurrent_increments_all_land() throws Exception {
+    int writers = 50;
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(0L))), 0L).await().indefinitely());
+
+    // One call on this thread first, against a key that does not exist (so it changes nothing but
+    // still builds a Uni). Mutiny initializes its context-propagation interceptor on first use, and
+    // that initialization is not itself thread-safe: without this, several of the writers below can
+    // race into it and fail with "ContextManagerProvider already set". A Quarkus process has it set
+    // up at startup; a bare JVM test has to warm it explicitly.
+    kv.updateMetadataAttrsIfExists(key("pk1", "absent"), Map.of(), Map.of("hits", 1L))
+        .await()
+        .indefinitely();
+
+    ExecutorService pool = Executors.newFixedThreadPool(8);
+    try {
+      CountDownLatch start = new CountDownLatch(1);
+      List<Future<Optional<Long>>> results = new ArrayList<>(writers);
+      for (int i = 0; i < writers; i++) {
+        results.add(
+            pool.submit(
+                () -> {
+                  start.await();
+                  return kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L))
+                      .await()
+                      .indefinitely();
+                }));
+      }
+      start.countDown();
+
+      Set<Long> versions = new TreeSet<>();
+      for (Future<Optional<Long>> result : results) {
+        versions.add(result.get(30, TimeUnit.SECONDS).orElseThrow());
+      }
+      // Every caller got a distinct version; a get-then-put implementation would hand out dupes.
+      assertEquals(writers, versions.size());
+    } finally {
+      pool.shutdownNow();
+    }
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(AttrValue.of((long) writers), got.attrs().get("hits"));
+    assertEquals(1L + writers, got.version());
+  }
+
   private void putSeries(String pk, String skPrefix, int count) {
     for (int i = 0; i < count; i++) {
       assertTrue(kv.putCas(record(pk, skPrefix + i, 1L, "v" + i), 0L).await().indefinitely());
@@ -141,5 +432,10 @@ class KvStoreContractTest {
   private static KvStore.Record record(String pk, String sk, long version, String value) {
     return new KvStore.Record(
         key(pk, sk), "KIND", value.getBytes(StandardCharsets.UTF_8), null, version);
+  }
+
+  private static KvStore.Record attrsRecord(
+      KvStore.Key key, long version, Map<String, AttrValue> attrs) {
+    return new KvStore.Record(key, "META", new byte[0], attrs, version);
   }
 }

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -140,8 +140,7 @@ class KvStoreContractTest {
 
   @Test
   void putCas_rejects_numeric_expiry_stamp() {
-    // Refused by the fake exactly as DynamoDB's writer refuses it, so an entity test cannot pass
-    // here on a record the real store would reject. Rule and reason: AttrWriteRules.
+    // Rule and reason: AttrWriteRules.
     KvStore.Key k = key("pk1", "ttl");
     assertThrows(
         IllegalArgumentException.class,
@@ -208,10 +207,8 @@ class KvStoreContractTest {
 
   @Test
   void updateMetadataAttrsIfExists_applies_once_however_often_the_uni_is_subscribed() {
-    // The update must have already happened by the time the Uni is returned, not on subscription:
-    // a Uni carries no once-only guarantee, so a caller that awaits or chains the same one twice
-    // would otherwise increment twice. An atomic counter whose value depends on how many times its
-    // Uni was consumed is not a counter.
+    // The update must have already happened by the time the Uni is returned: a Uni carries no
+    // once-only guarantee, so a caller awaiting the same one twice would otherwise increment twice.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(0L))), 0L).await().indefinitely());
@@ -368,9 +365,8 @@ class KvStoreContractTest {
 
   @Test
   void updateMetadataAttrsIfExists_increment_of_string_attr_fails() {
-    // The in-memory store guards on the AttrValue type and throws IllegalStateException; the
-    // DynamoDB store has no local view of the stored type and lets the SDK's ValidationException
-    // surface instead, so the two contract tests assert different exception types here by design.
+    // The in-memory store throws IllegalStateException; the DynamoDB store surfaces the SDK's
+    // error instead, so the two contract tests assert different exception types by design.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of("abc"))), 0L)
@@ -391,7 +387,7 @@ class KvStoreContractTest {
   @Test
   void updateMetadataAttrsIfExists_increment_of_numeric_looking_string_attr_fails() {
     // "42" parses, but DynamoDB's ADD rejects an S-typed attribute regardless of its content, so
-    // the in-memory store rejects it too — otherwise a caller would pass here and fail in prod.
+    // the in-memory store must too.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of("42"))), 0L)
@@ -410,8 +406,7 @@ class KvStoreContractTest {
 
   @Test
   void updateMetadataAttrsIfExists_increment_past_long_max_fails_and_changes_nothing() {
-    // A wrap would have reported success while storing MIN_VALUE. Failing is the whole point: a
-    // counter silently 18 quintillion off is worse than an update that refuses.
+    // A wrap would have reported success while storing MIN_VALUE.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(Long.MAX_VALUE))), 0L)
@@ -431,8 +426,7 @@ class KvStoreContractTest {
 
   @Test
   void updateMetadataAttrsIfExists_increment_past_long_min_fails() {
-    // The negative boundary matters too: deltas are signed, so a decrementing counter can walk off
-    // the other end.
+    // Deltas are signed, so a decrementing counter can walk off the other end.
     KvStore.Key k = key("pk1", "meta");
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(Long.MIN_VALUE))), 0L)
@@ -498,11 +492,10 @@ class KvStoreContractTest {
     assertTrue(
         kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(0L))), 0L).await().indefinitely());
 
-    // One call on this thread first, against a key that does not exist (so it changes nothing but
-    // still builds a Uni). Mutiny initializes its context-propagation interceptor on first use, and
-    // that initialization is not itself thread-safe: without this, several of the writers below can
-    // race into it and fail with "ContextManagerProvider already set". A Quarkus process has it set
-    // up at startup; a bare JVM test has to warm it explicitly.
+    // Warm-up call (no-op against an absent key): Mutiny's context-propagation interceptor
+    // initializes on first use and that initialization is not thread-safe — without it, the
+    // writers below can race into "ContextManagerProvider already set". Quarkus does this at
+    // startup; a bare JVM test must do it explicitly.
     kv.updateMetadataAttrsIfExists(key("pk1", "absent"), Map.of(), Map.of("hits", 1L))
         .await()
         .indefinitely();

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -24,6 +24,7 @@ import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.memory.InMemoryKvStore;
+import io.smallrye.mutiny.Uni;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -203,6 +204,25 @@ class KvStoreContractTest {
     assertEquals(AttrValue.of("new"), got.attrs().get("target"));
     assertEquals(AttrValue.of(8L), got.attrs().get("hits"));
     assertEquals(AttrValue.of("stay"), got.attrs().get("keep"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_applies_once_however_often_the_uni_is_subscribed() {
+    // The update must have already happened by the time the Uni is returned, not on subscription:
+    // a Uni carries no once-only guarantee, so a caller that awaits or chains the same one twice
+    // would otherwise increment twice. An atomic counter whose value depends on how many times its
+    // Uni was consumed is not a counter.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(0L))), 0L).await().indefinitely());
+
+    Uni<Optional<Long>> update = kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L));
+    assertEquals(Optional.of(2L), update.await().indefinitely());
+    assertEquals(Optional.of(2L), update.await().indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(2L, got.version());
+    assertEquals(AttrValue.of(1L), got.attrs().get("hits"));
   }
 
   @Test

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -138,6 +138,45 @@ class KvStoreContractTest {
   }
 
   @Test
+  void putCas_rejects_numeric_expiry_stamp() {
+    // Refused by the fake exactly as DynamoDB's writer refuses it, so an entity test cannot pass
+    // here on a record the real store would reject. Rule and reason: AttrWriteRules.
+    KvStore.Key k = key("pk1", "ttl");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            kv.putCas(
+                attrsRecord(k, 1L, Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of(2L))), 0L));
+    assertTrue(kv.get(k).await().indefinitely().isEmpty());
+  }
+
+  @Test
+  void putCas_accepts_string_expiry_stamp() {
+    KvStore.Key k = key("pk1", "ttl-ok");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of("2"))), 0L)
+            .await()
+            .indefinitely());
+    assertEquals(
+        AttrValue.of("2"),
+        kv.get(k).await().indefinitely().orElseThrow().attrs().get(KvAttributes.ATTR_EXPIRES_AT));
+  }
+
+  @Test
+  void txnWriteCas_rejects_numeric_expiry_stamp_before_applying_anything() {
+    var ops =
+        List.<KvStore.TxnOp>of(
+            new KvStore.TxnPut(record("pk1", "sk1", 1L, "v1"), 0L),
+            new KvStore.TxnPut(
+                attrsRecord(
+                    key("pk1", "ttl"), 1L, Map.of(KvAttributes.ATTR_EXPIRES_AT, AttrValue.of(2L))),
+                0L));
+
+    assertThrows(IllegalArgumentException.class, () -> kv.txnWriteCas(ops).await().indefinitely());
+    assertTrue(kv.get(key("pk1", "sk1")).await().indefinitely().isEmpty());
+  }
+
+  @Test
   void updateMetadataAttrsIfExists_sets_and_increments_and_bumps_version() {
     KvStore.Key k = key("pk1", "meta");
     assertTrue(

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -328,8 +328,8 @@ class KvStoreContractTest {
   }
 
   @Test
-  void updateMetadataAttrsIfExists_rejects_structural_attr_names_in_sets() {
-    for (String name : KvAttributes.STRUCTURAL_ATTRS) {
+  void updateMetadataAttrsIfExists_rejects_reserved_attr_names_in_sets() {
+    for (String name : KvAttributes.RESERVED_ATTRS) {
       Map<String, AttrValue> sets = Map.of(name, AttrValue.of("x"));
       assertThrows(
           IllegalArgumentException.class,

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/KvStoreContractTest.java
@@ -389,6 +389,66 @@ class KvStoreContractTest {
   }
 
   @Test
+  void updateMetadataAttrsIfExists_increment_past_long_max_fails_and_changes_nothing() {
+    // A wrap would have reported success while storing MIN_VALUE. Failing is the whole point: a
+    // counter silently 18 quintillion off is worse than an update that refuses.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(Long.MAX_VALUE))), 0L)
+            .await()
+            .indefinitely());
+
+    assertThrows(
+        ArithmeticException.class,
+        () ->
+            kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L)).await().indefinitely());
+
+    // Not half-applied: the version must not advance either, since the remap threw.
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of(Long.MAX_VALUE), got.attrs().get("hits"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increment_past_long_min_fails() {
+    // The negative boundary matters too: deltas are signed, so a decrementing counter can walk off
+    // the other end.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(Long.MIN_VALUE))), 0L)
+            .await()
+            .indefinitely());
+
+    assertThrows(
+        ArithmeticException.class,
+        () ->
+            kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", -1L))
+                .await()
+                .indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(1L, got.version());
+    assertEquals(AttrValue.of(Long.MIN_VALUE), got.attrs().get("hits"));
+  }
+
+  @Test
+  void updateMetadataAttrsIfExists_increment_to_exactly_long_max_succeeds() {
+    // The guard rejects only what it cannot represent — the boundary value itself is fine.
+    KvStore.Key k = key("pk1", "meta");
+    assertTrue(
+        kv.putCas(attrsRecord(k, 1L, Map.of("hits", AttrValue.of(Long.MAX_VALUE - 1L))), 0L)
+            .await()
+            .indefinitely());
+
+    assertEquals(
+        Optional.of(2L),
+        kv.updateMetadataAttrsIfExists(k, Map.of(), Map.of("hits", 1L)).await().indefinitely());
+
+    KvStore.Record got = kv.get(k).await().indefinitely().orElseThrow();
+    assertEquals(AttrValue.of(Long.MAX_VALUE), got.attrs().get("hits"));
+  }
+
+  @Test
   void updateMetadataAttrsIfExists_version_bump_is_visible_to_putCas() {
     KvStore.Key k = key("pk1", "meta");
     assertTrue(


### PR DESCRIPTION
## Summary

  `Record.attrs` was `Map<String, String>`, so numeric bookkeeping values had to be
  stored as decimal strings, and the DynamoDB read path silently dropped every
  non-`S` attribute. Together those made an atomic counter impossible: incrementing
  meant read-parse-write under CAS, which loses bumps whenever two writers race.

  - Add `AttrValue`, a sealed string/number type, and retype `Record.attrs` to
    `Map<String, AttrValue>`.
  - Map `S`↔`StringValue` and `N`↔`NumberValue` in both directions in
    `DynamoDbKvStore`, so `N` attributes are no longer dropped on read. An
    unparseable `N` degrades to a string of its raw text rather than vanishing.
  - Add `KvStore.updateMetadataAttrsIfExists(key, sets, increments)`: one atomic
    partial update that sets attributes, adds to numeric attributes, and advances
    the CAS version together, and never creates a record. One `UpdateItem` on
    DynamoDB; one `computeIfPresent` in memory. 
  - Share the argument validation in `MetadataAttrUpdates` so both stores reject
    the same caller mistakes, synchronously, before any request is issued.
   
  Two deliberate limits, both documented at the SPI rather than papered over:

  - The new update is restricted to attrs-only records via
    `attribute_not_exists(#value)`. That guard is necessary but **not sufficient** —
    an empty value does not prove a record is attrs-only, since `PointerStoreEntity`
    encodes to no bytes and foreign writers share the table. The javadoc states the
    limit rather than claiming structural enforcement.
  - `ATTR_EXPIRES_AT` is still *written* as a string. Reads accept both forms, but
    writing it as `N` is unsafe under a rolling deploy: an old replica drops `N`
    attributes on read, and its next write then persists the pointer with no expiry
    attribute at all — permanent loss, not transient invisibility.
   
  Increments are strict about type in both stores, matching DynamoDB's `ADD`, which
  rejects an `S`-typed attribute regardless of whether its content looks numeric.
  The two stores differ only in exception type. The second commit fixes the
  `EntityContractTest` fake, which had been checking "does the text parse as a
  number" and so accepted `StringValue("42")` where production rejects it — no live
  failure, but a false pass waiting for the next entity test.


## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

  - New `KvStoreContractTest` (both the in-memory and DynamoDB variants) pins the
    set/increment/version semantics so the two stores can't drift.
  - `EntityContractTest` (17 tests) for the fake-vs-production increment fix.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

  Reads are backward-compatible in both directions: new binaries parse `S`-typed
  legacy values, and `ATTR_EXPIRES_AT` is still written as `S` specifically so old
  replicas keep seeing it.

  The one asymmetry worth understanding before merging a consumer: **an old replica
  drops `N` attributes on read.** Any table that a new binary starts writing numeric
  attributes into is no longer safe for an old binary to read-modify-write. This PR
  itself writes no numeric attributes to an existing table; it only makes them
  possible. The consumer in `core` handles the consequence by pointing at a fresh
  table.


## Checklist

- [ ] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

  - Merge order: this PR must land before eng-floe/core#<core PR number>, which
    bumps the submodule to it.
  - `ControllerLeaseEntity` / `KvLeaseStore` (core side) deliberately do **not**
    adopt the new primitive — it has no expected-version check, so a lease renew
    would overwrite a lease another holder had stolen. Reviewers may want to sanity
    check that reasoning, since it is the main "why wasn't this used everywhere"
    question.
