### PR TITLE
feat: Add complete connector definition export and import tooling

### DIFF
--- a/core/proto/src/main/proto/floecat/connector/connector.proto
+++ b/core/proto/src/main/proto/floecat/connector/connector.proto
@@ -253,6 +253,34 @@ message ValidateConnectorResponse {
   map<string,string> capabilities = 3;
 }
 
+// Administrative export payload. Unlike GetConnector/ListConnectors, this response is not
+// masked. Access is guarded by the connector.export permission.
+message ExportConnectorRequest {
+  ai.floedb.floecat.common.ResourceId connector_id = 1;
+  bool include_credentials = 2;
+}
+
+message ExportConnectorResponse {
+  Connector connector = 1;
+  optional AuthCredentials credentials = 2;
+}
+
+// Portable on-disk format used by floecat-connector-transfer. connector preserves the exact
+// source record for inspection, while portable_spec replaces account-scoped destination IDs with
+// names and paths suitable for CreateConnector in another account.
+message ConnectorTransferEntry {
+  Connector connector = 1;
+  ConnectorSpec portable_spec = 2;
+  optional AuthCredentials credentials = 3;
+}
+
+message ConnectorTransferBundle {
+  uint32 format_version = 1;
+  string source_account_id = 2;
+  google.protobuf.Timestamp exported_at = 3;
+  repeated ConnectorTransferEntry entries = 4;
+}
+
 service Connectors {
   rpc GetConnector(GetConnectorRequest) returns (GetConnectorResponse);
   rpc ListConnectors(ListConnectorsRequest) returns (ListConnectorsResponse);
@@ -261,4 +289,5 @@ service Connectors {
   rpc DeleteConnector(DeleteConnectorRequest) returns (DeleteConnectorResponse);
 
   rpc ValidateConnector(ValidateConnectorRequest) returns (ValidateConnectorResponse);
+  rpc ExportConnector(ExportConnectorRequest) returns (ExportConnectorResponse);
 }

--- a/docs/fixed-roles.md
+++ b/docs/fixed-roles.md
@@ -9,8 +9,8 @@ Source of truth: `service/src/main/java/ai/floedb/floecat/service/security/RoleP
 | Role name | Purpose | Granted permissions |
 |-----------|---------|---------------------|
 | `default` | Baseline read-only tenant access. Used when no roles are provided in normal (`oidc`) mode. | `account.read`, `catalog.read`, `namespace.read`, `table.read`, `view.read` |
-| `administrator` | Full tenant-scoped administration of metadata and connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `system-objects.read`, `account.delete` |
-| `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `system-objects.read`, `account.delete` |
+| `administrator` | Full tenant-scoped administration of metadata and connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `connector.export`, `system-objects.read`, `account.delete` |
+| `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `connector.export`, `system-objects.read`, `account.delete` |
 | `platform-admin` (or configured value of `floecat.auth.platform-admin.role`) | Platform-level account management role from IdP. | `account.read`, `account.write`, `account.delete` |
 | `init-account` | Bootstrap role used to initialize account + initial resources. | `account.write`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `connector.create` |
 | `delete-account` | Narrow internal role used to trigger account teardown. Floecat performs the implied cleanup internally. | `account.delete` |

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -61,7 +61,7 @@ CLI, and reconciler.
 | `TableConstraintsService` | `GetTableConstraints`, `ListTableConstraints`, `PutTableConstraints`, `MergeTableConstraints`, `AppendTableConstraints`, `DeleteTableConstraints`, `AddTableConstraint`, `DeleteTableConstraint` | Snapshot-scoped constraints CRUD for user tables. `PutTableConstraints` is full-bundle upsert, `MergeTableConstraints` is server-side merge by `constraint.name` plus shallow merge of bundle `properties` (incoming keys win), `AppendTableConstraints` is server-side append-only (duplicate names rejected), and `AddTableConstraint`/`DeleteTableConstraint` are single-constraint partial mutations. All write operations require snapshot existence (`NOT_FOUND` when missing). |
 | `DirectoryService` | `Resolve*` & `Lookup*` RPCs | Translates between names and `ResourceId`s with pagination for batched lookups. |
 | `AccountService` | Account CRUD. |
-| `Connectors` | Connector CRUD, `ValidateConnector`, `StartCapture`, `GetReconcileJob`. |
+| `Connectors` | Connector CRUD, credential-bearing `ExportConnector`, `ValidateConnector`, `StartCapture`, `GetReconcileJob`. |
 | `QueryService` | `BeginQuery`, `RenewQuery`, `EndQuery`, `GetQuery`. |
 | `QuerySchemaService` | `DescribeInputs`. |
 | `QueryScanService` | `InitScan`, `StreamDeleteFiles`, `StreamDataFiles`, `CloseScan`. |

--- a/docs/service.md
+++ b/docs/service.md
@@ -81,7 +81,8 @@ helpers like `randomResourceId` (UUIDv4). Highlights:
   reuses the graph’s ResolveFQ helpers for list/prefix pagination.
 - **AccountServiceImpl** – Administers accounts and enforces conventional permissions.
 - **ConnectorsImpl** – Manages connector lifecycle, validates `ConnectorSpec` via SPI factories,
-  wires reconciliation job submission, and exposes `ValidateConnector` + `StartCapture`.
+  wires reconciliation job submission, and exposes credential-bearing `ExportConnector`,
+  `ValidateConnector`, and `StartCapture`.
   `CaptureNow` maps to reconciler capture modes:
   - metadata only -> `METADATA_ONLY`
   - capture only -> `CAPTURE_ONLY`
@@ -221,7 +222,9 @@ Extension points:
   durable reconcile backend evolves further; they are no longer intended to share one generic
   pointer-prefix queue abstraction.
 - **Security** – Replace `Authorizer` or interceptors with CDI alternatives.
-- **Connectors** – Register new SPI implementations and expose them via `ConnectorRepository`.
+- **Connectors** – Register new SPI implementations and expose them via `ConnectorRepository`;
+  `ExportConnector` returns complete definitions and requires the dedicated `connector.export`
+  permission.
 - **QueryService** – Extend query metadata by enriching `QueryContext` creation or injecting
   additional connector metadata via the `QueryScanService` streaming RPCs / `ScanBundleService` on the query
   path. Reconcile planning/execution does not use `ScanBundleService`; it goes through

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
 
       <!-- Tools -->
       <module>tools/builtin-validator</module>
+      <module>tools/connector-transfer</module>
       <module>tools/error-messages-generator</module>
 
       <!-- Telemetry hub -->

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -32,6 +32,8 @@ import ai.floedb.floecat.connector.rpc.CreateConnectorResponse;
 import ai.floedb.floecat.connector.rpc.DeleteConnectorRequest;
 import ai.floedb.floecat.connector.rpc.DeleteConnectorResponse;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.ExportConnectorRequest;
+import ai.floedb.floecat.connector.rpc.ExportConnectorResponse;
 import ai.floedb.floecat.connector.rpc.GetConnectorRequest;
 import ai.floedb.floecat.connector.rpc.GetConnectorResponse;
 import ai.floedb.floecat.connector.rpc.ListConnectorsRequest;
@@ -214,6 +216,58 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                   return GetConnectorResponse.newBuilder()
                       .setConnector(maskConnector(connector))
                       .build();
+                }),
+            correlationId())
+        .onFailure()
+        .invoke(L::fail)
+        .onItem()
+        .invoke(L::ok);
+  }
+
+  @Override
+  public Uni<ExportConnectorResponse> exportConnector(ExportConnectorRequest request) {
+    var L = LogHelper.start(LOG, "ExportConnector");
+
+    return mapFailures(
+            run(
+                () -> {
+                  var principalContext = principalProvider.get();
+                  var correlationId = principalContext.getCorrelationId();
+                  var accountId = principalContext.getAccountId();
+
+                  authz.require(principalContext, "connector.export");
+                  var connectorId =
+                      scopedConnectorId(accountId, request.getConnectorId(), correlationId);
+
+                  for (int attempt = 0; attempt < 3; attempt++) {
+                    var before = connectorRepo.getById(connectorId);
+                    if (before.isEmpty()) {
+                      throw GrpcErrors.notFound(
+                          correlationId,
+                          GeneratedErrorMessages.MessageKey.CONNECTOR,
+                          Map.of("id", connectorId.getId()));
+                    }
+
+                    Optional<AuthCredentials> firstCredentials = Optional.empty();
+                    Optional<AuthCredentials> secondCredentials = Optional.empty();
+                    if (request.getIncludeCredentials()) {
+                      firstCredentials = credentialResolver.resolve(accountId, connectorId.getId());
+                      secondCredentials =
+                          credentialResolver.resolve(accountId, connectorId.getId());
+                    }
+                    var after = connectorRepo.getById(connectorId);
+
+                    if (after.isPresent()
+                        && before.get().equals(after.get())
+                        && firstCredentials.equals(secondCredentials)) {
+                      var response =
+                          ExportConnectorResponse.newBuilder().setConnector(before.get());
+                      firstCredentials.ifPresent(response::setCredentials);
+                      return response.build();
+                    }
+                  }
+
+                  throw GrpcErrors.aborted(correlationId, Map.of("id", connectorId.getId()));
                 }),
             correlationId())
         .onFailure()

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -574,63 +574,76 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                                       Map.of("id", connectorId.getId())));
 
                   FieldMask normalizedMask = normalizeMask(request.getUpdateMask());
+                  String accountId = pc.getAccountId();
                   var desired =
                       applyConnectorSpecPatch(current, request.getSpec(), normalizedMask, corr)
                           .toBuilder()
                           .setUpdatedAt(nowTs())
                           .build();
+                  if (desired.hasDestination()) {
+                    desired =
+                        desired.toBuilder()
+                            .setDestination(
+                                resolveUpdatedDestination(
+                                    desired.getDestination(), accountId, corr))
+                            .build();
+                  }
                   validateConnectorProperties(
                       desired.getKind(), desired.getPropertiesMap(), corr, "properties");
                   validatePersistedAuthConfig(desired.getAuth(), corr);
                   validateReconcilePolicy(desired.getPolicy(), corr);
-                  String accountId = pc.getAccountId();
                   String secretId = connectorId.getId();
                   boolean authTouched =
                       maskTargets(normalizedMask, "auth")
                           || maskTargets(normalizedMask, "auth.credentials");
                   boolean incomingHasCredentials = hasAuthCredentials(desired.getAuth());
-                  Optional<AuthCredentials> priorCredentials = Optional.empty();
+                  boolean shouldDeleteSecret = authTouched && !incomingHasCredentials;
+                  Optional<AuthCredentials> priorCredentials =
+                      authTouched
+                          ? credentialResolver.resolve(accountId, secretId)
+                          : Optional.empty();
                   AuthConfig storedAuth = desired.getAuth();
                   if (incomingHasCredentials) {
-                    priorCredentials = credentialResolver.resolve(accountId, secretId);
                     storedAuth =
                         storeAuthCredentials(desired.getAuth(), accountId, connectorId.getId());
                     if (storedAuth != desired.getAuth()) {
                       desired = desired.toBuilder().setAuth(storedAuth).build();
                     }
+                  } else if (shouldDeleteSecret) {
+                    credentialResolver.delete(accountId, secretId);
                   }
                   ensureNoStoredCredentials(desired.getAuth());
-                  boolean shouldDeleteSecret = authTouched && !incomingHasCredentials;
 
                   if (desired.equals(current)) {
-                    if (shouldDeleteSecret) {
-                      credentialResolver.delete(accountId, secretId);
+                    try {
+                      var metaNoop = connectorRepo.metaFor(connectorId);
+                      boolean callerCares = hasMeaningfulPrecondition(request.getPrecondition());
+                      if (callerCares && metaNoop.getPointerVersion() != meta.getPointerVersion()) {
+                        throw GrpcErrors.preconditionFailed(
+                            corr,
+                            GeneratedErrorMessages.MessageKey.VERSION_MISMATCH,
+                            Map.of(
+                                "expected", Long.toString(meta.getPointerVersion()),
+                                "actual", Long.toString(metaNoop.getPointerVersion())));
+                      }
+                      MutationOps.BaseServiceChecks.enforcePreconditions(
+                          corr, metaNoop, request.getPrecondition());
+                      return UpdateConnectorResponse.newBuilder()
+                          .setConnector(maskConnector(current))
+                          .setMeta(metaNoop)
+                          .build();
+                    } catch (RuntimeException failure) {
+                      if (authTouched) {
+                        restoreCredentials(accountId, secretId, priorCredentials);
+                      }
+                      throw failure;
                     }
-                    var metaNoop = connectorRepo.metaFor(connectorId);
-                    boolean callerCares = hasMeaningfulPrecondition(request.getPrecondition());
-                    if (callerCares && metaNoop.getPointerVersion() != meta.getPointerVersion()) {
-                      throw GrpcErrors.preconditionFailed(
-                          corr,
-                          GeneratedErrorMessages.MessageKey.VERSION_MISMATCH,
-                          Map.of(
-                              "expected", Long.toString(meta.getPointerVersion()),
-                              "actual", Long.toString(metaNoop.getPointerVersion())));
-                    }
-                    MutationOps.BaseServiceChecks.enforcePreconditions(
-                        corr, metaNoop, request.getPrecondition());
-                    return UpdateConnectorResponse.newBuilder()
-                        .setConnector(maskConnector(current))
-                        .setMeta(metaNoop)
-                        .build();
                   }
 
                   try {
                     boolean ok = connectorRepo.update(desired, meta.getPointerVersion());
                     if (!ok) {
                       var nowMeta = connectorRepo.metaForSafe(connectorId);
-                      if (incomingHasCredentials) {
-                        restoreCredentials(accountId, secretId, priorCredentials);
-                      }
                       throw GrpcErrors.preconditionFailed(
                           corr,
                           GeneratedErrorMessages.MessageKey.VERSION_MISMATCH,
@@ -639,7 +652,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                               "actual", Long.toString(nowMeta.getPointerVersion())));
                     }
                   } catch (BaseResourceRepository.NameConflictException nce) {
-                    if (incomingHasCredentials) {
+                    if (authTouched) {
                       restoreCredentials(accountId, secretId, priorCredentials);
                     }
                     throw GrpcErrors.alreadyExists(
@@ -648,7 +661,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                         Map.of("display_name", desired.getDisplayName()));
                   } catch (BaseResourceRepository.PreconditionFailedException pfe) {
                     var nowMeta = connectorRepo.metaForSafe(connectorId);
-                    if (incomingHasCredentials) {
+                    if (authTouched) {
                       restoreCredentials(accountId, secretId, priorCredentials);
                     }
                     throw GrpcErrors.preconditionFailed(
@@ -657,10 +670,11 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                         Map.of(
                             "expected", Long.toString(meta.getPointerVersion()),
                             "actual", Long.toString(nowMeta.getPointerVersion())));
-                  }
-
-                  if (shouldDeleteSecret) {
-                    credentialResolver.delete(accountId, secretId);
+                  } catch (RuntimeException failure) {
+                    if (authTouched) {
+                      restoreCredentials(accountId, secretId, priorCredentials);
+                    }
+                    throw failure;
                   }
 
                   var outMeta = connectorRepo.metaForSafe(connectorId);
@@ -826,6 +840,43 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
     }
     return auth.getCredentials().getCredentialCase()
         != AuthCredentials.CredentialCase.CREDENTIAL_NOT_SET;
+  }
+
+  private DestinationTarget resolveUpdatedDestination(
+      DestinationTarget destination, String accountId, String corr) {
+    var resolved = destination.toBuilder();
+    if (destination.hasCatalogDisplayName()) {
+      String displayName = destination.getCatalogDisplayName().trim();
+      var catalog = catalogRepo.getByName(accountId, displayName);
+      if (catalog.isEmpty()) {
+        throw GrpcErrors.notFound(
+            corr,
+            GeneratedErrorMessages.MessageKey.CONNECTOR_DESTINATION_CATALOG_NOT_FOUND,
+            Map.of("display_name", displayName));
+      }
+      resolved.setCatalogId(catalog.get().getResourceId());
+    }
+    if (resolved.hasCatalogId() && destination.hasNamespace()) {
+      namespaceRepo
+          .getByPath(
+              accountId,
+              resolved.getCatalogId().getId(),
+              destination.getNamespace().getSegmentsList())
+          .ifPresent(namespace -> resolved.setNamespaceId(namespace.getResourceId()));
+    }
+    if (resolved.hasCatalogId() && resolved.hasNamespaceId() && destination.hasTableDisplayName()) {
+      String displayName = destination.getTableDisplayName().trim();
+      tableRepo
+          .getByName(
+              accountId,
+              resolved.getCatalogId().getId(),
+              resolved.getNamespaceId().getId(),
+              displayName)
+          .ifPresentOrElse(
+              table -> resolved.setTableId(table.getResourceId()),
+              () -> resolved.setTableDisplayName(displayName));
+    }
+    return resolved.build();
   }
 
   private void restoreCredentials(

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -300,6 +300,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
 
                   var display = mustNonEmpty(spec.getDisplayName(), "display_name", corr);
                   var uri = mustNonEmpty(spec.getUri(), "uri", corr);
+                  var initialState = initialConnectorState(spec.getState(), corr);
                   validateConnectorProperties(spec.getKind(), spec.getPropertiesMap(), corr);
                   validatePersistedAuthConfig(spec.getAuth(), corr);
                   validateReconcilePolicy(spec.getPolicy(), corr);
@@ -430,7 +431,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                           .setPolicy(spec.getPolicy())
                           .setCreatedAt(tsNow)
                           .setUpdatedAt(tsNow)
-                          .setState(ConnectorState.CS_ACTIVE);
+                          .setState(initialState);
 
                   if (spec.hasDescription()) builder.setDescription(spec.getDescription());
                   if (spec.hasSource()) builder.setSource(spec.getSource());
@@ -848,6 +849,16 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
         != AuthCredentials.CredentialCase.CREDENTIAL_NOT_SET;
   }
 
+  static ConnectorState initialConnectorState(ConnectorState requestedState, String corr) {
+    return switch (requestedState) {
+      case CS_UNSPECIFIED, CS_ACTIVE -> ConnectorState.CS_ACTIVE;
+      case CS_PAUSED -> ConnectorState.CS_PAUSED;
+      case CS_DELETING, UNRECOGNIZED ->
+          throw GrpcErrors.invalidArgument(
+              corr, GeneratedErrorMessages.MessageKey.FIELD, Map.of("field", "state"));
+    };
+  }
+
   private DestinationTarget resolveUpdatedDestination(
       DestinationTarget destination, SourceSelector source, String accountId, String corr) {
     var resolved = destination.toBuilder();
@@ -1225,21 +1236,12 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
       boolean hasCatalogRef =
           inDst.hasCatalogId()
               || (inDst.hasCatalogDisplayName() && !inDst.getCatalogDisplayName().isBlank());
-      boolean hasNamespaceRef =
-          inDst.hasNamespaceId()
-              || (inDst.hasNamespace() && inDst.getNamespace().getSegmentsCount() > 0);
 
       if (!hasCatalogRef) {
         throw GrpcErrors.invalidArgument(
             corr,
             GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_DESTINATION_CATALOG,
             Map.of("field", "destination.catalog"));
-      }
-      if (!hasNamespaceRef) {
-        throw GrpcErrors.invalidArgument(
-            corr,
-            GeneratedErrorMessages.MessageKey.FIELD,
-            Map.of("field", "destination.namespace"));
       }
       if (inDst.hasCatalogId()) {
         ensureKind(
@@ -1419,14 +1421,6 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
             corr,
             GeneratedErrorMessages.MessageKey.CONNECTOR_MISSING_DESTINATION_CATALOG,
             Map.of("field", "destination.catalog"));
-      }
-      boolean hasNamespaceRef =
-          d.hasNamespaceId() || (d.hasNamespace() && d.getNamespace().getSegmentsCount() > 0);
-      if (!hasNamespaceRef) {
-        throw GrpcErrors.invalidArgument(
-            corr,
-            GeneratedErrorMessages.MessageKey.FIELD,
-            Map.of("field", "destination.namespace"));
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -378,7 +378,10 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                   if (destB.hasCatalogId()
                       && destB.hasNamespaceId()
                       && dest.hasTableDisplayName()
-                      && !dest.hasTableId()) {
+                      && !dest.hasTableId()
+                      && spec.hasSource()
+                      && spec.getSource().hasTable()
+                      && !spec.getSource().getTable().isBlank()) {
                     String dTbl = dest.getTableDisplayName().trim();
                     var tblOpt =
                         tableRepo.getByName(
@@ -580,12 +583,15 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                           .toBuilder()
                           .setUpdatedAt(nowTs())
                           .build();
-                  if (desired.hasDestination()) {
+                  boolean destinationTouched =
+                      maskTargets(normalizedMask, "destination")
+                          || maskTargetsUnder(normalizedMask, "destination");
+                  if (destinationTouched && desired.hasDestination()) {
                     desired =
                         desired.toBuilder()
                             .setDestination(
                                 resolveUpdatedDestination(
-                                    desired.getDestination(), accountId, corr))
+                                    desired.getDestination(), desired.getSource(), accountId, corr))
                             .build();
                   }
                   validateConnectorProperties(
@@ -843,7 +849,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
   }
 
   private DestinationTarget resolveUpdatedDestination(
-      DestinationTarget destination, String accountId, String corr) {
+      DestinationTarget destination, SourceSelector source, String accountId, String corr) {
     var resolved = destination.toBuilder();
     if (destination.hasCatalogDisplayName()) {
       String displayName = destination.getCatalogDisplayName().trim();
@@ -864,7 +870,11 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
               destination.getNamespace().getSegmentsList())
           .ifPresent(namespace -> resolved.setNamespaceId(namespace.getResourceId()));
     }
-    if (resolved.hasCatalogId() && resolved.hasNamespaceId() && destination.hasTableDisplayName()) {
+    if (resolved.hasCatalogId()
+        && resolved.hasNamespaceId()
+        && destination.hasTableDisplayName()
+        && source.hasTable()
+        && !source.getTable().isBlank()) {
       String displayName = destination.getTableDisplayName().trim();
       tableRepo
           .getByName(

--- a/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
@@ -47,6 +47,7 @@ public final class RolePermissions {
           "view.read",
           "view.write",
           "connector.manage",
+          "connector.export",
           "system-objects.read",
           "account.delete");
   private static final List<String> PLATFORM_PERMS =

--- a/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplCreateConnectorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplCreateConnectorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.connector.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.rpc.Catalog;
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorKind;
+import ai.floedb.floecat.connector.rpc.ConnectorSpec;
+import ai.floedb.floecat.connector.rpc.ConnectorState;
+import ai.floedb.floecat.connector.rpc.CreateConnectorRequest;
+import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceSelector;
+import ai.floedb.floecat.connector.spi.CredentialResolver;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import java.lang.reflect.Field;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ConnectorsImplCreateConnectorTest {
+  @Test
+  void createsPausedConnectorAtomically() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.catalogRepo = mock(CatalogRepository.class);
+    service.namespaceRepo = mock(NamespaceRepository.class);
+    service.tableRepo = mock(TableRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var principal =
+        PrincipalContext.newBuilder()
+            .setAccountId("acct")
+            .setCorrelationId("corr")
+            .addPermissions("connector.manage")
+            .addPermissions("connector.create")
+            .build();
+    var catalogId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("catalog-id")
+            .setKind(ResourceKind.RK_CATALOG)
+            .build();
+    when(service.principalProvider.get()).thenReturn(principal);
+    when(service.catalogRepo.getByName("acct", "catalog"))
+        .thenReturn(Optional.of(Catalog.newBuilder().setResourceId(catalogId).build()));
+    when(service.namespaceRepo.getByPath(any(), any(), any())).thenReturn(Optional.empty());
+    when(service.connectorRepo.getByName("acct", "connector")).thenReturn(Optional.empty());
+    when(service.connectorRepo.metaFor(any())).thenReturn(MutationMeta.getDefaultInstance());
+
+    var response =
+        service
+            .createConnector(
+                CreateConnectorRequest.newBuilder()
+                    .setSpec(
+                        ConnectorSpec.newBuilder()
+                            .setDisplayName("connector")
+                            .setKind(ConnectorKind.CK_ICEBERG)
+                            .setUri("https://source.example")
+                            .setSource(
+                                SourceSelector.newBuilder()
+                                    .setNamespace(
+                                        NamespacePath.newBuilder().addSegments("source")))
+                            .setDestination(
+                                DestinationTarget.newBuilder()
+                                    .setCatalogDisplayName("catalog"))
+                            .setState(ConnectorState.CS_PAUSED))
+                    .build())
+            .await()
+            .indefinitely();
+
+    var created = ArgumentCaptor.forClass(Connector.class);
+    org.mockito.Mockito.verify(service.connectorRepo).create(created.capture());
+    assertThat(created.getValue().getState()).isEqualTo(ConnectorState.CS_PAUSED);
+    assertThat(response.getConnector().getState()).isEqualTo(ConnectorState.CS_PAUSED);
+  }
+
+  private static void installBasePrincipal(
+      ConnectorsImpl service, PrincipalProvider principalProvider) {
+    try {
+      Field field =
+          ai.floedb.floecat.service.common.BaseServiceImpl.class.getDeclaredField("principal");
+      field.setAccessible(true);
+      field.set(service, principalProvider);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to inject BaseServiceImpl principal provider", e);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplCreateConnectorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplCreateConnectorTest.java
@@ -90,11 +90,9 @@ class ConnectorsImplCreateConnectorTest {
                             .setUri("https://source.example")
                             .setSource(
                                 SourceSelector.newBuilder()
-                                    .setNamespace(
-                                        NamespacePath.newBuilder().addSegments("source")))
+                                    .setNamespace(NamespacePath.newBuilder().addSegments("source")))
                             .setDestination(
-                                DestinationTarget.newBuilder()
-                                    .setCatalogDisplayName("catalog"))
+                                DestinationTarget.newBuilder().setCatalogDisplayName("catalog"))
                             .setState(ConnectorState.CS_PAUSED))
                     .build())
             .await()

--- a/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplExportConnectorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplExportConnectorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.connector.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.AuthConfig;
+import ai.floedb.floecat.connector.rpc.AuthCredentials;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ExportConnectorRequest;
+import ai.floedb.floecat.connector.spi.CredentialResolver;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import java.lang.reflect.Field;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ConnectorsImplExportConnectorTest {
+  @Test
+  void exportsUnmaskedConnectorAndSeparateCredentials() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("connector-1")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    var connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setDisplayName("upstream")
+            .setAuth(AuthConfig.newBuilder().putProperties("client_id", "not-masked"))
+            .build();
+    var credentials =
+        AuthCredentials.newBuilder()
+            .setBearer(AuthCredentials.BearerToken.newBuilder().setToken("secret-token"))
+            .build();
+    var principal =
+        PrincipalContext.newBuilder()
+            .setAccountId("acct")
+            .setCorrelationId("corr-1")
+            .addPermissions("connector.export")
+            .build();
+
+    when(service.principalProvider.get()).thenReturn(principal);
+    when(service.connectorRepo.getById(connectorId)).thenReturn(Optional.of(connector));
+    when(service.credentialResolver.resolve("acct", "connector-1"))
+        .thenReturn(Optional.of(credentials));
+
+    var response =
+        service
+            .exportConnector(
+                ExportConnectorRequest.newBuilder()
+                    .setConnectorId(connectorId)
+                    .setIncludeCredentials(true)
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertThat(response.getConnector()).isEqualTo(connector);
+    assertThat(response.getCredentials()).isEqualTo(credentials);
+    verify(service.authz).require(principal, "connector.export");
+  }
+
+  private static void installBasePrincipal(
+      ConnectorsImpl service, PrincipalProvider principalProvider) {
+    try {
+      Field field =
+          ai.floedb.floecat.service.common.BaseServiceImpl.class.getDeclaredField("principal");
+      field.setAccessible(true);
+      field.set(service, principalProvider);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to inject BaseServiceImpl principal provider", e);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplUpdateConnectorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplUpdateConnectorTest.java
@@ -35,6 +35,7 @@ import ai.floedb.floecat.connector.rpc.AuthCredentials;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorKind;
 import ai.floedb.floecat.connector.rpc.ConnectorSpec;
+import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
 import ai.floedb.floecat.connector.rpc.NamespacePath;
 import ai.floedb.floecat.connector.rpc.SourceSelector;
@@ -52,6 +53,23 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class ConnectorsImplUpdateConnectorTest {
+  @Test
+  void createStatePreservesPausedAndDefaultsUnspecifiedToActive() {
+    assertEquals(
+        ConnectorState.CS_PAUSED,
+        ConnectorsImpl.initialConnectorState(ConnectorState.CS_PAUSED, "corr"));
+    assertEquals(
+        ConnectorState.CS_ACTIVE,
+        ConnectorsImpl.initialConnectorState(ConnectorState.CS_UNSPECIFIED, "corr"));
+  }
+
+  @Test
+  void createStateRejectsDeleting() {
+    assertThrows(
+        RuntimeException.class,
+        () -> ConnectorsImpl.initialConnectorState(ConnectorState.CS_DELETING, "corr"));
+  }
+
   @Test
   void uriUpdateDoesNotResolveExistingDestinationReferences() throws Exception {
     var service = new ConnectorsImpl();
@@ -144,6 +162,48 @@ class ConnectorsImplUpdateConnectorTest {
     var updated = captureUpdatedConnector(service);
     assertEquals(replacement, updated.getDestination());
     verifyNoInteractions(service.tableRepo);
+  }
+
+  @Test
+  void fullDestinationUpdateAcceptsCatalogOnlyTarget() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.tableRepo = mock(TableRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var connectorId = resourceId("connector-1", ResourceKind.RK_CONNECTOR);
+    var catalogId = resourceId("catalog-1", ResourceKind.RK_CATALOG);
+    var current =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setDisplayName("connector")
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setUri("uri")
+            .setSource(
+                SourceSelector.newBuilder()
+                    .setNamespace(NamespacePath.newBuilder().addSegments("sales")))
+            .setDestination(
+                DestinationTarget.newBuilder()
+                    .setCatalogId(catalogId)
+                    .setNamespaceId(resourceId("namespace-1", ResourceKind.RK_NAMESPACE)))
+            .build();
+    var replacement = DestinationTarget.newBuilder().setCatalogId(catalogId).build();
+    stubSuccessfulUpdate(service, connectorId, current);
+
+    service
+        .updateConnector(
+            UpdateConnectorRequest.newBuilder()
+                .setConnectorId(connectorId)
+                .setSpec(ConnectorSpec.newBuilder().setDestination(replacement))
+                .setUpdateMask(FieldMask.newBuilder().addPaths("destination"))
+                .build())
+        .await()
+        .indefinitely();
+
+    assertEquals(replacement, captureUpdatedConnector(service).getDestination());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplUpdateConnectorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplUpdateConnectorTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.connector.impl;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.AuthConfig;
+import ai.floedb.floecat.connector.rpc.AuthCredentials;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorKind;
+import ai.floedb.floecat.connector.rpc.ConnectorSpec;
+import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.UpdateConnectorRequest;
+import ai.floedb.floecat.connector.spi.CredentialResolver;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import com.google.protobuf.FieldMask;
+import java.lang.reflect.Field;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ConnectorsImplUpdateConnectorTest {
+  @Test
+  void restoresRemovedCredentialsWhenRepositoryUpdateFails() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("connector-1")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    var current =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setDisplayName("connector")
+            .setKind(ConnectorKind.CK_UNITY)
+            .setUri("old-uri")
+            .setAuth(AuthConfig.newBuilder().setScheme("bearer"))
+            .build();
+    var previous =
+        AuthCredentials.newBuilder()
+            .setBearer(AuthCredentials.BearerToken.newBuilder().setToken("previous"))
+            .build();
+    var principal =
+        PrincipalContext.newBuilder()
+            .setAccountId("acct")
+            .setCorrelationId("corr-1")
+            .addPermissions("connector.manage")
+            .build();
+
+    when(service.principalProvider.get()).thenReturn(principal);
+    when(service.connectorRepo.metaFor(connectorId))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(7L).build());
+    when(service.connectorRepo.getById(connectorId)).thenReturn(Optional.of(current));
+    when(service.credentialResolver.resolve("acct", "connector-1"))
+        .thenReturn(Optional.of(previous));
+    when(service.connectorRepo.update(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(7L)))
+        .thenThrow(new IllegalStateException("repository unavailable"));
+
+    var request =
+        UpdateConnectorRequest.newBuilder()
+            .setConnectorId(connectorId)
+            .setSpec(
+                ConnectorSpec.newBuilder()
+                    .setUri("new-uri")
+                    .setAuth(AuthConfig.newBuilder().setScheme("none")))
+            .setUpdateMask(FieldMask.newBuilder().addPaths("uri").addPaths("auth"))
+            .build();
+
+    assertThrows(
+        RuntimeException.class, () -> service.updateConnector(request).await().indefinitely());
+
+    var ordered = inOrder(service.credentialResolver);
+    ordered.verify(service.credentialResolver).delete("acct", "connector-1");
+    ordered.verify(service.credentialResolver).store("acct", "connector-1", previous);
+  }
+
+  @Test
+  void rejectsUnresolvedReplacementCatalogBeforeUpdatingConnector() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.catalogRepo = mock(CatalogRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("connector-1")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    var current = Connector.newBuilder().setResourceId(connectorId).build();
+    var principal =
+        PrincipalContext.newBuilder()
+            .setAccountId("acct")
+            .setCorrelationId("corr-1")
+            .addPermissions("connector.manage")
+            .build();
+
+    when(service.principalProvider.get()).thenReturn(principal);
+    when(service.connectorRepo.metaFor(connectorId))
+        .thenReturn(MutationMeta.newBuilder().setPointerVersion(7L).build());
+    when(service.connectorRepo.getById(connectorId)).thenReturn(Optional.of(current));
+    when(service.catalogRepo.getByName("acct", "missing-catalog")).thenReturn(Optional.empty());
+
+    var request =
+        UpdateConnectorRequest.newBuilder()
+            .setConnectorId(connectorId)
+            .setSpec(
+                ConnectorSpec.newBuilder()
+                    .setDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogDisplayName("missing-catalog")
+                            .setNamespace(NamespacePath.newBuilder().addSegments("namespace"))))
+            .setUpdateMask(FieldMask.newBuilder().addPaths("destination"))
+            .build();
+
+    assertThrows(
+        RuntimeException.class, () -> service.updateConnector(request).await().indefinitely());
+
+    verify(service.connectorRepo, never())
+        .update(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyLong());
+  }
+
+  @Test
+  void restoresPriorCredentialsWhenRepositoryUpdateFailsUnexpectedly() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("connector-1")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    var current =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setDisplayName("connector")
+            .setKind(ConnectorKind.CK_UNITY)
+            .setUri("old-uri")
+            .setAuth(AuthConfig.newBuilder().setScheme("bearer"))
+            .build();
+    var previous =
+        AuthCredentials.newBuilder()
+            .setBearer(AuthCredentials.BearerToken.newBuilder().setToken("previous"))
+            .build();
+    var replacement =
+        AuthCredentials.newBuilder()
+            .setBearer(AuthCredentials.BearerToken.newBuilder().setToken("replacement"))
+            .build();
+    var principal =
+        PrincipalContext.newBuilder()
+            .setAccountId("acct")
+            .setCorrelationId("corr-1")
+            .addPermissions("connector.manage")
+            .build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+
+    when(service.principalProvider.get()).thenReturn(principal);
+    when(service.connectorRepo.metaFor(connectorId)).thenReturn(meta);
+    when(service.connectorRepo.getById(connectorId)).thenReturn(Optional.of(current));
+    when(service.credentialResolver.resolve("acct", "connector-1"))
+        .thenReturn(Optional.of(previous));
+    when(service.connectorRepo.update(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(7L)))
+        .thenThrow(new IllegalStateException("repository unavailable"));
+
+    var request =
+        UpdateConnectorRequest.newBuilder()
+            .setConnectorId(connectorId)
+            .setSpec(
+                ConnectorSpec.newBuilder()
+                    .setUri("new-uri")
+                    .setAuth(
+                        AuthConfig.newBuilder().setScheme("bearer").setCredentials(replacement)))
+            .setUpdateMask(FieldMask.newBuilder().addPaths("uri").addPaths("auth"))
+            .build();
+
+    assertThrows(
+        RuntimeException.class, () -> service.updateConnector(request).await().indefinitely());
+
+    var ordered = inOrder(service.credentialResolver);
+    ordered.verify(service.credentialResolver).store("acct", "connector-1", replacement);
+    ordered.verify(service.credentialResolver).store("acct", "connector-1", previous);
+  }
+
+  private static void installBasePrincipal(
+      ConnectorsImpl service, PrincipalProvider principalProvider) {
+    try {
+      Field field =
+          ai.floedb.floecat.service.common.BaseServiceImpl.class.getDeclaredField("principal");
+      field.setAccessible(true);
+      field.set(service, principalProvider);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to inject BaseServiceImpl principal provider", e);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplUpdateConnectorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplUpdateConnectorTest.java
@@ -16,13 +16,16 @@
 
 package ai.floedb.floecat.service.connector.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -34,18 +37,169 @@ import ai.floedb.floecat.connector.rpc.ConnectorKind;
 import ai.floedb.floecat.connector.rpc.ConnectorSpec;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
 import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceSelector;
 import ai.floedb.floecat.connector.rpc.UpdateConnectorRequest;
 import ai.floedb.floecat.connector.spi.CredentialResolver;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import com.google.protobuf.FieldMask;
 import java.lang.reflect.Field;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class ConnectorsImplUpdateConnectorTest {
+  @Test
+  void uriUpdateDoesNotResolveExistingDestinationReferences() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.tableRepo = mock(TableRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var connectorId = resourceId("connector-1", ResourceKind.RK_CONNECTOR);
+    var destination =
+        DestinationTarget.newBuilder()
+            .setCatalogId(resourceId("catalog-1", ResourceKind.RK_CATALOG))
+            .setNamespaceId(resourceId("namespace-1", ResourceKind.RK_NAMESPACE))
+            .setTableDisplayName("orders")
+            .build();
+    var current =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setDisplayName("connector")
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setUri("old-uri")
+            .setSource(
+                SourceSelector.newBuilder()
+                    .setNamespace(NamespacePath.newBuilder().addSegments("sales")))
+            .setDestination(destination)
+            .build();
+    stubSuccessfulUpdate(service, connectorId, current);
+
+    service
+        .updateConnector(
+            UpdateConnectorRequest.newBuilder()
+                .setConnectorId(connectorId)
+                .setSpec(ConnectorSpec.newBuilder().setUri("new-uri"))
+                .setUpdateMask(FieldMask.newBuilder().addPaths("uri"))
+                .build())
+        .await()
+        .indefinitely();
+
+    var updated = captureUpdatedConnector(service);
+    assertEquals(destination, updated.getDestination());
+    verifyNoInteractions(service.tableRepo);
+  }
+
+  @Test
+  void destinationUpdateDoesNotPinNamespaceDiscoveryConnectorToExistingTable() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.tableRepo = mock(TableRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var connectorId = resourceId("connector-1", ResourceKind.RK_CONNECTOR);
+    var current =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setDisplayName("connector")
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setUri("uri")
+            .setSource(
+                SourceSelector.newBuilder()
+                    .setNamespace(NamespacePath.newBuilder().addSegments("sales")))
+            .setDestination(
+                DestinationTarget.newBuilder()
+                    .setCatalogId(resourceId("catalog-1", ResourceKind.RK_CATALOG))
+                    .setNamespaceId(resourceId("namespace-1", ResourceKind.RK_NAMESPACE))
+                    .setTableDisplayName("old-name"))
+            .build();
+    var replacement =
+        DestinationTarget.newBuilder()
+            .setCatalogId(resourceId("catalog-1", ResourceKind.RK_CATALOG))
+            .setNamespaceId(resourceId("namespace-1", ResourceKind.RK_NAMESPACE))
+            .setTableDisplayName("orders")
+            .build();
+    stubSuccessfulUpdate(service, connectorId, current);
+
+    service
+        .updateConnector(
+            UpdateConnectorRequest.newBuilder()
+                .setConnectorId(connectorId)
+                .setSpec(ConnectorSpec.newBuilder().setDestination(replacement))
+                .setUpdateMask(FieldMask.newBuilder().addPaths("destination"))
+                .build())
+        .await()
+        .indefinitely();
+
+    var updated = captureUpdatedConnector(service);
+    assertEquals(replacement, updated.getDestination());
+    verifyNoInteractions(service.tableRepo);
+  }
+
+  @Test
+  void destinationUpdateStillResolvesTableForSingleTableConnector() throws Exception {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.tableRepo = mock(TableRepository.class);
+    service.principalProvider = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    installBasePrincipal(service, service.principalProvider);
+
+    var connectorId = resourceId("connector-1", ResourceKind.RK_CONNECTOR);
+    var catalogId = resourceId("catalog-1", ResourceKind.RK_CATALOG);
+    var namespaceId = resourceId("namespace-1", ResourceKind.RK_NAMESPACE);
+    var tableId = resourceId("table-1", ResourceKind.RK_TABLE);
+    var current =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setDisplayName("connector")
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setUri("uri")
+            .setSource(
+                SourceSelector.newBuilder()
+                    .setNamespace(NamespacePath.newBuilder().addSegments("sales"))
+                    .setTable("orders"))
+            .setDestination(
+                DestinationTarget.newBuilder()
+                    .setCatalogId(catalogId)
+                    .setNamespaceId(namespaceId)
+                    .setTableDisplayName("old-name"))
+            .build();
+    var replacement =
+        DestinationTarget.newBuilder()
+            .setCatalogId(catalogId)
+            .setNamespaceId(namespaceId)
+            .setTableDisplayName("orders")
+            .build();
+    stubSuccessfulUpdate(service, connectorId, current);
+    when(service.tableRepo.getByName("acct", "catalog-1", "namespace-1", "orders"))
+        .thenReturn(Optional.of(Table.newBuilder().setResourceId(tableId).build()));
+
+    service
+        .updateConnector(
+            UpdateConnectorRequest.newBuilder()
+                .setConnectorId(connectorId)
+                .setSpec(ConnectorSpec.newBuilder().setDestination(replacement))
+                .setUpdateMask(FieldMask.newBuilder().addPaths("destination"))
+                .build())
+        .await()
+        .indefinitely();
+
+    var updated = captureUpdatedConnector(service);
+    assertEquals(tableId, updated.getDestination().getTableId());
+  }
+
   @Test
   void restoresRemovedCredentialsWhenRepositoryUpdateFails() throws Exception {
     var service = new ConnectorsImpl();
@@ -234,5 +388,33 @@ class ConnectorsImplUpdateConnectorTest {
     } catch (ReflectiveOperationException e) {
       throw new AssertionError("Failed to inject BaseServiceImpl principal provider", e);
     }
+  }
+
+  private static ResourceId resourceId(String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("acct").setId(id).setKind(kind).build();
+  }
+
+  private static void stubSuccessfulUpdate(
+      ConnectorsImpl service, ResourceId connectorId, Connector current) {
+    var principal =
+        PrincipalContext.newBuilder()
+            .setAccountId("acct")
+            .setCorrelationId("corr-1")
+            .addPermissions("connector.manage")
+            .build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    when(service.principalProvider.get()).thenReturn(principal);
+    when(service.connectorRepo.metaFor(connectorId)).thenReturn(meta);
+    when(service.connectorRepo.getById(connectorId)).thenReturn(Optional.of(current));
+    when(service.connectorRepo.update(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(7L)))
+        .thenReturn(true);
+    when(service.connectorRepo.metaForSafe(connectorId)).thenReturn(meta);
+  }
+
+  private static Connector captureUpdatedConnector(ConnectorsImpl service) {
+    var captor = ArgumentCaptor.forClass(Connector.class);
+    verify(service.connectorRepo).update(captor.capture(), org.mockito.ArgumentMatchers.eq(7L));
+    return captor.getValue();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
@@ -37,6 +37,7 @@ class RolePermissionsTest {
           "view.read",
           "view.write",
           "connector.manage",
+          "connector.export",
           "system-objects.read",
           "account.delete");
   private static final List<String> INIT_ACCOUNT_PERMS =

--- a/tools/connector-transfer/README.md
+++ b/tools/connector-transfer/README.md
@@ -19,7 +19,7 @@ Export every connector from an account:
 
 ```shell
 tools/connector-transfer/floecat-connector-transfer \
-  --host localhost --port 9100 --account-id ACCOUNT_ID \
+  --host localhost --port 9100 --plaintext --account-id ACCOUNT_ID \
   export connectors.zip --plaintext-secrets
 ```
 
@@ -56,5 +56,5 @@ same-name connector in place, preserving its target connector ID. The tool emits
 connector ID and target connector ID for each successful import.
 
 Authentication can be provided through `--token`, `--session-token`, `FLOECAT_TOKEN`, or
-`FLOECAT_SESSION_TOKEN`. Connections are plaintext by default, matching the Floecat development
-CLI; pass `--tls` for a TLS endpoint.
+`FLOECAT_SESSION_TOKEN`. Connections use TLS by default. For a local development endpoint that
+does not support TLS, pass `--plaintext` explicitly; never use it across an untrusted network.

--- a/tools/connector-transfer/README.md
+++ b/tools/connector-transfer/README.md
@@ -1,0 +1,57 @@
+# Floecat connector transfer
+
+`floecat-connector-transfer` exports and imports complete connector definitions. The export archive
+contains the unmasked connector protobuf and, when present, its separate `AuthCredentials`
+protobuf. Treat the archive as a secret.
+
+The tool uses the project's Java 25 target. The source Floecat service must include the
+`ExportConnector` RPC added with this module. Avoid updating connector credentials while an export
+is running; connector records and secrets live in separate stores and cannot provide a distributed
+transactional snapshot.
+
+Build the executable jar:
+
+```shell
+mvn -pl tools/connector-transfer -am package
+```
+
+Export every connector from an account:
+
+```shell
+tools/connector-transfer/floecat-connector-transfer \
+  --host localhost --port 9100 --account-id ACCOUNT_ID \
+  export connectors.zip --plaintext-secrets
+```
+
+Use repeated `--connector NAME_OR_ID` options to select individual connectors. Export requires the
+`connector.export` permission. Administrator and developer roles receive this permission.
+
+Inspect an archive without printing credential values:
+
+```shell
+tools/connector-transfer/floecat-connector-transfer inspect connectors.zip
+```
+
+Validate an import without changing the target:
+
+```shell
+tools/connector-transfer/floecat-connector-transfer \
+  --host target.example --port 9100 --account-id TARGET_ACCOUNT \
+  import connectors.zip --dry-run
+```
+
+Import and fail if a display name already exists:
+
+```shell
+tools/connector-transfer/floecat-connector-transfer \
+  --host target.example --port 9100 --account-id TARGET_ACCOUNT \
+  import connectors.zip
+```
+
+`--conflict SKIP` leaves existing connectors unchanged. `--conflict REPLACE` deletes an existing
+same-name connector before creating the imported definition, so use it deliberately. The tool emits
+the source connector ID and new target connector ID for each successful import.
+
+Authentication can be provided through `--token`, `--session-token`, `FLOECAT_TOKEN`, or
+`FLOECAT_SESSION_TOKEN`. Connections are plaintext by default, matching the Floecat development
+CLI; pass `--tls` for a TLS endpoint.

--- a/tools/connector-transfer/README.md
+++ b/tools/connector-transfer/README.md
@@ -51,9 +51,9 @@ tools/connector-transfer/floecat-connector-transfer \
   import connectors.zip
 ```
 
-`--conflict SKIP` leaves existing connectors unchanged. `--conflict REPLACE` deletes an existing
-same-name connector before creating the imported definition, so use it deliberately. The tool emits
-the source connector ID and new target connector ID for each successful import.
+`--conflict SKIP` leaves existing connectors unchanged. `--conflict REPLACE` updates the existing
+same-name connector in place, preserving its target connector ID. The tool emits the source
+connector ID and target connector ID for each successful import.
 
 Authentication can be provided through `--token`, `--session-token`, `FLOECAT_TOKEN`, or
 `FLOECAT_SESSION_TOKEN`. Connections are plaintext by default, matching the Floecat development

--- a/tools/connector-transfer/README.md
+++ b/tools/connector-transfer/README.md
@@ -40,6 +40,9 @@ tools/connector-transfer/floecat-connector-transfer \
   import connectors.zip --dry-run
 ```
 
+The dry run reports whether each connector would be created, skipped, replaced, or rejected. It
+returns a nonzero exit status when `--conflict FAIL` encounters an existing display name.
+
 Import and fail if a display name already exists:
 
 ```shell

--- a/tools/connector-transfer/floecat-connector-transfer
+++ b/tools/connector-transfer/floecat-connector-transfer
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+JAR="$SCRIPT_DIR/target/floecat-connector-transfer.jar"
+
+if [ ! -f "$JAR" ]; then
+  echo "Missing $JAR; build it with: mvn -pl tools/connector-transfer -am package" >&2
+  exit 1
+fi
+
+exec java -jar "$JAR" "$@"

--- a/tools/connector-transfer/pom.xml
+++ b/tools/connector-transfer/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tools/connector-transfer/pom.xml
+++ b/tools/connector-transfer/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Yellowbrick Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.floedb.floecat</groupId>
+    <artifactId>floecat</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>floecat-connector-transfer</artifactId>
+  <name>floecat-connector-transfer</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-proto</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${version.protobuf}</version>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>${version.picocli}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.plugin.shade}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <finalName>floecat-connector-transfer</finalName>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/versions/**/module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>ai.floedb.floecat.tools.transfer.ConnectorTransferCli</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorArchive.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorArchive.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.tools.transfer;
+
+import ai.floedb.floecat.connector.rpc.ConnectorTransferBundle;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+final class ConnectorArchive {
+  static final int FORMAT_VERSION = 1;
+  private static final int MAX_BUNDLE_BYTES = 64 * 1024 * 1024;
+
+  private ConnectorArchive() {}
+
+  static void write(Path output, ConnectorTransferBundle bundle, boolean force) throws IOException {
+    Path absolute = output.toAbsolutePath();
+    if (Files.exists(absolute) && !force) {
+      throw new IOException("output already exists (use --force): " + absolute);
+    }
+    Path parent = absolute.getParent();
+    if (parent != null) Files.createDirectories(parent);
+    Path temporary = Files.createTempFile(parent, ".floecat-connectors-", ".tmp");
+    try {
+      setOwnerOnly(temporary);
+      try (var zip = new ZipOutputStream(Files.newOutputStream(temporary))) {
+        put(zip, "bundle.pb", bundle.toByteArray());
+        put(zip, "manifest.json", manifest(bundle).getBytes(StandardCharsets.UTF_8));
+        for (var entry : bundle.getEntriesList()) {
+          String base =
+              "connectors/" + safeSegment(entry.getConnector().getResourceId().getId()) + "/";
+          put(zip, base + "connector.pb", entry.getConnector().toByteArray());
+          put(
+              zip,
+              base + "portable-spec.json",
+              protobufJson(entry.getPortableSpec()).getBytes(StandardCharsets.UTF_8));
+          if (entry.hasCredentials()) {
+            put(zip, base + "credentials.pb", entry.getCredentials().toByteArray());
+          }
+        }
+      }
+      if (force) {
+        Files.move(
+            temporary,
+            absolute,
+            StandardCopyOption.REPLACE_EXISTING,
+            StandardCopyOption.ATOMIC_MOVE);
+      } else {
+        Files.move(temporary, absolute, StandardCopyOption.ATOMIC_MOVE);
+      }
+      setOwnerOnly(absolute);
+    } finally {
+      Files.deleteIfExists(temporary);
+    }
+  }
+
+  static ConnectorTransferBundle read(Path input) throws IOException {
+    try (var zip = new ZipFile(input.toFile())) {
+      ZipEntry entry = zip.getEntry("bundle.pb");
+      if (entry == null || entry.isDirectory()) {
+        throw new IOException("connector archive is missing bundle.pb");
+      }
+      byte[] bytes;
+      try (InputStream in = zip.getInputStream(entry)) {
+        bytes = readBounded(in, MAX_BUNDLE_BYTES);
+      }
+      try {
+        var bundle = ConnectorTransferBundle.parseFrom(bytes);
+        if (bundle.getFormatVersion() != FORMAT_VERSION) {
+          throw new IOException(
+              "unsupported connector archive format version: " + bundle.getFormatVersion());
+        }
+        return bundle;
+      } catch (InvalidProtocolBufferException e) {
+        throw new IOException("invalid connector archive bundle", e);
+      }
+    }
+  }
+
+  private static byte[] readBounded(InputStream in, int maxBytes) throws IOException {
+    var output = new ByteArrayOutputStream(Math.min(maxBytes, 8192));
+    byte[] buffer = new byte[8192];
+    int total = 0;
+    for (int read; (read = in.read(buffer)) != -1; ) {
+      total += read;
+      if (total > maxBytes) throw new IOException("connector archive bundle exceeds size limit");
+      output.write(buffer, 0, read);
+    }
+    return output.toByteArray();
+  }
+
+  private static void put(ZipOutputStream zip, String name, byte[] bytes) throws IOException {
+    var entry = new ZipEntry(name);
+    entry.setTime(0L);
+    zip.putNextEntry(entry);
+    zip.write(bytes);
+    zip.closeEntry();
+  }
+
+  private static String protobufJson(com.google.protobuf.MessageOrBuilder message)
+      throws IOException {
+    try {
+      return JsonFormat.printer().includingDefaultValueFields().print(message) + "\n";
+    } catch (InvalidProtocolBufferException e) {
+      throw new IOException("failed to render connector protobuf as JSON", e);
+    }
+  }
+
+  private static String manifest(ConnectorTransferBundle bundle) {
+    var out = new StringBuilder();
+    out.append("{\n  \"formatVersion\": ").append(bundle.getFormatVersion());
+    out.append(",\n  \"sourceAccountId\": \"")
+        .append(jsonEscape(bundle.getSourceAccountId()))
+        .append("\",");
+    out.append("\n  \"exportedAt\": \"")
+        .append(bundle.getExportedAt().getSeconds())
+        .append(".")
+        .append(bundle.getExportedAt().getNanos())
+        .append("Z\",");
+    out.append("\n  \"connectors\": [");
+    for (int i = 0; i < bundle.getEntriesCount(); i++) {
+      var entry = bundle.getEntries(i);
+      if (i > 0) out.append(',');
+      out.append("\n    {\"id\": \"")
+          .append(jsonEscape(entry.getConnector().getResourceId().getId()))
+          .append("\", \"displayName\": \"")
+          .append(jsonEscape(entry.getConnector().getDisplayName()))
+          .append("\", \"hasCredentials\": ")
+          .append(entry.hasCredentials())
+          .append('}');
+    }
+    if (bundle.getEntriesCount() > 0) out.append('\n').append("  ");
+    return out.append("]\n}\n").toString();
+  }
+
+  private static String safeSegment(String value) {
+    String safe = value == null ? "" : value.replaceAll("[^A-Za-z0-9._-]", "_");
+    return safe.isBlank() ? "connector" : safe;
+  }
+
+  private static String jsonEscape(String value) {
+    if (value == null) return "";
+    var out = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '\\' -> out.append("\\\\");
+        case '"' -> out.append("\\\"");
+        case '\n' -> out.append("\\n");
+        case '\r' -> out.append("\\r");
+        case '\t' -> out.append("\\t");
+        default -> {
+          if (c < 0x20) out.append(String.format("\\u%04x", (int) c));
+          else out.append(c);
+        }
+      }
+    }
+    return out.toString();
+  }
+
+  private static void setOwnerOnly(Path path) {
+    try {
+      Set<PosixFilePermission> permissions =
+          EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
+      Files.setPosixFilePermissions(path, permissions);
+    } catch (IOException | UnsupportedOperationException ignored) {
+      // Non-POSIX filesystems do not expose these permissions.
+    }
+  }
+}

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorArchive.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorArchive.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.tools.transfer;
 import ai.floedb.floecat.connector.rpc.ConnectorTransferBundle;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.Timestamps;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,6 +42,8 @@ final class ConnectorArchive {
   private ConnectorArchive() {}
 
   static void write(Path output, ConnectorTransferBundle bundle, boolean force) throws IOException {
+    int bundleSize = bundle.getSerializedSize();
+    validateBundleSize(bundleSize);
     Path absolute = output.toAbsolutePath();
     if (Files.exists(absolute) && !force) {
       throw new IOException("output already exists (use --force): " + absolute);
@@ -78,6 +81,17 @@ final class ConnectorArchive {
       setOwnerOnly(absolute);
     } finally {
       Files.deleteIfExists(temporary);
+    }
+  }
+
+  static void validateBundleSize(int bundleSize) throws IOException {
+    if (bundleSize > MAX_BUNDLE_BYTES) {
+      throw new IOException(
+          "connector archive bundle exceeds size limit: "
+              + bundleSize
+              + " bytes (maximum "
+              + MAX_BUNDLE_BYTES
+              + ")");
     }
   }
 
@@ -172,10 +186,8 @@ final class ConnectorArchive {
         .append(jsonEscape(bundle.getSourceAccountId()))
         .append("\",");
     out.append("\n  \"exportedAt\": \"")
-        .append(bundle.getExportedAt().getSeconds())
-        .append(".")
-        .append(bundle.getExportedAt().getNanos())
-        .append("Z\",");
+        .append(Timestamps.toString(bundle.getExportedAt()))
+        .append("\",");
     out.append("\n  \"connectors\": [");
     for (int i = 0; i < bundle.getEntriesCount(); i++) {
       var entry = bundle.getEntries(i);
@@ -217,13 +229,14 @@ final class ConnectorArchive {
     return out.toString();
   }
 
-  private static void setOwnerOnly(Path path) {
+  private static void setOwnerOnly(Path path) throws IOException {
     try {
       Set<PosixFilePermission> permissions =
           EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
       Files.setPosixFilePermissions(path, permissions);
-    } catch (IOException | UnsupportedOperationException ignored) {
-      // Non-POSIX filesystems do not expose these permissions.
+    } catch (UnsupportedOperationException e) {
+      throw new IOException(
+          "cannot protect connector archive with owner-only file permissions: " + path, e);
     }
   }
 }

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorArchive.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorArchive.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -96,9 +97,41 @@ final class ConnectorArchive {
           throw new IOException(
               "unsupported connector archive format version: " + bundle.getFormatVersion());
         }
+        validate(bundle);
         return bundle;
       } catch (InvalidProtocolBufferException e) {
         throw new IOException("invalid connector archive bundle", e);
+      }
+    }
+  }
+
+  private static void validate(ConnectorTransferBundle bundle) throws IOException {
+    var connectorIds = new HashSet<String>();
+    var displayNames = new HashSet<String>();
+    for (var entry : bundle.getEntriesList()) {
+      String connectorId = entry.getConnector().getResourceId().getId().trim();
+      String connectorName = entry.getConnector().getDisplayName().trim();
+      String portableName = entry.getPortableSpec().getDisplayName().trim();
+      if (connectorId.isBlank()) {
+        throw new IOException("connector archive contains an entry without a source connector id");
+      }
+      if (!connectorIds.add(connectorId)) {
+        throw new IOException("connector archive contains duplicate connector id: " + connectorId);
+      }
+      if (portableName.isBlank()) {
+        throw new IOException("connector archive contains an entry without a display name");
+      }
+      if (!displayNames.add(portableName)) {
+        throw new IOException(
+            "connector archive contains duplicate connector display name: " + portableName);
+      }
+      if (!connectorName.equals(portableName)) {
+        throw new IOException(
+            "connector archive display name does not match portable specification: " + connectorId);
+      }
+      if (entry.getPortableSpec().hasAuth() && entry.getPortableSpec().getAuth().hasCredentials()) {
+        throw new IOException(
+            "connector archive embeds credentials in a portable specification: " + connectorId);
       }
     }
   }

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.tools.transfer;
+
+import ai.floedb.floecat.catalog.rpc.DirectoryServiceGrpc;
+import ai.floedb.floecat.common.rpc.IdempotencyKey;
+import ai.floedb.floecat.common.rpc.PageRequest;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorSpec;
+import ai.floedb.floecat.connector.rpc.ConnectorState;
+import ai.floedb.floecat.connector.rpc.ConnectorTransferBundle;
+import ai.floedb.floecat.connector.rpc.ConnectorTransferEntry;
+import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
+import ai.floedb.floecat.connector.rpc.CreateConnectorRequest;
+import ai.floedb.floecat.connector.rpc.DeleteConnectorRequest;
+import ai.floedb.floecat.connector.rpc.ExportConnectorRequest;
+import ai.floedb.floecat.connector.rpc.ListConnectorsRequest;
+import ai.floedb.floecat.connector.rpc.UpdateConnectorRequest;
+import ai.floedb.floecat.connector.rpc.ValidateConnectorRequest;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.Timestamp;
+import io.grpc.Channel;
+import io.grpc.ClientInterceptors;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "floecat-connector-transfer",
+    mixinStandardHelpOptions = true,
+    version = "floecat-connector-transfer 1",
+    description = "Export and import complete Floecat connector definitions.",
+    subcommands = {
+      ConnectorTransferCli.ExportCommand.class,
+      ConnectorTransferCli.ImportCommand.class,
+      ConnectorTransferCli.InspectCommand.class
+    })
+public final class ConnectorTransferCli implements Runnable {
+  @CommandLine.Option(names = "--host", description = "gRPC host (default: ${DEFAULT-VALUE})")
+  String host = env("FLOECAT_GRPC_HOST", "localhost");
+
+  @CommandLine.Option(names = "--port", description = "gRPC port (default: ${DEFAULT-VALUE})")
+  int port = envInt("FLOECAT_GRPC_PORT", 9100);
+
+  @CommandLine.Option(names = "--tls", description = "Use TLS for the gRPC connection")
+  boolean tls;
+
+  @CommandLine.Option(names = "--token", description = "Bearer token (or FLOECAT_TOKEN)")
+  String token = env("FLOECAT_TOKEN", "");
+
+  @CommandLine.Option(
+      names = "--session-token",
+      description = "Session token (or FLOECAT_SESSION_TOKEN)")
+  String sessionToken = env("FLOECAT_SESSION_TOKEN", "");
+
+  @CommandLine.Option(
+      names = "--account-id",
+      description = "Account header value (or FLOECAT_ACCOUNT)")
+  String accountId = env("FLOECAT_ACCOUNT", "");
+
+  public static void main(String[] args) {
+    int exit = new CommandLine(new ConnectorTransferCli()).execute(args);
+    System.exit(exit);
+  }
+
+  @Override
+  public void run() {
+    CommandLine.usage(this, System.out);
+  }
+
+  private Client client() {
+    return new Client(host, port, tls, token, sessionToken, accountId);
+  }
+
+  @CommandLine.Command(
+      name = "export",
+      mixinStandardHelpOptions = true,
+      description = "Export connector definitions and credentials to a protected zip archive.")
+  static final class ExportCommand implements Callable<Integer> {
+    @CommandLine.ParentCommand ConnectorTransferCli parent;
+
+    @CommandLine.Parameters(index = "0", description = "Output archive path")
+    Path output;
+
+    @CommandLine.Option(
+        names = "--connector",
+        description = "Connector display name or ID to include; repeatable (default: all)")
+    List<String> requested = new ArrayList<>();
+
+    @CommandLine.Option(names = "--force", description = "Replace an existing output archive")
+    boolean force;
+
+    @CommandLine.Option(
+        names = "--plaintext-secrets",
+        required = true,
+        description = "Acknowledge that the archive contains plaintext connector credentials")
+    boolean plaintextSecrets;
+
+    @Override
+    public Integer call() throws Exception {
+      if (!plaintextSecrets) {
+        throw new IllegalArgumentException("--plaintext-secrets acknowledgement is required");
+      }
+      try (var client = parent.client()) {
+        List<Connector> connectors = client.listConnectors();
+        connectors = select(connectors, requested);
+        if (connectors.isEmpty()) throw new IllegalArgumentException("no connectors selected");
+
+        var bundle =
+            ConnectorTransferBundle.newBuilder()
+                .setFormatVersion(ConnectorArchive.FORMAT_VERSION)
+                .setExportedAt(now());
+
+        for (Connector listed : connectors) {
+          var exported =
+              client.connectors.exportConnector(
+                  ExportConnectorRequest.newBuilder()
+                      .setConnectorId(listed.getResourceId())
+                      .setIncludeCredentials(true)
+                      .build());
+          var credentials =
+              exported.hasCredentials()
+                  ? java.util.Optional.of(exported.getCredentials())
+                  : java.util.Optional.<ai.floedb.floecat.connector.rpc.AuthCredentials>empty();
+          ConnectorSpec portable =
+              PortableConnectorSpecs.from(exported.getConnector(), client.directory);
+          var entry =
+              ConnectorTransferEntry.newBuilder()
+                  .setConnector(exported.getConnector())
+                  .setPortableSpec(portable);
+          credentials.ifPresent(entry::setCredentials);
+          bundle.addEntries(entry);
+        }
+        String sourceAccount = parent.accountId;
+        if (sourceAccount == null || sourceAccount.isBlank()) {
+          sourceAccount = bundle.getEntries(0).getConnector().getResourceId().getAccountId();
+        }
+        bundle.setSourceAccountId(sourceAccount);
+        ConnectorArchive.write(output, bundle.build(), force);
+        System.out.printf("Exported %d connector(s) to %s%n", connectors.size(), output);
+        return 0;
+      }
+    }
+  }
+
+  enum ConflictMode {
+    FAIL,
+    SKIP,
+    REPLACE
+  }
+
+  @CommandLine.Command(
+      name = "import",
+      mixinStandardHelpOptions = true,
+      description = "Import connector definitions through the Floecat gRPC API.")
+  static final class ImportCommand implements Callable<Integer> {
+    @CommandLine.ParentCommand ConnectorTransferCli parent;
+
+    @CommandLine.Parameters(index = "0", description = "Input archive path")
+    Path input;
+
+    @CommandLine.Option(
+        names = "--conflict",
+        defaultValue = "FAIL",
+        description =
+            "Existing-name behavior: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})")
+    ConflictMode conflictMode;
+
+    @CommandLine.Option(
+        names = "--dry-run",
+        description = "Validate every portable specification without mutating connectors")
+    boolean dryRun;
+
+    @Override
+    public Integer call() throws Exception {
+      ConnectorTransferBundle bundle = ConnectorArchive.read(input);
+      try (var client = parent.client()) {
+        Map<String, Connector> existing = new HashMap<>();
+        for (Connector connector : client.listConnectors()) {
+          existing.put(connector.getDisplayName(), connector);
+        }
+
+        int imported = 0;
+        int skipped = 0;
+        for (var entry : bundle.getEntriesList()) {
+          ConnectorSpec spec = specWithCredentials(entry);
+          if (spec.getState() == ConnectorState.CS_DELETING) {
+            throw new IllegalArgumentException(
+                "cannot import connector in deleting state: " + spec.getDisplayName());
+          }
+          var validation =
+              client.connectors.validateConnector(
+                  ValidateConnectorRequest.newBuilder().setSpec(spec).build());
+          if (!validation.getOk()) {
+            throw new IllegalArgumentException(
+                "connector validation failed for "
+                    + spec.getDisplayName()
+                    + ": "
+                    + validation.getSummary());
+          }
+          if (dryRun) {
+            System.out.printf("VALID %s: %s%n", spec.getDisplayName(), validation.getSummary());
+            continue;
+          }
+
+          Connector current = existing.get(spec.getDisplayName());
+          String replacementId = "";
+          if (current != null) {
+            switch (conflictMode) {
+              case FAIL ->
+                  throw new IllegalArgumentException(
+                      "connector already exists: " + spec.getDisplayName());
+              case SKIP -> {
+                System.out.println("Skipped existing connector " + spec.getDisplayName());
+                skipped++;
+                continue;
+              }
+              case REPLACE -> {
+                replacementId = current.getResourceId().getId();
+                client.connectors.deleteConnector(
+                    DeleteConnectorRequest.newBuilder()
+                        .setConnectorId(current.getResourceId())
+                        .build());
+              }
+            }
+          }
+
+          var created =
+              client
+                  .connectors
+                  .createConnector(
+                      CreateConnectorRequest.newBuilder()
+                          .setSpec(spec)
+                          .setIdempotency(
+                              IdempotencyKey.newBuilder()
+                                  .setKey(idempotencyKey(bundle, entry, replacementId)))
+                          .build())
+                  .getConnector();
+          restoreState(client.connectors, created, spec.getState());
+          System.out.printf(
+              "%s -> %s%n",
+              entry.getConnector().getResourceId().getId(), created.getResourceId().getId());
+          imported++;
+        }
+        if (dryRun) {
+          System.out.printf(
+              "Validated %d connector(s); no changes made%n", bundle.getEntriesCount());
+        } else {
+          System.out.printf("Imported %d connector(s); skipped %d%n", imported, skipped);
+        }
+        return 0;
+      }
+    }
+  }
+
+  @CommandLine.Command(
+      name = "inspect",
+      mixinStandardHelpOptions = true,
+      description = "Print the contents of a connector archive without exposing secret values.")
+  static final class InspectCommand implements Callable<Integer> {
+    @CommandLine.ParentCommand ConnectorTransferCli parent;
+
+    @CommandLine.Parameters(index = "0", description = "Archive path")
+    Path input;
+
+    @Override
+    public Integer call() throws Exception {
+      ConnectorTransferBundle bundle = ConnectorArchive.read(input);
+      System.out.printf(
+          "format=%d source_account=%s connectors=%d%n",
+          bundle.getFormatVersion(), bundle.getSourceAccountId(), bundle.getEntriesCount());
+      for (var entry : bundle.getEntriesList()) {
+        System.out.printf(
+            "%s  %s  %s  credentials=%s%n",
+            entry.getConnector().getResourceId().getId(),
+            entry.getPortableSpec().getKind().name(),
+            entry.getPortableSpec().getDisplayName(),
+            entry.hasCredentials() ? "present" : "absent");
+      }
+      return 0;
+    }
+  }
+
+  private static void restoreState(
+      ConnectorsGrpc.ConnectorsBlockingStub connectors,
+      Connector created,
+      ConnectorState requestedState) {
+    if (requestedState == ConnectorState.CS_UNSPECIFIED
+        || requestedState == ConnectorState.CS_ACTIVE) return;
+    connectors.updateConnector(
+        UpdateConnectorRequest.newBuilder()
+            .setConnectorId(created.getResourceId())
+            .setSpec(ConnectorSpec.newBuilder().setState(requestedState))
+            .setUpdateMask(FieldMask.newBuilder().addPaths("state"))
+            .build());
+  }
+
+  private static ConnectorSpec specWithCredentials(ConnectorTransferEntry entry) {
+    if (!entry.hasCredentials()) return entry.getPortableSpec();
+    var spec = entry.getPortableSpec().toBuilder();
+    var auth =
+        entry.getPortableSpec().hasAuth()
+            ? entry.getPortableSpec().getAuth().toBuilder()
+            : ai.floedb.floecat.connector.rpc.AuthConfig.newBuilder();
+    auth.setCredentials(entry.getCredentials());
+    return spec.setAuth(auth).build();
+  }
+
+  private static List<Connector> select(List<Connector> all, List<String> requested) {
+    all = all.stream().sorted(Comparator.comparing(Connector::getDisplayName)).toList();
+    if (requested == null || requested.isEmpty()) return all;
+    Set<String> wanted = new HashSet<>(requested);
+    List<Connector> selected =
+        all.stream()
+            .filter(
+                connector ->
+                    wanted.contains(connector.getDisplayName())
+                        || wanted.contains(connector.getResourceId().getId()))
+            .toList();
+    Set<String> found = new HashSet<>();
+    for (Connector connector : selected) {
+      found.add(connector.getDisplayName());
+      found.add(connector.getResourceId().getId());
+    }
+    List<String> missing =
+        wanted.stream().filter(value -> !found.contains(value)).sorted().toList();
+    if (!missing.isEmpty()) {
+      throw new IllegalArgumentException("unknown connector(s): " + String.join(", ", missing));
+    }
+    return selected;
+  }
+
+  private static String idempotencyKey(
+      ConnectorTransferBundle bundle, ConnectorTransferEntry entry, String replacementId)
+      throws Exception {
+    String source =
+        bundle.getSourceAccountId()
+            + "\n"
+            + entry.getConnector().getResourceId().getId()
+            + "\n"
+            + entry.getPortableSpec().getDisplayName()
+            + "\n"
+            + replacementId;
+    byte[] digest =
+        MessageDigest.getInstance("SHA-256").digest(source.getBytes(StandardCharsets.UTF_8));
+    return "connector-transfer-" + HexFormat.of().formatHex(digest);
+  }
+
+  private static Timestamp now() {
+    Instant now = Instant.now();
+    return Timestamp.newBuilder().setSeconds(now.getEpochSecond()).setNanos(now.getNano()).build();
+  }
+
+  private static String env(String name, String fallback) {
+    String value = System.getenv(name);
+    return value == null || value.isBlank() ? fallback : value.trim();
+  }
+
+  private static int envInt(String name, int fallback) {
+    String value = System.getenv(name);
+    return value == null || value.isBlank() ? fallback : Integer.parseInt(value.trim());
+  }
+
+  private static final class Client implements AutoCloseable {
+    private final ManagedChannel managedChannel;
+    final ConnectorsGrpc.ConnectorsBlockingStub connectors;
+    final DirectoryServiceGrpc.DirectoryServiceBlockingStub directory;
+
+    Client(
+        String host, int port, boolean tls, String token, String sessionToken, String accountId) {
+      var builder = ManagedChannelBuilder.forAddress(host, port);
+      if (tls) builder.useTransportSecurity();
+      else builder.usePlaintext();
+      managedChannel = builder.build();
+      Channel channel =
+          ClientInterceptors.intercept(
+              managedChannel, new GrpcHeaders(token, sessionToken, accountId));
+      connectors = ConnectorsGrpc.newBlockingStub(channel);
+      directory = DirectoryServiceGrpc.newBlockingStub(channel);
+    }
+
+    List<Connector> listConnectors() {
+      var output = new ArrayList<Connector>();
+      String token = "";
+      do {
+        var response =
+            connectors.listConnectors(
+                ListConnectorsRequest.newBuilder()
+                    .setPage(PageRequest.newBuilder().setPageSize(100).setPageToken(token).build())
+                    .build());
+        output.addAll(response.getConnectorsList());
+        token = response.hasPage() ? response.getPage().getNextPageToken() : "";
+      } while (!token.isBlank());
+      return output;
+    }
+
+    @Override
+    public void close() throws InterruptedException {
+      managedChannel.shutdown();
+      if (!managedChannel.awaitTermination(5, TimeUnit.SECONDS)) {
+        managedChannel.shutdownNow();
+      }
+    }
+  }
+}

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
@@ -242,11 +242,7 @@ public final class ConnectorTransferCli implements Runnable {
         for (var entry : bundle.getEntriesList()) {
           Connector current = existing.get(entry.getPortableSpec().getDisplayName());
           prepared.add(
-              prepareImport(
-                  entry,
-                  current,
-                  conflictMode,
-                  spec -> validateImport(client, spec)));
+              prepareImport(entry, current, conflictMode, spec -> validateImport(client, spec)));
         }
 
         for (PreparedImport item : prepared) {

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
@@ -26,7 +26,6 @@ import ai.floedb.floecat.connector.rpc.ConnectorTransferBundle;
 import ai.floedb.floecat.connector.rpc.ConnectorTransferEntry;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
 import ai.floedb.floecat.connector.rpc.CreateConnectorRequest;
-import ai.floedb.floecat.connector.rpc.DeleteConnectorRequest;
 import ai.floedb.floecat.connector.rpc.ExportConnectorRequest;
 import ai.floedb.floecat.connector.rpc.ListConnectorsRequest;
 import ai.floedb.floecat.connector.rpc.UpdateConnectorRequest;
@@ -65,6 +64,20 @@ import picocli.CommandLine;
       ConnectorTransferCli.InspectCommand.class
     })
 public final class ConnectorTransferCli implements Runnable {
+  private static final FieldMask REPLACE_UPDATE_MASK =
+      FieldMask.newBuilder()
+          .addPaths("display_name")
+          .addPaths("description")
+          .addPaths("kind")
+          .addPaths("source")
+          .addPaths("destination")
+          .addPaths("uri")
+          .addPaths("auth")
+          .addPaths("policy")
+          .addPaths("state")
+          .addPaths("properties")
+          .build();
+
   @CommandLine.Option(names = "--host", description = "gRPC host (default: ${DEFAULT-VALUE})")
   String host = env("FLOECAT_GRPC_HOST", "localhost");
 
@@ -223,6 +236,7 @@ public final class ConnectorTransferCli implements Runnable {
         int wouldSkip = 0;
         int wouldFail = 0;
         String importRunNonce = UUID.randomUUID().toString();
+        List<PreparedImport> prepared = new ArrayList<>();
         for (var entry : bundle.getEntriesList()) {
           ConnectorSpec spec = specWithCredentials(entry);
           if (spec.getState() == ConnectorState.CS_DELETING) {
@@ -241,78 +255,87 @@ public final class ConnectorTransferCli implements Runnable {
           }
           Connector current = existing.get(spec.getDisplayName());
           ImportAction action = importAction(current != null, conflictMode);
-          if (dryRun) {
-            switch (action) {
-              case CREATE -> {
-                System.out.printf(
-                    "WOULD CREATE %s: %s%n", spec.getDisplayName(), validation.getSummary());
-                wouldCreate++;
-                existing.put(spec.getDisplayName(), entry.getConnector());
-              }
-              case FAIL -> {
-                System.out.println("WOULD FAIL existing connector " + spec.getDisplayName());
-                wouldFail++;
-              }
-              case SKIP -> {
-                System.out.println("WOULD SKIP existing connector " + spec.getDisplayName());
-                wouldSkip++;
-              }
-              case REPLACE -> {
-                System.out.println("WOULD REPLACE existing connector " + spec.getDisplayName());
-                wouldReplace++;
-                existing.put(spec.getDisplayName(), entry.getConnector());
-              }
-            }
-            continue;
-          }
+          prepared.add(new PreparedImport(entry, spec, current, action, validation.getSummary()));
+        }
 
-          String replacementId = "";
-          switch (action) {
-            case FAIL ->
-                throw new IllegalArgumentException(
-                    "connector already exists: " + spec.getDisplayName());
+        for (PreparedImport item : prepared) {
+          String displayName = item.spec().getDisplayName();
+          switch (item.action()) {
+            case CREATE -> {
+              if (dryRun) {
+                System.out.printf("WOULD CREATE %s: %s%n", displayName, item.validationSummary());
+              }
+              wouldCreate++;
+            }
+            case FAIL -> {
+              if (dryRun) System.out.println("WOULD FAIL existing connector " + displayName);
+              wouldFail++;
+            }
             case SKIP -> {
-              System.out.println("Skipped existing connector " + spec.getDisplayName());
-              skipped++;
-              continue;
+              if (dryRun) System.out.println("WOULD SKIP existing connector " + displayName);
+              wouldSkip++;
             }
             case REPLACE -> {
-              replacementId = current.getResourceId().getId();
-              client.connectors.deleteConnector(
-                  DeleteConnectorRequest.newBuilder()
-                      .setConnectorId(current.getResourceId())
-                      .build());
+              if (dryRun) System.out.println("WOULD REPLACE existing connector " + displayName);
+              wouldReplace++;
             }
-            case CREATE -> {}
           }
-
-          var created =
-              client
-                  .connectors
-                  .createConnector(
-                      CreateConnectorRequest.newBuilder()
-                          .setSpec(spec)
-                          .setIdempotency(
-                              IdempotencyKey.newBuilder()
-                                  .setKey(
-                                      idempotencyKey(importRunNonce, bundle, entry, replacementId)))
-                          .build())
-                  .getConnector();
-          restoreState(client.connectors, created, spec.getState());
-          existing.put(spec.getDisplayName(), created);
-          System.out.printf(
-              "%s -> %s%n",
-              entry.getConnector().getResourceId().getId(), created.getResourceId().getId());
-          imported++;
         }
+
         if (dryRun) {
           System.out.printf(
               "Dry run: would create %d, replace %d, skip %d, fail %d; no changes made%n",
               wouldCreate, wouldReplace, wouldSkip, wouldFail);
-        } else {
-          System.out.printf("Imported %d connector(s); skipped %d%n", imported, skipped);
+          return wouldFail > 0 ? 1 : 0;
         }
-        return dryRun && wouldFail > 0 ? 1 : 0;
+
+        if (wouldFail > 0) {
+          String displayName =
+              prepared.stream()
+                  .filter(item -> item.action() == ImportAction.FAIL)
+                  .findFirst()
+                  .orElseThrow()
+                  .spec()
+                  .getDisplayName();
+          throw new IllegalArgumentException("connector already exists: " + displayName);
+        }
+
+        for (PreparedImport item : prepared) {
+          if (item.action() == ImportAction.SKIP) {
+            System.out.println("Skipped existing connector " + item.spec().getDisplayName());
+            skipped++;
+            continue;
+          }
+
+          Connector importedConnector;
+          if (item.action() == ImportAction.REPLACE) {
+            importedConnector =
+                client
+                    .connectors
+                    .updateConnector(replacementRequest(item.current(), item.spec()))
+                    .getConnector();
+          } else {
+            importedConnector =
+                client
+                    .connectors
+                    .createConnector(
+                        CreateConnectorRequest.newBuilder()
+                            .setSpec(item.spec())
+                            .setIdempotency(
+                                IdempotencyKey.newBuilder()
+                                    .setKey(idempotencyKey(importRunNonce, bundle, item.entry())))
+                            .build())
+                    .getConnector();
+            restoreState(client.connectors, importedConnector, item.spec().getState());
+          }
+          System.out.printf(
+              "%s -> %s%n",
+              item.entry().getConnector().getResourceId().getId(),
+              importedConnector.getResourceId().getId());
+          imported++;
+        }
+        System.out.printf("Imported %d connector(s); skipped %d%n", imported, skipped);
+        return 0;
       }
     }
   }
@@ -403,11 +426,20 @@ public final class ConnectorTransferCli implements Runnable {
     };
   }
 
