### PR TITLE
GetUserObjects - 2: resolve pins concurrently and safely

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/spi/decorator/EngineMetadataDecorator.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/spi/decorator/EngineMetadataDecorator.java
@@ -24,7 +24,11 @@ import java.util.Set;
  * ai.floedb.floecat.service.query.catalog.UserObjectBundleService}.
  *
  * <p>Implementations are invoked during bundle construction and receive normalized engine kind +
- * version. Decoration remains optional and is not part of scanner implementations.
+ * version. GetUserObjects invokes relation/view/column decoration synchronously on its
+ * bundle-producer thread, preserving caller-thread state. Implementations that perform blocking I/O
+ * must enforce their own downstream deadlines; stream cancellation is observed between callbacks
+ * but does not interrupt an active callback. Decoration remains optional and is not part of scanner
+ * implementations.
  */
 public interface EngineMetadataDecorator {
 

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -198,7 +198,8 @@ public interface CatalogOverlay {
    *
    * <p>The default preserves compatibility for existing overlays, whose lifecycle state may be tied
    * to one request thread. Implementations backed by thread-safe services may opt in to concurrent
-   * resolution.
+   * resolution. Opting in permits {@link #catalog}, {@link #resolve}, {@code resolveName(s)}, and
+   * {@link #tablePinFor} callbacks to execute concurrently and off the caller thread.
    */
   default boolean supportsConcurrentResolution() {
     return false;

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -199,7 +199,11 @@ public interface CatalogOverlay {
    * <p>The default preserves compatibility for existing overlays, whose lifecycle state may be tied
    * to one request thread. Implementations backed by thread-safe services may opt in to concurrent
    * resolution. Opting in permits {@link #catalog}, {@link #resolve}, {@code resolveName(s)}, and
-   * {@link #tablePinFor} callbacks to execute concurrently and off the caller thread.
+   * {@link #tablePinFor} callbacks to execute concurrently and off the caller thread. It also
+   * permits GetUserObjects relation construction to run off-thread, including schema/name reads,
+   * pin validation, stats access, and the engine metadata decorator lifecycle. Implementations
+   * opting in must therefore make all of those callbacks thread-safe and must not depend on custom
+   * caller-thread state that the service context propagation does not capture.
    */
   default boolean supportsConcurrentResolution() {
     return false;

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -199,11 +199,13 @@ public interface CatalogOverlay {
    * <p>The default preserves compatibility for existing overlays, whose lifecycle state may be tied
    * to one request thread. Implementations backed by thread-safe services may opt in to concurrent
    * resolution. Opting in permits {@link #catalog}, {@link #resolve}, {@code resolveName(s)}, and
-   * {@link #tablePinFor} callbacks to execute concurrently and off the caller thread. It also
-   * permits GetUserObjects relation construction to run off-thread, including schema/name reads,
-   * pin validation, stats access, and the engine metadata decorator lifecycle. Implementations
-   * opting in must therefore make all of those callbacks thread-safe and must not depend on custom
-   * caller-thread state that the service context propagation does not capture.
+   * {@link #tablePinFor} callbacks to execute concurrently and off the caller thread, together with
+   * overlay-owned schema/name callbacks used while assembling GetUserObjects relations ({@link
+   * #schemaFor}, {@link #tableSchema}, {@link #tableName}, and {@link #viewName}). It does not
+   * change the caller-thread contract of separately injected stats, pin-validation, or
+   * engine-decoration collaborators. Implementations opting in must make the listed overlay
+   * callbacks thread-safe and must not depend on custom caller-thread state that service context
+   * propagation does not capture.
    */
   default boolean supportsConcurrentResolution() {
     return false;

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -194,6 +194,17 @@ public interface CatalogOverlay {
   }
 
   /**
+   * Whether independent resolution callbacks may run concurrently on this overlay instance.
+   *
+   * <p>The default preserves compatibility for existing overlays, whose lifecycle state may be tied
+   * to one request thread. Implementations backed by thread-safe services may opt in to concurrent
+   * resolution.
+   */
+  default boolean supportsConcurrentResolution() {
+    return false;
+  }
+
+  /**
    * Resolves a relation (table or view) by name reference using an explicit engine context.
    *
    * <p>Prefer this overload wherever the caller already holds the request's engine context — see

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/StatsProvider.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/StatsProvider.java
@@ -21,7 +21,14 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-/** Shared provider that surfaces table/column stats to metadata consumers. */
+/**
+ * Shared provider that surfaces table/column stats to metadata consumers.
+ *
+ * <p>GetUserObjects invokes these callbacks synchronously on its bundle-producer thread so provider
+ * implementations may retain caller-thread state. Implementations that perform blocking I/O must
+ * enforce their own downstream deadlines; stream cancellation is observed between callbacks but
+ * does not interrupt an active provider callback.
+ */
 public interface StatsProvider {
 
   default Optional<TableStatsView> tableStats(ResourceId tableId) {

--- a/docs/service.md
+++ b/docs/service.md
@@ -203,7 +203,8 @@ Notable `application.properties` keys:
 | `floecat.seed.enabled` | Enable demo data seeding. |
 | `floecat.kv` / `floecat.blob` | Select pointer/blob store implementation (`memory`, `dynamodb`, `s3`). |
 | `floecat.query.*` | Default TTL, grace period, max cache size, safety expiry for query contexts. |
-| `floecat.query.resolver.max_parallel_inputs` | Per-request query-input pin-resolution fan-out. Defaults to `8`; values are clamped to `1`–`16`. All requests also share the service-wide metadata I/O admission bound. |
+| `floecat.query.resolver.max_parallel_inputs` | Per-request query-input pin-resolution fan-out. Defaults to `8`; values are clamped to `1`–`16`. |
+| `floecat.query.metadata_io.max_concurrency` | Process-wide admission bound for blocking metadata I/O shared by all requests. Defaults to `64`; values are clamped to `1`–`256`. |
 | `floecat.gc.idempotency.*` | Cadence, page size, batch limit, slice duration for idempotency GC. |
 | `floecat.gc.cas.*` | Cadence, page size, min-age, tick slice settings for CAS blob GC. |
 | `floecat.gc.pointer.*` | Cadence, page size, min-age, tick slice settings for pointer GC. |

--- a/docs/service.md
+++ b/docs/service.md
@@ -203,6 +203,7 @@ Notable `application.properties` keys:
 | `floecat.seed.enabled` | Enable demo data seeding. |
 | `floecat.kv` / `floecat.blob` | Select pointer/blob store implementation (`memory`, `dynamodb`, `s3`). |
 | `floecat.query.*` | Default TTL, grace period, max cache size, safety expiry for query contexts. |
+| `floecat.query.resolver.max_parallel_inputs` | Per-request query-input pin-resolution fan-out. Defaults to `8`; values are clamped to `1`–`16`. All requests also share the service-wide metadata I/O admission bound. |
 | `floecat.gc.idempotency.*` | Cadence, page size, batch limit, slice duration for idempotency GC. |
 | `floecat.gc.cas.*` | Cadence, page size, min-age, tick slice settings for CAS blob GC. |
 | `floecat.gc.pointer.*` | Cadence, page size, min-age, tick slice settings for pointer GC. |

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -99,7 +99,9 @@ public final class BoundedFanout {
    * As {@link #mapOrdered(List, int, Executor, Function)}, but {@code cancelled} is polled so a
    * cancelled stream interrupts every submitted task and returns without waiting for a slow task's
    * completion. Tasks must cooperate with interruption while blocked in downstream calls. The
-   * permit wait is interruptible for the same reason.
+   * permit wait is interruptible for the same reason. A non-cancellation task failure waits for
+   * every already-submitted sibling before surfacing, so its latency is bounded by the slowest
+   * sibling; this completion guarantee lets callers safely release task-owned resources.
    */
   public static <I, O> List<O> mapOrdered(
       List<I> items,
@@ -164,7 +166,9 @@ public final class BoundedFanout {
 
   /**
    * Cancellation-aware ordered result consumption. A consumer failure has the same ordered
-   * precedence as a task failure, while submitted work is cancelled promptly when requested.
+   * precedence as a task failure, while submitted work is cancelled promptly when requested. A
+   * non-cancellation failure waits for already-submitted siblings before it surfaces, preserving
+   * the task-resource completion guarantee at the cost of slowest-sibling failure latency.
    */
   public static <I, O> void forEachOrdered(
       List<I> items,

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -418,6 +418,7 @@ public final class BoundedFanout {
     return new CancellationException("fan-out cancelled");
   }
 
+  /** One submitted input and the future through which its completion is observed. */
   private static final class CompletionSlot<O> {
     private final int index;
     private CompletableFuture<O> completion;
@@ -428,6 +429,7 @@ public final class BoundedFanout {
     }
   }
 
+  /** The successful result or unwrapped failure captured for one input. */
   private record TaskOutcome<O>(O result, Throwable failure) {
     private static <O> TaskOutcome<O> success(O result) {
       return new TaskOutcome<>(result, null);

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -159,11 +159,11 @@ public final class BoundedFanout {
         active.remove(slot);
         TaskOutcome<O> outcome = completedOutcome(slot.completion);
         outcomes.set(slot.index, outcome);
-        onCompletion.accept(slot.index, outcome);
         if (next < items.size()) {
           active.add(
               submitCompletionTask(next, items.get(next++), executor, context, task, completions));
         }
+        onCompletion.accept(slot.index, outcome);
       }
     } catch (RuntimeException | Error submissionFailure) {
       awaitCompletedTasks(active);
@@ -196,7 +196,6 @@ public final class BoundedFanout {
         CompletionSlot<O> slot = takeCancellableCompletion(completions, active, cancelled);
         TaskOutcome<O> outcome = completedOutcome(slot.task, active, cancelled);
         outcomes.set(slot.index, outcome);
-        onCompletion.accept(slot.index, outcome);
         active.remove(slot);
         if (next < items.size()) {
           checkCancelled(cancelled, active);
@@ -204,6 +203,7 @@ public final class BoundedFanout {
               submitCancellableTask(
                   next, items.get(next++), executor, context, task, cancelled, completions));
         }
+        onCompletion.accept(slot.index, outcome);
       }
     } catch (CancellationException cancellationFailure) {
       cancelSubmittedTasks(active);

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
+import java.util.function.Function;
+
+/** Runs independent, mostly-blocking tasks on a shared executor with a concurrency bound. */
+public final class BoundedFanout {
+
+  private BoundedFanout() {}
+
+  /**
+   * Apply {@code task} to each item on {@code executor}, at most {@code permits} running at once,
+   * and return the results in input order. Each task runs under the caller's OpenTelemetry context.
+   * A task failure surfaces unwrapped — its original {@link RuntimeException} or {@link Error},
+   * never a {@link CompletionException} wrapper — and the first such failure propagates to the
+   * caller once its future is joined.
+   */
+  public static <I, O> List<O> mapOrdered(
+      List<I> items, int permits, Executor executor, Function<I, O> task) {
+    Semaphore gate = new Semaphore(permits);
+    Context otelContext = Context.current();
+    List<CompletableFuture<O>> futures =
+        items.stream()
+            .map(
+                item ->
+                    CompletableFuture.supplyAsync(
+                        () -> {
+                          gate.acquireUninterruptibly();
+                          try (Scope ignored = otelContext.makeCurrent()) {
+                            return task.apply(item);
+                          } finally {
+                            gate.release();
+                          }
+                        },
+                        executor))
+            .toList();
+
+    List<O> results = new ArrayList<>(items.size());
+    for (CompletableFuture<O> future : futures) {
+      results.add(join(future));
+    }
+    return results;
+  }
+
+  private static <O> O join(CompletableFuture<O> future) {
+    try {
+      return future.join();
+    } catch (CompletionException ce) {
+      Throwable cause = ce.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error e) {
+        throw e;
+      }
+      throw new IllegalStateException("unexpected checked exception from parallel task", cause);
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -65,51 +65,13 @@ public final class BoundedFanout {
   }
 
   /**
-   * As {@link #mapOrdered(List, int, Executor, Function)}, but consumes each successful result on
-   * the caller thread before observing the next result. This preserves input-order validation
-   * precedence when a result consumer can itself fail, while still awaiting all submitted tasks
-   * before surfacing that failure so callers can safely release task-owned resources.
-   */
-  public static <I, O> void forEachOrdered(
-      List<I> items,
-      int permits,
-      Executor executor,
-      Function<I, O> task,
-      Consumer<? super O> consumer) {
-    List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
-    OrderedOutcomeConsumer<O> ordered = new OrderedOutcomeConsumer<>(outcomes, consumer);
-    completeAll(items, permits, executor, task, outcomes, ordered::accept);
-  }
-
-  /**
-   * As {@link #mapOrdered(List, int, Executor, Function)}, but {@code cancelled} is polled so a
-   * cancelled stream interrupts every submitted task and returns without waiting for a slow task's
-   * completion. Tasks must cooperate with interruption while blocked in downstream calls. The
-   * submission window observes cancellation before it submits more work. A non-cancellation task
-   * failure waits for every input task before surfacing, so callers can safely release task-owned
-   * resources. {@code cancelled} may be read concurrently by the scheduler and workers; it must be
-   * non-blocking and thread-safe (typically {@link java.util.concurrent.atomic.AtomicBoolean#get}).
-   * Observed cancellation throws {@link CancellationException}.
-   */
-  public static <I, O> List<O> mapOrdered(
-      List<I> items,
-      int permits,
-      ExecutorService executor,
-      Function<I, O> task,
-      BooleanSupplier cancelled) {
-    List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
-    completeAllCancellable(
-        items, permits, executor, task, cancelled, outcomes, (index, outcome) -> {});
-    return orderedResults(outcomes);
-  }
-
-  /**
    * Cancellation-aware ordered result consumption. A consumer failure has the same ordered
    * precedence as a task failure, while submitted work is cancelled promptly when requested. A
    * non-cancellation failure waits for already-submitted siblings before it surfaces, preserving
    * the task-resource completion guarantee at the cost of slowest-sibling failure latency. {@code
-   * cancelled} has the same concurrent-read contract and {@link CancellationException} behavior as
-   * the cancellable {@code mapOrdered} overload.
+   * cancelled} may be read concurrently by the scheduler and workers, so it must be non-blocking
+   * and thread-safe (typically {@link java.util.concurrent.atomic.AtomicBoolean#get}). Observed
+   * cancellation throws {@link CancellationException}.
    */
   public static <I, O> void forEachOrdered(
       List<I> items,
@@ -211,7 +173,11 @@ public final class BoundedFanout {
       cancelSubmittedTasks(active);
       throw cancellationFailure;
     } catch (RuntimeException | Error processingFailure) {
-      awaitSubmittedTasks(active, cancelled);
+      try {
+        awaitSubmittedTasks(active, cancelled);
+      } catch (CancellationException cancellationFailure) {
+        processingFailure.addSuppressed(cancellationFailure);
+      }
       throw processingFailure;
     }
   }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.concurrent;
 import ai.floedb.floecat.service.context.PropagatedContext;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -25,19 +26,21 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.Semaphore;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * Runs independent, mostly-blocking tasks with a concurrency bound.
  *
- * <p>All items are submitted immediately and wait on the internal semaphore, so callers must use an
- * executor that can queue the full input set without rejecting or starving runnable tasks.
+ * <p>At most the configured number of tasks are submitted at a time. A completed task immediately
+ * opens one submission slot, independent of input order; completed results are retained by index
+ * and observed in input order after the bounded window has drained.
  */
 public final class BoundedFanout {
 
@@ -56,18 +59,9 @@ public final class BoundedFanout {
    */
   public static <I, O> List<O> mapOrdered(
       List<I> items, int permits, Executor executor, Function<I, O> task) {
-    validatePermits(permits);
-    Semaphore gate = new Semaphore(permits);
-    PropagatedContext context = PropagatedContext.capture();
-    List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
-    for (I item : items) {
-      submitCompletionFuture(
-          futures,
-          () ->
-              CompletableFuture.supplyAsync(
-                  () -> runTask(gate, context, task, item, () -> false), executor));
-    }
-    return collectCompletedFutures(futures);
+    List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
+    completeAll(items, permits, executor, task, outcomes, (index, outcome) -> {});
+    return orderedResults(outcomes);
   }
 
   /**
@@ -82,27 +76,19 @@ public final class BoundedFanout {
       Executor executor,
       Function<I, O> task,
       Consumer<? super O> consumer) {
-    validatePermits(permits);
-    Semaphore gate = new Semaphore(permits);
-    PropagatedContext context = PropagatedContext.capture();
-    List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
-    for (I item : items) {
-      submitCompletionFuture(
-          futures,
-          () ->
-              CompletableFuture.supplyAsync(
-                  () -> runTask(gate, context, task, item, () -> false), executor));
-    }
-    consumeCompletedFutures(futures, consumer);
+    List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
+    OrderedOutcomeConsumer<O> ordered = new OrderedOutcomeConsumer<>(outcomes, consumer);
+    completeAll(items, permits, executor, task, outcomes, ordered::accept);
+    ordered.throwIfFailed();
   }
 
   /**
    * As {@link #mapOrdered(List, int, Executor, Function)}, but {@code cancelled} is polled so a
    * cancelled stream interrupts every submitted task and returns without waiting for a slow task's
    * completion. Tasks must cooperate with interruption while blocked in downstream calls. The
-   * permit wait is interruptible for the same reason. A non-cancellation task failure waits for
-   * every already-submitted sibling before surfacing, so its latency is bounded by the slowest
-   * sibling; this completion guarantee lets callers safely release task-owned resources.
+   * submission window observes cancellation before it submits more work. A non-cancellation task
+   * failure waits for every input task before surfacing, so callers can safely release task-owned
+   * resources.
    */
   public static <I, O> List<O> mapOrdered(
       List<I> items,
@@ -110,48 +96,10 @@ public final class BoundedFanout {
       ExecutorService executor,
       Function<I, O> task,
       BooleanSupplier cancelled) {
-    validatePermits(permits);
-    Semaphore gate = new Semaphore(permits);
-    PropagatedContext context = PropagatedContext.capture();
-    List<Future<O>> futures = new ArrayList<>(items.size());
-    try {
-      for (I item : items) {
-        if (cancelled.getAsBoolean()) {
-          cancelSubmittedTasks(futures);
-          throw cancelled();
-        }
-        submitTask(
-            futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
-      }
-    } catch (CancellationException cancellationFailure) {
-      cancelSubmittedTasks(futures);
-      throw cancellationFailure;
-    }
-
-    List<O> results = new ArrayList<>(items.size());
-    RuntimeException firstRuntimeFailure = null;
-    Error firstErrorFailure = null;
-    for (int index = 0; index < futures.size(); index++) {
-      Future<O> future = futures.get(index);
-      try {
-        results.add(awaitCancellable(future, futures, cancelled));
-      } catch (RuntimeException e) {
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          firstRuntimeFailure = e;
-        }
-      } catch (Error e) {
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          firstErrorFailure = e;
-        }
-      }
-    }
-    if (firstRuntimeFailure != null) {
-      throw firstRuntimeFailure;
-    }
-    if (firstErrorFailure != null) {
-      throw firstErrorFailure;
-    }
-    return results;
+    List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
+    completeAllCancellable(
+        items, permits, executor, task, cancelled, outcomes, (index, outcome) -> {});
+    return orderedResults(outcomes);
   }
 
   /**
@@ -167,198 +115,219 @@ public final class BoundedFanout {
       Function<I, O> task,
       Consumer<? super O> consumer,
       BooleanSupplier cancelled) {
-    validatePermits(permits);
-    Semaphore gate = new Semaphore(permits);
-    PropagatedContext context = PropagatedContext.capture();
-    List<Future<O>> futures = new ArrayList<>(items.size());
-    try {
-      for (I item : items) {
-        if (cancelled.getAsBoolean()) {
-          cancelSubmittedTasks(futures);
-          throw cancelled();
-        }
-        submitTask(
-            futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
-      }
-    } catch (CancellationException cancellationFailure) {
-      cancelSubmittedTasks(futures);
-      throw cancellationFailure;
-    }
-
-    RuntimeException firstRuntimeFailure = null;
-    Error firstErrorFailure = null;
-    for (int index = 0; index < futures.size(); index++) {
-      Future<O> future = futures.get(index);
-      try {
-        O result = awaitCancellable(future, futures, cancelled);
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          consumer.accept(result);
-        }
-      } catch (RuntimeException e) {
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          firstRuntimeFailure = e;
-        }
-      } catch (Error e) {
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          firstErrorFailure = e;
-        }
-      }
-    }
-    if (firstRuntimeFailure != null) {
-      throw firstRuntimeFailure;
-    }
-    if (firstErrorFailure != null) {
-      throw firstErrorFailure;
-    }
+    List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
+    OrderedOutcomeConsumer<O> ordered = new OrderedOutcomeConsumer<>(outcomes, consumer);
+    completeAllCancellable(items, permits, executor, task, cancelled, outcomes, ordered::accept);
+    ordered.throwIfFailed();
   }
 
-  /** Run one task under the captured context while holding one concurrency permit. */
-  private static <I, O> O runTask(
-      Semaphore gate,
-      PropagatedContext context,
-      Function<I, O> task,
-      I item,
-      BooleanSupplier cancelled) {
-    acquire(gate);
-    try {
-      return context.supply(
-          () -> {
-            if (cancelled.getAsBoolean()) {
-              throw cancelled();
-            }
-            return task.apply(item);
-          });
-    } finally {
-      gate.release();
-    }
-  }
-
-  /** Collect every completed future, preserving the first unwrapped task failure. */
-  private static <O> List<O> collectCompletedFutures(List<CompletableFuture<O>> futures) {
-    List<O> results = new ArrayList<>(futures.size());
-    RuntimeException firstRuntimeFailure = null;
-    Error firstErrorFailure = null;
-    for (int index = 0; index < futures.size(); index++) {
-      CompletableFuture<O> future = futures.get(index);
-      try {
-        results.add(Futures.join(future));
-      } catch (RuntimeException e) {
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          firstRuntimeFailure = e;
-        }
-      } catch (Error e) {
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          firstErrorFailure = e;
-        }
+  /** Re-throw the first input-ordered task failure after every bounded task has finished. */
+  private static <O> List<O> orderedResults(List<TaskOutcome<O>> outcomes) {
+    List<O> results = new ArrayList<>(outcomes.size());
+    for (TaskOutcome<O> outcome : outcomes) {
+      if (outcome.failure() != null) {
+        rethrowTaskFailure(outcome.failure());
       }
-    }
-    if (firstRuntimeFailure != null) {
-      throw firstRuntimeFailure;
-    }
-    if (firstErrorFailure != null) {
-      throw firstErrorFailure;
+      results.add(outcome.result());
     }
     return results;
   }
 
-  /** Consume completed futures in input order, preserving the first task or consumer failure. */
-  private static <O> void consumeCompletedFutures(
-      List<CompletableFuture<O>> futures, Consumer<? super O> consumer) {
-    RuntimeException firstRuntimeFailure = null;
-    Error firstErrorFailure = null;
-    for (int index = 0; index < futures.size(); index++) {
-      CompletableFuture<O> future = futures.get(index);
-      try {
-        O result = Futures.join(future);
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          consumer.accept(result);
-        }
-      } catch (RuntimeException e) {
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          firstRuntimeFailure = e;
-        }
-      } catch (Error e) {
-        if (firstRuntimeFailure == null && firstErrorFailure == null) {
-          firstErrorFailure = e;
+  /**
+   * Submit no more than {@code permits} tasks at once, recording each outcome as it completes so a
+   * fast later task immediately replenishes the window despite ordered result observation.
+   */
+  private static <I, O> void completeAll(
+      List<I> items,
+      int permits,
+      Executor executor,
+      Function<I, O> task,
+      List<TaskOutcome<O>> outcomes,
+      BiConsumer<Integer, TaskOutcome<O>> onCompletion) {
+    validatePermits(permits);
+    PropagatedContext context = PropagatedContext.capture();
+    BlockingQueue<CompletionSlot<O>> completions = new LinkedBlockingQueue<>();
+    List<CompletionSlot<O>> active = new ArrayList<>(permits);
+    int next = 0;
+    try {
+      while (next < items.size() && active.size() < permits) {
+        active.add(
+            submitCompletionTask(next, items.get(next++), executor, context, task, completions));
+      }
+      while (!active.isEmpty()) {
+        CompletionSlot<O> slot = takeCompletion(completions);
+        active.remove(slot);
+        TaskOutcome<O> outcome = completedOutcome(slot.completion);
+        outcomes.set(slot.index, outcome);
+        onCompletion.accept(slot.index, outcome);
+        if (next < items.size()) {
+          active.add(
+              submitCompletionTask(next, items.get(next++), executor, context, task, completions));
         }
       }
-    }
-    if (firstRuntimeFailure != null) {
-      throw firstRuntimeFailure;
-    }
-    if (firstErrorFailure != null) {
-      throw firstErrorFailure;
-    }
-  }
-
-  /** Await each already-submitted completion future after a submission failure. */
-  private static <O> void submitCompletionFuture(
-      List<CompletableFuture<O>> futures, Supplier<CompletableFuture<O>> submission) {
-    try {
-      futures.add(submission.get());
     } catch (RuntimeException | Error submissionFailure) {
-      awaitCompletedFutures(futures);
+      awaitCompletedTasks(active);
       throw submissionFailure;
     }
   }
 
-  /** Await each already-submitted task after an executor submission failure. */
-  private static <O> void submitTask(List<Future<O>> futures, Supplier<Future<O>> submission) {
+  /** Cancellable counterpart of the bounded completion scheduler. */
+  private static <I, O> void completeAllCancellable(
+      List<I> items,
+      int permits,
+      ExecutorService executor,
+      Function<I, O> task,
+      BooleanSupplier cancelled,
+      List<TaskOutcome<O>> outcomes,
+      BiConsumer<Integer, TaskOutcome<O>> onCompletion) {
+    validatePermits(permits);
+    PropagatedContext context = PropagatedContext.capture();
+    BlockingQueue<CompletionSlot<O>> completions = new LinkedBlockingQueue<>();
+    List<CompletionSlot<O>> active = new ArrayList<>(permits);
+    int next = 0;
     try {
-      futures.add(submission.get());
+      while (next < items.size() && active.size() < permits) {
+        checkCancelled(cancelled, active);
+        active.add(
+            submitCancellableTask(
+                next, items.get(next++), executor, context, task, cancelled, completions));
+      }
+      while (!active.isEmpty()) {
+        CompletionSlot<O> slot = takeCancellableCompletion(completions, active, cancelled);
+        TaskOutcome<O> outcome = completedOutcome(slot.task, active, cancelled);
+        outcomes.set(slot.index, outcome);
+        onCompletion.accept(slot.index, outcome);
+        active.remove(slot);
+        if (next < items.size()) {
+          checkCancelled(cancelled, active);
+          active.add(
+              submitCancellableTask(
+                  next, items.get(next++), executor, context, task, cancelled, completions));
+        }
+      }
+    } catch (CancellationException cancellationFailure) {
+      cancelSubmittedTasks(active);
+      throw cancellationFailure;
     } catch (RuntimeException | Error submissionFailure) {
-      awaitSubmittedTasks(futures);
+      awaitSubmittedTasks(active);
       throw submissionFailure;
     }
   }
 
-  /** Await each already-submitted completion future after a submission failure. */
-  private static void awaitCompletedFutures(List<? extends CompletableFuture<?>> futures) {
-    for (CompletableFuture<?> future : futures) {
-      try {
-        Futures.join(future);
-      } catch (RuntimeException | Error ignored) {
-        // The submission failure is the caller-visible outcome; task failures only complete
-        // cleanup.
-      }
-    }
+  private static <I, O> CompletionSlot<O> submitCompletionTask(
+      int index,
+      I item,
+      Executor executor,
+      PropagatedContext context,
+      Function<I, O> task,
+      BlockingQueue<CompletionSlot<O>> completions) {
+    CompletionSlot<O> slot = new CompletionSlot<>(index);
+    slot.completion =
+        CompletableFuture.supplyAsync(() -> context.supply(() -> task.apply(item)), executor);
+    // Completion stages run only after the CompletableFuture has reached its terminal state, so
+    // removing this slot cannot briefly exceed the submitted-task window.
+    slot.completion.whenComplete((ignored, failure) -> completions.add(slot));
+    return slot;
   }
 
-  /** Await each already-submitted task while preserving an executor submission failure. */
-  private static void awaitSubmittedTasks(List<? extends Future<?>> futures) {
+  private static <I, O> CompletionSlot<O> submitCancellableTask(
+      int index,
+      I item,
+      ExecutorService executor,
+      PropagatedContext context,
+      Function<I, O> task,
+      BooleanSupplier cancelled,
+      BlockingQueue<CompletionSlot<O>> completions) {
+    CompletionSlot<O> slot = new CompletionSlot<>(index);
+    FutureTask<O> submitted =
+        new FutureTask<O>(
+            () ->
+                context.supply(
+                    () -> {
+                      if (cancelled.getAsBoolean()) {
+                        throw cancelled();
+                      }
+                      return task.apply(item);
+                    })) {
+          @Override
+          protected void done() {
+            completions.add(slot);
+          }
+        };
+    slot.task = submitted;
+    executor.execute(submitted);
+    return slot;
+  }
+
+  private static <O> CompletionSlot<O> takeCompletion(
+      BlockingQueue<CompletionSlot<O>> completions) {
     boolean interrupted = false;
-    for (Future<?> future : futures) {
-      try {
-        future.get();
-      } catch (InterruptedException e) {
-        interrupted = true;
-        cancelSubmittedTasks(futures);
-        break;
-      } catch (ExecutionException | CancellationException ignored) {
-        // The submission failure is the caller-visible outcome; task failures only complete
-        // cleanup.
+    try {
+      while (true) {
+        try {
+          return completions.take();
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
       }
-    }
-    if (interrupted) {
-      Thread.currentThread().interrupt();
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 
-  /** Await one task while repeatedly observing stream cancellation. */
-  private static <O> O awaitCancellable(
-      Future<O> future, List<? extends Future<?>> futures, BooleanSupplier cancelled) {
+  /** Await an active completion while polling cancellation instead of joining a slow input. */
+  private static <O> CompletionSlot<O> takeCancellableCompletion(
+      BlockingQueue<CompletionSlot<O>> completions,
+      List<CompletionSlot<O>> active,
+      BooleanSupplier cancelled) {
     while (true) {
-      if (cancelled.getAsBoolean()) {
-        cancelSubmittedTasks(futures);
+      checkCancelled(cancelled, active);
+      try {
+        CompletionSlot<O> slot = completions.poll(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+        if (slot != null) {
+          return slot;
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        cancelSubmittedTasks(active);
         throw cancelled();
       }
+    }
+  }
+
+  private static <O> TaskOutcome<O> completedOutcome(CompletableFuture<O> future) {
+    try {
+      return TaskOutcome.success(Futures.join(future));
+    } catch (RuntimeException | Error failure) {
+      return TaskOutcome.failure(failure);
+    }
+  }
+
+  private static <O> TaskOutcome<O> completedOutcome(
+      Future<O> future, List<CompletionSlot<O>> active, BooleanSupplier cancelled) {
+    try {
+      return TaskOutcome.success(awaitCancellable(future, active, cancelled));
+    } catch (RuntimeException | Error failure) {
+      return TaskOutcome.failure(failure);
+    }
+  }
+
+  /**
+   * Await one just-completed task while still honoring a cancellation that races its completion.
+   */
+  private static <O> O awaitCancellable(
+      Future<O> future, List<? extends CompletionSlot<?>> active, BooleanSupplier cancelled) {
+    while (true) {
+      checkCancelled(cancelled, active);
       try {
         return future.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
       } catch (TimeoutException ignored) {
         // A bounded wait lets the next loop observe cancellation.
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        cancelSubmittedTasks(futures);
+        cancelSubmittedTasks(active);
         throw cancelled();
       } catch (ExecutionException e) {
         rethrowTaskFailure(e.getCause());
@@ -366,10 +335,56 @@ public final class BoundedFanout {
     }
   }
 
+  private static <O> List<TaskOutcome<O>> emptyOutcomes(int size) {
+    return new ArrayList<>(java.util.Collections.nCopies(size, null));
+  }
+
+  /** Wait for every completion future after rejecting one bounded-window submission. */
+  private static void awaitCompletedTasks(List<? extends CompletionSlot<?>> active) {
+    for (CompletionSlot<?> slot : active) {
+      try {
+        Futures.join(slot.completion);
+      } catch (RuntimeException | Error ignored) {
+        // The submission failure is the caller-visible outcome; task failures only complete
+        // task-owned cleanup.
+      }
+    }
+  }
+
+  /** Wait for every submitted task after rejecting one bounded-window submission. */
+  private static void awaitSubmittedTasks(List<? extends CompletionSlot<?>> active) {
+    boolean interrupted = false;
+    for (CompletionSlot<?> slot : active) {
+      try {
+        slot.task.get();
+      } catch (InterruptedException e) {
+        interrupted = true;
+        cancelSubmittedTasks(active);
+        break;
+      } catch (ExecutionException | CancellationException ignored) {
+        // The submission failure is the caller-visible outcome; task failures only complete
+        // task-owned cleanup.
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static void checkCancelled(
+      BooleanSupplier cancelled, List<? extends CompletionSlot<?>> active) {
+    if (cancelled.getAsBoolean()) {
+      cancelSubmittedTasks(active);
+      throw cancelled();
+    }
+  }
+
   /** Interrupt every submitted task, including work already inside a downstream call. */
-  private static void cancelSubmittedTasks(List<? extends Future<?>> futures) {
-    for (Future<?> future : futures) {
-      future.cancel(true);
+  private static void cancelSubmittedTasks(List<? extends CompletionSlot<?>> active) {
+    for (CompletionSlot<?> slot : active) {
+      if (slot.task != null) {
+        slot.task.cancel(true);
+      }
     }
   }
 
@@ -396,16 +411,70 @@ public final class BoundedFanout {
     return new CancellationException("fan-out cancelled");
   }
 
+  private static final class CompletionSlot<O> {
+    private final int index;
+    private CompletableFuture<O> completion;
+    private Future<O> task;
+
+    private CompletionSlot(int index) {
+      this.index = index;
+    }
+  }
+
+  private record TaskOutcome<O>(O result, Throwable failure) {
+    private static <O> TaskOutcome<O> success(O result) {
+      return new TaskOutcome<>(result, null);
+    }
+
+    private static <O> TaskOutcome<O> failure(Throwable failure) {
+      return new TaskOutcome<>(null, failure);
+    }
+  }
+
   /**
-   * Interruptible permit acquire: a shutdown/interrupt aborts the task instead of pinning the
-   * thread on an uninterruptible wait.
+   * Delivers completed results to a caller in input order without stalling the submission window.
    */
-  private static void acquire(Semaphore gate) {
-    try {
-      gate.acquire();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new CancellationException("interrupted while awaiting fan-out permit");
+  private static final class OrderedOutcomeConsumer<O> {
+    private final List<TaskOutcome<O>> outcomes;
+    private final Consumer<? super O> consumer;
+    private int nextIndex;
+    private RuntimeException firstRuntimeFailure;
+    private Error firstErrorFailure;
+
+    private OrderedOutcomeConsumer(List<TaskOutcome<O>> outcomes, Consumer<? super O> consumer) {
+      this.outcomes = outcomes;
+      this.consumer = consumer;
+    }
+
+    private void accept(int index, TaskOutcome<O> ignored) {
+      while (nextIndex < outcomes.size() && outcomes.get(nextIndex) != null) {
+        TaskOutcome<O> outcome = outcomes.get(nextIndex++);
+        try {
+          if (outcome.failure() != null) {
+            rethrowTaskFailure(outcome.failure());
+          }
+          if (firstRuntimeFailure == null && firstErrorFailure == null) {
+            consumer.accept(outcome.result());
+          }
+        } catch (RuntimeException e) {
+          if (firstRuntimeFailure == null && firstErrorFailure == null) {
+            firstRuntimeFailure = e;
+          }
+        } catch (Error e) {
+          if (firstRuntimeFailure == null && firstErrorFailure == null) {
+            firstErrorFailure = e;
+          }
+        }
+      }
+    }
+
+    private void throwIfFailed() {
+      if (firstRuntimeFailure != null) {
+        throw firstRuntimeFailure;
+      }
+      if (firstErrorFailure != null) {
+        throw firstErrorFailure;
+      }
     }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -39,8 +39,9 @@ import java.util.function.Function;
  *
  * <p>At most the configured number of tasks are submitted at a time. A completed task immediately
  * opens one submission slot, independent of input order. Completed results are retained by index;
- * mapping returns them after the bounded window drains, while ordered consumption delivers each
- * contiguous input-order prefix as soon as it is available.
+ * mapping and ordered consumption deliver each contiguous input-order prefix as soon as it is
+ * available. Once that prefix exposes a failure, active siblings are cancelled or abandoned and the
+ * original failure returns without waiting for unrelated work.
  */
 public final class BoundedFanout {
 
@@ -54,29 +55,30 @@ public final class BoundedFanout {
    * (OpenTelemetry, engine/principal/correlation, MDC) re-established via {@link
    * PropagatedContext}, so ambient reads behave off-thread as they do on the caller's thread. A
    * task failure surfaces unwrapped — its original {@link RuntimeException} or {@link Error}, never
-   * an execution-wrapper exception. With no cancellation, every task future completes before the
-   * first joined failure propagates, so callers can safely clean up task-owned resources.
+   * an execution-wrapper exception. The first failure reachable in input order propagates
+   * immediately; active siblings are cancelled or abandoned rather than drained.
    */
   public static <I, O> List<O> mapOrdered(
       List<I> items, int permits, Executor executor, Function<I, O> task) {
     List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
+    List<O> results = new ArrayList<>(items.size());
+    OrderedOutcomeConsumer<O> ordered = new OrderedOutcomeConsumer<>(outcomes, results::add);
     completeAll(
         items,
         permits,
         outcomes,
-        (index, outcome) -> {},
+        ordered::accept,
         new CompletionTaskRuntime<>(executor, PropagatedContext.capture(), task));
-    return orderedResults(outcomes);
+    return results;
   }
 
   /**
    * Cancellation-aware ordered result consumption. A consumer failure has the same ordered
-   * precedence as a task failure, while submitted work is cancelled promptly when requested. A
-   * non-cancellation failure waits for already-submitted siblings before it surfaces, preserving
-   * the task-resource completion guarantee at the cost of slowest-sibling failure latency. {@code
-   * cancelled} may be read concurrently by the scheduler and workers, so it must be non-blocking
-   * and thread-safe (typically {@link java.util.concurrent.atomic.AtomicBoolean#get}). Observed
-   * cancellation throws {@link CancellationException}.
+   * precedence as a task failure, while submitted work is cancelled promptly on failure or when
+   * cancellation is requested. {@code cancelled} may be read concurrently by the scheduler and
+   * workers, so it must be non-blocking and thread-safe (typically {@link
+   * java.util.concurrent.atomic.AtomicBoolean#get}). Observed cancellation throws {@link
+   * CancellationException}.
    */
   public static <I, O> void forEachOrdered(
       List<I> items,
@@ -93,18 +95,6 @@ public final class BoundedFanout {
         outcomes,
         ordered::accept,
         new CancellableTaskRuntime<>(executor, PropagatedContext.capture(), task, cancelled));
-  }
-
-  /** Re-throw the first input-ordered task failure after every bounded task has finished. */
-  private static <O> List<O> orderedResults(List<TaskOutcome<O>> outcomes) {
-    List<O> results = new ArrayList<>(outcomes.size());
-    for (TaskOutcome<O> outcome : outcomes) {
-      if (outcome.failure() != null) {
-        throw Futures.propagate(outcome.failure(), "unexpected checked exception from fan-out");
-      }
-      results.add(outcome.result());
-    }
-    return results;
   }
 
   /**
@@ -157,8 +147,8 @@ public final class BoundedFanout {
     TaskOutcome<O> outcome(CompletionSlot<O> slot, List<CompletionSlot<O>> active);
 
     /**
-     * Finish or cancel active work after scheduler/consumer failure. Cleanup must preserve the
-     * supplied failure as the caller-visible outcome and attach any raced cancellation to it.
+     * Cancel or abandon active work after scheduler/consumer failure without waiting for it. The
+     * supplied failure remains the caller-visible outcome.
      */
     void afterFailure(List<CompletionSlot<O>> active, Throwable processingFailure);
   }
@@ -216,7 +206,7 @@ public final class BoundedFanout {
 
     @Override
     public void afterFailure(List<CompletionSlot<O>> active, Throwable processingFailure) {
-      awaitCompletedTasks(active);
+      cancelCompletionTasks(active);
     }
   }
 
@@ -296,15 +286,7 @@ public final class BoundedFanout {
 
     @Override
     public void afterFailure(List<CompletionSlot<O>> active, Throwable processingFailure) {
-      if (processingFailure instanceof CancellationException) {
-        cancelSubmittedTasks(active);
-        return;
-      }
-      try {
-        awaitSubmittedTasks(active, cancelled);
-      } catch (CancellationException cancellationFailure) {
-        processingFailure.addSuppressed(cancellationFailure);
-      }
+      cancelSubmittedTasks(active);
     }
   }
 
@@ -333,42 +315,11 @@ public final class BoundedFanout {
     return new ArrayList<>(java.util.Collections.nCopies(size, null));
   }
 
-  /** Wait for every active completion after scheduling or ordered consumption fails. */
-  private static void awaitCompletedTasks(List<? extends CompletionSlot<?>> active) {
+  /** Best-effort cancellation for non-cancellable executor submissions; never wait for siblings. */
+  private static void cancelCompletionTasks(List<? extends CompletionSlot<?>> active) {
     for (CompletionSlot<?> slot : active) {
-      try {
-        Futures.join(slot.completion);
-      } catch (RuntimeException | Error ignored) {
-        // The scheduler or consumer failure is caller-visible; task failures only complete
-        // task-owned cleanup.
-      }
-    }
-  }
-
-  /**
-   * Wait for submitted tasks after scheduling or ordered consumption fails, while still returning
-   * promptly when the stream is cancelled. Without cancellation the original failure remains
-   * caller-visible.
-   */
-  private static void awaitSubmittedTasks(
-      List<? extends CompletionSlot<?>> active, BooleanSupplier cancelled) {
-    for (CompletionSlot<?> slot : active) {
-      while (true) {
-        checkCancelled(cancelled, active);
-        try {
-          slot.task.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
-          break;
-        } catch (TimeoutException ignored) {
-          // A bounded wait lets the next loop observe cancellation.
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          cancelSubmittedTasks(active);
-          throw cancelled();
-        } catch (ExecutionException | CancellationException ignored) {
-          // The scheduler or consumer failure is caller-visible; task failures only complete
-          // task-owned cleanup.
-          break;
-        }
+      if (slot.completion != null) {
+        slot.completion.cancel(true);
       }
     }
   }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -33,7 +33,12 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-/** Runs independent, mostly-blocking tasks on a shared executor with a concurrency bound. */
+/**
+ * Runs independent, mostly-blocking tasks with a concurrency bound.
+ *
+ * <p>All items are submitted immediately and wait on the internal semaphore, so callers must use an
+ * executor that can queue the full input set without rejecting or starving runnable tasks.
+ */
 public final class BoundedFanout {
 
   private static final long CANCELLATION_POLL_MILLIS = 10;

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -60,7 +60,12 @@ public final class BoundedFanout {
   public static <I, O> List<O> mapOrdered(
       List<I> items, int permits, Executor executor, Function<I, O> task) {
     List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
-    completeAll(items, permits, executor, task, outcomes, (index, outcome) -> {});
+    completeAll(
+        items,
+        permits,
+        outcomes,
+        (index, outcome) -> {},
+        new CompletionTaskRuntime<>(executor, PropagatedContext.capture(), task));
     return orderedResults(outcomes);
   }
 
@@ -82,7 +87,12 @@ public final class BoundedFanout {
       BooleanSupplier cancelled) {
     List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
     OrderedOutcomeConsumer<O> ordered = new OrderedOutcomeConsumer<>(outcomes, consumer);
-    completeAllCancellable(items, permits, executor, task, cancelled, outcomes, ordered::accept);
+    completeAll(
+        items,
+        permits,
+        outcomes,
+        ordered::accept,
+        new CancellableTaskRuntime<>(executor, PropagatedContext.capture(), task, cancelled));
   }
 
   /** Re-throw the first input-ordered task failure after every bounded task has finished. */
@@ -104,186 +114,197 @@ public final class BoundedFanout {
   private static <I, O> void completeAll(
       List<I> items,
       int permits,
-      Executor executor,
-      Function<I, O> task,
       List<TaskOutcome<O>> outcomes,
-      BiConsumer<Integer, TaskOutcome<O>> onCompletion) {
+      BiConsumer<Integer, TaskOutcome<O>> onCompletion,
+      TaskRuntime<I, O> runtime) {
     validatePermits(permits);
-    PropagatedContext context = PropagatedContext.capture();
-    BlockingQueue<CompletionSlot<O>> completions = new LinkedBlockingQueue<>();
     List<CompletionSlot<O>> active = new ArrayList<>(permits);
     int next = 0;
     try {
       while (next < items.size() && active.size() < permits) {
-        active.add(
-            submitCompletionTask(next, items.get(next++), executor, context, task, completions));
+        runtime.beforeSubmit(active);
+        active.add(runtime.submit(next, items.get(next++)));
       }
       while (!active.isEmpty()) {
-        CompletionSlot<O> slot = takeCompletion(completions);
-        active.remove(slot);
-        TaskOutcome<O> outcome = completedOutcome(slot.completion);
+        CompletionSlot<O> slot = runtime.take(active);
+        TaskOutcome<O> outcome = runtime.outcome(slot, active);
         outcomes.set(slot.index, outcome);
+        active.remove(slot);
         if (next < items.size()) {
-          active.add(
-              submitCompletionTask(next, items.get(next++), executor, context, task, completions));
+          runtime.beforeSubmit(active);
+          active.add(runtime.submit(next, items.get(next++)));
         }
         onCompletion.accept(slot.index, outcome);
       }
     } catch (RuntimeException | Error processingFailure) {
-      awaitCompletedTasks(active);
+      runtime.afterFailure(active, processingFailure);
       throw processingFailure;
     }
   }
 
-  /** Cancellable counterpart of the bounded completion scheduler. */
-  private static <I, O> void completeAllCancellable(
-      List<I> items,
-      int permits,
-      ExecutorService executor,
-      Function<I, O> task,
-      BooleanSupplier cancelled,
-      List<TaskOutcome<O>> outcomes,
-      BiConsumer<Integer, TaskOutcome<O>> onCompletion) {
-    validatePermits(permits);
-    PropagatedContext context = PropagatedContext.capture();
-    BlockingQueue<CompletionSlot<O>> completions = new LinkedBlockingQueue<>();
-    List<CompletionSlot<O>> active = new ArrayList<>(permits);
-    int next = 0;
-    try {
-      while (next < items.size() && active.size() < permits) {
-        checkCancelled(cancelled, active);
-        active.add(
-            submitCancellableTask(
-                next, items.get(next++), executor, context, task, cancelled, completions));
-      }
-      while (!active.isEmpty()) {
-        CompletionSlot<O> slot = takeCancellableCompletion(completions, active, cancelled);
-        TaskOutcome<O> outcome = completedOutcome(slot.task, active, cancelled);
-        outcomes.set(slot.index, outcome);
-        active.remove(slot);
-        if (next < items.size()) {
-          checkCancelled(cancelled, active);
-          active.add(
-              submitCancellableTask(
-                  next, items.get(next++), executor, context, task, cancelled, completions));
+  /** Task lifecycle strategy used by the shared bounded-window scheduler. */
+  private interface TaskRuntime<I, O> {
+    /** Validate scheduler state before submission without adding or removing active slots. */
+    default void beforeSubmit(List<CompletionSlot<O>> active) {}
+
+    /** Submit one indexed item and return the slot the scheduler owns until completion. */
+    CompletionSlot<O> submit(int index, I item);
+
+    /** Wait for and return one completed member of {@code active} without mutating that list. */
+    CompletionSlot<O> take(List<CompletionSlot<O>> active);
+
+    /** Capture a completed slot as data; only scheduler cancellation may escape this method. */
+    TaskOutcome<O> outcome(CompletionSlot<O> slot, List<CompletionSlot<O>> active);
+
+    /**
+     * Finish or cancel active work after scheduler/consumer failure. Cleanup must preserve the
+     * supplied failure as the caller-visible outcome and attach any raced cancellation to it.
+     */
+    void afterFailure(List<CompletionSlot<O>> active, Throwable processingFailure);
+  }
+
+  /** Non-cancellable CompletableFuture task lifecycle. */
+  private static final class CompletionTaskRuntime<I, O> implements TaskRuntime<I, O> {
+    private final Executor executor;
+    private final PropagatedContext context;
+    private final Function<I, O> task;
+    private final BlockingQueue<CompletionSlot<O>> completions = new LinkedBlockingQueue<>();
+
+    private CompletionTaskRuntime(
+        Executor executor, PropagatedContext context, Function<I, O> task) {
+      this.executor = executor;
+      this.context = context;
+      this.task = task;
+    }
+
+    @Override
+    public CompletionSlot<O> submit(int index, I item) {
+      CompletionSlot<O> slot = new CompletionSlot<>(index);
+      slot.completion =
+          CompletableFuture.supplyAsync(() -> context.supply(() -> task.apply(item)), executor);
+      // A terminal stage publishes the slot only after the task is no longer active.
+      slot.completion.whenComplete((ignored, failure) -> completions.add(slot));
+      return slot;
+    }
+
+    @Override
+    public CompletionSlot<O> take(List<CompletionSlot<O>> active) {
+      boolean interrupted = false;
+      try {
+        while (true) {
+          try {
+            return completions.take();
+          } catch (InterruptedException e) {
+            interrupted = true;
+          }
         }
-        onCompletion.accept(slot.index, outcome);
+      } finally {
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+        }
       }
-    } catch (CancellationException cancellationFailure) {
-      cancelSubmittedTasks(active);
-      throw cancellationFailure;
-    } catch (RuntimeException | Error processingFailure) {
+    }
+
+    @Override
+    public TaskOutcome<O> outcome(CompletionSlot<O> slot, List<CompletionSlot<O>> active) {
+      try {
+        return TaskOutcome.success(Futures.join(slot.completion));
+      } catch (RuntimeException | Error failure) {
+        return TaskOutcome.failure(failure);
+      }
+    }
+
+    @Override
+    public void afterFailure(List<CompletionSlot<O>> active, Throwable processingFailure) {
+      awaitCompletedTasks(active);
+    }
+  }
+
+  /** Interruptible FutureTask lifecycle with cooperative request cancellation. */
+  private static final class CancellableTaskRuntime<I, O> implements TaskRuntime<I, O> {
+    private final ExecutorService executor;
+    private final PropagatedContext context;
+    private final Function<I, O> task;
+    private final BooleanSupplier cancelled;
+    private final BlockingQueue<CompletionSlot<O>> completions = new LinkedBlockingQueue<>();
+
+    private CancellableTaskRuntime(
+        ExecutorService executor,
+        PropagatedContext context,
+        Function<I, O> task,
+        BooleanSupplier cancelled) {
+      this.executor = executor;
+      this.context = context;
+      this.task = task;
+      this.cancelled = cancelled;
+    }
+
+    @Override
+    public void beforeSubmit(List<CompletionSlot<O>> active) {
+      checkCancelled(cancelled, active);
+    }
+
+    @Override
+    public CompletionSlot<O> submit(int index, I item) {
+      CompletionSlot<O> slot = new CompletionSlot<>(index);
+      FutureTask<O> submitted =
+          new FutureTask<O>(
+              () ->
+                  context.supply(
+                      () -> {
+                        if (cancelled.getAsBoolean()) {
+                          throw cancelled();
+                        }
+                        return task.apply(item);
+                      })) {
+            @Override
+            protected void done() {
+              completions.add(slot);
+            }
+          };
+      slot.task = submitted;
+      executor.execute(submitted);
+      return slot;
+    }
+
+    @Override
+    public CompletionSlot<O> take(List<CompletionSlot<O>> active) {
+      while (true) {
+        checkCancelled(cancelled, active);
+        try {
+          CompletionSlot<O> slot =
+              completions.poll(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+          if (slot != null) {
+            return slot;
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          cancelSubmittedTasks(active);
+          throw cancelled();
+        }
+      }
+    }
+
+    @Override
+    public TaskOutcome<O> outcome(CompletionSlot<O> slot, List<CompletionSlot<O>> active) {
+      try {
+        return TaskOutcome.success(awaitCancellable(slot.task, active, cancelled));
+      } catch (RuntimeException | Error failure) {
+        return TaskOutcome.failure(failure);
+      }
+    }
+
+    @Override
+    public void afterFailure(List<CompletionSlot<O>> active, Throwable processingFailure) {
+      if (processingFailure instanceof CancellationException) {
+        cancelSubmittedTasks(active);
+        return;
+      }
       try {
         awaitSubmittedTasks(active, cancelled);
       } catch (CancellationException cancellationFailure) {
         processingFailure.addSuppressed(cancellationFailure);
       }
-      throw processingFailure;
-    }
-  }
-
-  /** Submit one non-cancellable task whose terminal stage publishes its indexed completion. */
-  private static <I, O> CompletionSlot<O> submitCompletionTask(
-      int index,
-      I item,
-      Executor executor,
-      PropagatedContext context,
-      Function<I, O> task,
-      BlockingQueue<CompletionSlot<O>> completions) {
-    CompletionSlot<O> slot = new CompletionSlot<>(index);
-    slot.completion =
-        CompletableFuture.supplyAsync(() -> context.supply(() -> task.apply(item)), executor);
-    // Completion stages run only after the CompletableFuture has reached its terminal state, so
-    // removing this slot cannot briefly exceed the submitted-task window.
-    slot.completion.whenComplete((ignored, failure) -> completions.add(slot));
-    return slot;
-  }
-
-  /** Submit one interruptible task whose FutureTask hook always publishes terminal completion. */
-  private static <I, O> CompletionSlot<O> submitCancellableTask(
-      int index,
-      I item,
-      ExecutorService executor,
-      PropagatedContext context,
-      Function<I, O> task,
-      BooleanSupplier cancelled,
-      BlockingQueue<CompletionSlot<O>> completions) {
-    CompletionSlot<O> slot = new CompletionSlot<>(index);
-    FutureTask<O> submitted =
-        new FutureTask<O>(
-            () ->
-                context.supply(
-                    () -> {
-                      if (cancelled.getAsBoolean()) {
-                        throw cancelled();
-                      }
-                      return task.apply(item);
-                    })) {
-          @Override
-          protected void done() {
-            completions.add(slot);
-          }
-        };
-    slot.task = submitted;
-    executor.execute(submitted);
-    return slot;
-  }
-
-  /** Wait uninterruptibly for a completion while restoring the caller's interrupt status. */
-  private static <O> CompletionSlot<O> takeCompletion(
-      BlockingQueue<CompletionSlot<O>> completions) {
-    boolean interrupted = false;
-    try {
-      while (true) {
-        try {
-          return completions.take();
-        } catch (InterruptedException e) {
-          interrupted = true;
-        }
-      }
-    } finally {
-      if (interrupted) {
-        Thread.currentThread().interrupt();
-      }
-    }
-  }
-
-  /** Await an active completion while polling cancellation instead of joining a slow input. */
-  private static <O> CompletionSlot<O> takeCancellableCompletion(
-      BlockingQueue<CompletionSlot<O>> completions,
-      List<CompletionSlot<O>> active,
-      BooleanSupplier cancelled) {
-    while (true) {
-      checkCancelled(cancelled, active);
-      try {
-        CompletionSlot<O> slot = completions.poll(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
-        if (slot != null) {
-          return slot;
-        }
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        cancelSubmittedTasks(active);
-        throw cancelled();
-      }
-    }
-  }
-
-  /** Capture a completed stage's result or unwrapped failure without throwing to the scheduler. */
-  private static <O> TaskOutcome<O> completedOutcome(CompletableFuture<O> future) {
-    try {
-      return TaskOutcome.success(Futures.join(future));
-    } catch (RuntimeException | Error failure) {
-      return TaskOutcome.failure(failure);
-    }
-  }
-
-  /** Capture an interruptible task's terminal outcome while preserving cancellation polling. */
-  private static <O> TaskOutcome<O> completedOutcome(
-      Future<O> future, List<CompletionSlot<O>> active, BooleanSupplier cancelled) {
-    try {
-      return TaskOutcome.success(awaitCancellable(future, active, cancelled));
-    } catch (RuntimeException | Error failure) {
-      return TaskOutcome.failure(failure);
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -209,7 +209,7 @@ public final class BoundedFanout {
       cancelSubmittedTasks(active);
       throw cancellationFailure;
     } catch (RuntimeException | Error submissionFailure) {
-      awaitSubmittedTasks(active);
+      awaitSubmittedTasks(active, cancelled);
       throw submissionFailure;
     }
   }
@@ -351,23 +351,30 @@ public final class BoundedFanout {
     }
   }
 
-  /** Wait for every submitted task after rejecting one bounded-window submission. */
-  private static void awaitSubmittedTasks(List<? extends CompletionSlot<?>> active) {
-    boolean interrupted = false;
+  /**
+   * Wait for submitted tasks after a rejected submission, while still returning promptly when the
+   * stream is cancelled. Without cancellation the original rejection remains caller-visible.
+   */
+  private static void awaitSubmittedTasks(
+      List<? extends CompletionSlot<?>> active, BooleanSupplier cancelled) {
     for (CompletionSlot<?> slot : active) {
-      try {
-        slot.task.get();
-      } catch (InterruptedException e) {
-        interrupted = true;
-        cancelSubmittedTasks(active);
-        break;
-      } catch (ExecutionException | CancellationException ignored) {
-        // The submission failure is the caller-visible outcome; task failures only complete
-        // task-owned cleanup.
+      while (true) {
+        checkCancelled(cancelled, active);
+        try {
+          slot.task.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+          break;
+        } catch (TimeoutException ignored) {
+          // A bounded wait lets the next loop observe cancellation.
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          cancelSubmittedTasks(active);
+          throw cancelled();
+        } catch (ExecutionException | CancellationException ignored) {
+          // The submission failure is the caller-visible outcome; task failures only complete
+          // task-owned cleanup.
+          break;
+        }
       }
-    }
-    if (interrupted) {
-      Thread.currentThread().interrupt();
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -15,67 +15,256 @@
  */
 package ai.floedb.floecat.service.concurrent;
 
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
+import ai.floedb.floecat.service.context.PropagatedContext;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
 /** Runs independent, mostly-blocking tasks on a shared executor with a concurrency bound. */
 public final class BoundedFanout {
 
+  private static final long CANCELLATION_POLL_MILLIS = 10;
+
   private BoundedFanout() {}
 
   /**
    * Apply {@code task} to each item on {@code executor}, at most {@code permits} running at once,
-   * and return the results in input order. Each task runs under the caller's OpenTelemetry context.
-   * A task failure surfaces unwrapped — its original {@link RuntimeException} or {@link Error},
-   * never a {@link CompletionException} wrapper — and the first such failure propagates to the
-   * caller once its future is joined.
+   * and return the results in input order. Each task runs under the caller's request context
+   * (OpenTelemetry, engine/principal/correlation, MDC) re-established via {@link
+   * PropagatedContext}, so ambient reads behave off-thread as they do on the caller's thread. A
+   * task failure surfaces unwrapped — its original {@link RuntimeException} or {@link Error}, never
+   * a {@link CompletionException} wrapper. With no cancellation, every task future completes before
+   * the first joined failure propagates, so callers can safely clean up task-owned resources.
    */
   public static <I, O> List<O> mapOrdered(
       List<I> items, int permits, Executor executor, Function<I, O> task) {
+    validatePermits(permits);
     Semaphore gate = new Semaphore(permits);
-    Context otelContext = Context.current();
-    List<CompletableFuture<O>> futures =
-        items.stream()
-            .map(
-                item ->
-                    CompletableFuture.supplyAsync(
-                        () -> {
-                          gate.acquireUninterruptibly();
-                          try (Scope ignored = otelContext.makeCurrent()) {
-                            return task.apply(item);
-                          } finally {
-                            gate.release();
-                          }
-                        },
-                        executor))
-            .toList();
+    PropagatedContext context = PropagatedContext.capture();
+    List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
+    try {
+      for (I item : items) {
+        futures.add(
+            CompletableFuture.supplyAsync(
+                () -> runTask(gate, context, task, item, () -> false), executor));
+      }
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitCompletedFutures(futures);
+      throw submissionFailure;
+    }
+    return collectCompletedFutures(futures);
+  }
+
+  /**
+   * As {@link #mapOrdered(List, int, Executor, Function)}, but {@code cancelled} is polled so a
+   * cancelled stream interrupts every submitted task and returns without waiting for a slow task's
+   * completion. Tasks must cooperate with interruption while blocked in downstream calls. The
+   * permit wait is interruptible for the same reason.
+   */
+  public static <I, O> List<O> mapOrdered(
+      List<I> items,
+      int permits,
+      ExecutorService executor,
+      Function<I, O> task,
+      BooleanSupplier cancelled) {
+    validatePermits(permits);
+    Semaphore gate = new Semaphore(permits);
+    PropagatedContext context = PropagatedContext.capture();
+    List<Future<O>> futures = new ArrayList<>(items.size());
+    try {
+      for (I item : items) {
+        if (cancelled.getAsBoolean()) {
+          cancelSubmittedTasks(futures);
+          throw cancelled();
+        }
+        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+      }
+    } catch (CancellationException cancellationFailure) {
+      cancelSubmittedTasks(futures);
+      throw cancellationFailure;
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitSubmittedTasks(futures);
+      throw submissionFailure;
+    }
 
     List<O> results = new ArrayList<>(items.size());
-    for (CompletableFuture<O> future : futures) {
-      results.add(join(future));
+    RuntimeException firstRuntimeFailure = null;
+    Error firstErrorFailure = null;
+    for (Future<O> future : futures) {
+      try {
+        results.add(awaitCancellable(future, futures, cancelled));
+      } catch (RuntimeException e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstRuntimeFailure = e;
+        }
+      } catch (Error e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstErrorFailure = e;
+        }
+      }
+    }
+    if (firstRuntimeFailure != null) {
+      throw firstRuntimeFailure;
+    }
+    if (firstErrorFailure != null) {
+      throw firstErrorFailure;
     }
     return results;
   }
 
-  private static <O> O join(CompletableFuture<O> future) {
+  /** Run one task under the captured context while holding one concurrency permit. */
+  private static <I, O> O runTask(
+      Semaphore gate,
+      PropagatedContext context,
+      Function<I, O> task,
+      I item,
+      BooleanSupplier cancelled) {
+    acquire(gate);
     try {
-      return future.join();
-    } catch (CompletionException ce) {
-      Throwable cause = ce.getCause();
-      if (cause instanceof RuntimeException re) {
-        throw re;
+      return context.supply(
+          () -> {
+            if (cancelled.getAsBoolean()) {
+              throw cancelled();
+            }
+            return task.apply(item);
+          });
+    } finally {
+      gate.release();
+    }
+  }
+
+  /** Collect every completed future, preserving the first unwrapped task failure. */
+  private static <O> List<O> collectCompletedFutures(List<CompletableFuture<O>> futures) {
+    List<O> results = new ArrayList<>(futures.size());
+    RuntimeException firstRuntimeFailure = null;
+    Error firstErrorFailure = null;
+    for (CompletableFuture<O> future : futures) {
+      try {
+        results.add(Futures.join(future));
+      } catch (RuntimeException e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstRuntimeFailure = e;
+        }
+      } catch (Error e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstErrorFailure = e;
+        }
       }
-      if (cause instanceof Error e) {
-        throw e;
+    }
+    if (firstRuntimeFailure != null) {
+      throw firstRuntimeFailure;
+    }
+    if (firstErrorFailure != null) {
+      throw firstErrorFailure;
+    }
+    return results;
+  }
+
+  /** Await each already-submitted completion future after a submission failure. */
+  private static void awaitCompletedFutures(List<? extends CompletableFuture<?>> futures) {
+    for (CompletableFuture<?> future : futures) {
+      try {
+        Futures.join(future);
+      } catch (RuntimeException | Error ignored) {
+        // The submission failure is the caller-visible outcome; task failures only complete
+        // cleanup.
       }
-      throw new IllegalStateException("unexpected checked exception from parallel task", cause);
+    }
+  }
+
+  /** Await each already-submitted task while preserving an executor submission failure. */
+  private static void awaitSubmittedTasks(List<? extends Future<?>> futures) {
+    boolean interrupted = false;
+    for (Future<?> future : futures) {
+      try {
+        future.get();
+      } catch (InterruptedException e) {
+        interrupted = true;
+        cancelSubmittedTasks(futures);
+        break;
+      } catch (ExecutionException | CancellationException ignored) {
+        // The submission failure is the caller-visible outcome; task failures only complete
+        // cleanup.
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /** Await one task while repeatedly observing stream cancellation. */
+  private static <O> O awaitCancellable(
+      Future<O> future, List<? extends Future<?>> futures, BooleanSupplier cancelled) {
+    while (true) {
+      if (cancelled.getAsBoolean()) {
+        cancelSubmittedTasks(futures);
+        throw cancelled();
+      }
+      try {
+        return future.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+      } catch (TimeoutException ignored) {
+        // A bounded wait lets the next loop observe cancellation.
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        cancelSubmittedTasks(futures);
+        throw cancelled();
+      } catch (ExecutionException e) {
+        rethrowTaskFailure(e.getCause());
+      }
+    }
+  }
+
+  /** Interrupt every submitted task, including work already inside a downstream call. */
+  private static void cancelSubmittedTasks(List<? extends Future<?>> futures) {
+    for (Future<?> future : futures) {
+      future.cancel(true);
+    }
+  }
+
+  /** Rethrow a task failure without an execution-wrapper layer. */
+  private static void rethrowTaskFailure(Throwable failure) {
+    if (failure instanceof RuntimeException runtime) {
+      throw runtime;
+    }
+    if (failure instanceof Error error) {
+      throw error;
+    }
+    throw new CompletionException(failure);
+  }
+
+  /** Validate the concurrency bound before any tasks are submitted. */
+  private static void validatePermits(int permits) {
+    if (permits < 1) {
+      throw new IllegalArgumentException("BoundedFanout permits must be >= 1, got " + permits);
+    }
+  }
+
+  /** Build the canonical cancellation failure returned to a stopped stream driver. */
+  private static CancellationException cancelled() {
+    return new CancellationException("fan-out cancelled");
+  }
+
+  /**
+   * Interruptible permit acquire: a shutdown/interrupt aborts the task instead of pinning the
+   * thread on an uninterruptible wait.
+   */
+  private static void acquire(Semaphore gate) {
+    try {
+      gate.acquire();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CancellationException("interrupted while awaiting fan-out permit");
     }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -39,8 +38,9 @@ import java.util.function.Function;
  * Runs independent, mostly-blocking tasks with a concurrency bound.
  *
  * <p>At most the configured number of tasks are submitted at a time. A completed task immediately
- * opens one submission slot, independent of input order; completed results are retained by index
- * and observed in input order after the bounded window has drained.
+ * opens one submission slot, independent of input order. Completed results are retained by index;
+ * mapping returns them after the bounded window drains, while ordered consumption delivers each
+ * contiguous input-order prefix as soon as it is available.
  */
 public final class BoundedFanout {
 
@@ -54,8 +54,8 @@ public final class BoundedFanout {
    * (OpenTelemetry, engine/principal/correlation, MDC) re-established via {@link
    * PropagatedContext}, so ambient reads behave off-thread as they do on the caller's thread. A
    * task failure surfaces unwrapped — its original {@link RuntimeException} or {@link Error}, never
-   * a {@link CompletionException} wrapper. With no cancellation, every task future completes before
-   * the first joined failure propagates, so callers can safely clean up task-owned resources.
+   * an execution-wrapper exception. With no cancellation, every task future completes before the
+   * first joined failure propagates, so callers can safely clean up task-owned resources.
    */
   public static <I, O> List<O> mapOrdered(
       List<I> items, int permits, Executor executor, Function<I, O> task) {
@@ -79,7 +79,6 @@ public final class BoundedFanout {
     List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
     OrderedOutcomeConsumer<O> ordered = new OrderedOutcomeConsumer<>(outcomes, consumer);
     completeAll(items, permits, executor, task, outcomes, ordered::accept);
-    ordered.throwIfFailed();
   }
 
   /**
@@ -88,7 +87,9 @@ public final class BoundedFanout {
    * completion. Tasks must cooperate with interruption while blocked in downstream calls. The
    * submission window observes cancellation before it submits more work. A non-cancellation task
    * failure waits for every input task before surfacing, so callers can safely release task-owned
-   * resources.
+   * resources. {@code cancelled} may be read concurrently by the scheduler and workers; it must be
+   * non-blocking and thread-safe (typically {@link java.util.concurrent.atomic.AtomicBoolean#get}).
+   * Observed cancellation throws {@link CancellationException}.
    */
   public static <I, O> List<O> mapOrdered(
       List<I> items,
@@ -106,7 +107,9 @@ public final class BoundedFanout {
    * Cancellation-aware ordered result consumption. A consumer failure has the same ordered
    * precedence as a task failure, while submitted work is cancelled promptly when requested. A
    * non-cancellation failure waits for already-submitted siblings before it surfaces, preserving
-   * the task-resource completion guarantee at the cost of slowest-sibling failure latency.
+   * the task-resource completion guarantee at the cost of slowest-sibling failure latency. {@code
+   * cancelled} has the same concurrent-read contract and {@link CancellationException} behavior as
+   * the cancellable {@code mapOrdered} overload.
    */
   public static <I, O> void forEachOrdered(
       List<I> items,
@@ -118,7 +121,6 @@ public final class BoundedFanout {
     List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
     OrderedOutcomeConsumer<O> ordered = new OrderedOutcomeConsumer<>(outcomes, consumer);
     completeAllCancellable(items, permits, executor, task, cancelled, outcomes, ordered::accept);
-    ordered.throwIfFailed();
   }
 
   /** Re-throw the first input-ordered task failure after every bounded task has finished. */
@@ -126,7 +128,7 @@ public final class BoundedFanout {
     List<O> results = new ArrayList<>(outcomes.size());
     for (TaskOutcome<O> outcome : outcomes) {
       if (outcome.failure() != null) {
-        rethrowTaskFailure(outcome.failure());
+        throw Futures.propagate(outcome.failure(), "unexpected checked exception from fan-out");
       }
       results.add(outcome.result());
     }
@@ -165,9 +167,9 @@ public final class BoundedFanout {
         }
         onCompletion.accept(slot.index, outcome);
       }
-    } catch (RuntimeException | Error submissionFailure) {
+    } catch (RuntimeException | Error processingFailure) {
       awaitCompletedTasks(active);
-      throw submissionFailure;
+      throw processingFailure;
     }
   }
 
@@ -208,12 +210,13 @@ public final class BoundedFanout {
     } catch (CancellationException cancellationFailure) {
       cancelSubmittedTasks(active);
       throw cancellationFailure;
-    } catch (RuntimeException | Error submissionFailure) {
+    } catch (RuntimeException | Error processingFailure) {
       awaitSubmittedTasks(active, cancelled);
-      throw submissionFailure;
+      throw processingFailure;
     }
   }
 
+  /** Submit one non-cancellable task whose terminal stage publishes its indexed completion. */
   private static <I, O> CompletionSlot<O> submitCompletionTask(
       int index,
       I item,
@@ -230,6 +233,7 @@ public final class BoundedFanout {
     return slot;
   }
 
+  /** Submit one interruptible task whose FutureTask hook always publishes terminal completion. */
   private static <I, O> CompletionSlot<O> submitCancellableTask(
       int index,
       I item,
@@ -259,6 +263,7 @@ public final class BoundedFanout {
     return slot;
   }
 
+  /** Wait uninterruptibly for a completion while restoring the caller's interrupt status. */
   private static <O> CompletionSlot<O> takeCompletion(
       BlockingQueue<CompletionSlot<O>> completions) {
     boolean interrupted = false;
@@ -297,6 +302,7 @@ public final class BoundedFanout {
     }
   }
 
+  /** Capture a completed stage's result or unwrapped failure without throwing to the scheduler. */
   private static <O> TaskOutcome<O> completedOutcome(CompletableFuture<O> future) {
     try {
       return TaskOutcome.success(Futures.join(future));
@@ -305,6 +311,7 @@ public final class BoundedFanout {
     }
   }
 
+  /** Capture an interruptible task's terminal outcome while preserving cancellation polling. */
   private static <O> TaskOutcome<O> completedOutcome(
       Future<O> future, List<CompletionSlot<O>> active, BooleanSupplier cancelled) {
     try {
@@ -330,7 +337,7 @@ public final class BoundedFanout {
         cancelSubmittedTasks(active);
         throw cancelled();
       } catch (ExecutionException e) {
-        rethrowTaskFailure(e.getCause());
+        throw Futures.propagate(e.getCause(), "unexpected checked exception from fan-out");
       }
     }
   }
@@ -339,21 +346,22 @@ public final class BoundedFanout {
     return new ArrayList<>(java.util.Collections.nCopies(size, null));
   }
 
-  /** Wait for every completion future after rejecting one bounded-window submission. */
+  /** Wait for every active completion after scheduling or ordered consumption fails. */
   private static void awaitCompletedTasks(List<? extends CompletionSlot<?>> active) {
     for (CompletionSlot<?> slot : active) {
       try {
         Futures.join(slot.completion);
       } catch (RuntimeException | Error ignored) {
-        // The submission failure is the caller-visible outcome; task failures only complete
+        // The scheduler or consumer failure is caller-visible; task failures only complete
         // task-owned cleanup.
       }
     }
   }
 
   /**
-   * Wait for submitted tasks after a rejected submission, while still returning promptly when the
-   * stream is cancelled. Without cancellation the original rejection remains caller-visible.
+   * Wait for submitted tasks after scheduling or ordered consumption fails, while still returning
+   * promptly when the stream is cancelled. Without cancellation the original failure remains
+   * caller-visible.
    */
   private static void awaitSubmittedTasks(
       List<? extends CompletionSlot<?>> active, BooleanSupplier cancelled) {
@@ -370,7 +378,7 @@ public final class BoundedFanout {
           cancelSubmittedTasks(active);
           throw cancelled();
         } catch (ExecutionException | CancellationException ignored) {
-          // The submission failure is the caller-visible outcome; task failures only complete
+          // The scheduler or consumer failure is caller-visible; task failures only complete
           // task-owned cleanup.
           break;
         }
@@ -378,6 +386,7 @@ public final class BoundedFanout {
     }
   }
 
+  /** Cancel every active task and fail the caller when its cooperative signal is set. */
   private static void checkCancelled(
       BooleanSupplier cancelled, List<? extends CompletionSlot<?>> active) {
     if (cancelled.getAsBoolean()) {
@@ -393,17 +402,6 @@ public final class BoundedFanout {
         slot.task.cancel(true);
       }
     }
-  }
-
-  /** Rethrow a task failure without an execution-wrapper layer. */
-  private static void rethrowTaskFailure(Throwable failure) {
-    if (failure instanceof RuntimeException runtime) {
-      throw runtime;
-    }
-    if (failure instanceof Error error) {
-      throw error;
-    }
-    throw new CompletionException(failure);
   }
 
   /** Validate the concurrency bound before any tasks are submitted. */
@@ -447,42 +445,20 @@ public final class BoundedFanout {
     private final List<TaskOutcome<O>> outcomes;
     private final Consumer<? super O> consumer;
     private int nextIndex;
-    private RuntimeException firstRuntimeFailure;
-    private Error firstErrorFailure;
 
     private OrderedOutcomeConsumer(List<TaskOutcome<O>> outcomes, Consumer<? super O> consumer) {
       this.outcomes = outcomes;
       this.consumer = consumer;
     }
 
+    /** Deliver every newly contiguous outcome, stopping at the first unfinished input index. */
     private void accept(int index, TaskOutcome<O> ignored) {
       while (nextIndex < outcomes.size() && outcomes.get(nextIndex) != null) {
         TaskOutcome<O> outcome = outcomes.get(nextIndex++);
-        try {
-          if (outcome.failure() != null) {
-            rethrowTaskFailure(outcome.failure());
-          }
-          if (firstRuntimeFailure == null && firstErrorFailure == null) {
-            consumer.accept(outcome.result());
-          }
-        } catch (RuntimeException e) {
-          if (firstRuntimeFailure == null && firstErrorFailure == null) {
-            firstRuntimeFailure = e;
-          }
-        } catch (Error e) {
-          if (firstRuntimeFailure == null && firstErrorFailure == null) {
-            firstErrorFailure = e;
-          }
+        if (outcome.failure() != null) {
+          throw Futures.propagate(outcome.failure(), "unexpected checked exception from fan-out");
         }
-      }
-    }
-
-    private void throwIfFailed() {
-      if (firstRuntimeFailure != null) {
-        throw firstRuntimeFailure;
-      }
-      if (firstErrorFailure != null) {
-        throw firstErrorFailure;
+        consumer.accept(outcome.result());
       }
     }
   }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -55,16 +55,14 @@ public final class BoundedFanout {
     Semaphore gate = new Semaphore(permits);
     PropagatedContext context = PropagatedContext.capture();
     List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
-    int nextItem = 0;
-    while (nextItem < items.size() && futures.size() < permits) {
-      I item = items.get(nextItem++);
+    for (I item : items) {
       submitCompletionFuture(
           futures,
           () ->
               CompletableFuture.supplyAsync(
                   () -> runTask(gate, context, task, item, () -> false), executor));
     }
-    return collectCompletedFutures(futures, items, nextItem, gate, context, executor, task);
+    return collectCompletedFutures(futures);
   }
 
   /**
@@ -83,16 +81,14 @@ public final class BoundedFanout {
     Semaphore gate = new Semaphore(permits);
     PropagatedContext context = PropagatedContext.capture();
     List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
-    int nextItem = 0;
-    while (nextItem < items.size() && futures.size() < permits) {
-      I item = items.get(nextItem++);
+    for (I item : items) {
       submitCompletionFuture(
           futures,
           () ->
               CompletableFuture.supplyAsync(
                   () -> runTask(gate, context, task, item, () -> false), executor));
     }
-    consumeCompletedFutures(futures, items, nextItem, gate, context, executor, task, consumer);
+    consumeCompletedFutures(futures, consumer);
   }
 
   /**
@@ -113,14 +109,12 @@ public final class BoundedFanout {
     Semaphore gate = new Semaphore(permits);
     PropagatedContext context = PropagatedContext.capture();
     List<Future<O>> futures = new ArrayList<>(items.size());
-    int nextItem = 0;
     try {
-      while (nextItem < items.size() && futures.size() < permits) {
+      for (I item : items) {
         if (cancelled.getAsBoolean()) {
           cancelSubmittedTasks(futures);
           throw cancelled();
         }
-        I item = items.get(nextItem++);
         submitTask(
             futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
@@ -144,15 +138,6 @@ public final class BoundedFanout {
         if (firstRuntimeFailure == null && firstErrorFailure == null) {
           firstErrorFailure = e;
         }
-      }
-      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
-        if (cancelled.getAsBoolean()) {
-          cancelSubmittedTasks(futures);
-          throw cancelled();
-        }
-        I item = items.get(nextItem++);
-        submitTask(
-            futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
     }
     if (firstRuntimeFailure != null) {
@@ -181,14 +166,12 @@ public final class BoundedFanout {
     Semaphore gate = new Semaphore(permits);
     PropagatedContext context = PropagatedContext.capture();
     List<Future<O>> futures = new ArrayList<>(items.size());
-    int nextItem = 0;
     try {
-      while (nextItem < items.size() && futures.size() < permits) {
+      for (I item : items) {
         if (cancelled.getAsBoolean()) {
           cancelSubmittedTasks(futures);
           throw cancelled();
         }
-        I item = items.get(nextItem++);
         submitTask(
             futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
@@ -214,15 +197,6 @@ public final class BoundedFanout {
         if (firstRuntimeFailure == null && firstErrorFailure == null) {
           firstErrorFailure = e;
         }
-      }
-      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
-        if (cancelled.getAsBoolean()) {
-          cancelSubmittedTasks(futures);
-          throw cancelled();
-        }
-        I item = items.get(nextItem++);
-        submitTask(
-            futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
     }
     if (firstRuntimeFailure != null) {
@@ -255,14 +229,7 @@ public final class BoundedFanout {
   }
 
   /** Collect every completed future, preserving the first unwrapped task failure. */
-  private static <I, O> List<O> collectCompletedFutures(
-      List<CompletableFuture<O>> futures,
-      List<I> items,
-      int nextItem,
-      Semaphore gate,
-      PropagatedContext context,
-      Executor executor,
-      Function<I, O> task) {
+  private static <O> List<O> collectCompletedFutures(List<CompletableFuture<O>> futures) {
     List<O> results = new ArrayList<>(futures.size());
     RuntimeException firstRuntimeFailure = null;
     Error firstErrorFailure = null;
@@ -279,14 +246,6 @@ public final class BoundedFanout {
           firstErrorFailure = e;
         }
       }
-      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
-        I item = items.get(nextItem++);
-        submitCompletionFuture(
-            futures,
-            () ->
-                CompletableFuture.supplyAsync(
-                    () -> runTask(gate, context, task, item, () -> false), executor));
-      }
     }
     if (firstRuntimeFailure != null) {
       throw firstRuntimeFailure;
@@ -298,15 +257,8 @@ public final class BoundedFanout {
   }
 
   /** Consume completed futures in input order, preserving the first task or consumer failure. */
-  private static <I, O> void consumeCompletedFutures(
-      List<CompletableFuture<O>> futures,
-      List<I> items,
-      int nextItem,
-      Semaphore gate,
-      PropagatedContext context,
-      Executor executor,
-      Function<I, O> task,
-      Consumer<? super O> consumer) {
+  private static <O> void consumeCompletedFutures(
+      List<CompletableFuture<O>> futures, Consumer<? super O> consumer) {
     RuntimeException firstRuntimeFailure = null;
     Error firstErrorFailure = null;
     for (int index = 0; index < futures.size(); index++) {
@@ -324,14 +276,6 @@ public final class BoundedFanout {
         if (firstRuntimeFailure == null && firstErrorFailure == null) {
           firstErrorFailure = e;
         }
-      }
-      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
-        I item = items.get(nextItem++);
-        submitCompletionFuture(
-            futures,
-            () ->
-                CompletableFuture.supplyAsync(
-                    () -> runTask(gate, context, task, item, () -> false), executor));
       }
     }
     if (firstRuntimeFailure != null) {

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /** Runs independent, mostly-blocking tasks on a shared executor with a concurrency bound. */
 public final class BoundedFanout {
@@ -55,16 +56,13 @@ public final class BoundedFanout {
     PropagatedContext context = PropagatedContext.capture();
     List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
     int nextItem = 0;
-    try {
-      while (nextItem < items.size() && futures.size() < permits) {
-        I item = items.get(nextItem++);
-        futures.add(
-            CompletableFuture.supplyAsync(
-                () -> runTask(gate, context, task, item, () -> false), executor));
-      }
-    } catch (RuntimeException | Error submissionFailure) {
-      awaitCompletedFutures(futures);
-      throw submissionFailure;
+    while (nextItem < items.size() && futures.size() < permits) {
+      I item = items.get(nextItem++);
+      submitCompletionFuture(
+          futures,
+          () ->
+              CompletableFuture.supplyAsync(
+                  () -> runTask(gate, context, task, item, () -> false), executor));
     }
     return collectCompletedFutures(futures, items, nextItem, gate, context, executor, task);
   }
@@ -86,16 +84,13 @@ public final class BoundedFanout {
     PropagatedContext context = PropagatedContext.capture();
     List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
     int nextItem = 0;
-    try {
-      while (nextItem < items.size() && futures.size() < permits) {
-        I item = items.get(nextItem++);
-        futures.add(
-            CompletableFuture.supplyAsync(
-                () -> runTask(gate, context, task, item, () -> false), executor));
-      }
-    } catch (RuntimeException | Error submissionFailure) {
-      awaitCompletedFutures(futures);
-      throw submissionFailure;
+    while (nextItem < items.size() && futures.size() < permits) {
+      I item = items.get(nextItem++);
+      submitCompletionFuture(
+          futures,
+          () ->
+              CompletableFuture.supplyAsync(
+                  () -> runTask(gate, context, task, item, () -> false), executor));
     }
     consumeCompletedFutures(futures, items, nextItem, gate, context, executor, task, consumer);
   }
@@ -124,14 +119,12 @@ public final class BoundedFanout {
           throw cancelled();
         }
         I item = items.get(nextItem++);
-        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+        submitTask(
+            futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
     } catch (CancellationException cancellationFailure) {
       cancelSubmittedTasks(futures);
       throw cancellationFailure;
-    } catch (RuntimeException | Error submissionFailure) {
-      awaitSubmittedTasks(futures);
-      throw submissionFailure;
     }
 
     List<O> results = new ArrayList<>(items.size());
@@ -156,7 +149,8 @@ public final class BoundedFanout {
           throw cancelled();
         }
         I item = items.get(nextItem++);
-        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+        submitTask(
+            futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
     }
     if (firstRuntimeFailure != null) {
@@ -191,14 +185,12 @@ public final class BoundedFanout {
           throw cancelled();
         }
         I item = items.get(nextItem++);
-        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+        submitTask(
+            futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
     } catch (CancellationException cancellationFailure) {
       cancelSubmittedTasks(futures);
       throw cancellationFailure;
-    } catch (RuntimeException | Error submissionFailure) {
-      awaitSubmittedTasks(futures);
-      throw submissionFailure;
     }
 
     RuntimeException firstRuntimeFailure = null;
@@ -225,7 +217,8 @@ public final class BoundedFanout {
           throw cancelled();
         }
         I item = items.get(nextItem++);
-        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+        submitTask(
+            futures, () -> executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
     }
     if (firstRuntimeFailure != null) {
@@ -284,9 +277,11 @@ public final class BoundedFanout {
       }
       if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
         I item = items.get(nextItem++);
-        futures.add(
-            CompletableFuture.supplyAsync(
-                () -> runTask(gate, context, task, item, () -> false), executor));
+        submitCompletionFuture(
+            futures,
+            () ->
+                CompletableFuture.supplyAsync(
+                    () -> runTask(gate, context, task, item, () -> false), executor));
       }
     }
     if (firstRuntimeFailure != null) {
@@ -328,9 +323,11 @@ public final class BoundedFanout {
       }
       if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
         I item = items.get(nextItem++);
-        futures.add(
-            CompletableFuture.supplyAsync(
-                () -> runTask(gate, context, task, item, () -> false), executor));
+        submitCompletionFuture(
+            futures,
+            () ->
+                CompletableFuture.supplyAsync(
+                    () -> runTask(gate, context, task, item, () -> false), executor));
       }
     }
     if (firstRuntimeFailure != null) {
@@ -338,6 +335,27 @@ public final class BoundedFanout {
     }
     if (firstErrorFailure != null) {
       throw firstErrorFailure;
+    }
+  }
+
+  /** Await each already-submitted completion future after a submission failure. */
+  private static <O> void submitCompletionFuture(
+      List<CompletableFuture<O>> futures, Supplier<CompletableFuture<O>> submission) {
+    try {
+      futures.add(submission.get());
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitCompletedFutures(futures);
+      throw submissionFailure;
+    }
+  }
+
+  /** Await each already-submitted task after an executor submission failure. */
+  private static <O> void submitTask(List<Future<O>> futures, Supplier<Future<O>> submission) {
+    try {
+      futures.add(submission.get());
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitSubmittedTasks(futures);
+      throw submissionFailure;
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /** Runs independent, mostly-blocking tasks on a shared executor with a concurrency bound. */
@@ -53,8 +54,10 @@ public final class BoundedFanout {
     Semaphore gate = new Semaphore(permits);
     PropagatedContext context = PropagatedContext.capture();
     List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
+    int nextItem = 0;
     try {
-      for (I item : items) {
+      while (nextItem < items.size() && futures.size() < permits) {
+        I item = items.get(nextItem++);
         futures.add(
             CompletableFuture.supplyAsync(
                 () -> runTask(gate, context, task, item, () -> false), executor));
@@ -63,7 +66,38 @@ public final class BoundedFanout {
       awaitCompletedFutures(futures);
       throw submissionFailure;
     }
-    return collectCompletedFutures(futures);
+    return collectCompletedFutures(futures, items, nextItem, gate, context, executor, task);
+  }
+
+  /**
+   * As {@link #mapOrdered(List, int, Executor, Function)}, but consumes each successful result on
+   * the caller thread before observing the next result. This preserves input-order validation
+   * precedence when a result consumer can itself fail, while still awaiting all submitted tasks
+   * before surfacing that failure so callers can safely release task-owned resources.
+   */
+  public static <I, O> void forEachOrdered(
+      List<I> items,
+      int permits,
+      Executor executor,
+      Function<I, O> task,
+      Consumer<? super O> consumer) {
+    validatePermits(permits);
+    Semaphore gate = new Semaphore(permits);
+    PropagatedContext context = PropagatedContext.capture();
+    List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
+    int nextItem = 0;
+    try {
+      while (nextItem < items.size() && futures.size() < permits) {
+        I item = items.get(nextItem++);
+        futures.add(
+            CompletableFuture.supplyAsync(
+                () -> runTask(gate, context, task, item, () -> false), executor));
+      }
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitCompletedFutures(futures);
+      throw submissionFailure;
+    }
+    consumeCompletedFutures(futures, items, nextItem, gate, context, executor, task, consumer);
   }
 
   /**
@@ -82,12 +116,14 @@ public final class BoundedFanout {
     Semaphore gate = new Semaphore(permits);
     PropagatedContext context = PropagatedContext.capture();
     List<Future<O>> futures = new ArrayList<>(items.size());
+    int nextItem = 0;
     try {
-      for (I item : items) {
+      while (nextItem < items.size() && futures.size() < permits) {
         if (cancelled.getAsBoolean()) {
           cancelSubmittedTasks(futures);
           throw cancelled();
         }
+        I item = items.get(nextItem++);
         futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
     } catch (CancellationException cancellationFailure) {
@@ -101,7 +137,8 @@ public final class BoundedFanout {
     List<O> results = new ArrayList<>(items.size());
     RuntimeException firstRuntimeFailure = null;
     Error firstErrorFailure = null;
-    for (Future<O> future : futures) {
+    for (int index = 0; index < futures.size(); index++) {
+      Future<O> future = futures.get(index);
       try {
         results.add(awaitCancellable(future, futures, cancelled));
       } catch (RuntimeException e) {
@@ -113,6 +150,14 @@ public final class BoundedFanout {
           firstErrorFailure = e;
         }
       }
+      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
+        if (cancelled.getAsBoolean()) {
+          cancelSubmittedTasks(futures);
+          throw cancelled();
+        }
+        I item = items.get(nextItem++);
+        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+      }
     }
     if (firstRuntimeFailure != null) {
       throw firstRuntimeFailure;
@@ -121,6 +166,74 @@ public final class BoundedFanout {
       throw firstErrorFailure;
     }
     return results;
+  }
+
+  /**
+   * Cancellation-aware ordered result consumption. A consumer failure has the same ordered
+   * precedence as a task failure, while submitted work is cancelled promptly when requested.
+   */
+  public static <I, O> void forEachOrdered(
+      List<I> items,
+      int permits,
+      ExecutorService executor,
+      Function<I, O> task,
+      Consumer<? super O> consumer,
+      BooleanSupplier cancelled) {
+    validatePermits(permits);
+    Semaphore gate = new Semaphore(permits);
+    PropagatedContext context = PropagatedContext.capture();
+    List<Future<O>> futures = new ArrayList<>(items.size());
+    int nextItem = 0;
+    try {
+      while (nextItem < items.size() && futures.size() < permits) {
+        if (cancelled.getAsBoolean()) {
+          cancelSubmittedTasks(futures);
+          throw cancelled();
+        }
+        I item = items.get(nextItem++);
+        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+      }
+    } catch (CancellationException cancellationFailure) {
+      cancelSubmittedTasks(futures);
+      throw cancellationFailure;
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitSubmittedTasks(futures);
+      throw submissionFailure;
+    }
+
+    RuntimeException firstRuntimeFailure = null;
+    Error firstErrorFailure = null;
+    for (int index = 0; index < futures.size(); index++) {
+      Future<O> future = futures.get(index);
+      try {
+        O result = awaitCancellable(future, futures, cancelled);
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          consumer.accept(result);
+        }
+      } catch (RuntimeException e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstRuntimeFailure = e;
+        }
+      } catch (Error e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstErrorFailure = e;
+        }
+      }
+      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
+        if (cancelled.getAsBoolean()) {
+          cancelSubmittedTasks(futures);
+          throw cancelled();
+        }
+        I item = items.get(nextItem++);
+        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+      }
+    }
+    if (firstRuntimeFailure != null) {
+      throw firstRuntimeFailure;
+    }
+    if (firstErrorFailure != null) {
+      throw firstErrorFailure;
+    }
   }
 
   /** Run one task under the captured context while holding one concurrency permit. */
@@ -145,11 +258,19 @@ public final class BoundedFanout {
   }
 
   /** Collect every completed future, preserving the first unwrapped task failure. */
-  private static <O> List<O> collectCompletedFutures(List<CompletableFuture<O>> futures) {
+  private static <I, O> List<O> collectCompletedFutures(
+      List<CompletableFuture<O>> futures,
+      List<I> items,
+      int nextItem,
+      Semaphore gate,
+      PropagatedContext context,
+      Executor executor,
+      Function<I, O> task) {
     List<O> results = new ArrayList<>(futures.size());
     RuntimeException firstRuntimeFailure = null;
     Error firstErrorFailure = null;
-    for (CompletableFuture<O> future : futures) {
+    for (int index = 0; index < futures.size(); index++) {
+      CompletableFuture<O> future = futures.get(index);
       try {
         results.add(Futures.join(future));
       } catch (RuntimeException e) {
@@ -161,6 +282,12 @@ public final class BoundedFanout {
           firstErrorFailure = e;
         }
       }
+      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
+        I item = items.get(nextItem++);
+        futures.add(
+            CompletableFuture.supplyAsync(
+                () -> runTask(gate, context, task, item, () -> false), executor));
+      }
     }
     if (firstRuntimeFailure != null) {
       throw firstRuntimeFailure;
@@ -169,6 +296,49 @@ public final class BoundedFanout {
       throw firstErrorFailure;
     }
     return results;
+  }
+
+  /** Consume completed futures in input order, preserving the first task or consumer failure. */
+  private static <I, O> void consumeCompletedFutures(
+      List<CompletableFuture<O>> futures,
+      List<I> items,
+      int nextItem,
+      Semaphore gate,
+      PropagatedContext context,
+      Executor executor,
+      Function<I, O> task,
+      Consumer<? super O> consumer) {
+    RuntimeException firstRuntimeFailure = null;
+    Error firstErrorFailure = null;
+    for (int index = 0; index < futures.size(); index++) {
+      CompletableFuture<O> future = futures.get(index);
+      try {
+        O result = Futures.join(future);
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          consumer.accept(result);
+        }
+      } catch (RuntimeException e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstRuntimeFailure = e;
+        }
+      } catch (Error e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstErrorFailure = e;
+        }
+      }
+      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
+        I item = items.get(nextItem++);
+        futures.add(
+            CompletableFuture.supplyAsync(
+                () -> runTask(gate, context, task, item, () -> false), executor));
+      }
+    }
+    if (firstRuntimeFailure != null) {
+      throw firstRuntimeFailure;
+    }
+    if (firstErrorFailure != null) {
+      throw firstErrorFailure;
+    }
   }
 
   /** Await each already-submitted completion future after a submission failure. */

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,32 +49,28 @@ public final class CancellableCallRunner {
    *
    * <p>Returns the operation result, propagates operation and executor failures unchanged, and
    * throws {@link CancellationException} when cancellation or interruption wins. Admission remains
-   * held until the operation exits, including when the caller has already returned.
+   * held until the operation exits, including when the caller has already returned. The executor
+   * must dispatch work asynchronously; an executor that invokes tasks on the submitting thread is
+   * rejected before the operation starts so it cannot bypass cancellation polling. {@code
+   * cancelled} is read from the caller and worker threads and must be non-blocking and thread-safe
+   * (typically {@link java.util.concurrent.atomic.AtomicBoolean#get}).
    */
   public static <T> T call(
       Executor executor,
       Semaphore permits,
       BooleanSupplier cancelled,
       Supplier<T> operation,
-      String cancellationMessage,
-      String interruptionMessage) {
-    acquire(permits, cancelled, cancellationMessage, interruptionMessage);
+      FailureMessages messages) {
+    acquire(permits, cancelled, messages);
     SubmittedCallHandle<T> submitted =
-        submit(
-            executor,
-            permits,
-            operation,
-            cancelled,
-            true,
-            cancellationMessage,
-            TimeoutListener.NOOP);
+        submit(executor, permits, operation, cancelled, true, messages);
     CompletableFuture<T> result = submitted.result;
     CallLifecycle lifecycle = submitted.lifecycle;
     try {
       while (true) {
         if (cancelled.getAsBoolean()) {
           lifecycle.cancel();
-          throw new CancellationException(cancellationMessage);
+          throw new CancellationException(messages.cancellation());
         }
         try {
           return result.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
@@ -82,9 +79,10 @@ public final class CancellableCallRunner {
         } catch (InterruptedException e) {
           lifecycle.cancel();
           Thread.currentThread().interrupt();
-          throw new CancellationException(interruptionMessage);
+          throw new CancellationException(messages.interruption());
         } catch (ExecutionException e) {
-          rethrow(e.getCause());
+          throw Futures.propagate(
+              e.getCause(), "unexpected checked exception from cancellable call");
         }
       }
     } catch (CancellationException e) {
@@ -94,122 +92,42 @@ public final class CancellableCallRunner {
   }
 
   /**
-   * Run a call with no caller cancellation signal on {@code executor}, blocking for fair admission
-   * and its result until {@code timeout}.
-   *
-   * <p>This keeps potentially carrier-pinning store calls off a virtual planning thread while
-   * preserving legacy synchronous completion semantics. On timeout the caller is released and the
-   * task is interrupted, but admission remains held until an interruption-insensitive operation
-   * truly exits. Returns the operation result and propagates operation and executor failures
-   * unchanged; throws {@link CallTimeoutException} when admission or completion outlives the
-   * supplied timeout, and {@link CancellationException} if the waiting thread is interrupted.
+   * Run {@code operation} off-thread under the supplied admission semaphore when the caller has no
+   * cancellation signal. Admission and completion have no deadline, keeping blocking store work off
+   * virtual planning threads without changing synchronous completion semantics. Interruption
+   * cancels the submitted task and returns {@link CancellationException}; a downstream call that
+   * ignores interruption retains its permit until it truly exits.
    */
-  public static <T> T callUncancellable(
-      Executor executor,
-      Semaphore permits,
-      Supplier<T> operation,
-      long timeout,
-      TimeUnit timeoutUnit,
-      String cancellationMessage,
-      String interruptionMessage,
-      String timeoutMessage) {
-    return callUncancellable(
-        executor,
-        permits,
-        operation,
-        timeout,
-        timeoutUnit,
-        cancellationMessage,
-        interruptionMessage,
-        timeoutMessage,
-        TimeoutListener.NOOP);
-  }
-
-  /**
-   * Variant of {@link #callUncancellable(Executor, Semaphore, Supplier, long, TimeUnit, String,
-   * String, String)} that reports calls which outlive their caller's timeout.
-   *
-   * <p>The listener is notified once when the caller times out and once when the underlying
-   * callable finally exits (or is discarded before it starts). It lets an owner expose retained
-   * admission as an operational gauge without ever releasing capacity while I/O is still live.
-   */
-  public static <T> T callUncancellable(
-      Executor executor,
-      Semaphore permits,
-      Supplier<T> operation,
-      long timeout,
-      TimeUnit timeoutUnit,
-      String cancellationMessage,
-      String interruptionMessage,
-      String timeoutMessage,
-      TimeoutListener timeoutListener) {
-    long timeoutNanos = timeoutUnit.toNanos(timeout);
-    long startedNanos = System.nanoTime();
+  public static <T> T callWithoutCancellation(
+      Executor executor, Semaphore permits, Supplier<T> operation, FailureMessages messages) {
     try {
-      if (!permits.tryAcquire(timeoutNanos, TimeUnit.NANOSECONDS)) {
-        throw new CallTimeoutException(timeoutMessage);
-      }
+      permits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new CancellationException(interruptionMessage);
+      throw new CancellationException(messages.interruption());
     }
 
     SubmittedCallHandle<T> submitted =
-        submit(
-            executor, permits, operation, () -> false, false, cancellationMessage, timeoutListener);
+        submit(executor, permits, operation, () -> false, false, messages);
     CompletableFuture<T> result = submitted.result;
     CallLifecycle lifecycle = submitted.lifecycle;
     try {
-      long remainingNanos = timeoutNanos - (System.nanoTime() - startedNanos);
-      if (remainingNanos <= 0) {
-        lifecycle.timedOut();
-        lifecycle.cancel();
-        throw new CallTimeoutException(timeoutMessage);
-      }
-      return result.get(remainingNanos, TimeUnit.NANOSECONDS);
+      return result.get();
     } catch (InterruptedException e) {
       lifecycle.cancel();
       Thread.currentThread().interrupt();
-      throw new CancellationException(interruptionMessage);
-    } catch (TimeoutException e) {
-      // The callable may ignore interruption. Keep its permit until it really returns so timed-out
-      // callers cannot cause unbounded live store I/O; this only releases a caller thread.
-      lifecycle.timedOut();
-      lifecycle.cancel();
-      throw new CallTimeoutException(timeoutMessage, e);
+      throw new CancellationException(messages.interruption());
     } catch (ExecutionException e) {
-      rethrow(e.getCause());
-      throw new AssertionError("rethrow must not return");
+      throw Futures.propagate(e.getCause(), "unexpected checked exception from cancellable call");
     }
   }
 
-  /** A caller-visible timeout for bounded admission or completion of a metadata operation. */
-  public static final class CallTimeoutException extends RuntimeException {
-    CallTimeoutException(String message) {
-      super(message);
+  /** Caller-facing cancellation outcomes for a dispatched blocking call. */
+  public record FailureMessages(String cancellation, String interruption) {
+    public FailureMessages {
+      java.util.Objects.requireNonNull(cancellation, "cancellation");
+      java.util.Objects.requireNonNull(interruption, "interruption");
     }
-
-    CallTimeoutException(String message, Throwable cause) {
-      super(message, cause);
-    }
-  }
-
-  /** Receives lifecycle notifications for a call which outlives its caller timeout. */
-  public interface TimeoutListener {
-    TimeoutListener NOOP =
-        new TimeoutListener() {
-          @Override
-          public void timedOut() {}
-
-          @Override
-          public void finished() {}
-        };
-
-    /** The caller timed out while the callable may still own an admission permit. */
-    void timedOut();
-
-    /** A callable previously reported as timed out has finally exited or been discarded. */
-    void finished();
   }
 
   /**
@@ -228,21 +146,19 @@ public final class CancellableCallRunner {
     }
   }
 
+  /** Acquire admission in cancellable polling intervals without losing interrupt semantics. */
   private static void acquire(
-      Semaphore permits,
-      BooleanSupplier cancelled,
-      String cancellationMessage,
-      String interruptionMessage) {
+      Semaphore permits, BooleanSupplier cancelled, FailureMessages messages) {
     try {
       while (true) {
-        throwIfCancelled(cancelled, cancellationMessage);
+        throwIfCancelled(cancelled, messages.cancellation());
         if (permits.tryAcquire(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS)) {
           return;
         }
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new CancellationException(interruptionMessage);
+      throw new CancellationException(messages.interruption());
     }
   }
 
@@ -255,8 +171,7 @@ public final class CancellableCallRunner {
   /**
    * Capture context and submit an admitted call, retaining its permit until the callable exits or
    * the executor discards it. A cancellable caller asks the worker to reject a task that starts
-   * after cancellation; an uncancellable caller executes even if its waiting thread later times
-   * out.
+   * after cancellation; an uncancellable caller executes unless its waiting thread is interrupted.
    */
   private static <T> SubmittedCallHandle<T> submit(
       Executor executor,
@@ -264,11 +179,10 @@ public final class CancellableCallRunner {
       Supplier<T> operation,
       BooleanSupplier cancelled,
       boolean rejectCancelledStart,
-      String cancellationMessage,
-      TimeoutListener timeoutListener) {
+      FailureMessages messages) {
     PropagatedContext context = PropagatedContext.capture();
     CompletableFuture<T> result = new CompletableFuture<>();
-    CallLifecycle lifecycle = new CallLifecycle(timeoutListener);
+    CallLifecycle lifecycle = new CallLifecycle();
     PermitLease permitLease = new PermitLease(permits);
     SubmittedCall task =
         new SubmittedCall(
@@ -277,22 +191,23 @@ public final class CancellableCallRunner {
               try {
                 if (rejectCancelledStart) {
                   if (lifecycle.cancellationRequested.get()) {
-                    throw new CancellationException(cancellationMessage);
+                    throw new CancellationException(messages.cancellation());
                   }
-                  throwIfCancelled(cancelled, cancellationMessage);
+                  throwIfCancelled(cancelled, messages.cancellation());
                 }
                 result.complete(context.supply(operation));
               } catch (Throwable failure) {
                 result.completeExceptionally(failure);
               } finally {
-                lifecycle.operationFinished();
                 permitLease.release();
               }
             },
             result,
             lifecycle,
             permitLease,
-            cancellationMessage);
+            messages,
+            executor instanceof ThreadPoolExecutor pool ? pool : null,
+            Thread.currentThread());
     lifecycle.task = task;
     try {
       // An explicit FutureTask prevents ForkJoinPool from help-running a submitted lambda inline
@@ -321,40 +236,9 @@ public final class CancellableCallRunner {
     private final AtomicBoolean operationStarted = new AtomicBoolean();
     private final AtomicBoolean runnerInstalled = new AtomicBoolean();
     private final AtomicBoolean cancellationRequested = new AtomicBoolean();
-    private final AtomicBoolean timedOut = new AtomicBoolean();
-    private final AtomicBoolean operationFinished = new AtomicBoolean();
-    private final AtomicBoolean finishedAfterTimeout = new AtomicBoolean();
-    private final TimeoutListener timeoutListener;
     private volatile FutureTask<?> task;
 
-    CallLifecycle() {
-      this(TimeoutListener.NOOP);
-    }
-
-    CallLifecycle(TimeoutListener timeoutListener) {
-      this.timeoutListener = timeoutListener;
-    }
-
-    void timedOut() {
-      if (timedOut.compareAndSet(false, true)) {
-        timeoutListener.timedOut();
-        reportFinishedAfterTimeout();
-      }
-    }
-
-    void operationFinished() {
-      operationFinished.set(true);
-      reportFinishedAfterTimeout();
-    }
-
-    private void reportFinishedAfterTimeout() {
-      if (timedOut.get()
-          && operationFinished.get()
-          && finishedAfterTimeout.compareAndSet(false, true)) {
-        timeoutListener.finished();
-      }
-    }
-
+    /** Atomically bind interruption to this task's current runner, never a reused pool worker. */
     void cancel() {
       cancellationRequested.set(true);
       // FutureTask atomically owns its runner while it is executing. Its cancellation path cannot
@@ -384,23 +268,36 @@ public final class CancellableCallRunner {
     private final CompletableFuture<?> result;
     private final CallLifecycle lifecycle;
     private final PermitLease permitLease;
-    private final String cancellationMessage;
+    private final FailureMessages messages;
+    private final ThreadPoolExecutor owningPool;
+    private final Thread submissionThread;
 
     SubmittedCall(
         Runnable runnable,
         CompletableFuture<?> result,
         CallLifecycle lifecycle,
         PermitLease permitLease,
-        String cancellationMessage) {
+        FailureMessages messages,
+        ThreadPoolExecutor owningPool,
+        Thread submissionThread) {
       super(runnable, null);
       this.result = result;
       this.lifecycle = lifecycle;
       this.permitLease = permitLease;
-      this.cancellationMessage = cancellationMessage;
+      this.messages = messages;
+      this.owningPool = owningPool;
+      this.submissionThread = submissionThread;
     }
 
+    /** Install runner ownership before FutureTask exposes its cancellation transition. */
     @Override
     public void run() {
+      if (Thread.currentThread() == submissionThread) {
+        result.completeExceptionally(
+            new IllegalArgumentException("blocking call executor must dispatch asynchronously"));
+        permitLease.release();
+        return;
+      }
       // Mark this before FutureTask installs its runner. Cancellation can otherwise observe a
       // cancelled task between FutureTask's runner CAS and the submitted Runnable's first line,
       // incorrectly classify live work as executor-discarded, and release its admission early.
@@ -411,30 +308,25 @@ public final class CancellableCallRunner {
       // not enter the downstream operation and is safe to discard.
       if (!lifecycle.operationStarted.get()) {
         if (isCancelled()) {
-          result.completeExceptionally(new CancellationException(cancellationMessage));
+          result.completeExceptionally(new CancellationException(messages.cancellation()));
         }
-        lifecycle.operationFinished();
         permitLease.release();
       }
     }
 
+    /** Release admission when cancellation discards a task before any runner installs. */
     @Override
     protected void done() {
       if (isCancelled() && !lifecycle.runnerInstalled.get()) {
-        result.completeExceptionally(new CancellationException(cancellationMessage));
-        lifecycle.operationFinished();
+        // ThreadPoolExecutor retains cancelled FutureTasks in its work queue. Remove this
+        // tombstone before recycling admission, otherwise cancellation bursts can fill the
+        // bounded queue and make a later admitted call fail with RejectedExecutionException.
+        if (owningPool != null) {
+          owningPool.remove(this);
+        }
+        result.completeExceptionally(new CancellationException(messages.cancellation()));
         permitLease.release();
       }
     }
-  }
-
-  private static void rethrow(Throwable failure) {
-    if (failure instanceof RuntimeException runtime) {
-      throw runtime;
-    }
-    if (failure instanceof Error error) {
-      throw error;
-    }
-    throw new IllegalStateException("unexpected checked exception from cancellable call", failure);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -24,7 +24,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -55,22 +55,25 @@ public final class CancellableCallRunner {
     acquire(permits, cancelled, cancellationMessage, interruptionMessage);
     PropagatedContext context = PropagatedContext.capture();
     CompletableFuture<T> result = new CompletableFuture<>();
-    AtomicReference<Thread> worker = new AtomicReference<>();
+    CallLifecycle lifecycle = new CallLifecycle();
     FutureTask<Void> submitted =
         new FutureTask<>(
             () -> {
-              worker.set(Thread.currentThread());
+              lifecycle.operationStarted.set(true);
               try {
+                if (lifecycle.cancellationRequested.get()) {
+                  throw new CancellationException(cancellationMessage);
+                }
                 throwIfCancelled(cancelled, cancellationMessage);
                 result.complete(context.supply(operation));
               } catch (Throwable failure) {
                 result.completeExceptionally(failure);
               } finally {
-                worker.set(null);
                 permits.release();
               }
             },
             null);
+    lifecycle.task = submitted;
     try {
       // An explicit FutureTask prevents ForkJoinPool from help-running a submitted lambda inline
       // on the caller, which would bypass this method's cancellation polling loop.
@@ -82,7 +85,7 @@ public final class CancellableCallRunner {
     try {
       while (true) {
         if (cancelled.getAsBoolean()) {
-          interrupt(worker);
+          lifecycle.cancel();
           throw new CancellationException(cancellationMessage);
         }
         try {
@@ -90,7 +93,7 @@ public final class CancellableCallRunner {
         } catch (TimeoutException ignored) {
           // A bounded wait lets the caller interrupt a stalled operation on cancellation.
         } catch (InterruptedException e) {
-          interrupt(worker);
+          lifecycle.cancel();
           Thread.currentThread().interrupt();
           throw new CancellationException(interruptionMessage);
         } catch (ExecutionException e) {
@@ -98,7 +101,7 @@ public final class CancellableCallRunner {
         }
       }
     } catch (CancellationException e) {
-      interrupt(worker);
+      lifecycle.cancel();
       throw e;
     }
   }
@@ -127,10 +130,19 @@ public final class CancellableCallRunner {
     }
   }
 
-  private static void interrupt(AtomicReference<Thread> worker) {
-    Thread active = worker.get();
-    if (active != null) {
-      active.interrupt();
+  /** Owns cancellation state for one submitted callable. */
+  private static final class CallLifecycle {
+    private final AtomicBoolean operationStarted = new AtomicBoolean();
+    private final AtomicBoolean cancellationRequested = new AtomicBoolean();
+    private volatile FutureTask<?> task;
+
+    void cancel() {
+      cancellationRequested.set(true);
+      // FutureTask atomically owns its runner while it is executing. Its cancellation path cannot
+      // interrupt a platform thread after that task has completed and been returned to the pool.
+      if (operationStarted.get()) {
+        task.cancel(true);
+      }
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -319,6 +319,7 @@ public final class CancellableCallRunner {
   /** Owns cancellation state for one submitted callable. */
   private static final class CallLifecycle {
     private final AtomicBoolean operationStarted = new AtomicBoolean();
+    private final AtomicBoolean runnerInstalled = new AtomicBoolean();
     private final AtomicBoolean cancellationRequested = new AtomicBoolean();
     private final AtomicBoolean timedOut = new AtomicBoolean();
     private final AtomicBoolean operationFinished = new AtomicBoolean();
@@ -399,8 +400,27 @@ public final class CancellableCallRunner {
     }
 
     @Override
+    public void run() {
+      // Mark this before FutureTask installs its runner. Cancellation can otherwise observe a
+      // cancelled task between FutureTask's runner CAS and the submitted Runnable's first line,
+      // incorrectly classify live work as executor-discarded, and release its admission early.
+      lifecycle.runnerInstalled.set(true);
+      super.run();
+      // A cancellation before FutureTask invokes the submitted Runnable leaves no runnable
+      // finally block to release the admission. At this point run() has returned, so the task did
+      // not enter the downstream operation and is safe to discard.
+      if (!lifecycle.operationStarted.get()) {
+        if (isCancelled()) {
+          result.completeExceptionally(new CancellationException(cancellationMessage));
+        }
+        lifecycle.operationFinished();
+        permitLease.release();
+      }
+    }
+
+    @Override
     protected void done() {
-      if (isCancelled() && !lifecycle.operationStarted.get()) {
+      if (isCancelled() && !lifecycle.runnerInstalled.get()) {
         result.completeExceptionally(new CancellationException(cancellationMessage));
         lifecycle.operationFinished();
         permitLease.release();

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -112,6 +112,64 @@ public final class CancellableCallRunner {
   }
 
   /**
+   * Run an uncancellable call on {@code executor}, blocking for fair admission and its result.
+   *
+   * <p>This keeps potentially carrier-pinning store calls off a virtual planning thread while
+   * preserving the legacy caller's synchronous completion semantics.
+   */
+  public static <T> T callUncancellable(
+      Executor executor,
+      Semaphore permits,
+      Supplier<T> operation,
+      String cancellationMessage,
+      String interruptionMessage) {
+    try {
+      permits.acquire();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CancellationException(interruptionMessage);
+    }
+
+    PropagatedContext context = PropagatedContext.capture();
+    CompletableFuture<T> result = new CompletableFuture<>();
+    CallLifecycle lifecycle = new CallLifecycle();
+    PermitLease permitLease = new PermitLease(permits);
+    SubmittedCall submitted =
+        new SubmittedCall(
+            () -> {
+              lifecycle.operationStarted.set(true);
+              try {
+                result.complete(context.supply(operation));
+              } catch (Throwable failure) {
+                result.completeExceptionally(failure);
+              } finally {
+                permitLease.release();
+              }
+            },
+            result,
+            lifecycle,
+            permitLease,
+            cancellationMessage);
+    lifecycle.task = submitted;
+    try {
+      executor.execute(submitted);
+    } catch (RuntimeException | Error submissionFailure) {
+      permitLease.release();
+      throw submissionFailure;
+    }
+    try {
+      return result.get();
+    } catch (InterruptedException e) {
+      lifecycle.cancel();
+      Thread.currentThread().interrupt();
+      throw new CancellationException(interruptionMessage);
+    } catch (ExecutionException e) {
+      rethrow(e.getCause());
+      throw new AssertionError("rethrow must not return");
+    }
+  }
+
+  /**
    * Complete and release calls returned from {@link
    * java.util.concurrent.ExecutorService#shutdownNow}.
    *

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -16,6 +16,7 @@
 package ai.floedb.floecat.service.concurrent;
 
 import ai.floedb.floecat.service.context.PropagatedContext;
+import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -56,8 +57,9 @@ public final class CancellableCallRunner {
     PropagatedContext context = PropagatedContext.capture();
     CompletableFuture<T> result = new CompletableFuture<>();
     CallLifecycle lifecycle = new CallLifecycle();
-    FutureTask<Void> submitted =
-        new FutureTask<>(
+    PermitLease permitLease = new PermitLease(permits);
+    SubmittedCall submitted =
+        new SubmittedCall(
             () -> {
               lifecycle.operationStarted.set(true);
               try {
@@ -69,17 +71,20 @@ public final class CancellableCallRunner {
               } catch (Throwable failure) {
                 result.completeExceptionally(failure);
               } finally {
-                permits.release();
+                permitLease.release();
               }
             },
-            null);
+            result,
+            lifecycle,
+            permitLease,
+            cancellationMessage);
     lifecycle.task = submitted;
     try {
       // An explicit FutureTask prevents ForkJoinPool from help-running a submitted lambda inline
       // on the caller, which would bypass this method's cancellation polling loop.
       executor.execute(submitted);
     } catch (RuntimeException | Error submissionFailure) {
-      permits.release();
+      permitLease.release();
       throw submissionFailure;
     }
     try {
@@ -103,6 +108,22 @@ public final class CancellableCallRunner {
     } catch (CancellationException e) {
       lifecycle.cancel();
       throw e;
+    }
+  }
+
+  /**
+   * Complete and release calls returned from {@link
+   * java.util.concurrent.ExecutorService#shutdownNow}.
+   *
+   * <p>A queued call has already acquired its admission permit, but its callable (and therefore its
+   * normal {@code finally}) will never run. Cancelling it here returns that permit and unblocks its
+   * caller instead of leaving either stranded during application shutdown.
+   */
+  public static void cancelDiscardedTasks(List<Runnable> discardedTasks) {
+    for (Runnable task : discardedTasks) {
+      if (task instanceof SubmittedCall submitted) {
+        submitted.cancel(false);
+      }
     }
   }
 
@@ -140,8 +161,51 @@ public final class CancellableCallRunner {
       cancellationRequested.set(true);
       // FutureTask atomically owns its runner while it is executing. Its cancellation path cannot
       // interrupt a platform thread after that task has completed and been returned to the pool.
-      if (operationStarted.get()) {
-        task.cancel(true);
+      task.cancel(true);
+    }
+  }
+
+  /** A permit lease that remains held until the dispatched callable truly exits. */
+  private static final class PermitLease {
+    private final Semaphore permits;
+    private final AtomicBoolean released = new AtomicBoolean();
+
+    PermitLease(Semaphore permits) {
+      this.permits = permits;
+    }
+
+    void release() {
+      if (released.compareAndSet(false, true)) {
+        permits.release();
+      }
+    }
+  }
+
+  /** FutureTask variant that cleans up admission when an executor discards it before execution. */
+  private static final class SubmittedCall extends FutureTask<Void> {
+    private final CompletableFuture<?> result;
+    private final CallLifecycle lifecycle;
+    private final PermitLease permitLease;
+    private final String cancellationMessage;
+
+    SubmittedCall(
+        Runnable runnable,
+        CompletableFuture<?> result,
+        CallLifecycle lifecycle,
+        PermitLease permitLease,
+        String cancellationMessage) {
+      super(runnable, null);
+      this.result = result;
+      this.lifecycle = lifecycle;
+      this.permitLease = permitLease;
+      this.cancellationMessage = cancellationMessage;
+    }
+
+    @Override
+    protected void done() {
+      if (isCancelled() && !lifecycle.operationStarted.get()) {
+        result.completeExceptionally(new CancellationException(cancellationMessage));
+        permitLease.release();
       }
     }
   }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import ai.floedb.floecat.service.context.PropagatedContext;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Runs one blocking call behind process-wide admission while preserving prompt caller cancellation.
+ *
+ * <p>Admission transfers to the dispatched task and remains held until its callable returns. A
+ * caller that cancels interrupts the worker when possible and returns immediately; an
+ * interruption-insensitive downstream call still owns its admission slot, bounding retained work.
+ */
+public final class CancellableCallRunner {
+
+  private static final long CANCELLATION_POLL_MILLIS = 10;
+
+  private CancellableCallRunner() {}
+
+  /**
+   * Run {@code operation} under {@code permits}, polling {@code cancelled} while awaiting both
+   * admission and completion. The operation receives the caller's propagated request context.
+   */
+  public static <T> T call(
+      Executor executor,
+      Semaphore permits,
+      BooleanSupplier cancelled,
+      Supplier<T> operation,
+      String cancellationMessage,
+      String interruptionMessage) {
+    acquire(permits, cancelled, cancellationMessage, interruptionMessage);
+    PropagatedContext context = PropagatedContext.capture();
+    CompletableFuture<T> result = new CompletableFuture<>();
+    AtomicReference<Thread> worker = new AtomicReference<>();
+    FutureTask<Void> submitted =
+        new FutureTask<>(
+            () -> {
+              worker.set(Thread.currentThread());
+              try {
+                throwIfCancelled(cancelled, cancellationMessage);
+                result.complete(context.supply(operation));
+              } catch (Throwable failure) {
+                result.completeExceptionally(failure);
+              } finally {
+                worker.set(null);
+                permits.release();
+              }
+            },
+            null);
+    try {
+      // An explicit FutureTask prevents ForkJoinPool from help-running a submitted lambda inline
+      // on the caller, which would bypass this method's cancellation polling loop.
+      executor.execute(submitted);
+    } catch (RuntimeException | Error submissionFailure) {
+      permits.release();
+      throw submissionFailure;
+    }
+    try {
+      while (true) {
+        if (cancelled.getAsBoolean()) {
+          interrupt(worker);
+          throw new CancellationException(cancellationMessage);
+        }
+        try {
+          return result.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException ignored) {
+          // A bounded wait lets the caller interrupt a stalled operation on cancellation.
+        } catch (InterruptedException e) {
+          interrupt(worker);
+          Thread.currentThread().interrupt();
+          throw new CancellationException(interruptionMessage);
+        } catch (ExecutionException e) {
+          rethrow(e.getCause());
+        }
+      }
+    } catch (CancellationException e) {
+      interrupt(worker);
+      throw e;
+    }
+  }
+
+  private static void acquire(
+      Semaphore permits,
+      BooleanSupplier cancelled,
+      String cancellationMessage,
+      String interruptionMessage) {
+    try {
+      while (true) {
+        throwIfCancelled(cancelled, cancellationMessage);
+        if (permits.tryAcquire(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS)) {
+          return;
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CancellationException(interruptionMessage);
+    }
+  }
+
+  private static void throwIfCancelled(BooleanSupplier cancelled, String message) {
+    if (cancelled.getAsBoolean()) {
+      throw new CancellationException(message);
+    }
+  }
+
+  private static void interrupt(AtomicReference<Thread> worker) {
+    Thread active = worker.get();
+    if (active != null) {
+      active.interrupt();
+    }
+  }
+
+  private static void rethrow(Throwable failure) {
+    if (failure instanceof RuntimeException runtime) {
+      throw runtime;
+    }
+    if (failure instanceof Error error) {
+      throw error;
+    }
+    throw new IllegalStateException("unexpected checked exception from cancellable call", failure);
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -129,6 +129,36 @@ public final class CancellableCallRunner {
       String cancellationMessage,
       String interruptionMessage,
       String timeoutMessage) {
+    return callUncancellable(
+        executor,
+        permits,
+        operation,
+        timeout,
+        timeoutUnit,
+        cancellationMessage,
+        interruptionMessage,
+        timeoutMessage,
+        TimeoutListener.NOOP);
+  }
+
+  /**
+   * Variant of {@link #callUncancellable(Executor, Semaphore, Supplier, long, TimeUnit, String,
+   * String, String)} that reports calls which outlive their caller's timeout.
+   *
+   * <p>The listener is notified once when the caller times out and once when the underlying
+   * callable finally exits (or is discarded before it starts). It lets an owner expose retained
+   * admission as an operational gauge without ever releasing capacity while I/O is still live.
+   */
+  public static <T> T callUncancellable(
+      Executor executor,
+      Semaphore permits,
+      Supplier<T> operation,
+      long timeout,
+      TimeUnit timeoutUnit,
+      String cancellationMessage,
+      String interruptionMessage,
+      String timeoutMessage,
+      TimeoutListener timeoutListener) {
     long timeoutNanos = timeoutUnit.toNanos(timeout);
     long startedNanos = System.nanoTime();
     try {
@@ -142,7 +172,7 @@ public final class CancellableCallRunner {
 
     PropagatedContext context = PropagatedContext.capture();
     CompletableFuture<T> result = new CompletableFuture<>();
-    CallLifecycle lifecycle = new CallLifecycle();
+    CallLifecycle lifecycle = new CallLifecycle(timeoutListener);
     PermitLease permitLease = new PermitLease(permits);
     SubmittedCall submitted =
         new SubmittedCall(
@@ -153,6 +183,7 @@ public final class CancellableCallRunner {
               } catch (Throwable failure) {
                 result.completeExceptionally(failure);
               } finally {
+                lifecycle.operationFinished();
                 permitLease.release();
               }
             },
@@ -170,6 +201,7 @@ public final class CancellableCallRunner {
     try {
       long remainingNanos = timeoutNanos - (System.nanoTime() - startedNanos);
       if (remainingNanos <= 0) {
+        lifecycle.timedOut();
         lifecycle.cancel();
         throw new CallTimeoutException(timeoutMessage);
       }
@@ -181,6 +213,7 @@ public final class CancellableCallRunner {
     } catch (TimeoutException e) {
       // The callable may ignore interruption. Keep its permit until it really returns so timed-out
       // callers cannot cause unbounded live store I/O; this only releases a caller thread.
+      lifecycle.timedOut();
       lifecycle.cancel();
       throw new CallTimeoutException(timeoutMessage, e);
     } catch (ExecutionException e) {
@@ -198,6 +231,24 @@ public final class CancellableCallRunner {
     CallTimeoutException(String message, Throwable cause) {
       super(message, cause);
     }
+  }
+
+  /** Receives lifecycle notifications for a call which outlives its caller timeout. */
+  public interface TimeoutListener {
+    TimeoutListener NOOP =
+        new TimeoutListener() {
+          @Override
+          public void timedOut() {}
+
+          @Override
+          public void finished() {}
+        };
+
+    /** The caller timed out while the callable may still own an admission permit. */
+    void timedOut();
+
+    /** A callable previously reported as timed out has finally exited or been discarded. */
+    void finished();
   }
 
   /**
@@ -244,7 +295,39 @@ public final class CancellableCallRunner {
   private static final class CallLifecycle {
     private final AtomicBoolean operationStarted = new AtomicBoolean();
     private final AtomicBoolean cancellationRequested = new AtomicBoolean();
+    private final AtomicBoolean timedOut = new AtomicBoolean();
+    private final AtomicBoolean operationFinished = new AtomicBoolean();
+    private final AtomicBoolean finishedAfterTimeout = new AtomicBoolean();
+    private final TimeoutListener timeoutListener;
     private volatile FutureTask<?> task;
+
+    CallLifecycle() {
+      this(TimeoutListener.NOOP);
+    }
+
+    CallLifecycle(TimeoutListener timeoutListener) {
+      this.timeoutListener = timeoutListener;
+    }
+
+    void timedOut() {
+      if (timedOut.compareAndSet(false, true)) {
+        timeoutListener.timedOut();
+        reportFinishedAfterTimeout();
+      }
+    }
+
+    void operationFinished() {
+      operationFinished.set(true);
+      reportFinishedAfterTimeout();
+    }
+
+    private void reportFinishedAfterTimeout() {
+      if (timedOut.get()
+          && operationFinished.get()
+          && finishedAfterTimeout.compareAndSet(false, true)) {
+        timeoutListener.finished();
+      }
+    }
 
     void cancel() {
       cancellationRequested.set(true);
@@ -294,6 +377,7 @@ public final class CancellableCallRunner {
     protected void done() {
       if (isCancelled() && !lifecycle.operationStarted.get()) {
         result.completeExceptionally(new CancellationException(cancellationMessage));
+        lifecycle.operationFinished();
         permitLease.release();
       }
     }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -112,17 +112,23 @@ public final class CancellableCallRunner {
   }
 
   /**
-   * Run an uncancellable call on {@code executor}, blocking for fair admission and its result.
+   * Run a call with no caller cancellation signal on {@code executor}, blocking for fair admission
+   * and its result until {@code timeout}.
    *
    * <p>This keeps potentially carrier-pinning store calls off a virtual planning thread while
-   * preserving the legacy caller's synchronous completion semantics.
+   * preserving legacy synchronous completion semantics. On timeout the caller is released and the
+   * task is interrupted, but admission remains held until an interruption-insensitive operation
+   * truly exits.
    */
   public static <T> T callUncancellable(
       Executor executor,
       Semaphore permits,
       Supplier<T> operation,
+      long timeout,
+      TimeUnit timeoutUnit,
       String cancellationMessage,
-      String interruptionMessage) {
+      String interruptionMessage,
+      String timeoutMessage) {
     try {
       permits.acquire();
     } catch (InterruptedException e) {
@@ -158,11 +164,16 @@ public final class CancellableCallRunner {
       throw submissionFailure;
     }
     try {
-      return result.get();
+      return result.get(timeout, timeoutUnit);
     } catch (InterruptedException e) {
       lifecycle.cancel();
       Thread.currentThread().interrupt();
       throw new CancellationException(interruptionMessage);
+    } catch (TimeoutException e) {
+      // The callable may ignore interruption. Keep its permit until it really returns so timed-out
+      // callers cannot cause unbounded live store I/O; this only releases a caller thread.
+      lifecycle.cancel();
+      throw new IllegalStateException(timeoutMessage, e);
     } catch (ExecutionException e) {
       rethrow(e.getCause());
       throw new AssertionError("rethrow must not return");

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -129,8 +129,12 @@ public final class CancellableCallRunner {
       String cancellationMessage,
       String interruptionMessage,
       String timeoutMessage) {
+    long timeoutNanos = timeoutUnit.toNanos(timeout);
+    long startedNanos = System.nanoTime();
     try {
-      permits.acquire();
+      if (!permits.tryAcquire(timeoutNanos, TimeUnit.NANOSECONDS)) {
+        throw new CallTimeoutException(timeoutMessage);
+      }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new CancellationException(interruptionMessage);
@@ -164,7 +168,12 @@ public final class CancellableCallRunner {
       throw submissionFailure;
     }
     try {
-      return result.get(timeout, timeoutUnit);
+      long remainingNanos = timeoutNanos - (System.nanoTime() - startedNanos);
+      if (remainingNanos <= 0) {
+        lifecycle.cancel();
+        throw new CallTimeoutException(timeoutMessage);
+      }
+      return result.get(remainingNanos, TimeUnit.NANOSECONDS);
     } catch (InterruptedException e) {
       lifecycle.cancel();
       Thread.currentThread().interrupt();
@@ -173,10 +182,21 @@ public final class CancellableCallRunner {
       // The callable may ignore interruption. Keep its permit until it really returns so timed-out
       // callers cannot cause unbounded live store I/O; this only releases a caller thread.
       lifecycle.cancel();
-      throw new IllegalStateException(timeoutMessage, e);
+      throw new CallTimeoutException(timeoutMessage, e);
     } catch (ExecutionException e) {
       rethrow(e.getCause());
       throw new AssertionError("rethrow must not return");
+    }
+  }
+
+  /** A caller-visible timeout for bounded admission or completion of a metadata operation. */
+  public static final class CallTimeoutException extends RuntimeException {
+    CallTimeoutException(String message) {
+      super(message);
+    }
+
+    CallTimeoutException(String message, Throwable cause) {
+      super(message, cause);
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/CancellableCallRunner.java
@@ -45,6 +45,10 @@ public final class CancellableCallRunner {
   /**
    * Run {@code operation} under {@code permits}, polling {@code cancelled} while awaiting both
    * admission and completion. The operation receives the caller's propagated request context.
+   *
+   * <p>Returns the operation result, propagates operation and executor failures unchanged, and
+   * throws {@link CancellationException} when cancellation or interruption wins. Admission remains
+   * held until the operation exits, including when the caller has already returned.
    */
   public static <T> T call(
       Executor executor,
@@ -54,39 +58,17 @@ public final class CancellableCallRunner {
       String cancellationMessage,
       String interruptionMessage) {
     acquire(permits, cancelled, cancellationMessage, interruptionMessage);
-    PropagatedContext context = PropagatedContext.capture();
-    CompletableFuture<T> result = new CompletableFuture<>();
-    CallLifecycle lifecycle = new CallLifecycle();
-    PermitLease permitLease = new PermitLease(permits);
-    SubmittedCall submitted =
-        new SubmittedCall(
-            () -> {
-              lifecycle.operationStarted.set(true);
-              try {
-                if (lifecycle.cancellationRequested.get()) {
-                  throw new CancellationException(cancellationMessage);
-                }
-                throwIfCancelled(cancelled, cancellationMessage);
-                result.complete(context.supply(operation));
-              } catch (Throwable failure) {
-                result.completeExceptionally(failure);
-              } finally {
-                permitLease.release();
-              }
-            },
-            result,
-            lifecycle,
-            permitLease,
-            cancellationMessage);
-    lifecycle.task = submitted;
-    try {
-      // An explicit FutureTask prevents ForkJoinPool from help-running a submitted lambda inline
-      // on the caller, which would bypass this method's cancellation polling loop.
-      executor.execute(submitted);
-    } catch (RuntimeException | Error submissionFailure) {
-      permitLease.release();
-      throw submissionFailure;
-    }
+    SubmittedCallHandle<T> submitted =
+        submit(
+            executor,
+            permits,
+            operation,
+            cancelled,
+            true,
+            cancellationMessage,
+            TimeoutListener.NOOP);
+    CompletableFuture<T> result = submitted.result;
+    CallLifecycle lifecycle = submitted.lifecycle;
     try {
       while (true) {
         if (cancelled.getAsBoolean()) {
@@ -118,7 +100,9 @@ public final class CancellableCallRunner {
    * <p>This keeps potentially carrier-pinning store calls off a virtual planning thread while
    * preserving legacy synchronous completion semantics. On timeout the caller is released and the
    * task is interrupted, but admission remains held until an interruption-insensitive operation
-   * truly exits.
+   * truly exits. Returns the operation result and propagates operation and executor failures
+   * unchanged; throws {@link CallTimeoutException} when admission or completion outlives the
+   * supplied timeout, and {@link CancellationException} if the waiting thread is interrupted.
    */
   public static <T> T callUncancellable(
       Executor executor,
@@ -170,34 +154,11 @@ public final class CancellableCallRunner {
       throw new CancellationException(interruptionMessage);
     }
 
-    PropagatedContext context = PropagatedContext.capture();
-    CompletableFuture<T> result = new CompletableFuture<>();
-    CallLifecycle lifecycle = new CallLifecycle(timeoutListener);
-    PermitLease permitLease = new PermitLease(permits);
-    SubmittedCall submitted =
-        new SubmittedCall(
-            () -> {
-              lifecycle.operationStarted.set(true);
-              try {
-                result.complete(context.supply(operation));
-              } catch (Throwable failure) {
-                result.completeExceptionally(failure);
-              } finally {
-                lifecycle.operationFinished();
-                permitLease.release();
-              }
-            },
-            result,
-            lifecycle,
-            permitLease,
-            cancellationMessage);
-    lifecycle.task = submitted;
-    try {
-      executor.execute(submitted);
-    } catch (RuntimeException | Error submissionFailure) {
-      permitLease.release();
-      throw submissionFailure;
-    }
+    SubmittedCallHandle<T> submitted =
+        submit(
+            executor, permits, operation, () -> false, false, cancellationMessage, timeoutListener);
+    CompletableFuture<T> result = submitted.result;
+    CallLifecycle lifecycle = submitted.lifecycle;
     try {
       long remainingNanos = timeoutNanos - (System.nanoTime() - startedNanos);
       if (remainingNanos <= 0) {
@@ -288,6 +249,70 @@ public final class CancellableCallRunner {
   private static void throwIfCancelled(BooleanSupplier cancelled, String message) {
     if (cancelled.getAsBoolean()) {
       throw new CancellationException(message);
+    }
+  }
+
+  /**
+   * Capture context and submit an admitted call, retaining its permit until the callable exits or
+   * the executor discards it. A cancellable caller asks the worker to reject a task that starts
+   * after cancellation; an uncancellable caller executes even if its waiting thread later times
+   * out.
+   */
+  private static <T> SubmittedCallHandle<T> submit(
+      Executor executor,
+      Semaphore permits,
+      Supplier<T> operation,
+      BooleanSupplier cancelled,
+      boolean rejectCancelledStart,
+      String cancellationMessage,
+      TimeoutListener timeoutListener) {
+    PropagatedContext context = PropagatedContext.capture();
+    CompletableFuture<T> result = new CompletableFuture<>();
+    CallLifecycle lifecycle = new CallLifecycle(timeoutListener);
+    PermitLease permitLease = new PermitLease(permits);
+    SubmittedCall task =
+        new SubmittedCall(
+            () -> {
+              lifecycle.operationStarted.set(true);
+              try {
+                if (rejectCancelledStart) {
+                  if (lifecycle.cancellationRequested.get()) {
+                    throw new CancellationException(cancellationMessage);
+                  }
+                  throwIfCancelled(cancelled, cancellationMessage);
+                }
+                result.complete(context.supply(operation));
+              } catch (Throwable failure) {
+                result.completeExceptionally(failure);
+              } finally {
+                lifecycle.operationFinished();
+                permitLease.release();
+              }
+            },
+            result,
+            lifecycle,
+            permitLease,
+            cancellationMessage);
+    lifecycle.task = task;
+    try {
+      // An explicit FutureTask prevents ForkJoinPool from help-running a submitted lambda inline
+      // on the caller, which would bypass this method's cancellation polling loop.
+      executor.execute(task);
+    } catch (RuntimeException | Error submissionFailure) {
+      permitLease.release();
+      throw submissionFailure;
+    }
+    return new SubmittedCallHandle<>(result, lifecycle);
+  }
+
+  /** Result and cancellation ownership for one submitted callable. */
+  private static final class SubmittedCallHandle<T> {
+    private final CompletableFuture<T> result;
+    private final CallLifecycle lifecycle;
+
+    private SubmittedCallHandle(CompletableFuture<T> result, CallLifecycle lifecycle) {
+      this.result = result;
+      this.lifecycle = lifecycle;
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/** Helpers for joining {@link CompletableFuture}s. */
+public final class Futures {
+
+  private Futures() {}
+
+  /**
+   * Join {@code future}, unwrapping the {@link CompletionException} so the caller sees the task's
+   * original {@link RuntimeException} or {@link Error} rather than a wrapper. A checked-exception
+   * cause is a should-never-happen (the tasks here throw only unchecked) and surfaces as an {@link
+   * IllegalStateException}.
+   */
+  public static <T> T join(CompletableFuture<T> future) {
+    try {
+      return future.join();
+    } catch (CompletionException ce) {
+      Throwable cause = ce.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error e) {
+        throw e;
+      }
+      throw new IllegalStateException("unexpected checked exception from async task", cause);
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
@@ -33,14 +33,18 @@ public final class Futures {
     try {
       return future.join();
     } catch (CompletionException ce) {
-      Throwable cause = ce.getCause();
-      if (cause instanceof RuntimeException re) {
-        throw re;
-      }
-      if (cause instanceof Error e) {
-        throw e;
-      }
-      throw new IllegalStateException("unexpected checked exception from async task", cause);
+      throw propagate(ce.getCause(), "unexpected checked exception from async task");
     }
+  }
+
+  /** Preserve unchecked failures and wrap an impossible checked asynchronous failure. */
+  public static RuntimeException propagate(Throwable failure, String checkedFailureMessage) {
+    if (failure instanceof RuntimeException runtime) {
+      return runtime;
+    }
+    if (failure instanceof Error error) {
+      throw error;
+    }
+    return new IllegalStateException(checkedFailureMessage, failure);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoExecutors.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoExecutors.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Creates and tears down bounded platform-worker pools for blocking metadata I/O.
+ *
+ * <p>The pools use daemon threads so an interruption-insensitive client cannot hold JVM exit, a
+ * bounded queue so cancelled request closures cannot accumulate without limit, and abort-on-full
+ * submission so the owning admission semaphore remains the single backpressure policy.
+ */
+public final class MetadataIoExecutors {
+  private MetadataIoExecutors() {}
+
+  /**
+   * Create a fixed-size daemon pool with a bounded handoff queue and diagnostic thread names.
+   * Invalid sizes fail before a request can submit work.
+   */
+  public static ExecutorService newBoundedDaemonPool(
+      int workers, int queueCapacity, String threadPrefix) {
+    if (workers < 1 || queueCapacity < 1) {
+      throw new IllegalArgumentException("metadata worker and queue sizes must be positive");
+    }
+    String prefix = Objects.requireNonNull(threadPrefix, "threadPrefix");
+    AtomicInteger sequence = new AtomicInteger();
+    ThreadFactory threads =
+        runnable -> {
+          Thread thread = new Thread(runnable, prefix + sequence.incrementAndGet());
+          thread.setDaemon(true);
+          return thread;
+        };
+    return new ThreadPoolExecutor(
+        workers,
+        workers,
+        0L,
+        TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<>(queueCapacity),
+        threads,
+        new ThreadPoolExecutor.AbortPolicy());
+  }
+
+  /**
+   * Interrupt live work, release admission held by tasks discarded from the queue, and await no
+   * longer than the supplied bound. Returns whether the pool terminated; interruption restores the
+   * caller's interrupt status and returns {@code false}.
+   */
+  public static boolean shutdownNowAndAwait(ExecutorService executor, long timeout, TimeUnit unit) {
+    CancellableCallRunner.cancelDiscardedTasks(executor.shutdownNow());
+    try {
+      return executor.awaitTermination(timeout, unit);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoRunner.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import org.jboss.logging.Logger;
+
+/**
+ * Application-wide admission and platform-worker ownership for blocking metadata I/O.
+ *
+ * <p>Every concurrent overlay caller shares this runner, so the configured capacity is a process
+ * ceiling rather than a per-service multiplier. Admission remains held until the downstream call
+ * exits, even when its waiting request has already cancelled.
+ */
+@ApplicationScoped
+public class MetadataIoRunner {
+  private static final Logger LOG = Logger.getLogger(MetadataIoRunner.class);
+  private static final int DEFAULT_CAPACITY = 64;
+  private static final long SHUTDOWN_TIMEOUT_SECONDS = 5;
+  private static final long CANCELLATION_POLL_MILLIS = 10;
+
+  private final int capacity;
+  private final Semaphore permits;
+  private volatile ExecutorService executor = ForkJoinPool.commonPool();
+  private ExecutorService ownedExecutor;
+
+  /** Create the production runner with the application-wide default capacity. */
+  public MetadataIoRunner() {
+    this(DEFAULT_CAPACITY);
+  }
+
+  /** Create an isolated runner with a caller-selected capacity, primarily for focused tests. */
+  public MetadataIoRunner(int capacity) {
+    if (capacity < 1) {
+      throw new IllegalArgumentException("metadata I/O capacity must be positive");
+    }
+    this.capacity = capacity;
+    this.permits = new Semaphore(capacity, true /* best-effort request fairness */);
+  }
+
+  /** Start the owned bounded platform-worker pool; repeated lifecycle calls are harmless. */
+  @PostConstruct
+  public synchronized void start() {
+    if (ownedExecutor != null) {
+      return;
+    }
+    ownedExecutor =
+        MetadataIoExecutors.newBoundedDaemonPool(capacity, capacity, "floecat-metadata-io-");
+    executor = ownedExecutor;
+  }
+
+  /** Run one blocking call with cancellation polling and application-wide admission. */
+  public <T> T call(
+      BooleanSupplier cancelled,
+      Supplier<T> operation,
+      CancellableCallRunner.FailureMessages failureMessages) {
+    return CancellableCallRunner.call(executor, permits, cancelled, operation, failureMessages);
+  }
+
+  /** Run one blocking call off-thread without imposing cancellation or a new deadline. */
+  public <T> T callWithoutCancellation(
+      Supplier<T> operation, CancellableCallRunner.FailureMessages failureMessages) {
+    return CancellableCallRunner.callWithoutCancellation(
+        executor, permits, operation, failureMessages);
+  }
+
+  /** Run one thread-confined callback on its caller while polling cancellation during admission. */
+  public <T> T callOnCallerThread(
+      BooleanSupplier cancelled,
+      Supplier<T> operation,
+      CancellableCallRunner.FailureMessages failureMessages) {
+    boolean acquired = false;
+    try {
+      while (!acquired) {
+        if (cancelled.getAsBoolean()) {
+          throw new CancellationException(failureMessages.cancellation());
+        }
+        try {
+          acquired = permits.tryAcquire(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new CancellationException(failureMessages.interruption());
+        }
+      }
+      T result = operation.get();
+      if (cancelled.getAsBoolean()) {
+        throw new CancellationException(failureMessages.cancellation());
+      }
+      return result;
+    } finally {
+      if (acquired) {
+        permits.release();
+      }
+    }
+  }
+
+  /** Run one thread-confined callback with blocking fair admission and no invented deadline. */
+  public <T> T callOnCallerThreadWithoutCancellation(Supplier<T> operation, String interruption) {
+    boolean acquired = false;
+    try {
+      try {
+        permits.acquire();
+        acquired = true;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new CancellationException(interruption);
+      }
+      return operation.get();
+    } finally {
+      if (acquired) {
+        permits.release();
+      }
+    }
+  }
+
+  /** Stop owned workers without allowing an interruption-insensitive call to block JVM exit. */
+  @PreDestroy
+  public synchronized void close() {
+    if (ownedExecutor == null) {
+      return;
+    }
+    ExecutorService closing = ownedExecutor;
+    ownedExecutor = null;
+    executor = ForkJoinPool.commonPool();
+    if (!MetadataIoExecutors.shutdownNowAndAwait(
+        closing, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      LOG.warn("metadata I/O executor did not terminate before shutdown timeout");
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoRunner.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 /**
@@ -37,7 +38,9 @@ import org.jboss.logging.Logger;
 @ApplicationScoped
 public class MetadataIoRunner {
   private static final Logger LOG = Logger.getLogger(MetadataIoRunner.class);
+  static final String MAX_CONCURRENCY_PROPERTY = "floecat.query.metadata_io.max_concurrency";
   private static final int DEFAULT_CAPACITY = 64;
+  private static final int MAX_CAPACITY = 256;
   private static final long SHUTDOWN_TIMEOUT_SECONDS = 5;
   private static final long CANCELLATION_POLL_MILLIS = 10;
 
@@ -59,6 +62,26 @@ public class MetadataIoRunner {
   /** Create an isolated runner with a caller-selected capacity, primarily for focused tests. */
   public MetadataIoRunner(int capacity) {
     this(new RuntimeState(capacity));
+  }
+
+  /** Clamp deployment input before it can determine semaphore, worker, and queue sizes. */
+  static int clampConfiguredCapacity(int configured) {
+    return Math.max(1, Math.min(MAX_CAPACITY, configured));
+  }
+
+  /** Read the process-wide capacity once when the shared runtime is first requested. */
+  private static int configuredCapacity() {
+    int configured =
+        ConfigProvider.getConfig()
+            .getOptionalValue(MAX_CONCURRENCY_PROPERTY, Integer.class)
+            .orElse(DEFAULT_CAPACITY);
+    int clamped = clampConfiguredCapacity(configured);
+    if (configured != clamped) {
+      LOG.warnf(
+          "%s must be between 1 and %d; using %d instead of %d",
+          MAX_CONCURRENCY_PROPERTY, MAX_CAPACITY, clamped, configured);
+    }
+    return clamped;
   }
 
   private MetadataIoRunner(RuntimeState runtime) {
@@ -154,7 +177,7 @@ public class MetadataIoRunner {
 
   /** Holder indirection avoids eagerly starting the process runtime when this class is unused. */
   private static final class SharedRuntime {
-    private static final RuntimeState RUNTIME = new RuntimeState(DEFAULT_CAPACITY);
+    private static final RuntimeState RUNTIME = new RuntimeState(configuredCapacity());
   }
 
   /** Stable facade used by direct-construction compatibility paths. */

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoRunner.java
@@ -20,7 +20,6 @@ import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -30,9 +29,10 @@ import org.jboss.logging.Logger;
 /**
  * Application-wide admission and platform-worker ownership for blocking metadata I/O.
  *
- * <p>Every concurrent overlay caller shares this runner, so the configured capacity is a process
- * ceiling rather than a per-service multiplier. Admission remains held until the downstream call
- * exits, even when its waiting request has already cancelled.
+ * <p>Every production/default overlay caller shares one runtime, so the configured capacity is a
+ * process ceiling rather than a per-service multiplier. Admission remains held until the downstream
+ * call exits, even when its waiting request has already cancelled. Explicit-capacity instances are
+ * isolated for focused tests.
  */
 @ApplicationScoped
 public class MetadataIoRunner {
@@ -41,34 +41,40 @@ public class MetadataIoRunner {
   private static final long SHUTDOWN_TIMEOUT_SECONDS = 5;
   private static final long CANCELLATION_POLL_MILLIS = 10;
 
-  private final int capacity;
-  private final Semaphore permits;
-  private volatile ExecutorService executor = ForkJoinPool.commonPool();
-  private ExecutorService ownedExecutor;
+  private final RuntimeState runtime;
 
-  /** Create the production runner with the application-wide default capacity. */
+  /**
+   * Create a facade over the process-wide production runtime. Direct and CDI construction share the
+   * same admission semaphore and bounded daemon worker pool.
+   */
   public MetadataIoRunner() {
-    this(DEFAULT_CAPACITY);
+    this(SharedRuntime.RUNTIME);
+  }
+
+  /** Return the process-wide runner for compatibility constructors outside CDI. */
+  public static MetadataIoRunner shared() {
+    return SharedRunner.INSTANCE;
   }
 
   /** Create an isolated runner with a caller-selected capacity, primarily for focused tests. */
   public MetadataIoRunner(int capacity) {
-    if (capacity < 1) {
-      throw new IllegalArgumentException("metadata I/O capacity must be positive");
-    }
-    this.capacity = capacity;
-    this.permits = new Semaphore(capacity, true /* best-effort request fairness */);
+    this(new RuntimeState(capacity));
   }
 
-  /** Start the owned bounded platform-worker pool; repeated lifecycle calls are harmless. */
+  private MetadataIoRunner(RuntimeState runtime) {
+    this.runtime = java.util.Objects.requireNonNull(runtime, "runtime");
+    runtime.start();
+  }
+
+  /** Start the bounded platform-worker pool; repeated lifecycle calls are harmless. */
   @PostConstruct
-  public synchronized void start() {
-    if (ownedExecutor != null) {
-      return;
-    }
-    ownedExecutor =
-        MetadataIoExecutors.newBoundedDaemonPool(capacity, capacity, "floecat-metadata-io-");
-    executor = ownedExecutor;
+  public void start() {
+    runtime.start();
+  }
+
+  /** True when two facades share the same process or test runtime. */
+  boolean sharesRuntimeWith(MetadataIoRunner other) {
+    return other != null && runtime == other.runtime;
   }
 
   /** Run one blocking call with cancellation polling and application-wide admission. */
@@ -76,14 +82,15 @@ public class MetadataIoRunner {
       BooleanSupplier cancelled,
       Supplier<T> operation,
       CancellableCallRunner.FailureMessages failureMessages) {
-    return CancellableCallRunner.call(executor, permits, cancelled, operation, failureMessages);
+    return CancellableCallRunner.call(
+        runtime.executor(), runtime.permits, cancelled, operation, failureMessages);
   }
 
   /** Run one blocking call off-thread without imposing cancellation or a new deadline. */
   public <T> T callWithoutCancellation(
       Supplier<T> operation, CancellableCallRunner.FailureMessages failureMessages) {
     return CancellableCallRunner.callWithoutCancellation(
-        executor, permits, operation, failureMessages);
+        runtime.executor(), runtime.permits, operation, failureMessages);
   }
 
   /** Run one thread-confined callback on its caller while polling cancellation during admission. */
@@ -98,7 +105,7 @@ public class MetadataIoRunner {
           throw new CancellationException(failureMessages.cancellation());
         }
         try {
-          acquired = permits.tryAcquire(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+          acquired = runtime.permits.tryAcquire(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           throw new CancellationException(failureMessages.interruption());
@@ -111,7 +118,7 @@ public class MetadataIoRunner {
       return result;
     } finally {
       if (acquired) {
-        permits.release();
+        runtime.permits.release();
       }
     }
   }
@@ -121,7 +128,7 @@ public class MetadataIoRunner {
     boolean acquired = false;
     try {
       try {
-        permits.acquire();
+        runtime.permits.acquire();
         acquired = true;
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -130,23 +137,69 @@ public class MetadataIoRunner {
       return operation.get();
     } finally {
       if (acquired) {
-        permits.release();
+        runtime.permits.release();
       }
     }
   }
 
-  /** Stop owned workers without allowing an interruption-insensitive call to block JVM exit. */
+  /**
+   * Stop this runtime's workers without allowing an interruption-insensitive call to block exit.
+   */
   @PreDestroy
-  public synchronized void close() {
-    if (ownedExecutor == null) {
-      return;
-    }
-    ExecutorService closing = ownedExecutor;
-    ownedExecutor = null;
-    executor = ForkJoinPool.commonPool();
-    if (!MetadataIoExecutors.shutdownNowAndAwait(
-        closing, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+  public void close() {
+    if (!runtime.close()) {
       LOG.warn("metadata I/O executor did not terminate before shutdown timeout");
+    }
+  }
+
+  /** Holder indirection avoids eagerly starting the process runtime when this class is unused. */
+  private static final class SharedRuntime {
+    private static final RuntimeState RUNTIME = new RuntimeState(DEFAULT_CAPACITY);
+  }
+
+  /** Stable facade used by direct-construction compatibility paths. */
+  private static final class SharedRunner {
+    private static final MetadataIoRunner INSTANCE = new MetadataIoRunner(SharedRuntime.RUNTIME);
+  }
+
+  /** Shared lifecycle and admission state behind one or more runner facades. */
+  private static final class RuntimeState {
+    private final int capacity;
+    private final Semaphore permits;
+    private volatile ExecutorService executor;
+
+    private RuntimeState(int capacity) {
+      if (capacity < 1) {
+        throw new IllegalArgumentException("metadata I/O capacity must be positive");
+      }
+      this.capacity = capacity;
+      this.permits = new Semaphore(capacity, true /* best-effort request fairness */);
+    }
+
+    private synchronized void start() {
+      if (executor == null || executor.isShutdown()) {
+        executor =
+            MetadataIoExecutors.newBoundedDaemonPool(capacity, capacity, "floecat-metadata-io-");
+      }
+    }
+
+    private ExecutorService executor() {
+      ExecutorService current = executor;
+      if (current == null || current.isShutdown()) {
+        start();
+        current = executor;
+      }
+      return current;
+    }
+
+    private synchronized boolean close() {
+      if (executor == null) {
+        return true;
+      }
+      ExecutorService closing = executor;
+      executor = null;
+      return MetadataIoExecutors.shutdownNowAndAwait(
+          closing, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
@@ -51,18 +51,23 @@ public final class PropagatedContext {
           "floecat_subject",
           "floecat_engine_kind",
           "floecat_engine_version");
+  private static final List<String> SOURCE_MDC_DIMENSIONS =
+      List.of("floecat_component", "floecat_operation");
 
   private final Context otel;
   private final ResolvedCallContext call; // null off any request (e.g. unit tests, startup)
+  private final Map<String, Object> sourceMdc;
 
-  private PropagatedContext(Context otel, ResolvedCallContext call) {
+  private PropagatedContext(Context otel, ResolvedCallContext call, Map<String, Object> sourceMdc) {
     this.otel = otel;
     this.call = call;
+    this.sourceMdc = sourceMdc;
   }
 
   /** Snapshot the calling thread's ambient context. Call on the request/driver thread. */
   public static PropagatedContext capture() {
-    return new PropagatedContext(Context.current(), ResolvedCallContexts.currentOrNull());
+    return new PropagatedContext(
+        Context.current(), ResolvedCallContexts.currentOrNull(), snapshotMdc());
   }
 
   /**
@@ -73,23 +78,24 @@ public final class PropagatedContext {
    */
   public <T> T supply(Supplier<T> body) {
     try (Scope ignored = otel.makeCurrent()) {
-      if (call == null) {
-        return body.get();
-      }
-      return ResolvedCallContexts.callWith(
-          call,
-          () -> {
-            // MDC is a projection of the call context; re-derive it so off-thread log lines carry
-            // the request's ids, then restore the worker's prior values for nested scopes and
-            // executors that already propagate MDC.
-            Map<String, Object> priorMdc = snapshotMdc();
-            InboundContextInterceptor.populateMdc(call);
-            try {
+      Map<String, Object> priorMdc = snapshotMdc();
+      installMdc(sourceMdc);
+      try {
+        if (call == null) {
+          return body.get();
+        }
+        return ResolvedCallContexts.callWith(
+            call,
+            () -> {
+              // Call-derived identifiers are canonical, while the source component and operation
+              // describe the work that dispatched this fan-out rather than the inbound RPC.
+              InboundContextInterceptor.populateMdc(call);
+              installMdc(sourceMdc, SOURCE_MDC_DIMENSIONS);
               return body.get();
-            } finally {
-              restoreMdc(priorMdc);
-            }
-          });
+            });
+      } finally {
+        restoreMdc(priorMdc);
+      }
     }
   }
 
@@ -116,6 +122,21 @@ public final class PropagatedContext {
   private static void restoreMdc(Map<String, Object> priorMdc) {
     for (String key : MDC_KEYS) {
       Object value = priorMdc.get(key);
+      if (value == null) {
+        MDC.remove(key);
+      } else {
+        MDC.put(key, value);
+      }
+    }
+  }
+
+  private static void installMdc(Map<String, Object> sourceMdc) {
+    installMdc(sourceMdc, MDC_KEYS);
+  }
+
+  private static void installMdc(Map<String, Object> sourceMdc, List<String> keys) {
+    for (String key : keys) {
+      Object value = sourceMdc.get(key);
       if (value == null) {
         MDC.remove(key);
       } else {

--- a/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.context;
+
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import java.util.function.Supplier;
+
+/**
+ * An immutable snapshot of a thread's ambient request context, for re-establishing it on another
+ * thread. Request context does not follow a task across a thread hop on its own — it lives in
+ * thread-locals (OpenTelemetry's {@link Context}, the resolved call context's scope) — so work
+ * dispatched to an executor loses it, and ambient reads ({@code engineContext()}, principal,
+ * correlation, log MDC) silently read empty off-thread. That is how engine-gated system objects
+ * become unresolvable across a fan-out (eng-floe/floecat#361).
+ *
+ * <p>{@link #capture()} on the originating thread, {@link #supply}/{@link #run} on the worker
+ * thread. The {@link ResolvedCallContext} is the single source of truth: engine, principal,
+ * correlation and the log MDC all derive from it. Add a new carrier here once, and every dispatch
+ * point that already propagates through this snapshot gets it for free.
+ */
+public final class PropagatedContext {
+
+  private final Context otel;
+  private final ResolvedCallContext call; // null off any request (e.g. unit tests, startup)
+
+  private PropagatedContext(Context otel, ResolvedCallContext call) {
+    this.otel = otel;
+    this.call = call;
+  }
+
+  /** Snapshot the calling thread's ambient context. Call on the request/driver thread. */
+  public static PropagatedContext capture() {
+    return new PropagatedContext(Context.current(), ResolvedCallContexts.currentOrNull());
+  }
+
+  /**
+   * Run {@code body} on the current thread with the captured context re-established for its
+   * duration and torn down afterward, so its ambient reads behave as they did on the capturing
+   * thread. Checked exceptions from {@code body} propagate as {@link RuntimeException} (via {@link
+   * ResolvedCallContexts#callWith}).
+   */
+  public <T> T supply(Supplier<T> body) {
+    try (Scope ignored = otel.makeCurrent()) {
+      if (call == null) {
+        return body.get();
+      }
+      return ResolvedCallContexts.callWith(
+          call,
+          () -> {
+            // MDC is a projection of the call context; re-derive it so off-thread log lines carry
+            // the request's ids, then clear so a pooled worker does not leak them to the next task.
+            InboundContextInterceptor.populateMdc(call);
+            try {
+              return body.get();
+            } finally {
+              InboundContextInterceptor.clearMdc();
+            }
+          });
+    }
+  }
+
+  /** {@link #supply} for a body with no return value. */
+  public void run(Runnable body) {
+    supply(
+        () -> {
+          body.run();
+          return null;
+        });
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
@@ -20,7 +20,11 @@ import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
+import org.jboss.logging.MDC;
 
 /**
  * An immutable snapshot of a thread's ambient request context, for re-establishing it on another
@@ -36,6 +40,17 @@ import java.util.function.Supplier;
  * point that already propagates through this snapshot gets it for free.
  */
 public final class PropagatedContext {
+
+  private static final List<String> MDC_KEYS =
+      List.of(
+          "floecat_component",
+          "floecat_operation",
+          "query_id",
+          "correlation_id",
+          "floecat_account_id",
+          "floecat_subject",
+          "floecat_engine_kind",
+          "floecat_engine_version");
 
   private final Context otel;
   private final ResolvedCallContext call; // null off any request (e.g. unit tests, startup)
@@ -65,12 +80,14 @@ public final class PropagatedContext {
           call,
           () -> {
             // MDC is a projection of the call context; re-derive it so off-thread log lines carry
-            // the request's ids, then clear so a pooled worker does not leak them to the next task.
+            // the request's ids, then restore the worker's prior values for nested scopes and
+            // executors that already propagate MDC.
+            Map<String, Object> priorMdc = snapshotMdc();
             InboundContextInterceptor.populateMdc(call);
             try {
               return body.get();
             } finally {
-              InboundContextInterceptor.clearMdc();
+              restoreMdc(priorMdc);
             }
           });
     }
@@ -83,5 +100,27 @@ public final class PropagatedContext {
           body.run();
           return null;
         });
+  }
+
+  private static Map<String, Object> snapshotMdc() {
+    Map<String, Object> values = new HashMap<>();
+    for (String key : MDC_KEYS) {
+      Object value = MDC.get(key);
+      if (value != null) {
+        values.put(key, value);
+      }
+    }
+    return values;
+  }
+
+  private static void restoreMdc(Map<String, Object> priorMdc) {
+    for (String key : MDC_KEYS) {
+      Object value = priorMdc.get(key);
+      if (value == null) {
+        MDC.remove(key);
+      } else {
+        MDC.put(key, value);
+      }
+    }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
@@ -36,21 +36,11 @@ import org.jboss.logging.MDC;
  *
  * <p>{@link #capture()} on the originating thread, {@link #supply}/{@link #run} on the worker
  * thread. The {@link ResolvedCallContext} is the single source of truth: engine, principal,
- * correlation and the log MDC all derive from it. Add a new carrier here once, and every dispatch
- * point that already propagates through this snapshot gets it for free.
+ * correlation and the log MDC all derive from it. Centralizing carriers here keeps every dispatch
+ * point that uses this snapshot on the same context set.
  */
 public final class PropagatedContext {
 
-  private static final List<String> MDC_KEYS =
-      List.of(
-          "floecat_component",
-          "floecat_operation",
-          "query_id",
-          "correlation_id",
-          "floecat_account_id",
-          "floecat_subject",
-          "floecat_engine_kind",
-          "floecat_engine_version");
   private static final List<String> SOURCE_MDC_DIMENSIONS =
       List.of("floecat_component", "floecat_operation");
 
@@ -79,7 +69,7 @@ public final class PropagatedContext {
   public <T> T supply(Supplier<T> body) {
     try (Scope ignored = otel.makeCurrent()) {
       Map<String, Object> priorMdc = snapshotMdc();
-      installMdc(sourceMdc);
+      replaceMdc(sourceMdc);
       try {
         if (call == null) {
           return body.get();
@@ -94,7 +84,7 @@ public final class PropagatedContext {
               return body.get();
             });
       } finally {
-        restoreMdc(priorMdc);
+        replaceMdc(priorMdc);
       }
     }
   }
@@ -108,22 +98,21 @@ public final class PropagatedContext {
         });
   }
 
+  /** Copy the complete MDC so extension-defined keys participate in isolation and restoration. */
   private static Map<String, Object> snapshotMdc() {
     Map<String, Object> values = MDC.getMap();
     return values == null ? new HashMap<>() : new HashMap<>(values);
   }
 
-  private static void restoreMdc(Map<String, Object> priorMdc) {
+  /** Replace, rather than merge, MDC state so pooled workers cannot leak foreign request keys. */
+  private static void replaceMdc(Map<String, Object> values) {
     MDC.clear();
-    for (Map.Entry<String, Object> entry : priorMdc.entrySet()) {
+    for (Map.Entry<String, Object> entry : values.entrySet()) {
       MDC.put(entry.getKey(), entry.getValue());
     }
   }
 
-  private static void installMdc(Map<String, Object> sourceMdc) {
-    installMdc(sourceMdc, MDC_KEYS);
-  }
-
+  /** Overlay selected dispatch dimensions after canonical call-derived fields are populated. */
   private static void installMdc(Map<String, Object> sourceMdc, List<String> keys) {
     for (String key : keys) {
       Object value = sourceMdc.get(key);

--- a/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
@@ -109,24 +109,14 @@ public final class PropagatedContext {
   }
 
   private static Map<String, Object> snapshotMdc() {
-    Map<String, Object> values = new HashMap<>();
-    for (String key : MDC_KEYS) {
-      Object value = MDC.get(key);
-      if (value != null) {
-        values.put(key, value);
-      }
-    }
-    return values;
+    Map<String, Object> values = MDC.getMap();
+    return values == null ? new HashMap<>() : new HashMap<>(values);
   }
 
   private static void restoreMdc(Map<String, Object> priorMdc) {
-    for (String key : MDC_KEYS) {
-      Object value = priorMdc.get(key);
-      if (value == null) {
-        MDC.remove(key);
-      } else {
-        MDC.put(key, value);
-      }
+    MDC.clear();
+    for (Map.Entry<String, Object> entry : priorMdc.entrySet()) {
+      MDC.put(entry.getKey(), entry.getValue());
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
@@ -48,10 +48,10 @@ import org.jboss.logging.MDC;
  *       io.grpc.Context} directly (unit tests, non-Vert.x threads).
  * </ol>
  *
- * <p>History: mirroring only the principal onto the duplicated context moved the context-loss
- * failure from a loud {@code PERMISSION_DENIED} into a silent engine-gated {@code NOT_FOUND}
- * (eng-floe/floecat#361). Carrying the whole {@link ResolvedCallContext} on one channel keeps the
- * principal, correlation id, and engine context from ever diverging again.
+ * <p>Mirroring only the principal onto the duplicated context turns context loss from a loud {@code
+ * PERMISSION_DENIED} into a silent engine-gated {@code NOT_FOUND} (eng-floe/floecat#361). Carrying
+ * the whole {@link ResolvedCallContext} on one channel keeps the principal, correlation id, and
+ * engine context from ever diverging.
  */
 public final class ResolvedCallContexts {
 

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -94,6 +94,11 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     return ctx != null ? ctx : fallback.get();
   }
 
+  @Override
+  public boolean supportsConcurrentResolution() {
+    return true;
+  }
+
   /**
    * Resolves a graph node by ID, checking system graph first, then user graph.
    *

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
@@ -39,10 +40,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Semaphore;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.context.ManagedExecutor;
 
@@ -401,40 +400,15 @@ public final class NameResolver {
 
   /**
    * Fans out per-namespace work across up to {@value #MAX_PARALLEL_NS_SCANS} concurrent tasks on
-   * the injected blocking executor. Each namespace is an independent DynamoDB scan; parallel
-   * execution reduces wall-clock time from O(N) to O(1) for warm DynamoDB connections.
+   * the injected blocking executor and flattens the per-namespace results. Each namespace is an
+   * independent DynamoDB scan; parallel execution reduces wall-clock time from O(N) to O(1) for
+   * warm DynamoDB connections.
    */
   private <T> List<T> parallelScan(
       List<ResourceId> nsIds, java.util.function.Function<ResourceId, List<T>> task) {
-    Semaphore gate = new Semaphore(MAX_PARALLEL_NS_SCANS);
-    io.opentelemetry.context.Context otelContext = io.opentelemetry.context.Context.current();
-    List<CompletableFuture<List<T>>> futures =
-        nsIds.stream()
-            .<CompletableFuture<List<T>>>map(
-                ns ->
-                    CompletableFuture.<List<T>>supplyAsync(
-                        () -> {
-                          gate.acquireUninterruptibly();
-                          try (io.opentelemetry.context.Scope ignored = otelContext.makeCurrent()) {
-                            return task.apply(ns);
-                          } finally {
-                            gate.release();
-                          }
-                        },
-                        blockingExecutor))
-            .toList();
-    List<T> out = new ArrayList<>();
-    for (CompletableFuture<List<T>> f : futures) {
-      try {
-        out.addAll(f.join());
-      } catch (java.util.concurrent.CompletionException ce) {
-        Throwable cause = ce.getCause();
-        if (cause instanceof RuntimeException re) throw re;
-        if (cause instanceof Error e) throw e;
-        throw new IllegalStateException("unexpected checked exception from async task", cause);
-      }
-    }
-    return out;
+    return BoundedFanout.mapOrdered(nsIds, MAX_PARALLEL_NS_SCANS, blockingExecutor, task).stream()
+        .flatMap(List::stream)
+        .toList();
   }
 
   private ResourceId requireCanonicalTableId(ResourceId tableId) {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -401,8 +401,8 @@ public final class NameResolver {
   /**
    * Fans out per-namespace work across up to {@value #MAX_PARALLEL_NS_SCANS} concurrent tasks on
    * the injected blocking executor and flattens the per-namespace results. Each namespace is an
-   * independent DynamoDB scan; parallel execution reduces wall-clock time from O(N) to O(1) for
-   * warm DynamoDB connections.
+   * independent DynamoDB scan; warm connections complete in bounded waves of up to {@value
+   * #MAX_PARALLEL_NS_SCANS} scans instead of one serial scan per namespace.
    */
   private <T> List<T> parallelScan(
       List<ResourceId> nsIds, java.util.function.Function<ResourceId, List<T>> task) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -80,6 +80,7 @@ import ai.floedb.floecat.types.LogicalType;
 import ai.floedb.floecat.types.LogicalTypeFormat;
 import io.opentelemetry.api.trace.Span;
 import io.smallrye.mutiny.Multi;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayDeque;
@@ -98,6 +99,9 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -140,8 +144,17 @@ public class UserObjectBundleService {
   private final long slowRpcMs;
   private final LogicalSchemaMapper logicalSchemaMapper = new LogicalSchemaMapper();
   private final FlightEndpointRef floecatFlightEndpoint;
+  // Cancellation can be signalled by a transport thread; release its store roots on a managed
+  // virtual-thread executor instead of blocking that termination callback.
+  private final ExecutorService cancellationTeardownExecutor =
+      Executors.newVirtualThreadPerTaskExecutor();
 
   @Inject Observability observability;
+
+  @PreDestroy
+  void closeCancellationTeardownExecutor() {
+    cancellationTeardownExecutor.close();
+  }
 
   private static void warnFlightHost(String flightHost, String quarkusProfile) {
     if (flightHost == null) {
@@ -277,7 +290,12 @@ public class UserObjectBundleService {
               return Multi.createFrom()
                   .iterable(() -> iterator)
                   .onFailure()
-                  .invoke(ignored -> iterator.publishStreamTelemetry("failed"))
+                  .invoke(
+                      failure -> {
+                        if (!(failure instanceof CancellationException)) {
+                          iterator.publishStreamTelemetry("failed");
+                        }
+                      })
                   .onTermination()
                   .invoke(iterator::cancel);
             });
@@ -1626,6 +1644,11 @@ public class UserObjectBundleService {
     // after its cleanup pass. Store I/O always happens outside this lock.
     private final Object pendingChunkPinsLock = new Object();
     private RelationPinSet pendingChunkPins = RelationPinSet.getDefaultInstance();
+    // Serializes the producer's mutable iterator state with cancellation telemetry. A teardown
+    // task may publish only after the active next() call has finished mutating diagnostics/caches.
+    private final Object producerStateLock = new Object();
+    private boolean producerActive;
+    private boolean cancellationTelemetryPending;
 
     private int seq = 1;
     private int nextInputIndex = 0;
@@ -1692,35 +1715,39 @@ public class UserObjectBundleService {
 
     @Override
     public UserObjectsBundleChunk next() {
-      throwIfCancelled(this::isCancelled);
-      if (!headerEmitted) {
-        headerEmitted = true;
-        if (LOG.isDebugEnabled()) {
-          LOG.debugf("Emitting header chunk query_id=%s seq=%d", ctx.getQueryId(), seq);
+      beginProducerStep();
+      try {
+        if (!headerEmitted) {
+          headerEmitted = true;
+          if (LOG.isDebugEnabled()) {
+            LOG.debugf("Emitting header chunk query_id=%s seq=%d", ctx.getQueryId(), seq);
+          }
+          return headerChunk(ctx.getQueryId(), seq++);
         }
-        return headerChunk(ctx.getQueryId(), seq++);
-      }
 
-      if (pending.isEmpty() && (nextInputIndex < resolutionCount || !eagerBaseQueue.isEmpty())) {
-        fillPending();
-      }
-
-      if (!pending.isEmpty()) {
-        return flushResolutionChunk();
-      }
-
-      if (!endEmitted) {
-        endEmitted = true;
-        publishStreamTelemetry("completed");
-        if (LOG.isDebugEnabled()) {
-          LOG.debugf(
-              "Emitting end chunk query_id=%s seq=%d resolutions=%d found=%d not_found=%d",
-              ctx.getQueryId(), seq, resolutionCount, foundCount, notFoundCount);
+        if (pending.isEmpty() && (nextInputIndex < resolutionCount || !eagerBaseQueue.isEmpty())) {
+          fillPending();
         }
-        return endChunk(ctx.getQueryId(), seq++, resolutionCount, foundCount, notFoundCount);
-      }
 
-      throw new NoSuchElementException();
+        if (!pending.isEmpty()) {
+          return flushResolutionChunk();
+        }
+
+        if (!endEmitted) {
+          endEmitted = true;
+          publishStreamTelemetry("completed");
+          if (LOG.isDebugEnabled()) {
+            LOG.debugf(
+                "Emitting end chunk query_id=%s seq=%d resolutions=%d found=%d not_found=%d",
+                ctx.getQueryId(), seq, resolutionCount, foundCount, notFoundCount);
+          }
+          return endChunk(ctx.getQueryId(), seq++, resolutionCount, foundCount, notFoundCount);
+        }
+
+        throw new NoSuchElementException();
+      } finally {
+        finishProducerStep();
+      }
     }
 
     private void fillPending() {
@@ -1783,14 +1810,72 @@ public class UserObjectBundleService {
           toRelease = pendingChunkPins;
           pendingChunkPins = RelationPinSet.getDefaultInstance();
         }
+        synchronized (producerStateLock) {
+          cancellationTelemetryPending = true;
+        }
         // onTermination may run on a transport/event-loop thread. Root release can perform store
-        // I/O and telemetry finishes spans, so only the state handoff runs inline there.
-        Thread.startVirtualThread(
-            () -> {
-              queryStore.releaseResolvingPinBlobs(
-                  ctx.getQueryId(), QueryPins.gcRootUris(toRelease));
-              publishStreamTelemetry("cancelled");
-            });
+        // I/O, so teardown runs on a managed executor. Telemetry is published only after the
+        // producer reports that no mutable iterator state remains active.
+        try {
+          cancellationTeardownExecutor.submit(
+              () -> {
+                try {
+                  queryStore.releaseResolvingPinBlobs(
+                      ctx.getQueryId(), QueryPins.gcRootUris(toRelease));
+                } catch (RuntimeException releaseFailure) {
+                  LOG.warnf(
+                      releaseFailure,
+                      "Failed to release cancelled stream pin roots query_id=%s",
+                      ctx.getQueryId());
+                }
+                publishCancellationTelemetryIfIdle();
+              });
+        } catch (RejectedExecutionException shutdown) {
+          LOG.warnf(
+              shutdown,
+              "Cancellation teardown executor stopped before pin-root release query_id=%s",
+              ctx.getQueryId());
+        }
+      }
+    }
+
+    private void beginProducerStep() {
+      synchronized (producerStateLock) {
+        throwIfCancelled(this::isCancelled);
+        producerActive = true;
+      }
+    }
+
+    private void finishProducerStep() {
+      boolean publishCancellation;
+      synchronized (producerStateLock) {
+        producerActive = false;
+        publishCancellation = cancellationTelemetryPending;
+        cancellationTelemetryPending = false;
+      }
+      if (publishCancellation) {
+        publishCancellationTelemetry();
+      }
+    }
+
+    private void publishCancellationTelemetryIfIdle() {
+      synchronized (producerStateLock) {
+        if (producerActive || !cancellationTelemetryPending) {
+          return;
+        }
+        cancellationTelemetryPending = false;
+      }
+      publishCancellationTelemetry();
+    }
+
+    private void publishCancellationTelemetry() {
+      try {
+        publishStreamTelemetry("cancelled");
+      } catch (RuntimeException telemetryFailure) {
+        LOG.warnf(
+            telemetryFailure,
+            "Failed to publish cancelled stream telemetry query_id=%s",
+            ctx.getQueryId());
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -319,8 +319,9 @@ public class UserObjectBundleService {
                         if (!(failure instanceof CancellationException)) {
                           iterator.publishStreamTelemetry("failed");
                         }
+                        iterator.cancel();
                       })
-                  .onTermination()
+                  .onCancellation()
                   .invoke(iterator::cancel);
             });
   }

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -943,7 +943,8 @@ public class UserObjectBundleService {
       StatsProvider statsProvider,
       Set<String> knownBlobVersions,
       TimingAccumulator timings,
-      BooleanSupplier cancelled) {
+      BooleanSupplier cancelled,
+      MetadataLookup metadataLookup) {
     // The token is the engine-scoped payload token (scopedIdentity), not the bare content version,
     // so a client that proved possession under a different engine cannot be served identity-only.
     // A blank version can never prove possession: a user table whose definition blob had no etag
@@ -956,7 +957,8 @@ public class UserObjectBundleService {
         || !knownBlobVersions.contains(scopedIdentity.get().getTableBlobVersion())) {
       return null;
     }
-    RelationInfo.Builder slim = baseRelationInfo(relation).setPinIdentity(scopedIdentity.get());
+    RelationInfo.Builder slim =
+        baseRelationInfo(relation, metadataLookup).setPinIdentity(scopedIdentity.get());
     // Time the stats lookup exactly as the full path does (buildRelation): the slim path still hits
     // the stats provider, which can block on its latency budget. Without this, once the
     // conditional-request feature is doing its job a large fraction of resolutions would contribute
@@ -973,10 +975,11 @@ public class UserObjectBundleService {
    * name, kind, and origin. Both the slim identity-only reply and the full payload start here, so
    * the two can never disagree on a relation's identity.
    */
-  private RelationInfo.Builder baseRelationInfo(ResolvedRelation relation) {
+  private RelationInfo.Builder baseRelationInfo(
+      ResolvedRelation relation, MetadataLookup metadataLookup) {
     return RelationInfo.newBuilder()
         .setRelationId(relation.relationId())
-        .setName(canonicalName(relation.relationId(), relation.node()))
+        .setName(canonicalName(relation.relationId(), relation.node(), metadataLookup))
         .setKind(mapKind(relation.node().kind(), relation.node().origin()))
         .setOrigin(mapOrigin(relation.node().origin()));
   }
@@ -1002,7 +1005,8 @@ public class UserObjectBundleService {
       StatsProvider statsProvider,
       TimingAccumulator timings,
       Optional<RelationPinIdentity> scopedIdentity,
-      BooleanSupplier cancelled) {
+      BooleanSupplier cancelled,
+      MetadataLookup metadataLookup) {
     throwIfCancelled(cancelled);
     if (LOG.isTraceEnabled()) {
       LOG.tracef(
@@ -1022,9 +1026,14 @@ public class UserObjectBundleService {
             : relation.node() instanceof UserTableNode userTable
                 ? UserObjectBundleUtils.qualifyNestedColumnNames(
                     logicalSchemaForRelation(
-                            correlationId, relation.relationId(), userTable, queryContext)
+                            correlationId,
+                            relation.relationId(),
+                            userTable,
+                            queryContext,
+                            metadataLookup)
                         .getColumnsList())
-                : Optional.ofNullable(overlay.tableSchema(relation.node().id()))
+                : Optional.ofNullable(
+                        metadataLookup.get(() -> overlay.tableSchema(relation.node().id())))
                     .orElseGet(List::of);
 
     List<SchemaColumn> pruned =
@@ -1034,7 +1043,7 @@ public class UserObjectBundleService {
         UserObjectBundleUtils.columnsFor(schemaColumns, pruned, origin, correlationId);
     throwIfCancelled(cancelled);
 
-    RelationInfo.Builder builder = baseRelationInfo(relation);
+    RelationInfo.Builder builder = baseRelationInfo(relation, metadataLookup);
 
     /*
      * Populate the bundled endpoint metadata so workers know how to reach the table. FLOECAT
@@ -1688,7 +1697,8 @@ public class UserObjectBundleService {
       String correlationId,
       ResourceId relationId,
       UserTableNode userTable,
-      QueryContext queryContext) {
+      QueryContext queryContext,
+      MetadataLookup metadataLookup) {
     Optional<TablePin> pin = queryContext.findTablePin(relationId, correlationId);
     if (pin.isEmpty()) {
       // Not yet pinned (e.g. a relation resolved outside the pinned set): fall back to the table's
@@ -1701,21 +1711,27 @@ public class UserObjectBundleService {
     SnapshotRef snapshotRef =
         SnapshotRef.newBuilder().setSnapshotId(pin.get().getSnapshotId()).build();
     CatalogOverlay.SchemaResolution resolved =
-        overlay.schemaFor(
-            correlationId,
-            relationId,
-            snapshotRef,
-            pin.get().getTableBlobUri(),
-            pin.get().getSnapshotBlobUri());
+        metadataLookup.get(
+            () ->
+                overlay.schemaFor(
+                    correlationId,
+                    relationId,
+                    snapshotRef,
+                    pin.get().getTableBlobUri(),
+                    pin.get().getSnapshotBlobUri()));
     return logicalSchemaMapper.map(resolved.table(), resolved.schemaJson());
   }
 
-  private NameRef canonicalName(ResourceId id, GraphNode node) {
+  private NameRef canonicalName(ResourceId id, GraphNode node, MetadataLookup metadataLookup) {
     return switch (node.kind()) {
       case TABLE ->
-          overlay.tableName(id).orElse(NameRef.newBuilder().setName(node.displayName()).build());
+          metadataLookup
+              .get(() -> overlay.tableName(id))
+              .orElse(NameRef.newBuilder().setName(node.displayName()).build());
       case VIEW ->
-          overlay.viewName(id).orElse(NameRef.newBuilder().setName(node.displayName()).build());
+          metadataLookup
+              .get(() -> overlay.viewName(id))
+              .orElse(NameRef.newBuilder().setName(node.displayName()).build());
       default -> NameRef.newBuilder().setName(node.displayName()).build();
     };
   }
@@ -1781,6 +1797,12 @@ public class UserObjectBundleService {
 
   private record NormalizedNameRef(String catalog, List<String> path, String name) {}
 
+  /** Runs one overlay-owned repository lookup under its concurrency and cancellation contract. */
+  private interface MetadataLookup {
+    /** Return one lookup result without moving surrounding relation assembly off its caller. */
+    <T> T get(Supplier<T> lookup);
+  }
+
   private static final class GraphNodeMissingException extends RuntimeException {
     private final ResourceId relationId;
 
@@ -1823,6 +1845,13 @@ public class UserObjectBundleService {
     private final PhaseDiagnostics diagnostics = diagnostics("get_user_objects");
     private final long streamStartNs = System.nanoTime();
     private final Span parentSpan = Span.current();
+    private final MetadataLookup metadataLookup =
+        new MetadataLookup() {
+          @Override
+          public <T> T get(Supplier<T> lookup) {
+            return awaitCancellableMetadataLookup(lookup);
+          }
+        };
     // Coordinates the resolving-root handoff. Cancellation can arrive on a different thread than
     // chunk production, so it must neither release pins being committed nor miss pins accumulated
     // after its cleanup pass. Store I/O always happens outside this lock.
@@ -2066,41 +2095,40 @@ public class UserObjectBundleService {
     }
 
     /**
-     * Build one relation on bounded platform I/O capacity. The task owns its timing accumulator so
-     * an interruption-insensitive call cannot mutate iterator telemetry after cancellation returns.
+     * Assemble one relation on the producer thread. Only overlay-owned repository reads cross the
+     * metadata runner; stats, validation, and decorator callbacks retain their caller-thread
+     * contract. The local timing accumulator is merged only after a successful build.
      */
     private BuiltRelation buildRelationCancellably(
         PendingFound found,
         QueryContext liveContext,
         Optional<RelationPinIdentity> scopedIdentity) {
-      return awaitCancellableMetadataLookup(
-          () -> {
-            TimingAccumulator taskTimings = new TimingAccumulator();
-            long buildStartNs = System.nanoTime();
-            RelationInfo identityOnly =
-                identityOnlyOrNull(
-                    found.relation(),
-                    scopedIdentity,
-                    statsProvider,
-                    knownBlobVersions,
-                    taskTimings,
-                    this::isCancelled);
-            if (identityOnly != null) {
-              return new BuiltRelation(
-                  identityOnly, true, System.nanoTime() - buildStartNs, taskTimings);
-            }
-            RelationInfo full =
-                buildRelation(
-                    correlationId,
-                    found.relation(),
-                    liveContext,
-                    resolutionContext,
-                    statsProvider,
-                    taskTimings,
-                    scopedIdentity,
-                    this::isCancelled);
-            return new BuiltRelation(full, false, System.nanoTime() - buildStartNs, taskTimings);
-          });
+      TimingAccumulator taskTimings = new TimingAccumulator();
+      long buildStartNs = System.nanoTime();
+      RelationInfo identityOnly =
+          identityOnlyOrNull(
+              found.relation(),
+              scopedIdentity,
+              statsProvider,
+              knownBlobVersions,
+              taskTimings,
+              this::isCancelled,
+              metadataLookup);
+      if (identityOnly != null) {
+        return new BuiltRelation(identityOnly, true, System.nanoTime() - buildStartNs, taskTimings);
+      }
+      RelationInfo full =
+          buildRelation(
+              correlationId,
+              found.relation(),
+              liveContext,
+              resolutionContext,
+              statsProvider,
+              taskTimings,
+              scopedIdentity,
+              this::isCancelled,
+              metadataLookup);
+      return new BuiltRelation(full, false, System.nanoTime() - buildStartNs, taskTimings);
     }
 
     /** Publish a claimed outcome without allowing telemetry failure to mask stream termination. */

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1077,9 +1077,9 @@ public class UserObjectBundleService {
       builder.setViewDefinition(viewBuilder);
     }
 
-    // The engine captured at iterator construction, not a live provider re-read: this runs on
-    // executor threads where the request context is unreliable, and a silently empty engine would
-    // skip engine-specific decoration with no log line (eng-floe/floecat#361).
+    // Use the engine captured at iterator construction. Overlay reads may cross executor boundaries
+    // before decoration resumes here, so re-reading ambient request context is fragile and a
+    // silently empty engine would skip engine-specific decoration (eng-floe/floecat#361).
     EngineContext ctx = resolutionContext.engineContext();
     boolean decorationRequired = decorationRequired(ctx);
     Optional<EngineMetadataDecorator> decorator = currentDecorator(ctx);
@@ -2097,9 +2097,11 @@ public class UserObjectBundleService {
     /**
      * Assemble one relation on the producer thread. Only overlay-owned repository reads cross the
      * metadata runner; stats, validation, and decorator callbacks retain their caller-thread
-     * contract. The local timing accumulator is merged only after a successful build.
+     * contract. Cancellation is checked between those synchronous callbacks; each collaborator owns
+     * any deadline needed for its active call. The local timing accumulator is merged only after a
+     * successful build.
      */
-    private BuiltRelation buildRelationCancellably(
+    private BuiltRelation buildRelationWithCancellationChecks(
         PendingFound found,
         QueryContext liveContext,
         Optional<RelationPinIdentity> scopedIdentity) {
@@ -2330,7 +2332,7 @@ public class UserObjectBundleService {
         Optional<RelationPinIdentity> scopedIdentity =
             scopedPinIdentity(
                 correlationId, found.relation(), liveCtx, resolutionContext.engineContext());
-        BuiltRelation built = buildRelationCancellably(found, liveCtx, scopedIdentity);
+        BuiltRelation built = buildRelationWithCancellationChecks(found, liveCtx, scopedIdentity);
         TimingAccumulator buildTimings = built.timings();
         timings.addFrom(buildTimings);
         long statsNanos = buildTimings.statsLookupNanos();

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -105,9 +105,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -120,6 +122,7 @@ import org.jboss.logging.Logger;
 public class UserObjectBundleService {
 
   private static final int MAX_RESOLUTIONS_PER_CHUNK = 25;
+  private static final int MAX_CONCURRENT_METADATA_LOOKUPS = 64;
   private static final long CANCELLATION_POLL_MILLIS = 10;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
 
@@ -168,6 +171,10 @@ public class UserObjectBundleService {
   // stream producer so cancellation can interrupt them without waiting for a stalled store client.
   private final ExecutorService metadataLookupExecutor =
       Executors.newVirtualThreadPerTaskExecutor();
+  // Holds capacity until the actual overlay call exits, including after its stream subscriber has
+  // cancelled. This bounds interruption-insensitive repository calls across all active streams.
+  private final Semaphore metadataLookupPermits =
+      new Semaphore(MAX_CONCURRENT_METADATA_LOOKUPS, true /* FIFO across streams */);
 
   @Inject Observability observability;
 
@@ -1829,22 +1836,43 @@ public class UserObjectBundleService {
      * when the subscriber cancels, even if the downstream client ignores interruption.
      */
     private <T> T awaitCancellableMetadataLookup(Supplier<T> lookup) {
-      throwIfCancelled(this::isCancelled);
+      acquireMetadataLookupPermit();
       PropagatedContext context = PropagatedContext.capture();
-      FutureTask<T> submitted = new FutureTask<>(() -> context.supply(lookup));
-      metadataLookupExecutor.execute(submitted);
+      CompletableFuture<T> result = new CompletableFuture<>();
+      AtomicReference<Thread> worker = new AtomicReference<>();
+      FutureTask<Void> submitted =
+          new FutureTask<>(
+              () -> {
+                worker.set(Thread.currentThread());
+                try {
+                  throwIfCancelled(this::isCancelled);
+                  result.complete(context.supply(lookup));
+                } catch (Throwable failure) {
+                  result.completeExceptionally(failure);
+                } finally {
+                  worker.set(null);
+                  metadataLookupPermits.release();
+                }
+              },
+              null);
+      try {
+        metadataLookupExecutor.execute(submitted);
+      } catch (RuntimeException | Error submissionFailure) {
+        metadataLookupPermits.release();
+        throw submissionFailure;
+      }
       try {
         while (true) {
           if (isCancelled()) {
-            submitted.cancel(true);
+            interruptMetadataLookup(worker);
             throw new CancellationException("GetUserObjects stream cancelled");
           }
           try {
-            return submitted.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+            return result.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
           } catch (TimeoutException ignored) {
             // A bounded wait lets the producer interrupt a stalled lookup on cancellation.
           } catch (InterruptedException e) {
-            submitted.cancel(true);
+            interruptMetadataLookup(worker);
             Thread.currentThread().interrupt();
             throw new CancellationException("GetUserObjects metadata lookup interrupted");
           } catch (ExecutionException e) {
@@ -1852,8 +1880,30 @@ public class UserObjectBundleService {
           }
         }
       } catch (CancellationException e) {
-        submitted.cancel(true);
+        interruptMetadataLookup(worker);
         throw e;
+      }
+    }
+
+    /** Wait for global lookup capacity without holding a stream producer after cancellation. */
+    private void acquireMetadataLookupPermit() {
+      try {
+        while (true) {
+          throwIfCancelled(this::isCancelled);
+          if (metadataLookupPermits.tryAcquire(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS)) {
+            return;
+          }
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new CancellationException("GetUserObjects metadata lookup interrupted");
+      }
+    }
+
+    private static void interruptMetadataLookup(AtomicReference<Thread> worker) {
+      Thread active = worker.get();
+      if (active != null) {
+        active.interrupt();
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1623,7 +1623,7 @@ public class UserObjectBundleService {
     private final Span parentSpan = Span.current();
     // Coordinates the resolving-root handoff. Cancellation can arrive on a different thread than
     // chunk production, so it must neither release pins being committed nor miss pins accumulated
-    // after its cleanup pass.
+    // after its cleanup pass. Store I/O always happens outside this lock.
     private final Object pendingChunkPinsLock = new Object();
     private RelationPinSet pendingChunkPins = RelationPinSet.getDefaultInstance();
 
@@ -1783,8 +1783,14 @@ public class UserObjectBundleService {
           toRelease = pendingChunkPins;
           pendingChunkPins = RelationPinSet.getDefaultInstance();
         }
-        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toRelease));
-        publishStreamTelemetry("cancelled");
+        // onTermination may run on a transport/event-loop thread. Root release can perform store
+        // I/O and telemetry finishes spans, so only the state handoff runs inline there.
+        Thread.startVirtualThread(
+            () -> {
+              queryStore.releaseResolvingPinBlobs(
+                  ctx.getQueryId(), QueryPins.gcRootUris(toRelease));
+              publishStreamTelemetry("cancelled");
+            });
       }
     }
 
@@ -2349,6 +2355,7 @@ public class UserObjectBundleService {
     }
 
     private void commitChunkPins() {
+      RelationPinSet toCommit;
       synchronized (pendingChunkPinsLock) {
         throwIfCancelled(this::isCancelled);
         if (pendingChunkPins.getPinsCount() == 0) {
@@ -2359,32 +2366,36 @@ public class UserObjectBundleService {
               "Committing chunk pins query_id=%s pin_count=%d",
               ctx.getQueryId(), pendingChunkPins.getPinsCount());
         }
-        RelationPinSet toCommit = pendingChunkPins;
-        // Keep the cancellation cleanup out of this handoff until update establishes the durable
-        // query-context root. Otherwise a concurrent cancel could reopen the blob-GC window.
-        Optional<QueryContext> updated;
-        try {
-          updated =
-              queryStore.update(
-                  ctx.getQueryId(),
-                  existing -> mergeRelationPins(existing, toCommit, correlationId));
-        } catch (RuntimeException | Error e) {
-          pendingChunkPins = RelationPinSet.getDefaultInstance();
-          queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
-          throw e;
-        }
+        toCommit = pendingChunkPins;
         pendingChunkPins = RelationPinSet.getDefaultInstance();
-        if (updated.isEmpty()) {
-          queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
-          LOG.warnf(
-              "Failed to commit chunk pins query_id=%s query context missing", ctx.getQueryId());
-          throw GrpcErrors.notFound(
-              correlationId, QUERY_NOT_FOUND, Map.of("query_id", ctx.getQueryId()));
-        }
+      }
+
+      // A concurrent cancellation sees this set as in-flight and leaves it to this method: a
+      // successful update establishes the durable root; a failed update releases the transient
+      // root below. That avoids both the GC window and blocking cancellation on store I/O.
+      Optional<QueryContext> updated;
+      try {
+        updated =
+            queryStore.update(
+                ctx.getQueryId(), existing -> mergeRelationPins(existing, toCommit, correlationId));
+      } catch (RuntimeException | Error e) {
+        finishFailedPinCommit(toCommit);
+        throw e;
+      }
+      if (updated.isEmpty()) {
+        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
+        LOG.warnf(
+            "Failed to commit chunk pins query_id=%s query context missing", ctx.getQueryId());
+        throw GrpcErrors.notFound(
+            correlationId, QUERY_NOT_FOUND, Map.of("query_id", ctx.getQueryId()));
       }
       if (LOG.isDebugEnabled()) {
         LOG.debugf("Committed chunk pins query_id=%s", ctx.getQueryId());
       }
+    }
+
+    private void finishFailedPinCommit(RelationPinSet toCommit) {
+      queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
     }
 
     private int pendingChunkPinCount() {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1785,6 +1785,7 @@ public class UserObjectBundleService {
     @Override
     public UserObjectsBundleChunk next() {
       beginProducerStep();
+      String terminalOutcome = null;
       try {
         if (!headerEmitted) {
           headerEmitted = true;
@@ -1814,8 +1815,13 @@ public class UserObjectBundleService {
         }
 
         throw new NoSuchElementException();
+      } catch (RuntimeException | Error failure) {
+        if (!(failure instanceof CancellationException)) {
+          terminalOutcome = "failed";
+        }
+        throw failure;
       } finally {
-        finishProducerStep();
+        finishProducerStep(terminalOutcome);
       }
     }
 
@@ -1938,14 +1944,16 @@ public class UserObjectBundleService {
       }
     }
 
-    private void finishProducerStep() {
+    private void finishProducerStep(String terminalOutcome) {
       boolean publishCancellation;
       synchronized (producerStateLock) {
         producerActive = false;
-        publishCancellation = cancellationTelemetryPending;
+        publishCancellation = terminalOutcome == null && cancellationTelemetryPending;
         cancellationTelemetryPending = false;
       }
-      if (publishCancellation) {
+      if (terminalOutcome != null) {
+        publishStreamTelemetry(terminalOutcome);
+      } else if (publishCancellation) {
         publishCancellationTelemetry();
       }
     }

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -341,7 +341,7 @@ public class UserObjectBundleService {
     this(
         overlay,
         inputResolver,
-        new MetadataIoRunner(),
+        MetadataIoRunner.shared(),
         queryStore,
         statsFactory,
         decoratorProvider,
@@ -373,7 +373,7 @@ public class UserObjectBundleService {
     this(
         overlay,
         inputResolver,
-        new MetadataIoRunner(),
+        MetadataIoRunner.shared(),
         queryStore,
         statsFactory,
         decoratorProvider,

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -96,6 +96,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -104,8 +105,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -119,8 +123,13 @@ public class UserObjectBundleService {
 
   private static final int MAX_RESOLUTIONS_PER_CHUNK = 25;
   private static final int MAX_CONCURRENT_METADATA_LOOKUPS = 64;
+  // Every admitted lookup is submitted to this pool. The queue only bridges worker turnover, so
+  // keep its capacity at least as large as the global admission bound below.
+  private static final int METADATA_LOOKUP_POOL_SIZE = MAX_CONCURRENT_METADATA_LOOKUPS;
+  private static final int METADATA_LOOKUP_QUEUE_CAPACITY = METADATA_LOOKUP_POOL_SIZE;
   private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
+  private static final AtomicInteger METADATA_LOOKUP_THREAD_SEQUENCE = new AtomicInteger();
 
   private static void throwIfCancelled(BooleanSupplier cancelled) {
     if (cancelled.getAsBoolean()) {
@@ -153,14 +162,40 @@ public class UserObjectBundleService {
   // virtual-thread executor instead of blocking that termination callback.
   private final ExecutorService cancellationTeardownExecutor =
       Executors.newVirtualThreadPerTaskExecutor();
-  // Candidate resolution can call repository-backed overlay operations. Keep those calls off the
-  // stream producer so cancellation can interrupt them without waiting for a stalled store client.
-  private final ExecutorService metadataLookupExecutor =
-      Executors.newVirtualThreadPerTaskExecutor();
+  // Candidate resolution can call DynamoDB-backed overlay operations, which can pin a virtual
+  // thread's carrier while blocking. Isolate those calls on bounded platform workers so
+  // cancellation releases the stream producer without starving unrelated virtual-thread work.
+  private final ExecutorService metadataLookupExecutor = newMetadataLookupExecutor();
   // Holds capacity until the actual overlay call exits, including after its stream subscriber has
   // cancelled. This bounds interruption-insensitive repository calls across all active streams.
   private final Semaphore metadataLookupPermits =
       new Semaphore(MAX_CONCURRENT_METADATA_LOOKUPS, true /* FIFO across streams */);
+
+  private static ExecutorService newMetadataLookupExecutor() {
+    if (MAX_CONCURRENT_METADATA_LOOKUPS > METADATA_LOOKUP_POOL_SIZE) {
+      throw new IllegalStateException(
+          "bundle metadata admission must not exceed metadata lookup worker capacity");
+    }
+    return new ThreadPoolExecutor(
+        METADATA_LOOKUP_POOL_SIZE,
+        METADATA_LOOKUP_POOL_SIZE,
+        0L,
+        TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<>(METADATA_LOOKUP_QUEUE_CAPACITY),
+        daemonMetadataLookupThreadFactory(),
+        new ThreadPoolExecutor.AbortPolicy());
+  }
+
+  private static ThreadFactory daemonMetadataLookupThreadFactory() {
+    return runnable -> {
+      Thread thread =
+          new Thread(
+              runnable,
+              "floecat-bundle-metadata-" + METADATA_LOOKUP_THREAD_SEQUENCE.incrementAndGet());
+      thread.setDaemon(true);
+      return thread;
+    };
+  }
 
   @Inject Observability observability;
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -104,7 +104,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
@@ -119,11 +118,6 @@ import org.jboss.logging.Logger;
 public class UserObjectBundleService {
 
   private static final int MAX_RESOLUTIONS_PER_CHUNK = 25;
-  private static final int MAX_CONCURRENT_METADATA_LOOKUPS = 64;
-  // Every admitted lookup is submitted to this pool. The queue only bridges worker turnover, so
-  // keep its capacity at least as large as the global admission bound below.
-  private static final int METADATA_LOOKUP_POOL_SIZE = MAX_CONCURRENT_METADATA_LOOKUPS;
-  private static final int METADATA_LOOKUP_QUEUE_CAPACITY = METADATA_LOOKUP_POOL_SIZE;
   private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
   private static final BooleanSupplier NEVER_CANCELLED = () -> false;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
@@ -241,33 +235,11 @@ public class UserObjectBundleService {
   // virtual-thread executor instead of blocking that termination callback.
   private final ExecutorService cancellationTeardownExecutor =
       Executors.newVirtualThreadPerTaskExecutor();
-  // Candidate resolution can call DynamoDB-backed overlay operations, which can pin a virtual
-  // thread's carrier while blocking. Isolate those calls on bounded platform workers so
-  // cancellation releases the stream producer without starving unrelated virtual-thread work.
-  private final ExecutorService metadataLookupExecutor = newMetadataLookupExecutor();
-  // Holds capacity until the actual overlay call exits, including after its stream subscriber has
-  // cancelled. This bounds interruption-insensitive repository calls across all active streams.
-  private final Semaphore metadataLookupPermits =
-      new Semaphore(MAX_CONCURRENT_METADATA_LOOKUPS, true /* best-effort stream fairness */);
-
-  /** Create the bounded platform-worker pool used for potentially carrier-pinning store calls. */
-  private static ExecutorService newMetadataLookupExecutor() {
-    if (MAX_CONCURRENT_METADATA_LOOKUPS > METADATA_LOOKUP_POOL_SIZE) {
-      throw new IllegalStateException(
-          "bundle metadata admission must not exceed metadata lookup worker capacity");
-    }
-    return MetadataIoExecutors.newBoundedDaemonPool(
-        METADATA_LOOKUP_POOL_SIZE, METADATA_LOOKUP_QUEUE_CAPACITY, "floecat-bundle-metadata-");
-  }
-
   @Inject Observability observability;
 
-  /**
-   * Stop both owned executors while bounding teardown if a downstream call ignores interruption.
-   */
+  /** Stop cancellation teardown work without owning the resolver's shared metadata executor. */
   @PreDestroy
-  void closeExecutors() {
-    shutdownExecutor(metadataLookupExecutor);
+  void closeCancellationTeardownExecutor() {
     shutdownExecutor(cancellationTeardownExecutor);
   }
 
@@ -275,7 +247,7 @@ public class UserObjectBundleService {
   private static void shutdownExecutor(ExecutorService executor) {
     if (!MetadataIoExecutors.shutdownNowAndAwait(
         executor, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-      LOG.warn("bundle executor did not terminate before shutdown timeout");
+      LOG.warn("bundle cancellation teardown executor did not terminate before shutdown timeout");
     }
   }
 
@@ -1992,12 +1964,7 @@ public class UserObjectBundleService {
         throwIfCancelled(this::isCancelled);
         return result;
       }
-      return CancellableCallRunner.call(
-          metadataLookupExecutor,
-          metadataLookupPermits,
-          this::isCancelled,
-          lookup,
-          METADATA_LOOKUP_FAILURES);
+      return inputResolver.runMetadataIo(this::isCancelled, lookup, METADATA_LOOKUP_FAILURES);
     }
 
     /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -395,11 +395,19 @@ public class UserObjectBundleService {
             diagnostics,
             cancelled);
     diagnostics.nanos("pin.resolver", System.nanoTime() - resolverStartNs);
-    throwIfCancelled(cancelled);
     RelationPinSet incoming = resolution.relationPinSet();
     RelationPinSet pins = incoming == null ? RelationPinSet.getDefaultInstance() : incoming;
-    diagnostics.add("pin.output_pins", pins.getPinsCount());
-    return pins;
+    boolean handedOff = false;
+    try {
+      throwIfCancelled(cancelled);
+      diagnostics.add("pin.output_pins", pins.getPinsCount());
+      handedOff = true;
+      return pins;
+    } finally {
+      if (!handedOff) {
+        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(pins));
+      }
+    }
   }
 
   private UserObjectsBundleChunk headerChunk(String queryId, int seq) {
@@ -1736,12 +1744,21 @@ public class UserObjectBundleService {
                   currentSnapshotPinCache,
                   diagnostics,
                   this::isCancelled);
-          throwIfCancelled(this::isCancelled);
-          long accumulateStartNs = System.nanoTime();
+          boolean pinsAccumulated = false;
           try {
-            accumulateChunkPins(chunkPins);
+            throwIfCancelled(this::isCancelled);
+            long accumulateStartNs = System.nanoTime();
+            try {
+              accumulateChunkPins(chunkPins);
+              pinsAccumulated = true;
+            } finally {
+              diagnostics.nanos("pin.accumulate", System.nanoTime() - accumulateStartNs);
+            }
           } finally {
-            diagnostics.nanos("pin.accumulate", System.nanoTime() - accumulateStartNs);
+            if (!pinsAccumulated) {
+              queryStore.releaseResolvingPinBlobs(
+                  ctx.getQueryId(), QueryPins.gcRootUris(chunkPins));
+            }
           }
         } finally {
           pinCollectNanos += System.nanoTime() - pinStartNs;
@@ -2303,12 +2320,7 @@ public class UserObjectBundleService {
       if (incomingPins == null || incomingPins.getPinsCount() == 0) {
         return;
       }
-      try {
-        pendingChunkPins = QueryPins.mergeSets(pendingChunkPins, incomingPins, correlationId);
-      } catch (RuntimeException | Error e) {
-        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(incomingPins));
-        throw e;
-      }
+      pendingChunkPins = QueryPins.mergeSets(pendingChunkPins, incomingPins, correlationId);
     }
 
     private void commitChunkPins() {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -59,6 +59,7 @@ import ai.floedb.floecat.scanner.spi.MetadataResolutionContext;
 import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.context.EngineContextProvider;
+import ai.floedb.floecat.service.context.PropagatedContext;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.PinValidator;
 import ai.floedb.floecat.service.query.QueryContextStore;
@@ -99,9 +100,13 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -115,12 +120,23 @@ import org.jboss.logging.Logger;
 public class UserObjectBundleService {
 
   private static final int MAX_RESOLUTIONS_PER_CHUNK = 25;
+  private static final long CANCELLATION_POLL_MILLIS = 10;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
 
   private static void throwIfCancelled(BooleanSupplier cancelled) {
     if (cancelled.getAsBoolean()) {
       throw new CancellationException("GetUserObjects stream cancelled");
     }
+  }
+
+  private static void rethrowAsyncFailure(Throwable failure) {
+    if (failure instanceof RuntimeException runtime) {
+      throw runtime;
+    }
+    if (failure instanceof Error error) {
+      throw error;
+    }
+    throw new IllegalStateException("unexpected checked exception from metadata lookup", failure);
   }
 
   private static final Set<String> LOCAL_FLIGHT_HOSTS = Set.of("localhost", "127.0.0.1", "0.0.0.0");
@@ -148,11 +164,16 @@ public class UserObjectBundleService {
   // virtual-thread executor instead of blocking that termination callback.
   private final ExecutorService cancellationTeardownExecutor =
       Executors.newVirtualThreadPerTaskExecutor();
+  // Candidate resolution can call repository-backed overlay operations. Keep those calls off the
+  // stream producer so cancellation can interrupt them without waiting for a stalled store client.
+  private final ExecutorService metadataLookupExecutor =
+      Executors.newVirtualThreadPerTaskExecutor();
 
   @Inject Observability observability;
 
   @PreDestroy
   void closeCancellationTeardownExecutor() {
+    metadataLookupExecutor.shutdownNow();
     cancellationTeardownExecutor.close();
   }
 
@@ -1803,6 +1824,39 @@ public class UserObjectBundleService {
       return cancelled.get();
     }
 
+    /**
+     * Runs one repository-backed overlay lookup away from the stream producer and returns promptly
+     * when the subscriber cancels, even if the downstream client ignores interruption.
+     */
+    private <T> T awaitCancellableMetadataLookup(Supplier<T> lookup) {
+      throwIfCancelled(this::isCancelled);
+      PropagatedContext context = PropagatedContext.capture();
+      FutureTask<T> submitted = new FutureTask<>(() -> context.supply(lookup));
+      metadataLookupExecutor.execute(submitted);
+      try {
+        while (true) {
+          if (isCancelled()) {
+            submitted.cancel(true);
+            throw new CancellationException("GetUserObjects stream cancelled");
+          }
+          try {
+            return submitted.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+          } catch (TimeoutException ignored) {
+            // A bounded wait lets the producer interrupt a stalled lookup on cancellation.
+          } catch (InterruptedException e) {
+            submitted.cancel(true);
+            Thread.currentThread().interrupt();
+            throw new CancellationException("GetUserObjects metadata lookup interrupted");
+          } catch (ExecutionException e) {
+            rethrowAsyncFailure(e.getCause());
+          }
+        }
+      } catch (CancellationException e) {
+        submitted.cancel(true);
+        throw e;
+      }
+    }
+
     private void cancel() {
       if (cancelled.compareAndSet(false, true)) {
         RelationPinSet toRelease;
@@ -2283,7 +2337,8 @@ public class UserObjectBundleService {
         long startNs = System.nanoTime();
         try {
           defaultCatalogName =
-              overlay.catalog(defaultCatalogId).map(CatalogNode::displayName).orElse("");
+              awaitCancellableMetadataLookup(
+                  () -> overlay.catalog(defaultCatalogId).map(CatalogNode::displayName).orElse(""));
           defaultCatalogResolved = true;
           defaultCatalogLookups++;
         } finally {
@@ -2311,7 +2366,8 @@ public class UserObjectBundleService {
         // context per lookup is fragile across executor hops, and an empty engine silently
         // un-resolves engine-gated system objects (eng-floe/floecat#361).
         Optional<ResourceId> resolved =
-            overlay.resolveName(correlationId, ref, resolutionContext.engineContext());
+            awaitCancellableMetadataLookup(
+                () -> overlay.resolveName(correlationId, ref, resolutionContext.engineContext()));
         nameResolutionCache.put(key, resolved);
         nameResolutionCacheMisses++;
         return resolved;
@@ -2331,7 +2387,9 @@ public class UserObjectBundleService {
       try {
         // Pass the engine captured at iterator construction: re-reading it from the request
         // context per lookup is fragile across executor hops (eng-floe/floecat#361).
-        Optional<GraphNode> resolved = overlay.resolve(id, resolutionContext.engineContext());
+        Optional<GraphNode> resolved =
+            awaitCancellableMetadataLookup(
+                () -> overlay.resolve(id, resolutionContext.engineContext()));
         nodeResolutionCache.put(id, resolved);
         nodeResolutionCacheMisses++;
         return resolved;

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1810,8 +1810,18 @@ public class UserObjectBundleService {
           toRelease = pendingChunkPins;
           pendingChunkPins = RelationPinSet.getDefaultInstance();
         }
+        boolean publishIdleCancellation;
         synchronized (producerStateLock) {
           cancellationTelemetryPending = true;
+          publishIdleCancellation = !producerActive;
+          if (publishIdleCancellation) {
+            cancellationTelemetryPending = false;
+          }
+        }
+        if (publishIdleCancellation) {
+          // No producer is mutating diagnostics or caches, but the RPC span may end as soon as
+          // this termination callback returns. Emit while it is still recording.
+          publishCancellationTelemetry();
         }
         // onTermination may run on a transport/event-loop thread. Root release can perform store
         // I/O, so teardown runs on a managed executor. Telemetry is published only after the
@@ -1828,7 +1838,6 @@ public class UserObjectBundleService {
                       "Failed to release cancelled stream pin roots query_id=%s",
                       ctx.getQueryId());
                 }
-                publishCancellationTelemetryIfIdle();
               });
         } catch (RejectedExecutionException shutdown) {
           LOG.warnf(
@@ -1856,16 +1865,6 @@ public class UserObjectBundleService {
       if (publishCancellation) {
         publishCancellationTelemetry();
       }
-    }
-
-    private void publishCancellationTelemetryIfIdle() {
-      synchronized (producerStateLock) {
-        if (producerActive || !cancellationTelemetryPending) {
-          return;
-        }
-        cancellationTelemetryPending = false;
-      }
-      publishCancellationTelemetry();
     }
 
     private void publishCancellationTelemetry() {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -59,6 +59,7 @@ import ai.floedb.floecat.scanner.spi.MetadataResolutionContext;
 import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.concurrent.CancellableCallRunner;
+import ai.floedb.floecat.service.concurrent.MetadataIoExecutors;
 import ai.floedb.floecat.service.context.EngineContextProvider;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.PinValidator;
@@ -96,7 +97,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -105,11 +105,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -128,12 +125,94 @@ public class UserObjectBundleService {
   private static final int METADATA_LOOKUP_POOL_SIZE = MAX_CONCURRENT_METADATA_LOOKUPS;
   private static final int METADATA_LOOKUP_QUEUE_CAPACITY = METADATA_LOOKUP_POOL_SIZE;
   private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
+  private static final BooleanSupplier NEVER_CANCELLED = () -> false;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
-  private static final AtomicInteger METADATA_LOOKUP_THREAD_SEQUENCE = new AtomicInteger();
+  private static final CancellableCallRunner.FailureMessages METADATA_LOOKUP_FAILURES =
+      new CancellableCallRunner.FailureMessages(
+          "GetUserObjects stream cancelled", "GetUserObjects metadata lookup interrupted");
 
   private static void throwIfCancelled(BooleanSupplier cancelled) {
     if (cancelled.getAsBoolean()) {
       throw new CancellationException("GetUserObjects stream cancelled");
+    }
+  }
+
+  /** Arbitrates the single terminal telemetry outcome against producer activity. */
+  static final class StreamTelemetryGate {
+    /** The terminal outcome whose sole telemetry publication a gate transition may grant. */
+    enum Publication {
+      NONE,
+      COMPLETION,
+      FAILURE,
+      CANCELLATION
+    }
+
+    /** Whether this cancellation is duplicate, owns teardown, or also publishes immediately. */
+    enum CancellationDecision {
+      IGNORED,
+      ACCEPTED,
+      PUBLISH
+    }
+
+    private boolean producerActive;
+    private boolean cancellationPending;
+    private boolean publicationClaimed;
+
+    /** Begin one producer step unless cancellation already won. */
+    synchronized void begin(BooleanSupplier cancelled) {
+      throwIfCancelled(cancelled);
+      producerActive = true;
+    }
+
+    /**
+     * Atomically expose cancellation to request work and terminal-outcome arbitration. The caller
+     * owns teardown unless another cancellation already won.
+     */
+    synchronized CancellationDecision cancel(AtomicBoolean cancelled) {
+      if (!cancelled.compareAndSet(false, true)) {
+        return CancellationDecision.IGNORED;
+      }
+      cancellationPending = true;
+      if (producerActive) {
+        return CancellationDecision.ACCEPTED;
+      }
+      cancellationPending = false;
+      return claimInternal() ? CancellationDecision.PUBLISH : CancellationDecision.ACCEPTED;
+    }
+
+    /**
+     * Finish a producer step with {@link Publication#NONE}, {@link Publication#COMPLETION}, or
+     * {@link Publication#FAILURE}. Failure takes precedence over racing cancellation, and
+     * cancellation takes precedence over completion. A non-{@code NONE} return grants ownership of
+     * the stream's sole terminal telemetry publication.
+     */
+    synchronized Publication finish(Publication terminalOutcome) {
+      boolean publishFailure = terminalOutcome == Publication.FAILURE && claimInternal();
+      producerActive = false;
+      boolean publishCancellation = !publishFailure && cancellationPending && claimInternal();
+      cancellationPending = false;
+      if (publishFailure) {
+        return Publication.FAILURE;
+      }
+      if (publishCancellation) {
+        return Publication.CANCELLATION;
+      }
+      return terminalOutcome == Publication.COMPLETION && claimInternal()
+          ? Publication.COMPLETION
+          : Publication.NONE;
+    }
+
+    /** Claim publication from a non-racing terminal path. */
+    synchronized boolean claim() {
+      return claimInternal();
+    }
+
+    private boolean claimInternal() {
+      if (publicationClaimed) {
+        return false;
+      }
+      publicationClaimed = true;
+      return true;
     }
   }
 
@@ -169,36 +248,23 @@ public class UserObjectBundleService {
   // Holds capacity until the actual overlay call exits, including after its stream subscriber has
   // cancelled. This bounds interruption-insensitive repository calls across all active streams.
   private final Semaphore metadataLookupPermits =
-      new Semaphore(MAX_CONCURRENT_METADATA_LOOKUPS, true /* FIFO across streams */);
+      new Semaphore(MAX_CONCURRENT_METADATA_LOOKUPS, true /* best-effort stream fairness */);
 
+  /** Create the bounded platform-worker pool used for potentially carrier-pinning store calls. */
   private static ExecutorService newMetadataLookupExecutor() {
     if (MAX_CONCURRENT_METADATA_LOOKUPS > METADATA_LOOKUP_POOL_SIZE) {
       throw new IllegalStateException(
           "bundle metadata admission must not exceed metadata lookup worker capacity");
     }
-    return new ThreadPoolExecutor(
-        METADATA_LOOKUP_POOL_SIZE,
-        METADATA_LOOKUP_POOL_SIZE,
-        0L,
-        TimeUnit.MILLISECONDS,
-        new ArrayBlockingQueue<>(METADATA_LOOKUP_QUEUE_CAPACITY),
-        daemonMetadataLookupThreadFactory(),
-        new ThreadPoolExecutor.AbortPolicy());
-  }
-
-  private static ThreadFactory daemonMetadataLookupThreadFactory() {
-    return runnable -> {
-      Thread thread =
-          new Thread(
-              runnable,
-              "floecat-bundle-metadata-" + METADATA_LOOKUP_THREAD_SEQUENCE.incrementAndGet());
-      thread.setDaemon(true);
-      return thread;
-    };
+    return MetadataIoExecutors.newBoundedDaemonPool(
+        METADATA_LOOKUP_POOL_SIZE, METADATA_LOOKUP_QUEUE_CAPACITY, "floecat-bundle-metadata-");
   }
 
   @Inject Observability observability;
 
+  /**
+   * Stop both owned executors while bounding teardown if a downstream call ignores interruption.
+   */
   @PreDestroy
   void closeExecutors() {
     shutdownExecutor(metadataLookupExecutor);
@@ -207,11 +273,9 @@ public class UserObjectBundleService {
 
   /** Bound bean destruction even if a store call ignores interruption during shutdown. */
   private static void shutdownExecutor(ExecutorService executor) {
-    CancellableCallRunner.cancelDiscardedTasks(executor.shutdownNow());
-    try {
-      executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
+    if (!MetadataIoExecutors.shutdownNowAndAwait(
+        executor, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      LOG.warn("bundle executor did not terminate before shutdown timeout");
     }
   }
 
@@ -433,6 +497,11 @@ public class UserObjectBundleService {
     }
   }
 
+  /**
+   * Resolve canonical inputs for one chunk and transfer transient-root ownership to the iterator.
+   * Cancellation after resolution releases the returned pins before propagating instead of leaving
+   * an uncommitted root behind.
+   */
   private RelationPinSet collectChunkPins(
       String correlationId,
       QueryContext ctx,
@@ -607,7 +676,24 @@ public class UserObjectBundleService {
           + decorateColumnsNanos
           + decorateCompleteNanos;
     }
+
+    /** Merge one completed build task's isolated timings on the stream producer thread. */
+    private void addFrom(TimingAccumulator other) {
+      statsLookupNanos += other.statsLookupNanos;
+      decorateRelationNanos += other.decorateRelationNanos;
+      decorateViewNanos += other.decorateViewNanos;
+      decorateColumnsNanos += other.decorateColumnsNanos;
+      decorateColumnInvokeNanos += other.decorateColumnInvokeNanos;
+      decorateCompleteNanos += other.decorateCompleteNanos;
+      decoratePersistRelationNanos += other.decoratePersistRelationNanos;
+      decoratePersistColumnsNanos += other.decoratePersistColumnsNanos;
+      decorateColumnWarmHits += other.decorateColumnWarmHits;
+    }
   }
+
+  /** One relation payload and the task-local timing measurements produced while building it. */
+  private record BuiltRelation(
+      RelationInfo info, boolean identityOnly, long buildNanos, TimingAccumulator timings) {}
 
   /**
    * True when the payload built for this candidate carries the relation's complete column set (no
@@ -845,7 +931,8 @@ public class UserObjectBundleService {
       Optional<RelationPinIdentity> scopedIdentity,
       StatsProvider statsProvider,
       Set<String> knownBlobVersions,
-      TimingAccumulator timings) {
+      TimingAccumulator timings,
+      BooleanSupplier cancelled) {
     // The token is the engine-scoped payload token (scopedIdentity), not the bare content version,
     // so a client that proved possession under a different engine cannot be served identity-only.
     // A blank version can never prove possession: a user table whose definition blob had no etag
@@ -866,6 +953,7 @@ public class UserObjectBundleService {
     long statsLookupStartNs = System.nanoTime();
     attachTableStats(slim, relation.relationId(), statsProvider);
     timings.addStatsLookupNanos(System.nanoTime() - statsLookupStartNs);
+    throwIfCancelled(cancelled);
     return slim.build();
   }
 
@@ -902,7 +990,9 @@ public class UserObjectBundleService {
       MetadataResolutionContext resolutionContext,
       StatsProvider statsProvider,
       TimingAccumulator timings,
-      Optional<RelationPinIdentity> scopedIdentity) {
+      Optional<RelationPinIdentity> scopedIdentity,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
     if (LOG.isTraceEnabled()) {
       LOG.tracef(
           "Building relation bundle query_id=%s relation=%s kind=%s origin=%s",
@@ -931,6 +1021,7 @@ public class UserObjectBundleService {
 
     List<ColumnInfo> columns =
         UserObjectBundleUtils.columnsFor(schemaColumns, pruned, origin, correlationId);
+    throwIfCancelled(cancelled);
 
     RelationInfo.Builder builder = baseRelationInfo(relation);
 
@@ -957,6 +1048,7 @@ public class UserObjectBundleService {
     long statsLookupStartNs = System.nanoTime();
     attachTableStats(builder, relation.relationId(), statsProvider);
     timings.addStatsLookupNanos(System.nanoTime() - statsLookupStartNs);
+    throwIfCancelled(cancelled);
 
     // If this is a view, keep a mutable builder around for decoration.
     ViewDefinition.Builder viewBuilder = null;
@@ -993,12 +1085,14 @@ public class UserObjectBundleService {
               resolutionContext);
 
       try {
+        throwIfCancelled(cancelled);
         long decorateRelationStartNs = System.nanoTime();
         try {
           decorator.get().decorateRelation(ctx, relationDecoration);
         } finally {
           timings.addDecorateRelationNanos(System.nanoTime() - decorateRelationStartNs);
         }
+        throwIfCancelled(cancelled);
       } catch (CancellationException e) {
         throw e;
       } catch (RuntimeException e) {
@@ -1020,12 +1114,14 @@ public class UserObjectBundleService {
                 builder, viewBuilder, relation.relationId(), relation.node(), resolutionContext);
 
         try {
+          throwIfCancelled(cancelled);
           long decorateViewStartNs = System.nanoTime();
           try {
             decorator.get().decorateView(ctx, viewDecoration);
           } finally {
             timings.addDecorateViewNanos(System.nanoTime() - decorateViewStartNs);
           }
+          throwIfCancelled(cancelled);
         } catch (CancellationException e) {
           throw e;
         } catch (RuntimeException e) {
@@ -1048,7 +1144,9 @@ public class UserObjectBundleService {
             ctx,
             decorationRequired,
             relation.relationId(),
-            timings);
+            timings,
+            cancelled);
+    throwIfCancelled(cancelled);
     long relationWarmHitCount = decorationCounter(relationDecoration, COLUMN_WARM_HIT_COUNT_KEY);
     timings.addDecorateColumnWarmHits(relationWarmHitCount);
 
@@ -1068,6 +1166,7 @@ public class UserObjectBundleService {
             readyColumnIds.size());
       }
       try {
+        throwIfCancelled(cancelled);
         long decorateCompleteStartNs = System.nanoTime();
         try {
           decorator
@@ -1081,6 +1180,7 @@ public class UserObjectBundleService {
           timings.addDecoratePersistColumnsNanos(
               decorationTimingNanos(relationDecoration, COLUMN_HINT_PERSIST_NANOS_KEY));
         }
+        throwIfCancelled(cancelled);
       } catch (CancellationException e) {
         throw e;
       } catch (RuntimeException e) {
@@ -1219,7 +1319,8 @@ public class UserObjectBundleService {
         ctx,
         decorationRequired,
         relationId,
-        new TimingAccumulator());
+        new TimingAccumulator(),
+        NEVER_CANCELLED);
   }
 
   private List<ColumnResult> decorateColumns(
@@ -1230,7 +1331,8 @@ public class UserObjectBundleService {
       EngineContext ctx,
       boolean decorationRequired,
       ResourceId relationId,
-      TimingAccumulator timings) {
+      TimingAccumulator timings,
+      BooleanSupplier cancelled) {
 
     if (pruned == null || pruned.size() != columns.size()) {
       String msg =
@@ -1281,6 +1383,7 @@ public class UserObjectBundleService {
 
     List<ColumnResult> decorated = new ArrayList<>(columns.size());
     for (int i = 0; i < columns.size(); i++) {
+      throwIfCancelled(cancelled);
       long decorateColumnTotalStartNs = System.nanoTime();
       ColumnInfo column = columns.get(i);
       SchemaColumn schema = pruned.get(i);
@@ -1296,6 +1399,7 @@ public class UserObjectBundleService {
         } finally {
           timings.addDecorateColumnInvokeNanos(System.nanoTime() - decorateColumnInvokeStartNs);
         }
+        throwIfCancelled(cancelled);
         ColumnInfo decoratedColumn = columnDecoration.builder().build();
         if (hasRequiredEnginePayload(decoratedColumn, ctx)) {
           decorated.add(readyColumn(decoratedColumn));
@@ -1713,11 +1817,9 @@ public class UserObjectBundleService {
     // after its cleanup pass. Store I/O always happens outside this lock.
     private final Object pendingChunkPinsLock = new Object();
     private RelationPinSet pendingChunkPins = RelationPinSet.getDefaultInstance();
-    // Serializes the producer's mutable iterator state with cancellation telemetry. A teardown
-    // task may publish only after the active next() call has finished mutating diagnostics/caches.
-    private final Object producerStateLock = new Object();
-    private boolean producerActive;
-    private boolean cancellationTelemetryPending;
+    // A teardown may publish only after the active next() call has finished mutating iterator
+    // diagnostics and caches; a real failure wins when cancellation races that final step.
+    private final StreamTelemetryGate telemetryGate = new StreamTelemetryGate();
 
     private int seq = 1;
     private int nextInputIndex = 0;
@@ -1726,7 +1828,6 @@ public class UserObjectBundleService {
     private int emittedResolutionChunks = 0;
     private boolean headerEmitted = false;
     private boolean endEmitted = false;
-    private final AtomicBoolean telemetryPublished = new AtomicBoolean(false);
     private final AtomicBoolean cancelled = new AtomicBoolean(false);
     private boolean defaultCatalogResolved = false;
     private String defaultCatalogName = "";
@@ -1785,7 +1886,7 @@ public class UserObjectBundleService {
     @Override
     public UserObjectsBundleChunk next() {
       beginProducerStep();
-      String terminalOutcome = null;
+      StreamTelemetryGate.Publication terminalOutcome = StreamTelemetryGate.Publication.NONE;
       try {
         if (!headerEmitted) {
           headerEmitted = true;
@@ -1805,7 +1906,7 @@ public class UserObjectBundleService {
 
         if (!endEmitted) {
           endEmitted = true;
-          publishStreamTelemetry("completed");
+          terminalOutcome = StreamTelemetryGate.Publication.COMPLETION;
           if (LOG.isDebugEnabled()) {
             LOG.debugf(
                 "Emitting end chunk query_id=%s seq=%d resolutions=%d found=%d not_found=%d",
@@ -1817,7 +1918,7 @@ public class UserObjectBundleService {
         throw new NoSuchElementException();
       } catch (RuntimeException | Error failure) {
         if (!(failure instanceof CancellationException)) {
-          terminalOutcome = "failed";
+          terminalOutcome = StreamTelemetryGate.Publication.FAILURE;
         }
         throw failure;
       } finally {
@@ -1879,38 +1980,42 @@ public class UserObjectBundleService {
     }
 
     /**
-     * Runs one repository-backed overlay lookup away from the stream producer and returns promptly
-     * when the subscriber cancels, even if the downstream client ignores interruption.
+     * Runs one repository-backed overlay lookup according to the overlay's concurrency contract.
+     * Concurrent overlays use bounded off-thread I/O and return promptly when the subscriber
+     * cancels. An overlay that opts out stays on the producer thread because it may own
+     * thread-confined state; cancellation is then observed immediately before and after its call.
      */
     private <T> T awaitCancellableMetadataLookup(Supplier<T> lookup) {
+      if (!overlay.supportsConcurrentResolution()) {
+        throwIfCancelled(this::isCancelled);
+        T result = lookup.get();
+        throwIfCancelled(this::isCancelled);
+        return result;
+      }
       return CancellableCallRunner.call(
           metadataLookupExecutor,
           metadataLookupPermits,
           this::isCancelled,
           lookup,
-          "GetUserObjects stream cancelled",
-          "GetUserObjects metadata lookup interrupted");
+          METADATA_LOOKUP_FAILURES);
     }
 
+    /**
+     * Mark the iterator cancelled, detach pending pins, publish only stable telemetry, and offload
+     * root release so a transport/event-loop termination callback never performs store I/O.
+     */
     private void cancel() {
-      if (cancelled.compareAndSet(false, true)) {
+      StreamTelemetryGate.CancellationDecision cancellation = telemetryGate.cancel(cancelled);
+      if (cancellation != StreamTelemetryGate.CancellationDecision.IGNORED) {
         RelationPinSet toRelease;
         synchronized (pendingChunkPinsLock) {
           toRelease = pendingChunkPins;
           pendingChunkPins = RelationPinSet.getDefaultInstance();
         }
-        boolean publishIdleCancellation;
-        synchronized (producerStateLock) {
-          cancellationTelemetryPending = true;
-          publishIdleCancellation = !producerActive;
-          if (publishIdleCancellation) {
-            cancellationTelemetryPending = false;
-          }
-        }
-        if (publishIdleCancellation) {
+        if (cancellation == StreamTelemetryGate.CancellationDecision.PUBLISH) {
           // No producer is mutating diagnostics or caches, but the RPC span may end as soon as
           // this termination callback returns. Emit while it is still recording.
-          publishCancellationTelemetry();
+          publishClaimedTelemetrySafely("cancelled");
         }
         // onTermination may run on a transport/event-loop thread. Root release can perform store
         // I/O, so teardown runs on a managed executor. Telemetry is published only after the
@@ -1937,34 +2042,72 @@ public class UserObjectBundleService {
       }
     }
 
+    /** Claim mutable iterator state for one producer step unless cancellation already won. */
     private void beginProducerStep() {
-      synchronized (producerStateLock) {
-        throwIfCancelled(this::isCancelled);
-        producerActive = true;
+      telemetryGate.begin(this::isCancelled);
+    }
+
+    /**
+     * Release producer ownership and publish exactly one terminal outcome, giving a real failure
+     * precedence over cancellation that raced the active step.
+     */
+    private void finishProducerStep(StreamTelemetryGate.Publication terminalOutcome) {
+      StreamTelemetryGate.Publication publication = telemetryGate.finish(terminalOutcome);
+      switch (publication) {
+        case COMPLETION -> publishClaimedTelemetrySafely("completed");
+        case FAILURE -> publishClaimedTelemetrySafely("failed");
+        case CANCELLATION -> publishClaimedTelemetrySafely("cancelled");
+        case NONE -> {}
       }
     }
 
-    private void finishProducerStep(String terminalOutcome) {
-      boolean publishCancellation;
-      synchronized (producerStateLock) {
-        producerActive = false;
-        publishCancellation = terminalOutcome == null && cancellationTelemetryPending;
-        cancellationTelemetryPending = false;
-      }
-      if (terminalOutcome != null) {
-        publishStreamTelemetry(terminalOutcome);
-      } else if (publishCancellation) {
-        publishCancellationTelemetry();
-      }
+    /**
+     * Build one relation on bounded platform I/O capacity. The task owns its timing accumulator so
+     * an interruption-insensitive call cannot mutate iterator telemetry after cancellation returns.
+     */
+    private BuiltRelation buildRelationCancellably(
+        PendingFound found,
+        QueryContext liveContext,
+        Optional<RelationPinIdentity> scopedIdentity) {
+      return awaitCancellableMetadataLookup(
+          () -> {
+            TimingAccumulator taskTimings = new TimingAccumulator();
+            long buildStartNs = System.nanoTime();
+            RelationInfo identityOnly =
+                identityOnlyOrNull(
+                    found.relation(),
+                    scopedIdentity,
+                    statsProvider,
+                    knownBlobVersions,
+                    taskTimings,
+                    this::isCancelled);
+            if (identityOnly != null) {
+              return new BuiltRelation(
+                  identityOnly, true, System.nanoTime() - buildStartNs, taskTimings);
+            }
+            RelationInfo full =
+                buildRelation(
+                    correlationId,
+                    found.relation(),
+                    liveContext,
+                    resolutionContext,
+                    statsProvider,
+                    taskTimings,
+                    scopedIdentity,
+                    this::isCancelled);
+            return new BuiltRelation(full, false, System.nanoTime() - buildStartNs, taskTimings);
+          });
     }
 
-    private void publishCancellationTelemetry() {
+    /** Publish a claimed outcome without allowing telemetry failure to mask stream termination. */
+    private void publishClaimedTelemetrySafely(String outcome) {
       try {
-        publishStreamTelemetry("cancelled");
+        publishClaimedStreamTelemetry(outcome);
       } catch (RuntimeException telemetryFailure) {
         LOG.warnf(
             telemetryFailure,
-            "Failed to publish cancelled stream telemetry query_id=%s",
+            "Failed to publish %s stream telemetry query_id=%s",
+            outcome,
             ctx.getQueryId());
       }
     }
@@ -2143,9 +2286,6 @@ public class UserObjectBundleService {
                   .build());
           continue;
         }
-        long statsBeforeNanos = timings.statsLookupNanos();
-        long decorationBeforeNanos = timings.decorationTotalNanos();
-        long buildStartNs = System.nanoTime();
         if (liveCtx == null) {
           liveCtx = queryStore.get(ctx.getQueryId()).orElse(ctx);
         }
@@ -2158,47 +2298,31 @@ public class UserObjectBundleService {
         Optional<RelationPinIdentity> scopedIdentity =
             scopedPinIdentity(
                 correlationId, found.relation(), liveCtx, resolutionContext.engineContext());
-        /* Identity-only fast path: never cached — the info cache must only
-         * ever hold full payloads, or a later request that did NOT prove
-         * possession would be served a payload-less relation. */
-        RelationInfo slim =
-            identityOnlyOrNull(
-                found.relation(), scopedIdentity, statsProvider, knownBlobVersions, timings);
-        if (slim != null) {
-          // Account the slim path symmetric with the full path below: its stats time already landed
-          // in timings via identityOnlyOrNull; fold the remaining (identity-build) time into
-          // relationBuildNanos so identity-only resolutions are not invisible to the summary event.
-          long buildNanos = System.nanoTime() - buildStartNs;
-          long statsDeltaNanos = timings.statsLookupNanos() - statsBeforeNanos;
-          relationBuildNanos += Math.max(0L, buildNanos - statsDeltaNanos);
+        BuiltRelation built = buildRelationCancellably(found, liveCtx, scopedIdentity);
+        TimingAccumulator buildTimings = built.timings();
+        timings.addFrom(buildTimings);
+        long statsNanos = buildTimings.statsLookupNanos();
+        long buildDecorationNanos = buildTimings.decorationTotalNanos();
+        if (built.identityOnly()) {
+          // Identity-only responses are not cached: the cache must hold full payloads for later
+          // requests that did not prove possession.
+          relationBuildNanos += Math.max(0L, built.buildNanos() - statsNanos);
           resolutions.add(
               RelationResolution.newBuilder()
                   .setInputIndex(found.inputIndex())
                   .setStatus(ResolutionStatus.RESOLUTION_STATUS_FOUND)
-                  .setRelation(slim)
+                  .setRelation(built.info())
                   .build());
           continue;
         }
-        RelationInfo info =
-            buildRelation(
-                correlationId,
-                found.relation(),
-                liveCtx,
-                resolutionContext,
-                statsProvider,
-                timings,
-                scopedIdentity);
-        long buildNanos = System.nanoTime() - buildStartNs;
-        long statsDeltaNanos = timings.statsLookupNanos() - statsBeforeNanos;
-        long decorationDeltaNanos = timings.decorationTotalNanos() - decorationBeforeNanos;
-        relationBuildNanos += Math.max(0L, buildNanos - statsDeltaNanos - decorationDeltaNanos);
-        decorationNanos += Math.max(0L, decorationDeltaNanos);
-        relationInfoCache.put(cacheKey, info);
+        relationBuildNanos += Math.max(0L, built.buildNanos() - statsNanos - buildDecorationNanos);
+        decorationNanos += Math.max(0L, buildDecorationNanos);
+        relationInfoCache.put(cacheKey, built.info());
         resolutions.add(
             RelationResolution.newBuilder()
                 .setInputIndex(found.inputIndex())
                 .setStatus(ResolutionStatus.RESOLUTION_STATUS_FOUND)
-                .setRelation(info)
+                .setRelation(built.info())
                 .build());
       }
       emittedResolutionChunks++;
@@ -2222,9 +2346,14 @@ public class UserObjectBundleService {
     }
 
     private void publishStreamTelemetry(String outcome) {
-      if (!telemetryPublished.compareAndSet(false, true)) {
+      if (!telemetryGate.claim()) {
         return;
       }
+      publishClaimedStreamTelemetry(outcome);
+    }
+
+    /** Publish after the telemetry gate has atomically selected this terminal outcome. */
+    private void publishClaimedStreamTelemetry(String outcome) {
       long totalNanos = System.nanoTime() - streamStartNs;
       long schedulingNanos =
           Math.max(
@@ -2519,7 +2648,7 @@ public class UserObjectBundleService {
       }
     }
 
-    // Track every pin that must be durable before the next chunk is emitted.
+    /** Merge pins into pending commit ownership unless cancellation already detached that state. */
     private boolean accumulateChunkPins(RelationPinSet incomingPins) {
       if (incomingPins == null || incomingPins.getPinsCount() == 0) {
         return true;
@@ -2533,6 +2662,11 @@ public class UserObjectBundleService {
       }
     }
 
+    /**
+     * Atomically detach pending pins, commit them as durable query roots, and release their
+     * transient roots on every failed or missing-context outcome. Store I/O runs outside the
+     * cancellation lock so termination cannot block behind the update.
+     */
     private void commitChunkPins() {
       RelationPinSet toCommit;
       synchronized (pendingChunkPinsLock) {
@@ -2558,7 +2692,7 @@ public class UserObjectBundleService {
             queryStore.update(
                 ctx.getQueryId(), existing -> mergeRelationPins(existing, toCommit, correlationId));
       } catch (RuntimeException | Error e) {
-        finishFailedPinCommit(toCommit);
+        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
         throw e;
       }
       if (updated.isEmpty()) {
@@ -2571,10 +2705,6 @@ public class UserObjectBundleService {
       if (LOG.isDebugEnabled()) {
         LOG.debugf("Committed chunk pins query_id=%s", ctx.getQueryId());
       }
-    }
-
-    private void finishFailedPinCommit(RelationPinSet toCommit) {
-      queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
     }
 
     private int pendingChunkPinCount() {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -60,6 +60,7 @@ import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.concurrent.CancellableCallRunner;
 import ai.floedb.floecat.service.concurrent.MetadataIoExecutors;
+import ai.floedb.floecat.service.concurrent.MetadataIoRunner;
 import ai.floedb.floecat.service.context.EngineContextProvider;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.PinValidator;
@@ -219,6 +220,7 @@ public class UserObjectBundleService {
 
   private final CatalogOverlay overlay;
   private final QueryInputResolver inputResolver;
+  private final MetadataIoRunner metadataIoRunner;
   private final QueryContextStore queryStore;
   private final EngineMetadataDecoratorProvider decoratorProvider;
   private final EngineContextProvider engineContext;
@@ -283,6 +285,7 @@ public class UserObjectBundleService {
   public UserObjectBundleService(
       CatalogOverlay overlay,
       QueryInputResolver inputResolver,
+      MetadataIoRunner metadataIoRunner,
       QueryContextStore queryStore,
       StatsProviderFactory statsFactory,
       EngineMetadataDecoratorProvider decoratorProvider,
@@ -301,6 +304,7 @@ public class UserObjectBundleService {
       @ConfigProperty(name = "floecat.rpc.log.slow-ms", defaultValue = "250") long slowRpcMs) {
     this.overlay = overlay;
     this.inputResolver = inputResolver;
+    this.metadataIoRunner = metadataIoRunner;
     this.queryStore = queryStore;
     this.statsFactory = statsFactory;
     this.decoratorProvider = decoratorProvider;
@@ -316,6 +320,40 @@ public class UserObjectBundleService {
             .setTls(!grpcPlainText)
             .build();
     warnFlightHost(flightHost, quarkusProfile);
+  }
+
+  /** Constructor preserving the public direct-construction API. */
+  public UserObjectBundleService(
+      CatalogOverlay overlay,
+      QueryInputResolver inputResolver,
+      QueryContextStore queryStore,
+      StatsProviderFactory statsFactory,
+      EngineMetadataDecoratorProvider decoratorProvider,
+      EngineContextProvider engineContext,
+      PinValidator pinValidator,
+      boolean engineSpecificEnabled,
+      String decorationEpoch,
+      String flightHost,
+      int flightPort,
+      boolean grpcPlainText,
+      String quarkusProfile,
+      long slowRpcMs) {
+    this(
+        overlay,
+        inputResolver,
+        new MetadataIoRunner(),
+        queryStore,
+        statsFactory,
+        decoratorProvider,
+        engineContext,
+        pinValidator,
+        engineSpecificEnabled,
+        decorationEpoch,
+        flightHost,
+        flightPort,
+        grpcPlainText,
+        quarkusProfile,
+        slowRpcMs);
   }
 
   UserObjectBundleService(
@@ -335,6 +373,7 @@ public class UserObjectBundleService {
     this(
         overlay,
         inputResolver,
+        new MetadataIoRunner(),
         queryStore,
         statsFactory,
         decoratorProvider,
@@ -1959,12 +1998,10 @@ public class UserObjectBundleService {
      */
     private <T> T awaitCancellableMetadataLookup(Supplier<T> lookup) {
       if (!overlay.supportsConcurrentResolution()) {
-        throwIfCancelled(this::isCancelled);
-        T result = lookup.get();
-        throwIfCancelled(this::isCancelled);
-        return result;
+        return metadataIoRunner.callOnCallerThread(
+            this::isCancelled, lookup, METADATA_LOOKUP_FAILURES);
       }
-      return inputResolver.runMetadataIo(this::isCancelled, lookup, METADATA_LOOKUP_FAILURES);
+      return metadataIoRunner.call(this::isCancelled, lookup, METADATA_LOOKUP_FAILURES);
     }
 
     /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1720,10 +1720,13 @@ public class UserObjectBundleService {
     }
 
     private void fillPending() {
+      throwIfCancelled(this::isCancelled);
       List<ResolvedRelation> toPin = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
       drainEagerBaseTables(toPin);
       while (nextInputIndex < resolutionCount && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
+        throwIfCancelled(this::isCancelled);
         PendingItem item = resolveNextResolution();
+        throwIfCancelled(this::isCancelled);
         pending.add(item);
         if (item instanceof PendingFound found) {
           toPin.add(found.relation());
@@ -1771,8 +1774,12 @@ public class UserObjectBundleService {
     }
 
     private void cancel() {
-      cancelled.set(true);
-      publishStreamTelemetry("cancelled");
+      if (cancelled.compareAndSet(false, true)) {
+        RelationPinSet toRelease = pendingChunkPins;
+        pendingChunkPins = RelationPinSet.getDefaultInstance();
+        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toRelease));
+        publishStreamTelemetry("cancelled");
+      }
     }
 
     /**
@@ -1786,6 +1793,7 @@ public class UserObjectBundleService {
      */
     private void drainEagerBaseTables(List<ResolvedRelation> toPin) {
       while (pending.size() < MAX_RESOLUTIONS_PER_CHUNK && !eagerBaseQueue.isEmpty()) {
+        throwIfCancelled(this::isCancelled);
         EagerBaseCursor cursor = eagerBaseQueue.peekFirst();
         if (cursor == null) {
           break;
@@ -1800,6 +1808,7 @@ public class UserObjectBundleService {
       List<NameRef> baseRelations = cursor.view.baseRelations();
       while (cursor.nextBaseIndex < baseRelations.size()
           && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
+        throwIfCancelled(this::isCancelled);
         NameRef baseRef = baseRelations.get(cursor.nextBaseIndex++);
         long resolveStartNs = System.nanoTime();
         try {
@@ -1835,6 +1844,7 @@ public class UserObjectBundleService {
     }
 
     private PendingItem resolveNextResolution() {
+      throwIfCancelled(this::isCancelled);
       long resolveStartNs = System.nanoTime();
       try {
         TableReferenceCandidate candidate = tables.get(nextInputIndex);
@@ -1912,6 +1922,7 @@ public class UserObjectBundleService {
     }
 
     private UserObjectsBundleChunk flushResolutionChunk() {
+      throwIfCancelled(this::isCancelled);
       List<PendingItem> chunkItems = new ArrayList<>(pending);
       pending.clear();
       if (LOG.isDebugEnabled()) {
@@ -1921,12 +1932,14 @@ public class UserObjectBundleService {
       }
       // Ensure pins are durable before accessing stats (which expect the QueryContext to be
       // pinned).
+      throwIfCancelled(this::isCancelled);
       long pinCommitStartNs = System.nanoTime();
       commitChunkPins();
       pinCommitNanos += System.nanoTime() - pinCommitStartNs;
       QueryContext liveCtx = null;
       List<RelationResolution> resolutions = new ArrayList<>(chunkItems.size());
       for (PendingItem item : chunkItems) {
+        throwIfCancelled(this::isCancelled);
         if (item instanceof PendingResolved resolved) {
           resolutions.add(resolved.resolution());
           continue;

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -163,7 +163,7 @@ public class UserObjectBundleService {
   @Inject Observability observability;
 
   @PreDestroy
-  void closeCancellationTeardownExecutor() {
+  void closeExecutors() {
     metadataLookupExecutor.shutdownNow();
     cancellationTeardownExecutor.close();
   }

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -94,7 +94,9 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -348,7 +350,7 @@ public class UserObjectBundleService {
       String correlationId,
       QueryContext ctx,
       List<ResolvedRelation> relations,
-      Map<ResourceId, TablePin> currentSnapshotPinCache,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
     if (relations == null || relations.isEmpty()) {
       return RelationPinSet.getDefaultInstance();
@@ -1592,7 +1594,8 @@ public class UserObjectBundleService {
     private final ArrayDeque<EagerBaseCursor> eagerBaseQueue = new ArrayDeque<>();
     private final Set<String> eagerBaseSeen = new HashSet<>();
     private final Map<RelationCacheKey, RelationInfo> relationInfoCache = new HashMap<>();
-    private final Map<ResourceId, TablePin> currentSnapshotPinCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache =
+        new ConcurrentHashMap<>();
     private final TimingAccumulator timings = new TimingAccumulator();
     private final PhaseDiagnostics diagnostics = diagnostics("get_user_objects");
     private final long streamStartNs = System.nanoTime();

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1621,6 +1621,10 @@ public class UserObjectBundleService {
     private final PhaseDiagnostics diagnostics = diagnostics("get_user_objects");
     private final long streamStartNs = System.nanoTime();
     private final Span parentSpan = Span.current();
+    // Coordinates the resolving-root handoff. Cancellation can arrive on a different thread than
+    // chunk production, so it must neither release pins being committed nor miss pins accumulated
+    // after its cleanup pass.
+    private final Object pendingChunkPinsLock = new Object();
     private RelationPinSet pendingChunkPins = RelationPinSet.getDefaultInstance();
 
     private int seq = 1;
@@ -1752,8 +1756,7 @@ public class UserObjectBundleService {
             throwIfCancelled(this::isCancelled);
             long accumulateStartNs = System.nanoTime();
             try {
-              accumulateChunkPins(chunkPins);
-              pinsAccumulated = true;
+              pinsAccumulated = accumulateChunkPins(chunkPins);
             } finally {
               diagnostics.nanos("pin.accumulate", System.nanoTime() - accumulateStartNs);
             }
@@ -1775,8 +1778,11 @@ public class UserObjectBundleService {
 
     private void cancel() {
       if (cancelled.compareAndSet(false, true)) {
-        RelationPinSet toRelease = pendingChunkPins;
-        pendingChunkPins = RelationPinSet.getDefaultInstance();
+        RelationPinSet toRelease;
+        synchronized (pendingChunkPinsLock) {
+          toRelease = pendingChunkPins;
+          pendingChunkPins = RelationPinSet.getDefaultInstance();
+        }
         queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toRelease));
         publishStreamTelemetry("cancelled");
       }
@@ -1928,7 +1934,7 @@ public class UserObjectBundleService {
       if (LOG.isDebugEnabled()) {
         LOG.debugf(
             "Flushing resolution chunk query_id=%s seq=%d pending_items=%d pending_pins=%d",
-            ctx.getQueryId(), seq, chunkItems.size(), pendingChunkPins.getPinsCount());
+            ctx.getQueryId(), seq, chunkItems.size(), pendingChunkPinCount());
       }
       // Ensure pins are durable before accessing stats (which expect the QueryContext to be
       // pinned).
@@ -2329,44 +2335,61 @@ public class UserObjectBundleService {
     }
 
     // Track every pin that must be durable before the next chunk is emitted.
-    private void accumulateChunkPins(RelationPinSet incomingPins) {
+    private boolean accumulateChunkPins(RelationPinSet incomingPins) {
       if (incomingPins == null || incomingPins.getPinsCount() == 0) {
-        return;
+        return true;
       }
-      pendingChunkPins = QueryPins.mergeSets(pendingChunkPins, incomingPins, correlationId);
+      synchronized (pendingChunkPinsLock) {
+        if (isCancelled()) {
+          return false;
+        }
+        pendingChunkPins = QueryPins.mergeSets(pendingChunkPins, incomingPins, correlationId);
+        return true;
+      }
     }
 
     private void commitChunkPins() {
-      if (pendingChunkPins.getPinsCount() == 0) {
-        return;
-      }
-      if (LOG.isDebugEnabled()) {
-        LOG.debugf(
-            "Committing chunk pins query_id=%s pin_count=%d",
-            ctx.getQueryId(), pendingChunkPins.getPinsCount());
-      }
-      RelationPinSet toCommit = pendingChunkPins;
-      // The resolver registered these pins' blobs as transient GC roots at resolution, so they are
-      // protected across the collect→commit window; this update makes the context a durable root.
-      Optional<QueryContext> updated;
-      try {
-        updated =
-            queryStore.update(
-                ctx.getQueryId(), existing -> mergeRelationPins(existing, toCommit, correlationId));
-      } catch (RuntimeException | Error e) {
-        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
-        throw e;
-      }
-      pendingChunkPins = RelationPinSet.getDefaultInstance();
-      if (updated.isEmpty()) {
-        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
-        LOG.warnf(
-            "Failed to commit chunk pins query_id=%s query context missing", ctx.getQueryId());
-        throw GrpcErrors.notFound(
-            correlationId, QUERY_NOT_FOUND, Map.of("query_id", ctx.getQueryId()));
+      synchronized (pendingChunkPinsLock) {
+        throwIfCancelled(this::isCancelled);
+        if (pendingChunkPins.getPinsCount() == 0) {
+          return;
+        }
+        if (LOG.isDebugEnabled()) {
+          LOG.debugf(
+              "Committing chunk pins query_id=%s pin_count=%d",
+              ctx.getQueryId(), pendingChunkPins.getPinsCount());
+        }
+        RelationPinSet toCommit = pendingChunkPins;
+        // Keep the cancellation cleanup out of this handoff until update establishes the durable
+        // query-context root. Otherwise a concurrent cancel could reopen the blob-GC window.
+        Optional<QueryContext> updated;
+        try {
+          updated =
+              queryStore.update(
+                  ctx.getQueryId(),
+                  existing -> mergeRelationPins(existing, toCommit, correlationId));
+        } catch (RuntimeException | Error e) {
+          pendingChunkPins = RelationPinSet.getDefaultInstance();
+          queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
+          throw e;
+        }
+        pendingChunkPins = RelationPinSet.getDefaultInstance();
+        if (updated.isEmpty()) {
+          queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
+          LOG.warnf(
+              "Failed to commit chunk pins query_id=%s query context missing", ctx.getQueryId());
+          throw GrpcErrors.notFound(
+              correlationId, QUERY_NOT_FOUND, Map.of("query_id", ctx.getQueryId()));
+        }
       }
       if (LOG.isDebugEnabled()) {
         LOG.debugf("Committed chunk pins query_id=%s", ctx.getQueryId());
+      }
+    }
+
+    private int pendingChunkPinCount() {
+      synchronized (pendingChunkPinsLock) {
+        return pendingChunkPins.getPinsCount();
       }
     }
   }

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -94,6 +94,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -1591,7 +1592,7 @@ public class UserObjectBundleService {
     private final ArrayDeque<EagerBaseCursor> eagerBaseQueue = new ArrayDeque<>();
     private final Set<String> eagerBaseSeen = new HashSet<>();
     private final Map<RelationCacheKey, RelationInfo> relationInfoCache = new HashMap<>();
-    private final Map<ResourceId, TablePin> currentSnapshotPinCache = new HashMap<>();
+    private final Map<ResourceId, TablePin> currentSnapshotPinCache = new ConcurrentHashMap<>();
     private final TimingAccumulator timings = new TimingAccumulator();
     private final PhaseDiagnostics diagnostics = diagnostics("get_user_objects");
     private final long streamStartNs = System.nanoTime();

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -94,10 +94,12 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.Config;
@@ -110,6 +112,13 @@ public class UserObjectBundleService {
 
   private static final int MAX_RESOLUTIONS_PER_CHUNK = 25;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
+
+  private static void throwIfCancelled(BooleanSupplier cancelled) {
+    if (cancelled.getAsBoolean()) {
+      throw new CancellationException("GetUserObjects stream cancelled");
+    }
+  }
+
   private static final Set<String> LOCAL_FLIGHT_HOSTS = Set.of("localhost", "127.0.0.1", "0.0.0.0");
   private static final String SYSTEM_FLIGHT_ENDPOINTS_PREFIX = "floedb.system-flight.endpoints.";
   private static final String RELATION_HINT_PERSIST_NANOS_KEY =
@@ -270,7 +279,7 @@ public class UserObjectBundleService {
                   .onFailure()
                   .invoke(ignored -> iterator.publishStreamTelemetry("failed"))
                   .onTermination()
-                  .invoke(() -> iterator.publishStreamTelemetry("cancelled"));
+                  .invoke(iterator::cancel);
             });
   }
 
@@ -351,7 +360,9 @@ public class UserObjectBundleService {
       QueryContext ctx,
       List<ResolvedRelation> relations,
       ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-      PhaseDiagnostics diagnostics) {
+      PhaseDiagnostics diagnostics,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
     if (relations == null || relations.isEmpty()) {
       return RelationPinSet.getDefaultInstance();
     }
@@ -381,8 +392,10 @@ public class UserObjectBundleService {
             asOfDefault,
             Optional.of(ctx.getQueryDefaultCatalogId()),
             currentSnapshotPinCache,
-            diagnostics);
+            diagnostics,
+            cancelled);
     diagnostics.nanos("pin.resolver", System.nanoTime() - resolverStartNs);
+    throwIfCancelled(cancelled);
     RelationPinSet incoming = resolution.relationPinSet();
     RelationPinSet pins = incoming == null ? RelationPinSet.getDefaultInstance() : incoming;
     diagnostics.add("pin.output_pins", pins.getPinsCount());
@@ -1610,6 +1623,7 @@ public class UserObjectBundleService {
     private boolean headerEmitted = false;
     private boolean endEmitted = false;
     private final AtomicBoolean telemetryPublished = new AtomicBoolean(false);
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
     private boolean defaultCatalogResolved = false;
     private String defaultCatalogName = "";
     private long resolveNanos = 0L;
@@ -1666,6 +1680,7 @@ public class UserObjectBundleService {
 
     @Override
     public UserObjectsBundleChunk next() {
+      throwIfCancelled(this::isCancelled);
       if (!headerEmitted) {
         headerEmitted = true;
         if (LOG.isDebugEnabled()) {
@@ -1714,7 +1729,14 @@ public class UserObjectBundleService {
         long pinStartNs = System.nanoTime();
         try {
           RelationPinSet chunkPins =
-              collectChunkPins(correlationId, ctx, toPin, currentSnapshotPinCache, diagnostics);
+              collectChunkPins(
+                  correlationId,
+                  ctx,
+                  toPin,
+                  currentSnapshotPinCache,
+                  diagnostics,
+                  this::isCancelled);
+          throwIfCancelled(this::isCancelled);
           long accumulateStartNs = System.nanoTime();
           try {
             accumulateChunkPins(chunkPins);
@@ -1725,6 +1747,15 @@ public class UserObjectBundleService {
           pinCollectNanos += System.nanoTime() - pinStartNs;
         }
       }
+    }
+
+    private boolean isCancelled() {
+      return cancelled.get();
+    }
+
+    private void cancel() {
+      cancelled.set(true);
+      publishStreamTelemetry("cancelled");
     }
 
     /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -104,6 +104,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -118,6 +119,7 @@ public class UserObjectBundleService {
 
   private static final int MAX_RESOLUTIONS_PER_CHUNK = 25;
   private static final int MAX_CONCURRENT_METADATA_LOOKUPS = 64;
+  private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
 
   private static void throwIfCancelled(BooleanSupplier cancelled) {
@@ -164,8 +166,18 @@ public class UserObjectBundleService {
 
   @PreDestroy
   void closeExecutors() {
-    metadataLookupExecutor.shutdownNow();
-    cancellationTeardownExecutor.close();
+    shutdownExecutor(metadataLookupExecutor);
+    shutdownExecutor(cancellationTeardownExecutor);
+  }
+
+  /** Bound bean destruction even if a store call ignores interruption during shutdown. */
+  private static void shutdownExecutor(ExecutorService executor) {
+    CancellableCallRunner.cancelDiscardedTasks(executor.shutdownNow());
+    try {
+      executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   private static void warnFlightHost(String flightHost, String quarkusProfile) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -58,8 +58,8 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.scanner.spi.MetadataResolutionContext;
 import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.concurrent.CancellableCallRunner;
 import ai.floedb.floecat.service.context.EngineContextProvider;
-import ai.floedb.floecat.service.context.PropagatedContext;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.PinValidator;
 import ai.floedb.floecat.service.query.QueryContextStore;
@@ -100,16 +100,11 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -123,23 +118,12 @@ public class UserObjectBundleService {
 
   private static final int MAX_RESOLUTIONS_PER_CHUNK = 25;
   private static final int MAX_CONCURRENT_METADATA_LOOKUPS = 64;
-  private static final long CANCELLATION_POLL_MILLIS = 10;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
 
   private static void throwIfCancelled(BooleanSupplier cancelled) {
     if (cancelled.getAsBoolean()) {
       throw new CancellationException("GetUserObjects stream cancelled");
     }
-  }
-
-  private static void rethrowAsyncFailure(Throwable failure) {
-    if (failure instanceof RuntimeException runtime) {
-      throw runtime;
-    }
-    if (failure instanceof Error error) {
-      throw error;
-    }
-    throw new IllegalStateException("unexpected checked exception from metadata lookup", failure);
   }
 
   private static final Set<String> LOCAL_FLIGHT_HOSTS = Set.of("localhost", "127.0.0.1", "0.0.0.0");
@@ -1836,75 +1820,13 @@ public class UserObjectBundleService {
      * when the subscriber cancels, even if the downstream client ignores interruption.
      */
     private <T> T awaitCancellableMetadataLookup(Supplier<T> lookup) {
-      acquireMetadataLookupPermit();
-      PropagatedContext context = PropagatedContext.capture();
-      CompletableFuture<T> result = new CompletableFuture<>();
-      AtomicReference<Thread> worker = new AtomicReference<>();
-      FutureTask<Void> submitted =
-          new FutureTask<>(
-              () -> {
-                worker.set(Thread.currentThread());
-                try {
-                  throwIfCancelled(this::isCancelled);
-                  result.complete(context.supply(lookup));
-                } catch (Throwable failure) {
-                  result.completeExceptionally(failure);
-                } finally {
-                  worker.set(null);
-                  metadataLookupPermits.release();
-                }
-              },
-              null);
-      try {
-        metadataLookupExecutor.execute(submitted);
-      } catch (RuntimeException | Error submissionFailure) {
-        metadataLookupPermits.release();
-        throw submissionFailure;
-      }
-      try {
-        while (true) {
-          if (isCancelled()) {
-            interruptMetadataLookup(worker);
-            throw new CancellationException("GetUserObjects stream cancelled");
-          }
-          try {
-            return result.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
-          } catch (TimeoutException ignored) {
-            // A bounded wait lets the producer interrupt a stalled lookup on cancellation.
-          } catch (InterruptedException e) {
-            interruptMetadataLookup(worker);
-            Thread.currentThread().interrupt();
-            throw new CancellationException("GetUserObjects metadata lookup interrupted");
-          } catch (ExecutionException e) {
-            rethrowAsyncFailure(e.getCause());
-          }
-        }
-      } catch (CancellationException e) {
-        interruptMetadataLookup(worker);
-        throw e;
-      }
-    }
-
-    /** Wait for global lookup capacity without holding a stream producer after cancellation. */
-    private void acquireMetadataLookupPermit() {
-      try {
-        while (true) {
-          throwIfCancelled(this::isCancelled);
-          if (metadataLookupPermits.tryAcquire(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS)) {
-            return;
-          }
-        }
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new CancellationException("GetUserObjects metadata lookup interrupted");
-      }
-    }
-
-    private static void interruptMetadataLookup(AtomicReference<Thread> worker) {
-      Thread active = worker.get();
-      if (active != null) {
-        active.interrupt();
-      }
+      return CancellableCallRunner.call(
+          metadataLookupExecutor,
+          metadataLookupPermits,
+          this::isCancelled,
+          lookup,
+          "GetUserObjects stream cancelled",
+          "GetUserObjects metadata lookup interrupted");
     }
 
     private void cancel() {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -923,7 +923,8 @@ public class UserObjectBundleService {
                     logicalSchemaForRelation(
                             correlationId, relation.relationId(), userTable, queryContext)
                         .getColumnsList())
-                : overlay.tableSchema(relation.node().id());
+                : Optional.ofNullable(overlay.tableSchema(relation.node().id()))
+                    .orElseGet(List::of);
 
     List<SchemaColumn> pruned =
         UserObjectBundleUtils.pruneSchema(schemaColumns, relation.candidate(), correlationId);
@@ -998,6 +999,8 @@ public class UserObjectBundleService {
         } finally {
           timings.addDecorateRelationNanos(System.nanoTime() - decorateRelationStartNs);
         }
+      } catch (CancellationException e) {
+        throw e;
       } catch (RuntimeException e) {
         relationDecorationSucceeded = false;
         LOG.debugf(
@@ -1023,6 +1026,8 @@ public class UserObjectBundleService {
           } finally {
             timings.addDecorateViewNanos(System.nanoTime() - decorateViewStartNs);
           }
+        } catch (CancellationException e) {
+          throw e;
         } catch (RuntimeException e) {
           viewDecorationSucceeded = false;
           LOG.debugf(
@@ -1076,6 +1081,8 @@ public class UserObjectBundleService {
           timings.addDecoratePersistColumnsNanos(
               decorationTimingNanos(relationDecoration, COLUMN_HINT_PERSIST_NANOS_KEY));
         }
+      } catch (CancellationException e) {
+        throw e;
       } catch (RuntimeException e) {
         completeRelationSucceeded = false;
         LOG.debugf(
@@ -1311,6 +1318,8 @@ public class UserObjectBundleService {
                       "engine_kind", safe(ctx == null ? null : ctx.normalizedKind()),
                       "engine_version", safe(ctx == null ? null : ctx.normalizedVersion()))));
         }
+      } catch (CancellationException e) {
+        throw e;
       } catch (RuntimeException e) {
         ColumnFailure failure = mapFailure(e, ctx);
         LOG.debugf(

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
@@ -32,9 +32,9 @@ import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class QueryInputMetadataAssembler {
@@ -81,7 +81,7 @@ public class QueryInputMetadataAssembler {
                       inputs,
                       asOfDefault,
                       Optional.of(defaultCatalogId),
-                      new LinkedHashMap<>(),
+                      new ConcurrentHashMap<>(),
                       diagnostics));
       diagnostics.put("resolved_inputs", resolution.resolved().size());
       RelationPinSet relationPinSet = resolution.relationPinSet();

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.query.rpc.ExpansionMap;
 import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TableObligations;
+import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.resolver.ObligationsResolver;
 import ai.floedb.floecat.service.query.resolver.QueryInputResolver;
@@ -34,6 +35,7 @@ import jakarta.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
@@ -81,7 +83,7 @@ public class QueryInputMetadataAssembler {
                       inputs,
                       asOfDefault,
                       Optional.of(defaultCatalogId),
-                      new ConcurrentHashMap<>(),
+                      new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                       diagnostics));
       diagnostics.put("resolved_inputs", resolution.resolved().size());
       RelationPinSet relationPinSet = resolution.relationPinSet();

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.jboss.logging.Logger;
 
 /**
@@ -118,7 +119,8 @@ public class QuerySchemaServiceImpl extends BaseServiceImpl implements QuerySche
                                     request.getInputsList(),
                                     asOfDefault,
                                     Optional.of(ctx.getQueryDefaultCatalogId()),
-                                    new java.util.concurrent.ConcurrentHashMap<>(),
+                                    new java.util.concurrent.ConcurrentHashMap<
+                                        ResourceId, CompletableFuture<TablePin>>(),
                                     diagnostics));
                     diagnostics.put("resolved_inputs", rr.resolved().size());
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
@@ -118,7 +118,7 @@ public class QuerySchemaServiceImpl extends BaseServiceImpl implements QuerySche
                                     request.getInputsList(),
                                     asOfDefault,
                                     Optional.of(ctx.getQueryDefaultCatalogId()),
-                                    new java.util.LinkedHashMap<>(),
+                                    new java.util.concurrent.ConcurrentHashMap<>(),
                                     diagnostics));
                     diagnostics.put("resolved_inputs", rr.resolved().size());
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -440,14 +440,17 @@ public class QueryInputResolver {
       Map<NameRef, Optional<ResourceId>> resolvedNames) {
     AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
     ResolutionState taskState = state.withDiagnostics(taskDiagnostics);
-    List<InputPlan> plans =
-        BoundedFanout.mapOrdered(
-            inputs,
-            maxParallelInputResolutions,
-            blockingExecutor,
-            in -> planInput(taskState, in, resolvedNames));
-    taskDiagnostics.flushInto(state.diagnostics);
-    return plans;
+    try {
+      return BoundedFanout.mapOrdered(
+          inputs,
+          maxParallelInputResolutions,
+          blockingExecutor,
+          in -> planInput(taskState, in, resolvedNames));
+    } finally {
+      // A failed or cancelled sibling can still leave completed tasks' pin work in this
+      // accumulator. Preserve those counters for the request's failure telemetry too.
+      taskDiagnostics.flushInto(state.diagnostics);
+    }
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -116,6 +116,8 @@ public class QueryInputResolver {
   // global admission bound without changing the invariant check in postConstruct().
   private static final int METADATA_IO_POOL_SIZE = MAX_CONCURRENT_INPUT_RESOLUTIONS;
   private static final int METADATA_IO_QUEUE_CAPACITY = METADATA_IO_POOL_SIZE;
+  // Legacy callers cannot provide a cancellation signal. Bound their complete admission-plus-I/O
+  // wait so an unresponsive metadata store yields DEADLINE_EXCEEDED instead of pinning the RPC.
   private static final long UNINTERRUPTIBLE_METADATA_WAIT_SECONDS = 30;
   private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
   private static final long GLOBAL_PERMIT_POLL_MILLIS = 10;
@@ -529,6 +531,7 @@ public class QueryInputResolver {
       try {
         defaultCatalog =
             withInputResolutionPermit(
+                correlationId,
                 cancelled,
                 () -> metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName));
       } finally {
@@ -560,7 +563,9 @@ public class QueryInputResolver {
           nameInputs.isEmpty()
               ? Map.of()
               : withInputResolutionPermit(
-                  cancelled, () -> metadataGraph.resolveNames(correlationId, nameInputs));
+                  correlationId,
+                  cancelled,
+                  () -> metadataGraph.resolveNames(correlationId, nameInputs));
       throwIfCancelled(cancelled);
 
       // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
@@ -673,7 +678,8 @@ public class QueryInputResolver {
     }
   }
 
-  private <T> T withInputResolutionPermit(BooleanSupplier cancelled, Supplier<T> operation) {
+  private <T> T withInputResolutionPermit(
+      String correlationId, BooleanSupplier cancelled, Supplier<T> operation) {
     if (!metadataGraph.supportsConcurrentResolution()) {
       // An overlay can opt out because it owns request-thread-confined state. Preserve that
       // contract even for a cancellable caller; it can cancel while awaiting admission, but an
@@ -681,15 +687,19 @@ public class QueryInputResolver {
       return withInputResolutionPermitSynchronously(cancelled, operation);
     }
     if (cancelled == NEVER_CANCELLED) {
-      return CancellableCallRunner.callUncancellable(
-          metadataIoExecutor,
-          concurrentInputResolutionPermits,
-          operation,
-          UNINTERRUPTIBLE_METADATA_WAIT_SECONDS,
-          TimeUnit.SECONDS,
-          "resolver metadata I/O executor shut down",
-          "interrupted while awaiting resolver I/O",
-          "resolver metadata I/O timed out");
+      try {
+        return CancellableCallRunner.callUncancellable(
+            metadataIoExecutor,
+            concurrentInputResolutionPermits,
+            operation,
+            UNINTERRUPTIBLE_METADATA_WAIT_SECONDS,
+            TimeUnit.SECONDS,
+            "resolver metadata I/O executor shut down",
+            "interrupted while awaiting resolver I/O",
+            "resolver metadata I/O timed out");
+      } catch (CancellableCallRunner.CallTimeoutException e) {
+        throw GrpcErrors.timeout(correlationId, null, Map.of(), e);
+      }
     }
     return CancellableCallRunner.call(
         metadataIoExecutor,
@@ -846,6 +856,7 @@ public class QueryInputResolver {
           long snapshotPinStartNs = System.nanoTime();
           pin =
               withInputResolutionPermit(
+                  state.correlationId,
                   state.cancelled,
                   () -> {
                     TablePin constructed =
@@ -904,6 +915,7 @@ public class QueryInputResolver {
     long snapshotPinStartNs = System.nanoTime();
     TablePin resolved =
         withInputResolutionPermit(
+            state.correlationId,
             state.cancelled,
             () -> {
               TablePin constructed =
@@ -1029,6 +1041,7 @@ public class QueryInputResolver {
     long viewResolveStartNs = System.nanoTime();
     Optional<ViewNode> view =
         withInputResolutionPermit(
+            state.correlationId,
             state.cancelled,
             () ->
                 metadataGraph
@@ -1053,7 +1066,9 @@ public class QueryInputResolver {
           long baseNameStartNs = System.nanoTime();
           Map<NameRef, Optional<ResourceId>> baseIds =
               withInputResolutionPermit(
-                  state.cancelled, () -> metadataGraph.resolveNames(state.correlationId, baseRefs));
+                  state.correlationId,
+                  state.cancelled,
+                  () -> metadataGraph.resolveNames(state.correlationId, baseRefs));
           state.diagnostics.nanos(
               "pin.view_base_name_resolve", System.nanoTime() - baseNameStartNs);
           for (NameRef baseRef : baseRefs) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -331,6 +331,13 @@ public class QueryInputResolver {
     }
   }
 
+  private void mergePlan(ResolutionState state, InputPlan plan) {
+    state.resolved.add(plan.resolvedId());
+    for (TablePin pin : plan.pins()) {
+      mergePin(state, pin);
+    }
+  }
+
   /**
    * Resolve one input to its {@link InputPlan}, reading the metadata graph and updating the shared
    * current-snapshot cache and diagnostics. It does not read or write {@code state.resolved} or

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.PinKind;
@@ -208,7 +209,7 @@ public class QueryInputResolver {
       ownedBlockingExecutor.shutdownNow();
     }
     if (ownedMetadataIoExecutor != null) {
-      ownedMetadataIoExecutor.shutdownNow();
+      CancellableCallRunner.cancelDiscardedTasks(ownedMetadataIoExecutor.shutdownNow());
     }
   }
 
@@ -633,8 +634,11 @@ public class QueryInputResolver {
   }
 
   private <T> T withInputResolutionPermit(BooleanSupplier cancelled, Supplier<T> operation) {
-    if (cancelled == NEVER_CANCELLED) {
-      return withInputResolutionPermitSynchronously(operation);
+    if (cancelled == NEVER_CANCELLED || !metadataGraph.supportsConcurrentResolution()) {
+      // An overlay can opt out because it owns request-thread-confined state. Preserve that
+      // contract even for a cancellable caller; it can cancel while awaiting admission, but an
+      // active callback remains on the request thread until the overlay returns.
+      return withInputResolutionPermitSynchronously(cancelled, operation);
     }
     return CancellableCallRunner.call(
         metadataIoExecutor,
@@ -668,6 +672,12 @@ public class QueryInputResolver {
   /** Acquire process-wide metadata capacity while leaving a cancelled caller responsive. */
   private void acquireInputResolutionPermit(BooleanSupplier cancelled) {
     try {
+      if (cancelled == NEVER_CANCELLED) {
+        // Legacy callers cannot become cancelled, so a blocking fair acquire preserves FIFO
+        // ordering without repeatedly removing and re-enqueuing this waiter.
+        concurrentInputResolutionPermits.acquire();
+        return;
+      }
       // Timed waits let serial callers observe cancellation too. This is best-effort fairness:
       // a timed-out waiter must rejoin the fair semaphore's queue, trading strict FIFO for prompt
       // request cancellation when all store-I/O slots are occupied.
@@ -769,7 +779,9 @@ public class QueryInputResolver {
       ResourceId rid,
       SnapshotRef override,
       Optional<Timestamp> asOfDefault) {
-    if (usesCurrentSnapshotFallback(override, asOfDefault)) {
+    Optional<Timestamp> effectiveAsOfDefault =
+        isExplicitCurrentSnapshot(override) ? Optional.empty() : asOfDefault;
+    if (usesCurrentSnapshotFallback(override, effectiveAsOfDefault)) {
       // Single-flight per table: two references to the same table's CURRENT snapshot must freeze
       // the
       // SAME snapshot even when they resolve on different threads, or an ingest landing between two
@@ -789,7 +801,9 @@ public class QueryInputResolver {
           pin =
               withInputResolutionPermit(
                   state.cancelled,
-                  () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
+                  () ->
+                      metadataGraph.tablePinFor(
+                          state.correlationId, rid, override, effectiveAsOfDefault));
           state.resolvingPinRoots.register(pin);
           state.diagnostics.count("pin.snapshot_calls");
           state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -882,10 +896,20 @@ public class QueryInputResolver {
 
   private boolean usesCurrentSnapshotFallback(
       SnapshotRef override, Optional<Timestamp> asOfDefault) {
+    if (isExplicitCurrentSnapshot(override)) {
+      return true;
+    }
     if (override != null && override.getWhichCase() != SnapshotRef.WhichCase.WHICH_NOT_SET) {
       return false;
     }
     return asOfDefault.isEmpty();
+  }
+
+  /** An explicit CURRENT selector takes precedence over a request-wide AS-OF default. */
+  private boolean isExplicitCurrentSnapshot(SnapshotRef override) {
+    return override != null
+        && override.getWhichCase() == SnapshotRef.WhichCase.SPECIAL
+        && override.getSpecial() == SpecialSnapshot.SS_CURRENT;
   }
 
   private void validateViewOverride(String correlationId, ResourceId viewId, SnapshotRef override) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -130,6 +130,7 @@ public class QueryInputResolver {
   // per-request bound only. ConfigProvider keeps construction dependent on graph/store
   // collaborators while production still reads the deployment setting once per resolver.
   private final int maxParallelInputResolutions;
+  private final int maxConcurrentInputResolutions;
 
   // Bounds metadata I/O across every request handled by this application-scoped resolver. The
   // request-local BoundedFanout limit avoids one request monopolizing this capacity; this limiter
@@ -157,11 +158,6 @@ public class QueryInputResolver {
   private volatile ExecutorService metadataIoExecutor = ForkJoinPool.commonPool();
   private ExecutorService ownedMetadataIoExecutor;
 
-  // All overloads retain virtual dispatch through the completed-pin Map extension seam. This
-  // per-thread scope carries the single-flight cache and cancellation signal through that seam
-  // without exposing their synchronization details in its signature.
-  private final ThreadLocal<ResolutionInvocation> resolutionInvocation = new ThreadLocal<>();
-
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
     this(
@@ -179,6 +175,7 @@ public class QueryInputResolver {
     this.metadataGraph = metadataGraph;
     this.queryStore = queryStore;
     this.maxParallelInputResolutions = maxParallelInputResolutions;
+    this.maxConcurrentInputResolutions = maxConcurrentInputResolutions;
     this.concurrentInputResolutionPermits =
         new Semaphore(maxConcurrentInputResolutions, true /* best-effort request fairness */);
   }
@@ -209,10 +206,8 @@ public class QueryInputResolver {
    */
   @PostConstruct
   void postConstruct() {
-    if (MAX_CONCURRENT_INPUT_RESOLUTIONS > METADATA_IO_POOL_SIZE) {
-      throw new IllegalStateException(
-          "resolver metadata admission must not exceed metadata I/O worker capacity");
-    }
+    validateMetadataIoSizing(
+        maxConcurrentInputResolutions, METADATA_IO_POOL_SIZE, METADATA_IO_QUEUE_CAPACITY);
     ExecutorService planningExecutor = Executors.newVirtualThreadPerTaskExecutor();
     ExecutorService ioExecutor =
         MetadataIoExecutors.newBoundedDaemonPool(
@@ -221,6 +216,39 @@ public class QueryInputResolver {
     ownedMetadataIoExecutor = ioExecutor;
     blockingExecutor = planningExecutor;
     metadataIoExecutor = ioExecutor;
+  }
+
+  /** Validate that every admitted call can be accepted during worker turnover. */
+  static void validateMetadataIoSizing(int admission, int workers, int queueCapacity) {
+    if (admission < 1 || workers < admission || queueCapacity < admission) {
+      throw new IllegalStateException(
+          "metadata I/O workers and queue must each cover the admission bound"
+              + " (admission="
+              + admission
+              + ", workers="
+              + workers
+              + ", queue="
+              + queueCapacity
+              + ")");
+    }
+  }
+
+  /**
+   * Run metadata I/O on this resolver's application-wide executor and admission bound.
+   *
+   * <p>GetUserObjects uses this same runner for candidate and relation work, so all metadata-store
+   * calls share one ceiling instead of multiplying independent per-service limits.
+   */
+  public <T> T runMetadataIo(
+      BooleanSupplier cancelled,
+      Supplier<T> operation,
+      CancellableCallRunner.FailureMessages failureMessages) {
+    return CancellableCallRunner.call(
+        metadataIoExecutor,
+        concurrentInputResolutionPermits,
+        cancelled,
+        operation,
+        failureMessages);
   }
 
   /**
@@ -509,94 +537,15 @@ public class QueryInputResolver {
       Optional<ResourceId> defaultCatalogId,
       ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
-    ResolutionInvocation current = resolutionInvocation.get();
-    if (current != null) {
-      return resolveInputsViaLegacyOverride(
-          queryId,
-          correlationId,
-          inputs,
-          asOfDefault,
-          defaultCatalogId,
-          currentSnapshotPinCache,
-          diagnostics);
-    }
-    return withResolutionInvocation(
-        new ResolutionInvocation(currentSnapshotPinCache, NEVER_CANCELLED),
-        () ->
-            resolveInputsViaLegacyOverride(
-                queryId,
-                correlationId,
-                inputs,
-                asOfDefault,
-                defaultCatalogId,
-                currentSnapshotPinCache,
-                diagnostics));
-  }
-
-  /**
-   * Compatibility overload for callers that own a completed-pin {@link Map} cache.
-   *
-   * <p>The supplied cache is not required to be concurrent. Copy it into a concurrent single-flight
-   * cache for this call, then copy successfully resolved pins back on the calling thread. Worker
-   * tasks therefore never mutate a caller-owned plain map. If copy-back fails, restore the map's
-   * original contents before releasing the attempt's transient roots. When restoration cannot be
-   * proven, retain those roots until the store grace period so any copied prefix remains protected.
-   */
-  public ResolutionResult resolveInputs(
-      String queryId,
-      String correlationId,
-      List<QueryInput> inputs,
-      Optional<Timestamp> asOfDefault,
-      Optional<ResourceId> defaultCatalogId,
-      Map<ResourceId, TablePin> currentSnapshotPinCache,
-      PhaseDiagnostics diagnostics) {
-    ResolutionInvocation current = resolutionInvocation.get();
-    if (current != null) {
-      return resolveInputsCore(
-          queryId,
-          correlationId,
-          inputs,
-          asOfDefault,
-          defaultCatalogId,
-          current.currentSnapshotPinCache(),
-          diagnostics,
-          current.cancelled());
-    }
-    Map<ResourceId, TablePin> initialCache = snapshotCompletedPinCache(currentSnapshotPinCache);
-    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
-        toSingleFlightCache(initialCache);
-    ResolutionResult result =
-        resolveInputsCore(
-            queryId,
-            correlationId,
-            inputs,
-            asOfDefault,
-            defaultCatalogId,
-            singleFlightCache,
-            diagnostics,
-            NEVER_CANCELLED);
-    try {
-      copyCompletedPins(singleFlightCache, currentSnapshotPinCache);
-    } catch (RuntimeException | Error copyFailure) {
-      if (restoreCompletedPinCache(currentSnapshotPinCache, initialCache, copyFailure)) {
-        try {
-          if (queryStore != null && queryId != null && !queryId.isEmpty()) {
-            queryStore.releaseResolvingPinBlobs(
-                queryId, QueryPins.gcRootUris(result.relationPinSet()));
-          }
-        } catch (RuntimeException | Error cleanupFailure) {
-          copyFailure.addSuppressed(cleanupFailure);
-        }
-      } else {
-        // A map with non-transactional or rejecting mutations may retain a copied prefix. Keep the
-        // attempt's roots until the store grace period rather than exposing that prefix unrooted.
-        LOG.warnf(
-            "Retaining resolving pin roots after legacy cache rollback failed query_id=%s",
-            queryId);
-      }
-      throw copyFailure;
-    }
-    return result;
+    return resolveInputsCore(
+        queryId,
+        correlationId,
+        inputs,
+        asOfDefault,
+        defaultCatalogId,
+        currentSnapshotPinCache,
+        diagnostics,
+        NEVER_CANCELLED);
   }
 
   /**
@@ -616,20 +565,18 @@ public class QueryInputResolver {
       PhaseDiagnostics diagnostics,
       BooleanSupplier cancelled) {
     throwIfCancelled(cancelled);
-    return withResolutionInvocation(
-        new ResolutionInvocation(currentSnapshotPinCache, cancelled),
-        () ->
-            resolveInputs(
-                queryId,
-                correlationId,
-                inputs,
-                asOfDefault,
-                defaultCatalogId,
-                currentSnapshotPinCache,
-                diagnostics));
+    return resolveInputsCore(
+        queryId,
+        correlationId,
+        inputs,
+        asOfDefault,
+        defaultCatalogId,
+        currentSnapshotPinCache,
+        diagnostics,
+        cancelled);
   }
 
-  /** Run the base resolution implementation after compatibility overload dispatch has completed. */
+  /** Run the shared resolution implementation for cancellable and non-cancellable callers. */
   private ResolutionResult resolveInputsCore(
       String queryId,
       String correlationId,
@@ -721,116 +668,6 @@ public class QueryInputResolver {
       throw e;
     }
   }
-
-  /** Dispatch through the completed-pin extension seam and copy any subclass cache writes. */
-  private ResolutionResult resolveInputsViaLegacyOverride(
-      String queryId,
-      String correlationId,
-      List<QueryInput> inputs,
-      Optional<Timestamp> asOfDefault,
-      Optional<ResourceId> defaultCatalogId,
-      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-      PhaseDiagnostics diagnostics) {
-    Map<ResourceId, TablePin> completedPinCache = completedPins(currentSnapshotPinCache);
-    ResolutionResult result =
-        resolveInputs(
-            queryId,
-            correlationId,
-            inputs,
-            asOfDefault,
-            defaultCatalogId,
-            completedPinCache,
-            diagnostics);
-    completedPinCache.forEach(
-        (tableId, pin) ->
-            currentSnapshotPinCache.putIfAbsent(tableId, CompletableFuture.completedFuture(pin)));
-    return result;
-  }
-
-  /**
-   * Install one cancellable invocation while preserving nested resolver calls on the same thread.
-   */
-  private <T> T withResolutionInvocation(ResolutionInvocation invocation, Supplier<T> operation) {
-    ResolutionInvocation previous = resolutionInvocation.get();
-    resolutionInvocation.set(invocation);
-    try {
-      return operation.get();
-    } finally {
-      if (previous == null) {
-        resolutionInvocation.remove();
-      } else {
-        resolutionInvocation.set(previous);
-      }
-    }
-  }
-
-  /** Snapshot a completed-pin cache without exposing it to resolution workers. */
-  private static Map<ResourceId, TablePin> snapshotCompletedPinCache(
-      Map<ResourceId, TablePin> completedPinCache) {
-    synchronized (completedPinCache) {
-      return new LinkedHashMap<>(completedPinCache);
-    }
-  }
-
-  /** Convert a completed-pin snapshot into the resolver's single-flight representation. */
-  private static ConcurrentMap<ResourceId, CompletableFuture<TablePin>> toSingleFlightCache(
-      Map<ResourceId, TablePin> completedPinCache) {
-    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
-        new ConcurrentHashMap<>();
-    completedPinCache.forEach(
-        (tableId, pin) -> singleFlightCache.put(tableId, CompletableFuture.completedFuture(pin)));
-    return singleFlightCache;
-  }
-
-  /** Restore the caller cache after a failed copy, recording rollback failures on the cause. */
-  private static boolean restoreCompletedPinCache(
-      Map<ResourceId, TablePin> completedPinCache,
-      Map<ResourceId, TablePin> initialCache,
-      Throwable copyFailure) {
-    synchronized (completedPinCache) {
-      if (completedPinCache.equals(initialCache)) {
-        return true;
-      }
-      try {
-        completedPinCache.clear();
-        completedPinCache.putAll(initialCache);
-      } catch (RuntimeException | Error rollbackFailure) {
-        copyFailure.addSuppressed(rollbackFailure);
-      }
-      return completedPinCache.equals(initialCache);
-    }
-  }
-
-  /**
-   * Snapshot successful single-flight entries into a completed-pin map after resolution succeeds.
-   */
-  private static void copyCompletedPins(
-      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache,
-      Map<ResourceId, TablePin> completedPinCache) {
-    synchronized (completedPinCache) {
-      completedPins(singleFlightCache).forEach(completedPinCache::put);
-    }
-  }
-
-  /** Snapshot only successfully completed single-flight entries. */
-  private static Map<ResourceId, TablePin> completedPins(
-      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache) {
-    Map<ResourceId, TablePin> completed = new LinkedHashMap<>();
-    singleFlightCache.forEach(
-        (tableId, pinFuture) -> {
-          if (pinFuture.isDone()
-              && !pinFuture.isCompletedExceptionally()
-              && !pinFuture.isCancelled()) {
-            completed.put(tableId, Futures.join(pinFuture));
-          }
-        });
-    return completed;
-  }
-
-  /** Per-thread state carried through the completed-pin virtual extension seam. */
-  private record ResolutionInvocation(
-      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-      BooleanSupplier cancelled) {}
 
   // =============================================================================
   // Pin resolution
@@ -941,12 +778,7 @@ public class QueryInputResolver {
       return CancellableCallRunner.callWithoutCancellation(
           metadataIoExecutor, concurrentInputResolutionPermits, operation, METADATA_CALL_FAILURES);
     }
-    return CancellableCallRunner.call(
-        metadataIoExecutor,
-        concurrentInputResolutionPermits,
-        cancelled,
-        operation,
-        METADATA_CANCELLATION_FAILURES);
+    return runMetadataIo(cancelled, operation, METADATA_CANCELLATION_FAILURES);
   }
 
   /** Runs one metadata operation while retaining its global permit until the call truly returns. */

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -56,6 +56,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -96,6 +98,10 @@ import org.jboss.logging.Logger;
 public class QueryInputResolver {
 
   private static final Logger LOG = Logger.getLogger(QueryInputResolver.class);
+  private static final int DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
+  private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 16;
+  private static final int MAX_CONCURRENT_INPUT_RESOLUTIONS = 64;
+  private static final long GLOBAL_PERMIT_POLL_MILLIS = 10;
 
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
   // store reads; a small fan-out overlaps their round-trips without flooding the store. This is a
@@ -103,6 +109,11 @@ public class QueryInputResolver {
   // via ConfigProvider (not a @ConfigProperty ctor param) so the new-constructed test call sites
   // keep compiling while production still honors config.
   private final int maxParallelInputResolutions;
+
+  // Bounds metadata I/O across every request handled by this application-scoped resolver. The
+  // request-local BoundedFanout limit avoids one request monopolizing this capacity; this limiter
+  // prevents many requests from multiplying store pressure.
+  private final Semaphore concurrentInputResolutionPermits;
 
   private final CatalogOverlay metadataGraph;
 
@@ -119,23 +130,43 @@ public class QueryInputResolver {
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
+    this(
+        metadataGraph,
+        queryStore,
+        configuredMaxParallelInputResolutions(),
+        MAX_CONCURRENT_INPUT_RESOLUTIONS);
+  }
+
+  QueryInputResolver(
+      CatalogOverlay metadataGraph,
+      QueryContextStore queryStore,
+      int maxParallelInputResolutions,
+      int maxConcurrentInputResolutions) {
     this.metadataGraph = metadataGraph;
     this.queryStore = queryStore;
-    int configuredMaxParallelResolutions =
-        ConfigProvider.getConfig()
-            .getOptionalValue("floecat.catalog.bundle.max_parallel_relations", Integer.class)
-            .orElse(8);
-    if (configuredMaxParallelResolutions < 1) {
-      LOG.warnf(
-          "floecat.catalog.bundle.max_parallel_relations must be >= 1; using 1 instead of %d",
-          configuredMaxParallelResolutions);
-    }
-    this.maxParallelInputResolutions = Math.max(1, configuredMaxParallelResolutions);
+    this.maxParallelInputResolutions = maxParallelInputResolutions;
+    this.concurrentInputResolutionPermits =
+        new Semaphore(maxConcurrentInputResolutions, true /* fair across requests */);
   }
 
   /** Test-only constructor: no store (no pin-root registration). */
   public QueryInputResolver(CatalogOverlay metadataGraph) {
     this(metadataGraph, null);
+  }
+
+  private static int configuredMaxParallelInputResolutions() {
+    int configured =
+        ConfigProvider.getConfig()
+            .getOptionalValue("floecat.catalog.bundle.max_parallel_relations", Integer.class)
+            .orElse(DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS);
+    int clamped = Math.max(1, Math.min(MAX_PARALLEL_INPUT_RESOLUTIONS, configured));
+    if (configured != clamped) {
+      LOG.warnf(
+          "floecat.catalog.bundle.max_parallel_relations must be between 1 and %d; using %d"
+              + " instead of %d",
+          MAX_PARALLEL_INPUT_RESOLUTIONS, clamped, configured);
+    }
+    return clamped;
   }
 
   /** Stop accepting fan-out work and wait for any in-flight resolution tasks during shutdown. */
@@ -416,8 +447,14 @@ public class QueryInputResolver {
       long defaultCatalogStartNs = System.nanoTime();
       try {
         defaultCatalog =
-            withMetadataGraph(
-                () -> metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName));
+            withInputResolutionPermit(
+                cancelled,
+                () ->
+                    withMetadataGraph(
+                        () ->
+                            metadataGraph
+                                .catalog(defaultCatalogId.get())
+                                .map(CatalogNode::displayName)));
       } finally {
         diag.nanos("pin.default_catalog_resolve", System.nanoTime() - defaultCatalogStartNs);
       }
@@ -445,7 +482,11 @@ public class QueryInputResolver {
       Map<NameRef, Optional<ResourceId>> resolvedNames =
           nameInputs.isEmpty()
               ? Map.of()
-              : withMetadataGraph(() -> metadataGraph.resolveNames(correlationId, nameInputs));
+              : withInputResolutionPermit(
+                  cancelled,
+                  () ->
+                      withMetadataGraph(
+                          () -> metadataGraph.resolveNames(correlationId, nameInputs)));
       throwIfCancelled(cancelled);
 
       // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
@@ -512,7 +553,7 @@ public class QueryInputResolver {
       BooleanSupplier cancelled) {
     for (QueryInput in : inputs) {
       throwIfCancelled(cancelled);
-      mergePlan(state, planInput(state, in, resolvedNames));
+      mergePlan(state, planInputWithPermit(state, in, resolvedNames, cancelled));
     }
   }
 
@@ -540,7 +581,7 @@ public class QueryInputResolver {
           inputs,
           maxParallelInputResolutions,
           blockingExecutor,
-          in -> planInput(taskState, in, resolvedNames),
+          in -> planInputWithPermit(taskState, in, resolvedNames, cancelled),
           plan -> mergePlan(state, plan),
           cancelled);
     } finally {
@@ -556,18 +597,43 @@ public class QueryInputResolver {
     }
   }
 
+  /** Run a metadata-resolution plan while holding the service-wide store-I/O capacity. */
+  private InputPlan planInputWithPermit(
+      ResolutionState state,
+      QueryInput input,
+      Map<NameRef, Optional<ResourceId>> resolvedNames,
+      BooleanSupplier cancelled) {
+    return withInputResolutionPermit(cancelled, () -> planInput(state, input, resolvedNames));
+  }
+
+  private <T> T withInputResolutionPermit(BooleanSupplier cancelled, Supplier<T> operation) {
+    boolean acquired = false;
+    try {
+      while (!acquired) {
+        throwIfCancelled(cancelled);
+        acquired =
+            concurrentInputResolutionPermits.tryAcquire(
+                GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
+      }
+      throwIfCancelled(cancelled);
+      return operation.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CancellationException("interrupted while awaiting resolver I/O capacity");
+    } finally {
+      if (acquired) {
+        concurrentInputResolutionPermits.release();
+      }
+    }
+  }
+
   /**
-   * CatalogOverlay callbacks are direct when the overlay opts into concurrent resolution. The
-   * serial planning path keeps all callbacks on the request thread for overlays that opt out; the
-   * synchronization here also protects the up-front catalog and name-resolution callbacks.
+   * The serial planning path keeps callbacks on the request thread for overlays that opt out.
+   * Synchronizing on an application-scoped overlay would incorrectly serialize independent
+   * requests, so the concurrency capability governs scheduling rather than a shared mutex.
    */
   private <T> T withMetadataGraph(Supplier<T> operation) {
-    if (metadataGraph.supportsConcurrentResolution()) {
-      return operation.get();
-    }
-    synchronized (metadataGraph) {
-      return operation.get();
-    }
+    return operation.get();
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -60,7 +60,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -195,10 +195,10 @@ public class QueryInputResolver {
   @PreDestroy
   void closeBlockingExecutor() {
     if (ownedBlockingExecutor != null) {
-      ownedBlockingExecutor.close();
+      ownedBlockingExecutor.shutdownNow();
     }
     if (ownedMetadataIoExecutor != null) {
-      ownedMetadataIoExecutor.close();
+      ownedMetadataIoExecutor.shutdownNow();
     }
   }
 
@@ -628,10 +628,13 @@ public class QueryInputResolver {
     }
 
     PropagatedContext context = PropagatedContext.capture();
-    Future<T> submitted =
-        metadataIoExecutor.submit(
+    // Do not use ExecutorService.submit here: ForkJoinPool may help-run its ForkJoinTask inline
+    // while this thread waits, preventing the cancellation poll below from ever running.
+    FutureTask<T> submitted =
+        new FutureTask<>(
             () ->
                 context.supply(() -> withInputResolutionPermitSynchronously(cancelled, operation)));
+    metadataIoExecutor.execute(submitted);
     try {
       while (true) {
         if (cancelled.getAsBoolean()) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -49,11 +49,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.BooleanSupplier;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
@@ -109,7 +111,7 @@ public class QueryInputResolver {
   // worker pool: the driver blocks joining this fan-out and must not contend with it for the same
   // pool. The semaphore in BoundedFanout bounds concurrency; OTel context is re-established per
   // task.
-  private final Executor blockingExecutor = Executors.newVirtualThreadPerTaskExecutor();
+  private final ExecutorService blockingExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -310,6 +312,32 @@ public class QueryInputResolver {
       Optional<ResourceId> defaultCatalogId,
       ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
+    return resolveInputs(
+        queryId,
+        correlationId,
+        inputs,
+        asOfDefault,
+        defaultCatalogId,
+        currentSnapshotPinCache,
+        diagnostics,
+        () -> false);
+  }
+
+  /**
+   * As {@link #resolveInputs(String, String, List, Optional, Optional, ConcurrentMap,
+   * PhaseDiagnostics)}, but stops before additional metadata work and interrupts fan-out tasks when
+   * {@code cancelled} becomes true.
+   */
+  public ResolutionResult resolveInputs(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
     PhaseDiagnostics diag = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
 
     // Resolve catalog display-name once up-front — used to fill in blank catalog fields in
@@ -325,6 +353,7 @@ public class QueryInputResolver {
         diag.nanos("pin.default_catalog_resolve", System.nanoTime() - defaultCatalogStartNs);
       }
     }
+    throwIfCancelled(cancelled);
 
     var state =
         new ResolutionState(
@@ -346,27 +375,17 @@ public class QueryInputResolver {
               .toList();
       Map<NameRef, Optional<ResourceId>> resolvedNames =
           nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
+      throwIfCancelled(cancelled);
 
       // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
       // a view yields its base tables' pins). planInput reads the metadata graph and the shared
       // current-snapshot cache; it does not touch `resolved` or `pinByTableId`. Inputs resolve
       // independently, so with more than one they are fanned out; the results are gathered in input
       // order for the merge below.
-      List<InputPlan> plans =
-          inputs.size() > 1
-              ? planInputsConcurrently(state, inputs, resolvedNames)
-              : planInputsSerially(state, inputs, resolvedNames);
-
-      // Merge the plans into the pin set in input order. Order decides two things: `resolved`
-      // mirrors the request order, and mergePin keeps the first pin seen for a table while raising
-      // QUERY_TABLE_PIN_CONFLICT when a later reference pins the same table with an incompatible
-      // snapshot/as-of. Every kept pin is already GC-rooted at construction, before the caller
-      // reads any schema/stats or persists the context.
-      for (InputPlan plan : plans) {
-        state.resolved.add(plan.resolvedId());
-        for (TablePin pin : plan.pins()) {
-          mergePin(state, pin);
-        }
+      if (inputs.size() > 1) {
+        planInputsConcurrently(state, inputs, resolvedNames, cancelled);
+      } else {
+        planInputsSerially(state, inputs, resolvedNames, cancelled);
       }
 
       RelationPinSet relationPinSet =
@@ -394,8 +413,10 @@ public class QueryInputResolver {
    * One input's resolution: the id recorded in {@code resolved}, and the table pins it contributes,
    * ordered. A view's id is recorded but the pins are its base tables'; a table records its id and
    * its own single pin.
-   */
+  */
   private record InputPlan(ResourceId resolvedId, List<TablePin> pins, Throwable terminalFailure) {}
+
+  /** Merge one completed plan on the request thread, preserving request-order semantics. */
   private void mergePlan(ResolutionState state, InputPlan plan) {
     state.resolved.add(plan.resolvedId());
     for (TablePin pin : plan.pins()) {
@@ -409,16 +430,18 @@ public class QueryInputResolver {
     }
   }
 
-  /** Resolve the inputs one at a time on the calling thread, reporting to the shared diagnostics. */
-  private List<InputPlan> planInputsSerially(
+  /**
+   * Resolve the inputs one at a time on the calling thread, reporting to the shared diagnostics.
+   */
+  private void planInputsSerially(
       ResolutionState state,
       List<QueryInput> inputs,
-      Map<NameRef, Optional<ResourceId>> resolvedNames) {
-    List<InputPlan> plans = new ArrayList<>(inputs.size());
+      Map<NameRef, Optional<ResourceId>> resolvedNames,
+      BooleanSupplier cancelled) {
     for (QueryInput in : inputs) {
-      plans.add(planInput(state, in, resolvedNames));
+      throwIfCancelled(cancelled);
+      mergePlan(state, planInput(state, in, resolvedNames));
     }
-    return plans;
   }
 
   /**
@@ -434,22 +457,31 @@ public class QueryInputResolver {
    * Gathering plans in input order keeps the caller's merge deterministic (first-touch-wins,
    * conflict detection).
    */
-  private List<InputPlan> planInputsConcurrently(
+  private void planInputsConcurrently(
       ResolutionState state,
       List<QueryInput> inputs,
-      Map<NameRef, Optional<ResourceId>> resolvedNames) {
+      Map<NameRef, Optional<ResourceId>> resolvedNames,
+      BooleanSupplier cancelled) {
     AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
     ResolutionState taskState = state.withDiagnostics(taskDiagnostics);
     try {
-      return BoundedFanout.mapOrdered(
+      BoundedFanout.forEachOrdered(
           inputs,
           maxParallelInputResolutions,
           blockingExecutor,
-          in -> planInput(taskState, in, resolvedNames));
+          in -> planInput(taskState, in, resolvedNames),
+          plan -> mergePlan(state, plan),
+          cancelled);
     } finally {
       // A failed or cancelled sibling can still leave completed tasks' pin work in this
       // accumulator. Preserve those counters for the request's failure telemetry too.
       taskDiagnostics.flushInto(state.diagnostics);
+    }
+  }
+
+  private static void throwIfCancelled(BooleanSupplier cancelled) {
+    if (cancelled.getAsBoolean()) {
+      throw new CancellationException("input resolution cancelled");
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -39,8 +39,8 @@ import ai.floedb.floecat.service.query.ViewContextUtils;
 import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
-import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -55,11 +55,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.logging.Logger;
 
 /**
@@ -100,12 +102,12 @@ public class QueryInputResolver {
   private static final int DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
   private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 16;
   private static final int MAX_CONCURRENT_INPUT_RESOLUTIONS = 64;
+  private static final long GLOBAL_PERMIT_POLL_MILLIS = 10;
 
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
   // store reads; a small fan-out overlaps their round-trips without flooding the store. This is a
-  // per-request bound only: the virtual-thread executor has no shared-pool ceiling. Read once here
-  // via ConfigProvider (not a @ConfigProperty ctor param) so the new-constructed test call sites
-  // keep compiling while production still honors config.
+  // per-request bound only. Read once here via ConfigProvider (not a @ConfigProperty ctor param)
+  // so the new-constructed test call sites keep compiling while production still honors config.
   private final int maxParallelInputResolutions;
 
   // Bounds metadata I/O across every request handled by this application-scoped resolver. The
@@ -120,11 +122,10 @@ public class QueryInputResolver {
   // without a store — registration is simply skipped then.
   private final QueryContextStore queryStore;
 
-  // Runs per-input resolution off the request thread on virtual threads, not the shared Quarkus
-  // worker pool: the driver blocks joining this fan-out and must not contend with it for the same
-  // pool. The semaphore in BoundedFanout bounds concurrency; OTel context is re-established per
-  // task.
-  private final ExecutorService blockingExecutor = Executors.newVirtualThreadPerTaskExecutor();
+  // DynamoDB-backed metadata calls can pin a carrier while they block. Production uses Quarkus's
+  // managed platform-thread executor, matching NameResolver.parallelScan; the common pool is a
+  // non-owning test fallback for direct constructor call sites.
+  private volatile ExecutorService blockingExecutor = ForkJoinPool.commonPool();
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -167,10 +168,11 @@ public class QueryInputResolver {
     return clamped;
   }
 
-  /** Stop accepting fan-out work and wait for any in-flight resolution tasks during shutdown. */
-  @PreDestroy
-  void closeBlockingExecutor() {
-    blockingExecutor.close();
+  @Inject
+  void init(Instance<ManagedExecutor> managedExecutors) {
+    if (managedExecutors != null) {
+      managedExecutors.stream().findFirst().ifPresent(executor -> blockingExecutor = executor);
+    }
   }
 
   // =============================================================================
@@ -561,7 +563,9 @@ public class QueryInputResolver {
    * measured by the caller around this call regardless. One task state is shared by all tasks
    * because everything they touch is immutable or thread-safe (the current-snapshot cache and the
    * accumulator). Keep off-thread diagnostics to counters and durations only; one-shot put/emit
-   * values must stay on the request thread because the accumulator rejects them. Gathering plans in
+   * values must stay on the request thread because the accumulator rejects them. The task timing
+   * keys are aggregate work time in this concurrent path, so they may exceed the enclosing
+   * wall-clock resolver phase; dashboards must not treat them as elapsed time. Gathering plans in
    * input order keeps the caller's merge deterministic (first-touch-wins, conflict detection).
    */
   private void planInputsConcurrently(
@@ -596,11 +600,15 @@ public class QueryInputResolver {
     boolean acquired = false;
     try {
       throwIfCancelled(cancelled);
-      // A blocking acquire retains Semaphore's FIFO queue. BoundedFanout interrupts a queued
-      // worker on stream cancellation, so cancellation remains prompt without repeatedly leaving
-      // and rejoining the fair queue at its tail.
-      concurrentInputResolutionPermits.acquire();
-      acquired = true;
+      // Timed waits let serial callers observe cancellation too. This is best-effort fairness:
+      // a timed-out waiter must rejoin the fair semaphore's queue, trading strict FIFO for prompt
+      // request cancellation when all store-I/O slots are occupied.
+      while (!acquired) {
+        throwIfCancelled(cancelled);
+        acquired =
+            concurrentInputResolutionPermits.tryAcquire(
+                GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
+      }
       throwIfCancelled(cancelled);
       return operation.get();
     } catch (InterruptedException e) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -111,6 +111,12 @@ public class QueryInputResolver {
   private static final int DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
   private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 16;
   private static final int MAX_CONCURRENT_INPUT_RESOLUTIONS = 64;
+  // Every admitted call is submitted to this pool. The queue only bridges the brief interval
+  // between a task releasing admission and its worker becoming idle; do not lower this below the
+  // global admission bound without changing the invariant check in postConstruct().
+  private static final int METADATA_IO_POOL_SIZE = MAX_CONCURRENT_INPUT_RESOLUTIONS;
+  private static final int METADATA_IO_QUEUE_CAPACITY = METADATA_IO_POOL_SIZE;
+  private static final long UNINTERRUPTIBLE_METADATA_WAIT_SECONDS = 30;
   private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
   private static final long GLOBAL_PERMIT_POLL_MILLIS = 10;
   private static final BooleanSupplier NEVER_CANCELLED = () -> false;
@@ -192,14 +198,18 @@ public class QueryInputResolver {
 
   @PostConstruct
   void postConstruct() {
+    if (MAX_CONCURRENT_INPUT_RESOLUTIONS > METADATA_IO_POOL_SIZE) {
+      throw new IllegalStateException(
+          "resolver metadata admission must not exceed metadata I/O worker capacity");
+    }
     ExecutorService planningExecutor = Executors.newVirtualThreadPerTaskExecutor();
     ExecutorService ioExecutor =
         new ThreadPoolExecutor(
-            MAX_CONCURRENT_INPUT_RESOLUTIONS,
-            MAX_CONCURRENT_INPUT_RESOLUTIONS,
+            METADATA_IO_POOL_SIZE,
+            METADATA_IO_POOL_SIZE,
             0L,
             TimeUnit.MILLISECONDS,
-            new ArrayBlockingQueue<>(MAX_CONCURRENT_INPUT_RESOLUTIONS),
+            new ArrayBlockingQueue<>(METADATA_IO_QUEUE_CAPACITY),
             daemonMetadataIoThreadFactory(),
             new ThreadPoolExecutor.AbortPolicy());
     ownedBlockingExecutor = planningExecutor;
@@ -675,8 +685,11 @@ public class QueryInputResolver {
           metadataIoExecutor,
           concurrentInputResolutionPermits,
           operation,
+          UNINTERRUPTIBLE_METADATA_WAIT_SECONDS,
+          TimeUnit.SECONDS,
           "resolver metadata I/O executor shut down",
-          "interrupted while awaiting resolver I/O");
+          "interrupted while awaiting resolver I/O",
+          "resolver metadata I/O timed out");
     }
     return CancellableCallRunner.call(
         metadataIoExecutor,
@@ -834,10 +847,13 @@ public class QueryInputResolver {
           pin =
               withInputResolutionPermit(
                   state.cancelled,
-                  () ->
-                      metadataGraph.tablePinFor(
-                          state.correlationId, rid, override, effectiveAsOfDefault));
-          state.resolvingPinRoots.register(pin);
+                  () -> {
+                    TablePin constructed =
+                        metadataGraph.tablePinFor(
+                            state.correlationId, rid, override, effectiveAsOfDefault);
+                    state.resolvingPinRoots.register(constructed);
+                    return constructed;
+                  });
           state.diagnostics.count("pin.snapshot_calls");
           state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
         } catch (RuntimeException | Error e) {
@@ -889,8 +905,12 @@ public class QueryInputResolver {
     TablePin resolved =
         withInputResolutionPermit(
             state.cancelled,
-            () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
-    state.resolvingPinRoots.register(resolved);
+            () -> {
+              TablePin constructed =
+                  metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+              state.resolvingPinRoots.register(constructed);
+              return constructed;
+            });
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
     return resolved;

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -34,7 +34,7 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.concurrent.CancellableCallRunner;
 import ai.floedb.floecat.service.concurrent.Futures;
-import ai.floedb.floecat.service.concurrent.MetadataIoExecutors;
+import ai.floedb.floecat.service.concurrent.MetadataIoRunner;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
@@ -62,7 +62,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -109,14 +108,7 @@ public class QueryInputResolver {
   private static final Logger LOG = Logger.getLogger(QueryInputResolver.class);
   private static final int DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
   private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 16;
-  private static final int MAX_CONCURRENT_INPUT_RESOLUTIONS = 64;
-  // Every admitted call is submitted to this pool. The queue only bridges the brief interval
-  // between a task releasing admission and its worker becoming idle; do not lower this below the
-  // global admission bound without changing the invariant check in postConstruct().
-  private static final int METADATA_IO_POOL_SIZE = MAX_CONCURRENT_INPUT_RESOLUTIONS;
-  private static final int METADATA_IO_QUEUE_CAPACITY = METADATA_IO_POOL_SIZE;
-  private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
-  private static final long GLOBAL_PERMIT_POLL_MILLIS = 10;
+  private static final long SNAPSHOT_WAIT_POLL_MILLIS = 10;
   private static final BooleanSupplier NEVER_CANCELLED = () -> false;
   private static final CancellableCallRunner.FailureMessages METADATA_CALL_FAILURES =
       new CancellableCallRunner.FailureMessages(
@@ -130,13 +122,9 @@ public class QueryInputResolver {
   // per-request bound only. ConfigProvider keeps construction dependent on graph/store
   // collaborators while production still reads the deployment setting once per resolver.
   private final int maxParallelInputResolutions;
-  private final int maxConcurrentInputResolutions;
-
-  // Bounds metadata I/O across every request handled by this application-scoped resolver. The
-  // request-local BoundedFanout limit avoids one request monopolizing this capacity; this limiter
-  // prevents many requests from multiplying store pressure.
-  private final Semaphore concurrentInputResolutionPermits;
   private final CatalogOverlay metadataGraph;
+  private final MetadataIoRunner metadataIoRunner;
+  private final boolean ownsMetadataIoRunner;
 
   // Registers each resolved pin's blobs as a transient GC root at construction time (see
   // QueryContextStore.registerResolvingPinBlobs). Null in unit tests that construct the resolver
@@ -150,21 +138,30 @@ public class QueryInputResolver {
   private volatile ExecutorService blockingExecutor = ForkJoinPool.commonPool();
   private ExecutorService ownedBlockingExecutor;
 
-  // Metadata calls run separately from planning because DynamoDB-backed calls can pin a carrier
-  // while blocking. Cancellation can therefore release the waiting virtual planning thread without
-  // waiting for a non-cooperating client. Admission happens before submission and remains held
-  // until the underlying call exits. Its bounded queue bridges worker turnover without retaining
-  // unbounded cancelled request closures.
-  private volatile ExecutorService metadataIoExecutor = ForkJoinPool.commonPool();
-  private ExecutorService ownedMetadataIoExecutor;
+  // Carries cancellable single-flight state through the overridable completed-pin Map seam.
+  private final ThreadLocal<ResolutionInvocation> resolutionInvocation = new ThreadLocal<>();
 
   @Inject
+  public QueryInputResolver(
+      CatalogOverlay metadataGraph,
+      QueryContextStore queryStore,
+      MetadataIoRunner metadataIoRunner) {
+    this(
+        metadataGraph,
+        queryStore,
+        configuredMaxParallelInputResolutions(),
+        metadataIoRunner,
+        false);
+  }
+
+  /** Compatibility constructor for direct callers outside CDI. */
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
     this(
         metadataGraph,
         queryStore,
         configuredMaxParallelInputResolutions(),
-        MAX_CONCURRENT_INPUT_RESOLUTIONS);
+        new MetadataIoRunner(),
+        true);
   }
 
   QueryInputResolver(
@@ -172,12 +169,25 @@ public class QueryInputResolver {
       QueryContextStore queryStore,
       int maxParallelInputResolutions,
       int maxConcurrentInputResolutions) {
+    this(
+        metadataGraph,
+        queryStore,
+        maxParallelInputResolutions,
+        new MetadataIoRunner(maxConcurrentInputResolutions),
+        true);
+  }
+
+  private QueryInputResolver(
+      CatalogOverlay metadataGraph,
+      QueryContextStore queryStore,
+      int maxParallelInputResolutions,
+      MetadataIoRunner metadataIoRunner,
+      boolean ownsMetadataIoRunner) {
     this.metadataGraph = metadataGraph;
     this.queryStore = queryStore;
     this.maxParallelInputResolutions = maxParallelInputResolutions;
-    this.maxConcurrentInputResolutions = maxConcurrentInputResolutions;
-    this.concurrentInputResolutionPermits =
-        new Semaphore(maxConcurrentInputResolutions, true /* best-effort request fairness */);
+    this.metadataIoRunner = java.util.Objects.requireNonNull(metadataIoRunner, "metadataIoRunner");
+    this.ownsMetadataIoRunner = ownsMetadataIoRunner;
   }
 
   /** Test-only constructor: no store (no pin-root registration). */
@@ -201,54 +211,15 @@ public class QueryInputResolver {
     return clamped;
   }
 
-  /**
-   * Create the owned planning and metadata executors after validating their admission invariant.
-   */
+  /** Create the owned virtual-thread planning executor. */
   @PostConstruct
   void postConstruct() {
-    validateMetadataIoSizing(
-        maxConcurrentInputResolutions, METADATA_IO_POOL_SIZE, METADATA_IO_QUEUE_CAPACITY);
     ExecutorService planningExecutor = Executors.newVirtualThreadPerTaskExecutor();
-    ExecutorService ioExecutor =
-        MetadataIoExecutors.newBoundedDaemonPool(
-            METADATA_IO_POOL_SIZE, METADATA_IO_QUEUE_CAPACITY, "floecat-query-input-metadata-");
     ownedBlockingExecutor = planningExecutor;
-    ownedMetadataIoExecutor = ioExecutor;
     blockingExecutor = planningExecutor;
-    metadataIoExecutor = ioExecutor;
-  }
-
-  /** Validate that every admitted call can be accepted during worker turnover. */
-  static void validateMetadataIoSizing(int admission, int workers, int queueCapacity) {
-    if (admission < 1 || workers < admission || queueCapacity < admission) {
-      throw new IllegalStateException(
-          "metadata I/O workers and queue must each cover the admission bound"
-              + " (admission="
-              + admission
-              + ", workers="
-              + workers
-              + ", queue="
-              + queueCapacity
-              + ")");
+    if (ownsMetadataIoRunner) {
+      metadataIoRunner.start();
     }
-  }
-
-  /**
-   * Run metadata I/O on this resolver's application-wide executor and admission bound.
-   *
-   * <p>GetUserObjects uses this same runner for candidate and relation work, so all metadata-store
-   * calls share one ceiling instead of multiplying independent per-service limits.
-   */
-  public <T> T runMetadataIo(
-      BooleanSupplier cancelled,
-      Supplier<T> operation,
-      CancellableCallRunner.FailureMessages failureMessages) {
-    return CancellableCallRunner.call(
-        metadataIoExecutor,
-        concurrentInputResolutionPermits,
-        cancelled,
-        operation,
-        failureMessages);
   }
 
   /**
@@ -259,11 +230,8 @@ public class QueryInputResolver {
     if (ownedBlockingExecutor != null) {
       ownedBlockingExecutor.shutdownNow();
     }
-    if (ownedMetadataIoExecutor != null) {
-      if (!MetadataIoExecutors.shutdownNowAndAwait(
-          ownedMetadataIoExecutor, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-        LOG.warn("resolver metadata I/O executor did not terminate before shutdown timeout");
-      }
+    if (ownsMetadataIoRunner) {
+      metadataIoRunner.close();
     }
   }
 
@@ -537,15 +505,101 @@ public class QueryInputResolver {
       Optional<ResourceId> defaultCatalogId,
       ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
-    return resolveInputsCore(
-        queryId,
-        correlationId,
-        inputs,
-        asOfDefault,
-        defaultCatalogId,
+    ResolutionInvocation invocation = resolutionInvocation.get();
+    if (invocation != null) {
+      return resolveViaLegacyOverride(
+          queryId,
+          correlationId,
+          inputs,
+          asOfDefault,
+          defaultCatalogId,
+          invocation.currentSnapshotPinCache(),
+          diagnostics);
+    }
+    return withResolutionInvocation(
         currentSnapshotPinCache,
-        diagnostics,
-        NEVER_CANCELLED);
+        NEVER_CANCELLED,
+        () ->
+            resolveViaLegacyOverride(
+                queryId,
+                correlationId,
+                inputs,
+                asOfDefault,
+                defaultCatalogId,
+                currentSnapshotPinCache,
+                diagnostics));
+  }
+
+  /**
+   * Compatibility overload for callers and subclasses using the completed-pin cache contract. Plain
+   * maps are copied into the concurrent single-flight representation before fan-out and are updated
+   * only after successful resolution on the calling thread.
+   */
+  public ResolutionResult resolveInputs(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      Map<ResourceId, TablePin> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics) {
+    ResolutionInvocation invocation = resolutionInvocation.get();
+    if (invocation != null) {
+      return resolveInputsCore(
+          queryId,
+          correlationId,
+          inputs,
+          asOfDefault,
+          defaultCatalogId,
+          invocation.currentSnapshotPinCache(),
+          diagnostics,
+          invocation.cancelled());
+    }
+
+    Map<ResourceId, TablePin> initialCache = new LinkedHashMap<>(currentSnapshotPinCache);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
+        toSingleFlightCache(initialCache);
+    ResolutionResult result =
+        resolveInputsCore(
+            queryId,
+            correlationId,
+            inputs,
+            asOfDefault,
+            defaultCatalogId,
+            singleFlightCache,
+            diagnostics,
+            NEVER_CANCELLED);
+    try {
+      completedPins(singleFlightCache)
+          .forEach(
+              (tableId, pin) -> {
+                if (!initialCache.containsKey(tableId)
+                    || !java.util.Objects.equals(initialCache.get(tableId), pin)) {
+                  currentSnapshotPinCache.put(tableId, pin);
+                }
+              });
+    } catch (RuntimeException | Error copyFailure) {
+      boolean restored = false;
+      try {
+        if (!currentSnapshotPinCache.equals(initialCache)) {
+          currentSnapshotPinCache.clear();
+          currentSnapshotPinCache.putAll(initialCache);
+        }
+        restored = currentSnapshotPinCache.equals(initialCache);
+      } catch (RuntimeException | Error rollbackFailure) {
+        copyFailure.addSuppressed(rollbackFailure);
+      }
+      if (restored && queryStore != null && queryId != null && !queryId.isEmpty()) {
+        try {
+          queryStore.releaseResolvingPinBlobs(
+              queryId, QueryPins.gcRootUris(result.relationPinSet()));
+        } catch (RuntimeException | Error cleanupFailure) {
+          copyFailure.addSuppressed(cleanupFailure);
+        }
+      }
+      throw copyFailure;
+    }
+    return result;
   }
 
   /**
@@ -565,16 +619,92 @@ public class QueryInputResolver {
       PhaseDiagnostics diagnostics,
       BooleanSupplier cancelled) {
     throwIfCancelled(cancelled);
-    return resolveInputsCore(
-        queryId,
-        correlationId,
-        inputs,
-        asOfDefault,
-        defaultCatalogId,
+    return withResolutionInvocation(
         currentSnapshotPinCache,
-        diagnostics,
-        cancelled);
+        cancelled,
+        () ->
+            resolveInputs(
+                queryId,
+                correlationId,
+                inputs,
+                asOfDefault,
+                defaultCatalogId,
+                currentSnapshotPinCache,
+                diagnostics));
   }
+
+  /** Invoke the completed-pin compatibility seam and publish its successful cache entries. */
+  private ResolutionResult resolveViaLegacyOverride(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics) {
+    Map<ResourceId, TablePin> completedPinCache = completedPins(currentSnapshotPinCache);
+    ResolutionResult result =
+        resolveInputs(
+            queryId,
+            correlationId,
+            inputs,
+            asOfDefault,
+            defaultCatalogId,
+            completedPinCache,
+            diagnostics);
+    completedPinCache.forEach(
+        (tableId, pin) ->
+            currentSnapshotPinCache.putIfAbsent(tableId, CompletableFuture.completedFuture(pin)));
+    return result;
+  }
+
+  /** Install one invocation while retaining any outer invocation on the same request thread. */
+  private <T> T withResolutionInvocation(
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      BooleanSupplier cancelled,
+      Supplier<T> operation) {
+    ResolutionInvocation previous = resolutionInvocation.get();
+    resolutionInvocation.set(new ResolutionInvocation(currentSnapshotPinCache, cancelled));
+    try {
+      return operation.get();
+    } finally {
+      if (previous == null) {
+        resolutionInvocation.remove();
+      } else {
+        resolutionInvocation.set(previous);
+      }
+    }
+  }
+
+  /** Convert completed pins to the concurrent placeholder representation used during fan-out. */
+  private static ConcurrentMap<ResourceId, CompletableFuture<TablePin>> toSingleFlightCache(
+      Map<ResourceId, TablePin> completedPinCache) {
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
+        new ConcurrentHashMap<>();
+    completedPinCache.forEach(
+        (tableId, pin) -> singleFlightCache.put(tableId, CompletableFuture.completedFuture(pin)));
+    return singleFlightCache;
+  }
+
+  /** Snapshot successfully completed placeholders without waiting for active lookups. */
+  private static Map<ResourceId, TablePin> completedPins(
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache) {
+    Map<ResourceId, TablePin> completed = new LinkedHashMap<>();
+    singleFlightCache.forEach(
+        (tableId, pinFuture) -> {
+          if (pinFuture.isDone()
+              && !pinFuture.isCompletedExceptionally()
+              && !pinFuture.isCancelled()) {
+            completed.put(tableId, Futures.join(pinFuture));
+          }
+        });
+    return completed;
+  }
+
+  /** Per-thread state carried through the completed-pin override seam. */
+  private record ResolutionInvocation(
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      BooleanSupplier cancelled) {}
 
   /** Run the shared resolution implementation for cancellable and non-cancellable callers. */
   private ResolutionResult resolveInputsCore(
@@ -644,6 +774,7 @@ public class QueryInputResolver {
       } else {
         planInputsSerially(state, inputs, resolvedNames, cancelled);
       }
+      throwIfCancelled(cancelled);
 
       RelationPinSet relationPinSet =
           RelationPinSet.newBuilder()
@@ -772,53 +903,16 @@ public class QueryInputResolver {
       // An overlay can opt out because it owns request-thread-confined state. Preserve that
       // contract even for a cancellable caller; it can cancel while awaiting admission, but an
       // active callback remains on the request thread until the overlay returns.
-      return withInputResolutionPermitSynchronously(cancelled, operation);
+      return cancelled == NEVER_CANCELLED
+          ? metadataIoRunner.callOnCallerThreadWithoutCancellation(
+              operation, METADATA_CALL_FAILURES.interruption())
+          : metadataIoRunner.callOnCallerThread(
+              cancelled, operation, METADATA_CANCELLATION_FAILURES);
     }
     if (cancelled == NEVER_CANCELLED) {
-      return CancellableCallRunner.callWithoutCancellation(
-          metadataIoExecutor, concurrentInputResolutionPermits, operation, METADATA_CALL_FAILURES);
+      return metadataIoRunner.callWithoutCancellation(operation, METADATA_CALL_FAILURES);
     }
-    return runMetadataIo(cancelled, operation, METADATA_CANCELLATION_FAILURES);
-  }
-
-  /** Runs one metadata operation while retaining its global permit until the call truly returns. */
-  private <T> T withInputResolutionPermitSynchronously(
-      BooleanSupplier cancelled, Supplier<T> operation) {
-    boolean acquired = false;
-    try {
-      acquireInputResolutionPermit(cancelled);
-      acquired = true;
-      return operation.get();
-    } finally {
-      if (acquired) {
-        concurrentInputResolutionPermits.release();
-      }
-    }
-  }
-
-  /** Acquire process-wide metadata capacity while leaving a cancelled caller responsive. */
-  private void acquireInputResolutionPermit(BooleanSupplier cancelled) {
-    try {
-      if (cancelled == NEVER_CANCELLED) {
-        // Legacy callers cannot become cancelled, so a blocking fair acquire preserves FIFO
-        // ordering without repeatedly removing and re-enqueuing this waiter.
-        concurrentInputResolutionPermits.acquire();
-        return;
-      }
-      // Timed waits let serial callers observe cancellation too. This is best-effort fairness:
-      // a timed-out waiter must rejoin the fair semaphore's queue, trading strict FIFO for prompt
-      // request cancellation when all store-I/O slots are occupied.
-      while (true) {
-        throwIfCancelled(cancelled);
-        if (concurrentInputResolutionPermits.tryAcquire(
-            GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS)) {
-          return;
-        }
-      }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new CancellationException("interrupted while awaiting resolver I/O capacity");
-    }
+    return metadataIoRunner.call(cancelled, operation, METADATA_CANCELLATION_FAILURES);
   }
 
   /**
@@ -1016,7 +1110,7 @@ public class QueryInputResolver {
         throw new CancellationException("interrupted while awaiting current snapshot pin");
       }
       try {
-        return inflight.get(GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
+        return inflight.get(SNAPSHOT_WAIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
       } catch (TimeoutException ignored) {
         // A bounded wait lets the next loop observe cancellation or an executor interrupt.
       } catch (InterruptedException e) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -39,8 +39,9 @@ import ai.floedb.floecat.service.query.ViewContextUtils;
 import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -56,6 +57,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -63,7 +65,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.logging.Logger;
 
 /**
@@ -124,10 +125,12 @@ public class QueryInputResolver {
   // without a store — registration is simply skipped then.
   private final QueryContextStore queryStore;
 
-  // DynamoDB-backed metadata calls can pin a carrier while they block. Production uses Quarkus's
-  // managed platform-thread executor, matching NameResolver.parallelScan; the common pool is a
-  // non-owning test fallback for direct constructor call sites.
+  // DynamoDB-backed metadata calls can pin a carrier while they block. Production therefore owns
+  // a dedicated bounded platform-thread pool, independent of the Mutiny request executor whose
+  // driver synchronously awaits this fan-out. Direct unit construction retains a non-owning common
+  // pool fallback until CDI invokes postConstruct().
   private volatile ExecutorService blockingExecutor = ForkJoinPool.commonPool();
+  private ExecutorService ownedBlockingExecutor;
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -170,10 +173,17 @@ public class QueryInputResolver {
     return clamped;
   }
 
-  @Inject
-  void init(Instance<ManagedExecutor> managedExecutors) {
-    if (managedExecutors != null) {
-      managedExecutors.stream().findFirst().ifPresent(executor -> blockingExecutor = executor);
+  @PostConstruct
+  void postConstruct() {
+    ExecutorService executor = Executors.newFixedThreadPool(MAX_PARALLEL_INPUT_RESOLUTIONS);
+    ownedBlockingExecutor = executor;
+    blockingExecutor = executor;
+  }
+
+  @PreDestroy
+  void closeBlockingExecutor() {
+    if (ownedBlockingExecutor != null) {
+      ownedBlockingExecutor.close();
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
@@ -218,6 +219,7 @@ public class QueryInputResolver {
     private final QueryContextStore queryStore;
     private final String queryId;
     private final Map<TablePin, List<String>> rootsByPin = new IdentityHashMap<>();
+    private boolean terminal;
 
     ResolvingPinRoots(QueryContextStore queryStore, String queryId) {
       this.queryStore = queryStore;
@@ -229,7 +231,7 @@ public class QueryInputResolver {
      * callers propagate the failure without attempting a compensating release.
      */
     synchronized void register(TablePin pin) {
-      if (queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
+      if (terminal || queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
         return;
       }
       if (rootsByPin.containsKey(pin)) {
@@ -248,6 +250,9 @@ public class QueryInputResolver {
      * store failure retains ownership so a later failure cleanup can retry the release.
      */
     synchronized void discard(TablePin pin) {
+      if (terminal) {
+        return;
+      }
       List<String> roots = rootsByPin.get(pin);
       if (roots != null) {
         queryStore.releaseResolvingPinBlobs(queryId, roots);
@@ -260,6 +265,9 @@ public class QueryInputResolver {
      * and propagates to the caller, which retains the original resolution failure.
      */
     synchronized void releaseAll() {
+      // Cancellation can return from the fan-out before an uninterruptible task reaches register.
+      // Close ownership first so such a late task cannot add roots after this cleanup sweep.
+      terminal = true;
       var iterator = rootsByPin.entrySet().iterator();
       while (iterator.hasNext()) {
         Map.Entry<TablePin, List<String>> entry = iterator.next();
@@ -284,7 +292,13 @@ public class QueryInputResolver {
       Optional<Timestamp> asOfDefault,
       Optional<ResourceId> defaultCatalogId) {
     return resolveInputs(
-        "", correlationId, inputs, asOfDefault, defaultCatalogId, new ConcurrentHashMap<>(), null);
+        "",
+        correlationId,
+        inputs,
+        asOfDefault,
+        defaultCatalogId,
+        new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+        null);
   }
 
   /**
@@ -324,6 +338,50 @@ public class QueryInputResolver {
   }
 
   /**
+   * Backward-compatible overload for callers compiled against the original cache contract.
+   *
+   * <p>The legacy cache stores completed pins and is not required to be concurrent. Copy it into a
+   * concurrent single-flight cache for this call, then copy successfully resolved pins back on the
+   * calling thread. Worker tasks therefore never mutate a caller-owned plain {@link Map}.
+   */
+  public ResolutionResult resolveInputs(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      Map<ResourceId, TablePin> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics) {
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
+        new ConcurrentHashMap<>();
+    synchronized (currentSnapshotPinCache) {
+      currentSnapshotPinCache.forEach(
+          (tableId, pin) -> singleFlightCache.put(tableId, CompletableFuture.completedFuture(pin)));
+    }
+    try {
+      return resolveInputs(
+          queryId,
+          correlationId,
+          inputs,
+          asOfDefault,
+          defaultCatalogId,
+          singleFlightCache,
+          diagnostics);
+    } finally {
+      synchronized (currentSnapshotPinCache) {
+        singleFlightCache.forEach(
+            (tableId, pinFuture) -> {
+              if (pinFuture.isDone()
+                  && !pinFuture.isCompletedExceptionally()
+                  && !pinFuture.isCancelled()) {
+                currentSnapshotPinCache.put(tableId, Futures.join(pinFuture));
+              }
+            });
+      }
+    }
+  }
+
+  /**
    * As {@link #resolveInputs(String, String, List, Optional, Optional, ConcurrentMap,
    * PhaseDiagnostics)}, but stops before additional metadata work and interrupts fan-out tasks when
    * {@code cancelled} becomes true.
@@ -348,7 +406,8 @@ public class QueryInputResolver {
       long defaultCatalogStartNs = System.nanoTime();
       try {
         defaultCatalog =
-            metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName);
+            withMetadataGraph(
+                () -> metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName));
       } finally {
         diag.nanos("pin.default_catalog_resolve", System.nanoTime() - defaultCatalogStartNs);
       }
@@ -374,7 +433,9 @@ public class QueryInputResolver {
               .map(QueryInput::getName)
               .toList();
       Map<NameRef, Optional<ResourceId>> resolvedNames =
-          nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
+          nameInputs.isEmpty()
+              ? Map.of()
+              : withMetadataGraph(() -> metadataGraph.resolveNames(correlationId, nameInputs));
       throwIfCancelled(cancelled);
 
       // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
@@ -486,6 +547,20 @@ public class QueryInputResolver {
   }
 
   /**
+   * CatalogOverlay predates parallel resolution and does not require implementations to be
+   * thread-safe. Keep its callbacks serialized while allowing the rest of input planning to run
+   * concurrently.
+   */
+  private <T> T withMetadataGraph(Supplier<T> operation) {
+    if (metadataGraph.supportsConcurrentResolution()) {
+      return operation.get();
+    }
+    synchronized (metadataGraph) {
+      return operation.get();
+    }
+  }
+
+  /**
    * Resolve one input to its {@link InputPlan}, reading the metadata graph and updating the shared
    * current-snapshot cache and diagnostics. It does not read or write {@code state.resolved} or
    * {@code state.pinByTableId}; the caller merges the returned pins. Callers invoke this method
@@ -587,7 +662,9 @@ public class QueryInputResolver {
       if (inflight == null) {
         try {
           long snapshotPinStartNs = System.nanoTime();
-          pin = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+          pin =
+              withMetadataGraph(
+                  () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
           state.resolvingPinRoots.register(pin);
           state.diagnostics.count("pin.snapshot_calls");
           state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -602,6 +679,7 @@ public class QueryInputResolver {
         state.diagnostics.count("pin.current_snapshot_cache_misses");
       } else {
         pin = Futures.join(inflight);
+        state.resolvingPinRoots.register(pin);
         state.diagnostics.count("pin.current_snapshot_cache_hits");
       }
       return pin;
@@ -636,7 +714,9 @@ public class QueryInputResolver {
       }
     }
     long snapshotPinStartNs = System.nanoTime();
-    TablePin resolved = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+    TablePin resolved =
+        withMetadataGraph(
+            () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
     state.resolvingPinRoots.register(resolved);
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -711,10 +791,12 @@ public class QueryInputResolver {
     }
     long viewResolveStartNs = System.nanoTime();
     Optional<ViewNode> view =
-        metadataGraph
-            .resolve(relationId)
-            .filter(ViewNode.class::isInstance)
-            .map(ViewNode.class::cast);
+        withMetadataGraph(
+            () ->
+                metadataGraph
+                    .resolve(relationId)
+                    .filter(ViewNode.class::isInstance)
+                    .map(ViewNode.class::cast));
     state.diagnostics.nanos("pin.view_node_resolve", System.nanoTime() - viewResolveStartNs);
     view.ifPresent(
         resolvedView -> {
@@ -732,7 +814,7 @@ public class QueryInputResolver {
           }
           long baseNameStartNs = System.nanoTime();
           Map<NameRef, Optional<ResourceId>> baseIds =
-              metadataGraph.resolveNames(state.correlationId, baseRefs);
+              withMetadataGraph(() -> metadataGraph.resolveNames(state.correlationId, baseRefs));
           state.diagnostics.nanos(
               "pin.view_base_name_resolve", System.nanoTime() - baseNameStartNs);
           for (NameRef baseRef : baseRefs) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -157,12 +157,12 @@ public class QueryInputResolver {
   private static int configuredMaxParallelInputResolutions() {
     int configured =
         ConfigProvider.getConfig()
-            .getOptionalValue("floecat.catalog.bundle.max_parallel_relations", Integer.class)
+            .getOptionalValue("floecat.query.resolver.max_parallel_inputs", Integer.class)
             .orElse(DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS);
     int clamped = Math.max(1, Math.min(MAX_PARALLEL_INPUT_RESOLUTIONS, configured));
     if (configured != clamped) {
       LOG.warnf(
-          "floecat.catalog.bundle.max_parallel_relations must be between 1 and %d; using %d"
+          "floecat.query.resolver.max_parallel_inputs must be between 1 and %d; using %d"
               + " instead of %d",
           MAX_PARALLEL_INPUT_RESOLUTIONS, clamped, configured);
     }
@@ -449,12 +449,7 @@ public class QueryInputResolver {
         defaultCatalog =
             withInputResolutionPermit(
                 cancelled,
-                () ->
-                    withMetadataGraph(
-                        () ->
-                            metadataGraph
-                                .catalog(defaultCatalogId.get())
-                                .map(CatalogNode::displayName)));
+                () -> metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName));
       } finally {
         diag.nanos("pin.default_catalog_resolve", System.nanoTime() - defaultCatalogStartNs);
       }
@@ -483,10 +478,7 @@ public class QueryInputResolver {
           nameInputs.isEmpty()
               ? Map.of()
               : withInputResolutionPermit(
-                  cancelled,
-                  () ->
-                      withMetadataGraph(
-                          () -> metadataGraph.resolveNames(correlationId, nameInputs)));
+                  cancelled, () -> metadataGraph.resolveNames(correlationId, nameInputs));
       throwIfCancelled(cancelled);
 
       // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
@@ -628,15 +620,6 @@ public class QueryInputResolver {
   }
 
   /**
-   * The serial planning path keeps callbacks on the request thread for overlays that opt out.
-   * Synchronizing on an application-scoped overlay would incorrectly serialize independent
-   * requests, so the concurrency capability governs scheduling rather than a shared mutex.
-   */
-  private <T> T withMetadataGraph(Supplier<T> operation) {
-    return operation.get();
-  }
-
-  /**
    * Resolve one input to its {@link InputPlan}, reading the metadata graph and updating the shared
    * current-snapshot cache and diagnostics. It does not read or write {@code state.resolved} or
    * {@code state.pinByTableId}; the caller merges the returned pins. Callers invoke this method
@@ -738,9 +721,7 @@ public class QueryInputResolver {
       if (inflight == null) {
         try {
           long snapshotPinStartNs = System.nanoTime();
-          pin =
-              withMetadataGraph(
-                  () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
+          pin = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
           state.resolvingPinRoots.register(pin);
           state.diagnostics.count("pin.snapshot_calls");
           state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -790,9 +771,7 @@ public class QueryInputResolver {
       }
     }
     long snapshotPinStartNs = System.nanoTime();
-    TablePin resolved =
-        withMetadataGraph(
-            () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
+    TablePin resolved = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
     state.resolvingPinRoots.register(resolved);
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -867,12 +846,10 @@ public class QueryInputResolver {
     }
     long viewResolveStartNs = System.nanoTime();
     Optional<ViewNode> view =
-        withMetadataGraph(
-            () ->
-                metadataGraph
-                    .resolve(relationId)
-                    .filter(ViewNode.class::isInstance)
-                    .map(ViewNode.class::cast));
+        metadataGraph
+            .resolve(relationId)
+            .filter(ViewNode.class::isInstance)
+            .map(ViewNode.class::cast);
     state.diagnostics.nanos("pin.view_node_resolve", System.nanoTime() - viewResolveStartNs);
     view.ifPresent(
         resolvedView -> {
@@ -890,7 +867,7 @@ public class QueryInputResolver {
           }
           long baseNameStartNs = System.nanoTime();
           Map<NameRef, Optional<ResourceId>> baseIds =
-              withMetadataGraph(() -> metadataGraph.resolveNames(state.correlationId, baseRefs));
+              metadataGraph.resolveNames(state.correlationId, baseRefs);
           state.diagnostics.nanos(
               "pin.view_base_name_resolve", System.nanoTime() - baseNameStartNs);
           for (NameRef baseRef : baseRefs) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -317,7 +317,6 @@ public class QueryInputResolver {
    * its own single pin.
    */
   private record InputPlan(ResourceId resolvedId, List<TablePin> pins, Throwable terminalFailure) {}
-
   private void mergePlan(ResolutionState state, InputPlan plan) {
     state.resolved.add(plan.resolvedId());
     for (TablePin pin : plan.pins()) {
@@ -328,13 +327,6 @@ public class QueryInputResolver {
     }
     if (plan.terminalFailure() instanceof Error error) {
       throw error;
-    }
-  }
-
-  private void mergePlan(ResolutionState state, InputPlan plan) {
-    state.resolved.add(plan.resolvedId());
-    for (TablePin pin : plan.pins()) {
-      mergePin(state, pin);
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -160,8 +160,8 @@ public class QueryInputResolver {
         metadataGraph,
         queryStore,
         configuredMaxParallelInputResolutions(),
-        new MetadataIoRunner(),
-        true);
+        MetadataIoRunner.shared(),
+        false);
   }
 
   QueryInputResolver(

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -34,9 +34,13 @@ import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.ViewContextUtils;
+import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -46,6 +50,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Semaphore;
+import org.eclipse.microprofile.context.ManagedExecutor;
 
 /**
  * QueryInputResolver
@@ -81,12 +92,20 @@ import java.util.Set;
 @ApplicationScoped
 public class QueryInputResolver {
 
+  // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
+  // store reads; a small fan-out overlaps their round-trips without flooding the store or executor.
+  private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
+
   private final CatalogOverlay metadataGraph;
 
   // Registers each resolved pin's blobs as a transient GC root at construction time (see
   // QueryContextStore.registerResolvingPinBlobs). Null in unit tests that construct the resolver
   // without a store — registration is simply skipped then.
   private final QueryContextStore queryStore;
+
+  // Runs per-input resolution off the request thread. The Quarkus ManagedExecutor is injected in
+  // init(); tests (and any wiring without one) fall back to the common pool.
+  private volatile Executor blockingExecutor = ForkJoinPool.commonPool();
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -97,6 +116,13 @@ public class QueryInputResolver {
   /** Test-only constructor: no store (no pin-root registration). */
   public QueryInputResolver(CatalogOverlay metadataGraph) {
     this(metadataGraph, null);
+  }
+
+  @Inject
+  void init(Instance<ManagedExecutor> managedExecutors) {
+    if (managedExecutors != null) {
+      managedExecutors.stream().findFirst().ifPresent(e -> blockingExecutor = e);
+    }
   }
 
   // =============================================================================
@@ -155,6 +181,23 @@ public class QueryInputResolver {
       this.currentSnapshotPinCache = currentSnapshotPinCache;
       this.resolvingPinRoots = resolvingPinRoots;
       this.diagnostics = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
+    }
+
+    /**
+     * A view of this state that reports to {@code taskDiagnostics} instead of the shared
+     * diagnostics, for resolving one input off the request thread. Shares the read-only fields and
+     * the current-snapshot cache (which must be thread-safe); its own {@code resolved} / {@code
+     * pinByTableId} are unused, since off-thread resolution only computes pins and never merges.
+     */
+    ResolutionState withDiagnostics(PhaseDiagnostics taskDiagnostics) {
+      return new ResolutionState(
+          queryId,
+          correlationId,
+          asOfDefault,
+          defaultCatalog,
+          currentSnapshotPinCache,
+          resolvingPinRoots,
+          taskDiagnostics);
     }
   }
 
@@ -221,7 +264,7 @@ public class QueryInputResolver {
       Optional<Timestamp> asOfDefault,
       Optional<ResourceId> defaultCatalogId) {
     return resolveInputs(
-        "", correlationId, inputs, asOfDefault, defaultCatalogId, new LinkedHashMap<>(), null);
+        "", correlationId, inputs, asOfDefault, defaultCatalogId, new ConcurrentHashMap<>(), null);
   }
 
   /**
@@ -284,10 +327,12 @@ public class QueryInputResolver {
       Map<NameRef, Optional<ResourceId>> resolvedNames =
           nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
 
-      // Resolve and merge in input order. A later malformed input must not mask a conflict that
-      // was already established by an earlier pair.
-      for (QueryInput in : inputs) {
-        mergePlan(state, planInput(state, in, resolvedNames));
+      List<InputPlan> plans =
+          inputs.size() > 1
+              ? planInputsConcurrently(state, inputs, resolvedNames)
+              : planInputsSerially(state, inputs, resolvedNames);
+      for (InputPlan plan : plans) {
+        mergePlan(state, plan);
       }
 
       RelationPinSet relationPinSet =
@@ -327,6 +372,77 @@ public class QueryInputResolver {
     }
     if (plan.terminalFailure() instanceof Error error) {
       throw error;
+    }
+  }
+
+  /** Resolve the inputs one at a time on the calling thread, reporting to the shared diagnostics. */
+  private List<InputPlan> planInputsSerially(
+      ResolutionState state,
+      List<QueryInput> inputs,
+      Map<NameRef, Optional<ResourceId>> resolvedNames) {
+    List<InputPlan> plans = new ArrayList<>(inputs.size());
+    for (QueryInput in : inputs) {
+      plans.add(planInput(state, in, resolvedNames));
+    }
+    return plans;
+  }
+
+  /**
+   * Resolve the inputs across the blocking executor and gather their plans in input order. Tasks
+   * report to a shared thread-safe accumulator instead of the request's diagnostics (which is not
+   * guaranteed thread-safe); its per-key totals — snapshot-lookup calls and time, cache hits/misses
+   * — are flushed to the real diagnostics once resolution has joined. The result is the per-RPC
+   * aggregate of those counters, not a per-relation breakdown; the coarse phase timings are
+   * measured by the caller around this call regardless. One task state is shared by all tasks
+   * because everything they touch is immutable or thread-safe (the current-snapshot cache and the
+   * accumulator). Gathering plans in input order keeps the caller's merge deterministic
+   * (first-touch-wins, conflict detection).
+   */
+  private List<InputPlan> planInputsConcurrently(
+      ResolutionState state,
+      List<QueryInput> inputs,
+      Map<NameRef, Optional<ResourceId>> resolvedNames) {
+    Semaphore gate = new Semaphore(MAX_PARALLEL_INPUT_RESOLUTIONS);
+    Context otelContext = Context.current();
+    AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
+    ResolutionState taskState = state.withDiagnostics(taskDiagnostics);
+    List<CompletableFuture<InputPlan>> futures =
+        inputs.stream()
+            .map(
+                in ->
+                    CompletableFuture.supplyAsync(
+                        () -> {
+                          gate.acquireUninterruptibly();
+                          try (Scope ignored = otelContext.makeCurrent()) {
+                            return planInput(taskState, in, resolvedNames);
+                          } finally {
+                            gate.release();
+                          }
+                        },
+                        blockingExecutor))
+            .toList();
+
+    List<InputPlan> plans = new ArrayList<>(inputs.size());
+    for (CompletableFuture<InputPlan> future : futures) {
+      plans.add(joinUnwrapped(future));
+    }
+    taskDiagnostics.flushInto(state.diagnostics);
+    return plans;
+  }
+
+  /** Join a resolution task, surfacing its original (unwrapped) failure rather than a wrapper. */
+  private static InputPlan joinUnwrapped(CompletableFuture<InputPlan> future) {
+    try {
+      return future.join();
+    } catch (CompletionException ce) {
+      Throwable cause = ce.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error e) {
+        throw e;
+      }
+      throw new IllegalStateException("unexpected checked exception from input resolution", cause);
     }
   }
 
@@ -416,21 +532,33 @@ public class QueryInputResolver {
       SnapshotRef override,
       Optional<Timestamp> asOfDefault) {
     if (usesCurrentSnapshotFallback(override, asOfDefault)) {
-      TablePin cached = state.currentSnapshotPinCache.get(rid);
-      if (cached != null) {
-        state.diagnostics.count("pin.current_snapshot_cache_hits");
-        state.resolvingPinRoots.register(cached);
-        return cached;
-      }
-      state.diagnostics.count("pin.current_snapshot_cache_misses");
-      long snapshotPinStartNs = System.nanoTime();
-      TablePin resolved =
-          metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
-      state.diagnostics.count("pin.snapshot_calls");
-      state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
-      state.resolvingPinRoots.register(resolved);
-      state.currentSnapshotPinCache.put(rid, resolved);
-      return resolved;
+      // Single-flight per table: two references to the same table's CURRENT snapshot must freeze
+      // the
+      // SAME snapshot even when they resolve on different threads, or an ingest landing between two
+      // independent lookups would give them different snapshots and turn a compatible pair into a
+      // pin conflict. computeIfAbsent runs the lookup once per table id; concurrent callers for
+      // that
+      // id wait for and share its result. (Requires a thread-safe cache — see resolveInputs.)
+      boolean[] resolvedHere = {false};
+      TablePin pin =
+          state.currentSnapshotPinCache.computeIfAbsent(
+              rid,
+              id -> {
+                resolvedHere[0] = true;
+                long snapshotPinStartNs = System.nanoTime();
+                TablePin resolved =
+                    metadataGraph.tablePinFor(state.correlationId, id, override, asOfDefault);
+                state.resolvingPinRoots.register(resolved);
+                state.diagnostics.count("pin.snapshot_calls");
+                state.diagnostics.nanos(
+                    "pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
+                return resolved;
+              });
+      state.diagnostics.count(
+          resolvedHere[0]
+              ? "pin.current_snapshot_cache_misses"
+              : "pin.current_snapshot_cache_hits");
+      return pin;
     }
     state.diagnostics.count(
         "pin.explicit_snapshot_pins", override != null && override.hasSnapshotId());

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -32,6 +32,7 @@ import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.concurrent.Futures;
+import ai.floedb.floecat.service.context.PropagatedContext;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
@@ -59,6 +60,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -106,6 +108,7 @@ public class QueryInputResolver {
   private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 16;
   private static final int MAX_CONCURRENT_INPUT_RESOLUTIONS = 64;
   private static final long GLOBAL_PERMIT_POLL_MILLIS = 10;
+  private static final BooleanSupplier NEVER_CANCELLED = () -> false;
 
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
   // store reads; a small fan-out overlaps their round-trips without flooding the store. This is a
@@ -131,6 +134,12 @@ public class QueryInputResolver {
   // pool fallback until CDI invokes postConstruct().
   private volatile ExecutorService blockingExecutor = ForkJoinPool.commonPool();
   private ExecutorService ownedBlockingExecutor;
+
+  // Metadata calls run separately from the bounded planning pool so cancellation can interrupt the
+  // active store call and release its planning worker without waiting for a non-cooperating client.
+  // The global semaphore remains held until that call actually exits, preserving the store-I/O cap.
+  private volatile ExecutorService metadataIoExecutor = ForkJoinPool.commonPool();
+  private ExecutorService ownedMetadataIoExecutor;
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -175,15 +184,21 @@ public class QueryInputResolver {
 
   @PostConstruct
   void postConstruct() {
-    ExecutorService executor = Executors.newFixedThreadPool(MAX_PARALLEL_INPUT_RESOLUTIONS);
-    ownedBlockingExecutor = executor;
-    blockingExecutor = executor;
+    ExecutorService planningExecutor = Executors.newFixedThreadPool(MAX_PARALLEL_INPUT_RESOLUTIONS);
+    ExecutorService ioExecutor = Executors.newFixedThreadPool(MAX_CONCURRENT_INPUT_RESOLUTIONS);
+    ownedBlockingExecutor = planningExecutor;
+    ownedMetadataIoExecutor = ioExecutor;
+    blockingExecutor = planningExecutor;
+    metadataIoExecutor = ioExecutor;
   }
 
   @PreDestroy
   void closeBlockingExecutor() {
     if (ownedBlockingExecutor != null) {
       ownedBlockingExecutor.close();
+    }
+    if (ownedMetadataIoExecutor != null) {
+      ownedMetadataIoExecutor.close();
     }
   }
 
@@ -391,7 +406,7 @@ public class QueryInputResolver {
         defaultCatalogId,
         currentSnapshotPinCache,
         diagnostics,
-        () -> false);
+        NEVER_CANCELLED);
   }
 
   /**
@@ -608,6 +623,47 @@ public class QueryInputResolver {
   }
 
   private <T> T withInputResolutionPermit(BooleanSupplier cancelled, Supplier<T> operation) {
+    if (cancelled == NEVER_CANCELLED) {
+      return withInputResolutionPermitSynchronously(operation);
+    }
+
+    PropagatedContext context = PropagatedContext.capture();
+    Future<T> submitted =
+        metadataIoExecutor.submit(
+            () ->
+                context.supply(() -> withInputResolutionPermitSynchronously(cancelled, operation)));
+    try {
+      while (true) {
+        if (cancelled.getAsBoolean()) {
+          submitted.cancel(true);
+          throw new CancellationException("input resolution cancelled");
+        }
+        try {
+          return submitted.get(GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException ignored) {
+          // A bounded wait lets the caller interrupt a metadata operation as soon as it cancels.
+        } catch (InterruptedException e) {
+          submitted.cancel(true);
+          Thread.currentThread().interrupt();
+          throw new CancellationException("interrupted while awaiting resolver I/O");
+        } catch (ExecutionException e) {
+          rethrowAsyncFailure(e.getCause());
+        }
+      }
+    } catch (CancellationException e) {
+      submitted.cancel(true);
+      throw e;
+    }
+  }
+
+  /** Acquires the global store-I/O slot and runs an uncancellable legacy call on the caller. */
+  private <T> T withInputResolutionPermitSynchronously(Supplier<T> operation) {
+    return withInputResolutionPermitSynchronously(NEVER_CANCELLED, operation);
+  }
+
+  /** Runs one metadata operation while retaining its global permit until the call truly returns. */
+  private <T> T withInputResolutionPermitSynchronously(
+      BooleanSupplier cancelled, Supplier<T> operation) {
     boolean acquired = false;
     try {
       throwIfCancelled(cancelled);

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -39,6 +39,7 @@ import ai.floedb.floecat.service.query.ViewContextUtils;
 import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
@@ -58,6 +59,7 @@ import java.util.concurrent.Executors;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
 
 /**
  * QueryInputResolver
@@ -93,12 +95,13 @@ import org.eclipse.microprofile.config.ConfigProvider;
 @ApplicationScoped
 public class QueryInputResolver {
 
+  private static final Logger LOG = Logger.getLogger(QueryInputResolver.class);
+
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
-  // store reads; a small fan-out overlaps their round-trips without flooding the store. Shared with
-  // the catalog bundle's relation fan-out via the same config property. Per-request bound only: the
-  // virtual-thread executor has no shared-pool ceiling. Read once here via ConfigProvider (not a
-  // @ConfigProperty ctor param) so the new-constructed test call sites keep compiling while prod
-  // still honors config.
+  // store reads; a small fan-out overlaps their round-trips without flooding the store. This is a
+  // per-request bound only: the virtual-thread executor has no shared-pool ceiling. Read once here
+  // via ConfigProvider (not a @ConfigProperty ctor param) so the new-constructed test call sites
+  // keep compiling while production still honors config.
   private final int maxParallelInputResolutions;
 
   private final CatalogOverlay metadataGraph;
@@ -118,20 +121,27 @@ public class QueryInputResolver {
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
     this.metadataGraph = metadataGraph;
     this.queryStore = queryStore;
-    // Clamp to >=1: a 0/negative permit count would wedge the fan-out's permit wait forever.
-    // UserObjectBundleService warns on this same config key; clamp silently here to avoid a
-    // duplicate warning.
-    this.maxParallelInputResolutions =
-        Math.max(
-            1,
-            ConfigProvider.getConfig()
-                .getOptionalValue("floecat.catalog.bundle.max_parallel_relations", Integer.class)
-                .orElse(8));
+    int configuredMaxParallelResolutions =
+        ConfigProvider.getConfig()
+            .getOptionalValue("floecat.catalog.bundle.max_parallel_relations", Integer.class)
+            .orElse(8);
+    if (configuredMaxParallelResolutions < 1) {
+      LOG.warnf(
+          "floecat.catalog.bundle.max_parallel_relations must be >= 1; using 1 instead of %d",
+          configuredMaxParallelResolutions);
+    }
+    this.maxParallelInputResolutions = Math.max(1, configuredMaxParallelResolutions);
   }
 
   /** Test-only constructor: no store (no pin-root registration). */
   public QueryInputResolver(CatalogOverlay metadataGraph) {
     this(metadataGraph, null);
+  }
+
+  /** Stop accepting fan-out work and wait for any in-flight resolution tasks during shutdown. */
+  @PreDestroy
+  void closeBlockingExecutor() {
+    blockingExecutor.close();
   }
 
   // =============================================================================
@@ -441,9 +451,10 @@ public class QueryInputResolver {
       // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
       // a view yields its base tables' pins). planInput reads the metadata graph and the shared
       // current-snapshot cache; it does not touch `resolved` or `pinByTableId`. Inputs resolve
-      // independently, so with more than one they are fanned out; the results are gathered in input
-      // order for the merge below.
-      if (inputs.size() > 1) {
+      // independently, so overlays that explicitly support concurrent resolution fan them out. An
+      // overlay that opts out may retain request-thread-confined lifecycle state, so its entire
+      // planning loop remains on the caller thread. Results always merge in input order below.
+      if (inputs.size() > 1 && metadataGraph.supportsConcurrentResolution()) {
         planInputsConcurrently(state, inputs, resolvedNames, cancelled);
       } else {
         planInputsSerially(state, inputs, resolvedNames, cancelled);
@@ -514,9 +525,8 @@ public class QueryInputResolver {
    * measured by the caller around this call regardless. One task state is shared by all tasks
    * because everything they touch is immutable or thread-safe (the current-snapshot cache and the
    * accumulator). Keep off-thread diagnostics to counters and durations only; one-shot put/emit
-   * values must stay on the request thread because the accumulator intentionally drops them.
-   * Gathering plans in input order keeps the caller's merge deterministic (first-touch-wins,
-   * conflict detection).
+   * values must stay on the request thread because the accumulator rejects them. Gathering plans in
+   * input order keeps the caller's merge deterministic (first-touch-wins, conflict detection).
    */
   private void planInputsConcurrently(
       ResolutionState state,
@@ -547,9 +557,9 @@ public class QueryInputResolver {
   }
 
   /**
-   * CatalogOverlay predates parallel resolution and does not require implementations to be
-   * thread-safe. Keep its callbacks serialized while allowing the rest of input planning to run
-   * concurrently.
+   * CatalogOverlay callbacks are direct when the overlay opts into concurrent resolution. The
+   * serial planning path keeps all callbacks on the request thread for overlays that opt out; the
+   * synchronization here also protects the up-front catalog and name-resolution callbacks.
    */
   private <T> T withMetadataGraph(Supplier<T> operation) {
     if (metadataGraph.supportsConcurrentResolution()) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -63,9 +63,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -109,8 +111,10 @@ public class QueryInputResolver {
   private static final int DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
   private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 16;
   private static final int MAX_CONCURRENT_INPUT_RESOLUTIONS = 64;
+  private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
   private static final long GLOBAL_PERMIT_POLL_MILLIS = 10;
   private static final BooleanSupplier NEVER_CANCELLED = () -> false;
+  private static final AtomicInteger METADATA_IO_THREAD_SEQUENCE = new AtomicInteger();
 
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
   // store reads; a small fan-out overlaps their round-trips without flooding the store. This is a
@@ -196,6 +200,7 @@ public class QueryInputResolver {
             0L,
             TimeUnit.MILLISECONDS,
             new ArrayBlockingQueue<>(MAX_CONCURRENT_INPUT_RESOLUTIONS),
+            daemonMetadataIoThreadFactory(),
             new ThreadPoolExecutor.AbortPolicy());
     ownedBlockingExecutor = planningExecutor;
     ownedMetadataIoExecutor = ioExecutor;
@@ -210,6 +215,31 @@ public class QueryInputResolver {
     }
     if (ownedMetadataIoExecutor != null) {
       CancellableCallRunner.cancelDiscardedTasks(ownedMetadataIoExecutor.shutdownNow());
+      awaitMetadataIoTermination(ownedMetadataIoExecutor);
+    }
+  }
+
+  private static ThreadFactory daemonMetadataIoThreadFactory() {
+    return runnable -> {
+      Thread thread =
+          new Thread(
+              runnable,
+              "floecat-query-input-metadata-" + METADATA_IO_THREAD_SEQUENCE.incrementAndGet());
+      thread.setDaemon(true);
+      return thread;
+    };
+  }
+
+  /**
+   * Bound shutdown while daemon workers let an interruption-insensitive store call be abandoned.
+   */
+  private static void awaitMetadataIoTermination(ExecutorService executor) {
+    try {
+      if (!executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        LOG.warn("resolver metadata I/O executor did not terminate before shutdown timeout");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 
@@ -634,11 +664,19 @@ public class QueryInputResolver {
   }
 
   private <T> T withInputResolutionPermit(BooleanSupplier cancelled, Supplier<T> operation) {
-    if (cancelled == NEVER_CANCELLED || !metadataGraph.supportsConcurrentResolution()) {
+    if (!metadataGraph.supportsConcurrentResolution()) {
       // An overlay can opt out because it owns request-thread-confined state. Preserve that
       // contract even for a cancellable caller; it can cancel while awaiting admission, but an
       // active callback remains on the request thread until the overlay returns.
       return withInputResolutionPermitSynchronously(cancelled, operation);
+    }
+    if (cancelled == NEVER_CANCELLED) {
+      return CancellableCallRunner.callUncancellable(
+          metadataIoExecutor,
+          concurrentInputResolutionPermits,
+          operation,
+          "resolver metadata I/O executor shut down",
+          "interrupted while awaiting resolver I/O");
     }
     return CancellableCallRunner.call(
         metadataIoExecutor,

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -34,13 +34,12 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.concurrent.CancellableCallRunner;
 import ai.floedb.floecat.service.concurrent.Futures;
+import ai.floedb.floecat.service.concurrent.MetadataIoExecutors;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.ViewContextUtils;
-import ai.floedb.floecat.service.telemetry.ServiceMetrics;
 import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
-import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
 import jakarta.annotation.PostConstruct;
@@ -55,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -65,12 +63,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
@@ -118,29 +115,26 @@ public class QueryInputResolver {
   // global admission bound without changing the invariant check in postConstruct().
   private static final int METADATA_IO_POOL_SIZE = MAX_CONCURRENT_INPUT_RESOLUTIONS;
   private static final int METADATA_IO_QUEUE_CAPACITY = METADATA_IO_POOL_SIZE;
-  // Legacy callers cannot provide a cancellation signal. Bound their complete admission-plus-I/O
-  // wait so an unresponsive metadata store yields DEADLINE_EXCEEDED instead of pinning the RPC.
-  private static final long UNINTERRUPTIBLE_METADATA_WAIT_SECONDS = 30;
   private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
   private static final long GLOBAL_PERMIT_POLL_MILLIS = 10;
   private static final BooleanSupplier NEVER_CANCELLED = () -> false;
-  private static final AtomicInteger METADATA_IO_THREAD_SEQUENCE = new AtomicInteger();
+  private static final CancellableCallRunner.FailureMessages METADATA_CALL_FAILURES =
+      new CancellableCallRunner.FailureMessages(
+          "resolver metadata I/O executor shut down", "interrupted while awaiting resolver I/O");
+  private static final CancellableCallRunner.FailureMessages METADATA_CANCELLATION_FAILURES =
+      new CancellableCallRunner.FailureMessages(
+          "input resolution cancelled", "interrupted while awaiting resolver I/O");
 
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
   // store reads; a small fan-out overlaps their round-trips without flooding the store. This is a
-  // per-request bound only. Read once here via ConfigProvider (not a @ConfigProperty ctor param)
-  // so the new-constructed test call sites keep compiling while production still honors config.
+  // per-request bound only. ConfigProvider keeps construction dependent on graph/store
+  // collaborators while production still reads the deployment setting once per resolver.
   private final int maxParallelInputResolutions;
 
   // Bounds metadata I/O across every request handled by this application-scoped resolver. The
   // request-local BoundedFanout limit avoids one request monopolizing this capacity; this limiter
   // prevents many requests from multiplying store pressure.
   private final Semaphore concurrentInputResolutionPermits;
-  // Calls which timed out at the caller but still own metadata I/O admission because the
-  // downstream client has not returned. This must remain visible to operators before it exhausts
-  // the global permit pool.
-  private final AtomicInteger timedOutMetadataCalls = new AtomicInteger();
-
   private final CatalogOverlay metadataGraph;
 
   // Registers each resolved pin's blobs as a transient GC root at construction time (see
@@ -163,7 +157,10 @@ public class QueryInputResolver {
   private volatile ExecutorService metadataIoExecutor = ForkJoinPool.commonPool();
   private ExecutorService ownedMetadataIoExecutor;
 
-  @Inject Observability observability;
+  // All overloads retain virtual dispatch through the completed-pin Map extension seam. This
+  // per-thread scope carries the single-flight cache and cancellation signal through that seam
+  // without exposing their synchronization details in its signature.
+  private final ThreadLocal<ResolutionInvocation> resolutionInvocation = new ThreadLocal<>();
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -183,7 +180,7 @@ public class QueryInputResolver {
     this.queryStore = queryStore;
     this.maxParallelInputResolutions = maxParallelInputResolutions;
     this.concurrentInputResolutionPermits =
-        new Semaphore(maxConcurrentInputResolutions, true /* FIFO across requests */);
+        new Semaphore(maxConcurrentInputResolutions, true /* best-effort request fairness */);
   }
 
   /** Test-only constructor: no store (no pin-root registration). */
@@ -191,6 +188,7 @@ public class QueryInputResolver {
     this(metadataGraph, null);
   }
 
+  /** Read and clamp the per-request fan-out width so invalid deployment values remain safe. */
   private static int configuredMaxParallelInputResolutions() {
     int configured =
         ConfigProvider.getConfig()
@@ -206,6 +204,9 @@ public class QueryInputResolver {
     return clamped;
   }
 
+  /**
+   * Create the owned planning and metadata executors after validating their admission invariant.
+   */
   @PostConstruct
   void postConstruct() {
     if (MAX_CONCURRENT_INPUT_RESOLUTIONS > METADATA_IO_POOL_SIZE) {
@@ -214,58 +215,27 @@ public class QueryInputResolver {
     }
     ExecutorService planningExecutor = Executors.newVirtualThreadPerTaskExecutor();
     ExecutorService ioExecutor =
-        new ThreadPoolExecutor(
-            METADATA_IO_POOL_SIZE,
-            METADATA_IO_POOL_SIZE,
-            0L,
-            TimeUnit.MILLISECONDS,
-            new ArrayBlockingQueue<>(METADATA_IO_QUEUE_CAPACITY),
-            daemonMetadataIoThreadFactory(),
-            new ThreadPoolExecutor.AbortPolicy());
+        MetadataIoExecutors.newBoundedDaemonPool(
+            METADATA_IO_POOL_SIZE, METADATA_IO_QUEUE_CAPACITY, "floecat-query-input-metadata-");
     ownedBlockingExecutor = planningExecutor;
     ownedMetadataIoExecutor = ioExecutor;
     blockingExecutor = planningExecutor;
     metadataIoExecutor = ioExecutor;
-    if (observability != null) {
-      observability.gauge(
-          ServiceMetrics.Query.METADATA_CALLS_STUCK,
-          timedOutMetadataCalls::get,
-          "Metadata calls still holding resolver admission after their caller timed out");
-    }
   }
 
+  /**
+   * Stop owned executors without allowing interruption-insensitive metadata calls to block exit.
+   */
   @PreDestroy
-  void closeBlockingExecutor() {
+  void closeExecutors() {
     if (ownedBlockingExecutor != null) {
       ownedBlockingExecutor.shutdownNow();
     }
     if (ownedMetadataIoExecutor != null) {
-      CancellableCallRunner.cancelDiscardedTasks(ownedMetadataIoExecutor.shutdownNow());
-      awaitMetadataIoTermination(ownedMetadataIoExecutor);
-    }
-  }
-
-  private static ThreadFactory daemonMetadataIoThreadFactory() {
-    return runnable -> {
-      Thread thread =
-          new Thread(
-              runnable,
-              "floecat-query-input-metadata-" + METADATA_IO_THREAD_SEQUENCE.incrementAndGet());
-      thread.setDaemon(true);
-      return thread;
-    };
-  }
-
-  /**
-   * Bound shutdown while daemon workers let an interruption-insensitive store call be abandoned.
-   */
-  private static void awaitMetadataIoTermination(ExecutorService executor) {
-    try {
-      if (!executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      if (!MetadataIoExecutors.shutdownNowAndAwait(
+          ownedMetadataIoExecutor, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
         LOG.warn("resolver metadata I/O executor did not terminate before shutdown timeout");
       }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
     }
   }
 
@@ -306,6 +276,8 @@ public class QueryInputResolver {
     final Map<ResourceId, TablePin> pinByTableId = new LinkedHashMap<>();
     // Request-local cache for current-snapshot table pins (no override, no as-of).
     final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache;
+    // Entries inserted into the caller cache by this attempt, for conditional eviction on failure.
+    final CurrentSnapshotCacheOwnership currentSnapshotCacheOwnership;
     // Tracks transient roots owned by this resolution attempt until they are retained or discarded.
     final ResolvingPinRoots resolvingPinRoots;
     final PhaseDiagnostics diagnostics;
@@ -317,6 +289,7 @@ public class QueryInputResolver {
         Optional<Timestamp> asOfDefault,
         Optional<String> defaultCatalog,
         ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+        CurrentSnapshotCacheOwnership currentSnapshotCacheOwnership,
         ResolvingPinRoots resolvingPinRoots,
         PhaseDiagnostics diagnostics,
         BooleanSupplier cancelled) {
@@ -325,6 +298,7 @@ public class QueryInputResolver {
       this.asOfDefault = asOfDefault;
       this.defaultCatalog = defaultCatalog;
       this.currentSnapshotPinCache = currentSnapshotPinCache;
+      this.currentSnapshotCacheOwnership = currentSnapshotCacheOwnership;
       this.resolvingPinRoots = resolvingPinRoots;
       this.diagnostics = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
       this.cancelled = cancelled;
@@ -343,9 +317,79 @@ public class QueryInputResolver {
           asOfDefault,
           defaultCatalog,
           currentSnapshotPinCache,
+          currentSnapshotCacheOwnership,
           resolvingPinRoots,
           taskDiagnostics,
           cancelled);
+    }
+  }
+
+  /**
+   * Tracks single-flight holders inserted by one resolution attempt. A failed attempt evicts only
+   * its own holders, leaving entries supplied by earlier or concurrent owners untouched. Closing is
+   * terminal: a late task that records after cancellation removes and fails its holder instead of
+   * publishing an unrooted pin after cleanup has completed.
+   */
+  private static final class CurrentSnapshotCacheOwnership {
+    private final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache;
+    private final Map<ResourceId, CompletableFuture<TablePin>> owned = new LinkedHashMap<>();
+    private boolean terminal;
+
+    CurrentSnapshotCacheOwnership(ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache) {
+      this.cache = cache;
+    }
+
+    /** Claim a newly inserted holder, or discard it when failure cleanup already won. */
+    synchronized boolean claim(ResourceId tableId, CompletableFuture<TablePin> holder) {
+      if (terminal) {
+        synchronized (holder) {
+          cache.remove(tableId, holder);
+          holder.completeExceptionally(
+              new CancellationException("input resolution no longer active"));
+        }
+        return false;
+      }
+      owned.put(tableId, holder);
+      return true;
+    }
+
+    /** Forget a holder that its lookup failure already evicted from the caller cache. */
+    synchronized void forget(ResourceId tableId, CompletableFuture<TablePin> holder) {
+      owned.remove(tableId, holder);
+    }
+
+    /**
+     * Retire a completed CURRENT entry before its pin relinquishes transient-root ownership. The
+     * holder lock makes cache removal atomic with a waiter's published-entry check.
+     */
+    synchronized void retire(ResourceId tableId, TablePin pin) {
+      CompletableFuture<TablePin> holder = cache.get(tableId);
+      if (holder == null
+          || !holder.isDone()
+          || holder.isCompletedExceptionally()
+          || holder.isCancelled()) {
+        return;
+      }
+      synchronized (holder) {
+        if (cache.get(tableId) == holder
+            && holder.getNow(null) == pin
+            && cache.remove(tableId, holder)) {
+          owned.remove(tableId, holder);
+        }
+      }
+    }
+
+    /** Evict and fail every holder still owned by this failed resolution attempt. */
+    synchronized void closeAndEvict() {
+      terminal = true;
+      owned.forEach(
+          (tableId, holder) -> {
+            synchronized (holder) {
+              cache.remove(tableId, holder);
+              holder.completeExceptionally(new CancellationException("input resolution failed"));
+            }
+          });
+      owned.clear();
     }
   }
 
@@ -465,23 +509,38 @@ public class QueryInputResolver {
       Optional<ResourceId> defaultCatalogId,
       ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
-    return resolveInputs(
-        queryId,
-        correlationId,
-        inputs,
-        asOfDefault,
-        defaultCatalogId,
-        currentSnapshotPinCache,
-        diagnostics,
-        NEVER_CANCELLED);
+    ResolutionInvocation current = resolutionInvocation.get();
+    if (current != null) {
+      return resolveInputsViaLegacyOverride(
+          queryId,
+          correlationId,
+          inputs,
+          asOfDefault,
+          defaultCatalogId,
+          currentSnapshotPinCache,
+          diagnostics);
+    }
+    return withResolutionInvocation(
+        new ResolutionInvocation(currentSnapshotPinCache, NEVER_CANCELLED),
+        () ->
+            resolveInputsViaLegacyOverride(
+                queryId,
+                correlationId,
+                inputs,
+                asOfDefault,
+                defaultCatalogId,
+                currentSnapshotPinCache,
+                diagnostics));
   }
 
   /**
-   * Backward-compatible overload for callers compiled against the original cache contract.
+   * Compatibility overload for callers that own a completed-pin {@link Map} cache.
    *
-   * <p>The legacy cache stores completed pins and is not required to be concurrent. Copy it into a
-   * concurrent single-flight cache for this call, then copy successfully resolved pins back on the
-   * calling thread. Worker tasks therefore never mutate a caller-owned plain {@link Map}.
+   * <p>The supplied cache is not required to be concurrent. Copy it into a concurrent single-flight
+   * cache for this call, then copy successfully resolved pins back on the calling thread. Worker
+   * tasks therefore never mutate a caller-owned plain map. If copy-back fails, restore the map's
+   * original contents before releasing the attempt's transient roots. When restoration cannot be
+   * proven, retain those roots until the store grace period so any copied prefix remains protected.
    */
   public ResolutionResult resolveInputs(
       String queryId,
@@ -491,30 +550,51 @@ public class QueryInputResolver {
       Optional<ResourceId> defaultCatalogId,
       Map<ResourceId, TablePin> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
-    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
-        new ConcurrentHashMap<>();
-    synchronized (currentSnapshotPinCache) {
-      currentSnapshotPinCache.forEach(
-          (tableId, pin) -> singleFlightCache.put(tableId, CompletableFuture.completedFuture(pin)));
+    ResolutionInvocation current = resolutionInvocation.get();
+    if (current != null) {
+      return resolveInputsCore(
+          queryId,
+          correlationId,
+          inputs,
+          asOfDefault,
+          defaultCatalogId,
+          current.currentSnapshotPinCache(),
+          diagnostics,
+          current.cancelled());
     }
+    Map<ResourceId, TablePin> initialCache = snapshotCompletedPinCache(currentSnapshotPinCache);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
+        toSingleFlightCache(initialCache);
     ResolutionResult result =
-        resolveInputs(
+        resolveInputsCore(
             queryId,
             correlationId,
             inputs,
             asOfDefault,
             defaultCatalogId,
             singleFlightCache,
-            diagnostics);
-    synchronized (currentSnapshotPinCache) {
-      singleFlightCache.forEach(
-          (tableId, pinFuture) -> {
-            if (pinFuture.isDone()
-                && !pinFuture.isCompletedExceptionally()
-                && !pinFuture.isCancelled()) {
-              currentSnapshotPinCache.put(tableId, Futures.join(pinFuture));
-            }
-          });
+            diagnostics,
+            NEVER_CANCELLED);
+    try {
+      copyCompletedPins(singleFlightCache, currentSnapshotPinCache);
+    } catch (RuntimeException | Error copyFailure) {
+      if (restoreCompletedPinCache(currentSnapshotPinCache, initialCache, copyFailure)) {
+        try {
+          if (queryStore != null && queryId != null && !queryId.isEmpty()) {
+            queryStore.releaseResolvingPinBlobs(
+                queryId, QueryPins.gcRootUris(result.relationPinSet()));
+          }
+        } catch (RuntimeException | Error cleanupFailure) {
+          copyFailure.addSuppressed(cleanupFailure);
+        }
+      } else {
+        // A map with non-transactional or rejecting mutations may retain a copied prefix. Keep the
+        // attempt's roots until the store grace period rather than exposing that prefix unrooted.
+        LOG.warnf(
+            "Retaining resolving pin roots after legacy cache rollback failed query_id=%s",
+            queryId);
+      }
+      throw copyFailure;
     }
     return result;
   }
@@ -522,9 +602,35 @@ public class QueryInputResolver {
   /**
    * As {@link #resolveInputs(String, String, List, Optional, Optional, ConcurrentMap,
    * PhaseDiagnostics)}, but stops before additional metadata work and interrupts fan-out tasks when
-   * {@code cancelled} becomes true.
+   * {@code cancelled} becomes true. The supplier may be read concurrently by the caller and worker
+   * threads, so it must be non-blocking and thread-safe (typically {@link AtomicBoolean#get}).
+   * Observed cancellation throws {@link CancellationException}.
    */
   public ResolutionResult resolveInputs(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
+    return withResolutionInvocation(
+        new ResolutionInvocation(currentSnapshotPinCache, cancelled),
+        () ->
+            resolveInputs(
+                queryId,
+                correlationId,
+                inputs,
+                asOfDefault,
+                defaultCatalogId,
+                currentSnapshotPinCache,
+                diagnostics));
+  }
+
+  /** Run the base resolution implementation after compatibility overload dispatch has completed. */
+  private ResolutionResult resolveInputsCore(
       String queryId,
       String correlationId,
       List<QueryInput> inputs,
@@ -545,7 +651,6 @@ public class QueryInputResolver {
       try {
         defaultCatalog =
             withInputResolutionPermit(
-                correlationId,
                 cancelled,
                 () -> metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName));
       } finally {
@@ -561,6 +666,7 @@ public class QueryInputResolver {
             asOfDefault,
             defaultCatalog,
             currentSnapshotPinCache,
+            new CurrentSnapshotCacheOwnership(currentSnapshotPinCache),
             new ResolvingPinRoots(queryStore, queryId),
             diag,
             cancelled);
@@ -577,9 +683,7 @@ public class QueryInputResolver {
           nameInputs.isEmpty()
               ? Map.of()
               : withInputResolutionPermit(
-                  correlationId,
-                  cancelled,
-                  () -> metadataGraph.resolveNames(correlationId, nameInputs));
+                  cancelled, () -> metadataGraph.resolveNames(correlationId, nameInputs));
       throwIfCancelled(cancelled);
 
       // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
@@ -603,6 +707,13 @@ public class QueryInputResolver {
           state.resolved, relationPinSet, asOfDefault.map(Timestamp::toByteArray).orElse(null));
     } catch (RuntimeException | Error e) {
       try {
+        // Evict attempt-owned cache entries before releasing their transient roots, so another
+        // resolve call cannot observe an unrooted completed pin in between those operations.
+        state.currentSnapshotCacheOwnership.closeAndEvict();
+      } catch (RuntimeException | Error cleanupFailure) {
+        e.addSuppressed(cleanupFailure);
+      }
+      try {
         state.resolvingPinRoots.releaseAll();
       } catch (RuntimeException | Error cleanupFailure) {
         e.addSuppressed(cleanupFailure);
@@ -611,6 +722,116 @@ public class QueryInputResolver {
     }
   }
 
+  /** Dispatch through the completed-pin extension seam and copy any subclass cache writes. */
+  private ResolutionResult resolveInputsViaLegacyOverride(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics) {
+    Map<ResourceId, TablePin> completedPinCache = completedPins(currentSnapshotPinCache);
+    ResolutionResult result =
+        resolveInputs(
+            queryId,
+            correlationId,
+            inputs,
+            asOfDefault,
+            defaultCatalogId,
+            completedPinCache,
+            diagnostics);
+    completedPinCache.forEach(
+        (tableId, pin) ->
+            currentSnapshotPinCache.putIfAbsent(tableId, CompletableFuture.completedFuture(pin)));
+    return result;
+  }
+
+  /**
+   * Install one cancellable invocation while preserving nested resolver calls on the same thread.
+   */
+  private <T> T withResolutionInvocation(ResolutionInvocation invocation, Supplier<T> operation) {
+    ResolutionInvocation previous = resolutionInvocation.get();
+    resolutionInvocation.set(invocation);
+    try {
+      return operation.get();
+    } finally {
+      if (previous == null) {
+        resolutionInvocation.remove();
+      } else {
+        resolutionInvocation.set(previous);
+      }
+    }
+  }
+
+  /** Snapshot a completed-pin cache without exposing it to resolution workers. */
+  private static Map<ResourceId, TablePin> snapshotCompletedPinCache(
+      Map<ResourceId, TablePin> completedPinCache) {
+    synchronized (completedPinCache) {
+      return new LinkedHashMap<>(completedPinCache);
+    }
+  }
+
+  /** Convert a completed-pin snapshot into the resolver's single-flight representation. */
+  private static ConcurrentMap<ResourceId, CompletableFuture<TablePin>> toSingleFlightCache(
+      Map<ResourceId, TablePin> completedPinCache) {
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
+        new ConcurrentHashMap<>();
+    completedPinCache.forEach(
+        (tableId, pin) -> singleFlightCache.put(tableId, CompletableFuture.completedFuture(pin)));
+    return singleFlightCache;
+  }
+
+  /** Restore the caller cache after a failed copy, recording rollback failures on the cause. */
+  private static boolean restoreCompletedPinCache(
+      Map<ResourceId, TablePin> completedPinCache,
+      Map<ResourceId, TablePin> initialCache,
+      Throwable copyFailure) {
+    synchronized (completedPinCache) {
+      if (completedPinCache.equals(initialCache)) {
+        return true;
+      }
+      try {
+        completedPinCache.clear();
+        completedPinCache.putAll(initialCache);
+      } catch (RuntimeException | Error rollbackFailure) {
+        copyFailure.addSuppressed(rollbackFailure);
+      }
+      return completedPinCache.equals(initialCache);
+    }
+  }
+
+  /**
+   * Snapshot successful single-flight entries into a completed-pin map after resolution succeeds.
+   */
+  private static void copyCompletedPins(
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache,
+      Map<ResourceId, TablePin> completedPinCache) {
+    synchronized (completedPinCache) {
+      completedPins(singleFlightCache).forEach(completedPinCache::put);
+    }
+  }
+
+  /** Snapshot only successfully completed single-flight entries. */
+  private static Map<ResourceId, TablePin> completedPins(
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache) {
+    Map<ResourceId, TablePin> completed = new LinkedHashMap<>();
+    singleFlightCache.forEach(
+        (tableId, pinFuture) -> {
+          if (pinFuture.isDone()
+              && !pinFuture.isCompletedExceptionally()
+              && !pinFuture.isCancelled()) {
+            completed.put(tableId, Futures.join(pinFuture));
+          }
+        });
+    return completed;
+  }
+
+  /** Per-thread state carried through the completed-pin virtual extension seam. */
+  private record ResolutionInvocation(
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      BooleanSupplier cancelled) {}
+
   // =============================================================================
   // Pin resolution
   // =============================================================================
@@ -618,15 +839,17 @@ public class QueryInputResolver {
   /**
    * One input's resolution: the id recorded in {@code resolved}, and the table pins it contributes,
    * ordered. A view's id is recorded but the pins are its base tables'; a table records its id and
-   * its own single pin.
+   * its own single pin. A view may retain a successfully resolved dependency prefix plus a terminal
+   * failure; ordered merge consumes that prefix before rethrowing the deferred failure.
    */
   private record InputPlan(ResourceId resolvedId, List<TablePin> pins, Throwable terminalFailure) {}
 
   /** Merge one completed plan on the request thread, preserving request-order semantics. */
-  private void mergePlan(ResolutionState state, InputPlan plan) {
+  private void mergePlan(
+      ResolutionState state, InputPlan plan, Consumer<TablePin> discardCompatiblePin) {
     state.resolved.add(plan.resolvedId());
     for (TablePin pin : plan.pins()) {
-      mergePin(state, pin);
+      mergePin(state, pin, discardCompatiblePin);
     }
     if (plan.terminalFailure() instanceof RuntimeException runtime) {
       throw runtime;
@@ -646,7 +869,8 @@ public class QueryInputResolver {
       BooleanSupplier cancelled) {
     for (QueryInput in : inputs) {
       throwIfCancelled(cancelled);
-      mergePlan(state, planInput(state, in, resolvedNames));
+      mergePlan(
+          state, planInput(state, in, resolvedNames), pin -> discardCompatiblePin(state, pin));
     }
   }
 
@@ -656,13 +880,14 @@ public class QueryInputResolver {
    * guaranteed thread-safe); its per-key totals — snapshot-lookup calls and time, cache hits/misses
    * — are flushed to the real diagnostics once resolution has joined. The result is the per-RPC
    * aggregate of those counters, not a per-relation breakdown; the coarse phase timings are
-   * measured by the caller around this call regardless. One task state is shared by all tasks
-   * because everything they touch is immutable or thread-safe (the current-snapshot cache and the
-   * accumulator). Keep off-thread diagnostics to counters and durations only; one-shot put/emit
-   * values must stay on the request thread because the accumulator rejects them. The task timing
-   * keys are aggregate work time in this concurrent path, so they may exceed the enclosing
-   * wall-clock resolver phase; dashboards must not treat them as elapsed time. Gathering plans in
-   * input order keeps the caller's merge deterministic (first-touch-wins, conflict detection).
+   * measured by the caller around this call regardless. Each input receives its own state view so
+   * mutable per-plan fields can never become shared task state; only immutable resolution context
+   * and the explicitly thread-safe single-flight cache, root tracker, and diagnostics accumulator
+   * are shared. Keep off-thread diagnostics to counters and durations only; the accumulator safely
+   * omits one-shot put/emit values that cannot be combined across inputs. The task timing keys are
+   * aggregate work time in this concurrent path, so they may exceed the enclosing wall-clock
+   * resolver phase; dashboards must not treat them as elapsed time. Gathering plans in input order
+   * keeps the caller's merge deterministic (first-touch-wins, conflict detection).
    */
   private void planInputsConcurrently(
       ResolutionState state,
@@ -670,15 +895,19 @@ public class QueryInputResolver {
       Map<NameRef, Optional<ResourceId>> resolvedNames,
       BooleanSupplier cancelled) {
     AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
-    ResolutionState taskState = state.withDiagnostics(taskDiagnostics);
+    List<TablePin> deferredDiscards = new ArrayList<>();
     try {
       BoundedFanout.forEachOrdered(
           inputs,
           maxParallelInputResolutions,
           blockingExecutor,
-          in -> planInput(taskState, in, resolvedNames),
-          plan -> mergePlan(state, plan),
+          in -> planInput(state.withDiagnostics(taskDiagnostics), in, resolvedNames),
+          plan -> mergePlan(state, plan, deferredDiscards::add),
           cancelled);
+      // Ordered merging can finish a compatible CURRENT holder while a later parallel planner is
+      // still registering its own use of that holder. Retire losing holders only after every
+      // planner has joined, so a waiter cannot observe retirement as a spurious cancellation.
+      deferredDiscards.forEach(pin -> discardCompatiblePin(state, pin));
     } finally {
       // A failed or cancelled sibling can still leave completed tasks' pin work in this
       // accumulator. Preserve those counters for the request's failure telemetry too.
@@ -692,8 +921,16 @@ public class QueryInputResolver {
     }
   }
 
-  private <T> T withInputResolutionPermit(
-      String correlationId, BooleanSupplier cancelled, Supplier<T> operation) {
+  /**
+   * Run one overlay call under process-wide metadata admission.
+   *
+   * <p>Thread-confined overlays execute on the caller. Concurrent overlays dispatch store I/O to
+   * the platform-worker pool so virtual planning threads cannot pin carriers. Cancellable callers
+   * return promptly when their signal or interrupt wins; calls without a cancellation signal
+   * deliberately wait without an invented deadline. Admission remains owned by live downstream work
+   * even after a cancellable caller returns.
+   */
+  private <T> T withInputResolutionPermit(BooleanSupplier cancelled, Supplier<T> operation) {
     if (!metadataGraph.supportsConcurrentResolution()) {
       // An overlay can opt out because it owns request-thread-confined state. Preserve that
       // contract even for a cancellable caller; it can cancel while awaiting admission, but an
@@ -701,42 +938,15 @@ public class QueryInputResolver {
       return withInputResolutionPermitSynchronously(cancelled, operation);
     }
     if (cancelled == NEVER_CANCELLED) {
-      try {
-        return CancellableCallRunner.callUncancellable(
-            metadataIoExecutor,
-            concurrentInputResolutionPermits,
-            operation,
-            UNINTERRUPTIBLE_METADATA_WAIT_SECONDS,
-            TimeUnit.SECONDS,
-            "resolver metadata I/O executor shut down",
-            "interrupted while awaiting resolver I/O",
-            "resolver metadata I/O timed out",
-            new CancellableCallRunner.TimeoutListener() {
-              @Override
-              public void timedOut() {
-                int stuck = timedOutMetadataCalls.incrementAndGet();
-                LOG.warnf(
-                    "resolver metadata call timed out while still active; %d call(s) retain"
-                        + " metadata admission",
-                    stuck);
-              }
-
-              @Override
-              public void finished() {
-                timedOutMetadataCalls.decrementAndGet();
-              }
-            });
-      } catch (CancellableCallRunner.CallTimeoutException e) {
-        throw GrpcErrors.timeout(correlationId, null, Map.of(), e);
-      }
+      return CancellableCallRunner.callWithoutCancellation(
+          metadataIoExecutor, concurrentInputResolutionPermits, operation, METADATA_CALL_FAILURES);
     }
     return CancellableCallRunner.call(
         metadataIoExecutor,
         concurrentInputResolutionPermits,
         cancelled,
         operation,
-        "input resolution cancelled",
-        "interrupted while awaiting resolver I/O");
+        METADATA_CANCELLATION_FAILURES);
   }
 
   /** Runs one metadata operation while retaining its global permit until the call truly returns. */
@@ -859,6 +1069,11 @@ public class QueryInputResolver {
     };
   }
 
+  /**
+   * Resolve one table pin. CURRENT lookups use a single-flight holder whose owner constructs and
+   * roots the pin before publication; failures evict the holder and wake waiters. Explicit and
+   * AS-OF requests reuse an exactly matching committed pin or construct and root a fresh one.
+   */
   private TablePin pinForTable(
       ResolutionState state,
       ResourceId rid,
@@ -868,65 +1083,69 @@ public class QueryInputResolver {
         isExplicitCurrentSnapshot(override) ? Optional.empty() : asOfDefault;
     if (usesCurrentSnapshotFallback(override, effectiveAsOfDefault)) {
       // Single-flight per table: two references to the same table's CURRENT snapshot must freeze
-      // the
-      // SAME snapshot even when they resolve on different threads, or an ingest landing between two
-      // independent lookups would give them different snapshots and turn a compatible pair into a
-      // pin conflict. A CompletableFuture placeholder gives that single-flight WITHOUT
-      // computeIfAbsent
-      // holding the map's bin lock across the store round-trip — which would serialize unrelated
-      // table ids that hash to the same bin. The winner (whoever inserts the incomplete future)
-      // runs
-      // the one lookup; concurrent same-id callers await its result.
-      CompletableFuture<TablePin> holder = new CompletableFuture<>();
-      CompletableFuture<TablePin> inflight = state.currentSnapshotPinCache.putIfAbsent(rid, holder);
-      TablePin pin;
-      if (inflight == null) {
-        try {
-          long snapshotPinStartNs = System.nanoTime();
-          pin =
-              withInputResolutionPermit(
-                  state.correlationId,
-                  state.cancelled,
-                  () -> {
-                    TablePin constructed =
-                        metadataGraph.tablePinFor(
-                            state.correlationId, rid, override, effectiveAsOfDefault);
-                    state.resolvingPinRoots.register(constructed);
-                    return constructed;
-                  });
-          state.diagnostics.count("pin.snapshot_calls");
-          state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
-        } catch (RuntimeException | Error e) {
-          // Never cache a failure: drop the placeholder so a retry re-resolves, and release any
-          // callers already awaiting this id with the same error.
-          state.currentSnapshotPinCache.remove(rid, holder);
-          holder.completeExceptionally(e);
-          throw e;
+      // the same snapshot even when they resolve on different threads. Otherwise, an ingest between
+      // independent lookups can turn a compatible pair into a conflict. A CompletableFuture
+      // placeholder provides single-flight without holding a map-bin lock across the store call:
+      // the task that inserts the placeholder performs the lookup, and same-table tasks await it.
+      while (true) {
+        CompletableFuture<TablePin> holder = new CompletableFuture<>();
+        CompletableFuture<TablePin> inflight =
+            state.currentSnapshotPinCache.putIfAbsent(rid, holder);
+        TablePin pin;
+        if (inflight == null) {
+          if (!state.currentSnapshotCacheOwnership.claim(rid, holder)) {
+            throw new CancellationException("input resolution no longer active");
+          }
+          try {
+            long snapshotPinStartNs = System.nanoTime();
+            pin =
+                withInputResolutionPermit(
+                    state.cancelled,
+                    () -> {
+                      TablePin constructed =
+                          metadataGraph.tablePinFor(
+                              state.correlationId, rid, override, effectiveAsOfDefault);
+                      state.resolvingPinRoots.register(constructed);
+                      return constructed;
+                    });
+            state.diagnostics.count("pin.snapshot_calls");
+            state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
+          } catch (RuntimeException | Error e) {
+            // Never cache a failure: drop the placeholder so a retry re-resolves, and release any
+            // callers already awaiting this id with the same error.
+            state.currentSnapshotPinCache.remove(rid, holder);
+            state.currentSnapshotCacheOwnership.forget(rid, holder);
+            holder.completeExceptionally(e);
+            throw e;
+          }
+          holder.complete(pin);
+          state.diagnostics.count("pin.current_snapshot_cache_misses");
+          return pin;
         }
-        holder.complete(pin);
-        state.diagnostics.count("pin.current_snapshot_cache_misses");
-      } else {
+
         pin = awaitCurrentSnapshot(state, inflight);
-        state.resolvingPinRoots.register(pin);
-        state.diagnostics.count("pin.current_snapshot_cache_hits");
+        // Failed owners remove the holder under this same lock before releasing their root. A
+        // waiter therefore either installs its own root while the holder remains published or
+        // retries against the replacement entry without using a retired pin.
+        synchronized (inflight) {
+          if (state.currentSnapshotPinCache.get(rid) == inflight) {
+            state.resolvingPinRoots.register(pin);
+            state.diagnostics.count("pin.current_snapshot_cache_hits");
+            return pin;
+          }
+        }
+        throwIfCancelled(state.cancelled);
       }
-      return pin;
     }
     state.diagnostics.count(
         "pin.explicit_snapshot_pins", override != null && override.hasSnapshotId());
     state.diagnostics.count(
         "pin.asof_snapshot_pins",
         (override != null && override.hasAsOf()) || asOfDefault.isPresent());
-    // Before re-resolving against the LIVE root (which throws once the pinned snapshot has left the
-    // manifest — deleted or expired), reuse the query's existing committed pin if it already froze
-    // THIS same request, mirroring the CURRENT path's per-request cache and the first-touch-wins
-    // rule. A snapshot pinned at BeginQuery keeps its blobs GC-rooted for the query's lifetime, so
-    // a
-    // later DescribeInputs restating the same request must get the pin back — not a spurious
-    // NOT_FOUND or a QUERY_TABLE_PIN_CONFLICT from resolving a different snapshot at the same time.
-    // Covers explicit snapshot_id AND AS_OF (incl. an asOfDefault): both resolve deterministically
-    // to one frozen snapshot. Only a genuinely different request (other id / other as-of)
-    // re-resolves.
+    // Reuse a committed pin that froze this exact explicit or AS-OF request. The committed query
+    // keeps its blobs rooted even after the live manifest no longer contains that snapshot, and
+    // first-touch semantics require subsequent resolution to return the same frozen pin. A
+    // different snapshot id or timestamp still resolves against the live root.
     if (queryStore != null) {
       Optional<TablePin> reused =
           queryStore
@@ -944,7 +1163,6 @@ public class QueryInputResolver {
     long snapshotPinStartNs = System.nanoTime();
     TablePin resolved =
         withInputResolutionPermit(
-            state.correlationId,
             state.cancelled,
             () -> {
               TablePin constructed =
@@ -973,19 +1191,9 @@ public class QueryInputResolver {
         Thread.currentThread().interrupt();
         throw new CancellationException("interrupted while awaiting current snapshot pin");
       } catch (ExecutionException e) {
-        rethrowAsyncFailure(e.getCause());
+        throw Futures.propagate(e.getCause(), "unexpected checked exception from async task");
       }
     }
-  }
-
-  private static void rethrowAsyncFailure(Throwable failure) {
-    if (failure instanceof RuntimeException runtime) {
-      throw runtime;
-    }
-    if (failure instanceof Error error) {
-      throw error;
-    }
-    throw new IllegalStateException("unexpected checked exception from async task", failure);
   }
 
   private boolean usesCurrentSnapshotFallback(
@@ -1013,7 +1221,10 @@ public class QueryInputResolver {
     }
   }
 
-  // Helper method to compute effective as-of timestamp for dependency pinning
+  /**
+   * Selects dependency pinning time: explicit CURRENT clears the request default, explicit AS-OF
+   * replaces it, and an input without either selector inherits the request default.
+   */
   private Optional<Timestamp> effectiveAsOf(SnapshotRef override, Optional<Timestamp> asOfDefault) {
     if (isExplicitCurrentSnapshot(override)) {
       return Optional.empty();
@@ -1070,7 +1281,6 @@ public class QueryInputResolver {
     long viewResolveStartNs = System.nanoTime();
     Optional<ViewNode> view =
         withInputResolutionPermit(
-            state.correlationId,
             state.cancelled,
             () ->
                 metadataGraph
@@ -1095,9 +1305,7 @@ public class QueryInputResolver {
           long baseNameStartNs = System.nanoTime();
           Map<NameRef, Optional<ResourceId>> baseIds =
               withInputResolutionPermit(
-                  state.correlationId,
-                  state.cancelled,
-                  () -> metadataGraph.resolveNames(state.correlationId, baseRefs));
+                  state.cancelled, () -> metadataGraph.resolveNames(state.correlationId, baseRefs));
           state.diagnostics.nanos(
               "pin.view_base_name_resolve", System.nanoTime() - baseNameStartNs);
           for (NameRef baseRef : baseRefs) {
@@ -1109,7 +1317,8 @@ public class QueryInputResolver {
         });
   }
 
-  private void mergePin(ResolutionState state, TablePin pin) {
+  private void mergePin(
+      ResolutionState state, TablePin pin, Consumer<TablePin> discardCompatiblePin) {
     if (pin == null) {
       return;
     }
@@ -1121,7 +1330,13 @@ public class QueryInputResolver {
     // First-touch wins: compatible later pins relinquish only their own provisional roots.
     QueryPins.reconcile(existing, pin, state.correlationId);
     if (existing != pin) {
-      state.resolvingPinRoots.discard(pin);
+      discardCompatiblePin.accept(pin);
     }
+  }
+
+  /** Retire a compatible losing pin's cache entry before releasing its provisional roots. */
+  private void discardCompatiblePin(ResolutionState state, TablePin pin) {
+    state.currentSnapshotCacheOwnership.retire(pin.getTableId(), pin);
+    state.resolvingPinRoots.discard(pin);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -687,11 +687,6 @@ public class QueryInputResolver {
         "interrupted while awaiting resolver I/O");
   }
 
-  /** Acquires the global store-I/O slot and runs an uncancellable legacy call on the caller. */
-  private <T> T withInputResolutionPermitSynchronously(Supplier<T> operation) {
-    return withInputResolutionPermitSynchronously(NEVER_CANCELLED, operation);
-  }
-
   /** Runs one metadata operation while retaining its global permit until the call truly returns. */
   private <T> T withInputResolutionPermitSynchronously(
       BooleanSupplier cancelled, Supplier<T> operation) {
@@ -959,6 +954,9 @@ public class QueryInputResolver {
 
   // Helper method to compute effective as-of timestamp for dependency pinning
   private Optional<Timestamp> effectiveAsOf(SnapshotRef override, Optional<Timestamp> asOfDefault) {
+    if (isExplicitCurrentSnapshot(override)) {
+      return Optional.empty();
+    }
     if (override != null && override.hasAsOf()) {
       return Optional.of(override.getAsOf());
     }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -30,6 +30,7 @@ import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
@@ -37,8 +38,6 @@ import ai.floedb.floecat.service.query.ViewContextUtils;
 import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -50,12 +49,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Semaphore;
 import org.eclipse.microprofile.context.ManagedExecutor;
 
 /**
@@ -402,48 +398,16 @@ public class QueryInputResolver {
       ResolutionState state,
       List<QueryInput> inputs,
       Map<NameRef, Optional<ResourceId>> resolvedNames) {
-    Semaphore gate = new Semaphore(MAX_PARALLEL_INPUT_RESOLUTIONS);
-    Context otelContext = Context.current();
     AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
     ResolutionState taskState = state.withDiagnostics(taskDiagnostics);
-    List<CompletableFuture<InputPlan>> futures =
-        inputs.stream()
-            .map(
-                in ->
-                    CompletableFuture.supplyAsync(
-                        () -> {
-                          gate.acquireUninterruptibly();
-                          try (Scope ignored = otelContext.makeCurrent()) {
-                            return planInput(taskState, in, resolvedNames);
-                          } finally {
-                            gate.release();
-                          }
-                        },
-                        blockingExecutor))
-            .toList();
-
-    List<InputPlan> plans = new ArrayList<>(inputs.size());
-    for (CompletableFuture<InputPlan> future : futures) {
-      plans.add(joinUnwrapped(future));
-    }
+    List<InputPlan> plans =
+        BoundedFanout.mapOrdered(
+            inputs,
+            MAX_PARALLEL_INPUT_RESOLUTIONS,
+            blockingExecutor,
+            in -> planInput(taskState, in, resolvedNames));
     taskDiagnostics.flushInto(state.diagnostics);
     return plans;
-  }
-
-  /** Join a resolution task, surfacing its original (unwrapped) failure rather than a wrapper. */
-  private static InputPlan joinUnwrapped(CompletableFuture<InputPlan> future) {
-    try {
-      return future.join();
-    } catch (CompletionException ce) {
-      Throwable cause = ce.getCause();
-      if (cause instanceof RuntimeException re) {
-        throw re;
-      }
-      if (cause instanceof Error e) {
-        throw e;
-      }
-      throw new IllegalStateException("unexpected checked exception from input resolution", cause);
-    }
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -54,10 +54,12 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -403,27 +405,26 @@ public class QueryInputResolver {
       currentSnapshotPinCache.forEach(
           (tableId, pin) -> singleFlightCache.put(tableId, CompletableFuture.completedFuture(pin)));
     }
-    try {
-      return resolveInputs(
-          queryId,
-          correlationId,
-          inputs,
-          asOfDefault,
-          defaultCatalogId,
-          singleFlightCache,
-          diagnostics);
-    } finally {
-      synchronized (currentSnapshotPinCache) {
-        singleFlightCache.forEach(
-            (tableId, pinFuture) -> {
-              if (pinFuture.isDone()
-                  && !pinFuture.isCompletedExceptionally()
-                  && !pinFuture.isCancelled()) {
-                currentSnapshotPinCache.put(tableId, Futures.join(pinFuture));
-              }
-            });
-      }
+    ResolutionResult result =
+        resolveInputs(
+            queryId,
+            correlationId,
+            inputs,
+            asOfDefault,
+            defaultCatalogId,
+            singleFlightCache,
+            diagnostics);
+    synchronized (currentSnapshotPinCache) {
+      singleFlightCache.forEach(
+          (tableId, pinFuture) -> {
+            if (pinFuture.isDone()
+                && !pinFuture.isCompletedExceptionally()
+                && !pinFuture.isCancelled()) {
+              currentSnapshotPinCache.put(tableId, Futures.join(pinFuture));
+            }
+          });
     }
+    return result;
   }
 
   /**
@@ -740,11 +741,7 @@ public class QueryInputResolver {
         holder.complete(pin);
         state.diagnostics.count("pin.current_snapshot_cache_misses");
       } else {
-        // Deliberately await the single-flight winner rather than issue a competing lookup. A
-        // waiter can therefore observe cancellation only when the winner completes; that bounded
-        // latency preserves the invariant that every same-table CURRENT reference freezes one
-        // snapshot identity.
-        pin = Futures.join(inflight);
+        pin = awaitCurrentSnapshot(state, inflight);
         state.resolvingPinRoots.register(pin);
         state.diagnostics.count("pin.current_snapshot_cache_hits");
       }
@@ -788,6 +785,37 @@ public class QueryInputResolver {
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
     return resolved;
+  }
+
+  /** Await a single-flight winner without stranding a cancelled waiter on the executor. */
+  private TablePin awaitCurrentSnapshot(
+      ResolutionState state, CompletableFuture<TablePin> inflight) {
+    while (true) {
+      throwIfCancelled(state.cancelled);
+      if (Thread.currentThread().isInterrupted()) {
+        throw new CancellationException("interrupted while awaiting current snapshot pin");
+      }
+      try {
+        return inflight.get(GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
+      } catch (TimeoutException ignored) {
+        // A bounded wait lets the next loop observe cancellation or an executor interrupt.
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new CancellationException("interrupted while awaiting current snapshot pin");
+      } catch (ExecutionException e) {
+        rethrowAsyncFailure(e.getCause());
+      }
+    }
+  }
+
+  private static void rethrowAsyncFailure(Throwable failure) {
+    if (failure instanceof RuntimeException runtime) {
+      throw runtime;
+    }
+    if (failure instanceof Error error) {
+      throw error;
+    }
+    throw new IllegalStateException("unexpected checked exception from async task", failure);
   }
 
   private boolean usesCurrentSnapshotFallback(

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -62,7 +63,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -140,8 +140,8 @@ public class QueryInputResolver {
 
   // Metadata calls run separately from the bounded planning pool so cancellation can interrupt the
   // active store call and release its planning worker without waiting for a non-cooperating client.
-  // A direct-handoff executor has no queue: admission happens before submission and remains held
-  // until the underlying call exits, so stalled work cannot retain cancelled request closures.
+  // Admission happens before submission and remains held until the underlying call exits. Its
+  // bounded queue bridges worker turnover without retaining unbounded cancelled request closures.
   private volatile ExecutorService metadataIoExecutor = ForkJoinPool.commonPool();
   private ExecutorService ownedMetadataIoExecutor;
 
@@ -195,7 +195,7 @@ public class QueryInputResolver {
             MAX_CONCURRENT_INPUT_RESOLUTIONS,
             0L,
             TimeUnit.MILLISECONDS,
-            new SynchronousQueue<>(),
+            new ArrayBlockingQueue<>(MAX_CONCURRENT_INPUT_RESOLUTIONS),
             new ThreadPoolExecutor.AbortPolicy());
     ownedBlockingExecutor = planningExecutor;
     ownedMetadataIoExecutor = ioExecutor;
@@ -709,9 +709,6 @@ public class QueryInputResolver {
       acquireInputResolutionPermit(cancelled);
       acquired = true;
       return operation.get();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new CancellationException("interrupted while awaiting resolver I/O capacity");
     } finally {
       if (acquired) {
         concurrentInputResolutionPermits.release();

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -31,8 +31,8 @@ import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.service.concurrent.BoundedFanout;
+import ai.floedb.floecat.service.concurrent.CancellableCallRunner;
 import ai.floedb.floecat.service.concurrent.Futures;
-import ai.floedb.floecat.service.context.PropagatedContext;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
@@ -61,12 +61,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -637,63 +635,13 @@ public class QueryInputResolver {
     if (cancelled == NEVER_CANCELLED) {
       return withInputResolutionPermitSynchronously(operation);
     }
-
-    acquireInputResolutionPermit(cancelled);
-    PropagatedContext context = PropagatedContext.capture();
-    CompletableFuture<T> result = new CompletableFuture<>();
-    AtomicReference<Thread> worker = new AtomicReference<>();
-    FutureTask<Void> submitted =
-        new FutureTask<>(
-            () -> {
-              worker.set(Thread.currentThread());
-              try {
-                throwIfCancelled(cancelled);
-                result.complete(context.supply(operation));
-              } catch (Throwable failure) {
-                result.completeExceptionally(failure);
-              } finally {
-                worker.set(null);
-                concurrentInputResolutionPermits.release();
-              }
-            },
-            null);
-    try {
-      // Do not use ExecutorService.submit here: ForkJoinPool may help-run its ForkJoinTask inline
-      // while this thread waits, preventing the cancellation poll below from ever running.
-      metadataIoExecutor.execute(submitted);
-    } catch (RuntimeException | Error submissionFailure) {
-      concurrentInputResolutionPermits.release();
-      throw submissionFailure;
-    }
-    try {
-      while (true) {
-        if (cancelled.getAsBoolean()) {
-          interrupt(worker);
-          throw new CancellationException("input resolution cancelled");
-        }
-        try {
-          return result.get(GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException ignored) {
-          // A bounded wait lets the caller interrupt a metadata operation as soon as it cancels.
-        } catch (InterruptedException e) {
-          interrupt(worker);
-          Thread.currentThread().interrupt();
-          throw new CancellationException("interrupted while awaiting resolver I/O");
-        } catch (ExecutionException e) {
-          rethrowAsyncFailure(e.getCause());
-        }
-      }
-    } catch (CancellationException e) {
-      interrupt(worker);
-      throw e;
-    }
-  }
-
-  private static void interrupt(AtomicReference<Thread> worker) {
-    Thread active = worker.get();
-    if (active != null) {
-      active.interrupt();
-    }
+    return CancellableCallRunner.call(
+        metadataIoExecutor,
+        concurrentInputResolutionPermits,
+        cancelled,
+        operation,
+        "input resolution cancelled",
+        "interrupted while awaiting resolver I/O");
   }
 
   /** Acquires the global store-I/O slot and runs an uncancellable legacy call on the caller. */

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -57,7 +57,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -101,7 +100,6 @@ public class QueryInputResolver {
   private static final int DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
   private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 16;
   private static final int MAX_CONCURRENT_INPUT_RESOLUTIONS = 64;
-  private static final long GLOBAL_PERMIT_POLL_MILLIS = 10;
 
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
   // store reads; a small fan-out overlaps their round-trips without flooding the store. This is a
@@ -146,7 +144,7 @@ public class QueryInputResolver {
     this.queryStore = queryStore;
     this.maxParallelInputResolutions = maxParallelInputResolutions;
     this.concurrentInputResolutionPermits =
-        new Semaphore(maxConcurrentInputResolutions, true /* fair across requests */);
+        new Semaphore(maxConcurrentInputResolutions, true /* FIFO across requests */);
   }
 
   /** Test-only constructor: no store (no pin-root registration). */
@@ -215,6 +213,7 @@ public class QueryInputResolver {
     // Tracks transient roots owned by this resolution attempt until they are retained or discarded.
     final ResolvingPinRoots resolvingPinRoots;
     final PhaseDiagnostics diagnostics;
+    final BooleanSupplier cancelled;
 
     ResolutionState(
         String queryId,
@@ -223,7 +222,8 @@ public class QueryInputResolver {
         Optional<String> defaultCatalog,
         ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
         ResolvingPinRoots resolvingPinRoots,
-        PhaseDiagnostics diagnostics) {
+        PhaseDiagnostics diagnostics,
+        BooleanSupplier cancelled) {
       this.queryId = queryId;
       this.correlationId = correlationId;
       this.asOfDefault = asOfDefault;
@@ -231,6 +231,7 @@ public class QueryInputResolver {
       this.currentSnapshotPinCache = currentSnapshotPinCache;
       this.resolvingPinRoots = resolvingPinRoots;
       this.diagnostics = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
+      this.cancelled = cancelled;
     }
 
     /**
@@ -247,7 +248,8 @@ public class QueryInputResolver {
           defaultCatalog,
           currentSnapshotPinCache,
           resolvingPinRoots,
-          taskDiagnostics);
+          taskDiagnostics,
+          cancelled);
     }
   }
 
@@ -464,7 +466,8 @@ public class QueryInputResolver {
             defaultCatalog,
             currentSnapshotPinCache,
             new ResolvingPinRoots(queryStore, queryId),
-            diag);
+            diag,
+            cancelled);
 
     try {
       // Batch-resolve all NAME inputs up front: names sharing a catalog/namespace resolve their
@@ -545,7 +548,7 @@ public class QueryInputResolver {
       BooleanSupplier cancelled) {
     for (QueryInput in : inputs) {
       throwIfCancelled(cancelled);
-      mergePlan(state, planInputWithPermit(state, in, resolvedNames, cancelled));
+      mergePlan(state, planInput(state, in, resolvedNames));
     }
   }
 
@@ -573,7 +576,7 @@ public class QueryInputResolver {
           inputs,
           maxParallelInputResolutions,
           blockingExecutor,
-          in -> planInputWithPermit(taskState, in, resolvedNames, cancelled),
+          in -> planInput(taskState, in, resolvedNames),
           plan -> mergePlan(state, plan),
           cancelled);
     } finally {
@@ -589,24 +592,15 @@ public class QueryInputResolver {
     }
   }
 
-  /** Run a metadata-resolution plan while holding the service-wide store-I/O capacity. */
-  private InputPlan planInputWithPermit(
-      ResolutionState state,
-      QueryInput input,
-      Map<NameRef, Optional<ResourceId>> resolvedNames,
-      BooleanSupplier cancelled) {
-    return withInputResolutionPermit(cancelled, () -> planInput(state, input, resolvedNames));
-  }
-
   private <T> T withInputResolutionPermit(BooleanSupplier cancelled, Supplier<T> operation) {
     boolean acquired = false;
     try {
-      while (!acquired) {
-        throwIfCancelled(cancelled);
-        acquired =
-            concurrentInputResolutionPermits.tryAcquire(
-                GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
-      }
+      throwIfCancelled(cancelled);
+      // A blocking acquire retains Semaphore's FIFO queue. BoundedFanout interrupts a queued
+      // worker on stream cancellation, so cancellation remains prompt without repeatedly leaving
+      // and rejoining the fair queue at its tail.
+      concurrentInputResolutionPermits.acquire();
+      acquired = true;
       throwIfCancelled(cancelled);
       return operation.get();
     } catch (InterruptedException e) {
@@ -721,7 +715,10 @@ public class QueryInputResolver {
       if (inflight == null) {
         try {
           long snapshotPinStartNs = System.nanoTime();
-          pin = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+          pin =
+              withInputResolutionPermit(
+                  state.cancelled,
+                  () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
           state.resolvingPinRoots.register(pin);
           state.diagnostics.count("pin.snapshot_calls");
           state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -775,7 +772,10 @@ public class QueryInputResolver {
       }
     }
     long snapshotPinStartNs = System.nanoTime();
-    TablePin resolved = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+    TablePin resolved =
+        withInputResolutionPermit(
+            state.cancelled,
+            () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
     state.resolvingPinRoots.register(resolved);
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -850,10 +850,13 @@ public class QueryInputResolver {
     }
     long viewResolveStartNs = System.nanoTime();
     Optional<ViewNode> view =
-        metadataGraph
-            .resolve(relationId)
-            .filter(ViewNode.class::isInstance)
-            .map(ViewNode.class::cast);
+        withInputResolutionPermit(
+            state.cancelled,
+            () ->
+                metadataGraph
+                    .resolve(relationId)
+                    .filter(ViewNode.class::isInstance)
+                    .map(ViewNode.class::cast));
     state.diagnostics.nanos("pin.view_node_resolve", System.nanoTime() - viewResolveStartNs);
     view.ifPresent(
         resolvedView -> {
@@ -871,7 +874,8 @@ public class QueryInputResolver {
           }
           long baseNameStartNs = System.nanoTime();
           Map<NameRef, Optional<ResourceId>> baseIds =
-              metadataGraph.resolveNames(state.correlationId, baseRefs);
+              withInputResolutionPermit(
+                  state.cancelled, () -> metadataGraph.resolveNames(state.correlationId, baseRefs));
           state.diagnostics.nanos(
               "pin.view_base_name_resolve", System.nanoTime() - baseNameStartNs);
           for (NameRef baseRef : baseRefs) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -62,8 +62,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -137,7 +140,8 @@ public class QueryInputResolver {
 
   // Metadata calls run separately from the bounded planning pool so cancellation can interrupt the
   // active store call and release its planning worker without waiting for a non-cooperating client.
-  // The global semaphore remains held until that call actually exits, preserving the store-I/O cap.
+  // A direct-handoff executor has no queue: admission happens before submission and remains held
+  // until the underlying call exits, so stalled work cannot retain cancelled request closures.
   private volatile ExecutorService metadataIoExecutor = ForkJoinPool.commonPool();
   private ExecutorService ownedMetadataIoExecutor;
 
@@ -185,7 +189,14 @@ public class QueryInputResolver {
   @PostConstruct
   void postConstruct() {
     ExecutorService planningExecutor = Executors.newFixedThreadPool(MAX_PARALLEL_INPUT_RESOLUTIONS);
-    ExecutorService ioExecutor = Executors.newFixedThreadPool(MAX_CONCURRENT_INPUT_RESOLUTIONS);
+    ExecutorService ioExecutor =
+        new ThreadPoolExecutor(
+            MAX_CONCURRENT_INPUT_RESOLUTIONS,
+            MAX_CONCURRENT_INPUT_RESOLUTIONS,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new SynchronousQueue<>(),
+            new ThreadPoolExecutor.AbortPolicy());
     ownedBlockingExecutor = planningExecutor;
     ownedMetadataIoExecutor = ioExecutor;
     blockingExecutor = planningExecutor;
@@ -627,26 +638,45 @@ public class QueryInputResolver {
       return withInputResolutionPermitSynchronously(operation);
     }
 
+    acquireInputResolutionPermit(cancelled);
     PropagatedContext context = PropagatedContext.capture();
-    // Do not use ExecutorService.submit here: ForkJoinPool may help-run its ForkJoinTask inline
-    // while this thread waits, preventing the cancellation poll below from ever running.
-    FutureTask<T> submitted =
+    CompletableFuture<T> result = new CompletableFuture<>();
+    AtomicReference<Thread> worker = new AtomicReference<>();
+    FutureTask<Void> submitted =
         new FutureTask<>(
-            () ->
-                context.supply(() -> withInputResolutionPermitSynchronously(cancelled, operation)));
-    metadataIoExecutor.execute(submitted);
+            () -> {
+              worker.set(Thread.currentThread());
+              try {
+                throwIfCancelled(cancelled);
+                result.complete(context.supply(operation));
+              } catch (Throwable failure) {
+                result.completeExceptionally(failure);
+              } finally {
+                worker.set(null);
+                concurrentInputResolutionPermits.release();
+              }
+            },
+            null);
+    try {
+      // Do not use ExecutorService.submit here: ForkJoinPool may help-run its ForkJoinTask inline
+      // while this thread waits, preventing the cancellation poll below from ever running.
+      metadataIoExecutor.execute(submitted);
+    } catch (RuntimeException | Error submissionFailure) {
+      concurrentInputResolutionPermits.release();
+      throw submissionFailure;
+    }
     try {
       while (true) {
         if (cancelled.getAsBoolean()) {
-          submitted.cancel(true);
+          interrupt(worker);
           throw new CancellationException("input resolution cancelled");
         }
         try {
-          return submitted.get(GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
+          return result.get(GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
         } catch (TimeoutException ignored) {
           // A bounded wait lets the caller interrupt a metadata operation as soon as it cancels.
         } catch (InterruptedException e) {
-          submitted.cancel(true);
+          interrupt(worker);
           Thread.currentThread().interrupt();
           throw new CancellationException("interrupted while awaiting resolver I/O");
         } catch (ExecutionException e) {
@@ -654,8 +684,15 @@ public class QueryInputResolver {
         }
       }
     } catch (CancellationException e) {
-      submitted.cancel(true);
+      interrupt(worker);
       throw e;
+    }
+  }
+
+  private static void interrupt(AtomicReference<Thread> worker) {
+    Thread active = worker.get();
+    if (active != null) {
+      active.interrupt();
     }
   }
 
@@ -669,17 +706,8 @@ public class QueryInputResolver {
       BooleanSupplier cancelled, Supplier<T> operation) {
     boolean acquired = false;
     try {
-      throwIfCancelled(cancelled);
-      // Timed waits let serial callers observe cancellation too. This is best-effort fairness:
-      // a timed-out waiter must rejoin the fair semaphore's queue, trading strict FIFO for prompt
-      // request cancellation when all store-I/O slots are occupied.
-      while (!acquired) {
-        throwIfCancelled(cancelled);
-        acquired =
-            concurrentInputResolutionPermits.tryAcquire(
-                GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
-      }
-      throwIfCancelled(cancelled);
+      acquireInputResolutionPermit(cancelled);
+      acquired = true;
       return operation.get();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -688,6 +716,25 @@ public class QueryInputResolver {
       if (acquired) {
         concurrentInputResolutionPermits.release();
       }
+    }
+  }
+
+  /** Acquire process-wide metadata capacity while leaving a cancelled caller responsive. */
+  private void acquireInputResolutionPermit(BooleanSupplier cancelled) {
+    try {
+      // Timed waits let serial callers observe cancellation too. This is best-effort fairness:
+      // a timed-out waiter must rejoin the fair semaphore's queue, trading strict FIFO for prompt
+      // request cancellation when all store-I/O slots are occupied.
+      while (true) {
+        throwIfCancelled(cancelled);
+        if (concurrentInputResolutionPermits.tryAcquire(
+            GLOBAL_PERMIT_POLL_MILLIS, TimeUnit.MILLISECONDS)) {
+          return;
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CancellationException("interrupted while awaiting resolver I/O capacity");
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -38,7 +38,9 @@ import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.ViewContextUtils;
+import ai.floedb.floecat.service.telemetry.ServiceMetrics;
 import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
+import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
 import jakarta.annotation.PostConstruct;
@@ -134,6 +136,10 @@ public class QueryInputResolver {
   // request-local BoundedFanout limit avoids one request monopolizing this capacity; this limiter
   // prevents many requests from multiplying store pressure.
   private final Semaphore concurrentInputResolutionPermits;
+  // Calls which timed out at the caller but still own metadata I/O admission because the
+  // downstream client has not returned. This must remain visible to operators before it exhausts
+  // the global permit pool.
+  private final AtomicInteger timedOutMetadataCalls = new AtomicInteger();
 
   private final CatalogOverlay metadataGraph;
 
@@ -156,6 +162,8 @@ public class QueryInputResolver {
   // unbounded cancelled request closures.
   private volatile ExecutorService metadataIoExecutor = ForkJoinPool.commonPool();
   private ExecutorService ownedMetadataIoExecutor;
+
+  @Inject Observability observability;
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -218,6 +226,12 @@ public class QueryInputResolver {
     ownedMetadataIoExecutor = ioExecutor;
     blockingExecutor = planningExecutor;
     metadataIoExecutor = ioExecutor;
+    if (observability != null) {
+      observability.gauge(
+          ServiceMetrics.Query.METADATA_CALLS_STUCK,
+          timedOutMetadataCalls::get,
+          "Metadata calls still holding resolver admission after their caller timed out");
+    }
   }
 
   @PreDestroy
@@ -696,7 +710,22 @@ public class QueryInputResolver {
             TimeUnit.SECONDS,
             "resolver metadata I/O executor shut down",
             "interrupted while awaiting resolver I/O",
-            "resolver metadata I/O timed out");
+            "resolver metadata I/O timed out",
+            new CancellableCallRunner.TimeoutListener() {
+              @Override
+              public void timedOut() {
+                int stuck = timedOutMetadataCalls.incrementAndGet();
+                LOG.warnf(
+                    "resolver metadata call timed out while still active; %d call(s) retain"
+                        + " metadata admission",
+                    stuck);
+              }
+
+              @Override
+              public void finished() {
+                timedOutMetadataCalls.decrementAndGet();
+              }
+            });
       } catch (CancellableCallRunner.CallTimeoutException e) {
         throw GrpcErrors.timeout(correlationId, null, Map.of(), e);
       }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.service.concurrent.BoundedFanout;
+import ai.floedb.floecat.service.concurrent.Futures;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
@@ -39,7 +40,6 @@ import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -49,10 +49,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
-import org.eclipse.microprofile.context.ManagedExecutor;
+import java.util.concurrent.Executors;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
  * QueryInputResolver
@@ -89,8 +91,12 @@ import org.eclipse.microprofile.context.ManagedExecutor;
 public class QueryInputResolver {
 
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
-  // store reads; a small fan-out overlaps their round-trips without flooding the store or executor.
-  private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
+  // store reads; a small fan-out overlaps their round-trips without flooding the store. Shared with
+  // the catalog bundle's relation fan-out via the same config property. Per-request bound only: the
+  // virtual-thread executor has no shared-pool ceiling. Read once here via ConfigProvider (not a
+  // @ConfigProperty ctor param) so the new-constructed test call sites keep compiling while prod
+  // still honors config.
+  private final int maxParallelInputResolutions;
 
   private final CatalogOverlay metadataGraph;
 
@@ -99,26 +105,30 @@ public class QueryInputResolver {
   // without a store — registration is simply skipped then.
   private final QueryContextStore queryStore;
 
-  // Runs per-input resolution off the request thread. The Quarkus ManagedExecutor is injected in
-  // init(); tests (and any wiring without one) fall back to the common pool.
-  private volatile Executor blockingExecutor = ForkJoinPool.commonPool();
+  // Runs per-input resolution off the request thread on virtual threads, not the shared Quarkus
+  // worker pool: the driver blocks joining this fan-out and must not contend with it for the same
+  // pool. The semaphore in BoundedFanout bounds concurrency; OTel context is re-established per
+  // task.
+  private final Executor blockingExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
     this.metadataGraph = metadataGraph;
     this.queryStore = queryStore;
+    // Clamp to >=1: a 0/negative permit count would wedge the fan-out's permit wait forever.
+    // UserObjectBundleService warns on this same config key; clamp silently here to avoid a
+    // duplicate warning.
+    this.maxParallelInputResolutions =
+        Math.max(
+            1,
+            ConfigProvider.getConfig()
+                .getOptionalValue("floecat.catalog.bundle.max_parallel_relations", Integer.class)
+                .orElse(8));
   }
 
   /** Test-only constructor: no store (no pin-root registration). */
   public QueryInputResolver(CatalogOverlay metadataGraph) {
     this(metadataGraph, null);
-  }
-
-  @Inject
-  void init(Instance<ManagedExecutor> managedExecutors) {
-    if (managedExecutors != null) {
-      managedExecutors.stream().findFirst().ifPresent(e -> blockingExecutor = e);
-    }
   }
 
   // =============================================================================
@@ -157,8 +167,8 @@ public class QueryInputResolver {
     // Keep insertion order (matching input order) while deduplicating by table ID.
     final Map<ResourceId, TablePin> pinByTableId = new LinkedHashMap<>();
     // Request-local cache for current-snapshot table pins (no override, no as-of).
-    final Map<ResourceId, TablePin> currentSnapshotPinCache;
-    // Transient roots owned by this resolution attempt until the pins are committed or discarded.
+    final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache;
+    // Tracks transient roots owned by this resolution attempt until they are retained or discarded.
     final ResolvingPinRoots resolvingPinRoots;
     final PhaseDiagnostics diagnostics;
 
@@ -167,7 +177,7 @@ public class QueryInputResolver {
         String correlationId,
         Optional<Timestamp> asOfDefault,
         Optional<String> defaultCatalog,
-        Map<ResourceId, TablePin> currentSnapshotPinCache,
+        ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
         ResolvingPinRoots resolvingPinRoots,
         PhaseDiagnostics diagnostics) {
       this.queryId = queryId;
@@ -198,9 +208,9 @@ public class QueryInputResolver {
   }
 
   /**
-   * Owns transient registrations made while one resolution attempt constructs pins. Retained pins
-   * remain rooted until their query context is committed; compatible duplicates and failed
-   * resolutions release only the roots registered by this attempt.
+   * Owns the transient registrations made while one {@link #resolveInputs} call constructs pins. A
+   * retained pin stays registered until its context commit makes it durable; a discarded pin or
+   * failed resolution releases only the registration this attempt created.
    */
   private static final class ResolvingPinRoots {
     private final QueryContextStore queryStore;
@@ -212,6 +222,10 @@ public class QueryInputResolver {
       this.queryId = queryId;
     }
 
+    /**
+     * Register a pin's roots once for this attempt. A store failure leaves the pin untracked so
+     * callers propagate the failure without attempting a compensating release.
+     */
     synchronized void register(TablePin pin) {
       if (queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
         return;
@@ -227,6 +241,10 @@ public class QueryInputResolver {
       rootsByPin.put(pin, roots);
     }
 
+    /**
+     * Release this attempt's registration for a compatible pin that lost ordered first-touch. A
+     * store failure retains ownership so a later failure cleanup can retry the release.
+     */
     synchronized void discard(TablePin pin) {
       List<String> roots = rootsByPin.get(pin);
       if (roots != null) {
@@ -235,6 +253,10 @@ public class QueryInputResolver {
       }
     }
 
+    /**
+     * Release every registration still owned by this failed attempt. A store failure stops release
+     * and propagates to the caller, which retains the original resolution failure.
+     */
     synchronized void releaseAll() {
       var iterator = rootsByPin.entrySet().iterator();
       while (iterator.hasNext()) {
@@ -276,7 +298,9 @@ public class QueryInputResolver {
    *
    * <p>{@code defaultCatalogId} is used only when expanding view base relations: if a base-relation
    * {@link NameRef} has a blank catalog or empty path it is enriched with the query's default
-   * catalog / creation search-path before resolution. Non-view inputs are unaffected.
+   * catalog / creation search-path before resolution. Non-view inputs are unaffected. {@code
+   * currentSnapshotPinCache} is shared by concurrent input tasks, so it must provide atomic {@link
+   * ConcurrentMap#putIfAbsent} and conditional removal.
    */
   public ResolutionResult resolveInputs(
       String queryId,
@@ -284,7 +308,7 @@ public class QueryInputResolver {
       List<QueryInput> inputs,
       Optional<Timestamp> asOfDefault,
       Optional<ResourceId> defaultCatalogId,
-      Map<ResourceId, TablePin> currentSnapshotPinCache,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
     PhaseDiagnostics diag = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
 
@@ -323,12 +347,26 @@ public class QueryInputResolver {
       Map<NameRef, Optional<ResourceId>> resolvedNames =
           nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
 
+      // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
+      // a view yields its base tables' pins). planInput reads the metadata graph and the shared
+      // current-snapshot cache; it does not touch `resolved` or `pinByTableId`. Inputs resolve
+      // independently, so with more than one they are fanned out; the results are gathered in input
+      // order for the merge below.
       List<InputPlan> plans =
           inputs.size() > 1
               ? planInputsConcurrently(state, inputs, resolvedNames)
               : planInputsSerially(state, inputs, resolvedNames);
+
+      // Merge the plans into the pin set in input order. Order decides two things: `resolved`
+      // mirrors the request order, and mergePin keeps the first pin seen for a table while raising
+      // QUERY_TABLE_PIN_CONFLICT when a later reference pins the same table with an incompatible
+      // snapshot/as-of. Every kept pin is already GC-rooted at construction, before the caller
+      // reads any schema/stats or persists the context.
       for (InputPlan plan : plans) {
-        mergePlan(state, plan);
+        state.resolved.add(plan.resolvedId());
+        for (TablePin pin : plan.pins()) {
+          mergePin(state, pin);
+        }
       }
 
       RelationPinSet relationPinSet =
@@ -391,8 +429,10 @@ public class QueryInputResolver {
    * aggregate of those counters, not a per-relation breakdown; the coarse phase timings are
    * measured by the caller around this call regardless. One task state is shared by all tasks
    * because everything they touch is immutable or thread-safe (the current-snapshot cache and the
-   * accumulator). Gathering plans in input order keeps the caller's merge deterministic
-   * (first-touch-wins, conflict detection).
+   * accumulator). Keep off-thread diagnostics to counters and durations only; one-shot put/emit
+   * values must stay on the request thread because the accumulator intentionally drops them.
+   * Gathering plans in input order keeps the caller's merge deterministic (first-touch-wins,
+   * conflict detection).
    */
   private List<InputPlan> planInputsConcurrently(
       ResolutionState state,
@@ -403,7 +443,7 @@ public class QueryInputResolver {
     List<InputPlan> plans =
         BoundedFanout.mapOrdered(
             inputs,
-            MAX_PARALLEL_INPUT_RESOLUTIONS,
+            maxParallelInputResolutions,
             blockingExecutor,
             in -> planInput(taskState, in, resolvedNames));
     taskDiagnostics.flushInto(state.diagnostics);
@@ -500,28 +540,35 @@ public class QueryInputResolver {
       // the
       // SAME snapshot even when they resolve on different threads, or an ingest landing between two
       // independent lookups would give them different snapshots and turn a compatible pair into a
-      // pin conflict. computeIfAbsent runs the lookup once per table id; concurrent callers for
-      // that
-      // id wait for and share its result. (Requires a thread-safe cache — see resolveInputs.)
-      boolean[] resolvedHere = {false};
-      TablePin pin =
-          state.currentSnapshotPinCache.computeIfAbsent(
-              rid,
-              id -> {
-                resolvedHere[0] = true;
-                long snapshotPinStartNs = System.nanoTime();
-                TablePin resolved =
-                    metadataGraph.tablePinFor(state.correlationId, id, override, asOfDefault);
-                state.resolvingPinRoots.register(resolved);
-                state.diagnostics.count("pin.snapshot_calls");
-                state.diagnostics.nanos(
-                    "pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
-                return resolved;
-              });
-      state.diagnostics.count(
-          resolvedHere[0]
-              ? "pin.current_snapshot_cache_misses"
-              : "pin.current_snapshot_cache_hits");
+      // pin conflict. A CompletableFuture placeholder gives that single-flight WITHOUT
+      // computeIfAbsent
+      // holding the map's bin lock across the store round-trip — which would serialize unrelated
+      // table ids that hash to the same bin. The winner (whoever inserts the incomplete future)
+      // runs
+      // the one lookup; concurrent same-id callers await its result.
+      CompletableFuture<TablePin> holder = new CompletableFuture<>();
+      CompletableFuture<TablePin> inflight = state.currentSnapshotPinCache.putIfAbsent(rid, holder);
+      TablePin pin;
+      if (inflight == null) {
+        try {
+          long snapshotPinStartNs = System.nanoTime();
+          pin = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+          state.resolvingPinRoots.register(pin);
+          state.diagnostics.count("pin.snapshot_calls");
+          state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
+        } catch (RuntimeException | Error e) {
+          // Never cache a failure: drop the placeholder so a retry re-resolves, and release any
+          // callers already awaiting this id with the same error.
+          state.currentSnapshotPinCache.remove(rid, holder);
+          holder.completeExceptionally(e);
+          throw e;
+        }
+        holder.complete(pin);
+        state.diagnostics.count("pin.current_snapshot_cache_misses");
+      } else {
+        pin = Futures.join(inflight);
+        state.diagnostics.count("pin.current_snapshot_cache_hits");
+      }
       return pin;
     }
     state.diagnostics.count(
@@ -555,9 +602,9 @@ public class QueryInputResolver {
     }
     long snapshotPinStartNs = System.nanoTime();
     TablePin resolved = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+    state.resolvingPinRoots.register(resolved);
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
-    state.resolvingPinRoots.register(resolved);
     return resolved;
   }
 
@@ -671,6 +718,7 @@ public class QueryInputResolver {
       state.pinByTableId.put(pin.getTableId(), pin);
       return;
     }
+    // First-touch wins: compatible later pins relinquish only their own provisional roots.
     QueryPins.reconcile(existing, pin, state.correlationId);
     if (existing != pin) {
       state.resolvingPinRoots.discard(pin);

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -129,17 +129,18 @@ public class QueryInputResolver {
   // without a store — registration is simply skipped then.
   private final QueryContextStore queryStore;
 
-  // DynamoDB-backed metadata calls can pin a carrier while they block. Production therefore owns
-  // a dedicated bounded platform-thread pool, independent of the Mutiny request executor whose
-  // driver synchronously awaits this fan-out. Direct unit construction retains a non-owning common
-  // pool fallback until CDI invokes postConstruct().
+  // Planning tasks only await the separately-dispatched metadata call, so production uses virtual
+  // threads here rather than limiting every request to a shared set of parked platform threads.
+  // Direct unit construction retains a non-owning common-pool fallback until CDI invokes
+  // postConstruct().
   private volatile ExecutorService blockingExecutor = ForkJoinPool.commonPool();
   private ExecutorService ownedBlockingExecutor;
 
-  // Metadata calls run separately from the bounded planning pool so cancellation can interrupt the
-  // active store call and release its planning worker without waiting for a non-cooperating client.
-  // Admission happens before submission and remains held until the underlying call exits. Its
-  // bounded queue bridges worker turnover without retaining unbounded cancelled request closures.
+  // Metadata calls run separately from planning because DynamoDB-backed calls can pin a carrier
+  // while blocking. Cancellation can therefore release the waiting virtual planning thread without
+  // waiting for a non-cooperating client. Admission happens before submission and remains held
+  // until the underlying call exits. Its bounded queue bridges worker turnover without retaining
+  // unbounded cancelled request closures.
   private volatile ExecutorService metadataIoExecutor = ForkJoinPool.commonPool();
   private ExecutorService ownedMetadataIoExecutor;
 
@@ -186,7 +187,7 @@ public class QueryInputResolver {
 
   @PostConstruct
   void postConstruct() {
-    ExecutorService planningExecutor = Executors.newFixedThreadPool(MAX_PARALLEL_INPUT_RESOLUTIONS);
+    ExecutorService planningExecutor = Executors.newVirtualThreadPerTaskExecutor();
     ExecutorService ioExecutor =
         new ThreadPoolExecutor(
             MAX_CONCURRENT_INPUT_RESOLUTIONS,

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -518,7 +518,7 @@ public class QueryInputResolver {
    * One input's resolution: the id recorded in {@code resolved}, and the table pins it contributes,
    * ordered. A view's id is recorded but the pins are its base tables'; a table records its id and
    * its own single pin.
-  */
+   */
   private record InputPlan(ResourceId resolvedId, List<TablePin> pins, Throwable terminalFailure) {}
 
   /** Merge one completed plan on the request thread, preserving request-order semantics. */
@@ -735,6 +735,10 @@ public class QueryInputResolver {
         holder.complete(pin);
         state.diagnostics.count("pin.current_snapshot_cache_misses");
       } else {
+        // Deliberately await the single-flight winner rather than issue a competing lookup. A
+        // waiter can therefore observe cancellation only when the winner completes; that bounded
+        // latency preserves the invariant that every same-table CURRENT reference freezes one
+        // snapshot identity.
         pin = Futures.join(inflight);
         state.resolvingPinRoots.register(pin);
         state.diagnostics.count("pin.current_snapshot_cache_hits");

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
@@ -309,23 +309,6 @@ public final class ServiceMetrics {
             "service");
   }
 
-  /** Query-resolution saturation signals. */
-  public static final class Query {
-    private Query() {}
-
-    /**
-     * Metadata calls whose callers reached their deadline but whose downstream I/O still holds
-     * resolver admission. A non-zero value indicates a store timeout or abort path is needed.
-     */
-    public static final MetricId METADATA_CALLS_STUCK =
-        new MetricId(
-            "floecat.service.query.metadata.calls.stuck",
-            MetricType.GAUGE,
-            "count",
-            CONTRACT,
-            "service");
-  }
-
   /** CAS blob-GC backlog health: the signals that answer "is GC falling behind?". */
   public static final class Gc {
     private Gc() {}

--- a/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
+++ b/service/src/main/java/ai/floedb/floecat/service/telemetry/ServiceMetrics.java
@@ -309,6 +309,23 @@ public final class ServiceMetrics {
             "service");
   }
 
+  /** Query-resolution saturation signals. */
+  public static final class Query {
+    private Query() {}
+
+    /**
+     * Metadata calls whose callers reached their deadline but whose downstream I/O still holds
+     * resolver admission. A non-zero value indicates a store timeout or abort path is needed.
+     */
+    public static final MetricId METADATA_CALLS_STUCK =
+        new MetricId(
+            "floecat.service.query.metadata.calls.stuck",
+            MetricType.GAUGE,
+            "count",
+            CONTRACT,
+            "service");
+  }
+
   /** CAS blob-GC backlog health: the signals that answer "is GC falling behind?". */
   public static final class Gc {
     private Gc() {}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -37,6 +37,8 @@ quarkus.http.port=${FLOECAT_HTTP_PORT:9100}
 quarkus.grpc.clients.floecat.host=${FLOECAT_GRPC_HOST:127.0.0.1}
 quarkus.grpc.clients.floecat.port=${FLOECAT_GRPC_PORT:9100}
 quarkus.grpc.clients.floecat.plain-text=true
+## Process-wide query metadata I/O admission
+floecat.query.metadata_io.max_concurrency=${FLOECAT_QUERY_METADATA_IO_MAX_CONCURRENCY:64}
 ## Floecat repository seeding
 floecat.seed.enabled=${FLOECAT_SEED_ENABLED:true}
 floecat.seed.mode=${FLOECAT_SEED_MODE:fake}

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
+/** Verifies bounded scheduling, ordered delivery, failure draining, and prompt cancellation. */
 class BoundedFanoutTest {
 
   @Test
@@ -203,6 +204,58 @@ class BoundedFanoutTest {
         releaseSecondTask.countDown();
       }
       result.get(1, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void orderedConsumerFailureStopsFurtherWindowRefills() throws Exception {
+    CountDownLatch activeSiblingsStarted = new CountDownLatch(2);
+    CountDownLatch releaseActiveSiblings = new CountDownLatch(1);
+    AtomicInteger highestStarted = new AtomicInteger(-1);
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+      CompletableFuture<Throwable> result =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2, 3, 4),
+                      2,
+                      executor,
+                      value -> {
+                        highestStarted.accumulateAndGet(value, Math::max);
+                        if (value > 0) {
+                          activeSiblingsStarted.countDown();
+                          try {
+                            releaseActiveSiblings.await();
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new AssertionError(e);
+                          }
+                        }
+                        return value;
+                      },
+                      value -> {
+                        if (value == 0) {
+                          throw new IllegalStateException("ordered merge failed");
+                        }
+                      },
+                      () -> false);
+                  return null;
+                } catch (Throwable failure) {
+                  return failure;
+                }
+              });
+
+      assertThat(activeSiblingsStarted.await(1, TimeUnit.SECONDS)).isTrue();
+      releaseActiveSiblings.countDown();
+
+      assertThat(result.get(1, TimeUnit.SECONDS))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("ordered merge failed");
+      assertThat(highestStarted.get()).isEqualTo(2);
+    } finally {
+      releaseActiveSiblings.countDown();
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -19,7 +19,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -87,5 +96,116 @@ class BoundedFanoutTest {
                     }))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("boom");
+  }
+
+  @Test
+  void submissionFailureWaitsForAlreadySubmittedTasks() throws Exception {
+    CountDownLatch taskStarted = new CountDownLatch(1);
+    CountDownLatch allowTaskCompletion = new CountDownLatch(1);
+    CountDownLatch mapReturned = new CountDownLatch(1);
+    AtomicInteger submissions = new AtomicInteger();
+    Executor rejectSecondSubmission =
+        command -> {
+          if (submissions.getAndIncrement() == 0) {
+            CompletableFuture.runAsync(command);
+            return;
+          }
+          throw new RejectedExecutionException("executor saturated");
+        };
+
+    CompletableFuture<Throwable> result =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                BoundedFanout.mapOrdered(
+                    List.of(1, 2),
+                    2,
+                    rejectSecondSubmission,
+                    ignored -> {
+                      taskStarted.countDown();
+                      try {
+                        allowTaskCompletion.await();
+                      } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError("task interrupted", e);
+                      }
+                      return ignored;
+                    });
+                return null;
+              } catch (Throwable failure) {
+                return failure;
+              } finally {
+                mapReturned.countDown();
+              }
+            });
+
+    assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(mapReturned.await(100, TimeUnit.MILLISECONDS)).isFalse();
+    allowTaskCompletion.countDown();
+    assertThat(result.join())
+        .isInstanceOf(RejectedExecutionException.class)
+        .hasMessage("executor saturated");
+  }
+
+  @Test
+  void cancellationInterruptsRunningTaskAndReturnsWithoutWaitingForIt() throws Exception {
+    CountDownLatch taskStarted = new CountDownLatch(1);
+    CountDownLatch taskInterrupted = new CountDownLatch(1);
+    CountDownLatch allowTaskCompletion = new CountDownLatch(1);
+    AtomicBoolean cancelled = new AtomicBoolean();
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      CompletableFuture<Throwable> result =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  BoundedFanout.mapOrdered(
+                      List.of(1, 2),
+                      2,
+                      executor,
+                      ignored -> {
+                        taskStarted.countDown();
+                        try {
+                          allowTaskCompletion.await();
+                        } catch (InterruptedException e) {
+                          taskInterrupted.countDown();
+                          Thread.currentThread().interrupt();
+                          throw new CancellationException("task interrupted");
+                        }
+                        return ignored;
+                      },
+                      cancelled::get);
+                  return null;
+                } catch (Throwable failure) {
+                  return failure;
+                }
+              });
+
+      assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+      cancelled.set(true);
+      try {
+        assertThat(result.get(250, TimeUnit.MILLISECONDS))
+            .isInstanceOf(CancellationException.class)
+            .hasMessage("fan-out cancelled");
+        assertThat(taskInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
+      } finally {
+        allowTaskCompletion.countDown();
+      }
+    }
+  }
+
+  @Test
+  void rejectsZeroAndNegativePermits() {
+    // A 0/negative permit count would hand out no permits, blocking every task forever on an
+    // uninterruptible acquire while the caller blocks joining — a permanent hang. Fail fast.
+    for (int badPermits : new int[] {0, -1, -8}) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.mapOrdered(
+                      List.of(1, 2, 3), badPermits, ForkJoinPool.commonPool(), i -> i))
+          .as("permits=%d", badPermits)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("permits must be >= 1");
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -155,6 +155,58 @@ class BoundedFanoutTest {
   }
 
   @Test
+  void refillsBeforeDeliveringCompletionToTheCaller() throws Exception {
+    CountDownLatch firstCompletionDelivered = new CountDownLatch(1);
+    CountDownLatch thirdTaskStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirstCompletion = new CountDownLatch(1);
+    CountDownLatch releaseSecondTask = new CountDownLatch(1);
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+      CompletableFuture<Void> result =
+          CompletableFuture.runAsync(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2),
+                      2,
+                      executor,
+                      value -> {
+                        if (value == 1) {
+                          try {
+                            releaseSecondTask.await();
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new AssertionError(e);
+                          }
+                        }
+                        if (value == 2) {
+                          thirdTaskStarted.countDown();
+                        }
+                        return value;
+                      },
+                      value -> {
+                        if (value == 0) {
+                          firstCompletionDelivered.countDown();
+                          try {
+                            releaseFirstCompletion.await();
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new AssertionError(e);
+                          }
+                        }
+                      }));
+
+      try {
+        assertThat(firstCompletionDelivered.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(thirdTaskStarted.await(250, TimeUnit.MILLISECONDS)).isTrue();
+      } finally {
+        releaseFirstCompletion.countDown();
+        releaseSecondTask.countDown();
+      }
+      result.get(1, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
   void taskFailureSurfacesUnwrapped() {
     assertThatThrownBy(
             () ->

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -185,6 +185,57 @@ class BoundedFanoutTest {
   }
 
   @Test
+  void refillSubmissionFailureWaitsForAlreadySubmittedTasks() throws Exception {
+    CountDownLatch blockingTaskStarted = new CountDownLatch(1);
+    CountDownLatch allowBlockingTaskCompletion = new CountDownLatch(1);
+    CountDownLatch mapReturned = new CountDownLatch(1);
+    AtomicInteger submissions = new AtomicInteger();
+    Executor rejectRefillSubmission =
+        command -> {
+          if (submissions.getAndIncrement() < 2) {
+            CompletableFuture.runAsync(command);
+            return;
+          }
+          throw new RejectedExecutionException("executor saturated during refill");
+        };
+
+    CompletableFuture<Throwable> result =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                BoundedFanout.mapOrdered(
+                    List.of(1, 2, 3),
+                    2,
+                    rejectRefillSubmission,
+                    value -> {
+                      if (value == 2) {
+                        blockingTaskStarted.countDown();
+                        try {
+                          allowBlockingTaskCompletion.await();
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError("task interrupted", e);
+                        }
+                      }
+                      return value;
+                    });
+                return null;
+              } catch (Throwable failure) {
+                return failure;
+              } finally {
+                mapReturned.countDown();
+              }
+            });
+
+    assertThat(blockingTaskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(mapReturned.await(100, TimeUnit.MILLISECONDS)).isFalse();
+    allowBlockingTaskCompletion.countDown();
+    assertThat(result.join())
+        .isInstanceOf(RejectedExecutionException.class)
+        .hasMessage("executor saturated during refill");
+  }
+
+  @Test
   void cancellationInterruptsRunningTaskAndReturnsWithoutWaitingForIt() throws Exception {
     CountDownLatch taskStarted = new CountDownLatch(1);
     CountDownLatch taskInterrupted = new CountDownLatch(1);

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -194,7 +194,8 @@ class BoundedFanoutTest {
                             throw new AssertionError(e);
                           }
                         }
-                      }));
+                      },
+                      () -> false));
 
       try {
         assertThat(firstCompletionDelivered.await(1, TimeUnit.SECONDS)).isTrue();
@@ -256,6 +257,65 @@ class BoundedFanoutTest {
       assertThat(highestStarted.get()).isEqualTo(2);
     } finally {
       releaseActiveSiblings.countDown();
+    }
+  }
+
+  @Test
+  void processingFailureWinsWhenCancellationRacesFailureDrain() throws Exception {
+    CountDownLatch siblingStarted = new CountDownLatch(1);
+    CountDownLatch consumerFailed = new CountDownLatch(1);
+    CountDownLatch siblingInterrupted = new CountDownLatch(1);
+    AtomicBoolean cancelled = new AtomicBoolean();
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+      CompletableFuture<Throwable> result =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1),
+                      2,
+                      executor,
+                      value -> {
+                        if (value == 0) {
+                          try {
+                            siblingStarted.await();
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new AssertionError(e);
+                          }
+                          return value;
+                        }
+                        siblingStarted.countDown();
+                        try {
+                          new CountDownLatch(1).await();
+                          return value;
+                        } catch (InterruptedException e) {
+                          siblingInterrupted.countDown();
+                          Thread.currentThread().interrupt();
+                          throw new CancellationException("sibling interrupted");
+                        }
+                      },
+                      ignored -> {
+                        consumerFailed.countDown();
+                        throw new IllegalStateException("ordered merge failed");
+                      },
+                      cancelled::get);
+                  return null;
+                } catch (Throwable failure) {
+                  return failure;
+                }
+              });
+
+      assertThat(consumerFailed.await(1, TimeUnit.SECONDS)).isTrue();
+      cancelled.set(true);
+      Throwable failure = result.get(250, TimeUnit.MILLISECONDS);
+      assertThat(failure)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("ordered merge failed");
+      assertThat(failure.getSuppressed())
+          .anyMatch(suppressed -> suppressed instanceof CancellationException);
+      assertThat(siblingInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
     }
   }
 
@@ -389,7 +449,7 @@ class BoundedFanoutTest {
           CompletableFuture.supplyAsync(
               () -> {
                 try {
-                  BoundedFanout.mapOrdered(
+                  BoundedFanout.forEachOrdered(
                       List.of(1, 2),
                       2,
                       executor,
@@ -404,6 +464,7 @@ class BoundedFanoutTest {
                         }
                         return ignored;
                       },
+                      ignored -> {},
                       cancelled::get);
                   return null;
                 } catch (Throwable failure) {
@@ -425,7 +486,7 @@ class BoundedFanoutTest {
   }
 
   @Test
-  void cancellationDuringRejectedSubmissionInterruptsActiveTasks() throws Exception {
+  void rejectedSubmissionWinsWhenCancellationInterruptsActiveTasks() throws Exception {
     CountDownLatch taskStarted = new CountDownLatch(1);
     CountDownLatch taskInterrupted = new CountDownLatch(1);
     AtomicBoolean cancelled = new AtomicBoolean();
@@ -441,7 +502,7 @@ class BoundedFanoutTest {
           CompletableFuture.supplyAsync(
               () -> {
                 try {
-                  BoundedFanout.mapOrdered(
+                  BoundedFanout.forEachOrdered(
                       List.of(1, 2),
                       2,
                       executor,
@@ -456,6 +517,7 @@ class BoundedFanoutTest {
                           throw new CancellationException("task interrupted");
                         }
                       },
+                      ignored -> {},
                       cancelled::get);
                   return null;
                 } catch (Throwable failure) {
@@ -465,9 +527,10 @@ class BoundedFanoutTest {
 
       assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
       cancelled.set(true);
-      assertThat(result.get(250, TimeUnit.MILLISECONDS))
-          .isInstanceOf(CancellationException.class)
-          .hasMessage("fan-out cancelled");
+      Throwable failure = result.get(250, TimeUnit.MILLISECONDS);
+      assertThat(failure).isInstanceOf(RejectedExecutionException.class);
+      assertThat(failure.getSuppressed())
+          .anyMatch(suppressed -> suppressed instanceof CancellationException);
       assertThat(taskInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
     }
   }

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -314,6 +316,54 @@ class BoundedFanoutTest {
       } finally {
         allowTaskCompletion.countDown();
       }
+    }
+  }
+
+  @Test
+  void cancellationDuringRejectedSubmissionInterruptsActiveTasks() throws Exception {
+    CountDownLatch taskStarted = new CountDownLatch(1);
+    CountDownLatch taskInterrupted = new CountDownLatch(1);
+    AtomicBoolean cancelled = new AtomicBoolean();
+    try (ExecutorService executor =
+        new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            new SynchronousQueue<>(),
+            new ThreadPoolExecutor.AbortPolicy())) {
+      CompletableFuture<Throwable> result =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  BoundedFanout.mapOrdered(
+                      List.of(1, 2),
+                      2,
+                      executor,
+                      ignored -> {
+                        taskStarted.countDown();
+                        try {
+                          new CountDownLatch(1).await();
+                          return ignored;
+                        } catch (InterruptedException e) {
+                          taskInterrupted.countDown();
+                          Thread.currentThread().interrupt();
+                          throw new CancellationException("task interrupted");
+                        }
+                      },
+                      cancelled::get);
+                  return null;
+                } catch (Throwable failure) {
+                  return failure;
+                }
+              });
+
+      assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+      cancelled.set(true);
+      assertThat(result.get(250, TimeUnit.MILLISECONDS))
+          .isInstanceOf(CancellationException.class)
+          .hasMessage("fan-out cancelled");
+      assertThat(taskInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -81,6 +81,43 @@ class BoundedFanoutTest {
   }
 
   @Test
+  void submitsOnlyTheRollingWindowWhileTheFirstResultIsBlocked() throws Exception {
+    CountDownLatch firstStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirst = new CountDownLatch(1);
+    AtomicInteger submissions = new AtomicInteger();
+    Executor countingExecutor =
+        command -> {
+          submissions.incrementAndGet();
+          CompletableFuture.runAsync(command);
+        };
+
+    CompletableFuture<List<Integer>> result =
+        CompletableFuture.supplyAsync(
+            () ->
+                BoundedFanout.mapOrdered(
+                    IntStream.range(0, 100).boxed().toList(),
+                    3,
+                    countingExecutor,
+                    value -> {
+                      if (value == 0) {
+                        firstStarted.countDown();
+                        try {
+                          releaseFirst.await();
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError(e);
+                        }
+                      }
+                      return value;
+                    }));
+
+    assertThat(firstStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(submissions.get()).isEqualTo(3);
+    releaseFirst.countDown();
+    assertThat(result.get(1, TimeUnit.SECONDS)).hasSize(100);
+  }
+
+  @Test
   void taskFailureSurfacesUnwrapped() {
     assertThatThrownBy(
             () ->

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
-/** Verifies bounded scheduling, ordered delivery, failure draining, and prompt cancellation. */
+/** Verifies bounded scheduling, ordered delivery, fail-fast errors, and prompt cancellation. */
 class BoundedFanoutTest {
 
   @Test
@@ -209,9 +209,9 @@ class BoundedFanoutTest {
   }
 
   @Test
-  void orderedConsumerFailureStopsFurtherWindowRefills() throws Exception {
+  void orderedConsumerFailureCancelsActiveSiblingsAndReturnsPromptly() throws Exception {
     CountDownLatch activeSiblingsStarted = new CountDownLatch(2);
-    CountDownLatch releaseActiveSiblings = new CountDownLatch(1);
+    CountDownLatch activeSiblingInterrupted = new CountDownLatch(1);
     AtomicInteger highestStarted = new AtomicInteger(-1);
 
     try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
@@ -227,10 +227,11 @@ class BoundedFanoutTest {
                       if (value > 0) {
                         activeSiblingsStarted.countDown();
                         try {
-                          releaseActiveSiblings.await();
+                          new CountDownLatch(1).await();
                         } catch (InterruptedException e) {
+                          activeSiblingInterrupted.countDown();
                           Thread.currentThread().interrupt();
-                          throw new AssertionError(e);
+                          throw new CancellationException("active sibling interrupted");
                         }
                       }
                       return value;
@@ -244,23 +245,18 @@ class BoundedFanoutTest {
               });
 
       assertThat(activeSiblingsStarted.await(1, TimeUnit.SECONDS)).isTrue();
-      releaseActiveSiblings.countDown();
-
-      assertThat(result.get(1, TimeUnit.SECONDS))
+      assertThat(result.get(250, TimeUnit.MILLISECONDS))
           .isInstanceOf(IllegalStateException.class)
           .hasMessage("ordered merge failed");
+      assertThat(activeSiblingInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
       assertThat(highestStarted.get()).isEqualTo(2);
-    } finally {
-      releaseActiveSiblings.countDown();
     }
   }
 
   @Test
-  void processingFailureWinsWhenCancellationRacesFailureDrain() throws Exception {
+  void orderedTaskFailureDoesNotWaitForStalledSibling() throws Exception {
     CountDownLatch siblingStarted = new CountDownLatch(1);
-    CountDownLatch consumerFailed = new CountDownLatch(1);
-    CountDownLatch siblingInterrupted = new CountDownLatch(1);
-    AtomicBoolean cancelled = new AtomicBoolean();
+    CountDownLatch releaseSibling = new CountDownLatch(1);
 
     try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
       CompletableFuture<Throwable> result =
@@ -278,34 +274,74 @@ class BoundedFanoutTest {
                           Thread.currentThread().interrupt();
                           throw new AssertionError(e);
                         }
-                        return value;
+                        throw new IllegalStateException("ordered task failed");
                       }
                       siblingStarted.countDown();
-                      try {
-                        new CountDownLatch(1).await();
-                        return value;
-                      } catch (InterruptedException e) {
-                        siblingInterrupted.countDown();
-                        Thread.currentThread().interrupt();
-                        throw new CancellationException("sibling interrupted");
+                      while (releaseSibling.getCount() != 0) {
+                        try {
+                          releaseSibling.await();
+                        } catch (InterruptedException ignored) {
+                          // Deliberately ignore interruption: the known ordered failure must still
+                          // return without waiting for this unrelated downstream call.
+                        }
                       }
+                      return value;
                     },
-                    ignored -> {
-                      consumerFailed.countDown();
-                      throw new IllegalStateException("ordered merge failed");
-                    },
-                    cancelled::get);
+                    ignored -> {},
+                    () -> false);
               });
 
-      assertThat(consumerFailed.await(1, TimeUnit.SECONDS)).isTrue();
-      cancelled.set(true);
-      Throwable failure = result.get(250, TimeUnit.MILLISECONDS);
-      assertThat(failure)
+      assertThat(siblingStarted.await(1, TimeUnit.SECONDS)).isTrue();
+      try {
+        assertThat(result.get(250, TimeUnit.MILLISECONDS))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("ordered task failed");
+      } finally {
+        releaseSibling.countDown();
+      }
+    }
+  }
+
+  @Test
+  void orderedMapFailureDoesNotWaitForStalledSibling() throws Exception {
+    CountDownLatch siblingStarted = new CountDownLatch(1);
+    CountDownLatch releaseSibling = new CountDownLatch(1);
+
+    CompletableFuture<Throwable> result =
+        captureAsyncFailure(
+            () ->
+                BoundedFanout.mapOrdered(
+                    List.of(0, 1),
+                    2,
+                    ForkJoinPool.commonPool(),
+                    value -> {
+                      if (value == 0) {
+                        try {
+                          siblingStarted.await();
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError(e);
+                        }
+                        throw new IllegalStateException("ordered task failed");
+                      }
+                      siblingStarted.countDown();
+                      while (releaseSibling.getCount() != 0) {
+                        try {
+                          releaseSibling.await();
+                        } catch (InterruptedException ignored) {
+                          // CompletableFuture cancellation need not interrupt its running action.
+                        }
+                      }
+                      return value;
+                    }));
+
+    assertThat(siblingStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    try {
+      assertThat(result.get(250, TimeUnit.MILLISECONDS))
           .isInstanceOf(IllegalStateException.class)
-          .hasMessage("ordered merge failed");
-      assertThat(failure.getSuppressed())
-          .anyMatch(suppressed -> suppressed instanceof CancellationException);
-      assertThat(siblingInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
+          .hasMessage("ordered task failed");
+    } finally {
+      releaseSibling.countDown();
     }
   }
 
@@ -328,7 +364,7 @@ class BoundedFanoutTest {
   }
 
   @Test
-  void submissionFailureWaitsForAlreadySubmittedTasks() throws Exception {
+  void submissionFailureDoesNotWaitForAlreadySubmittedTasks() throws Exception {
     CountDownLatch taskStarted = new CountDownLatch(1);
     CountDownLatch allowTaskCompletion = new CountDownLatch(1);
     CountDownLatch mapReturned = new CountDownLatch(1);
@@ -366,15 +402,18 @@ class BoundedFanoutTest {
             });
 
     assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
-    assertThat(mapReturned.await(100, TimeUnit.MILLISECONDS)).isFalse();
-    allowTaskCompletion.countDown();
-    assertThat(result.join())
-        .isInstanceOf(RejectedExecutionException.class)
-        .hasMessage("executor saturated");
+    try {
+      assertThat(mapReturned.await(250, TimeUnit.MILLISECONDS)).isTrue();
+      assertThat(result.get(250, TimeUnit.MILLISECONDS))
+          .isInstanceOf(RejectedExecutionException.class)
+          .hasMessage("executor saturated");
+    } finally {
+      allowTaskCompletion.countDown();
+    }
   }
 
   @Test
-  void refillSubmissionFailureWaitsForAlreadySubmittedTasks() throws Exception {
+  void refillSubmissionFailureDoesNotWaitForAlreadySubmittedTasks() throws Exception {
     CountDownLatch blockingTaskStarted = new CountDownLatch(1);
     CountDownLatch allowBlockingTaskCompletion = new CountDownLatch(1);
     CountDownLatch mapReturned = new CountDownLatch(1);
@@ -397,6 +436,14 @@ class BoundedFanoutTest {
                     2,
                     rejectRefillSubmission,
                     value -> {
+                      if (value == 1) {
+                        try {
+                          blockingTaskStarted.await();
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError("first task interrupted", e);
+                        }
+                      }
                       if (value == 2) {
                         blockingTaskStarted.countDown();
                         try {
@@ -414,11 +461,14 @@ class BoundedFanoutTest {
             });
 
     assertThat(blockingTaskStarted.await(1, TimeUnit.SECONDS)).isTrue();
-    assertThat(mapReturned.await(100, TimeUnit.MILLISECONDS)).isFalse();
-    allowBlockingTaskCompletion.countDown();
-    assertThat(result.join())
-        .isInstanceOf(RejectedExecutionException.class)
-        .hasMessage("executor saturated during refill");
+    try {
+      assertThat(mapReturned.await(250, TimeUnit.MILLISECONDS)).isTrue();
+      assertThat(result.get(250, TimeUnit.MILLISECONDS))
+          .isInstanceOf(RejectedExecutionException.class)
+          .hasMessage("executor saturated during refill");
+    } finally {
+      allowBlockingTaskCompletion.countDown();
+    }
   }
 
   @Test
@@ -503,8 +553,6 @@ class BoundedFanoutTest {
       cancelled.set(true);
       Throwable failure = result.get(250, TimeUnit.MILLISECONDS);
       assertThat(failure).isInstanceOf(RejectedExecutionException.class);
-      assertThat(failure.getSuppressed())
-          .anyMatch(suppressed -> suppressed instanceof CancellationException);
       assertThat(taskInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
     }
   }

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -216,36 +216,31 @@ class BoundedFanoutTest {
 
     try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
       CompletableFuture<Throwable> result =
-          CompletableFuture.supplyAsync(
+          captureAsyncFailure(
               () -> {
-                try {
-                  BoundedFanout.forEachOrdered(
-                      List.of(0, 1, 2, 3, 4),
-                      2,
-                      executor,
-                      value -> {
-                        highestStarted.accumulateAndGet(value, Math::max);
-                        if (value > 0) {
-                          activeSiblingsStarted.countDown();
-                          try {
-                            releaseActiveSiblings.await();
-                          } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            throw new AssertionError(e);
-                          }
+                BoundedFanout.forEachOrdered(
+                    List.of(0, 1, 2, 3, 4),
+                    2,
+                    executor,
+                    value -> {
+                      highestStarted.accumulateAndGet(value, Math::max);
+                      if (value > 0) {
+                        activeSiblingsStarted.countDown();
+                        try {
+                          releaseActiveSiblings.await();
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError(e);
                         }
-                        return value;
-                      },
-                      value -> {
-                        if (value == 0) {
-                          throw new IllegalStateException("ordered merge failed");
-                        }
-                      },
-                      () -> false);
-                  return null;
-                } catch (Throwable failure) {
-                  return failure;
-                }
+                      }
+                      return value;
+                    },
+                    value -> {
+                      if (value == 0) {
+                        throw new IllegalStateException("ordered merge failed");
+                      }
+                    },
+                    () -> false);
               });
 
       assertThat(activeSiblingsStarted.await(1, TimeUnit.SECONDS)).isTrue();
@@ -269,42 +264,37 @@ class BoundedFanoutTest {
 
     try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
       CompletableFuture<Throwable> result =
-          CompletableFuture.supplyAsync(
+          captureAsyncFailure(
               () -> {
-                try {
-                  BoundedFanout.forEachOrdered(
-                      List.of(0, 1),
-                      2,
-                      executor,
-                      value -> {
-                        if (value == 0) {
-                          try {
-                            siblingStarted.await();
-                          } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            throw new AssertionError(e);
-                          }
-                          return value;
-                        }
-                        siblingStarted.countDown();
+                BoundedFanout.forEachOrdered(
+                    List.of(0, 1),
+                    2,
+                    executor,
+                    value -> {
+                      if (value == 0) {
                         try {
-                          new CountDownLatch(1).await();
-                          return value;
+                          siblingStarted.await();
                         } catch (InterruptedException e) {
-                          siblingInterrupted.countDown();
                           Thread.currentThread().interrupt();
-                          throw new CancellationException("sibling interrupted");
+                          throw new AssertionError(e);
                         }
-                      },
-                      ignored -> {
-                        consumerFailed.countDown();
-                        throw new IllegalStateException("ordered merge failed");
-                      },
-                      cancelled::get);
-                  return null;
-                } catch (Throwable failure) {
-                  return failure;
-                }
+                        return value;
+                      }
+                      siblingStarted.countDown();
+                      try {
+                        new CountDownLatch(1).await();
+                        return value;
+                      } catch (InterruptedException e) {
+                        siblingInterrupted.countDown();
+                        Thread.currentThread().interrupt();
+                        throw new CancellationException("sibling interrupted");
+                      }
+                    },
+                    ignored -> {
+                      consumerFailed.countDown();
+                      throw new IllegalStateException("ordered merge failed");
+                    },
+                    cancelled::get);
               });
 
       assertThat(consumerFailed.await(1, TimeUnit.SECONDS)).isTrue();
@@ -353,7 +343,7 @@ class BoundedFanoutTest {
         };
 
     CompletableFuture<Throwable> result =
-        CompletableFuture.supplyAsync(
+        captureAsyncFailure(
             () -> {
               try {
                 BoundedFanout.mapOrdered(
@@ -370,9 +360,6 @@ class BoundedFanoutTest {
                       }
                       return ignored;
                     });
-                return null;
-              } catch (Throwable failure) {
-                return failure;
               } finally {
                 mapReturned.countDown();
               }
@@ -402,7 +389,7 @@ class BoundedFanoutTest {
         };
 
     CompletableFuture<Throwable> result =
-        CompletableFuture.supplyAsync(
+        captureAsyncFailure(
             () -> {
               try {
                 BoundedFanout.mapOrdered(
@@ -421,9 +408,6 @@ class BoundedFanoutTest {
                       }
                       return value;
                     });
-                return null;
-              } catch (Throwable failure) {
-                return failure;
               } finally {
                 mapReturned.countDown();
               }
@@ -446,30 +430,25 @@ class BoundedFanoutTest {
 
     try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
       CompletableFuture<Throwable> result =
-          CompletableFuture.supplyAsync(
+          captureAsyncFailure(
               () -> {
-                try {
-                  BoundedFanout.forEachOrdered(
-                      List.of(1, 2),
-                      2,
-                      executor,
-                      ignored -> {
-                        taskStarted.countDown();
-                        try {
-                          allowTaskCompletion.await();
-                        } catch (InterruptedException e) {
-                          taskInterrupted.countDown();
-                          Thread.currentThread().interrupt();
-                          throw new CancellationException("task interrupted");
-                        }
-                        return ignored;
-                      },
-                      ignored -> {},
-                      cancelled::get);
-                  return null;
-                } catch (Throwable failure) {
-                  return failure;
-                }
+                BoundedFanout.forEachOrdered(
+                    List.of(1, 2),
+                    2,
+                    executor,
+                    ignored -> {
+                      taskStarted.countDown();
+                      try {
+                        allowTaskCompletion.await();
+                      } catch (InterruptedException e) {
+                        taskInterrupted.countDown();
+                        Thread.currentThread().interrupt();
+                        throw new CancellationException("task interrupted");
+                      }
+                      return ignored;
+                    },
+                    ignored -> {},
+                    cancelled::get);
               });
 
       assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
@@ -499,30 +478,25 @@ class BoundedFanoutTest {
             new SynchronousQueue<>(),
             new ThreadPoolExecutor.AbortPolicy())) {
       CompletableFuture<Throwable> result =
-          CompletableFuture.supplyAsync(
+          captureAsyncFailure(
               () -> {
-                try {
-                  BoundedFanout.forEachOrdered(
-                      List.of(1, 2),
-                      2,
-                      executor,
-                      ignored -> {
-                        taskStarted.countDown();
-                        try {
-                          new CountDownLatch(1).await();
-                          return ignored;
-                        } catch (InterruptedException e) {
-                          taskInterrupted.countDown();
-                          Thread.currentThread().interrupt();
-                          throw new CancellationException("task interrupted");
-                        }
-                      },
-                      ignored -> {},
-                      cancelled::get);
-                  return null;
-                } catch (Throwable failure) {
-                  return failure;
-                }
+                BoundedFanout.forEachOrdered(
+                    List.of(1, 2),
+                    2,
+                    executor,
+                    ignored -> {
+                      taskStarted.countDown();
+                      try {
+                        new CountDownLatch(1).await();
+                        return ignored;
+                      } catch (InterruptedException e) {
+                        taskInterrupted.countDown();
+                        Thread.currentThread().interrupt();
+                        throw new CancellationException("task interrupted");
+                      }
+                    },
+                    ignored -> {},
+                    cancelled::get);
               });
 
       assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
@@ -548,5 +522,18 @@ class BoundedFanoutTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("permits must be >= 1");
     }
+  }
+
+  /** Run one assertion scenario asynchronously and expose its terminal failure as a value. */
+  private static CompletableFuture<Throwable> captureAsyncFailure(Runnable scenario) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            scenario.run();
+            return null;
+          } catch (Throwable failure) {
+            return failure;
+          }
+        });
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -81,8 +81,9 @@ class BoundedFanoutTest {
   }
 
   @Test
-  void submitsOnlyTheRollingWindowWhileTheFirstResultIsBlocked() throws Exception {
+  void refillsPermitsWhileTheFirstResultIsBlocked() throws Exception {
     CountDownLatch firstStarted = new CountDownLatch(1);
+    CountDownLatch laterItemStarted = new CountDownLatch(1);
     CountDownLatch releaseFirst = new CountDownLatch(1);
     AtomicInteger submissions = new AtomicInteger();
     Executor countingExecutor =
@@ -107,13 +108,19 @@ class BoundedFanoutTest {
                           Thread.currentThread().interrupt();
                           throw new AssertionError(e);
                         }
+                      } else if (value >= 3) {
+                        laterItemStarted.countDown();
                       }
                       return value;
                     }));
 
     assertThat(firstStarted.await(1, TimeUnit.SECONDS)).isTrue();
-    assertThat(submissions.get()).isEqualTo(3);
-    releaseFirst.countDown();
+    assertThat(laterItemStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    try {
+      assertThat(submissions.get()).isEqualTo(100);
+    } finally {
+      releaseFirst.countDown();
+    }
     assertThat(result.get(1, TimeUnit.SECONDS)).hasSize(100);
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class BoundedFanoutTest {
+
+  @Test
+  void resultsAreReturnedInInputOrder() {
+    List<Integer> inputs = IntStream.range(0, 50).boxed().toList();
+    // Reverse the completion order (later items sleep less) to prove ordering is by input, not
+    // completion.
+    List<Integer> out =
+        BoundedFanout.mapOrdered(
+            inputs,
+            8,
+            ForkJoinPool.commonPool(),
+            i -> {
+              try {
+                Thread.sleep((50 - i) % 5);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return i * 10;
+            });
+    assertThat(out).isEqualTo(inputs.stream().map(i -> i * 10).toList());
+  }
+
+  @Test
+  void neverRunsMoreThanPermitsAtOnce() {
+    int permits = 3;
+    AtomicInteger inFlight = new AtomicInteger();
+    AtomicInteger peak = new AtomicInteger();
+    BoundedFanout.mapOrdered(
+        IntStream.range(0, 40).boxed().toList(),
+        permits,
+        ForkJoinPool.commonPool(),
+        i -> {
+          int now = inFlight.incrementAndGet();
+          peak.accumulateAndGet(now, Math::max);
+          try {
+            Thread.sleep(2);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            inFlight.decrementAndGet();
+          }
+          return i;
+        });
+    assertThat(peak.get()).isLessThanOrEqualTo(permits);
+  }
+
+  @Test
+  void taskFailureSurfacesUnwrapped() {
+    assertThatThrownBy(
+            () ->
+                BoundedFanout.mapOrdered(
+                    List.of(1, 2, 3),
+                    4,
+                    ForkJoinPool.commonPool(),
+                    i -> {
+                      if (i == 2) {
+                        throw new IllegalStateException("boom");
+                      }
+                      return i;
+                    }))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("boom");
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -84,15 +85,16 @@ class BoundedFanoutTest {
   void refillsPermitsWhileTheFirstResultIsBlocked() throws Exception {
     CountDownLatch firstStarted = new CountDownLatch(1);
     CountDownLatch laterItemStarted = new CountDownLatch(1);
-    CountDownLatch allItemsSubmitted = new CountDownLatch(1);
+    CountDownLatch initialWindowSubmitted = new CountDownLatch(1);
     CountDownLatch releaseFirst = new CountDownLatch(1);
     AtomicInteger submissions = new AtomicInteger();
+    LinkedBlockingQueue<Runnable> queuedTasks = new LinkedBlockingQueue<>();
     Executor countingExecutor =
         command -> {
-          if (submissions.incrementAndGet() == 100) {
-            allItemsSubmitted.countDown();
+          if (submissions.incrementAndGet() == 3) {
+            initialWindowSubmitted.countDown();
           }
-          CompletableFuture.runAsync(command);
+          queuedTasks.add(command);
         };
 
     CompletableFuture<List<Integer>> result =
@@ -117,15 +119,37 @@ class BoundedFanoutTest {
                       return value;
                     }));
 
-    assertThat(firstStarted.await(1, TimeUnit.SECONDS)).isTrue();
-    assertThat(laterItemStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    // Before any submitted task completes, only the bounded window may reach the executor.
+    assertThat(initialWindowSubmitted.await(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(submissions.get()).isEqualTo(3);
+    ExecutorService workers = Executors.newFixedThreadPool(3);
     try {
-      assertThat(allItemsSubmitted.await(1, TimeUnit.SECONDS)).isTrue();
-      assertThat(submissions.get()).isEqualTo(100);
+      try {
+        for (int i = 0; i < 3; i++) {
+          workers.submit(
+              () -> {
+                try {
+                  while (!result.isDone()) {
+                    Runnable submitted = queuedTasks.poll(10, TimeUnit.MILLISECONDS);
+                    if (submitted != null) {
+                      submitted.run();
+                    }
+                  }
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+              });
+        }
+        assertThat(firstStarted.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(laterItemStarted.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(submissions.get()).isGreaterThan(3);
+      } finally {
+        releaseFirst.countDown();
+      }
+      assertThat(result.get(1, TimeUnit.SECONDS)).hasSize(100);
     } finally {
-      releaseFirst.countDown();
+      workers.shutdownNow();
     }
-    assertThat(result.get(1, TimeUnit.SECONDS)).hasSize(100);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -84,11 +84,14 @@ class BoundedFanoutTest {
   void refillsPermitsWhileTheFirstResultIsBlocked() throws Exception {
     CountDownLatch firstStarted = new CountDownLatch(1);
     CountDownLatch laterItemStarted = new CountDownLatch(1);
+    CountDownLatch allItemsSubmitted = new CountDownLatch(1);
     CountDownLatch releaseFirst = new CountDownLatch(1);
     AtomicInteger submissions = new AtomicInteger();
     Executor countingExecutor =
         command -> {
-          submissions.incrementAndGet();
+          if (submissions.incrementAndGet() == 100) {
+            allItemsSubmitted.countDown();
+          }
           CompletableFuture.runAsync(command);
         };
 
@@ -117,6 +120,7 @@ class BoundedFanoutTest {
     assertThat(firstStarted.await(1, TimeUnit.SECONDS)).isTrue();
     assertThat(laterItemStarted.await(1, TimeUnit.SECONDS)).isTrue();
     try {
+      assertThat(allItemsSubmitted.await(1, TimeUnit.SECONDS)).isTrue();
       assertThat(submissions.get()).isEqualTo(100);
     } finally {
       releaseFirst.countDown();

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
@@ -16,17 +16,60 @@
 package ai.floedb.floecat.service.concurrent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class CancellableCallRunnerTest {
+
+  @Test
+  void uncancellableTimeoutReturnsCallerButRetainsActiveCallAdmission() throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    var permits = new Semaphore(1);
+    var started = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    try {
+      assertThrows(
+          IllegalStateException.class,
+          () ->
+              CancellableCallRunner.callUncancellable(
+                  executor,
+                  permits,
+                  () -> {
+                    started.countDown();
+                    while (true) {
+                      try {
+                        release.await();
+                        return "done";
+                      } catch (InterruptedException ignored) {
+                        // Simulate an interruption-insensitive downstream store call.
+                      }
+                    }
+                  },
+                  25,
+                  TimeUnit.MILLISECONDS,
+                  "cancelled",
+                  "interrupted",
+                  "timed out"));
+
+      assertTrue(started.await(1, TimeUnit.SECONDS));
+      assertEquals(0, permits.availablePermits(), "active I/O must retain its admission slot");
+    } finally {
+      release.countDown();
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+      assertEquals(1, permits.availablePermits());
+    }
+  }
 
   @Test
   void shutdownNowReleasesAndCompletesQueuedCall() throws Exception {

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class CancellableCallRunnerTest {
+
+  @Test
+  void shutdownNowReleasesAndCompletesQueuedCall() throws Exception {
+    var executor =
+        new ThreadPoolExecutor(
+            1, 1, 0L, TimeUnit.MILLISECONDS, new java.util.concurrent.LinkedBlockingQueue<>());
+    var permits = new Semaphore(2);
+    var firstStarted = new CountDownLatch(1);
+    var allowFirst = new CountDownLatch(1);
+    try {
+      CompletableFuture<String> first =
+          CompletableFuture.supplyAsync(
+              () ->
+                  CancellableCallRunner.call(
+                      executor,
+                      permits,
+                      () -> false,
+                      () -> {
+                        firstStarted.countDown();
+                        try {
+                          allowFirst.await();
+                        } catch (InterruptedException ignored) {
+                          // Simulate a store call that does not abort immediately.
+                          try {
+                            allowFirst.await();
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                          }
+                        }
+                        return "first";
+                      },
+                      "cancelled",
+                      "interrupted"));
+      assertTrue(firstStarted.await(1, TimeUnit.SECONDS));
+
+      CompletableFuture<Throwable> queued =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  CancellableCallRunner.call(
+                      executor, permits, () -> false, () -> "queued", "cancelled", "interrupted");
+                  return null;
+                } catch (Throwable failure) {
+                  return failure;
+                }
+              });
+      for (int attempt = 0; attempt < 100 && executor.getQueue().isEmpty(); attempt++) {
+        Thread.sleep(10);
+      }
+      assertEquals(1, executor.getQueue().size());
+
+      CancellableCallRunner.cancelDiscardedTasks(executor.shutdownNow());
+
+      assertTrue(queued.get(250, TimeUnit.MILLISECONDS) instanceof CancellationException);
+      assertEquals(1, permits.availablePermits(), "the discarded call must release its permit");
+
+      allowFirst.countDown();
+      assertEquals("first", first.get(1, TimeUnit.SECONDS));
+      assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+      assertEquals(2, permits.availablePermits());
+    } finally {
+      allowFirst.countDown();
+      executor.shutdownNow();
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
@@ -39,7 +39,7 @@ class CancellableCallRunnerTest {
     var release = new CountDownLatch(1);
     try {
       assertThrows(
-          IllegalStateException.class,
+          CancellableCallRunner.CallTimeoutException.class,
           () ->
               CancellableCallRunner.callUncancellable(
                   executor,
@@ -68,6 +68,26 @@ class CancellableCallRunnerTest {
       executor.shutdownNow();
       assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
       assertEquals(1, permits.availablePermits());
+    }
+  }
+
+  @Test
+  void uncancellableTimeoutIncludesPermitAdmission() {
+    var permits = new Semaphore(0);
+    try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+      assertThrows(
+          CancellableCallRunner.CallTimeoutException.class,
+          () ->
+              CancellableCallRunner.callUncancellable(
+                  executor,
+                  permits,
+                  () -> "unreachable",
+                  25,
+                  TimeUnit.MILLISECONDS,
+                  "cancelled",
+                  "interrupted",
+                  "timed out"));
+      assertEquals(0, permits.availablePermits());
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class CancellableCallRunnerTest {
@@ -68,6 +69,61 @@ class CancellableCallRunnerTest {
       executor.shutdownNow();
       assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
       assertEquals(1, permits.availablePermits());
+    }
+  }
+
+  @Test
+  void uncancellableTimeoutReportsRetainedAdmissionUntilTheCallActuallyExits() throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    var permits = new Semaphore(1);
+    var started = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    var stuckCalls = new AtomicInteger();
+    try {
+      assertThrows(
+          CancellableCallRunner.CallTimeoutException.class,
+          () ->
+              CancellableCallRunner.callUncancellable(
+                  executor,
+                  permits,
+                  () -> {
+                    started.countDown();
+                    while (true) {
+                      try {
+                        release.await();
+                        return "done";
+                      } catch (InterruptedException ignored) {
+                        // Simulate a store call whose HTTP client ignores interruption.
+                      }
+                    }
+                  },
+                  25,
+                  TimeUnit.MILLISECONDS,
+                  "cancelled",
+                  "interrupted",
+                  "timed out",
+                  new CancellableCallRunner.TimeoutListener() {
+                    @Override
+                    public void timedOut() {
+                      stuckCalls.incrementAndGet();
+                    }
+
+                    @Override
+                    public void finished() {
+                      stuckCalls.decrementAndGet();
+                    }
+                  }));
+
+      assertTrue(started.await(1, TimeUnit.SECONDS));
+      assertEquals(1, stuckCalls.get());
+      release.countDown();
+      for (int attempt = 0; attempt < 100 && stuckCalls.get() != 0; attempt++) {
+        Thread.sleep(10);
+      }
+      assertEquals(0, stuckCalls.get());
+    } finally {
+      release.countDown();
+      executor.shutdownNow();
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/CancellableCallRunnerTest.java
@@ -19,131 +19,74 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
+/** Exercises admission, cancellation ownership, and executor-discard races for blocking calls. */
 class CancellableCallRunnerTest {
 
+  private static final CancellableCallRunner.FailureMessages CALL_FAILURES =
+      new CancellableCallRunner.FailureMessages("cancelled", "interrupted");
+
   @Test
-  void uncancellableTimeoutReturnsCallerButRetainsActiveCallAdmission() throws Exception {
-    ExecutorService executor = Executors.newSingleThreadExecutor();
+  void rejectsAnExecutorThatRunsTheBlockingCallInline() {
+    Executor directExecutor = Runnable::run;
+    var permits = new Semaphore(1);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CancellableCallRunner.call(
+                directExecutor, permits, () -> false, () -> "must not run", CALL_FAILURES));
+    assertEquals(1, permits.availablePermits());
+  }
+
+  @Test
+  void callWithoutCancellationWaitsForTheEventualResult() throws Exception {
+    ExecutorService metadataExecutor = Executors.newSingleThreadExecutor();
+    ExecutorService callerExecutor = Executors.newSingleThreadExecutor();
     var permits = new Semaphore(1);
     var started = new CountDownLatch(1);
     var release = new CountDownLatch(1);
     try {
-      assertThrows(
-          CancellableCallRunner.CallTimeoutException.class,
-          () ->
-              CancellableCallRunner.callUncancellable(
-                  executor,
-                  permits,
-                  () -> {
-                    started.countDown();
-                    while (true) {
-                      try {
-                        release.await();
+      CompletableFuture<String> result =
+          CompletableFuture.supplyAsync(
+              () ->
+                  CancellableCallRunner.callWithoutCancellation(
+                      metadataExecutor,
+                      permits,
+                      () -> {
+                        started.countDown();
+                        try {
+                          release.await();
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                        }
                         return "done";
-                      } catch (InterruptedException ignored) {
-                        // Simulate an interruption-insensitive downstream store call.
-                      }
-                    }
-                  },
-                  25,
-                  TimeUnit.MILLISECONDS,
-                  "cancelled",
-                  "interrupted",
-                  "timed out"));
-
+                      },
+                      CALL_FAILURES),
+              callerExecutor);
       assertTrue(started.await(1, TimeUnit.SECONDS));
+      assertThrows(
+          java.util.concurrent.TimeoutException.class, () -> result.get(25, TimeUnit.MILLISECONDS));
       assertEquals(0, permits.availablePermits(), "active I/O must retain its admission slot");
-    } finally {
       release.countDown();
-      executor.shutdownNow();
-      assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+      assertEquals("done", result.get(1, TimeUnit.SECONDS));
       assertEquals(1, permits.availablePermits());
-    }
-  }
-
-  @Test
-  void uncancellableTimeoutReportsRetainedAdmissionUntilTheCallActuallyExits() throws Exception {
-    ExecutorService executor = Executors.newSingleThreadExecutor();
-    var permits = new Semaphore(1);
-    var started = new CountDownLatch(1);
-    var release = new CountDownLatch(1);
-    var stuckCalls = new AtomicInteger();
-    try {
-      assertThrows(
-          CancellableCallRunner.CallTimeoutException.class,
-          () ->
-              CancellableCallRunner.callUncancellable(
-                  executor,
-                  permits,
-                  () -> {
-                    started.countDown();
-                    while (true) {
-                      try {
-                        release.await();
-                        return "done";
-                      } catch (InterruptedException ignored) {
-                        // Simulate a store call whose HTTP client ignores interruption.
-                      }
-                    }
-                  },
-                  25,
-                  TimeUnit.MILLISECONDS,
-                  "cancelled",
-                  "interrupted",
-                  "timed out",
-                  new CancellableCallRunner.TimeoutListener() {
-                    @Override
-                    public void timedOut() {
-                      stuckCalls.incrementAndGet();
-                    }
-
-                    @Override
-                    public void finished() {
-                      stuckCalls.decrementAndGet();
-                    }
-                  }));
-
-      assertTrue(started.await(1, TimeUnit.SECONDS));
-      assertEquals(1, stuckCalls.get());
-      release.countDown();
-      for (int attempt = 0; attempt < 100 && stuckCalls.get() != 0; attempt++) {
-        Thread.sleep(10);
-      }
-      assertEquals(0, stuckCalls.get());
     } finally {
       release.countDown();
-      executor.shutdownNow();
-    }
-  }
-
-  @Test
-  void uncancellableTimeoutIncludesPermitAdmission() {
-    var permits = new Semaphore(0);
-    try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
-      assertThrows(
-          CancellableCallRunner.CallTimeoutException.class,
-          () ->
-              CancellableCallRunner.callUncancellable(
-                  executor,
-                  permits,
-                  () -> "unreachable",
-                  25,
-                  TimeUnit.MILLISECONDS,
-                  "cancelled",
-                  "interrupted",
-                  "timed out"));
-      assertEquals(0, permits.availablePermits());
+      metadataExecutor.shutdownNow();
+      callerExecutor.shutdownNow();
     }
   }
 
@@ -177,8 +120,7 @@ class CancellableCallRunnerTest {
                         }
                         return "first";
                       },
-                      "cancelled",
-                      "interrupted"));
+                      CALL_FAILURES));
       assertTrue(firstStarted.await(1, TimeUnit.SECONDS));
 
       CompletableFuture<Throwable> queued =
@@ -186,7 +128,7 @@ class CancellableCallRunnerTest {
               () -> {
                 try {
                   CancellableCallRunner.call(
-                      executor, permits, () -> false, () -> "queued", "cancelled", "interrupted");
+                      executor, permits, () -> false, () -> "queued", CALL_FAILURES);
                   return null;
                 } catch (Throwable failure) {
                   return failure;
@@ -210,5 +152,123 @@ class CancellableCallRunnerTest {
       allowFirst.countDown();
       executor.shutdownNow();
     }
+  }
+
+  @Test
+  void cancellingQueuedCallRemovesItBeforeRecyclingAdmission() throws Exception {
+    var executor =
+        new ThreadPoolExecutor(
+            1,
+            1,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1),
+            new ThreadPoolExecutor.AbortPolicy());
+    var permits = new Semaphore(2);
+    var firstStarted = new CountDownLatch(1);
+    var allowFirst = new CountDownLatch(1);
+    var cancelQueued = new AtomicBoolean();
+    try {
+      CompletableFuture<String> first =
+          CompletableFuture.supplyAsync(
+              () ->
+                  CancellableCallRunner.call(
+                      executor,
+                      permits,
+                      () -> false,
+                      () -> {
+                        firstStarted.countDown();
+                        try {
+                          allowFirst.await();
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                        }
+                        return "first";
+                      },
+                      CALL_FAILURES));
+      assertTrue(firstStarted.await(1, TimeUnit.SECONDS));
+
+      CompletableFuture<Throwable> cancelledQueued =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  CancellableCallRunner.call(
+                      executor, permits, cancelQueued::get, () -> "cancelled", CALL_FAILURES);
+                  return null;
+                } catch (Throwable failure) {
+                  return failure;
+                }
+              });
+      awaitQueueSize(executor, 1);
+
+      cancelQueued.set(true);
+      assertTrue(cancelledQueued.get(1, TimeUnit.SECONDS) instanceof CancellationException);
+      awaitQueueSize(executor, 0);
+
+      CompletableFuture<String> replacement =
+          CompletableFuture.supplyAsync(
+              () ->
+                  CancellableCallRunner.call(
+                      executor, permits, () -> false, () -> "replacement", CALL_FAILURES));
+      awaitQueueSize(executor, 1);
+
+      allowFirst.countDown();
+      assertEquals("first", first.get(1, TimeUnit.SECONDS));
+      assertEquals("replacement", replacement.get(1, TimeUnit.SECONDS));
+      assertEquals(2, permits.availablePermits());
+    } finally {
+      allowFirst.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void cancellingRunningCallRetainsAdmissionUntilOperationExits() throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    var permits = new Semaphore(1);
+    var cancel = new AtomicBoolean();
+    var blocker = new UninterruptibleBlocker();
+    try {
+      CompletableFuture<Throwable> caller =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  CancellableCallRunner.call(
+                      executor,
+                      permits,
+                      cancel::get,
+                      () -> {
+                        blocker.await();
+                        return "done";
+                      },
+                      CALL_FAILURES);
+                  return null;
+                } catch (Throwable failure) {
+                  return failure;
+                }
+              });
+      assertTrue(blocker.started.await(1, TimeUnit.SECONDS));
+
+      cancel.set(true);
+      assertTrue(caller.get(1, TimeUnit.SECONDS) instanceof CancellationException);
+      assertEquals(0, permits.availablePermits());
+      assertTrue(blocker.interrupted.await(1, TimeUnit.SECONDS));
+
+      blocker.release.countDown();
+      for (int attempt = 0; attempt < 100 && permits.availablePermits() == 0; attempt++) {
+        Thread.sleep(10);
+      }
+      assertEquals(1, permits.availablePermits());
+    } finally {
+      blocker.release.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  private static void awaitQueueSize(ThreadPoolExecutor executor, int expected) throws Exception {
+    for (int attempt = 0; attempt < 100 && executor.getQueue().size() != expected; attempt++) {
+      Thread.sleep(10);
+    }
+    assertEquals(expected, executor.getQueue().size());
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/MetadataIoRunnerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/MetadataIoRunnerTest.java
@@ -33,6 +33,13 @@ class MetadataIoRunnerTest {
       new CancellableCallRunner.FailureMessages("cancelled", "interrupted");
 
   @Test
+  void configuredProcessCapacityIsClampedToSafeBounds() {
+    assertEquals(1, MetadataIoRunner.clampConfiguredCapacity(Integer.MIN_VALUE));
+    assertEquals(64, MetadataIoRunner.clampConfiguredCapacity(64));
+    assertEquals(256, MetadataIoRunner.clampConfiguredCapacity(Integer.MAX_VALUE));
+  }
+
+  @Test
   void defaultConstructionSharesBoundedProcessRuntimeOutsideCdi() {
     MetadataIoRunner direct = new MetadataIoRunner();
     MetadataIoRunner shared = MetadataIoRunner.shared();

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/MetadataIoRunnerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/MetadataIoRunnerTest.java
@@ -33,6 +33,17 @@ class MetadataIoRunnerTest {
       new CancellableCallRunner.FailureMessages("cancelled", "interrupted");
 
   @Test
+  void defaultConstructionSharesBoundedProcessRuntimeOutsideCdi() {
+    MetadataIoRunner direct = new MetadataIoRunner();
+    MetadataIoRunner shared = MetadataIoRunner.shared();
+
+    assertTrue(direct.sharesRuntimeWith(shared));
+    String workerName =
+        direct.callWithoutCancellation(() -> Thread.currentThread().getName(), FAILURES);
+    assertTrue(workerName.startsWith("floecat-metadata-io-"), workerName);
+  }
+
+  @Test
   void oneRunnerAppliesOneAdmissionCeilingAcrossCallers() throws Exception {
     var runner = new MetadataIoRunner(1);
     var firstStarted = new CountDownLatch(1);

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/MetadataIoRunnerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/MetadataIoRunnerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+/** Verifies process-wide admission shared by metadata callers. */
+class MetadataIoRunnerTest {
+  private static final CancellableCallRunner.FailureMessages FAILURES =
+      new CancellableCallRunner.FailureMessages("cancelled", "interrupted");
+
+  @Test
+  void oneRunnerAppliesOneAdmissionCeilingAcrossCallers() throws Exception {
+    var runner = new MetadataIoRunner(1);
+    var firstStarted = new CountDownLatch(1);
+    var releaseFirst = new CountDownLatch(1);
+    var secondStarted = new CountDownLatch(1);
+    runner.start();
+    try {
+      CompletableFuture<String> first =
+          CompletableFuture.supplyAsync(
+              () ->
+                  runner.call(
+                      () -> false,
+                      () -> {
+                        firstStarted.countDown();
+                        await(releaseFirst);
+                        return "first";
+                      },
+                      FAILURES));
+      assertTrue(firstStarted.await(1, TimeUnit.SECONDS));
+
+      CompletableFuture<String> second =
+          CompletableFuture.supplyAsync(
+              () ->
+                  runner.call(
+                      () -> false,
+                      () -> {
+                        secondStarted.countDown();
+                        return "second";
+                      },
+                      FAILURES));
+
+      assertFalse(secondStarted.await(50, TimeUnit.MILLISECONDS));
+      releaseFirst.countDown();
+      assertEquals("first", first.get(1, TimeUnit.SECONDS));
+      assertEquals("second", second.get(1, TimeUnit.SECONDS));
+    } finally {
+      releaseFirst.countDown();
+      runner.close();
+    }
+  }
+
+  @Test
+  void cancelledCallerReturnsWhileWaitingForSharedAdmission() throws Exception {
+    var runner = new MetadataIoRunner(1);
+    var blocker = new UninterruptibleBlocker();
+    var cancelled = new AtomicBoolean();
+    var waitingOperationStarted = new AtomicBoolean();
+    runner.start();
+    try {
+      CompletableFuture<String> active =
+          CompletableFuture.supplyAsync(
+              () ->
+                  runner.call(
+                      () -> false,
+                      () -> {
+                        blocker.await();
+                        return "active";
+                      },
+                      FAILURES));
+      assertTrue(blocker.started.await(1, TimeUnit.SECONDS));
+
+      CompletableFuture<Throwable> waiting =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  runner.call(
+                      cancelled::get,
+                      () -> {
+                        waitingOperationStarted.set(true);
+                        return "waiting";
+                      },
+                      FAILURES);
+                  return null;
+                } catch (Throwable failure) {
+                  return failure;
+                }
+              });
+      cancelled.set(true);
+
+      assertInstanceOf(CancellationException.class, waiting.get(250, TimeUnit.MILLISECONDS));
+      assertFalse(waitingOperationStarted.get());
+      blocker.release.countDown();
+      assertEquals("active", active.get(1, TimeUnit.SECONDS));
+    } finally {
+      blocker.release.countDown();
+      runner.close();
+    }
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CancellationException("interrupted");
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/UninterruptibleBlocker.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/UninterruptibleBlocker.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Simulates a downstream call that records but does not obey interruption until released. */
+public final class UninterruptibleBlocker {
+
+  /** Signals that the downstream call entered the blocker. */
+  public final CountDownLatch started = new CountDownLatch(1);
+
+  /** Signals that the blocked call observed at least one interrupt. */
+  public final CountDownLatch interrupted = new CountDownLatch(1);
+
+  /** Allows the simulated downstream call to return. */
+  public final CountDownLatch release = new CountDownLatch(1);
+
+  /** Captures the thread that executes the simulated downstream call. */
+  public final AtomicReference<Thread> executionThread = new AtomicReference<>();
+
+  /** Block until released, recording and deliberately ignoring interrupts. */
+  public void await() {
+    executionThread.set(Thread.currentThread());
+    started.countDown();
+    while (true) {
+      try {
+        release.await();
+        return;
+      } catch (InterruptedException ignored) {
+        interrupted.countDown();
+      }
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
@@ -29,10 +29,9 @@ import org.junit.jupiter.api.Test;
 /**
  * Off-thread propagation is the whole point of {@link PropagatedContext}: a fan-out worker never
  * inherits the request thread's thread-locals, so without re-establishing them the ambient reads
- * ({@code engineContext()}, the log MDC) read empty — which is how an engine-gated multi-input
- * batch silently misclassified before this existed (eng-floe/floecat#361). These tests capture on a
- * context-bearing thread and assert the body sees that context on a plain executor thread that
- * carries none of its own.
+ * ({@code engineContext()}, the log MDC) read empty. These tests capture on a context-bearing
+ * thread and assert the body sees that context on a plain executor thread that carries none of its
+ * own.
  */
 class PropagatedContextTest {
 

--- a/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
@@ -52,6 +52,8 @@ class PropagatedContextTest {
     // A single-thread pool that never saw the request: its thread-locals are empty until supply()
     // re-establishes them, so a wrong read here would be the real regression.
     ExecutorService foreign = Executors.newSingleThreadExecutor();
+    MDC.put("floecat_component", "query-resolver");
+    MDC.put("floecat_operation", "resolve-inputs");
     try {
       String engineKind =
           ResolvedCallContexts.callWith(
@@ -69,6 +71,10 @@ class PropagatedContextTest {
                                   // carry the request's ids too.
                                   assertThat(MDC.get("floecat_engine_kind")).isEqualTo("duckdb");
                                   assertThat(MDC.get("correlation_id")).isEqualTo("corr-1");
+                                  assertThat(MDC.get("floecat_component"))
+                                      .isEqualTo("query-resolver");
+                                  assertThat(MDC.get("floecat_operation"))
+                                      .isEqualTo("resolve-inputs");
                                   return seen.engineContext().engineKind();
                                 }))
                     .get();
@@ -76,6 +82,8 @@ class PropagatedContextTest {
       assertThat(engineKind).isEqualTo("duckdb");
     } finally {
       foreign.shutdownNow();
+      MDC.remove("floecat_component");
+      MDC.remove("floecat_operation");
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
@@ -134,6 +134,26 @@ class PropagatedContextTest {
   }
 
   @Test
+  void replacesForeignWorkerMdcWithTheCompleteCapturedMap() throws Exception {
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    MDC.put("extension_tenant", "request-tenant");
+    try {
+      PropagatedContext captured = PropagatedContext.capture();
+      foreign.submit(() -> MDC.put("extension_tenant", "stale-worker-tenant")).get();
+
+      Object tenantSeenByBody =
+          foreign.submit(() -> captured.supply(() -> MDC.get("extension_tenant"))).get();
+      Object tenantRestoredAfterBody = foreign.submit(() -> MDC.get("extension_tenant")).get();
+
+      assertThat(tenantSeenByBody).isEqualTo("request-tenant");
+      assertThat(tenantRestoredAfterBody).isEqualTo("stale-worker-tenant");
+    } finally {
+      MDC.remove("extension_tenant");
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
   void restoresExistingMdcAfterAnInlineNestedScope() {
     MDC.put("floecat_component", "outer-component");
     MDC.put("floecat_operation", "outer-operation");

--- a/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
@@ -116,6 +116,25 @@ class PropagatedContextTest {
   }
 
   @Test
+  void clearsExtensionMdcKeysAddedByTheBody() throws Exception {
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    try {
+      Object mdcAfterBody =
+          foreign
+              .submit(
+                  () -> {
+                    PropagatedContext.capture().run(() -> MDC.put("extension_tenant", "tenant-a"));
+                    return MDC.get("extension_tenant");
+                  })
+              .get();
+
+      assertThat(mdcAfterBody).isNull();
+    } finally {
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
   void restoresExistingMdcAfterAnInlineNestedScope() {
     MDC.put("floecat_component", "outer-component");
     MDC.put("floecat_operation", "outer-operation");

--- a/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.jboss.logging.MDC;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Off-thread propagation is the whole point of {@link PropagatedContext}: a fan-out worker never
+ * inherits the request thread's thread-locals, so without re-establishing them the ambient reads
+ * ({@code engineContext()}, the log MDC) read empty — which is how an engine-gated multi-input
+ * batch silently misclassified before this existed (eng-floe/floecat#361). These tests capture on a
+ * context-bearing thread and assert the body sees that context on a plain executor thread that
+ * carries none of its own.
+ */
+class PropagatedContextTest {
+
+  private static ResolvedCallContext resolvedWithEngine(String engineKind) {
+    return new ResolvedCallContext(
+        PrincipalContext.getDefaultInstance(),
+        "query-1",
+        "corr-1",
+        EngineContext.of(engineKind, "16.0"),
+        null,
+        null);
+  }
+
+  @Test
+  void reEstablishesAmbientContextOnAForeignThread() throws Exception {
+    ResolvedCallContext resolved = resolvedWithEngine("duckdb");
+    // A single-thread pool that never saw the request: its thread-locals are empty until supply()
+    // re-establishes them, so a wrong read here would be the real regression.
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    try {
+      String engineKind =
+          ResolvedCallContexts.callWith(
+              resolved,
+              () -> {
+                PropagatedContext captured = PropagatedContext.capture();
+                return foreign
+                    .submit(
+                        () ->
+                            captured.supply(
+                                () -> {
+                                  ResolvedCallContext seen = ResolvedCallContexts.currentOrNull();
+                                  assertThat(seen).isNotNull();
+                                  // MDC is derived from the call context, so off-thread log lines
+                                  // carry the request's ids too.
+                                  assertThat(MDC.get("floecat_engine_kind")).isEqualTo("duckdb");
+                                  assertThat(MDC.get("correlation_id")).isEqualTo("corr-1");
+                                  return seen.engineContext().engineKind();
+                                }))
+                    .get();
+              });
+      assertThat(engineKind).isEqualTo("duckdb");
+    } finally {
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
+  void clearsMdcAfterTheBodySoAPooledThreadDoesNotLeakIt() throws Exception {
+    ResolvedCallContext resolved = resolvedWithEngine("spark");
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    try {
+      // MDC.get is typed Object, so keep the carrier Object too rather than casting.
+      Object mdcAfterBody =
+          ResolvedCallContexts.callWith(
+              resolved,
+              () -> {
+                PropagatedContext captured = PropagatedContext.capture();
+                return foreign
+                    .submit(
+                        () -> {
+                          captured.run(
+                              () -> assertThat(MDC.get("floecat_engine_kind")).isEqualTo("spark"));
+                          // Same pooled thread, outside the body: the request's ids must be gone so
+                          // the next unrelated task cannot inherit them.
+                          return MDC.get("floecat_engine_kind");
+                        })
+                    .get();
+              });
+      assertThat(mdcAfterBody).isNull();
+    } finally {
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
+  void offAnyRequestTheBodyStillRuns() {
+    // Captured with no ambient request (startup, unit tests): supply must run the body rather than
+    // fail, and no context is fabricated.
+    PropagatedContext captured = PropagatedContext.capture();
+    assertThat(captured.supply(() -> "ran")).isEqualTo("ran");
+    assertThat(ResolvedCallContexts.currentOrNull()).isNull();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
@@ -108,6 +108,30 @@ class PropagatedContextTest {
   }
 
   @Test
+  void restoresExistingMdcAfterAnInlineNestedScope() {
+    MDC.put("floecat_component", "outer-component");
+    MDC.put("floecat_operation", "outer-operation");
+    MDC.put("correlation_id", "outer-correlation");
+    try {
+      ResolvedCallContexts.callWith(
+          resolvedWithEngine("spark"),
+          () -> {
+            PropagatedContext.capture()
+                .run(() -> assertThat(MDC.get("floecat_engine_kind")).isEqualTo("spark"));
+            return null;
+          });
+
+      assertThat(MDC.get("floecat_component")).isEqualTo("outer-component");
+      assertThat(MDC.get("floecat_operation")).isEqualTo("outer-operation");
+      assertThat(MDC.get("correlation_id")).isEqualTo("outer-correlation");
+    } finally {
+      MDC.remove("floecat_component");
+      MDC.remove("floecat_operation");
+      MDC.remove("correlation_id");
+    }
+  }
+
+  @Test
   void offAnyRequestTheBodyStillRuns() {
     // Captured with no ambient request (startup, unit tests): supply must run the body rather than
     // fail, and no context is fabricated.

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -51,6 +51,7 @@ import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.CancellingSubscriber;
+import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.CollectingSubscriber;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.FakeCatalogOverlay;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.TestQueryContextStore;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.TestQueryInputResolver;
@@ -1226,6 +1227,63 @@ class UserObjectBundleServiceTest {
     UserObjectsBundleChunk resolutionChunk = subscriber.items().get(1);
     assertThat(resolutionChunk.hasResolutions()).isTrue();
     assertThat(queryStore.updateCount()).isEqualTo(1);
+  }
+
+  @Test
+  void cancellationAfterPinResolutionReleasesTransientRoots() {
+    class CancelAfterResolutionSubscriber extends CollectingSubscriber {
+      void cancelNow() {
+        subscription.cancel();
+        completeSuccessfully();
+      }
+    }
+
+    AtomicReference<CancelAfterResolutionSubscriber> subscriberRef = new AtomicReference<>();
+    QueryInputResolver cancellingResolver =
+        new QueryInputResolver(null) {
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+              PhaseDiagnostics diagnostics,
+              java.util.function.BooleanSupplier cancelled) {
+            RelationPinSet pins =
+                SnapshotTestSupport.relationPins(
+                    SnapshotTestSupport.blobBackedPin(TABLE_A, TABLE_A_SNAPSHOT_ID));
+            queryStore.registerResolvingPinBlobs(queryId, QueryPins.gcRootUris(pins));
+            subscriberRef.get().cancelNow();
+            return new ResolutionResult(List.of(TABLE_A), pins, null);
+          }
+        };
+    service =
+        new UserObjectBundleService(
+            overlay,
+            cancellingResolver,
+            queryStore,
+            statsFactory,
+            decoratorProvider,
+            engineContextProvider,
+            false,
+            "localhost",
+            47470,
+            false,
+            "test");
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+    CancelAfterResolutionSubscriber subscriber = new CancelAfterResolutionSubscriber();
+    subscriberRef.set(subscriber);
+
+    service.stream("cid", ctx, List.of(candidate)).subscribe().withSubscriber(subscriber);
+    subscriber.await();
+
+    assertThat(queryStore.resolvingPinBlobUris()).isEmpty();
+    assertThat(queryStore.updateCount()).isZero();
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -77,6 +77,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -801,7 +803,7 @@ class UserObjectBundleServiceTest {
               List<QueryInput> inputs,
               Optional<Timestamp> asOfDefault,
               Optional<ResourceId> defaultCatalogId,
-              Map<ResourceId, TablePin> currentSnapshotPinCache,
+              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
               PhaseDiagnostics diagnostics) {
             return new ResolutionResult(
                 List.of(inputs.get(0).getTableId()), RelationPinSet.getDefaultInstance(), null);

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -1381,7 +1381,6 @@ class UserObjectBundleServiceTest {
       Thread statsWorker = blocker.executionThread.get();
       assertThat(statsWorker).isNotNull();
       assertThat(statsWorker.isVirtual()).isFalse();
-      assertThat(statsWorker.getName()).startsWith("floecat-bundle-metadata-");
 
       subscriber.cancel();
 
@@ -2713,7 +2712,6 @@ class UserObjectBundleServiceTest {
       Thread lookupWorker = blocker.executionThread.get();
       assertThat(lookupWorker).isNotNull();
       assertThat(lookupWorker.isVirtual()).isFalse();
-      assertThat(lookupWorker.getName()).startsWith("floecat-bundle-metadata-");
       subscriber.cancel();
       assertThat(resolutionRequest.get(250, TimeUnit.MILLISECONDS)).isNull();
       assertThat(blocker.interrupted.await(1, TimeUnit.SECONDS)).isTrue();

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -805,6 +805,23 @@ class UserObjectBundleServiceTest {
               Optional<ResourceId> defaultCatalogId,
               ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
               PhaseDiagnostics diagnostics) {
+            return emptyPinResolution(inputs);
+          }
+
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+              PhaseDiagnostics diagnostics,
+              java.util.function.BooleanSupplier cancelled) {
+            return emptyPinResolution(inputs);
+          }
+
+          private ResolutionResult emptyPinResolution(List<QueryInput> inputs) {
             return new ResolutionResult(
                 List.of(inputs.get(0).getTableId()), RelationPinSet.getDefaultInstance(), null);
           }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -80,6 +80,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -1227,6 +1231,44 @@ class UserObjectBundleServiceTest {
     UserObjectsBundleChunk resolutionChunk = subscriber.items().get(1);
     assertThat(resolutionChunk.hasResolutions()).isTrue();
     assertThat(queryStore.updateCount()).isEqualTo(1);
+  }
+
+  @Test
+  void cancellationInterruptsBlockedCandidateNameLookup() throws Exception {
+    BlockingLookupOverlay blockingOverlay = new BlockingLookupOverlay(BlockingLookup.NAME);
+    service = serviceWith(blockingOverlay);
+
+    assertCancellationReturnsWhileCandidateLookupBlocks(
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(
+                QueryInput.newBuilder()
+                    .setName(NameRef.newBuilder().setCatalog("cat").setName("a")))
+            .build(),
+        blockingOverlay.blocker);
+  }
+
+  @Test
+  void cancellationInterruptsBlockedCandidateNodeLookup() throws Exception {
+    BlockingLookupOverlay blockingOverlay = new BlockingLookupOverlay(BlockingLookup.NODE);
+    service = serviceWith(blockingOverlay);
+
+    assertCancellationReturnsWhileCandidateLookupBlocks(
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build(),
+        blockingOverlay.blocker);
+  }
+
+  @Test
+  void cancellationInterruptsBlockedDefaultCatalogLookup() throws Exception {
+    BlockingLookupOverlay blockingOverlay = new BlockingLookupOverlay(BlockingLookup.CATALOG);
+    service = serviceWith(blockingOverlay);
+
+    assertCancellationReturnsWhileCandidateLookupBlocks(
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setName(NameRef.newBuilder().setName("a")))
+            .build(),
+        blockingOverlay.blocker);
   }
 
   @Test
@@ -2458,5 +2500,138 @@ class UserObjectBundleServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(allResolutions.stream().filter(r -> r.getInputIndex() == -1).count()).isEqualTo(30);
+  }
+
+  private UserObjectBundleService serviceWith(FakeCatalogOverlay testOverlay) {
+    testOverlay.registerTable(
+        TABLE_A,
+        UserObjectBundleTestSupport.schemaFor("id_a"),
+        NameRef.newBuilder().setCatalog("cat").setName("a").build());
+    testOverlay.registerCatalog(DEFAULT_CATALOG, "cat");
+    return new UserObjectBundleService(
+        testOverlay,
+        resolver,
+        queryStore,
+        statsFactory,
+        decoratorProvider,
+        engineContextProvider,
+        false,
+        "localhost",
+        47470,
+        false,
+        "test");
+  }
+
+  private void assertCancellationReturnsWhileCandidateLookupBlocks(
+      TableReferenceCandidate candidate, UninterruptibleBlocker blocker) throws Exception {
+    DemandSubscriber subscriber = new DemandSubscriber();
+    service.stream("cid", ctx, List.of(candidate)).subscribe().withSubscriber(subscriber);
+    assertThat(subscriber.awaitSubscription()).isTrue();
+    subscriber.request(1); // header
+    CompletableFuture<Void> resolutionRequest =
+        CompletableFuture.runAsync(() -> subscriber.request(1));
+    try {
+      assertThat(blocker.started.await(1, TimeUnit.SECONDS)).isTrue();
+      subscriber.cancel();
+      assertThat(resolutionRequest.get(250, TimeUnit.MILLISECONDS)).isNull();
+      assertThat(blocker.interrupted.await(1, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      blocker.release.countDown();
+    }
+  }
+
+  private enum BlockingLookup {
+    CATALOG,
+    NAME,
+    NODE
+  }
+
+  /** A catalog overlay whose selected metadata operation blocks even after interruption. */
+  private static final class BlockingLookupOverlay extends FakeCatalogOverlay {
+    private final BlockingLookup blockedLookup;
+    final UninterruptibleBlocker blocker = new UninterruptibleBlocker();
+
+    private BlockingLookupOverlay(BlockingLookup blockedLookup) {
+      this.blockedLookup = blockedLookup;
+    }
+
+    @Override
+    public Optional<ai.floedb.floecat.metagraph.model.CatalogNode> catalog(ResourceId id) {
+      if (blockedLookup == BlockingLookup.CATALOG) {
+        blocker.await();
+      }
+      return super.catalog(id);
+    }
+
+    @Override
+    public Optional<ResourceId> resolveName(
+        String correlationId, NameRef ref, EngineContext engineContext) {
+      if (blockedLookup == BlockingLookup.NAME) {
+        blocker.await();
+      }
+      return super.resolveName(correlationId, ref, engineContext);
+    }
+
+    @Override
+    public Optional<ai.floedb.floecat.metagraph.model.GraphNode> resolve(ResourceId id) {
+      if (blockedLookup == BlockingLookup.NODE) {
+        blocker.await();
+      }
+      return super.resolve(id);
+    }
+  }
+
+  /**
+   * Simulates a downstream metadata client that records but does not immediately obey interrupts.
+   */
+  private static final class UninterruptibleBlocker {
+    final CountDownLatch started = new CountDownLatch(1);
+    final CountDownLatch interrupted = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+
+    void await() {
+      started.countDown();
+      while (true) {
+        try {
+          release.await();
+          return;
+        } catch (InterruptedException ignored) {
+          interrupted.countDown();
+        }
+      }
+    }
+  }
+
+  /** Requests stream items explicitly so cancellation can race one active iterator step. */
+  private static final class DemandSubscriber implements Subscriber<UserObjectsBundleChunk> {
+    private final CountDownLatch subscribed = new CountDownLatch(1);
+    private volatile Subscription subscription;
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+      this.subscription = subscription;
+      subscribed.countDown();
+    }
+
+    @Override
+    public void onNext(UserObjectsBundleChunk ignored) {}
+
+    @Override
+    public void onError(Throwable ignored) {}
+
+    @Override
+    public void onComplete() {}
+
+    boolean awaitSubscription() throws InterruptedException {
+      return subscribed.await(1, TimeUnit.SECONDS);
+    }
+
+    void request(long count) {
+      subscription.request(count);
+    }
+
+    void cancel() {
+      subscription.cancel();
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -259,6 +259,29 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void treatsANullOverlaySchemaAsAnEmptySchema() {
+    FakeCatalogOverlay nullSchemaOverlay =
+        new FakeCatalogOverlay() {
+          @Override
+          public List<SchemaColumn> tableSchema(ResourceId tableId) {
+            return null;
+          }
+        };
+    service = serviceWith(nullSchemaOverlay);
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    RelationResolution resolution = chunks.get(1).getResolutions().getItems(0);
+    assertThat(resolution.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(resolution.getRelation().getColumnsCount()).isZero();
+  }
+
+  @Test
   void resolvedTableCarriesOpaquePinIdentity() {
     TableReferenceCandidate candidate =
         TableReferenceCandidate.newBuilder()

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.metagraph.model.GraphNode;
 import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.ColumnFailureCode;
@@ -45,7 +46,9 @@ import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.query.rpc.TableReferenceCandidate;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.concurrent.UninterruptibleBlocker;
 import ai.floedb.floecat.service.context.EngineContextProvider;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.query.QueryPins;
@@ -84,6 +87,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -1257,6 +1261,139 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void terminalFailureClaimWinsBeforeProducerBecomesIdle() {
+    var gate = new UserObjectBundleService.StreamTelemetryGate();
+    AtomicBoolean cancelled = new AtomicBoolean();
+    gate.begin(() -> false);
+
+    assertThat(gate.cancel(cancelled))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.CancellationDecision.ACCEPTED);
+    assertThat(gate.finish(UserObjectBundleService.StreamTelemetryGate.Publication.FAILURE))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.Publication.FAILURE);
+  }
+
+  @Test
+  void cancellationClaimWinsWhenItRacesFinalCompletion() {
+    var gate = new UserObjectBundleService.StreamTelemetryGate();
+    AtomicBoolean cancelled = new AtomicBoolean();
+    gate.begin(() -> false);
+
+    assertThat(gate.cancel(cancelled))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.CancellationDecision.ACCEPTED);
+    assertThat(cancelled).isTrue();
+    assertThat(gate.finish(UserObjectBundleService.StreamTelemetryGate.Publication.COMPLETION))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.Publication.CANCELLATION);
+  }
+
+  @Test
+  void completionClaimWinsWhenTheProducerFinishesBeforeCancellation() {
+    var gate = new UserObjectBundleService.StreamTelemetryGate();
+    AtomicBoolean cancelled = new AtomicBoolean();
+    gate.begin(() -> false);
+
+    assertThat(gate.finish(UserObjectBundleService.StreamTelemetryGate.Publication.COMPLETION))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.Publication.COMPLETION);
+    assertThat(gate.cancel(cancelled))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.CancellationDecision.ACCEPTED);
+  }
+
+  @Test
+  void cancellationInterruptsBlockedRelationStatsLookup() throws Exception {
+    UninterruptibleBlocker blocker = new UninterruptibleBlocker();
+    CountDownLatch decoratorCalled = new CountDownLatch(1);
+    StatsProvider blockingStats =
+        new StatsProvider() {
+          @Override
+          public Optional<TableStatsView> tableStats(ResourceId tableId) {
+            blocker.await();
+            return Optional.empty();
+          }
+        };
+    StatsProviderFactory blockingStatsFactory = Mockito.mock(StatsProviderFactory.class);
+    Mockito.when(blockingStatsFactory.forQuery(Mockito.any(), Mockito.anyString()))
+        .thenReturn(blockingStats);
+    FakeCatalogOverlay concurrentOverlay =
+        new FakeCatalogOverlay() {
+          @Override
+          public boolean supportsConcurrentResolution() {
+            return true;
+          }
+        };
+    concurrentOverlay.registerTable(
+        TABLE_A,
+        UserObjectBundleTestSupport.schemaFor("id_a"),
+        NameRef.newBuilder().setCatalog("cat").setName("a").build());
+    concurrentOverlay.registerCatalog(DEFAULT_CATALOG, "cat");
+    EngineMetadataDecoratorProvider cancellationSensitiveDecorator =
+        ignored ->
+            Optional.of(
+                new EngineMetadataDecorator() {
+                  @Override
+                  public void decorateRelation(
+                      EngineContext engine,
+                      ai.floedb.floecat.systemcatalog.spi.decorator.RelationDecoration relation) {
+                    decoratorCalled.countDown();
+                  }
+
+                  @Override
+                  public void completeRelation(
+                      EngineContext engine,
+                      ai.floedb.floecat.systemcatalog.spi.decorator.RelationDecoration relation,
+                      boolean commitRelation,
+                      boolean commitColumns,
+                      Set<Long> columnIds) {
+                    decoratorCalled.countDown();
+                  }
+                });
+    service =
+        new UserObjectBundleService(
+            concurrentOverlay,
+            resolver,
+            queryStore,
+            blockingStatsFactory,
+            cancellationSensitiveDecorator,
+            engineContextProvider,
+            true,
+            "localhost",
+            47470,
+            false,
+            "test");
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+    DemandSubscriber subscriber = new DemandSubscriber();
+    EngineContext engine = EngineContext.of("pg", "16.0");
+    Context requestContext =
+        Context.current().withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, engine);
+    Context previous = requestContext.attach();
+    try {
+      service.stream("cid", ctx, List.of(candidate)).subscribe().withSubscriber(subscriber);
+    } finally {
+      requestContext.detach(previous);
+    }
+    assertThat(subscriber.awaitSubscription()).isTrue();
+    subscriber.request(1);
+    CompletableFuture<Void> resolutionRequest =
+        CompletableFuture.runAsync(() -> subscriber.request(1));
+    try {
+      assertThat(blocker.started.await(1, TimeUnit.SECONDS)).isTrue();
+      Thread statsWorker = blocker.executionThread.get();
+      assertThat(statsWorker).isNotNull();
+      assertThat(statsWorker.isVirtual()).isFalse();
+      assertThat(statsWorker.getName()).startsWith("floecat-bundle-metadata-");
+
+      subscriber.cancel();
+
+      assertThat(resolutionRequest.get(250, TimeUnit.MILLISECONDS)).isNull();
+      assertThat(blocker.interrupted.await(1, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      blocker.release.countDown();
+    }
+    assertThat(decoratorCalled.await(250, TimeUnit.MILLISECONDS)).isFalse();
+  }
+
+  @Test
   void cancellationInterruptsBlockedCandidateNameLookup() throws Exception {
     BlockingLookupOverlay blockingOverlay = new BlockingLookupOverlay(BlockingLookup.NAME);
     service = serviceWith(blockingOverlay);
@@ -1295,7 +1432,25 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void threadConfinedOverlayLookupsStayOnTheStreamProducer() {
+    Thread producer = Thread.currentThread();
+    CallerThreadOnlyOverlay threadConfinedOverlay = new CallerThreadOnlyOverlay(producer);
+    service = serviceWith(threadConfinedOverlay);
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setName(NameRef.newBuilder().setName("a")))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    assertThat(chunks).anyMatch(UserObjectsBundleChunk::hasResolutions);
+    assertThat(threadConfinedOverlay.callbackCount.get()).isGreaterThanOrEqualTo(3);
+  }
+
+  @Test
   void cancellationAfterPinResolutionReleasesTransientRoots() {
+    /** Subscriber that exposes cancellation at the resolver-return ownership boundary. */
     class CancelAfterResolutionSubscriber extends CollectingSubscriber {
       void cancelNow() {
         subscription.cancel();
@@ -2583,6 +2738,11 @@ class UserObjectBundleServiceTest {
     }
 
     @Override
+    public boolean supportsConcurrentResolution() {
+      return true;
+    }
+
+    @Override
     public Optional<ai.floedb.floecat.metagraph.model.CatalogNode> catalog(ResourceId id) {
       if (blockedLookup == BlockingLookup.CATALOG) {
         blocker.await();
@@ -2608,26 +2768,44 @@ class UserObjectBundleServiceTest {
     }
   }
 
-  /**
-   * Simulates a downstream metadata client that records but does not immediately obey interrupts.
-   */
-  private static final class UninterruptibleBlocker {
-    final CountDownLatch started = new CountDownLatch(1);
-    final CountDownLatch interrupted = new CountDownLatch(1);
-    final CountDownLatch release = new CountDownLatch(1);
-    final AtomicReference<Thread> executionThread = new AtomicReference<>();
+  /** Fails when an overlay that opts out of concurrency is called away from its producer thread. */
+  private static final class CallerThreadOnlyOverlay extends FakeCatalogOverlay {
+    private final Thread producer;
+    private final AtomicInteger callbackCount = new AtomicInteger();
 
-    void await() {
-      executionThread.set(Thread.currentThread());
-      started.countDown();
-      while (true) {
-        try {
-          release.await();
-          return;
-        } catch (InterruptedException ignored) {
-          interrupted.countDown();
-        }
+    private CallerThreadOnlyOverlay(Thread producer) {
+      this.producer = producer;
+    }
+
+    @Override
+    public boolean supportsConcurrentResolution() {
+      return false;
+    }
+
+    @Override
+    public Optional<ai.floedb.floecat.metagraph.model.CatalogNode> catalog(ResourceId id) {
+      assertProducerThread();
+      return super.catalog(id);
+    }
+
+    @Override
+    public Optional<ResourceId> resolveName(
+        String correlationId, NameRef ref, EngineContext engineContext) {
+      assertProducerThread();
+      return super.resolveName(correlationId, ref, engineContext);
+    }
+
+    @Override
+    public Optional<GraphNode> resolve(ResourceId id) {
+      assertProducerThread();
+      return super.resolve(id);
+    }
+
+    private void assertProducerThread() {
+      if (Thread.currentThread() != producer) {
+        throw new AssertionError("thread-confined overlay callback left the stream producer");
       }
+      callbackCount.incrementAndGet();
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -2532,6 +2532,10 @@ class UserObjectBundleServiceTest {
         CompletableFuture.runAsync(() -> subscriber.request(1));
     try {
       assertThat(blocker.started.await(1, TimeUnit.SECONDS)).isTrue();
+      Thread lookupWorker = blocker.executionThread.get();
+      assertThat(lookupWorker).isNotNull();
+      assertThat(lookupWorker.isVirtual()).isFalse();
+      assertThat(lookupWorker.getName()).startsWith("floecat-bundle-metadata-");
       subscriber.cancel();
       assertThat(resolutionRequest.get(250, TimeUnit.MILLISECONDS)).isNull();
       assertThat(blocker.interrupted.await(1, TimeUnit.SECONDS)).isTrue();
@@ -2588,8 +2592,10 @@ class UserObjectBundleServiceTest {
     final CountDownLatch started = new CountDownLatch(1);
     final CountDownLatch interrupted = new CountDownLatch(1);
     final CountDownLatch release = new CountDownLatch(1);
+    final AtomicReference<Thread> executionThread = new AtomicReference<>();
 
     void await() {
+      executionThread.set(Thread.currentThread());
       started.countDown();
       while (true) {
         try {

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -835,21 +835,8 @@ class UserObjectBundleServiceTest {
               List<QueryInput> inputs,
               Optional<Timestamp> asOfDefault,
               Optional<ResourceId> defaultCatalogId,
-              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+              Map<ResourceId, TablePin> currentSnapshotPinCache,
               PhaseDiagnostics diagnostics) {
-            return emptyPinResolution(inputs);
-          }
-
-          @Override
-          public ResolutionResult resolveInputs(
-              String queryId,
-              String correlationId,
-              List<QueryInput> inputs,
-              Optional<Timestamp> asOfDefault,
-              Optional<ResourceId> defaultCatalogId,
-              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-              PhaseDiagnostics diagnostics,
-              java.util.function.BooleanSupplier cancelled) {
             return emptyPinResolution(inputs);
           }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -1285,25 +1285,33 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
-  void cancellationInterruptsBlockedRelationStatsLookup() throws Exception {
-    UninterruptibleBlocker blocker = new UninterruptibleBlocker();
-    CountDownLatch decoratorCalled = new CountDownLatch(1);
-    StatsProvider blockingStats =
+  void relationStatsAndDecoratorsStayOnProducerForConcurrentOverlay() {
+    Thread producer = Thread.currentThread();
+    AtomicReference<Thread> statsThread = new AtomicReference<>();
+    List<Thread> decoratorThreads = java.util.Collections.synchronizedList(new ArrayList<>());
+    AtomicReference<Thread> overlayLookupThread = new AtomicReference<>();
+    StatsProvider recordingStats =
         new StatsProvider() {
           @Override
           public Optional<TableStatsView> tableStats(ResourceId tableId) {
-            blocker.await();
+            statsThread.set(Thread.currentThread());
             return Optional.empty();
           }
         };
-    StatsProviderFactory blockingStatsFactory = Mockito.mock(StatsProviderFactory.class);
-    Mockito.when(blockingStatsFactory.forQuery(Mockito.any(), Mockito.anyString()))
-        .thenReturn(blockingStats);
+    StatsProviderFactory recordingStatsFactory = Mockito.mock(StatsProviderFactory.class);
+    Mockito.when(recordingStatsFactory.forQuery(Mockito.any(), Mockito.anyString()))
+        .thenReturn(recordingStats);
     FakeCatalogOverlay concurrentOverlay =
         new FakeCatalogOverlay() {
           @Override
           public boolean supportsConcurrentResolution() {
             return true;
+          }
+
+          @Override
+          public Optional<NameRef> tableName(ResourceId id) {
+            overlayLookupThread.set(Thread.currentThread());
+            return super.tableName(id);
           }
         };
     concurrentOverlay.registerTable(
@@ -1311,7 +1319,7 @@ class UserObjectBundleServiceTest {
         UserObjectBundleTestSupport.schemaFor("id_a"),
         NameRef.newBuilder().setCatalog("cat").setName("a").build());
     concurrentOverlay.registerCatalog(DEFAULT_CATALOG, "cat");
-    EngineMetadataDecoratorProvider cancellationSensitiveDecorator =
+    EngineMetadataDecoratorProvider recordingDecorator =
         ignored ->
             Optional.of(
                 new EngineMetadataDecorator() {
@@ -1319,7 +1327,13 @@ class UserObjectBundleServiceTest {
                   public void decorateRelation(
                       EngineContext engine,
                       ai.floedb.floecat.systemcatalog.spi.decorator.RelationDecoration relation) {
-                    decoratorCalled.countDown();
+                    decoratorThreads.add(Thread.currentThread());
+                  }
+
+                  @Override
+                  public void decorateColumn(
+                      EngineContext engine, ColumnDecoration columnDecoration) {
+                    decoratorThreads.add(Thread.currentThread());
                   }
 
                   @Override
@@ -1329,7 +1343,7 @@ class UserObjectBundleServiceTest {
                       boolean commitRelation,
                       boolean commitColumns,
                       Set<Long> columnIds) {
-                    decoratorCalled.countDown();
+                    decoratorThreads.add(Thread.currentThread());
                   }
                 });
     service =
@@ -1337,8 +1351,8 @@ class UserObjectBundleServiceTest {
             concurrentOverlay,
             resolver,
             queryStore,
-            blockingStatsFactory,
-            cancellationSensitiveDecorator,
+            recordingStatsFactory,
+            recordingDecorator,
             engineContextProvider,
             true,
             "localhost",
@@ -1349,34 +1363,20 @@ class UserObjectBundleServiceTest {
         TableReferenceCandidate.newBuilder()
             .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
             .build();
-    DemandSubscriber subscriber = new DemandSubscriber();
     EngineContext engine = EngineContext.of("pg", "16.0");
     Context requestContext =
         Context.current().withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, engine);
     Context previous = requestContext.attach();
     try {
-      service.stream("cid", ctx, List.of(candidate)).subscribe().withSubscriber(subscriber);
+      List<UserObjectsBundleChunk> chunks =
+          service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+      assertThat(chunks).anyMatch(UserObjectsBundleChunk::hasResolutions);
     } finally {
       requestContext.detach(previous);
     }
-    assertThat(subscriber.awaitSubscription()).isTrue();
-    subscriber.request(1);
-    CompletableFuture<Void> resolutionRequest =
-        CompletableFuture.runAsync(() -> subscriber.request(1));
-    try {
-      assertThat(blocker.started.await(1, TimeUnit.SECONDS)).isTrue();
-      Thread statsWorker = blocker.executionThread.get();
-      assertThat(statsWorker).isNotNull();
-      assertThat(statsWorker.isVirtual()).isFalse();
-
-      subscriber.cancel();
-
-      assertThat(resolutionRequest.get(250, TimeUnit.MILLISECONDS)).isNull();
-      assertThat(blocker.interrupted.await(1, TimeUnit.SECONDS)).isTrue();
-    } finally {
-      blocker.release.countDown();
-    }
-    assertThat(decoratorCalled.await(250, TimeUnit.MILLISECONDS)).isFalse();
+    assertThat(statsThread.get()).isSameAs(producer);
+    assertThat(decoratorThreads).isNotEmpty().allMatch(thread -> thread == producer);
+    assertThat(overlayLookupThread.get()).isNotNull().isNotSameAs(producer);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -458,6 +458,7 @@ public final class UserObjectBundleTestSupport {
     private final Map<String, QueryContext> contexts = new HashMap<>();
     private final List<QueryContext> updates = new ArrayList<>();
     private final Map<String, ScanSession> scanSessions = new HashMap<>();
+    private final Set<String> resolvingPinBlobUris = ConcurrentHashMap.newKeySet();
 
     public void seed(QueryContext ctx) {
       contexts.put(ctx.getQueryId(), ctx);
@@ -465,6 +466,10 @@ public final class UserObjectBundleTestSupport {
 
     public int updateCount() {
       return updates.size();
+    }
+
+    public Set<String> resolvingPinBlobUris() {
+      return Set.copyOf(resolvingPinBlobUris);
     }
 
     @Override
@@ -514,12 +519,12 @@ public final class UserObjectBundleTestSupport {
     @Override
     public void registerResolvingPinBlobs(
         String correlationId, java.util.Collection<String> blobUris) {
-      // no-op: this fake does not model GC roots
+      resolvingPinBlobUris.addAll(blobUris);
     }
 
     @Override
     public void releaseResolvingPinBlobs(String queryId, java.util.Collection<String> blobUris) {
-      // no-op: this fake does not model GC roots
+      resolvingPinBlobUris.removeAll(blobUris);
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -35,6 +35,7 @@ import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.impl.QueryContext;
@@ -76,7 +77,9 @@ public final class UserObjectBundleTestSupport {
     private final Map<String, NameRef> names = new HashMap<>();
     private final Map<String, CatalogNode> catalogs = new HashMap<>();
     private final Set<String> hidden = new HashSet<>();
+    private final Set<String> schemaFailures = new HashSet<>();
     private final Map<String, Integer> resolveCalls = new ConcurrentHashMap<>();
+    private final Map<NameRef, Integer> resolveNameCalls = new ConcurrentHashMap<>();
 
     public void clear() {
       nodes.clear();
@@ -84,7 +87,16 @@ public final class UserObjectBundleTestSupport {
       names.clear();
       catalogs.clear();
       hidden.clear();
+      schemaFailures.clear();
       resolveCalls.clear();
+      resolveNameCalls.clear();
+    }
+
+    /**
+     * Make {@link #tableSchema} throw for this relation, to exercise per-relation build failures.
+     */
+    public void failSchemaFor(ResourceId id) {
+      schemaFailures.add(id.getId());
     }
 
     public void registerTable(
@@ -197,10 +209,22 @@ public final class UserObjectBundleTestSupport {
 
     @Override
     public Optional<ResourceId> resolveName(String correlationId, NameRef ref) {
+      resolveNameCalls.merge(ref, 1, Integer::sum);
       return names.entrySet().stream()
           .filter(entry -> entry.getValue().equals(ref))
           .map(entry -> nodes.get(entry.getKey()).id())
           .findFirst();
+    }
+
+    @Override
+    public Optional<ResourceId> resolveName(
+        String correlationId, NameRef ref, EngineContext engineContext) {
+      return resolveName(correlationId, ref);
+    }
+
+    /** How many times {@link #resolveName} ran for the exact ref (batch loop included). */
+    public int resolveNameCount(NameRef ref) {
+      return resolveNameCalls.getOrDefault(ref, 0);
     }
 
     @Override
@@ -309,6 +333,9 @@ public final class UserObjectBundleTestSupport {
 
     @Override
     public List<ai.floedb.floecat.query.rpc.SchemaColumn> tableSchema(ResourceId tableId) {
+      if (schemaFailures.contains(tableId.getId())) {
+        throw new RuntimeException("schema unavailable for " + tableId.getId());
+      }
       return schemas.getOrDefault(tableId.getId(), List.of());
     }
   }
@@ -382,7 +409,8 @@ public final class UserObjectBundleTestSupport {
         List<QueryInput> inputs,
         Optional<Timestamp> asOfDefault,
         Optional<ResourceId> defaultCatalogId,
-        Map<ResourceId, TablePin> currentSnapshotPinCache,
+        java.util.concurrent.ConcurrentMap<ResourceId, CompletableFuture<TablePin>>
+            currentSnapshotPinCache,
         PhaseDiagnostics diagnostics) {
       List<ResourceId> resolved = new ArrayList<>(inputs.size());
       RelationPinSet.Builder pins = RelationPinSet.newBuilder();

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -56,7 +56,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
-import java.util.function.BooleanSupplier;
 import java.util.function.UnaryOperator;
 
 public final class UserObjectBundleTestSupport {
@@ -410,33 +409,15 @@ public final class UserObjectBundleTestSupport {
         List<QueryInput> inputs,
         Optional<Timestamp> asOfDefault,
         Optional<ResourceId> defaultCatalogId,
-        java.util.concurrent.ConcurrentMap<ResourceId, CompletableFuture<TablePin>>
-            currentSnapshotPinCache,
+        Map<ResourceId, TablePin> currentSnapshotPinCache,
         PhaseDiagnostics diagnostics) {
-      return resolveInputs(inputs, () -> false);
+      return resolveInputs(inputs);
     }
 
-    @Override
-    public ResolutionResult resolveInputs(
-        String queryId,
-        String correlationId,
-        List<QueryInput> inputs,
-        Optional<Timestamp> asOfDefault,
-        Optional<ResourceId> defaultCatalogId,
-        java.util.concurrent.ConcurrentMap<ResourceId, CompletableFuture<TablePin>>
-            currentSnapshotPinCache,
-        PhaseDiagnostics diagnostics,
-        BooleanSupplier cancelled) {
-      return resolveInputs(inputs, cancelled);
-    }
-
-    private ResolutionResult resolveInputs(List<QueryInput> inputs, BooleanSupplier cancelled) {
+    private ResolutionResult resolveInputs(List<QueryInput> inputs) {
       List<ResourceId> resolved = new ArrayList<>(inputs.size());
       RelationPinSet.Builder pins = RelationPinSet.newBuilder();
       for (QueryInput input : inputs) {
-        if (cancelled.getAsBoolean()) {
-          throw new java.util.concurrent.CancellationException("input resolution cancelled");
-        }
         calls.add(List.of(input));
         switch (input.getTargetCase()) {
           case TABLE_ID -> {

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -71,7 +71,7 @@ public final class UserObjectBundleTestSupport {
             .build());
   }
 
-  public static final class FakeCatalogOverlay implements CatalogOverlay {
+  public static class FakeCatalogOverlay implements CatalogOverlay {
     private final Map<String, GraphNode> nodes = new HashMap<>();
     private final Map<String, List<ai.floedb.floecat.query.rpc.SchemaColumn>> schemas =
         new HashMap<>();

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -56,6 +56,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
+import java.util.function.BooleanSupplier;
 import java.util.function.UnaryOperator;
 
 public final class UserObjectBundleTestSupport {
@@ -412,9 +413,30 @@ public final class UserObjectBundleTestSupport {
         java.util.concurrent.ConcurrentMap<ResourceId, CompletableFuture<TablePin>>
             currentSnapshotPinCache,
         PhaseDiagnostics diagnostics) {
+      return resolveInputs(inputs, () -> false);
+    }
+
+    @Override
+    public ResolutionResult resolveInputs(
+        String queryId,
+        String correlationId,
+        List<QueryInput> inputs,
+        Optional<Timestamp> asOfDefault,
+        Optional<ResourceId> defaultCatalogId,
+        java.util.concurrent.ConcurrentMap<ResourceId, CompletableFuture<TablePin>>
+            currentSnapshotPinCache,
+        PhaseDiagnostics diagnostics,
+        BooleanSupplier cancelled) {
+      return resolveInputs(inputs, cancelled);
+    }
+
+    private ResolutionResult resolveInputs(List<QueryInput> inputs, BooleanSupplier cancelled) {
       List<ResourceId> resolved = new ArrayList<>(inputs.size());
       RelationPinSet.Builder pins = RelationPinSet.newBuilder();
       for (QueryInput input : inputs) {
+        if (cancelled.getAsBoolean()) {
+          throw new java.util.concurrent.CancellationException("input resolution cancelled");
+        }
         calls.add(List.of(input));
         switch (input.getTargetCase()) {
           case TABLE_ID -> {

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.PinKind;
+import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.utils.EngineContext;
@@ -46,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -71,12 +73,101 @@ public class QueryInputResolverTest {
   }
 
   @Test
-  void metadataIoSizingMustCoverAdmissionWithWorkersAndQueue() {
-    assertThrows(
-        IllegalStateException.class, () -> QueryInputResolver.validateMetadataIoSizing(3, 2, 3));
-    assertThrows(
-        IllegalStateException.class, () -> QueryInputResolver.validateMetadataIoSizing(3, 3, 2));
-    QueryInputResolver.validateMetadataIoSizing(3, 3, 3);
+  void cancellableOverloadPreservesLegacyMapOverrideDispatch() {
+    AtomicBoolean legacyOverrideCalled = new AtomicBoolean();
+    QueryInputResolver legacySubclass =
+        new QueryInputResolver(metadataGraph) {
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              Map<ResourceId, TablePin> currentSnapshotPinCache,
+              ai.floedb.floecat.telemetry.PhaseDiagnostics diagnostics) {
+            legacyOverrideCalled.set(true);
+            ResourceId tableId = inputs.getFirst().getTableId();
+            TablePin pin =
+                metadataGraph.tablePinFor(
+                    correlationId, tableId, SnapshotRef.getDefaultInstance(), Optional.empty());
+            currentSnapshotPinCache.put(tableId, pin);
+            return new ResolutionResult(
+                List.of(tableId),
+                ai.floedb.floecat.query.rpc.RelationPinSet.newBuilder()
+                    .addPins(ai.floedb.floecat.service.query.QueryPins.ofTable(pin))
+                    .build(),
+                null);
+          }
+        };
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+    ResourceId tableId = rid("LEGACY");
+
+    legacySubclass.resolveInputs(
+        "query",
+        "cid",
+        List.of(QueryInput.newBuilder().setTableId(tableId).build()),
+        Optional.empty(),
+        Optional.empty(),
+        cache,
+        null,
+        () -> false);
+
+    assertTrue(legacyOverrideCalled.get());
+    assertEquals(tableId, cache.get(tableId).join().getTableId());
+  }
+
+  @Test
+  void cancellableOverloadPreservesConcurrentMapOverrideDispatch() {
+    AtomicBoolean concurrentOverrideCalled = new AtomicBoolean();
+    QueryInputResolver concurrentSubclass =
+        new QueryInputResolver(metadataGraph) {
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+              ai.floedb.floecat.telemetry.PhaseDiagnostics diagnostics) {
+            concurrentOverrideCalled.set(true);
+            return new ResolutionResult(List.of(), RelationPinSet.getDefaultInstance(), null);
+          }
+        };
+
+    concurrentSubclass.resolveInputs(
+        "query",
+        "cid",
+        List.of(),
+        Optional.empty(),
+        Optional.empty(),
+        new ConcurrentHashMap<>(),
+        null,
+        () -> false);
+
+    assertTrue(concurrentOverrideCalled.get());
+  }
+
+  @Test
+  void legacyMapOverloadDoesNotRewriteAnExistingCacheHit() {
+    ResourceId tableId = rid("CACHED");
+    TablePin cachedPin =
+        metadataGraph.tablePinFor(
+            "cid", tableId, SnapshotRef.getDefaultInstance(), Optional.empty());
+
+    var result =
+        resolver.resolveInputs(
+            "",
+            "cid",
+            List.of(QueryInput.newBuilder().setTableId(tableId).build()),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of(tableId, cachedPin),
+            null);
+
+    assertEquals(tableId, result.resolved().getFirst());
+    assertEquals(cachedPin, result.relationPinSet().getPins(0).getTablePin());
   }
 
   NameRef name(String cat, String... parts) {
@@ -182,7 +273,7 @@ public class QueryInputResolverTest {
           null);
 
       assertEquals(1, registrationThreads.size());
-      assertTrue(registrationThreads.get(0).getName().startsWith("floecat-query-input-metadata-"));
+      assertTrue(registrationThreads.get(0).getName().startsWith("floecat-metadata-io-"));
     } finally {
       resolverWithDedicatedExecutor.closeExecutors();
     }
@@ -276,6 +367,31 @@ public class QueryInputResolverTest {
                     cancelled::get));
 
     assertCancellationReturnsWhileBlocked(resolution, cancelled, blockingGraph.slowPinBlocker);
+  }
+
+  @Test
+  void cancellationAfterFinalThreadConfinedPinLookupDoesNotReturnSuccess() throws Exception {
+    var blockingGraph = new BlockingThreadConfinedPinGraph();
+    var withStore = new QueryInputResolver(blockingGraph);
+    var cancelled = new AtomicBoolean();
+
+    CompletableFuture<Throwable> resolution =
+        resolveCancellable(
+            () ->
+                withStore.resolveInputs(
+                    "q-cancel-thread-confined-pin",
+                    "cid",
+                    List.of(QueryInput.newBuilder().setTableId(rid("SLOW")).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                    null,
+                    cancelled::get));
+
+    assertTrue(blockingGraph.pinBlocker.started.await(1, TimeUnit.SECONDS));
+    cancelled.set(true);
+    blockingGraph.pinBlocker.release.countDown();
+    assertTrue(resolution.get(250, TimeUnit.MILLISECONDS) instanceof CancellationException);
   }
 
   @Test
@@ -446,8 +562,7 @@ public class QueryInputResolverTest {
           graph.metadataThreads().stream()
               .allMatch(
                   thread ->
-                      thread.isDaemon()
-                          && thread.getName().startsWith("floecat-query-input-metadata-")));
+                      thread.isDaemon() && thread.getName().startsWith("floecat-metadata-io-")));
     } finally {
       resolverWithDedicatedExecutor.closeExecutors();
     }
@@ -508,14 +623,12 @@ public class QueryInputResolverTest {
                                   cancelled.get(index)::get)))
               .toList();
       Thread.sleep(50);
-      assertEquals(0, metadataIoQueueSize(saturatedResolver));
       cancelled.forEach(flag -> flag.set(true));
       for (CompletableFuture<Throwable> request : cancelledRequests) {
         assertTrue(
             request.get(250, TimeUnit.MILLISECONDS)
                 instanceof java.util.concurrent.CancellationException);
       }
-      assertEquals(0, metadataIoQueueSize(saturatedResolver));
     } finally {
       graph.releasePins.countDown();
       CompletableFuture.allOf(activeRequests.toArray(CompletableFuture[]::new)).join();
@@ -2270,6 +2383,26 @@ public class QueryInputResolverTest {
     }
   }
 
+  /** Blocks the final caller-thread pin callback so cancellation can race its return. */
+  static final class BlockingThreadConfinedPinGraph extends FakeGraph {
+    final UninterruptibleBlocker pinBlocker = new UninterruptibleBlocker();
+
+    @Override
+    public boolean supportsConcurrentResolution() {
+      return false;
+    }
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      pinBlocker.await();
+      return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+  }
+
   /** Blocks the default-catalog lookup to exercise cancellation before fan-out starts. */
   static final class BlockingCatalogGraph extends FakeGraph {
     final UninterruptibleBlocker catalogBlocker = new UninterruptibleBlocker();
@@ -2435,17 +2568,6 @@ public class QueryInputResolverTest {
           // Simulate a store client that does not abort an active request on interruption.
         }
       }
-    }
-  }
-
-  private static int metadataIoQueueSize(QueryInputResolver resolver) {
-    try {
-      java.lang.reflect.Field field =
-          QueryInputResolver.class.getDeclaredField("metadataIoExecutor");
-      field.setAccessible(true);
-      return ((java.util.concurrent.ThreadPoolExecutor) field.get(resolver)).getQueue().size();
-    } catch (ReflectiveOperationException e) {
-      throw new AssertionError("unable to inspect resolver metadata executor", e);
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -145,6 +145,38 @@ public class QueryInputResolverTest {
                 uris -> uris.contains("s3://T1/table.pb") && uris.contains("s3://T1/snap.pb")));
   }
 
+  @Test
+  void registersPinRootsOnTheMetadataWorkerBeforeResultHandoff() {
+    var store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var resolverWithDedicatedExecutor = new QueryInputResolver(metadataGraph, store);
+    resolverWithDedicatedExecutor.postConstruct();
+    List<Thread> registrationThreads = java.util.Collections.synchronizedList(new ArrayList<>());
+    org.mockito.Mockito.doAnswer(
+            ignored -> {
+              registrationThreads.add(Thread.currentThread());
+              return null;
+            })
+        .when(store)
+        .registerResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyCollection());
+
+    try {
+      resolverWithDedicatedExecutor.resolveInputs(
+          "q-worker-registration",
+          "cid",
+          List.of(QueryInput.newBuilder().setTableId(rid("T1")).build()),
+          Optional.empty(),
+          Optional.empty(),
+          new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+          null);
+
+      assertEquals(1, registrationThreads.size());
+      assertTrue(registrationThreads.get(0).getName().startsWith("floecat-query-input-metadata-"));
+    } finally {
+      resolverWithDedicatedExecutor.closeBlockingExecutor();
+    }
+  }
+
   /** A completed parallel input roots its pin while another input is still resolving. */
   @Test
   void rootsCompletedParallelPinBeforeSlowerInputReturns() throws Exception {

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -437,6 +437,59 @@ public class QueryInputResolverTest {
     }
   }
 
+  @Test
+  void admittedLookupStartsWhenAStalledWorkerTurnsOver() throws Exception {
+    int capacity = 64;
+    var graph = new TurnoverPinGraph(capacity);
+    var resolverWithTurnover = new QueryInputResolver(graph, null, 1, capacity);
+    resolverWithTurnover.postConstruct();
+    List<CompletableFuture<?>> activeRequests =
+        java.util.stream.IntStream.range(0, capacity)
+            .mapToObj(
+                index ->
+                    CompletableFuture.runAsync(
+                        () ->
+                            resolverWithTurnover.resolveInputs(
+                                "q-turnover-active-" + index,
+                                "cid",
+                                List.of(
+                                    QueryInput.newBuilder()
+                                        .setTableId(rid("TURNOVER-ACTIVE-" + index))
+                                        .build()),
+                                Optional.empty(),
+                                Optional.empty(),
+                                new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                                null,
+                                () -> false)))
+            .toList();
+    CompletableFuture<Throwable> admitted = null;
+    try {
+      assertTrue(graph.allPinsStarted.await(2, TimeUnit.SECONDS));
+      admitted =
+          resolveCancellable(
+              () ->
+                  resolverWithTurnover.resolveInputs(
+                      "q-turnover-waiting",
+                      "cid",
+                      List.of(QueryInput.newBuilder().setTableId(rid("TURNOVER-WAITING")).build()),
+                      Optional.empty(),
+                      Optional.empty(),
+                      new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                      null,
+                      () -> false));
+      graph.releases.release();
+      assertTrue(graph.waitingPinStarted.await(1, TimeUnit.SECONDS));
+      assertFalse(admitted.isDone());
+    } finally {
+      graph.releases.release(capacity);
+      CompletableFuture.allOf(activeRequests.toArray(CompletableFuture[]::new)).join();
+      if (admitted != null) {
+        assertEquals(null, admitted.join());
+      }
+      resolverWithTurnover.closeBlockingExecutor();
+    }
+  }
+
   /** A failed parallel plan releases every provisional root it constructed. */
   @Test
   void releasesCompletedParallelPinWhenSiblingPlanningFails() {
@@ -1872,6 +1925,38 @@ public class QueryInputResolverTest {
       while (true) {
         try {
           releasePins.await();
+          return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+        } catch (InterruptedException ignored) {
+          // Simulate a store client that does not abort an active request on interruption.
+        }
+      }
+    }
+  }
+
+  /** Releases one blocked pin at a time to exercise executor-worker turnover. */
+  static final class TurnoverPinGraph extends FakeGraph {
+    final CountDownLatch allPinsStarted;
+    final CountDownLatch waitingPinStarted = new CountDownLatch(1);
+    final java.util.concurrent.Semaphore releases = new java.util.concurrent.Semaphore(0);
+
+    TurnoverPinGraph(int capacity) {
+      this.allPinsStarted = new CountDownLatch(capacity);
+    }
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      if ("TURNOVER-WAITING".equals(tableId.getId())) {
+        waitingPinStarted.countDown();
+      } else {
+        allPinsStarted.countDown();
+      }
+      while (true) {
+        try {
+          releases.acquire();
           return super.tablePinFor(correlationId, tableId, override, asOfDefault);
         } catch (InterruptedException ignored) {
           // Simulate a store client that does not abort an active request on interruption.

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -184,6 +184,23 @@ public class QueryInputResolverTest {
     }
   }
 
+  @Test
+  void serialPlanningStaysOnTheCallerThreadWhenOverlayOptsOutOfConcurrency() {
+    Thread callerThread = Thread.currentThread();
+    var threadConfinedGraph = new CallerThreadOnlyGraph(callerThread);
+    var threadConfinedResolver = new QueryInputResolver(threadConfinedGraph);
+
+    threadConfinedResolver.resolveInputs(
+        "cid",
+        List.of(
+            QueryInput.newBuilder().setTableId(rid("ONE")).build(),
+            QueryInput.newBuilder().setTableId(rid("TWO")).build()),
+        Optional.empty(),
+        Optional.empty());
+
+    assertEquals(List.of(callerThread, callerThread), threadConfinedGraph.planningThreads());
+  }
+
   /** A failed parallel plan releases every provisional root it constructed. */
   @Test
   void releasesCompletedParallelPinWhenSiblingPlanningFails() {
@@ -1469,6 +1486,38 @@ public class QueryInputResolverTest {
         }
       }
       return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+  }
+
+  /** Fails if a planning callback runs off the thread that began the request. */
+  static final class CallerThreadOnlyGraph extends FakeGraph {
+    private final Thread callerThread;
+    private final List<Thread> planningThreads = new ArrayList<>();
+
+    CallerThreadOnlyGraph(Thread callerThread) {
+      this.callerThread = callerThread;
+    }
+
+    @Override
+    public boolean supportsConcurrentResolution() {
+      return false;
+    }
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      if (Thread.currentThread() != callerThread) {
+        throw new AssertionError("planning callback escaped the request thread");
+      }
+      planningThreads.add(Thread.currentThread());
+      return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+
+    List<Thread> planningThreads() {
+      return planningThreads;
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.query.resolver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,6 +34,7 @@ import ai.floedb.floecat.query.rpc.PinKind;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.concurrent.UninterruptibleBlocker;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
 import com.google.protobuf.Timestamp;
@@ -53,6 +55,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,6 +99,48 @@ public class QueryInputResolverTest {
             return failure;
           }
         });
+  }
+
+  @Test
+  void cancellableOverloadPreservesLegacyMapOverrideDispatch() {
+    AtomicBoolean legacyOverrideCalled = new AtomicBoolean();
+    QueryInputResolver legacySubclass =
+        new QueryInputResolver(metadataGraph) {
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              Map<ResourceId, TablePin> currentSnapshotPinCache,
+              ai.floedb.floecat.telemetry.PhaseDiagnostics diagnostics) {
+            legacyOverrideCalled.set(true);
+            return super.resolveInputs(
+                queryId,
+                correlationId,
+                inputs,
+                asOfDefault,
+                defaultCatalogId,
+                currentSnapshotPinCache,
+                diagnostics);
+          }
+        };
+    ResourceId tableId = rid("legacy-dispatch");
+
+    var result =
+        legacySubclass.resolveInputs(
+            "q-legacy-dispatch",
+            "cid",
+            List.of(QueryInput.newBuilder().setTableId(tableId).build()),
+            Optional.empty(),
+            Optional.empty(),
+            new ConcurrentHashMap<>(),
+            null,
+            () -> false);
+
+    assertTrue(legacyOverrideCalled.get());
+    assertEquals(tableId, result.resolved().getFirst());
   }
 
   /** Verifies cancellation returns promptly even when the active metadata operation ignores it. */
@@ -173,7 +218,7 @@ public class QueryInputResolverTest {
       assertEquals(1, registrationThreads.size());
       assertTrue(registrationThreads.get(0).getName().startsWith("floecat-query-input-metadata-"));
     } finally {
-      resolverWithDedicatedExecutor.closeBlockingExecutor();
+      resolverWithDedicatedExecutor.closeExecutors();
     }
   }
 
@@ -412,7 +457,7 @@ public class QueryInputResolverTest {
         CompletableFuture.allOf(requests).join();
       }
     } finally {
-      resolverWithDedicatedExecutor.closeBlockingExecutor();
+      resolverWithDedicatedExecutor.closeExecutors();
     }
   }
 
@@ -438,7 +483,7 @@ public class QueryInputResolverTest {
                       thread.isDaemon()
                           && thread.getName().startsWith("floecat-query-input-metadata-")));
     } finally {
-      resolverWithDedicatedExecutor.closeBlockingExecutor();
+      resolverWithDedicatedExecutor.closeExecutors();
     }
   }
 
@@ -508,7 +553,7 @@ public class QueryInputResolverTest {
     } finally {
       graph.releasePins.countDown();
       CompletableFuture.allOf(activeRequests.toArray(CompletableFuture[]::new)).join();
-      saturatedResolver.closeBlockingExecutor();
+      saturatedResolver.closeExecutors();
     }
   }
 
@@ -561,7 +606,7 @@ public class QueryInputResolverTest {
       if (admitted != null) {
         assertEquals(null, admitted.join());
       }
-      resolverWithTurnover.closeBlockingExecutor();
+      resolverWithTurnover.closeExecutors();
     }
   }
 
@@ -1635,6 +1680,367 @@ public class QueryInputResolverTest {
   }
 
   @Test
+  void discardedCurrentPinIsEvictedBeforeItsRootsAreReleased() {
+    ResourceId tableId = rid("DISCARDED_CURRENT_CACHE");
+    var graph =
+        new FakeGraph() {
+          @Override
+          public TablePin tablePinFor(
+              String correlationId,
+              ResourceId id,
+              SnapshotRef override,
+              Optional<Timestamp> asOfDefault) {
+            TablePin pin = super.tablePinFor(correlationId, id, override, asOfDefault);
+            return pin.toBuilder()
+                .setTableBlobUri("s3://" + id.getId() + "/table-" + pin.getSnapshotId() + ".pb")
+                .setSnapshotBlobUri("s3://" + id.getId() + "/snap-" + pin.getSnapshotId() + ".pb")
+                .build();
+          }
+        };
+    graph.setCurrentSnapshot(tableId, 20L);
+    QueryContextStore store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var withStore = new QueryInputResolver(graph, store);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              assertFalse(cache.containsKey(tableId), "cache must retire before root release");
+              return null;
+            })
+        .when(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-discarded-current"),
+            org.mockito.ArgumentMatchers.argThat(
+                roots -> roots.contains("s3://DISCARDED_CURRENT_CACHE/snap-20.pb")));
+
+    QueryInput explicit =
+        QueryInput.newBuilder()
+            .setTableId(tableId)
+            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(10L))
+            .build();
+    QueryInput current = QueryInput.newBuilder().setTableId(tableId).build();
+    withStore.resolveInputs(
+        "q-discarded-current",
+        "cid-first",
+        List.of(explicit, current),
+        Optional.empty(),
+        Optional.empty(),
+        cache,
+        null);
+
+    assertFalse(cache.containsKey(tableId));
+    org.mockito.Mockito.verify(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-discarded-current"),
+            org.mockito.ArgumentMatchers.argThat(
+                roots -> roots.contains("s3://DISCARDED_CURRENT_CACHE/snap-20.pb")));
+    graph.setCurrentSnapshot(tableId, 30L);
+    TablePin refreshed =
+        withStore
+            .resolveInputs(
+                "q-discarded-current",
+                "cid-second",
+                List.of(current),
+                Optional.empty(),
+                Optional.empty(),
+                cache,
+                null)
+            .relationPinSet()
+            .getPins(0)
+            .getTablePin();
+
+    assertEquals(30L, refreshed.getSnapshotId());
+    assertEquals(
+        2L,
+        graph.pinCalls().stream()
+            .filter(
+                call ->
+                    call.tableId().equals(tableId)
+                        && (call.override() == null
+                            || call.override().getWhichCase()
+                                == SnapshotRef.WhichCase.WHICH_NOT_SET))
+            .count());
+  }
+
+  @Test
+  void concurrentPlanningDefersCurrentRetirementUntilEveryWaiterHasJoined() throws Exception {
+    ResourceId shared = rid("DEFERRED_CURRENT_RETIREMENT");
+    ResourceId blocked = rid("DEFERRED_CURRENT_BLOCKER");
+    metadataGraph.setCurrentSnapshot(shared, 20L);
+    metadataGraph.setCurrentSnapshot(blocked, 30L);
+    CountDownLatch blockerEntered = new CountDownLatch(1);
+    CountDownLatch releaseBlocker = new CountDownLatch(1);
+    metadataGraph.beforeTablePin(
+        tableId -> {
+          if (!tableId.equals(blocked)) {
+            return;
+          }
+          blockerEntered.countDown();
+          try {
+            releaseBlocker.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new java.util.concurrent.CancellationException();
+          }
+        });
+
+    CountDownLatch retired = new CountDownLatch(1);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache =
+        new ConcurrentHashMap<>() {
+          @Override
+          public boolean remove(Object key, Object value) {
+            boolean removed = super.remove(key, value);
+            if (removed && shared.equals(key)) {
+              retired.countDown();
+            }
+            return removed;
+          }
+        };
+    QueryInput explicit =
+        QueryInput.newBuilder()
+            .setTableId(shared)
+            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(10L))
+            .build();
+    QueryInput current = QueryInput.newBuilder().setTableId(shared).build();
+    QueryInput blocker = QueryInput.newBuilder().setTableId(blocked).build();
+
+    CompletableFuture<QueryInputResolver.ResolutionResult> resolution =
+        CompletableFuture.supplyAsync(
+            () ->
+                resolver.resolveInputs(
+                    "q-deferred-retirement",
+                    "cid",
+                    List.of(explicit, current, current, blocker),
+                    Optional.empty(),
+                    Optional.empty(),
+                    cache,
+                    null));
+
+    try {
+      assertTrue(blockerEntered.await(2, TimeUnit.SECONDS));
+      assertFalse(
+          retired.await(200, TimeUnit.MILLISECONDS),
+          "a compatible CURRENT holder must remain published until every planner has joined");
+    } finally {
+      releaseBlocker.countDown();
+    }
+    QueryInputResolver.ResolutionResult result = resolution.get(2, TimeUnit.SECONDS);
+
+    assertTrue(retired.await(2, TimeUnit.SECONDS));
+    assertEquals(List.of(shared, shared, shared, blocked), result.resolved());
+    assertEquals(2, result.relationPinSet().getPinsCount());
+  }
+
+  @Test
+  void currentSnapshotWaiterRetriesWhenSharedHolderRetiresBeforeValidation() {
+    ResourceId shared = rid("RETIRED_CURRENT_WAITER");
+    metadataGraph.setCurrentSnapshot(shared, 30L);
+    TablePin retiredPin =
+        TablePin.newBuilder()
+            .setTableId(shared)
+            .setPinKind(PinKind.PIN_KIND_CURRENT)
+            .setSnapshotId(20L)
+            .setTableBlobUri("s3://RETIRED_CURRENT_WAITER/table-20.pb")
+            .setSnapshotBlobUri("s3://RETIRED_CURRENT_WAITER/snapshot-20.pb")
+            .build();
+    AtomicBoolean retireBeforeValidation = new AtomicBoolean(true);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache =
+        new ConcurrentHashMap<>() {
+          @Override
+          public CompletableFuture<TablePin> get(Object key) {
+            if (shared.equals(key) && retireBeforeValidation.compareAndSet(true, false)) {
+              super.remove(key);
+              return null;
+            }
+            return super.get(key);
+          }
+        };
+    cache.put(shared, CompletableFuture.completedFuture(retiredPin));
+
+    QueryInputResolver.ResolutionResult result =
+        resolver.resolveInputs(
+            "q-retired-current-waiter",
+            "cid",
+            List.of(QueryInput.newBuilder().setTableId(shared).build()),
+            Optional.empty(),
+            Optional.empty(),
+            cache,
+            null);
+
+    assertEquals(30L, result.relationPinSet().getPins(0).getTablePin().getSnapshotId());
+    assertEquals(
+        1L,
+        metadataGraph.pinCalls().stream().filter(call -> call.tableId().equals(shared)).count());
+    assertTrue(cache.containsKey(shared));
+  }
+
+  @Test
+  void concurrentCacheEvictsPinsOwnedByAFailedResolution() {
+    ResourceId successful = rid("CONCURRENT_CACHE_SUCCESS");
+    ResourceId failing = rid("CONCURRENT_CACHE_FAILURE");
+    var graph = new FakeGraph();
+    graph.failPinFor(failing);
+    var withStore =
+        new QueryInputResolver(graph, org.mockito.Mockito.mock(QueryContextStore.class));
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-concurrent-cache",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(successful).build(),
+                    QueryInput.newBuilder().setTableId(failing).build()),
+                Optional.empty(),
+                Optional.empty(),
+                cache,
+                null));
+
+    assertTrue(cache.isEmpty());
+  }
+
+  @Test
+  void failedResolutionPreservesConcurrentCacheEntriesOwnedByAnEarlierCall() {
+    ResourceId cached = rid("CONCURRENT_CACHE_EXISTING");
+    ResourceId failing = rid("CONCURRENT_CACHE_NEW_FAILURE");
+    var graph = new FakeGraph();
+    graph.failPinFor(failing);
+    var withStore =
+        new QueryInputResolver(graph, org.mockito.Mockito.mock(QueryContextStore.class));
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+
+    withStore.resolveInputs(
+        "q-concurrent-cache-existing",
+        "cid-first",
+        List.of(QueryInput.newBuilder().setTableId(cached).build()),
+        Optional.empty(),
+        Optional.empty(),
+        cache,
+        null);
+    CompletableFuture<TablePin> existing = cache.get(cached);
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-concurrent-cache-existing",
+                "cid-second",
+                List.of(
+                    QueryInput.newBuilder().setTableId(cached).build(),
+                    QueryInput.newBuilder().setTableId(failing).build()),
+                Optional.empty(),
+                Optional.empty(),
+                cache,
+                null));
+
+    assertSame(existing, cache.get(cached));
+    assertEquals(Set.of(cached), cache.keySet());
+  }
+
+  @Test
+  void cacheWaiterRootsPinBeforeFailedOwnerCanReleaseIt() throws Exception {
+    ResourceId shared = rid("CONCURRENT_CACHE_HANDOFF");
+    ResourceId failing = rid("CONCURRENT_CACHE_HANDOFF_FAILURE");
+    CountDownLatch failingLookupStarted = new CountDownLatch(1);
+    CountDownLatch allowFailure = new CountDownLatch(1);
+    CountDownLatch waiterRegistrationStarted = new CountDownLatch(1);
+    CountDownLatch allowWaiterRegistration = new CountDownLatch(1);
+    CountDownLatch ownerReleasedRoot = new CountDownLatch(1);
+    AtomicInteger sharedRegistrations = new AtomicInteger();
+    var graph = new FakeGraph();
+    graph.failPinFor(failing);
+    graph.beforeTablePin(
+        tableId -> {
+          if (tableId.equals(failing)) {
+            failingLookupStarted.countDown();
+            try {
+              allowFailure.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new java.util.concurrent.CancellationException();
+            }
+          }
+        });
+    QueryContextStore store = org.mockito.Mockito.mock(QueryContextStore.class);
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              java.util.Collection<String> roots = invocation.getArgument(1);
+              if (roots.contains("s3://CONCURRENT_CACHE_HANDOFF/table.pb")
+                  && sharedRegistrations.incrementAndGet() == 2) {
+                waiterRegistrationStarted.countDown();
+                allowWaiterRegistration.await();
+              }
+              return null;
+            })
+        .when(store)
+        .registerResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              java.util.Collection<String> roots = invocation.getArgument(1);
+              if (roots.contains("s3://CONCURRENT_CACHE_HANDOFF/table.pb")) {
+                ownerReleasedRoot.countDown();
+              }
+              return null;
+            })
+        .when(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
+    var withStore = new QueryInputResolver(graph, store);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+
+    CompletableFuture<Throwable> owner =
+        resolveCancellable(
+            () ->
+                withStore.resolveInputs(
+                    "q-cache-owner",
+                    "cid-owner",
+                    List.of(
+                        QueryInput.newBuilder().setTableId(shared).build(),
+                        QueryInput.newBuilder().setTableId(failing).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    cache,
+                    null));
+    try {
+      assertTrue(failingLookupStarted.await(1, TimeUnit.SECONDS));
+      for (int attempt = 0;
+          attempt < 100 && (cache.get(shared) == null || !cache.get(shared).isDone());
+          attempt++) {
+        Thread.sleep(10);
+      }
+      assertTrue(cache.get(shared).isDone());
+
+      CompletableFuture<QueryInputResolver.ResolutionResult> waiter =
+          CompletableFuture.supplyAsync(
+              () ->
+                  withStore.resolveInputs(
+                      "q-cache-waiter",
+                      "cid-waiter",
+                      List.of(QueryInput.newBuilder().setTableId(shared).build()),
+                      Optional.empty(),
+                      Optional.empty(),
+                      cache,
+                      null));
+      assertTrue(waiterRegistrationStarted.await(1, TimeUnit.SECONDS));
+
+      allowFailure.countDown();
+      assertFalse(ownerReleasedRoot.await(100, TimeUnit.MILLISECONDS));
+      allowWaiterRegistration.countDown();
+
+      assertEquals(shared, waiter.get(1, TimeUnit.SECONDS).resolved().getFirst());
+      assertTrue(owner.get(1, TimeUnit.SECONDS) instanceof StatusRuntimeException);
+      assertTrue(ownerReleasedRoot.await(1, TimeUnit.SECONDS));
+    } finally {
+      allowFailure.countDown();
+      allowWaiterRegistration.countDown();
+    }
+  }
+
+  @Test
   void legacyMapCacheDoesNotRetainPinsFromAFailedResolution() {
     ResourceId successful = rid("LEGACY_CACHE_SUCCESS");
     ResourceId failing = rid("LEGACY_CACHE_FAILURE");
@@ -1659,6 +2065,100 @@ public class QueryInputResolverTest {
                 null));
 
     assertTrue(legacyCache.isEmpty());
+  }
+
+  @Test
+  void legacyMapCopyFailureReleasesSuccessfulResolutionRoots() {
+    ResourceId tableId = rid("LEGACY_CACHE_COPY_FAILURE");
+    var graph = new FakeGraph();
+    QueryContextStore store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var withStore = new QueryInputResolver(graph, store);
+    Map<ResourceId, TablePin> readOnlyCache =
+        java.util.Collections.unmodifiableMap(new HashMap<>());
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-legacy-copy-failure",
+                "cid",
+                List.of(QueryInput.newBuilder().setTableId(tableId).build()),
+                Optional.empty(),
+                Optional.empty(),
+                readOnlyCache,
+                null));
+
+    org.mockito.Mockito.verify(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-legacy-copy-failure"),
+            org.mockito.ArgumentMatchers.argThat(
+                roots ->
+                    roots.contains("s3://LEGACY_CACHE_COPY_FAILURE/table.pb")
+                        && roots.contains("s3://LEGACY_CACHE_COPY_FAILURE/snap.pb")));
+  }
+
+  @Test
+  void legacyMapSecondCopyFailureRollsBackCopiedPrefixBeforeReleasingRoots() {
+    ResourceId first = rid("LEGACY_CACHE_COPY_FIRST");
+    ResourceId second = rid("LEGACY_CACHE_COPY_SECOND");
+    var graph = new FakeGraph();
+    QueryContextStore store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var withStore = new QueryInputResolver(graph, store);
+    Map<ResourceId, TablePin> cache = new ThrowOnSecondPutMap<>();
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              assertTrue(cache.isEmpty(), "cache must be restored before roots are released");
+              return null;
+            })
+        .when(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-legacy-copy-prefix"),
+            org.mockito.ArgumentMatchers.any());
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-legacy-copy-prefix",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(first).build(),
+                    QueryInput.newBuilder().setTableId(second).build()),
+                Optional.empty(),
+                Optional.empty(),
+                cache,
+                null));
+
+    assertTrue(cache.isEmpty());
+    org.mockito.Mockito.verify(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-legacy-copy-prefix"),
+            org.mockito.ArgumentMatchers.argThat(roots -> roots.size() == 4));
+  }
+
+  @Test
+  void parallelResolutionKeepsTheLegacyMemoOnItsOwnerThread() {
+    ResourceId first = rid("LEGACY_MEMO_FIRST");
+    ResourceId second = rid("LEGACY_MEMO_SECOND");
+    ResourceId third = rid("LEGACY_MEMO_THIRD");
+    metadataGraph.setCurrentSnapshot(first, 1);
+    metadataGraph.setCurrentSnapshot(second, 2);
+    metadataGraph.setCurrentSnapshot(third, 3);
+    Map<ResourceId, TablePin> threadConfinedMemo = new ThreadConfinedMap<>();
+
+    resolver.resolveInputs(
+        "q-thread-confined-memo",
+        "cid",
+        List.of(
+            QueryInput.newBuilder().setTableId(first).build(),
+            QueryInput.newBuilder().setTableId(second).build(),
+            QueryInput.newBuilder().setTableId(third).build()),
+        Optional.empty(),
+        Optional.empty(),
+        threadConfinedMemo,
+        null);
+
+    assertEquals(Set.of(first, second, third), threadConfinedMemo.keySet());
   }
 
   // ----------------------------------------------------------------------
@@ -1757,6 +2257,60 @@ public class QueryInputResolverTest {
   // ----------------------------------------------------------------------
   // Helpers / test doubles (Composition, not inheritance)
   // ----------------------------------------------------------------------
+
+  /** A deliberately racy memo fake that rejects access from parallel resolver workers. */
+  private static final class ThreadConfinedMap<K, V> extends HashMap<K, V> {
+    private final Thread owner = Thread.currentThread();
+
+    private void requireOwnerThread() {
+      if (Thread.currentThread() != owner) {
+        throw new AssertionError("thread-confined memo accessed by a resolver worker");
+      }
+    }
+
+    @Override
+    public V get(Object key) {
+      requireOwnerThread();
+      return super.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+      requireOwnerThread();
+      return super.put(key, value);
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+      requireOwnerThread();
+      return super.putIfAbsent(key, value);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+      requireOwnerThread();
+      return super.remove(key, value);
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super K, ? super V> action) {
+      requireOwnerThread();
+      super.forEach(action);
+    }
+  }
+
+  /** Accepts one cache copy, rejects the next, and permits rollback through clear(). */
+  private static final class ThrowOnSecondPutMap<K, V> extends HashMap<K, V> {
+    private int puts;
+
+    @Override
+    public V put(K key, V value) {
+      if (++puts == 2) {
+        throw new UnsupportedOperationException("second cache write rejected");
+      }
+      return super.put(key, value);
+    }
+  }
 
   static class FakeGraph extends TestCatalogOverlay {
 
@@ -1949,24 +2503,6 @@ public class QueryInputResolverTest {
         resolved.put(ref, resolveName(correlationId, ref));
       }
       return resolved;
-    }
-  }
-
-  /** A deliberately interruption-insensitive metadata call used to prove prompt caller teardown. */
-  static final class UninterruptibleBlocker {
-    final CountDownLatch started = new CountDownLatch(1);
-    final CountDownLatch release = new CountDownLatch(1);
-
-    void await() {
-      started.countDown();
-      while (true) {
-        try {
-          release.await();
-          return;
-        } catch (InterruptedException ignored) {
-          // Simulate a downstream client that cannot abort an in-flight store call.
-        }
-      }
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -227,7 +227,6 @@ public class QueryInputResolverTest {
     } finally {
       graph.allowPinLookups.countDown();
       CompletableFuture.allOf(requests).join();
-      globallyLimitedResolver.closeBlockingExecutor();
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -220,9 +220,8 @@ public class QueryInputResolverTest {
     var cancelled = new java.util.concurrent.atomic.AtomicBoolean();
 
     CompletableFuture<Throwable> resolution =
-        CompletableFuture.supplyAsync(
-            () -> {
-              try {
+        resolveCancellable(
+            () ->
                 withStore.resolveInputs(
                     "q-cancel",
                     "cid",
@@ -233,12 +232,7 @@ public class QueryInputResolverTest {
                     Optional.empty(),
                     new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                     null,
-                    cancelled::get);
-                return null;
-              } catch (Throwable failure) {
-                return failure;
-              }
-            });
+                    cancelled::get));
 
     try {
       assertTrue(blockingGraph.slowPinStarted.await(1, TimeUnit.SECONDS));

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -176,6 +176,35 @@ public class QueryInputResolverTest {
             org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
   }
 
+  /** Completed sibling work still contributes pin diagnostics when another parallel plan fails. */
+  @Test
+  void flushesParallelPinDiagnosticsWhenSiblingPlanningFails() {
+    var failingGraph = new FailingAfterFastPinGraph();
+    var withStore = new QueryInputResolver(failingGraph);
+    var diagnostics = org.mockito.Mockito.mock(ai.floedb.floecat.telemetry.PhaseDiagnostics.class);
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-diagnostics-failure",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(rid("FAIL")).build(),
+                    QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                Optional.empty(),
+                Optional.empty(),
+                new java.util.concurrent.ConcurrentHashMap<>(),
+                diagnostics));
+
+    org.mockito.Mockito.verify(diagnostics).add("pin.snapshot_calls", 1L);
+    org.mockito.Mockito.verify(diagnostics).add("pin.current_snapshot_cache_misses", 1L);
+    org.mockito.Mockito.verify(diagnostics)
+        .nanos(
+            org.mockito.ArgumentMatchers.eq("pin.snapshot_lookup"),
+            org.mockito.ArgumentMatchers.anyLong());
+  }
+
   /** Resolving a name that maps only to a table should return the table id. */
   @Test
   void resolve_table_only() {

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -367,6 +367,76 @@ public class QueryInputResolverTest {
     }
   }
 
+  @Test
+  void cancellationDoesNotQueueMetadataWorkBehindStalledCalls() throws Exception {
+    int capacity = 64;
+    var graph = new SaturatedPinGraph(capacity);
+    var saturatedResolver = new QueryInputResolver(graph, null, 1, capacity);
+    saturatedResolver.postConstruct();
+    List<AtomicBoolean> activeCancellation =
+        java.util.stream.IntStream.range(0, capacity)
+            .mapToObj(ignored -> new java.util.concurrent.atomic.AtomicBoolean())
+            .toList();
+    List<CompletableFuture<Throwable>> activeRequests =
+        java.util.stream.IntStream.range(0, capacity)
+            .mapToObj(
+                index ->
+                    resolveCancellable(
+                        () ->
+                            saturatedResolver.resolveInputs(
+                                "q-active-" + index,
+                                "cid",
+                                List.of(
+                                    QueryInput.newBuilder()
+                                        .setTableId(rid("ACTIVE-" + index))
+                                        .build()),
+                                Optional.empty(),
+                                Optional.empty(),
+                                new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                                null,
+                                activeCancellation.get(index)::get)))
+            .toList();
+    try {
+      assertTrue(graph.allPinsStarted.await(2, TimeUnit.SECONDS));
+      List<AtomicBoolean> cancelled =
+          java.util.stream.IntStream.range(0, 16)
+              .mapToObj(ignored -> new java.util.concurrent.atomic.AtomicBoolean())
+              .toList();
+      List<CompletableFuture<Throwable>> cancelledRequests =
+          java.util.stream.IntStream.range(0, cancelled.size())
+              .mapToObj(
+                  index ->
+                      resolveCancellable(
+                          () ->
+                              saturatedResolver.resolveInputs(
+                                  "q-cancel-" + index,
+                                  "cid",
+                                  List.of(
+                                      QueryInput.newBuilder()
+                                          .setTableId(rid("CANCEL-" + index))
+                                          .build()),
+                                  Optional.empty(),
+                                  Optional.empty(),
+                                  new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                                  null,
+                                  cancelled.get(index)::get)))
+              .toList();
+      Thread.sleep(50);
+      assertEquals(0, metadataIoQueueSize(saturatedResolver));
+      cancelled.forEach(flag -> flag.set(true));
+      for (CompletableFuture<Throwable> request : cancelledRequests) {
+        assertTrue(
+            request.get(250, TimeUnit.MILLISECONDS)
+                instanceof java.util.concurrent.CancellationException);
+      }
+      assertEquals(0, metadataIoQueueSize(saturatedResolver));
+    } finally {
+      graph.releasePins.countDown();
+      CompletableFuture.allOf(activeRequests.toArray(CompletableFuture[]::new)).join();
+      saturatedResolver.closeBlockingExecutor();
+    }
+  }
+
   /** A failed parallel plan releases every provisional root it constructed. */
   @Test
   void releasesCompletedParallelPinWhenSiblingPlanningFails() {
@@ -1780,6 +1850,44 @@ public class QueryInputResolverTest {
         inFlightPinLookups.decrementAndGet();
       }
       return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+  }
+
+  /** Blocks every pin lookup so saturation can expose retained executor work. */
+  static final class SaturatedPinGraph extends FakeGraph {
+    final CountDownLatch allPinsStarted;
+    final CountDownLatch releasePins = new CountDownLatch(1);
+
+    SaturatedPinGraph(int capacity) {
+      this.allPinsStarted = new CountDownLatch(capacity);
+    }
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      allPinsStarted.countDown();
+      while (true) {
+        try {
+          releasePins.await();
+          return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+        } catch (InterruptedException ignored) {
+          // Simulate a store client that does not abort an active request on interruption.
+        }
+      }
+    }
+  }
+
+  private static int metadataIoQueueSize(QueryInputResolver resolver) {
+    try {
+      java.lang.reflect.Field field =
+          QueryInputResolver.class.getDeclaredField("metadataIoExecutor");
+      field.setAccessible(true);
+      return ((java.util.concurrent.ThreadPoolExecutor) field.get(resolver)).getQueue().size();
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("unable to inspect resolver metadata executor", e);
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -145,6 +145,44 @@ public class QueryInputResolverTest {
     resolution.join();
   }
 
+  @Test
+  void cancellationInterruptsBlockedParallelPinResolution() throws Exception {
+    var blockingGraph = new BlockingPinGraph("SLOW");
+    var withStore = new QueryInputResolver(blockingGraph);
+    var cancelled = new java.util.concurrent.atomic.AtomicBoolean();
+
+    CompletableFuture<Throwable> resolution =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                withStore.resolveInputs(
+                    "q-cancel",
+                    "cid",
+                    List.of(
+                        QueryInput.newBuilder().setTableId(rid("SLOW")).build(),
+                        QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new ConcurrentHashMap<>(),
+                    null,
+                    cancelled::get);
+                return null;
+              } catch (Throwable failure) {
+                return failure;
+              }
+            });
+
+    try {
+      assertTrue(blockingGraph.slowPinStarted.await(1, TimeUnit.SECONDS));
+      cancelled.set(true);
+      assertTrue(
+          resolution.get(250, TimeUnit.MILLISECONDS)
+              instanceof java.util.concurrent.CancellationException);
+    } finally {
+      blockingGraph.allowSlowPin.countDown();
+    }
+  }
+
   /** A failed parallel plan releases every provisional root it constructed. */
   @Test
   void releasesCompletedParallelPinWhenSiblingPlanningFails() {

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -199,6 +200,35 @@ public class QueryInputResolverTest {
         Optional.empty());
 
     assertEquals(List.of(callerThread, callerThread), threadConfinedGraph.planningThreads());
+  }
+
+  @Test
+  void boundsMetadataPinResolutionAcrossConcurrentRequests() throws Exception {
+    var graph = new GloballyLimitedPinGraph();
+    var globallyLimitedResolver = new QueryInputResolver(graph, null, 2, 2);
+    List<QueryInput> inputs =
+        List.of(
+            QueryInput.newBuilder().setTableId(rid("ONE")).build(),
+            QueryInput.newBuilder().setTableId(rid("TWO")).build());
+
+    CompletableFuture<?>[] requests =
+        java.util.stream.IntStream.range(0, 3)
+            .mapToObj(
+                ignored ->
+                    CompletableFuture.runAsync(
+                        () ->
+                            globallyLimitedResolver.resolveInputs(
+                                "cid", inputs, Optional.empty(), Optional.empty())))
+            .toArray(CompletableFuture[]::new);
+
+    try {
+      assertTrue(graph.twoPinLookupsStarted.await(1, TimeUnit.SECONDS));
+      assertEquals(2, graph.peakPinLookups.get());
+    } finally {
+      graph.allowPinLookups.countDown();
+      CompletableFuture.allOf(requests).join();
+      globallyLimitedResolver.closeBlockingExecutor();
+    }
   }
 
   /** A failed parallel plan releases every provisional root it constructed. */
@@ -1518,6 +1548,36 @@ public class QueryInputResolverTest {
 
     List<Thread> planningThreads() {
       return planningThreads;
+    }
+  }
+
+  /** Blocks pin lookups so the test can observe the resolver's process-wide I/O ceiling. */
+  static final class GloballyLimitedPinGraph extends FakeGraph {
+    final CountDownLatch twoPinLookupsStarted = new CountDownLatch(2);
+    final CountDownLatch allowPinLookups = new CountDownLatch(1);
+    final AtomicInteger inFlightPinLookups = new AtomicInteger();
+    final AtomicInteger peakPinLookups = new AtomicInteger();
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      int inFlight = inFlightPinLookups.incrementAndGet();
+      peakPinLookups.accumulateAndGet(inFlight, Math::max);
+      twoPinLookupsStarted.countDown();
+      try {
+        if (!allowPinLookups.await(1, TimeUnit.SECONDS)) {
+          throw new AssertionError("test did not release the pin lookups");
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("pin lookup interrupted", e);
+      } finally {
+        inFlightPinLookups.decrementAndGet();
+      }
+      return super.tablePinFor(correlationId, tableId, override, asOfDefault);
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -1248,6 +1248,33 @@ public class QueryInputResolverTest {
     assertEquals(1, cache.size());
   }
 
+  @Test
+  void legacyMapCacheDoesNotRetainPinsFromAFailedResolution() {
+    ResourceId successful = rid("LEGACY_CACHE_SUCCESS");
+    ResourceId failing = rid("LEGACY_CACHE_FAILURE");
+    var graph = new FakeGraph();
+    graph.failPinFor(failing);
+    var withStore =
+        new QueryInputResolver(graph, org.mockito.Mockito.mock(QueryContextStore.class));
+    Map<ResourceId, TablePin> legacyCache = new HashMap<>();
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-legacy-cache",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(successful).build(),
+                    QueryInput.newBuilder().setTableId(failing).build()),
+                Optional.empty(),
+                Optional.empty(),
+                legacyCache,
+                null));
+
+    assertTrue(legacyCache.isEmpty());
+  }
+
   // ----------------------------------------------------------------------
   // Base-relation enrichment (catalog + search-path fallback)
   // ----------------------------------------------------------------------

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -83,6 +83,36 @@ public class QueryInputResolverTest {
     return ResourceId.newBuilder().setId(id).setKind(ResourceKind.RK_VIEW).build();
   }
 
+  /** Runs a cancellable resolution without coupling the test to the caller's executor. */
+  private static CompletableFuture<Throwable> resolveCancellable(Runnable resolution) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            resolution.run();
+            return null;
+          } catch (Throwable failure) {
+            return failure;
+          }
+        });
+  }
+
+  /** Verifies cancellation returns promptly even when the active metadata operation ignores it. */
+  private static void assertCancellationReturnsWhileBlocked(
+      CompletableFuture<Throwable> resolution,
+      java.util.concurrent.atomic.AtomicBoolean cancelled,
+      UninterruptibleBlocker blocker)
+      throws Exception {
+    try {
+      assertTrue(blocker.started.await(1, TimeUnit.SECONDS));
+      cancelled.set(true);
+      assertTrue(
+          resolution.get(250, TimeUnit.MILLISECONDS)
+              instanceof java.util.concurrent.CancellationException);
+    } finally {
+      blocker.release.countDown();
+    }
+  }
+
   /**
    * As each pin is constructed, the resolver registers its blobs as transient GC roots — the single
    * transparent seam that protects a resolved-but-not-yet-persisted blob on every resolve path.
@@ -185,6 +215,77 @@ public class QueryInputResolverTest {
     } finally {
       blockingGraph.allowSlowPin.countDown();
     }
+  }
+
+  @Test
+  void cancellationReturnsWhileSingleInputPinLookupIgnoresInterrupts() throws Exception {
+    var blockingGraph = new BlockingPinGraph("SLOW");
+    var withStore = new QueryInputResolver(blockingGraph);
+    var cancelled = new java.util.concurrent.atomic.AtomicBoolean();
+
+    CompletableFuture<Throwable> resolution =
+        resolveCancellable(
+            () ->
+                withStore.resolveInputs(
+                    "q-cancel-single-pin",
+                    "cid",
+                    List.of(QueryInput.newBuilder().setTableId(rid("SLOW")).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                    null,
+                    cancelled::get));
+
+    assertCancellationReturnsWhileBlocked(resolution, cancelled, blockingGraph.slowPinBlocker);
+  }
+
+  @Test
+  void cancellationReturnsWhileDefaultCatalogLookupIgnoresInterrupts() throws Exception {
+    var blockingGraph = new BlockingCatalogGraph();
+    var withStore = new QueryInputResolver(blockingGraph);
+    var cancelled = new java.util.concurrent.atomic.AtomicBoolean();
+    ResourceId catalogId =
+        ResourceId.newBuilder().setId("CAT").setKind(ResourceKind.RK_CATALOG).build();
+    blockingGraph.setCatalogName(catalogId, "catalog");
+
+    CompletableFuture<Throwable> resolution =
+        resolveCancellable(
+            () ->
+                withStore.resolveInputs(
+                    "q-cancel-catalog",
+                    "cid",
+                    List.of(QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                    Optional.empty(),
+                    Optional.of(catalogId),
+                    new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                    null,
+                    cancelled::get));
+
+    assertCancellationReturnsWhileBlocked(resolution, cancelled, blockingGraph.catalogBlocker);
+  }
+
+  @Test
+  void cancellationReturnsWhileBatchedNameLookupIgnoresInterrupts() throws Exception {
+    var blockingGraph = new BlockingNameGraph();
+    var withStore = new QueryInputResolver(blockingGraph);
+    var cancelled = new java.util.concurrent.atomic.AtomicBoolean();
+    NameRef input = name("c", "ns", "t");
+    blockingGraph.bind(input, rid("TABLE"));
+
+    CompletableFuture<Throwable> resolution =
+        resolveCancellable(
+            () ->
+                withStore.resolveInputs(
+                    "q-cancel-names",
+                    "cid",
+                    List.of(QueryInput.newBuilder().setName(input).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                    null,
+                    cancelled::get));
+
+    assertCancellationReturnsWhileBlocked(resolution, cancelled, blockingGraph.namesBlocker);
   }
 
   @Test
@@ -1554,8 +1655,9 @@ public class QueryInputResolverTest {
   /** Blocks one table-pin lookup until the test releases it. */
   static final class BlockingPinGraph extends FakeGraph {
     private final String blockedTableId;
-    final CountDownLatch slowPinStarted = new CountDownLatch(1);
-    final CountDownLatch allowSlowPin = new CountDownLatch(1);
+    final UninterruptibleBlocker slowPinBlocker = new UninterruptibleBlocker();
+    final CountDownLatch slowPinStarted = slowPinBlocker.started;
+    final CountDownLatch allowSlowPin = slowPinBlocker.release;
 
     BlockingPinGraph(String blockedTableId) {
       this.blockedTableId = blockedTableId;
@@ -1568,17 +1670,54 @@ public class QueryInputResolverTest {
         SnapshotRef override,
         Optional<Timestamp> asOfDefault) {
       if (blockedTableId.equals(tableId.getId())) {
-        slowPinStarted.countDown();
-        try {
-          if (!allowSlowPin.await(1, TimeUnit.SECONDS)) {
-            throw new AssertionError("test did not release the slow pin lookup");
-          }
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new AssertionError("slow pin lookup interrupted", e);
-        }
+        slowPinBlocker.await();
       }
       return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+  }
+
+  /** Blocks the default-catalog lookup to exercise cancellation before fan-out starts. */
+  static final class BlockingCatalogGraph extends FakeGraph {
+    final UninterruptibleBlocker catalogBlocker = new UninterruptibleBlocker();
+
+    @Override
+    public Optional<ai.floedb.floecat.metagraph.model.CatalogNode> catalog(ResourceId id) {
+      catalogBlocker.await();
+      return super.catalog(id);
+    }
+  }
+
+  /** Blocks batched name resolution to exercise cancellation before input planning starts. */
+  static final class BlockingNameGraph extends FakeGraph {
+    final UninterruptibleBlocker namesBlocker = new UninterruptibleBlocker();
+
+    @Override
+    public Map<NameRef, Optional<ResourceId>> resolveNames(
+        String correlationId, List<NameRef> refs) {
+      namesBlocker.await();
+      Map<NameRef, Optional<ResourceId>> resolved = new HashMap<>();
+      for (NameRef ref : refs) {
+        resolved.put(ref, resolveName(correlationId, ref));
+      }
+      return resolved;
+    }
+  }
+
+  /** A deliberately interruption-insensitive metadata call used to prove prompt caller teardown. */
+  static final class UninterruptibleBlocker {
+    final CountDownLatch started = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+
+    void await() {
+      started.countDown();
+      while (true) {
+        try {
+          release.await();
+          return;
+        } catch (InterruptedException ignored) {
+          // Simulate a downstream client that cannot abort an in-flight store call.
+        }
+      }
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -47,6 +47,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -227,6 +229,40 @@ public class QueryInputResolverTest {
     } finally {
       graph.allowPinLookups.countDown();
       CompletableFuture.allOf(requests).join();
+    }
+  }
+
+  @Test
+  void dedicatedFanoutExecutorDoesNotStarveBehindBlockedCallers() throws Exception {
+    var graph = new GloballyLimitedPinGraph();
+    var resolverWithDedicatedExecutor = new QueryInputResolver(graph, null, 2, 2);
+    resolverWithDedicatedExecutor.postConstruct();
+    List<QueryInput> inputs =
+        List.of(
+            QueryInput.newBuilder().setTableId(rid("ONE")).build(),
+            QueryInput.newBuilder().setTableId(rid("TWO")).build());
+    try (ExecutorService callers = Executors.newFixedThreadPool(2)) {
+      CompletableFuture<?>[] requests =
+          java.util.stream.IntStream.range(0, 2)
+              .mapToObj(
+                  ignored ->
+                      CompletableFuture.runAsync(
+                          () ->
+                              resolverWithDedicatedExecutor.resolveInputs(
+                                  "cid", inputs, Optional.empty(), Optional.empty()),
+                          callers))
+              .toArray(CompletableFuture[]::new);
+
+      try {
+        // Both caller threads are synchronously awaiting resolver work. If that work shared this
+        // two-thread executor, no pin lookup could start and this latch would time out.
+        assertTrue(graph.twoPinLookupsStarted.await(1, TimeUnit.SECONDS));
+      } finally {
+        graph.allowPinLookups.countDown();
+        CompletableFuture.allOf(requests).join();
+      }
+    } finally {
+      resolverWithDedicatedExecutor.closeBlockingExecutor();
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.PinKind;
@@ -302,6 +303,27 @@ public class QueryInputResolverTest {
             QueryInput.newBuilder().setTableId(rid("TWO")).build()),
         Optional.empty(),
         Optional.empty());
+
+    assertEquals(List.of(callerThread, callerThread), threadConfinedGraph.planningThreads());
+  }
+
+  @Test
+  void cancellableSerialPlanningStaysOnTheCallerThreadWhenOverlayOptsOutOfConcurrency() {
+    Thread callerThread = Thread.currentThread();
+    var threadConfinedGraph = new CallerThreadOnlyGraph(callerThread);
+    var threadConfinedResolver = new QueryInputResolver(threadConfinedGraph);
+
+    threadConfinedResolver.resolveInputs(
+        "q-thread-confined",
+        "cid",
+        List.of(
+            QueryInput.newBuilder().setTableId(rid("ONE")).build(),
+            QueryInput.newBuilder().setTableId(rid("TWO")).build()),
+        Optional.empty(),
+        Optional.empty(),
+        new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+        null,
+        () -> false);
 
     assertEquals(List.of(callerThread, callerThread), threadConfinedGraph.planningThreads());
   }
@@ -651,6 +673,30 @@ public class QueryInputResolverTest {
     long tablePinCallsForT1 =
         metadataGraph.pinCalls().stream().filter(c -> c.tableId().equals(tableId)).count();
     assertEquals(1, tablePinCallsForT1, "CURRENT snapshot for a table must be resolved once");
+  }
+
+  @Test
+  void explicitCurrentSnapshotForRepeatedTableIsResolvedOnce() {
+    ResourceId tableId = rid("EXPLICIT_CURRENT");
+    metadataGraph.setCurrentSnapshot(tableId, 55);
+    SnapshotRef current = SnapshotRef.newBuilder().setSpecial(SpecialSnapshot.SS_CURRENT).build();
+    Timestamp defaultAsOf = Timestamp.newBuilder().setSeconds(1_000).build();
+
+    var result =
+        resolver.resolveInputs(
+            "cid",
+            List.of(
+                QueryInput.newBuilder().setTableId(tableId).setSnapshot(current).build(),
+                QueryInput.newBuilder().setTableId(tableId).setSnapshot(current).build()),
+            Optional.of(defaultAsOf),
+            Optional.empty());
+
+    assertEquals(1, result.snapshotSet().getPinsCount());
+    assertEquals(55L, result.snapshotSet().getPins(0).getSnapshotId());
+    List<FakeGraph.PinCall> calls =
+        metadataGraph.pinCalls().stream().filter(call -> call.tableId().equals(tableId)).toList();
+    assertEquals(1, calls.size());
+    assertTrue(calls.get(0).asOfDefault().isEmpty());
   }
 
   /** A batch of distinct relations resolves every one, preserving request order. */

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -203,6 +203,60 @@ public class QueryInputResolverTest {
                 Optional.empty()));
   }
 
+  /**
+   * Two references to the same table's CURRENT snapshot in one batch resolve the snapshot once,
+   * even though the inputs are resolved concurrently. Without single-flight the two references
+   * could resolve independently and, if an ingest landed between them, freeze different snapshots.
+   */
+  @Test
+  void currentSnapshotForRepeatedTableIsResolvedOnce() {
+    ResourceId tableId = rid("T1");
+    NameRef a = name("c", "ns", "a");
+    NameRef b = name("c", "ns", "b");
+    metadataGraph.bind(a, tableId);
+    metadataGraph.bind(b, tableId);
+    metadataGraph.setCurrentSnapshot(tableId, 55);
+
+    var result =
+        resolver.resolveInputs(
+            "cid",
+            List.of(
+                QueryInput.newBuilder().setName(a).build(),
+                QueryInput.newBuilder().setName(b).build()),
+            Optional.empty(),
+            Optional.empty());
+
+    long pinsForT1 =
+        result.snapshotSet().getPinsList().stream()
+            .filter(p -> p.getTableId().getId().equals("T1"))
+            .count();
+    assertEquals(1, pinsForT1, "the two references must merge into one pin");
+
+    long tablePinCallsForT1 =
+        metadataGraph.pinCalls().stream().filter(c -> c.tableId().equals(tableId)).count();
+    assertEquals(1, tablePinCallsForT1, "CURRENT snapshot for a table must be resolved once");
+  }
+
+  /** A batch of distinct relations resolves every one, preserving request order. */
+  @Test
+  void batchResolvesEveryInputInRequestOrder() {
+    List<QueryInput> inputs = new ArrayList<>();
+    List<String> expectedOrder = new ArrayList<>();
+    for (int i = 0; i < 12; i++) {
+      NameRef n = name("c", "ns", "t" + i);
+      ResourceId id = rid("T" + i);
+      metadataGraph.bind(n, id);
+      metadataGraph.setCurrentSnapshot(id, 100 + i);
+      inputs.add(QueryInput.newBuilder().setName(n).build());
+      expectedOrder.add("T" + i);
+    }
+
+    var result = resolver.resolveInputs("cid", inputs, Optional.empty(), Optional.empty());
+
+    assertEquals(expectedOrder, result.resolved().stream().map(ResourceId::getId).toList());
+    assertEquals(12, result.snapshotSet().getPinsCount());
+  }
+
   /** When a QueryInput specifies a snapshot_id override, the resolver must use it verbatim. */
   @Test
   void snapshot_override_id() {
@@ -1142,8 +1196,10 @@ public class QueryInputResolverTest {
     private final Map<NameRef, RuntimeException> failures = new HashMap<>();
     private final Map<String, Long> currentSnapshots = new HashMap<>();
     private final Map<String, Long> asOfSnapshots = new HashMap<>();
+    // Written from resolution tasks, which may run in parallel; keep it thread-safe.
+    private final List<PinCall> pinCalls =
+        java.util.Collections.synchronizedList(new ArrayList<>());
     private final Set<ResourceId> failingPins = new HashSet<>();
-    private final List<PinCall> pinCalls = new ArrayList<>();
     private final Map<ResourceId, String> catalogNames = new HashMap<>();
     private Consumer<ResourceId> beforeTablePin = ignored -> {};
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -55,7 +55,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,6 +68,15 @@ public class QueryInputResolverTest {
   void init() {
     metadataGraph = new FakeGraph();
     resolver = new QueryInputResolver(metadataGraph);
+  }
+
+  @Test
+  void metadataIoSizingMustCoverAdmissionWithWorkersAndQueue() {
+    assertThrows(
+        IllegalStateException.class, () -> QueryInputResolver.validateMetadataIoSizing(3, 2, 3));
+    assertThrows(
+        IllegalStateException.class, () -> QueryInputResolver.validateMetadataIoSizing(3, 3, 2));
+    QueryInputResolver.validateMetadataIoSizing(3, 3, 3);
   }
 
   NameRef name(String cat, String... parts) {
@@ -99,48 +107,6 @@ public class QueryInputResolverTest {
             return failure;
           }
         });
-  }
-
-  @Test
-  void cancellableOverloadPreservesLegacyMapOverrideDispatch() {
-    AtomicBoolean legacyOverrideCalled = new AtomicBoolean();
-    QueryInputResolver legacySubclass =
-        new QueryInputResolver(metadataGraph) {
-          @Override
-          public ResolutionResult resolveInputs(
-              String queryId,
-              String correlationId,
-              List<QueryInput> inputs,
-              Optional<Timestamp> asOfDefault,
-              Optional<ResourceId> defaultCatalogId,
-              Map<ResourceId, TablePin> currentSnapshotPinCache,
-              ai.floedb.floecat.telemetry.PhaseDiagnostics diagnostics) {
-            legacyOverrideCalled.set(true);
-            return super.resolveInputs(
-                queryId,
-                correlationId,
-                inputs,
-                asOfDefault,
-                defaultCatalogId,
-                currentSnapshotPinCache,
-                diagnostics);
-          }
-        };
-    ResourceId tableId = rid("legacy-dispatch");
-
-    var result =
-        legacySubclass.resolveInputs(
-            "q-legacy-dispatch",
-            "cid",
-            List.of(QueryInput.newBuilder().setTableId(tableId).build()),
-            Optional.empty(),
-            Optional.empty(),
-            new ConcurrentHashMap<>(),
-            null,
-            () -> false);
-
-    assertTrue(legacyOverrideCalled.get());
-    assertEquals(tableId, result.resolved().getFirst());
   }
 
   /** Verifies cancellation returns promptly even when the active metadata operation ignores it. */
@@ -2040,127 +2006,6 @@ public class QueryInputResolverTest {
     }
   }
 
-  @Test
-  void legacyMapCacheDoesNotRetainPinsFromAFailedResolution() {
-    ResourceId successful = rid("LEGACY_CACHE_SUCCESS");
-    ResourceId failing = rid("LEGACY_CACHE_FAILURE");
-    var graph = new FakeGraph();
-    graph.failPinFor(failing);
-    var withStore =
-        new QueryInputResolver(graph, org.mockito.Mockito.mock(QueryContextStore.class));
-    Map<ResourceId, TablePin> legacyCache = new HashMap<>();
-
-    assertThrows(
-        StatusRuntimeException.class,
-        () ->
-            withStore.resolveInputs(
-                "q-legacy-cache",
-                "cid",
-                List.of(
-                    QueryInput.newBuilder().setTableId(successful).build(),
-                    QueryInput.newBuilder().setTableId(failing).build()),
-                Optional.empty(),
-                Optional.empty(),
-                legacyCache,
-                null));
-
-    assertTrue(legacyCache.isEmpty());
-  }
-
-  @Test
-  void legacyMapCopyFailureReleasesSuccessfulResolutionRoots() {
-    ResourceId tableId = rid("LEGACY_CACHE_COPY_FAILURE");
-    var graph = new FakeGraph();
-    QueryContextStore store = org.mockito.Mockito.mock(QueryContextStore.class);
-    var withStore = new QueryInputResolver(graph, store);
-    Map<ResourceId, TablePin> readOnlyCache =
-        java.util.Collections.unmodifiableMap(new HashMap<>());
-
-    assertThrows(
-        UnsupportedOperationException.class,
-        () ->
-            withStore.resolveInputs(
-                "q-legacy-copy-failure",
-                "cid",
-                List.of(QueryInput.newBuilder().setTableId(tableId).build()),
-                Optional.empty(),
-                Optional.empty(),
-                readOnlyCache,
-                null));
-
-    org.mockito.Mockito.verify(store)
-        .releaseResolvingPinBlobs(
-            org.mockito.ArgumentMatchers.eq("q-legacy-copy-failure"),
-            org.mockito.ArgumentMatchers.argThat(
-                roots ->
-                    roots.contains("s3://LEGACY_CACHE_COPY_FAILURE/table.pb")
-                        && roots.contains("s3://LEGACY_CACHE_COPY_FAILURE/snap.pb")));
-  }
-
-  @Test
-  void legacyMapSecondCopyFailureRollsBackCopiedPrefixBeforeReleasingRoots() {
-    ResourceId first = rid("LEGACY_CACHE_COPY_FIRST");
-    ResourceId second = rid("LEGACY_CACHE_COPY_SECOND");
-    var graph = new FakeGraph();
-    QueryContextStore store = org.mockito.Mockito.mock(QueryContextStore.class);
-    var withStore = new QueryInputResolver(graph, store);
-    Map<ResourceId, TablePin> cache = new ThrowOnSecondPutMap<>();
-    org.mockito.Mockito.doAnswer(
-            invocation -> {
-              assertTrue(cache.isEmpty(), "cache must be restored before roots are released");
-              return null;
-            })
-        .when(store)
-        .releaseResolvingPinBlobs(
-            org.mockito.ArgumentMatchers.eq("q-legacy-copy-prefix"),
-            org.mockito.ArgumentMatchers.any());
-
-    assertThrows(
-        UnsupportedOperationException.class,
-        () ->
-            withStore.resolveInputs(
-                "q-legacy-copy-prefix",
-                "cid",
-                List.of(
-                    QueryInput.newBuilder().setTableId(first).build(),
-                    QueryInput.newBuilder().setTableId(second).build()),
-                Optional.empty(),
-                Optional.empty(),
-                cache,
-                null));
-
-    assertTrue(cache.isEmpty());
-    org.mockito.Mockito.verify(store)
-        .releaseResolvingPinBlobs(
-            org.mockito.ArgumentMatchers.eq("q-legacy-copy-prefix"),
-            org.mockito.ArgumentMatchers.argThat(roots -> roots.size() == 4));
-  }
-
-  @Test
-  void parallelResolutionKeepsTheLegacyMemoOnItsOwnerThread() {
-    ResourceId first = rid("LEGACY_MEMO_FIRST");
-    ResourceId second = rid("LEGACY_MEMO_SECOND");
-    ResourceId third = rid("LEGACY_MEMO_THIRD");
-    metadataGraph.setCurrentSnapshot(first, 1);
-    metadataGraph.setCurrentSnapshot(second, 2);
-    metadataGraph.setCurrentSnapshot(third, 3);
-    Map<ResourceId, TablePin> threadConfinedMemo = new ThreadConfinedMap<>();
-
-    resolver.resolveInputs(
-        "q-thread-confined-memo",
-        "cid",
-        List.of(
-            QueryInput.newBuilder().setTableId(first).build(),
-            QueryInput.newBuilder().setTableId(second).build(),
-            QueryInput.newBuilder().setTableId(third).build()),
-        Optional.empty(),
-        Optional.empty(),
-        threadConfinedMemo,
-        null);
-
-    assertEquals(Set.of(first, second, third), threadConfinedMemo.keySet());
-  }
-
   // ----------------------------------------------------------------------
   // Base-relation enrichment (catalog + search-path fallback)
   // ----------------------------------------------------------------------
@@ -2257,60 +2102,6 @@ public class QueryInputResolverTest {
   // ----------------------------------------------------------------------
   // Helpers / test doubles (Composition, not inheritance)
   // ----------------------------------------------------------------------
-
-  /** A deliberately racy memo fake that rejects access from parallel resolver workers. */
-  private static final class ThreadConfinedMap<K, V> extends HashMap<K, V> {
-    private final Thread owner = Thread.currentThread();
-
-    private void requireOwnerThread() {
-      if (Thread.currentThread() != owner) {
-        throw new AssertionError("thread-confined memo accessed by a resolver worker");
-      }
-    }
-
-    @Override
-    public V get(Object key) {
-      requireOwnerThread();
-      return super.get(key);
-    }
-
-    @Override
-    public V put(K key, V value) {
-      requireOwnerThread();
-      return super.put(key, value);
-    }
-
-    @Override
-    public V putIfAbsent(K key, V value) {
-      requireOwnerThread();
-      return super.putIfAbsent(key, value);
-    }
-
-    @Override
-    public boolean remove(Object key, Object value) {
-      requireOwnerThread();
-      return super.remove(key, value);
-    }
-
-    @Override
-    public void forEach(BiConsumer<? super K, ? super V> action) {
-      requireOwnerThread();
-      super.forEach(action);
-    }
-  }
-
-  /** Accepts one cache copy, rejects the next, and permits rollback through clear(). */
-  private static final class ThrowOnSecondPutMap<K, V> extends HashMap<K, V> {
-    private int puts;
-
-    @Override
-    public V put(K key, V value) {
-      if (++puts == 2) {
-        throw new UnsupportedOperationException("second cache write rejected");
-      }
-      return super.put(key, value);
-    }
-  }
 
   static class FakeGraph extends TestCatalogOverlay {
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
@@ -443,7 +444,7 @@ public class QueryInputResolverTest {
     var graph = new TurnoverPinGraph(capacity);
     var resolverWithTurnover = new QueryInputResolver(graph, null, 1, capacity);
     resolverWithTurnover.postConstruct();
-    List<CompletableFuture<?>> activeRequests =
+    List<CompletableFuture<Void>> activeRequests =
         java.util.stream.IntStream.range(0, capacity)
             .mapToObj(
                 index ->

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.PinKind;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
 import com.google.protobuf.Timestamp;
@@ -43,6 +44,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -92,7 +98,7 @@ public class QueryInputResolverTest {
         List.of(QueryInput.newBuilder().setName(n).build()),
         Optional.empty(),
         Optional.empty(),
-        new java.util.LinkedHashMap<>(),
+        new ConcurrentHashMap<>(),
         null);
 
     // Registered under the stable query id (not the per-RPC correlation id), so the committing RPC
@@ -104,37 +110,70 @@ public class QueryInputResolverTest {
                 uris -> uris.contains("s3://T1/table.pb") && uris.contains("s3://T1/snap.pb")));
   }
 
+  /** A completed parallel input roots its pin while another input is still resolving. */
   @Test
-  void rootsCompletedPinsBeforePlanningLaterInputs() {
+  void rootsCompletedParallelPinBeforeSlowerInputReturns() throws Exception {
+    var blockingGraph = new BlockingPinGraph("SLOW");
     var store = org.mockito.Mockito.mock(QueryContextStore.class);
-    var withStore = new QueryInputResolver(metadataGraph, store);
-    ResourceId first = rid("ROOTED_FIRST");
-    ResourceId second = rid("LATER_INPUT");
-    boolean[] observedBeforeLaterPlan = {false};
-    metadataGraph.beforeTablePin(
-        tableId -> {
-          if (tableId.equals(second)) {
-            org.mockito.Mockito.verify(store)
-                .registerResolvingPinBlobs(
-                    org.mockito.ArgumentMatchers.eq("q1"),
-                    org.mockito.ArgumentMatchers.argThat(
-                        uris -> uris.contains("s3://ROOTED_FIRST/table.pb")));
-            observedBeforeLaterPlan[0] = true;
-          }
-        });
+    var withStore = new QueryInputResolver(blockingGraph, store);
+    ResourceId slow = rid("SLOW");
+    ResourceId fast = rid("FAST");
 
-    withStore.resolveInputs(
-        "q1",
-        "cid",
-        List.of(
-            QueryInput.newBuilder().setTableId(first).build(),
-            QueryInput.newBuilder().setTableId(second).build()),
-        Optional.empty(),
-        Optional.empty(),
-        new java.util.LinkedHashMap<>(),
-        null);
+    CompletableFuture<Void> resolution =
+        CompletableFuture.runAsync(
+            () ->
+                withStore.resolveInputs(
+                    "q-parallel",
+                    "cid",
+                    List.of(
+                        QueryInput.newBuilder().setTableId(slow).build(),
+                        QueryInput.newBuilder().setTableId(fast).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new java.util.concurrent.ConcurrentHashMap<>(),
+                    null));
 
-    assertTrue(observedBeforeLaterPlan[0]);
+    try {
+      assertTrue(blockingGraph.slowPinStarted.await(1, TimeUnit.SECONDS));
+      org.mockito.Mockito.verify(store, org.mockito.Mockito.timeout(1_000))
+          .registerResolvingPinBlobs(
+              org.mockito.ArgumentMatchers.eq("q-parallel"),
+              org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
+    } finally {
+      blockingGraph.allowSlowPin.countDown();
+    }
+    resolution.join();
+  }
+
+  /** A failed parallel plan releases every provisional root it constructed. */
+  @Test
+  void releasesCompletedParallelPinWhenSiblingPlanningFails() {
+    var failingGraph = new FailingAfterFastPinGraph();
+    var store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var withStore = new QueryInputResolver(failingGraph, store);
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-failure",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(rid("FAIL")).build(),
+                    QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                Optional.empty(),
+                Optional.empty(),
+                new java.util.concurrent.ConcurrentHashMap<>(),
+                null));
+
+    org.mockito.Mockito.verify(store)
+        .registerResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-failure"),
+            org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
+    org.mockito.Mockito.verify(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-failure"),
+            org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
   }
 
   /** Resolving a name that maps only to a table should return the table id. */
@@ -333,7 +372,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new java.util.LinkedHashMap<>(),
+                new ConcurrentHashMap<>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -406,7 +445,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new java.util.LinkedHashMap<>(),
+                new ConcurrentHashMap<>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -461,7 +500,7 @@ public class QueryInputResolverTest {
             List.of(qi),
             Optional.<com.google.protobuf.Timestamp>empty(),
             Optional.<ResourceId>empty(),
-            new java.util.LinkedHashMap<>(),
+            new ConcurrentHashMap<>(),
             null)
         .snapshotSet();
 
@@ -1080,7 +1119,7 @@ public class QueryInputResolverTest {
     ResourceId tableId = rid("CACHE_TABLE");
     metadataGraph.setCurrentSnapshot(tableId, 1234L);
     QueryInput input = QueryInput.newBuilder().setTableId(tableId).build();
-    Map<ResourceId, TablePin> cache = new HashMap<>();
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
 
     resolver.resolveInputs(
         "", "cid-a", List.of(input), Optional.empty(), Optional.empty(), cache, null);
@@ -1190,7 +1229,7 @@ public class QueryInputResolverTest {
   // Helpers / test doubles (Composition, not inheritance)
   // ----------------------------------------------------------------------
 
-  static final class FakeGraph extends TestCatalogOverlay {
+  static class FakeGraph extends TestCatalogOverlay {
 
     private final Map<NameRef, ResourceId> nameBindings = new HashMap<>();
     private final Map<NameRef, RuntimeException> failures = new HashMap<>();
@@ -1241,6 +1280,12 @@ public class QueryInputResolverTest {
         return Optional.empty();
       }
       return Optional.of(id);
+    }
+
+    @Override
+    public Optional<ResourceId> resolveName(
+        String correlationId, NameRef ref, EngineContext engineContext) {
+      return resolveName(correlationId, ref);
     }
 
     @Override
@@ -1310,7 +1355,6 @@ public class QueryInputResolverTest {
     void beforeTablePin(Consumer<ResourceId> callback) {
       beforeTablePin = callback;
     }
-
     List<PinCall> pinCalls() {
       return pinCalls;
     }
@@ -1320,6 +1364,66 @@ public class QueryInputResolverTest {
         ResourceId tableId,
         SnapshotRef override,
         Optional<Timestamp> asOfDefault) {}
+  }
+
+  /** Blocks one table-pin lookup until the test releases it. */
+  static final class BlockingPinGraph extends FakeGraph {
+    private final String blockedTableId;
+    final CountDownLatch slowPinStarted = new CountDownLatch(1);
+    final CountDownLatch allowSlowPin = new CountDownLatch(1);
+
+    BlockingPinGraph(String blockedTableId) {
+      this.blockedTableId = blockedTableId;
+    }
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      if (blockedTableId.equals(tableId.getId())) {
+        slowPinStarted.countDown();
+        try {
+          if (!allowSlowPin.await(1, TimeUnit.SECONDS)) {
+            throw new AssertionError("test did not release the slow pin lookup");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError("slow pin lookup interrupted", e);
+        }
+      }
+      return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+  }
+
+  /** Fails one lookup only after the sibling's pin has been constructed. */
+  static final class FailingAfterFastPinGraph extends FakeGraph {
+    private final CountDownLatch fastPinCompleted = new CountDownLatch(1);
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      if ("FAIL".equals(tableId.getId())) {
+        try {
+          if (!fastPinCompleted.await(1, TimeUnit.SECONDS)) {
+            throw new AssertionError("fast pin lookup did not complete");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError("failing pin lookup interrupted", e);
+        }
+        throw new IllegalStateException("planned failure");
+      }
+      TablePin pin = super.tablePinFor(correlationId, tableId, override, asOfDefault);
+      if ("FAST".equals(tableId.getId())) {
+        fastPinCompleted.countDown();
+      }
+      return pin;
+    }
   }
 
   private static NameRef nameRef(ResourceId id) {

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -1381,6 +1381,33 @@ public class QueryInputResolverTest {
   }
 
   @Test
+  void view_with_explicit_current_override_ignores_asof_default_for_base_pins() {
+    ResourceId base = rid("BASE_EXPLICIT_CURRENT");
+    ResourceId viewId = viewRid("V_EXPLICIT_CURRENT");
+    metadataGraph.addNode(viewNode(viewId, List.of(nameRef(base))));
+    metadataGraph.setCurrentSnapshot(base, 101L);
+    metadataGraph.setAsOfSnapshot(base, 555L);
+    Timestamp defaultAsOf = Timestamp.newBuilder().setSeconds(202).build();
+
+    QueryInput input =
+        QueryInput.newBuilder()
+            .setViewId(viewId)
+            .setSnapshot(SnapshotRef.newBuilder().setSpecial(SpecialSnapshot.SS_CURRENT))
+            .build();
+
+    List<SnapshotPin> pins =
+        resolver
+            .resolveInputs("cid", List.of(input), Optional.of(defaultAsOf), Optional.empty())
+            .snapshotSet()
+            .getPinsList();
+
+    assertEquals(1, pins.size());
+    assertEquals(101L, pins.get(0).getSnapshotId());
+    FakeGraph.PinCall call = metadataGraph.pinCalls().get(metadataGraph.pinCalls().size() - 1);
+    assertTrue(call.asOfDefault().isEmpty());
+  }
+
+  @Test
   void view_with_snapshot_override_is_invalid() {
     ResourceId base = rid("BASE_INVALID");
     ResourceId viewId = viewRid("V_INVALID");

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -98,7 +98,7 @@ public class QueryInputResolverTest {
         List.of(QueryInput.newBuilder().setName(n).build()),
         Optional.empty(),
         Optional.empty(),
-        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
         null);
 
     // Registered under the stable query id (not the per-RPC correlation id), so the committing RPC
@@ -130,7 +130,8 @@ public class QueryInputResolverTest {
                         QueryInput.newBuilder().setTableId(fast).build()),
                     Optional.empty(),
                     Optional.empty(),
-                    new java.util.concurrent.ConcurrentHashMap<>(),
+                    new java.util.concurrent.ConcurrentHashMap<
+                        ResourceId, CompletableFuture<TablePin>>(),
                     null));
 
     try {
@@ -163,7 +164,7 @@ public class QueryInputResolverTest {
                         QueryInput.newBuilder().setTableId(rid("FAST")).build()),
                     Optional.empty(),
                     Optional.empty(),
-                    new ConcurrentHashMap<>(),
+                    new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                     null,
                     cancelled::get);
                 return null;
@@ -201,7 +202,8 @@ public class QueryInputResolverTest {
                     QueryInput.newBuilder().setTableId(rid("FAST")).build()),
                 Optional.empty(),
                 Optional.empty(),
-                new java.util.concurrent.ConcurrentHashMap<>(),
+                new java.util.concurrent.ConcurrentHashMap<
+                    ResourceId, CompletableFuture<TablePin>>(),
                 null));
 
     org.mockito.Mockito.verify(store)
@@ -232,7 +234,8 @@ public class QueryInputResolverTest {
                     QueryInput.newBuilder().setTableId(rid("FAST")).build()),
                 Optional.empty(),
                 Optional.empty(),
-                new java.util.concurrent.ConcurrentHashMap<>(),
+                new java.util.concurrent.ConcurrentHashMap<
+                    ResourceId, CompletableFuture<TablePin>>(),
                 diagnostics));
 
     org.mockito.Mockito.verify(diagnostics).add("pin.snapshot_calls", 1L);
@@ -439,7 +442,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new ConcurrentHashMap<>(),
+                new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -512,7 +515,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new ConcurrentHashMap<>(),
+                new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -567,7 +570,7 @@ public class QueryInputResolverTest {
             List.of(qi),
             Optional.<com.google.protobuf.Timestamp>empty(),
             Optional.<ResourceId>empty(),
-            new ConcurrentHashMap<>(),
+            new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
             null)
         .snapshotSet();
 
@@ -1310,6 +1313,11 @@ public class QueryInputResolverTest {
     private Consumer<ResourceId> beforeTablePin = ignored -> {};
 
     FakeGraph() {}
+
+    @Override
+    public boolean supportsConcurrentResolution() {
+      return true;
+    }
 
     void setCatalogName(ResourceId id, String name) {
       catalogNames.put(id, name);

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -391,6 +391,32 @@ public class QueryInputResolverTest {
   }
 
   @Test
+  void uncancellableConcurrentPlanningUsesDaemonMetadataIoThreads() {
+    var graph = new MetadataIoThreadGraph();
+    var resolverWithDedicatedExecutor = new QueryInputResolver(graph, null, 2, 2);
+    resolverWithDedicatedExecutor.postConstruct();
+    try {
+      resolverWithDedicatedExecutor.resolveInputs(
+          "cid",
+          List.of(
+              QueryInput.newBuilder().setTableId(rid("ONE")).build(),
+              QueryInput.newBuilder().setTableId(rid("TWO")).build()),
+          Optional.empty(),
+          Optional.empty());
+
+      assertEquals(2, graph.metadataThreads().size());
+      assertTrue(
+          graph.metadataThreads().stream()
+              .allMatch(
+                  thread ->
+                      thread.isDaemon()
+                          && thread.getName().startsWith("floecat-query-input-metadata-")));
+    } finally {
+      resolverWithDedicatedExecutor.closeBlockingExecutor();
+    }
+  }
+
+  @Test
   void cancellationDoesNotQueueMetadataWorkBehindStalledCalls() throws Exception {
     int capacity = 64;
     var graph = new SaturatedPinGraph(capacity);
@@ -1920,6 +1946,26 @@ public class QueryInputResolverTest {
 
     List<Thread> planningThreads() {
       return planningThreads;
+    }
+  }
+
+  /** Records callbacks to verify planning never runs store I/O directly on virtual threads. */
+  static final class MetadataIoThreadGraph extends FakeGraph {
+    private final List<Thread> metadataThreads =
+        java.util.Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      metadataThreads.add(Thread.currentThread());
+      return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+
+    List<Thread> metadataThreads() {
+      return metadataThreads;
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -43,13 +43,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -1477,6 +1477,7 @@ public class QueryInputResolverTest {
     void beforeTablePin(Consumer<ResourceId> callback) {
       beforeTablePin = callback;
     }
+
     List<PinCall> pinCalls() {
       return pinCalls;
     }

--- a/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
+++ b/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.LongAdder;
  * count}/{@code add} sum, {@code timer}/{@code nanos} sum the elapsed time, and each summed key is
  * flushed once as a single {@code add} / {@code nanos}. The per-key values (e.g. total snapshot
  * lookups and the total time spent in them) are the per-request aggregate; per-item ordering and
- * one-shot fields ({@code put}, {@code emit}) are not representable and are rejected — a caller
- * that needs them should record on the request thread.
+ * one-shot fields ({@code put}, {@code emit}) are not representable and are omitted — a caller that
+ * needs them should record on the request thread.
  */
 public final class AggregatingPhaseDiagnostics implements PhaseDiagnostics {
 
@@ -58,38 +58,22 @@ public final class AggregatingPhaseDiagnostics implements PhaseDiagnostics {
     counts.computeIfAbsent(key, k -> new LongAdder()).add(amount);
   }
 
-  // One-shot values do not aggregate across items. Fail loudly so a newly added off-thread
-  // diagnostic cannot silently appear only for serial requests.
+  // One-shot values do not aggregate across items. Omitting telemetry must never turn into a
+  // request failure when a concurrent path reaches a newly added diagnostic.
   @Override
-  public void put(String key, String value) {
-    throw unsupportedOneShot("put");
-  }
+  public void put(String key, String value) {}
 
   @Override
-  public void put(String key, long value) {
-    throw unsupportedOneShot("put");
-  }
+  public void put(String key, long value) {}
 
   @Override
-  public void put(String key, double value) {
-    throw unsupportedOneShot("put");
-  }
+  public void put(String key, double value) {}
 
   @Override
-  public void put(String key, boolean value) {
-    throw unsupportedOneShot("put");
-  }
+  public void put(String key, boolean value) {}
 
   @Override
-  public void emit(String eventName) {
-    throw unsupportedOneShot("emit");
-  }
-
-  private static UnsupportedOperationException unsupportedOneShot(String operation) {
-    return new UnsupportedOperationException(
-        operation
-            + " is not supported by AggregatingPhaseDiagnostics; record it on the request thread");
-  }
+  public void emit(String eventName) {}
 
   /**
    * Emit the accumulated totals to {@code target}: one {@code add} per counter, one summed {@code

--- a/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
+++ b/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.LongAdder;
  * count}/{@code add} sum, {@code timer}/{@code nanos} sum the elapsed time, and each summed key is
  * flushed once as a single {@code add} / {@code nanos}. The per-key values (e.g. total snapshot
  * lookups and the total time spent in them) are the per-request aggregate; per-item ordering and
- * one-shot fields ({@code put}, {@code emit}) are not represented and are dropped — a caller that
- * needs them should record on the request thread.
+ * one-shot fields ({@code put}, {@code emit}) are not representable and are rejected — a caller
+ * that needs them should record on the request thread.
  */
 public final class AggregatingPhaseDiagnostics implements PhaseDiagnostics {
 
@@ -58,22 +58,38 @@ public final class AggregatingPhaseDiagnostics implements PhaseDiagnostics {
     counts.computeIfAbsent(key, k -> new LongAdder()).add(amount);
   }
 
-  // One-shot values do not aggregate across items; callers that need them report on the request
-  // thread, not through this accumulator.
+  // One-shot values do not aggregate across items. Fail loudly so a newly added off-thread
+  // diagnostic cannot silently appear only for serial requests.
   @Override
-  public void put(String key, String value) {}
+  public void put(String key, String value) {
+    throw unsupportedOneShot("put");
+  }
 
   @Override
-  public void put(String key, long value) {}
+  public void put(String key, long value) {
+    throw unsupportedOneShot("put");
+  }
 
   @Override
-  public void put(String key, double value) {}
+  public void put(String key, double value) {
+    throw unsupportedOneShot("put");
+  }
 
   @Override
-  public void put(String key, boolean value) {}
+  public void put(String key, boolean value) {
+    throw unsupportedOneShot("put");
+  }
 
   @Override
-  public void emit(String eventName) {}
+  public void emit(String eventName) {
+    throw unsupportedOneShot("emit");
+  }
+
+  private static UnsupportedOperationException unsupportedOneShot(String operation) {
+    return new UnsupportedOperationException(
+        operation
+            + " is not supported by AggregatingPhaseDiagnostics; record it on the request thread");
+  }
 
   /**
    * Emit the accumulated totals to {@code target}: one {@code add} per counter, one summed {@code

--- a/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
+++ b/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
@@ -58,8 +58,8 @@ public final class AggregatingPhaseDiagnostics implements PhaseDiagnostics {
     counts.computeIfAbsent(key, k -> new LongAdder()).add(amount);
   }
 
-  // One-shot values do not aggregate across items. Omitting telemetry must never turn into a
-  // request failure when a concurrent path reaches a newly added diagnostic.
+  // One-shot values do not aggregate across items. Unsupported telemetry must not turn concurrent
+  // request work into a failure.
   @Override
   public void put(String key, String value) {}
 

--- a/telemetry-hub/core/src/test/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnosticsTest.java
+++ b/telemetry-hub/core/src/test/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnosticsTest.java
@@ -16,6 +16,7 @@
 package ai.floedb.floecat.telemetry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -84,17 +85,17 @@ class AggregatingPhaseDiagnosticsTest {
   }
 
   @Test
-  void oneShotAndEmitAreDropped() {
+  void oneShotAndEmitFailLoudly() {
     AggregatingPhaseDiagnostics agg = new AggregatingPhaseDiagnostics();
-    agg.put("k", "v");
-    agg.put("n", 1L);
-    agg.emit("event");
-
-    CapturingDiagnostics target = new CapturingDiagnostics();
-    agg.flushInto(target);
-
-    assertThat(target.added).isEmpty();
-    assertThat(target.nanos).isEmpty();
+    assertThatThrownBy(() -> agg.put("k", "v"))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("record it on the request thread");
+    assertThatThrownBy(() -> agg.put("n", 1L)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> agg.put("ratio", 1.0d))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> agg.put("enabled", true))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> agg.emit("event")).isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/telemetry-hub/core/src/test/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnosticsTest.java
+++ b/telemetry-hub/core/src/test/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnosticsTest.java
@@ -16,7 +16,6 @@
 package ai.floedb.floecat.telemetry;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -85,17 +84,19 @@ class AggregatingPhaseDiagnosticsTest {
   }
 
   @Test
-  void oneShotAndEmitFailLoudly() {
+  void oneShotAndEmitAreOmitted() {
     AggregatingPhaseDiagnostics agg = new AggregatingPhaseDiagnostics();
-    assertThatThrownBy(() -> agg.put("k", "v"))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("record it on the request thread");
-    assertThatThrownBy(() -> agg.put("n", 1L)).isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> agg.put("ratio", 1.0d))
-        .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> agg.put("enabled", true))
-        .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> agg.emit("event")).isInstanceOf(UnsupportedOperationException.class);
+    agg.put("k", "v");
+    agg.put("n", 1L);
+    agg.put("ratio", 1.0d);
+    agg.put("enabled", true);
+    agg.emit("event");
+
+    CapturingDiagnostics target = new CapturingDiagnostics();
+    agg.flushInto(target);
+
+    assertThat(target.added).isEmpty();
+    assertThat(target.nanos).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Resolve independent input pins concurrently through a bounded, cancellation-aware fan-out. 
Preserve request context, transient pin roots, single-flight current-snapshot lookup, 
failure diagnostics, and prompt cancellation cleanup.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x]  Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