+  static UpdateConnectorRequest replacementRequest(Connector current, ConnectorSpec spec) {
+    ConnectorSpec replacement = spec;
+    if (replacement.getState() == ConnectorState.CS_UNSPECIFIED) {
+      replacement = replacement.toBuilder().setState(ConnectorState.CS_ACTIVE).build();
+    }
+    return UpdateConnectorRequest.newBuilder()
+        .setConnectorId(current.getResourceId())
+        .setSpec(replacement)
+        .setUpdateMask(REPLACE_UPDATE_MASK)
+        .build();
+  }
+
   static String idempotencyKey(
-      String importRunNonce,
-      ConnectorTransferBundle bundle,
-      ConnectorTransferEntry entry,
-      String replacementId)
+      String importRunNonce, ConnectorTransferBundle bundle, ConnectorTransferEntry entry)
       throws Exception {
     String source =
         importRunNonce
@@ -416,9 +448,7 @@ public final class ConnectorTransferCli implements Runnable {
             + "\n"
             + entry.getConnector().getResourceId().getId()
             + "\n"
-            + entry.getPortableSpec().getDisplayName()
-            + "\n"
-            + replacementId;
+            + entry.getPortableSpec().getDisplayName();
     byte[] digest =
         MessageDigest.getInstance("SHA-256").digest(source.getBytes(StandardCharsets.UTF_8));
     return "connector-transfer-" + HexFormat.of().formatHex(digest);
@@ -438,6 +468,13 @@ public final class ConnectorTransferCli implements Runnable {
     String value = System.getenv(name);
     return value == null || value.isBlank() ? fallback : Integer.parseInt(value.trim());
   }
+
+  private record PreparedImport(
+      ConnectorTransferEntry entry,
+      ConnectorSpec spec,
+      Connector current,
+      ImportAction action,
+      String validationSummary) {}
 
   private static final class Client implements AutoCloseable {
     private final ManagedChannel managedChannel;

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
@@ -49,6 +49,7 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import picocli.CommandLine;
@@ -177,6 +178,13 @@ public final class ConnectorTransferCli implements Runnable {
     REPLACE
   }
 
+  enum ImportAction {
+    CREATE,
+    FAIL,
+    SKIP,
+    REPLACE
+  }
+
   @CommandLine.Command(
       name = "import",
       mixinStandardHelpOptions = true,
@@ -210,6 +218,11 @@ public final class ConnectorTransferCli implements Runnable {
 
         int imported = 0;
         int skipped = 0;
+        int wouldCreate = 0;
+        int wouldReplace = 0;
+        int wouldSkip = 0;
+        int wouldFail = 0;
+        String importRunNonce = UUID.randomUUID().toString();
         for (var entry : bundle.getEntriesList()) {
           ConnectorSpec spec = specWithCredentials(entry);
           if (spec.getState() == ConnectorState.CS_DELETING) {
@@ -226,31 +239,51 @@ public final class ConnectorTransferCli implements Runnable {
                     + ": "
                     + validation.getSummary());
           }
+          Connector current = existing.get(spec.getDisplayName());
+          ImportAction action = importAction(current != null, conflictMode);
           if (dryRun) {
-            System.out.printf("VALID %s: %s%n", spec.getDisplayName(), validation.getSummary());
+            switch (action) {
+              case CREATE -> {
+                System.out.printf(
+                    "WOULD CREATE %s: %s%n", spec.getDisplayName(), validation.getSummary());
+                wouldCreate++;
+                existing.put(spec.getDisplayName(), entry.getConnector());
+              }
+              case FAIL -> {
+                System.out.println("WOULD FAIL existing connector " + spec.getDisplayName());
+                wouldFail++;
+              }
+              case SKIP -> {
+                System.out.println("WOULD SKIP existing connector " + spec.getDisplayName());
+                wouldSkip++;
+              }
+              case REPLACE -> {
+                System.out.println("WOULD REPLACE existing connector " + spec.getDisplayName());
+                wouldReplace++;
+                existing.put(spec.getDisplayName(), entry.getConnector());
+              }
+            }
             continue;
           }
 
-          Connector current = existing.get(spec.getDisplayName());
           String replacementId = "";
-          if (current != null) {
-            switch (conflictMode) {
-              case FAIL ->
-                  throw new IllegalArgumentException(
-                      "connector already exists: " + spec.getDisplayName());
-              case SKIP -> {
-                System.out.println("Skipped existing connector " + spec.getDisplayName());
-                skipped++;
-                continue;
-              }
-              case REPLACE -> {
-                replacementId = current.getResourceId().getId();
-                client.connectors.deleteConnector(
-                    DeleteConnectorRequest.newBuilder()
-                        .setConnectorId(current.getResourceId())
-                        .build());
-              }
+          switch (action) {
+            case FAIL ->
+                throw new IllegalArgumentException(
+                    "connector already exists: " + spec.getDisplayName());
+            case SKIP -> {
+              System.out.println("Skipped existing connector " + spec.getDisplayName());
+              skipped++;
+              continue;
             }
+            case REPLACE -> {
+              replacementId = current.getResourceId().getId();
+              client.connectors.deleteConnector(
+                  DeleteConnectorRequest.newBuilder()
+                      .setConnectorId(current.getResourceId())
+                      .build());
+            }
+            case CREATE -> {}
           }
 
           var created =
@@ -261,10 +294,12 @@ public final class ConnectorTransferCli implements Runnable {
                           .setSpec(spec)
                           .setIdempotency(
                               IdempotencyKey.newBuilder()
-                                  .setKey(idempotencyKey(bundle, entry, replacementId)))
+                                  .setKey(
+                                      idempotencyKey(importRunNonce, bundle, entry, replacementId)))
                           .build())
                   .getConnector();
           restoreState(client.connectors, created, spec.getState());
+          existing.put(spec.getDisplayName(), created);
           System.out.printf(
               "%s -> %s%n",
               entry.getConnector().getResourceId().getId(), created.getResourceId().getId());
@@ -272,11 +307,12 @@ public final class ConnectorTransferCli implements Runnable {
         }
         if (dryRun) {
           System.out.printf(
-              "Validated %d connector(s); no changes made%n", bundle.getEntriesCount());
+              "Dry run: would create %d, replace %d, skip %d, fail %d; no changes made%n",
+              wouldCreate, wouldReplace, wouldSkip, wouldFail);
         } else {
           System.out.printf("Imported %d connector(s); skipped %d%n", imported, skipped);
         }
-        return 0;
+        return dryRun && wouldFail > 0 ? 1 : 0;
       }
     }
   }
@@ -358,11 +394,25 @@ public final class ConnectorTransferCli implements Runnable {
     return selected;
   }
 
-  private static String idempotencyKey(
-      ConnectorTransferBundle bundle, ConnectorTransferEntry entry, String replacementId)
+  static ImportAction importAction(boolean exists, ConflictMode conflictMode) {
+    if (!exists) return ImportAction.CREATE;
+    return switch (conflictMode) {
+      case FAIL -> ImportAction.FAIL;
+      case SKIP -> ImportAction.SKIP;
+      case REPLACE -> ImportAction.REPLACE;
+    };
+  }
+
+  static String idempotencyKey(
+      String importRunNonce,
+      ConnectorTransferBundle bundle,
+      ConnectorTransferEntry entry,
+      String replacementId)
       throws Exception {
     String source =
-        bundle.getSourceAccountId()
+        importRunNonce
+            + "\n"
+            + bundle.getSourceAccountId()
             + "\n"
             + entry.getConnector().getResourceId().getId()
             + "\n"

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCli.java
@@ -43,8 +43,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.HexFormat;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -84,8 +84,10 @@ public final class ConnectorTransferCli implements Runnable {
   @CommandLine.Option(names = "--port", description = "gRPC port (default: ${DEFAULT-VALUE})")
   int port = envInt("FLOECAT_GRPC_PORT", 9100);
 
-  @CommandLine.Option(names = "--tls", description = "Use TLS for the gRPC connection")
-  boolean tls;
+  @CommandLine.Option(
+      names = "--plaintext",
+      description = "Use an unencrypted gRPC connection (intended only for local development)")
+  boolean plaintext;
 
   @CommandLine.Option(names = "--token", description = "Bearer token (or FLOECAT_TOKEN)")
   String token = env("FLOECAT_TOKEN", "");
@@ -111,7 +113,7 @@ public final class ConnectorTransferCli implements Runnable {
   }
 
   private Client client() {
-    return new Client(host, port, tls, token, sessionToken, accountId);
+    return new Client(host, port, !plaintext, token, sessionToken, accountId);
   }
 
   @CommandLine.Command(
@@ -238,24 +240,13 @@ public final class ConnectorTransferCli implements Runnable {
         String importRunNonce = UUID.randomUUID().toString();
         List<PreparedImport> prepared = new ArrayList<>();
         for (var entry : bundle.getEntriesList()) {
-          ConnectorSpec spec = specWithCredentials(entry);
-          if (spec.getState() == ConnectorState.CS_DELETING) {
-            throw new IllegalArgumentException(
-                "cannot import connector in deleting state: " + spec.getDisplayName());
-          }
-          var validation =
-              client.connectors.validateConnector(
-                  ValidateConnectorRequest.newBuilder().setSpec(spec).build());
-          if (!validation.getOk()) {
-            throw new IllegalArgumentException(
-                "connector validation failed for "
-                    + spec.getDisplayName()
-                    + ": "
-                    + validation.getSummary());
-          }
-          Connector current = existing.get(spec.getDisplayName());
-          ImportAction action = importAction(current != null, conflictMode);
-          prepared.add(new PreparedImport(entry, spec, current, action, validation.getSummary()));
+          Connector current = existing.get(entry.getPortableSpec().getDisplayName());
+          prepared.add(
+              prepareImport(
+                  entry,
+                  current,
+                  conflictMode,
+                  spec -> validateImport(client, spec)));
         }
 
         for (PreparedImport item : prepared) {
@@ -326,7 +317,6 @@ public final class ConnectorTransferCli implements Runnable {
                                     .setKey(idempotencyKey(importRunNonce, bundle, item.entry())))
                             .build())
                     .getConnector();
-            restoreState(client.connectors, importedConnector, item.spec().getState());
           }
           System.out.printf(
               "%s -> %s%n",
@@ -368,20 +358,6 @@ public final class ConnectorTransferCli implements Runnable {
     }
   }
 
-  private static void restoreState(
-      ConnectorsGrpc.ConnectorsBlockingStub connectors,
-      Connector created,
-      ConnectorState requestedState) {
-    if (requestedState == ConnectorState.CS_UNSPECIFIED
-        || requestedState == ConnectorState.CS_ACTIVE) return;
-    connectors.updateConnector(
-        UpdateConnectorRequest.newBuilder()
-            .setConnectorId(created.getResourceId())
-            .setSpec(ConnectorSpec.newBuilder().setState(requestedState))
-            .setUpdateMask(FieldMask.newBuilder().addPaths("state"))
-            .build());
-  }
-
   private static ConnectorSpec specWithCredentials(ConnectorTransferEntry entry) {
     if (!entry.hasCredentials()) return entry.getPortableSpec();
     var spec = entry.getPortableSpec().toBuilder();
@@ -393,28 +369,63 @@ public final class ConnectorTransferCli implements Runnable {
     return spec.setAuth(auth).build();
   }
 
-  private static List<Connector> select(List<Connector> all, List<String> requested) {
+  static List<Connector> select(List<Connector> all, List<String> requested) {
     all = all.stream().sorted(Comparator.comparing(Connector::getDisplayName)).toList();
     if (requested == null || requested.isEmpty()) return all;
-    Set<String> wanted = new HashSet<>(requested);
-    List<Connector> selected =
-        all.stream()
-            .filter(
-                connector ->
-                    wanted.contains(connector.getDisplayName())
-                        || wanted.contains(connector.getResourceId().getId()))
-            .toList();
-    Set<String> found = new HashSet<>();
-    for (Connector connector : selected) {
-      found.add(connector.getDisplayName());
-      found.add(connector.getResourceId().getId());
+    Map<String, Connector> byId = new HashMap<>();
+    Map<String, Connector> byName = new HashMap<>();
+    for (Connector connector : all) {
+      byId.put(connector.getResourceId().getId(), connector);
+      byName.put(connector.getDisplayName(), connector);
     }
-    List<String> missing =
-        wanted.stream().filter(value -> !found.contains(value)).sorted().toList();
+    Set<String> selectedIds = new LinkedHashSet<>();
+    List<String> missing = new ArrayList<>();
+    for (String selector : new LinkedHashSet<>(requested)) {
+      Connector selected = byId.get(selector);
+      if (selected == null) selected = byName.get(selector);
+      if (selected == null) missing.add(selector);
+      else selectedIds.add(selected.getResourceId().getId());
+    }
     if (!missing.isEmpty()) {
+      missing.sort(String::compareTo);
       throw new IllegalArgumentException("unknown connector(s): " + String.join(", ", missing));
     }
-    return selected;
+    return all.stream()
+        .filter(connector -> selectedIds.contains(connector.getResourceId().getId()))
+        .toList();
+  }
+
+  static PreparedImport prepareImport(
+      ConnectorTransferEntry entry,
+      Connector current,
+      ConflictMode conflictMode,
+      ImportValidator validator) {
+    ConnectorSpec spec = specWithCredentials(entry);
+    ImportAction action = importAction(current != null, conflictMode);
+    String validationSummary = "";
+    if (action == ImportAction.CREATE || action == ImportAction.REPLACE) {
+      validationSummary = validator.validate(spec);
+    }
+    return new PreparedImport(entry, spec, current, action, validationSummary);
+  }
+
+  private static String validateImport(Client client, ConnectorSpec spec) {
+    if (spec.getState() == ConnectorState.CS_DELETING) {
+      throw new IllegalArgumentException(
+          "cannot import connector in deleting state: " + spec.getDisplayName());
+    }
+    PortableConnectorSpecs.validateForImport(spec, client.directory);
+    var validation =
+        client.connectors.validateConnector(
+            ValidateConnectorRequest.newBuilder().setSpec(spec).build());
+    if (!validation.getOk()) {
+      throw new IllegalArgumentException(
+          "connector validation failed for "
+              + spec.getDisplayName()
+              + ": "
+              + validation.getSummary());
+    }
+    return validation.getSummary();
   }
 
   static ImportAction importAction(boolean exists, ConflictMode conflictMode) {
@@ -469,7 +480,12 @@ public final class ConnectorTransferCli implements Runnable {
     return value == null || value.isBlank() ? fallback : Integer.parseInt(value.trim());
   }
 
-  private record PreparedImport(
+  @FunctionalInterface
+  interface ImportValidator {
+    String validate(ConnectorSpec spec);
+  }
+
+  record PreparedImport(
       ConnectorTransferEntry entry,
       ConnectorSpec spec,
       Connector current,

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/GrpcHeaders.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/GrpcHeaders.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.tools.transfer;
+
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+final class GrpcHeaders implements ClientInterceptor {
+  private final String token;
+  private final String sessionToken;
+  private final String accountId;
+
+  GrpcHeaders(String token, String sessionToken, String accountId) {
+    this.token = value(token);
+    this.sessionToken = value(sessionToken);
+    this.accountId = value(accountId);
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions options, io.grpc.Channel next) {
+    return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, options)) {
+      @Override
+      public void start(Listener<RespT> listener, Metadata headers) {
+        if (!token.isBlank()) {
+          String authorization =
+              token.regionMatches(true, 0, "bearer ", 0, 7) ? token : "Bearer " + token;
+          headers.put(
+              Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER), authorization);
+        }
+        if (!sessionToken.isBlank()) {
+          headers.put(
+              Metadata.Key.of("x-floe-session", Metadata.ASCII_STRING_MARSHALLER), sessionToken);
+        }
+        if (!accountId.isBlank()) {
+          headers.put(
+              Metadata.Key.of("x-floe-account", Metadata.ASCII_STRING_MARSHALLER), accountId);
+        }
+        super.start(listener, headers);
+      }
+    };
+  }
+
+  private static String value(String input) {
+    return input == null ? "" : input.trim();
+  }
+}

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecs.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecs.java
@@ -20,6 +20,8 @@ import ai.floedb.floecat.catalog.rpc.DirectoryServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.LookupCatalogRequest;
 import ai.floedb.floecat.catalog.rpc.LookupNamespaceRequest;
 import ai.floedb.floecat.catalog.rpc.LookupTableRequest;
+import ai.floedb.floecat.catalog.rpc.ResolveCatalogRequest;
+import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorSpec;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
@@ -46,6 +48,49 @@ final class PortableConnectorSpecs {
       spec.setDestination(portableDestination(connector.getDestination(), directory));
     }
     return spec.build();
+  }
+
+  static void validateForImport(
+      ConnectorSpec spec, DirectoryServiceGrpc.DirectoryServiceBlockingStub directory) {
+    if (!spec.hasDestination()) {
+      throw new IllegalArgumentException("connector destination is required");
+    }
+    var destination = spec.getDestination();
+    if (destination.hasCatalogDisplayName()) {
+      String displayName = destination.getCatalogDisplayName().trim();
+      if (displayName.isBlank()) {
+        throw new IllegalArgumentException("destination catalog display name is blank");
+      }
+      var response =
+          directory.resolveCatalog(
+              ResolveCatalogRequest.newBuilder()
+                  .setRef(NameRef.newBuilder().setCatalog(displayName))
+                  .build());
+      if (!response.hasResourceId() || response.getResourceId().getId().isBlank()) {
+        throw new IllegalArgumentException(
+            "destination catalog could not be resolved: " + displayName);
+      }
+    } else if (destination.hasCatalogId()) {
+      var response =
+          directory.lookupCatalog(
+              LookupCatalogRequest.newBuilder().setResourceId(destination.getCatalogId()).build());
+      if (response.getDisplayName().isBlank()) {
+        throw new IllegalArgumentException(
+            "destination catalog could not be resolved: " + destination.getCatalogId().getId());
+      }
+    } else {
+      throw new IllegalArgumentException("connector destination catalog is required");
+    }
+
+    if (destination.hasNamespace()
+        && (destination.getNamespace().getSegmentsCount() == 0
+            || destination.getNamespace().getSegmentsList().stream().anyMatch(String::isBlank))) {
+      throw new IllegalArgumentException("destination namespace contains an empty path segment");
+    }
+    if (destination.hasTableDisplayName()
+        && destination.getTableDisplayName().trim().isBlank()) {
+      throw new IllegalArgumentException("destination table display name is blank");
+    }
   }
 
   private static DestinationTarget portableDestination(

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecs.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecs.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.tools.transfer;
+
+import ai.floedb.floecat.catalog.rpc.DirectoryServiceGrpc;
+import ai.floedb.floecat.catalog.rpc.LookupCatalogRequest;
+import ai.floedb.floecat.catalog.rpc.LookupNamespaceRequest;
+import ai.floedb.floecat.catalog.rpc.LookupTableRequest;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorSpec;
+import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import java.util.ArrayList;
+
+final class PortableConnectorSpecs {
+  private PortableConnectorSpecs() {}
+
+  static ConnectorSpec from(
+      Connector connector, DirectoryServiceGrpc.DirectoryServiceBlockingStub directory) {
+    var spec =
+        ConnectorSpec.newBuilder()
+            .setDisplayName(connector.getDisplayName())
+            .setKind(connector.getKind())
+            .setUri(connector.getUri())
+            .setState(connector.getState())
+            .putAllProperties(connector.getPropertiesMap());
+    if (connector.hasDescription()) spec.setDescription(connector.getDescription());
+    if (connector.hasSource()) spec.setSource(connector.getSource());
+    if (connector.hasPolicy()) spec.setPolicy(connector.getPolicy());
+    if (connector.hasAuth()) spec.setAuth(connector.getAuth());
+    if (connector.hasDestination()) {
+      spec.setDestination(portableDestination(connector.getDestination(), directory));
+    }
+    return spec.build();
+  }
+
+  private static DestinationTarget portableDestination(
+      DestinationTarget destination, DirectoryServiceGrpc.DirectoryServiceBlockingStub directory) {
+    var portable = DestinationTarget.newBuilder();
+    if (destination.hasCatalogId()) {
+      portable.setCatalogDisplayName(
+          directory
+              .lookupCatalog(
+                  LookupCatalogRequest.newBuilder()
+                      .setResourceId(destination.getCatalogId())
+                      .build())
+              .getDisplayName());
+    } else if (destination.hasCatalogDisplayName()) {
+      portable.setCatalogDisplayName(destination.getCatalogDisplayName());
+    }
+
+    if (destination.hasNamespaceId()) {
+      var ref =
+          directory
+              .lookupNamespace(
+                  LookupNamespaceRequest.newBuilder()
+                      .setResourceId(destination.getNamespaceId())
+                      .build())
+              .getRef();
+      var segments = new ArrayList<>(ref.getPathList());
+      if (!ref.getName().isBlank()) segments.add(ref.getName());
+      portable.setNamespace(NamespacePath.newBuilder().addAllSegments(segments));
+    } else if (destination.hasNamespace()) {
+      portable.setNamespace(destination.getNamespace());
+    }
+
+    if (destination.hasTableId()) {
+      portable.setTableDisplayName(
+          directory
+              .lookupTable(
+                  LookupTableRequest.newBuilder().setResourceId(destination.getTableId()).build())
+              .getName()
+              .getName());
+    } else if (destination.hasTableDisplayName()) {
+      portable.setTableDisplayName(destination.getTableDisplayName());
+    }
+    return portable.build();
+  }
+}

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecs.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecs.java
@@ -52,42 +52,65 @@ final class PortableConnectorSpecs {
       DestinationTarget destination, DirectoryServiceGrpc.DirectoryServiceBlockingStub directory) {
     var portable = DestinationTarget.newBuilder();
     if (destination.hasCatalogId()) {
-      portable.setCatalogDisplayName(
-          directory
-              .lookupCatalog(
-                  LookupCatalogRequest.newBuilder()
-                      .setResourceId(destination.getCatalogId())
-                      .build())
-              .getDisplayName());
+      var response =
+          directory.lookupCatalog(
+              LookupCatalogRequest.newBuilder().setResourceId(destination.getCatalogId()).build());
+      String displayName = response.getDisplayName().trim();
+      if (displayName.isBlank()) {
+        throw unresolved("catalog", destination.getCatalogId().getId());
+      }
+      portable.setCatalogDisplayName(displayName);
     } else if (destination.hasCatalogDisplayName()) {
-      portable.setCatalogDisplayName(destination.getCatalogDisplayName());
+      String displayName = destination.getCatalogDisplayName().trim();
+      if (displayName.isBlank()) {
+        throw new IllegalArgumentException("destination catalog display name is blank");
+      }
+      portable.setCatalogDisplayName(displayName);
     }
 
     if (destination.hasNamespaceId()) {
-      var ref =
-          directory
-              .lookupNamespace(
-                  LookupNamespaceRequest.newBuilder()
-                      .setResourceId(destination.getNamespaceId())
-                      .build())
-              .getRef();
+      var response =
+          directory.lookupNamespace(
+              LookupNamespaceRequest.newBuilder()
+                  .setResourceId(destination.getNamespaceId())
+                  .build());
+      if (!response.hasRef()) {
+        throw unresolved("namespace", destination.getNamespaceId().getId());
+      }
+      var ref = response.getRef();
       var segments = new ArrayList<>(ref.getPathList());
       if (!ref.getName().isBlank()) segments.add(ref.getName());
+      if (segments.isEmpty() || segments.stream().anyMatch(String::isBlank)) {
+        throw unresolved("namespace", destination.getNamespaceId().getId());
+      }
       portable.setNamespace(NamespacePath.newBuilder().addAllSegments(segments));
     } else if (destination.hasNamespace()) {
+      if (destination.getNamespace().getSegmentsList().stream().anyMatch(String::isBlank)) {
+        throw new IllegalArgumentException("destination namespace contains a blank segment");
+      }
       portable.setNamespace(destination.getNamespace());
     }
 
     if (destination.hasTableId()) {
-      portable.setTableDisplayName(
-          directory
-              .lookupTable(
-                  LookupTableRequest.newBuilder().setResourceId(destination.getTableId()).build())
-              .getName()
-              .getName());
+      var response =
+          directory.lookupTable(
+              LookupTableRequest.newBuilder().setResourceId(destination.getTableId()).build());
+      if (!response.hasName() || response.getName().getName().isBlank()) {
+        throw unresolved("table", destination.getTableId().getId());
+      }
+      portable.setTableDisplayName(response.getName().getName().trim());
     } else if (destination.hasTableDisplayName()) {
-      portable.setTableDisplayName(destination.getTableDisplayName());
+      String displayName = destination.getTableDisplayName().trim();
+      if (displayName.isBlank()) {
+        throw new IllegalArgumentException("destination table display name is blank");
+      }
+      portable.setTableDisplayName(displayName);
     }
     return portable.build();
+  }
+
+  private static IllegalArgumentException unresolved(String kind, String id) {
+    return new IllegalArgumentException(
+        "cannot export connector: destination " + kind + " id could not be resolved: " + id);
   }
 }

--- a/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecs.java
+++ b/tools/connector-transfer/src/main/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecs.java
@@ -87,8 +87,7 @@ final class PortableConnectorSpecs {
             || destination.getNamespace().getSegmentsList().stream().anyMatch(String::isBlank))) {
       throw new IllegalArgumentException("destination namespace contains an empty path segment");
     }
-    if (destination.hasTableDisplayName()
-        && destination.getTableDisplayName().trim().isBlank()) {
+    if (destination.hasTableDisplayName() && destination.getTableDisplayName().trim().isBlank()) {
       throw new IllegalArgumentException("destination table display name is blank");
     }
   }

--- a/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorArchiveTest.java
+++ b/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorArchiveTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.tools.transfer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.AuthCredentials;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorKind;
+import ai.floedb.floecat.connector.rpc.ConnectorSpec;
+import ai.floedb.floecat.connector.rpc.ConnectorTransferBundle;
+import ai.floedb.floecat.connector.rpc.ConnectorTransferEntry;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.zip.ZipFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConnectorArchiveTest {
+  @TempDir Path temporaryDirectory;
+
+  @Test
+  void roundTripsBundleAndKeepsSecretsOutOfReadableMetadata() throws Exception {
+    Path archive = temporaryDirectory.resolve("connectors.zip");
+    var credentials =
+        AuthCredentials.newBuilder()
+            .setClient(
+                AuthCredentials.ClientCredentials.newBuilder()
+                    .setClientId("client")
+                    .setClientSecret("highly-secret"))
+            .build();
+    var connector =
+        Connector.newBuilder()
+            .setResourceId(
+                ResourceId.newBuilder()
+                    .setAccountId("acct")
+                    .setId("connector-1")
+                    .setKind(ResourceKind.RK_CONNECTOR))
+            .setDisplayName("upstream")
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .build();
+    var spec =
+        ConnectorSpec.newBuilder()
+            .setDisplayName("upstream")
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .build();
+    var bundle =
+        ConnectorTransferBundle.newBuilder()
+            .setFormatVersion(ConnectorArchive.FORMAT_VERSION)
+            .setSourceAccountId("acct")
+            .addEntries(
+                ConnectorTransferEntry.newBuilder()
+                    .setConnector(connector)
+                    .setPortableSpec(spec)
+                    .setCredentials(credentials))
+            .build();
+
+    ConnectorArchive.write(archive, bundle, false);
+
+    assertThat(ConnectorArchive.read(archive)).isEqualTo(bundle);
+    try (var zip = new ZipFile(archive.toFile())) {
+      String manifest = read(zip, "manifest.json");
+      String portableSpec = read(zip, "connectors/connector-1/portable-spec.json");
+      assertThat(manifest).contains("\"hasCredentials\": true").doesNotContain("highly-secret");
+      assertThat(portableSpec).contains("upstream").doesNotContain("highly-secret");
+      assertThat(zip.getEntry("connectors/connector-1/credentials.pb")).isNotNull();
+    }
+  }
+
+  @Test
+  void refusesToOverwriteWithoutForce() throws Exception {
+    Path archive = temporaryDirectory.resolve("connectors.zip");
+    var bundle =
+        ConnectorTransferBundle.newBuilder()
+            .setFormatVersion(ConnectorArchive.FORMAT_VERSION)
+            .build();
+    ConnectorArchive.write(archive, bundle, false);
+
+    assertThatThrownBy(() -> ConnectorArchive.write(archive, bundle, false))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("--force");
+  }
+
+  private static String read(ZipFile zip, String entry) throws IOException {
+    try (var in = zip.getInputStream(zip.getEntry(entry))) {
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorArchiveTest.java
+++ b/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorArchiveTest.java
@@ -99,6 +99,66 @@ class ConnectorArchiveTest {
         .hasMessageContaining("--force");
   }
 
+  @Test
+  void rejectsDuplicateConnectorNamesBeforeImport() throws Exception {
+    Path archive = temporaryDirectory.resolve("duplicates.zip");
+    var first =
+        ConnectorTransferEntry.newBuilder()
+            .setConnector(
+                Connector.newBuilder()
+                    .setResourceId(ResourceId.newBuilder().setId("connector-1"))
+                    .setDisplayName("duplicate"))
+            .setPortableSpec(ConnectorSpec.newBuilder().setDisplayName("duplicate"))
+            .build();
+    var second =
+        first.toBuilder()
+            .setConnector(
+                first.getConnector().toBuilder()
+                    .setResourceId(ResourceId.newBuilder().setId("connector-2")))
+            .build();
+    var bundle =
+        ConnectorTransferBundle.newBuilder()
+            .setFormatVersion(ConnectorArchive.FORMAT_VERSION)
+            .addEntries(first)
+            .addEntries(second)
+            .build();
+    ConnectorArchive.write(archive, bundle, false);
+
+    assertThatThrownBy(() -> ConnectorArchive.read(archive))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("duplicate connector display name");
+  }
+
+  @Test
+  void rejectsCredentialsEmbeddedInPortableSpecification() throws Exception {
+    Path archive = temporaryDirectory.resolve("embedded-credentials.zip");
+    var credentials =
+        AuthCredentials.newBuilder()
+            .setBearer(AuthCredentials.BearerToken.newBuilder().setToken("secret"))
+            .build();
+    var bundle =
+        ConnectorTransferBundle.newBuilder()
+            .setFormatVersion(ConnectorArchive.FORMAT_VERSION)
+            .addEntries(
+                ConnectorTransferEntry.newBuilder()
+                    .setConnector(
+                        Connector.newBuilder()
+                            .setResourceId(ResourceId.newBuilder().setId("connector-1"))
+                            .setDisplayName("connector"))
+                    .setPortableSpec(
+                        ConnectorSpec.newBuilder()
+                            .setDisplayName("connector")
+                            .setAuth(
+                                ai.floedb.floecat.connector.rpc.AuthConfig.newBuilder()
+                                    .setCredentials(credentials))))
+            .build();
+    ConnectorArchive.write(archive, bundle, false);
+
+    assertThatThrownBy(() -> ConnectorArchive.read(archive))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("embeds credentials");
+  }
+
   private static String read(ZipFile zip, String entry) throws IOException {
     try (var in = zip.getInputStream(zip.getEntry(entry))) {
       return new String(in.readAllBytes(), StandardCharsets.UTF_8);

--- a/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorArchiveTest.java
+++ b/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorArchiveTest.java
@@ -27,9 +27,13 @@ import ai.floedb.floecat.connector.rpc.ConnectorKind;
 import ai.floedb.floecat.connector.rpc.ConnectorSpec;
 import ai.floedb.floecat.connector.rpc.ConnectorTransferBundle;
 import ai.floedb.floecat.connector.rpc.ConnectorTransferEntry;
+import com.google.protobuf.Timestamp;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 import java.util.zip.ZipFile;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -157,6 +161,44 @@ class ConnectorArchiveTest {
     assertThatThrownBy(() -> ConnectorArchive.read(archive))
         .isInstanceOf(IOException.class)
         .hasMessageContaining("embeds credentials");
+  }
+
+  @Test
+  void rejectsBundlesLargerThanTheReaderLimit() {
+    assertThatThrownBy(() -> ConnectorArchive.validateBundleSize(64 * 1024 * 1024 + 1))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("exceeds size limit");
+  }
+
+  @Test
+  void writesRfc3339ManifestTimestampWithNanosecondPrecision() throws Exception {
+    Path archive = temporaryDirectory.resolve("timestamp.zip");
+    var bundle =
+        ConnectorTransferBundle.newBuilder()
+            .setFormatVersion(ConnectorArchive.FORMAT_VERSION)
+            .setExportedAt(Timestamp.newBuilder().setSeconds(123).setNanos(5))
+            .build();
+
+    ConnectorArchive.write(archive, bundle, false);
+
+    try (var zip = new ZipFile(archive.toFile())) {
+      assertThat(read(zip, "manifest.json"))
+          .contains("\"exportedAt\": \"1970-01-01T00:02:03.000000005Z\"");
+    }
+  }
+
+  @Test
+  void protectsArchiveWithOwnerOnlyPermissions() throws Exception {
+    Path archive = temporaryDirectory.resolve("permissions.zip");
+    var bundle =
+        ConnectorTransferBundle.newBuilder()
+            .setFormatVersion(ConnectorArchive.FORMAT_VERSION)
+            .build();
+
+    ConnectorArchive.write(archive, bundle, false);
+
+    assertThat(Files.getPosixFilePermissions(archive))
+        .isEqualTo(Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
   }
 
   private static String read(ZipFile zip, String entry) throws IOException {

--- a/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCliTest.java
+++ b/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCliTest.java
@@ -24,9 +24,23 @@ import ai.floedb.floecat.connector.rpc.ConnectorSpec;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.ConnectorTransferBundle;
 import ai.floedb.floecat.connector.rpc.ConnectorTransferEntry;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 class ConnectorTransferCliTest {
+  @Test
+  void usesTlsByDefaultAndRequiresExplicitPlaintextOptIn() {
+    var defaults = new ConnectorTransferCli();
+    var plaintext = new ConnectorTransferCli();
+
+    new CommandLine(plaintext).parseArgs("--plaintext");
+
+    assertThat(defaults.plaintext).isFalse();
+    assertThat(plaintext.plaintext).isTrue();
+  }
+
   @Test
   void selectsCreateWhenNoConnectorExists() {
     for (var mode : ConnectorTransferCli.ConflictMode.values()) {
@@ -86,5 +100,82 @@ class ConnectorTransferCliTest {
             "policy",
             "state",
             "properties");
+  }
+
+  @Test
+  void connectorIdSelectorWinsOverAnotherConnectorsDisplayName() {
+    var namedAfterId = connector("connector-a", "connector-b");
+    var idMatch = connector("connector-b", "other-name");
+
+    assertThat(ConnectorTransferCli.select(List.of(namedAfterId, idMatch), List.of("connector-b")))
+        .containsExactly(idMatch);
+  }
+
+  @Test
+  void skippedAndFailedImportsDoNotRunMutationValidation() {
+    var validations = new AtomicInteger();
+    var entry =
+        ConnectorTransferEntry.newBuilder()
+            .setPortableSpec(ConnectorSpec.newBuilder().setDisplayName("connector"))
+            .build();
+    var current = connector("connector-id", "connector");
+
+    var skipped =
+        ConnectorTransferCli.prepareImport(
+            entry,
+            current,
+            ConnectorTransferCli.ConflictMode.SKIP,
+            spec -> {
+              validations.incrementAndGet();
+              return "valid";
+            });
+    var failed =
+        ConnectorTransferCli.prepareImport(
+            entry,
+            current,
+            ConnectorTransferCli.ConflictMode.FAIL,
+            spec -> {
+              validations.incrementAndGet();
+              return "valid";
+            });
+
+    assertThat(skipped.action()).isEqualTo(ConnectorTransferCli.ImportAction.SKIP);
+    assertThat(failed.action()).isEqualTo(ConnectorTransferCli.ImportAction.FAIL);
+    assertThat(validations).hasValue(0);
+  }
+
+  @Test
+  void createdAndReplacedImportsRunMutationValidation() {
+    var validations = new AtomicInteger();
+    var entry =
+        ConnectorTransferEntry.newBuilder()
+            .setPortableSpec(ConnectorSpec.newBuilder().setDisplayName("connector"))
+            .build();
+    ConnectorTransferCli.ImportValidator validator =
+        spec -> {
+          validations.incrementAndGet();
+          return "valid";
+        };
+
+    var created =
+        ConnectorTransferCli.prepareImport(
+            entry, null, ConnectorTransferCli.ConflictMode.FAIL, validator);
+    var replaced =
+        ConnectorTransferCli.prepareImport(
+            entry,
+            connector("connector-id", "connector"),
+            ConnectorTransferCli.ConflictMode.REPLACE,
+            validator);
+
+    assertThat(created.validationSummary()).isEqualTo("valid");
+    assertThat(replaced.validationSummary()).isEqualTo("valid");
+    assertThat(validations).hasValue(2);
+  }
+
+  private static Connector connector(String id, String displayName) {
+    return Connector.newBuilder()
+        .setResourceId(ResourceId.newBuilder().setId(id))
+        .setDisplayName(displayName)
+        .build();
   }
 }

--- a/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCliTest.java
+++ b/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCliTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.tools.transfer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorSpec;
+import ai.floedb.floecat.connector.rpc.ConnectorTransferBundle;
+import ai.floedb.floecat.connector.rpc.ConnectorTransferEntry;
+import org.junit.jupiter.api.Test;
+
+class ConnectorTransferCliTest {
+  @Test
+  void selectsCreateWhenNoConnectorExists() {
+    for (var mode : ConnectorTransferCli.ConflictMode.values()) {
+      assertThat(ConnectorTransferCli.importAction(false, mode))
+          .isEqualTo(ConnectorTransferCli.ImportAction.CREATE);
+    }
+  }
+
+  @Test
+  void appliesSelectedConflictModeWhenConnectorExists() {
+    assertThat(ConnectorTransferCli.importAction(true, ConnectorTransferCli.ConflictMode.FAIL))
+        .isEqualTo(ConnectorTransferCli.ImportAction.FAIL);
+    assertThat(ConnectorTransferCli.importAction(true, ConnectorTransferCli.ConflictMode.SKIP))
+        .isEqualTo(ConnectorTransferCli.ImportAction.SKIP);
+    assertThat(ConnectorTransferCli.importAction(true, ConnectorTransferCli.ConflictMode.REPLACE))
+        .isEqualTo(ConnectorTransferCli.ImportAction.REPLACE);
+  }
+
+  @Test
+  void idempotencyKeyIsStableWithinRunAndUniqueAcrossRuns() throws Exception {
+    var entry =
+        ConnectorTransferEntry.newBuilder()
+            .setConnector(
+                Connector.newBuilder()
+                    .setResourceId(ResourceId.newBuilder().setId("source-connector")))
+            .setPortableSpec(ConnectorSpec.newBuilder().setDisplayName("connector"))
+            .build();
+    var bundle = ConnectorTransferBundle.newBuilder().setSourceAccountId("source-account").build();
+
+    String first = ConnectorTransferCli.idempotencyKey("run-1", bundle, entry, "");
+
+    assertThat(ConnectorTransferCli.idempotencyKey("run-1", bundle, entry, "")).isEqualTo(first);
+    assertThat(ConnectorTransferCli.idempotencyKey("run-2", bundle, entry, "")).isNotEqualTo(first);
+  }
+}

--- a/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCliTest.java
+++ b/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/ConnectorTransferCliTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorSpec;
+import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.rpc.ConnectorTransferBundle;
 import ai.floedb.floecat.connector.rpc.ConnectorTransferEntry;
 import org.junit.jupiter.api.Test;
@@ -55,9 +56,35 @@ class ConnectorTransferCliTest {
             .build();
     var bundle = ConnectorTransferBundle.newBuilder().setSourceAccountId("source-account").build();
 
-    String first = ConnectorTransferCli.idempotencyKey("run-1", bundle, entry, "");
+    String first = ConnectorTransferCli.idempotencyKey("run-1", bundle, entry);
 
-    assertThat(ConnectorTransferCli.idempotencyKey("run-1", bundle, entry, "")).isEqualTo(first);
-    assertThat(ConnectorTransferCli.idempotencyKey("run-2", bundle, entry, "")).isNotEqualTo(first);
+    assertThat(ConnectorTransferCli.idempotencyKey("run-1", bundle, entry)).isEqualTo(first);
+    assertThat(ConnectorTransferCli.idempotencyKey("run-2", bundle, entry)).isNotEqualTo(first);
+  }
+
+  @Test
+  void replacementUpdatesInPlaceAndCoversEveryPortableField() {
+    var current =
+        Connector.newBuilder()
+            .setResourceId(ResourceId.newBuilder().setId("target-connector"))
+            .build();
+    var request =
+        ConnectorTransferCli.replacementRequest(
+            current, ConnectorSpec.newBuilder().setDisplayName("connector").build());
+
+    assertThat(request.getConnectorId()).isEqualTo(current.getResourceId());
+    assertThat(request.getSpec().getState()).isEqualTo(ConnectorState.CS_ACTIVE);
+    assertThat(request.getUpdateMask().getPathsList())
+        .containsExactlyInAnyOrder(
+            "display_name",
+            "description",
+            "kind",
+            "source",
+            "destination",
+            "uri",
+            "auth",
+            "policy",
+            "state",
+            "properties");
   }
 }

--- a/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecsTest.java
+++ b/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecsTest.java
@@ -26,9 +26,11 @@ import ai.floedb.floecat.catalog.rpc.DirectoryServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.LookupCatalogResponse;
 import ai.floedb.floecat.catalog.rpc.LookupNamespaceResponse;
 import ai.floedb.floecat.catalog.rpc.LookupTableResponse;
+import ai.floedb.floecat.catalog.rpc.ResolveCatalogResponse;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorSpec;
 import ai.floedb.floecat.connector.rpc.DestinationTarget;
 import org.junit.jupiter.api.Test;
 
@@ -115,6 +117,36 @@ class PortableConnectorSpecsTest {
                     directory))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("table-id");
+  }
+
+  @Test
+  void validatesResolvableCatalogBeforeImport() {
+    var directory = mock(DirectoryServiceGrpc.DirectoryServiceBlockingStub.class);
+    when(directory.resolveCatalog(any()))
+        .thenReturn(
+            ResolveCatalogResponse.newBuilder()
+                .setResourceId(ResourceId.newBuilder().setId("catalog-id"))
+                .build());
+    var spec =
+        ConnectorSpec.newBuilder()
+            .setDestination(DestinationTarget.newBuilder().setCatalogDisplayName("catalog"))
+            .build();
+
+    PortableConnectorSpecs.validateForImport(spec, directory);
+  }
+
+  @Test
+  void rejectsUnresolvedCatalogBeforeImport() {
+    var directory = mock(DirectoryServiceGrpc.DirectoryServiceBlockingStub.class);
+    when(directory.resolveCatalog(any())).thenReturn(ResolveCatalogResponse.getDefaultInstance());
+    var spec =
+        ConnectorSpec.newBuilder()
+            .setDestination(DestinationTarget.newBuilder().setCatalogDisplayName("missing"))
+            .build();
+
+    assertThatThrownBy(() -> PortableConnectorSpecs.validateForImport(spec, directory))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("missing");
   }
 
   private static Connector connectorWithDestination(DestinationTarget destination) {

--- a/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecsTest.java
+++ b/tools/connector-transfer/src/test/java/ai/floedb/floecat/tools/transfer/PortableConnectorSpecsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.tools.transfer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.rpc.DirectoryServiceGrpc;
+import ai.floedb.floecat.catalog.rpc.LookupCatalogResponse;
+import ai.floedb.floecat.catalog.rpc.LookupNamespaceResponse;
+import ai.floedb.floecat.catalog.rpc.LookupTableResponse;
+import ai.floedb.floecat.common.rpc.NameRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import org.junit.jupiter.api.Test;
+
+class PortableConnectorSpecsTest {
+  @Test
+  void convertsResolvedDestinationIdsToPortableNames() {
+    var directory = mock(DirectoryServiceGrpc.DirectoryServiceBlockingStub.class);
+    when(directory.lookupCatalog(any()))
+        .thenReturn(LookupCatalogResponse.newBuilder().setDisplayName("catalog").build());
+    when(directory.lookupNamespace(any()))
+        .thenReturn(
+            LookupNamespaceResponse.newBuilder()
+                .setRef(NameRef.newBuilder().addPath("parent").setName("namespace"))
+                .build());
+    when(directory.lookupTable(any()))
+        .thenReturn(
+            LookupTableResponse.newBuilder()
+                .setName(NameRef.newBuilder().setName("table"))
+                .build());
+    var destination =
+        DestinationTarget.newBuilder()
+            .setCatalogId(ResourceId.newBuilder().setId("catalog-id"))
+            .setNamespaceId(ResourceId.newBuilder().setId("namespace-id"))
+            .setTableId(ResourceId.newBuilder().setId("table-id"))
+            .build();
+
+    var portable =
+        PortableConnectorSpecs.from(connectorWithDestination(destination), directory)
+            .getDestination();
+
+    assertThat(portable.getCatalogDisplayName()).isEqualTo("catalog");
+    assertThat(portable.getNamespace().getSegmentsList()).containsExactly("parent", "namespace");
+    assertThat(portable.getTableDisplayName()).isEqualTo("table");
+  }
+
+  @Test
+  void rejectsUnresolvedCatalogId() {
+    var directory = mock(DirectoryServiceGrpc.DirectoryServiceBlockingStub.class);
+    when(directory.lookupCatalog(any())).thenReturn(LookupCatalogResponse.getDefaultInstance());
+
+    assertThatThrownBy(
+            () ->
+                PortableConnectorSpecs.from(
+                    connectorWithDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogId(ResourceId.newBuilder().setId("catalog-id"))
+                            .build()),
+                    directory))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("catalog-id");
+  }
+
+  @Test
+  void rejectsUnresolvedNamespaceId() {
+    var directory = mock(DirectoryServiceGrpc.DirectoryServiceBlockingStub.class);
+    when(directory.lookupNamespace(any())).thenReturn(LookupNamespaceResponse.getDefaultInstance());
+
+    assertThatThrownBy(
+            () ->
+                PortableConnectorSpecs.from(
+                    connectorWithDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogDisplayName("catalog")
+                            .setNamespaceId(ResourceId.newBuilder().setId("namespace-id"))
+                            .build()),
+                    directory))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("namespace-id");
+  }
+
+  @Test
+  void rejectsUnresolvedTableId() {
+    var directory = mock(DirectoryServiceGrpc.DirectoryServiceBlockingStub.class);
+    when(directory.lookupTable(any())).thenReturn(LookupTableResponse.getDefaultInstance());
+
+    assertThatThrownBy(
+            () ->
+                PortableConnectorSpecs.from(
+                    connectorWithDestination(
+                        DestinationTarget.newBuilder()
+                            .setCatalogDisplayName("catalog")
+                            .setTableId(ResourceId.newBuilder().setId("table-id"))
+                            .build()),
+                    directory))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("table-id");
+  }
+
+  private static Connector connectorWithDestination(DestinationTarget destination) {
+    return Connector.newBuilder().setDestination(destination).build();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a protected RPC for exporting unmasked connector definitions and separately stored credentials.
- Adds a Java CLI for exporting, inspecting, validating, and importing connector archives.
- Converts account-scoped destination IDs into portable names and paths.
- Supports dry runs and configurable conflict handling.
- Protects archives with owner-only permissions and explicit plaintext-secret acknowledgement.
- Adds focused service, permission, and archive tests.

## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
