### PR TITLE
GetUserObjects - 3: parallelize ordered candidate selection

### DIFF
--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -194,6 +194,17 @@ public interface CatalogOverlay {
   }
 
   /**
+   * Whether independent resolution callbacks may run concurrently on this overlay instance.
+   *
+   * <p>The default preserves compatibility for existing overlays, whose lifecycle state may be tied
+   * to one request thread. Implementations backed by thread-safe services may opt in to concurrent
+   * resolution.
+   */
+  default boolean supportsConcurrentResolution() {
+    return false;
+  }
+
+  /**
    * Resolves a relation (table or view) by name reference using an explicit engine context.
    *
    * <p>Prefer this overload wherever the caller already holds the request's engine context — see

--- a/docs/telemetry/diagnostics.md
+++ b/docs/telemetry/diagnostics.md
@@ -92,7 +92,7 @@ Emitted by `GetUserObjects`. This is the main planner metadata lookup summary fo
 | `chunks` | Number of resolution chunks emitted. |
 | `found` / `not_found` | Candidate resolution result counts. |
 | `total_ms` | End-to-end service time for the operation body. |
-| `resolve_ms` | Total candidate resolution phase. |
+| `resolve_ms` | Wall-clock time spent in the concurrent candidate-selection stage; it is not the sum of individual worker-task durations. |
 | `normalize_ms` | Input/reference normalization time. |
 | `select_relation_ms` | Time choosing the selected relation/input for each candidate. |
 | `default_catalog_ms` | Time spent resolving default catalog state. |

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
+import java.util.function.Function;
+
+/** Runs independent, mostly-blocking tasks on a shared executor with a concurrency bound. */
+public final class BoundedFanout {
+
+  private BoundedFanout() {}
+
+  /**
+   * Apply {@code task} to each item on {@code executor}, at most {@code permits} running at once,
+   * and return the results in input order. Each task runs under the caller's OpenTelemetry context.
+   * A task failure surfaces unwrapped — its original {@link RuntimeException} or {@link Error},
+   * never a {@link CompletionException} wrapper — and the first such failure propagates to the
+   * caller once its future is joined.
+   */
+  public static <I, O> List<O> mapOrdered(
+      List<I> items, int permits, Executor executor, Function<I, O> task) {
+    Semaphore gate = new Semaphore(permits);
+    Context otelContext = Context.current();
+    List<CompletableFuture<O>> futures =
+        items.stream()
+            .map(
+                item ->
+                    CompletableFuture.supplyAsync(
+                        () -> {
+                          gate.acquireUninterruptibly();
+                          try (Scope ignored = otelContext.makeCurrent()) {
+                            return task.apply(item);
+                          } finally {
+                            gate.release();
+                          }
+                        },
+                        executor))
+            .toList();
+
+    List<O> results = new ArrayList<>(items.size());
+    for (CompletableFuture<O> future : futures) {
+      results.add(join(future));
+    }
+    return results;
+  }
+
+  private static <O> O join(CompletableFuture<O> future) {
+    try {
+      return future.join();
+    } catch (CompletionException ce) {
+      Throwable cause = ce.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error e) {
+        throw e;
+      }
+      throw new IllegalStateException("unexpected checked exception from parallel task", cause);
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -15,67 +15,256 @@
  */
 package ai.floedb.floecat.service.concurrent;
 
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
+import ai.floedb.floecat.service.context.PropagatedContext;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
 /** Runs independent, mostly-blocking tasks on a shared executor with a concurrency bound. */
 public final class BoundedFanout {
 
+  private static final long CANCELLATION_POLL_MILLIS = 10;
+
   private BoundedFanout() {}
 
   /**
    * Apply {@code task} to each item on {@code executor}, at most {@code permits} running at once,
-   * and return the results in input order. Each task runs under the caller's OpenTelemetry context.
-   * A task failure surfaces unwrapped — its original {@link RuntimeException} or {@link Error},
-   * never a {@link CompletionException} wrapper — and the first such failure propagates to the
-   * caller once its future is joined.
+   * and return the results in input order. Each task runs under the caller's request context
+   * (OpenTelemetry, engine/principal/correlation, MDC) re-established via {@link
+   * PropagatedContext}, so ambient reads behave off-thread as they do on the caller's thread. A
+   * task failure surfaces unwrapped — its original {@link RuntimeException} or {@link Error}, never
+   * a {@link CompletionException} wrapper. With no cancellation, every task future completes before
+   * the first joined failure propagates, so callers can safely clean up task-owned resources.
    */
   public static <I, O> List<O> mapOrdered(
       List<I> items, int permits, Executor executor, Function<I, O> task) {
+    validatePermits(permits);
     Semaphore gate = new Semaphore(permits);
-    Context otelContext = Context.current();
-    List<CompletableFuture<O>> futures =
-        items.stream()
-            .map(
-                item ->
-                    CompletableFuture.supplyAsync(
-                        () -> {
-                          gate.acquireUninterruptibly();
-                          try (Scope ignored = otelContext.makeCurrent()) {
-                            return task.apply(item);
-                          } finally {
-                            gate.release();
-                          }
-                        },
-                        executor))
-            .toList();
+    PropagatedContext context = PropagatedContext.capture();
+    List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
+    try {
+      for (I item : items) {
+        futures.add(
+            CompletableFuture.supplyAsync(
+                () -> runTask(gate, context, task, item, () -> false), executor));
+      }
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitCompletedFutures(futures);
+      throw submissionFailure;
+    }
+    return collectCompletedFutures(futures);
+  }
+
+  /**
+   * As {@link #mapOrdered(List, int, Executor, Function)}, but {@code cancelled} is polled so a
+   * cancelled stream interrupts every submitted task and returns without waiting for a slow task's
+   * completion. Tasks must cooperate with interruption while blocked in downstream calls. The
+   * permit wait is interruptible for the same reason.
+   */
+  public static <I, O> List<O> mapOrdered(
+      List<I> items,
+      int permits,
+      ExecutorService executor,
+      Function<I, O> task,
+      BooleanSupplier cancelled) {
+    validatePermits(permits);
+    Semaphore gate = new Semaphore(permits);
+    PropagatedContext context = PropagatedContext.capture();
+    List<Future<O>> futures = new ArrayList<>(items.size());
+    try {
+      for (I item : items) {
+        if (cancelled.getAsBoolean()) {
+          cancelSubmittedTasks(futures);
+          throw cancelled();
+        }
+        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+      }
+    } catch (CancellationException cancellationFailure) {
+      cancelSubmittedTasks(futures);
+      throw cancellationFailure;
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitSubmittedTasks(futures);
+      throw submissionFailure;
+    }
 
     List<O> results = new ArrayList<>(items.size());
-    for (CompletableFuture<O> future : futures) {
-      results.add(join(future));
+    RuntimeException firstRuntimeFailure = null;
+    Error firstErrorFailure = null;
+    for (Future<O> future : futures) {
+      try {
+        results.add(awaitCancellable(future, futures, cancelled));
+      } catch (RuntimeException e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstRuntimeFailure = e;
+        }
+      } catch (Error e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstErrorFailure = e;
+        }
+      }
+    }
+    if (firstRuntimeFailure != null) {
+      throw firstRuntimeFailure;
+    }
+    if (firstErrorFailure != null) {
+      throw firstErrorFailure;
     }
     return results;
   }
 
-  private static <O> O join(CompletableFuture<O> future) {
+  /** Run one task under the captured context while holding one concurrency permit. */
+  private static <I, O> O runTask(
+      Semaphore gate,
+      PropagatedContext context,
+      Function<I, O> task,
+      I item,
+      BooleanSupplier cancelled) {
+    acquire(gate);
     try {
-      return future.join();
-    } catch (CompletionException ce) {
-      Throwable cause = ce.getCause();
-      if (cause instanceof RuntimeException re) {
-        throw re;
+      return context.supply(
+          () -> {
+            if (cancelled.getAsBoolean()) {
+              throw cancelled();
+            }
+            return task.apply(item);
+          });
+    } finally {
+      gate.release();
+    }
+  }
+
+  /** Collect every completed future, preserving the first unwrapped task failure. */
+  private static <O> List<O> collectCompletedFutures(List<CompletableFuture<O>> futures) {
+    List<O> results = new ArrayList<>(futures.size());
+    RuntimeException firstRuntimeFailure = null;
+    Error firstErrorFailure = null;
+    for (CompletableFuture<O> future : futures) {
+      try {
+        results.add(Futures.join(future));
+      } catch (RuntimeException e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstRuntimeFailure = e;
+        }
+      } catch (Error e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstErrorFailure = e;
+        }
       }
-      if (cause instanceof Error e) {
-        throw e;
+    }
+    if (firstRuntimeFailure != null) {
+      throw firstRuntimeFailure;
+    }
+    if (firstErrorFailure != null) {
+      throw firstErrorFailure;
+    }
+    return results;
+  }
+
+  /** Await each already-submitted completion future after a submission failure. */
+  private static void awaitCompletedFutures(List<? extends CompletableFuture<?>> futures) {
+    for (CompletableFuture<?> future : futures) {
+      try {
+        Futures.join(future);
+      } catch (RuntimeException | Error ignored) {
+        // The submission failure is the caller-visible outcome; task failures only complete
+        // cleanup.
       }
-      throw new IllegalStateException("unexpected checked exception from parallel task", cause);
+    }
+  }
+
+  /** Await each already-submitted task while preserving an executor submission failure. */
+  private static void awaitSubmittedTasks(List<? extends Future<?>> futures) {
+    boolean interrupted = false;
+    for (Future<?> future : futures) {
+      try {
+        future.get();
+      } catch (InterruptedException e) {
+        interrupted = true;
+        cancelSubmittedTasks(futures);
+        break;
+      } catch (ExecutionException | CancellationException ignored) {
+        // The submission failure is the caller-visible outcome; task failures only complete
+        // cleanup.
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /** Await one task while repeatedly observing stream cancellation. */
+  private static <O> O awaitCancellable(
+      Future<O> future, List<? extends Future<?>> futures, BooleanSupplier cancelled) {
+    while (true) {
+      if (cancelled.getAsBoolean()) {
+        cancelSubmittedTasks(futures);
+        throw cancelled();
+      }
+      try {
+        return future.get(CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+      } catch (TimeoutException ignored) {
+        // A bounded wait lets the next loop observe cancellation.
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        cancelSubmittedTasks(futures);
+        throw cancelled();
+      } catch (ExecutionException e) {
+        rethrowTaskFailure(e.getCause());
+      }
+    }
+  }
+
+  /** Interrupt every submitted task, including work already inside a downstream call. */
+  private static void cancelSubmittedTasks(List<? extends Future<?>> futures) {
+    for (Future<?> future : futures) {
+      future.cancel(true);
+    }
+  }
+
+  /** Rethrow a task failure without an execution-wrapper layer. */
+  private static void rethrowTaskFailure(Throwable failure) {
+    if (failure instanceof RuntimeException runtime) {
+      throw runtime;
+    }
+    if (failure instanceof Error error) {
+      throw error;
+    }
+    throw new CompletionException(failure);
+  }
+
+  /** Validate the concurrency bound before any tasks are submitted. */
+  private static void validatePermits(int permits) {
+    if (permits < 1) {
+      throw new IllegalArgumentException("BoundedFanout permits must be >= 1, got " + permits);
+    }
+  }
+
+  /** Build the canonical cancellation failure returned to a stopped stream driver. */
+  private static CancellationException cancelled() {
+    return new CancellationException("fan-out cancelled");
+  }
+
+  /**
+   * Interruptible permit acquire: a shutdown/interrupt aborts the task instead of pinning the
+   * thread on an uninterruptible wait.
+   */
+  private static void acquire(Semaphore gate) {
+    try {
+      gate.acquire();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CancellationException("interrupted while awaiting fan-out permit");
     }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /** Runs independent, mostly-blocking tasks on a shared executor with a concurrency bound. */
@@ -53,8 +54,10 @@ public final class BoundedFanout {
     Semaphore gate = new Semaphore(permits);
     PropagatedContext context = PropagatedContext.capture();
     List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
+    int nextItem = 0;
     try {
-      for (I item : items) {
+      while (nextItem < items.size() && futures.size() < permits) {
+        I item = items.get(nextItem++);
         futures.add(
             CompletableFuture.supplyAsync(
                 () -> runTask(gate, context, task, item, () -> false), executor));
@@ -63,7 +66,38 @@ public final class BoundedFanout {
       awaitCompletedFutures(futures);
       throw submissionFailure;
     }
-    return collectCompletedFutures(futures);
+    return collectCompletedFutures(futures, items, nextItem, gate, context, executor, task);
+  }
+
+  /**
+   * As {@link #mapOrdered(List, int, Executor, Function)}, but consumes each successful result on
+   * the caller thread before observing the next result. This preserves input-order validation
+   * precedence when a result consumer can itself fail, while still awaiting all submitted tasks
+   * before surfacing that failure so callers can safely release task-owned resources.
+   */
+  public static <I, O> void forEachOrdered(
+      List<I> items,
+      int permits,
+      Executor executor,
+      Function<I, O> task,
+      Consumer<? super O> consumer) {
+    validatePermits(permits);
+    Semaphore gate = new Semaphore(permits);
+    PropagatedContext context = PropagatedContext.capture();
+    List<CompletableFuture<O>> futures = new ArrayList<>(items.size());
+    int nextItem = 0;
+    try {
+      while (nextItem < items.size() && futures.size() < permits) {
+        I item = items.get(nextItem++);
+        futures.add(
+            CompletableFuture.supplyAsync(
+                () -> runTask(gate, context, task, item, () -> false), executor));
+      }
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitCompletedFutures(futures);
+      throw submissionFailure;
+    }
+    consumeCompletedFutures(futures, items, nextItem, gate, context, executor, task, consumer);
   }
 
   /**
@@ -82,12 +116,14 @@ public final class BoundedFanout {
     Semaphore gate = new Semaphore(permits);
     PropagatedContext context = PropagatedContext.capture();
     List<Future<O>> futures = new ArrayList<>(items.size());
+    int nextItem = 0;
     try {
-      for (I item : items) {
+      while (nextItem < items.size() && futures.size() < permits) {
         if (cancelled.getAsBoolean()) {
           cancelSubmittedTasks(futures);
           throw cancelled();
         }
+        I item = items.get(nextItem++);
         futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
       }
     } catch (CancellationException cancellationFailure) {
@@ -101,7 +137,8 @@ public final class BoundedFanout {
     List<O> results = new ArrayList<>(items.size());
     RuntimeException firstRuntimeFailure = null;
     Error firstErrorFailure = null;
-    for (Future<O> future : futures) {
+    for (int index = 0; index < futures.size(); index++) {
+      Future<O> future = futures.get(index);
       try {
         results.add(awaitCancellable(future, futures, cancelled));
       } catch (RuntimeException e) {
@@ -113,6 +150,14 @@ public final class BoundedFanout {
           firstErrorFailure = e;
         }
       }
+      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
+        if (cancelled.getAsBoolean()) {
+          cancelSubmittedTasks(futures);
+          throw cancelled();
+        }
+        I item = items.get(nextItem++);
+        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+      }
     }
     if (firstRuntimeFailure != null) {
       throw firstRuntimeFailure;
@@ -121,6 +166,74 @@ public final class BoundedFanout {
       throw firstErrorFailure;
     }
     return results;
+  }
+
+  /**
+   * Cancellation-aware ordered result consumption. A consumer failure has the same ordered
+   * precedence as a task failure, while submitted work is cancelled promptly when requested.
+   */
+  public static <I, O> void forEachOrdered(
+      List<I> items,
+      int permits,
+      ExecutorService executor,
+      Function<I, O> task,
+      Consumer<? super O> consumer,
+      BooleanSupplier cancelled) {
+    validatePermits(permits);
+    Semaphore gate = new Semaphore(permits);
+    PropagatedContext context = PropagatedContext.capture();
+    List<Future<O>> futures = new ArrayList<>(items.size());
+    int nextItem = 0;
+    try {
+      while (nextItem < items.size() && futures.size() < permits) {
+        if (cancelled.getAsBoolean()) {
+          cancelSubmittedTasks(futures);
+          throw cancelled();
+        }
+        I item = items.get(nextItem++);
+        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+      }
+    } catch (CancellationException cancellationFailure) {
+      cancelSubmittedTasks(futures);
+      throw cancellationFailure;
+    } catch (RuntimeException | Error submissionFailure) {
+      awaitSubmittedTasks(futures);
+      throw submissionFailure;
+    }
+
+    RuntimeException firstRuntimeFailure = null;
+    Error firstErrorFailure = null;
+    for (int index = 0; index < futures.size(); index++) {
+      Future<O> future = futures.get(index);
+      try {
+        O result = awaitCancellable(future, futures, cancelled);
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          consumer.accept(result);
+        }
+      } catch (RuntimeException e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstRuntimeFailure = e;
+        }
+      } catch (Error e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstErrorFailure = e;
+        }
+      }
+      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
+        if (cancelled.getAsBoolean()) {
+          cancelSubmittedTasks(futures);
+          throw cancelled();
+        }
+        I item = items.get(nextItem++);
+        futures.add(executor.submit(() -> runTask(gate, context, task, item, cancelled)));
+      }
+    }
+    if (firstRuntimeFailure != null) {
+      throw firstRuntimeFailure;
+    }
+    if (firstErrorFailure != null) {
+      throw firstErrorFailure;
+    }
   }
 
   /** Run one task under the captured context while holding one concurrency permit. */
@@ -145,11 +258,19 @@ public final class BoundedFanout {
   }
 
   /** Collect every completed future, preserving the first unwrapped task failure. */
-  private static <O> List<O> collectCompletedFutures(List<CompletableFuture<O>> futures) {
+  private static <I, O> List<O> collectCompletedFutures(
+      List<CompletableFuture<O>> futures,
+      List<I> items,
+      int nextItem,
+      Semaphore gate,
+      PropagatedContext context,
+      Executor executor,
+      Function<I, O> task) {
     List<O> results = new ArrayList<>(futures.size());
     RuntimeException firstRuntimeFailure = null;
     Error firstErrorFailure = null;
-    for (CompletableFuture<O> future : futures) {
+    for (int index = 0; index < futures.size(); index++) {
+      CompletableFuture<O> future = futures.get(index);
       try {
         results.add(Futures.join(future));
       } catch (RuntimeException e) {
@@ -161,6 +282,12 @@ public final class BoundedFanout {
           firstErrorFailure = e;
         }
       }
+      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
+        I item = items.get(nextItem++);
+        futures.add(
+            CompletableFuture.supplyAsync(
+                () -> runTask(gate, context, task, item, () -> false), executor));
+      }
     }
     if (firstRuntimeFailure != null) {
       throw firstRuntimeFailure;
@@ -169,6 +296,49 @@ public final class BoundedFanout {
       throw firstErrorFailure;
     }
     return results;
+  }
+
+  /** Consume completed futures in input order, preserving the first task or consumer failure. */
+  private static <I, O> void consumeCompletedFutures(
+      List<CompletableFuture<O>> futures,
+      List<I> items,
+      int nextItem,
+      Semaphore gate,
+      PropagatedContext context,
+      Executor executor,
+      Function<I, O> task,
+      Consumer<? super O> consumer) {
+    RuntimeException firstRuntimeFailure = null;
+    Error firstErrorFailure = null;
+    for (int index = 0; index < futures.size(); index++) {
+      CompletableFuture<O> future = futures.get(index);
+      try {
+        O result = Futures.join(future);
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          consumer.accept(result);
+        }
+      } catch (RuntimeException e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstRuntimeFailure = e;
+        }
+      } catch (Error e) {
+        if (firstRuntimeFailure == null && firstErrorFailure == null) {
+          firstErrorFailure = e;
+        }
+      }
+      if (firstRuntimeFailure == null && firstErrorFailure == null && nextItem < items.size()) {
+        I item = items.get(nextItem++);
+        futures.add(
+            CompletableFuture.supplyAsync(
+                () -> runTask(gate, context, task, item, () -> false), executor));
+      }
+    }
+    if (firstRuntimeFailure != null) {
+      throw firstRuntimeFailure;
+    }
+    if (firstErrorFailure != null) {
+      throw firstErrorFailure;
+    }
   }
 
   /** Await each already-submitted completion future after a submission failure. */

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/** Helpers for joining {@link CompletableFuture}s. */
+public final class Futures {
+
+  private Futures() {}
+
+  /**
+   * Join {@code future}, unwrapping the {@link CompletionException} so the caller sees the task's
+   * original {@link RuntimeException} or {@link Error} rather than a wrapper. A checked-exception
+   * cause is a should-never-happen (the tasks here throw only unchecked) and surfaces as an {@link
+   * IllegalStateException}.
+   */
+  public static <T> T join(CompletableFuture<T> future) {
+    try {
+      return future.join();
+    } catch (CompletionException ce) {
+      Throwable cause = ce.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error e) {
+        throw e;
+      }
+      throw new IllegalStateException("unexpected checked exception from async task", cause);
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.context;
+
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import java.util.function.Supplier;
+
+/**
+ * An immutable snapshot of a thread's ambient request context, for re-establishing it on another
+ * thread. Request context does not follow a task across a thread hop on its own — it lives in
+ * thread-locals (OpenTelemetry's {@link Context}, the resolved call context's scope) — so work
+ * dispatched to an executor loses it, and ambient reads ({@code engineContext()}, principal,
+ * correlation, log MDC) silently read empty off-thread. That is how engine-gated system objects
+ * become unresolvable across a fan-out (eng-floe/floecat#361).
+ *
+ * <p>{@link #capture()} on the originating thread, {@link #supply}/{@link #run} on the worker
+ * thread. The {@link ResolvedCallContext} is the single source of truth: engine, principal,
+ * correlation and the log MDC all derive from it. Add a new carrier here once, and every dispatch
+ * point that already propagates through this snapshot gets it for free.
+ */
+public final class PropagatedContext {
+
+  private final Context otel;
+  private final ResolvedCallContext call; // null off any request (e.g. unit tests, startup)
+
+  private PropagatedContext(Context otel, ResolvedCallContext call) {
+    this.otel = otel;
+    this.call = call;
+  }
+
+  /** Snapshot the calling thread's ambient context. Call on the request/driver thread. */
+  public static PropagatedContext capture() {
+    return new PropagatedContext(Context.current(), ResolvedCallContexts.currentOrNull());
+  }
+
+  /**
+   * Run {@code body} on the current thread with the captured context re-established for its
+   * duration and torn down afterward, so its ambient reads behave as they did on the capturing
+   * thread. Checked exceptions from {@code body} propagate as {@link RuntimeException} (via {@link
+   * ResolvedCallContexts#callWith}).
+   */
+  public <T> T supply(Supplier<T> body) {
+    try (Scope ignored = otel.makeCurrent()) {
+      if (call == null) {
+        return body.get();
+      }
+      return ResolvedCallContexts.callWith(
+          call,
+          () -> {
+            // MDC is a projection of the call context; re-derive it so off-thread log lines carry
+            // the request's ids, then clear so a pooled worker does not leak them to the next task.
+            InboundContextInterceptor.populateMdc(call);
+            try {
+              return body.get();
+            } finally {
+              InboundContextInterceptor.clearMdc();
+            }
+          });
+    }
+  }
+
+  /** {@link #supply} for a body with no return value. */
+  public void run(Runnable body) {
+    supply(
+        () -> {
+          body.run();
+          return null;
+        });
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
@@ -20,7 +20,11 @@ import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
+import org.jboss.logging.MDC;
 
 /**
  * An immutable snapshot of a thread's ambient request context, for re-establishing it on another
@@ -36,6 +40,17 @@ import java.util.function.Supplier;
  * point that already propagates through this snapshot gets it for free.
  */
 public final class PropagatedContext {
+
+  private static final List<String> MDC_KEYS =
+      List.of(
+          "floecat_component",
+          "floecat_operation",
+          "query_id",
+          "correlation_id",
+          "floecat_account_id",
+          "floecat_subject",
+          "floecat_engine_kind",
+          "floecat_engine_version");
 
   private final Context otel;
   private final ResolvedCallContext call; // null off any request (e.g. unit tests, startup)
@@ -65,12 +80,14 @@ public final class PropagatedContext {
           call,
           () -> {
             // MDC is a projection of the call context; re-derive it so off-thread log lines carry
-            // the request's ids, then clear so a pooled worker does not leak them to the next task.
+            // the request's ids, then restore the worker's prior values for nested scopes and
+            // executors that already propagate MDC.
+            Map<String, Object> priorMdc = snapshotMdc();
             InboundContextInterceptor.populateMdc(call);
             try {
               return body.get();
             } finally {
-              InboundContextInterceptor.clearMdc();
+              restoreMdc(priorMdc);
             }
           });
     }
@@ -83,5 +100,27 @@ public final class PropagatedContext {
           body.run();
           return null;
         });
+  }
+
+  private static Map<String, Object> snapshotMdc() {
+    Map<String, Object> values = new HashMap<>();
+    for (String key : MDC_KEYS) {
+      Object value = MDC.get(key);
+      if (value != null) {
+        values.put(key, value);
+      }
+    }
+    return values;
+  }
+
+  private static void restoreMdc(Map<String, Object> priorMdc) {
+    for (String key : MDC_KEYS) {
+      Object value = priorMdc.get(key);
+      if (value == null) {
+        MDC.remove(key);
+      } else {
+        MDC.put(key, value);
+      }
+    }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
@@ -48,10 +48,10 @@ import org.jboss.logging.MDC;
  *       io.grpc.Context} directly (unit tests, non-Vert.x threads).
  * </ol>
  *
- * <p>History: mirroring only the principal onto the duplicated context moved the context-loss
- * failure from a loud {@code PERMISSION_DENIED} into a silent engine-gated {@code NOT_FOUND}
- * (eng-floe/floecat#361). Carrying the whole {@link ResolvedCallContext} on one channel keeps the
- * principal, correlation id, and engine context from ever diverging again.
+ * <p>Mirroring only the principal onto the duplicated context turns context loss from a loud {@code
+ * PERMISSION_DENIED} into a silent engine-gated {@code NOT_FOUND} (eng-floe/floecat#361). Carrying
+ * the whole {@link ResolvedCallContext} on one channel keeps the principal, correlation id, and
+ * engine context from ever diverging.
  */
 public final class ResolvedCallContexts {
 

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -94,6 +94,11 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     return ctx != null ? ctx : fallback.get();
   }
 
+  @Override
+  public boolean supportsConcurrentResolution() {
+    return true;
+  }
+
   /**
    * Resolves a graph node by ID, checking system graph first, then user graph.
    *

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
@@ -39,10 +40,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Semaphore;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.context.ManagedExecutor;
 
@@ -401,40 +400,15 @@ public final class NameResolver {
 
   /**
    * Fans out per-namespace work across up to {@value #MAX_PARALLEL_NS_SCANS} concurrent tasks on
-   * the injected blocking executor. Each namespace is an independent DynamoDB scan; parallel
-   * execution reduces wall-clock time from O(N) to O(1) for warm DynamoDB connections.
+   * the injected blocking executor and flattens the per-namespace results. Each namespace is an
+   * independent DynamoDB scan; parallel execution reduces wall-clock time from O(N) to O(1) for
+   * warm DynamoDB connections.
    */
   private <T> List<T> parallelScan(
       List<ResourceId> nsIds, java.util.function.Function<ResourceId, List<T>> task) {
-    Semaphore gate = new Semaphore(MAX_PARALLEL_NS_SCANS);
-    io.opentelemetry.context.Context otelContext = io.opentelemetry.context.Context.current();
-    List<CompletableFuture<List<T>>> futures =
-        nsIds.stream()
-            .<CompletableFuture<List<T>>>map(
-                ns ->
-                    CompletableFuture.<List<T>>supplyAsync(
-                        () -> {
-                          gate.acquireUninterruptibly();
-                          try (io.opentelemetry.context.Scope ignored = otelContext.makeCurrent()) {
-                            return task.apply(ns);
-                          } finally {
-                            gate.release();
-                          }
-                        },
-                        blockingExecutor))
-            .toList();
-    List<T> out = new ArrayList<>();
-    for (CompletableFuture<List<T>> f : futures) {
-      try {
-        out.addAll(f.join());
-      } catch (java.util.concurrent.CompletionException ce) {
-        Throwable cause = ce.getCause();
-        if (cause instanceof RuntimeException re) throw re;
-        if (cause instanceof Error e) throw e;
-        throw new IllegalStateException("unexpected checked exception from async task", cause);
-      }
-    }
-    return out;
+    return BoundedFanout.mapOrdered(nsIds, MAX_PARALLEL_NS_SCANS, blockingExecutor, task).stream()
+        .flatMap(List::stream)
+        .toList();
   }
 
   private ResourceId requireCanonicalTableId(ResourceId tableId) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -101,6 +101,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
+import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -1601,9 +1602,13 @@ public class UserObjectBundleService {
 
     // Maintains the order inputs were resolved so the emitted chunk mirrors the request order.
     private final List<PendingItem> pending = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
+    // Per-request resolution memos. Both resolve each key at most once: a repeated lookup returns
+    // the stored Optional (present or empty). See memoize() / resolveNameCached /
+    // resolveNodeCached.
     private final Map<NormalizedNameRef, Optional<ResourceId>> nameResolutionCache =
-        new HashMap<>();
-    private final Map<ResourceId, Optional<GraphNode>> nodeResolutionCache = new HashMap<>();
+        new ConcurrentHashMap<>();
+    private final Map<ResourceId, Optional<GraphNode>> nodeResolutionCache =
+        new ConcurrentHashMap<>();
     private final ArrayDeque<EagerBaseCursor> eagerBaseQueue = new ArrayDeque<>();
     private final Set<String> eagerBaseSeen = new HashSet<>();
     private final Map<RelationCacheKey, RelationInfo> relationInfoCache = new HashMap<>();
@@ -1651,7 +1656,9 @@ public class UserObjectBundleService {
       this.correlationId = correlationId;
       this.ctx = ctx;
       this.tables = tables;
-      this.knownBlobVersions = knownBlobVersions;
+      // Read-only for the life of the iterator (consulted by the identity-only fast path); copy so
+      // that stays true regardless of what the caller does with its set afterwards.
+      this.knownBlobVersions = Set.copyOf(knownBlobVersions);
       this.resolutionCount = tables.size();
       this.defaultCatalogId = ctx.getQueryDefaultCatalogId();
       this.statsProvider = statsFactory.forQuery(ctx, correlationId);
@@ -2172,46 +2179,65 @@ public class UserObjectBundleService {
     }
 
     private Optional<ResourceId> resolveNameCached(NameRef ref) {
-      NormalizedNameRef key = normalizedNameRef(ref);
-      // Stored values are non-null Optional instances; null means cache miss.
-      Optional<ResourceId> cached = nameResolutionCache.get(key);
-      if (cached != null) {
-        nameResolutionCacheHits++;
-        return cached;
-      }
-      long startNs = System.nanoTime();
-      try {
-        // Pass the engine captured at iterator construction: re-reading it from the request
-        // context per lookup is fragile across executor hops, and an empty engine silently
-        // un-resolves engine-gated system objects (eng-floe/floecat#361).
-        Optional<ResourceId> resolved =
-            overlay.resolveName(correlationId, ref, resolutionContext.engineContext());
-        nameResolutionCache.put(key, resolved);
+      // Engine captured at iterator construction is passed through: re-reading it from the request
+      // context per lookup is fragile across executor hops, and an empty engine silently
+      // un-resolves engine-gated system objects (eng-floe/floecat#361).
+      Memoized<ResourceId> m =
+          memoize(
+              nameResolutionCache,
+              normalizedNameRef(ref),
+              () -> overlay.resolveName(correlationId, ref, resolutionContext.engineContext()),
+              nanos -> nameResolveNanos += nanos);
+      if (m.resolved()) {
         nameResolutionCacheMisses++;
-        return resolved;
-      } finally {
-        nameResolveNanos += System.nanoTime() - startNs;
+      } else {
+        nameResolutionCacheHits++;
       }
+      return m.value();
     }
 
     private Optional<GraphNode> resolveNodeCached(ResourceId id) {
-      // Stored values are non-null Optional instances; null means cache miss.
-      Optional<GraphNode> cached = nodeResolutionCache.get(id);
-      if (cached != null) {
-        nodeResolutionCacheHits++;
-        return cached;
-      }
-      long startNs = System.nanoTime();
-      try {
-        // Pass the engine captured at iterator construction: re-reading it from the request
-        // context per lookup is fragile across executor hops (eng-floe/floecat#361).
-        Optional<GraphNode> resolved = overlay.resolve(id, resolutionContext.engineContext());
-        nodeResolutionCache.put(id, resolved);
+      Memoized<GraphNode> m =
+          memoize(
+              nodeResolutionCache,
+              id,
+              () -> overlay.resolve(id, resolutionContext.engineContext()),
+              nanos -> nodeResolveNanos += nanos);
+      if (m.resolved()) {
         nodeResolutionCacheMisses++;
-        return resolved;
-      } finally {
-        nodeResolveNanos += System.nanoTime() - startNs;
+      } else {
+        nodeResolutionCacheHits++;
       }
+      return m.value();
+    }
+
+    /**
+     * A memoized value together with whether this call resolved it (a miss) vs. found it cached.
+     */
+    private record Memoized<V>(Optional<V> value, boolean resolved) {}
+
+    /**
+     * Return {@code cache.get(key)}, resolving and storing it once if absent. The resolve runs at
+     * most once per key even under concurrent callers (computeIfAbsent single-flight); its elapsed
+     * time is reported to {@code addNanos}. {@link Memoized#resolved()} is true when this call ran
+     * the resolve.
+     */
+    private <K, V> Memoized<V> memoize(
+        Map<K, Optional<V>> cache, K key, Supplier<Optional<V>> resolve, LongConsumer addNanos) {
+      boolean[] resolvedHere = {false};
+      Optional<V> value =
+          cache.computeIfAbsent(
+              key,
+              k -> {
+                resolvedHere[0] = true;
+                long startNs = System.nanoTime();
+                try {
+                  return resolve.get();
+                } finally {
+                  addNanos.accept(System.nanoTime() - startNs);
+                }
+              });
+      return new Memoized<>(value, resolvedHere[0]);
     }
 
     private Optional<ResolvedRelation> selectResolvedRelationTimed(

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1763,7 +1763,6 @@ public class UserObjectBundleService {
           plan.add(planInput(nextInputIndex + i));
         }
         nextInputIndex += planCount;
-        seedNameResolutions(plan);
         // Resolve the planned inputs concurrently; results come back in plan order so the gather
         // below stays deterministic. resolveNanos is the wall-clock of this stage.
         long selectStageStartNs = System.nanoTime();

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1723,7 +1723,10 @@ public class UserObjectBundleService {
         return headerChunk(ctx.getQueryId(), seq++);
       }
 
-      if (pending.isEmpty() && (nextInputIndex < resolutionCount || !eagerBaseQueue.isEmpty())) {
+      if (pending.isEmpty()
+          && (nextInputIndex < resolutionCount
+              || !eagerBaseQueue.isEmpty()
+              || !resolvedSpillover.isEmpty())) {
         fillPending();
       }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -82,7 +82,6 @@ import ai.floedb.floecat.types.LogicalTypeFormat;
 import io.opentelemetry.api.trace.Span;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -100,16 +99,17 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BooleanSupplier;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -152,16 +152,9 @@ public class UserObjectBundleService {
   // store-bound resolution; a small fan-out overlaps their round-trips without flooding the store.
   private static final int MAX_PARALLEL_RELATION_TASKS = 8;
 
-  // Runs per-relation resolution off the request thread. The Quarkus ManagedExecutor is injected in
-  // init(); tests (and any wiring without one) fall back to the common pool.
-  private volatile Executor blockingExecutor = ForkJoinPool.commonPool();
-
-  @Inject
-  void init(Instance<ManagedExecutor> managedExecutors) {
-    if (managedExecutors != null) {
-      managedExecutors.stream().findFirst().ifPresent(e -> blockingExecutor = e);
-    }
-  }
+  // The stream driver blocks while it gathers this fan-out. Keep its blocking metadata work off
+  // the application worker pool so concurrent drivers cannot starve the executor that runs them.
+  private final ExecutorService blockingExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
   private static void warnFlightHost(String flightHost, String quarkusProfile) {
     if (flightHost == null) {
@@ -298,8 +291,10 @@ public class UserObjectBundleService {
                   .iterable(() -> iterator)
                   .onFailure()
                   .invoke(ignored -> iterator.publishStreamTelemetry("failed"))
+                  .onCancellation()
+                  .invoke(iterator::cancel)
                   .onTermination()
-                  .invoke(iterator::cancel);
+                  .invoke(() -> iterator.publishStreamTelemetry("terminated"));
             });
   }
 
@@ -1756,14 +1751,23 @@ public class UserObjectBundleService {
       while (!resolvedSpillover.isEmpty() && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
         gather(resolvedSpillover.removeFirst(), toPin);
       }
-      // Then newly requested inputs, up to this chunk's remaining capacity. Selecting is separated
-      // from gathering so the select step can later run in parallel; today it is a serial loop.
+      // Then newly requested inputs, up to this chunk's remaining capacity. Selection failures are
+      // kept as ordered outcomes: if a view ahead fills this chunk, a later failure waits in
+      // spillover and is not allowed to suppress the view and its eager base tables.
       int budget = MAX_RESOLUTIONS_PER_CHUNK - pending.size();
       if (budget > 0 && nextInputIndex < resolutionCount) {
         int planCount = Math.min(budget, resolutionCount - nextInputIndex);
         List<PlannedInput> plan = new ArrayList<>(planCount);
         for (int i = 0; i < planCount; i++) {
-          plan.add(planInput(nextInputIndex + i));
+          int inputIndex = nextInputIndex + i;
+          try {
+            throwIfCancelled(this::isCancelled);
+            plan.add(planInput(inputIndex));
+          } catch (CancellationException e) {
+            throw e;
+          } catch (RuntimeException e) {
+            plan.add(PlannedInput.failed(inputIndex, e));
+          }
         }
         nextInputIndex += planCount;
         // Resolve the planned inputs concurrently; results come back in plan order so the gather
@@ -1771,7 +1775,11 @@ public class UserObjectBundleService {
         long selectStageStartNs = System.nanoTime();
         List<PendingItem> selected =
             BoundedFanout.mapOrdered(
-                plan, MAX_PARALLEL_RELATION_TASKS, blockingExecutor, this::selectOne);
+                plan,
+                MAX_PARALLEL_RELATION_TASKS,
+                blockingExecutor,
+                this::selectOne,
+                this::isCancelled);
         resolveNanos += System.nanoTime() - selectStageStartNs;
         for (PendingItem item : selected) {
           // A view gathered earlier in this loop can fill the chunk via its base tables; the
@@ -1823,6 +1831,9 @@ public class UserObjectBundleService {
      * neither found nor not-found, matching the end-chunk contract.
      */
     private void gather(PendingItem item, List<ResolvedRelation> toPin) {
+      if (item instanceof PendingFailure failure) {
+        throw failure.failure();
+      }
       pending.add(item);
       if (item instanceof PendingFound found) {
         foundCount++;
@@ -1898,7 +1909,18 @@ public class UserObjectBundleService {
 
     /** A requested input paired with its normalized candidates, ready to select against. */
     private record PlannedInput(
-        int inputIndex, TableReferenceCandidate candidate, List<QueryInput> normalized) {}
+        int inputIndex,
+        TableReferenceCandidate candidate,
+        List<QueryInput> normalized,
+        RuntimeException planningFailure) {
+      static PlannedInput failed(int inputIndex, RuntimeException failure) {
+        return new PlannedInput(inputIndex, null, List.of(), failure);
+      }
+
+      boolean failed() {
+        return planningFailure != null;
+      }
+    }
 
     /**
      * Resolve every NAME candidate of the plan in one batch, seeding the name memo. Names sharing a
@@ -1940,7 +1962,7 @@ public class UserObjectBundleService {
       try {
         List<QueryInput> normalized =
             normalizeCandidates(correlationId, candidate, this::defaultCatalogName);
-        return new PlannedInput(inputIndex, candidate, normalized);
+        return new PlannedInput(inputIndex, candidate, normalized, null);
       } finally {
         normalizeNanos += System.nanoTime() - normalizeStartNs;
       }
@@ -1952,7 +1974,11 @@ public class UserObjectBundleService {
      */
     private PendingItem selectOne(PlannedInput planned) {
       int inputIndex = planned.inputIndex();
+      if (planned.failed()) {
+        return new PendingFailure(inputIndex, planned.planningFailure());
+      }
       try {
+        throwIfCancelled(this::isCancelled);
         long selectStartNs = System.nanoTime();
         Optional<ResolvedRelation> resolved;
         try {
@@ -1974,6 +2000,8 @@ public class UserObjectBundleService {
           }
           return new PendingFound(inputIndex, resolved.get());
         }
+      } catch (CancellationException e) {
+        throw e;
       } catch (GraphNodeMissingException e) {
         if (LOG.isDebugEnabled()) {
           LOG.debugf(
@@ -1994,6 +2022,8 @@ public class UserObjectBundleService {
                 .setStatus(ResolutionStatus.RESOLUTION_STATUS_ERROR)
                 .setFailure(failure)
                 .build());
+      } catch (RuntimeException e) {
+        return new PendingFailure(inputIndex, e);
       }
       if (LOG.isTraceEnabled()) {
         LOG.tracef(
@@ -2379,6 +2409,26 @@ public class UserObjectBundleService {
      */
     private interface PendingItem {
       int inputIndex();
+    }
+
+    /** A planning or selection exception deferred until its request-order position is emitted. */
+    private static final class PendingFailure implements PendingItem {
+      private final int inputIndex;
+      private final RuntimeException failure;
+
+      private PendingFailure(int inputIndex, RuntimeException failure) {
+        this.inputIndex = inputIndex;
+        this.failure = failure;
+      }
+
+      @Override
+      public int inputIndex() {
+        return inputIndex;
+      }
+
+      RuntimeException failure() {
+        return failure;
+      }
     }
 
     private static final class PendingResolved implements PendingItem {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -58,6 +58,7 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.scanner.spi.MetadataResolutionContext;
 import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.context.EngineContextProvider;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.PinValidator;
@@ -81,6 +82,7 @@ import ai.floedb.floecat.types.LogicalTypeFormat;
 import io.opentelemetry.api.trace.Span;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -100,12 +102,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -143,6 +147,21 @@ public class UserObjectBundleService {
   private final FlightEndpointRef floecatFlightEndpoint;
 
   @Inject Observability observability;
+
+  // Caps how many of a chunk's relations resolve concurrently. Each is an independent, mostly
+  // store-bound resolution; a small fan-out overlaps their round-trips without flooding the store.
+  private static final int MAX_PARALLEL_RELATION_TASKS = 8;
+
+  // Runs per-relation resolution off the request thread. The Quarkus ManagedExecutor is injected in
+  // init(); tests (and any wiring without one) fall back to the common pool.
+  private volatile Executor blockingExecutor = ForkJoinPool.commonPool();
+
+  @Inject
+  void init(Instance<ManagedExecutor> managedExecutors) {
+    if (managedExecutors != null) {
+      managedExecutors.stream().findFirst().ifPresent(e -> blockingExecutor = e);
+    }
+  }
 
   private static void warnFlightHost(String flightHost, String quarkusProfile) {
     if (flightHost == null) {
@@ -1635,22 +1654,26 @@ public class UserObjectBundleService {
     private final AtomicBoolean cancelled = new AtomicBoolean(false);
     private boolean defaultCatalogResolved = false;
     private String defaultCatalogName = "";
+    // Driver-thread wall-clock of the resolve stage (the parallel select fan-out), not a per-input
+    // sum — under concurrency the sum would exceed the elapsed time and mislead.
     private long resolveNanos = 0L;
     private long normalizeNanos = 0L;
-    private long selectRelationNanos = 0L;
     private long defaultCatalogNanos = 0L;
-    private long nameResolveNanos = 0L;
-    private long nodeResolveNanos = 0L;
     private long baseInjectNanos = 0L;
     private long pinCollectNanos = 0L;
     private long pinCommitNanos = 0L;
     private long relationBuildNanos = 0L;
     private long decorationNanos = 0L;
     private long defaultCatalogLookups = 0L;
-    private long nameResolutionCacheHits = 0L;
-    private long nameResolutionCacheMisses = 0L;
-    private long nodeResolutionCacheHits = 0L;
-    private long nodeResolutionCacheMisses = 0L;
+    // Written from the parallel select tasks: LongAdder so the totals stay correct without locking.
+    // These are aggregate sub-totals (total time/count across relations), not wall-clock.
+    private final LongAdder selectRelationNanos = new LongAdder();
+    private final LongAdder nameResolveNanos = new LongAdder();
+    private final LongAdder nodeResolveNanos = new LongAdder();
+    private final LongAdder nameResolutionCacheHits = new LongAdder();
+    private final LongAdder nameResolutionCacheMisses = new LongAdder();
+    private final LongAdder nodeResolutionCacheHits = new LongAdder();
+    private final LongAdder nodeResolutionCacheMisses = new LongAdder();
 
     UserObjectBundleIterator(
         String correlationId,
@@ -1741,10 +1764,13 @@ public class UserObjectBundleService {
         }
         nextInputIndex += planCount;
         seedNameResolutions(plan);
-        List<PendingItem> selected = new ArrayList<>(plan.size());
-        for (PlannedInput planned : plan) {
-          selected.add(selectOne(planned));
-        }
+        // Resolve the planned inputs concurrently; results come back in plan order so the gather
+        // below stays deterministic. resolveNanos is the wall-clock of this stage.
+        long selectStageStartNs = System.nanoTime();
+        List<PendingItem> selected =
+            BoundedFanout.mapOrdered(
+                plan, MAX_PARALLEL_RELATION_TASKS, blockingExecutor, this::selectOne);
+        resolveNanos += System.nanoTime() - selectStageStartNs;
         for (PendingItem item : selected) {
           // A view gathered earlier in this loop can fill the chunk via its base tables; the
           // remaining already-selected inputs wait for the next chunk (their nodes are cached).
@@ -1896,7 +1922,7 @@ public class UserObjectBundleService {
             .resolveNames(correlationId, refs)
             .forEach((ref, id) -> nameResolutionCache.putIfAbsent(normalizedNameRef(ref), id));
       } finally {
-        nameResolveNanos += System.nanoTime() - startNs;
+        nameResolveNanos.add(System.nanoTime() - startNs);
       }
     }
 
@@ -1924,64 +1950,68 @@ public class UserObjectBundleService {
      */
     private PendingItem selectOne(PlannedInput planned) {
       int inputIndex = planned.inputIndex();
-      long resolveStartNs = System.nanoTime();
       try {
+        long selectStartNs = System.nanoTime();
+        Optional<ResolvedRelation> resolved;
         try {
-          long selectStartNs = System.nanoTime();
-          Optional<ResolvedRelation> resolved =
-              selectResolvedRelationTimed(
-                  correlationId, planned.candidate(), planned.normalized(), selectStartNs);
-          if (resolved.isPresent()) {
-            if (LOG.isTraceEnabled()) {
-              LOG.tracef(
-                  "Resolved candidate query_id=%s input_index=%d relation=%s",
-                  ctx.getQueryId(), inputIndex, resolved.get().relationId());
-            }
-            return new PendingFound(inputIndex, resolved.get());
-          }
-        } catch (GraphNodeMissingException e) {
-          if (LOG.isDebugEnabled()) {
-            LOG.debugf(
-                "Resolved candidate missing graph node query_id=%s input_index=%d resource_id=%s",
-                ctx.getQueryId(), inputIndex, e.relationId() == null ? "" : e.relationId().getId());
-          }
-          ResolutionFailure failure =
-              ResolutionFailure.newBuilder()
-                  .setCode("catalog_bundle.graph.missing_node")
-                  .setMessage("relation resolved but missing from graph")
-                  .putDetails("resource_id", e.relationId().getId())
-                  .putDetails("default_catalog", defaultCatalogForDiagnostics())
-                  .addAllAttempted(planned.normalized())
-                  .build();
-          return new PendingResolved(
-              RelationResolution.newBuilder()
-                  .setInputIndex(inputIndex)
-                  .setStatus(ResolutionStatus.RESOLUTION_STATUS_ERROR)
-                  .setFailure(failure)
-                  .build());
+          resolved =
+              selectResolvedRelation(
+                  correlationId,
+                  planned.candidate(),
+                  planned.normalized(),
+                  this::resolveNameCached,
+                  this::resolveNodeCached);
+        } finally {
+          selectRelationNanos.add(System.nanoTime() - selectStartNs);
         }
-        if (LOG.isTraceEnabled()) {
-          LOG.tracef(
-              "Candidate not found query_id=%s input_index=%d attempted=%d",
-              ctx.getQueryId(), inputIndex, planned.normalized().size());
+        if (resolved.isPresent()) {
+          if (LOG.isTraceEnabled()) {
+            LOG.tracef(
+                "Resolved candidate query_id=%s input_index=%d relation=%s",
+                ctx.getQueryId(), inputIndex, resolved.get().relationId());
+          }
+          return new PendingFound(inputIndex, resolved.get());
+        }
+      } catch (GraphNodeMissingException e) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debugf(
+              "Resolved candidate missing graph node query_id=%s input_index=%d resource_id=%s",
+              ctx.getQueryId(), inputIndex, e.relationId() == null ? "" : e.relationId().getId());
         }
         ResolutionFailure failure =
             ResolutionFailure.newBuilder()
-                .setCode("catalog_bundle.relation_not_found")
-                .setMessage("relation not found")
-                .putDetails("candidate_count", Integer.toString(planned.normalized().size()))
+                .setCode("catalog_bundle.graph.missing_node")
+                .setMessage("relation resolved but missing from graph")
+                .putDetails("resource_id", e.relationId().getId())
                 .putDetails("default_catalog", defaultCatalogForDiagnostics())
                 .addAllAttempted(planned.normalized())
                 .build();
         return new PendingResolved(
             RelationResolution.newBuilder()
                 .setInputIndex(inputIndex)
-                .setStatus(ResolutionStatus.RESOLUTION_STATUS_NOT_FOUND)
+                .setStatus(ResolutionStatus.RESOLUTION_STATUS_ERROR)
                 .setFailure(failure)
                 .build());
-      } finally {
-        resolveNanos += System.nanoTime() - resolveStartNs;
       }
+      if (LOG.isTraceEnabled()) {
+        LOG.tracef(
+            "Candidate not found query_id=%s input_index=%d attempted=%d",
+            ctx.getQueryId(), inputIndex, planned.normalized().size());
+      }
+      ResolutionFailure failure =
+          ResolutionFailure.newBuilder()
+              .setCode("catalog_bundle.relation_not_found")
+              .setMessage("relation not found")
+              .putDetails("candidate_count", Integer.toString(planned.normalized().size()))
+              .putDetails("default_catalog", defaultCatalogForDiagnostics())
+              .addAllAttempted(planned.normalized())
+              .build();
+      return new PendingResolved(
+          RelationResolution.newBuilder()
+              .setInputIndex(inputIndex)
+              .setStatus(ResolutionStatus.RESOLUTION_STATUS_NOT_FOUND)
+              .setFailure(failure)
+              .build());
     }
 
     private UserObjectsBundleChunk flushResolutionChunk() {
@@ -2190,10 +2220,10 @@ public class UserObjectBundleService {
       diagnostics.put("total_ms", totalMs);
       diagnostics.nanos("resolve", resolveNanos);
       diagnostics.nanos("normalize", normalizeNanos);
-      diagnostics.nanos("select_relation", selectRelationNanos);
+      diagnostics.nanos("select_relation", selectRelationNanos.sum());
       diagnostics.nanos("default_catalog", defaultCatalogNanos);
-      diagnostics.nanos("name_resolve", nameResolveNanos);
-      diagnostics.nanos("node_resolve", nodeResolveNanos);
+      diagnostics.nanos("name_resolve", nameResolveNanos.sum());
+      diagnostics.nanos("node_resolve", nodeResolveNanos.sum());
       diagnostics.nanos("base_inject", baseInjectNanos);
       diagnostics.nanos("pin_collect", pinCollectNanos);
       diagnostics.nanos("pin_commit", pinCommitNanos);
@@ -2212,10 +2242,10 @@ public class UserObjectBundleService {
           "hint_persist",
           timings.decoratePersistRelationNanos() + timings.decoratePersistColumnsNanos());
       diagnostics.put("default_catalog_lookups", defaultCatalogLookups);
-      diagnostics.put("name_cache_hits", nameResolutionCacheHits);
-      diagnostics.put("name_cache_misses", nameResolutionCacheMisses);
-      diagnostics.put("node_cache_hits", nodeResolutionCacheHits);
-      diagnostics.put("node_cache_misses", nodeResolutionCacheMisses);
+      diagnostics.put("name_cache_hits", nameResolutionCacheHits.sum());
+      diagnostics.put("name_cache_misses", nameResolutionCacheMisses.sum());
+      diagnostics.put("node_cache_hits", nodeResolutionCacheHits.sum());
+      diagnostics.put("node_cache_misses", nodeResolutionCacheMisses.sum());
       diagnostics.put("name_cache_entries", nameResolutionCache.size());
       diagnostics.put("node_cache_entries", nodeResolutionCache.size());
       diagnostics.put("relation_cache_entries", relationInfoCache.size());
@@ -2270,11 +2300,11 @@ public class UserObjectBundleService {
               nameResolutionCache,
               normalizedNameRef(ref),
               () -> overlay.resolveName(correlationId, ref, resolutionContext.engineContext()),
-              nanos -> nameResolveNanos += nanos);
+              nameResolveNanos::add);
       if (m.resolved()) {
-        nameResolutionCacheMisses++;
+        nameResolutionCacheMisses.increment();
       } else {
-        nameResolutionCacheHits++;
+        nameResolutionCacheHits.increment();
       }
       return m.value();
     }
@@ -2285,11 +2315,11 @@ public class UserObjectBundleService {
               nodeResolutionCache,
               id,
               () -> overlay.resolve(id, resolutionContext.engineContext()),
-              nanos -> nodeResolveNanos += nanos);
+              nodeResolveNanos::add);
       if (m.resolved()) {
-        nodeResolutionCacheMisses++;
+        nodeResolutionCacheMisses.increment();
       } else {
-        nodeResolutionCacheHits++;
+        nodeResolutionCacheHits.increment();
       }
       return m.value();
     }
@@ -2321,19 +2351,6 @@ public class UserObjectBundleService {
                 }
               });
       return new Memoized<>(value, resolvedHere[0]);
-    }
-
-    private Optional<ResolvedRelation> selectResolvedRelationTimed(
-        String correlationId,
-        TableReferenceCandidate candidate,
-        List<QueryInput> normalized,
-        long selectStartNs) {
-      try {
-        return selectResolvedRelation(
-            correlationId, candidate, normalized, this::resolveNameCached, this::resolveNodeCached);
-      } finally {
-        selectRelationNanos += System.nanoTime() - selectStartNs;
-      }
     }
 
     private NormalizedNameRef normalizedNameRef(NameRef ref) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1770,25 +1770,29 @@ public class UserObjectBundleService {
           }
         }
         nextInputIndex += planCount;
-        // Resolve the planned inputs concurrently; results come back in plan order so the gather
-        // below stays deterministic. resolveNanos is the wall-clock of this stage.
+        // Resolve and consume planned inputs concurrently in request order. Consuming each result
+        // as it is joined gives an earlier deferred failure precedence over a later task failure,
+        // while still letting an eager view fill this chunk and spill later requested inputs.
         long selectStageStartNs = System.nanoTime();
-        List<PendingItem> selected =
-            BoundedFanout.mapOrdered(
-                plan,
-                MAX_PARALLEL_RELATION_TASKS,
-                blockingExecutor,
-                this::selectOne,
-                this::isCancelled);
-        resolveNanos += System.nanoTime() - selectStageStartNs;
-        for (PendingItem item : selected) {
-          // A view gathered earlier in this loop can fill the chunk via its base tables; the
-          // remaining already-selected inputs wait for the next chunk (their nodes are cached).
-          if (pending.size() >= MAX_RESOLUTIONS_PER_CHUNK) {
-            resolvedSpillover.addLast(item);
-          } else {
-            gather(item, toPin);
-          }
+        try {
+          BoundedFanout.forEachOrdered(
+              plan,
+              MAX_PARALLEL_RELATION_TASKS,
+              blockingExecutor,
+              this::selectOne,
+              item -> {
+                // A view gathered earlier in this loop can fill the chunk via its base tables;
+                // the remaining already-selected inputs wait for the next chunk (their nodes are
+                // cached).
+                if (pending.size() >= MAX_RESOLUTIONS_PER_CHUNK) {
+                  resolvedSpillover.addLast(item);
+                } else {
+                  gather(item, toPin);
+                }
+              },
+              this::isCancelled);
+        } finally {
+          resolveNanos += System.nanoTime() - selectStageStartNs;
         }
       }
       if (!toPin.isEmpty()) {
@@ -1919,34 +1923,6 @@ public class UserObjectBundleService {
 
       boolean failed() {
         return planningFailure != null;
-      }
-    }
-
-    /**
-     * Resolve every NAME candidate of the plan in one batch, seeding the name memo. Names sharing a
-     * catalog/namespace resolve their scope once here instead of once per candidate during select,
-     * and the memo turns each candidate's later resolveNameCached into a hit. Already-cached names
-     * (e.g. from a prior chunk's base-table drain) are left as they are.
-     */
-    private void seedNameResolutions(List<PlannedInput> plan) {
-      List<NameRef> refs = new ArrayList<>();
-      for (PlannedInput planned : plan) {
-        for (QueryInput candidate : planned.normalized()) {
-          if (candidate.getTargetCase() == QueryInput.TargetCase.NAME) {
-            refs.add(candidate.getName());
-          }
-        }
-      }
-      if (refs.isEmpty()) {
-        return;
-      }
-      long startNs = System.nanoTime();
-      try {
-        overlay
-            .resolveNames(correlationId, refs)
-            .forEach((ref, id) -> nameResolutionCache.putIfAbsent(normalizedNameRef(ref), id));
-      } finally {
-        nameResolveNanos.add(System.nanoTime() - startNs);
       }
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -94,7 +94,9 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -348,7 +350,7 @@ public class UserObjectBundleService {
       String correlationId,
       QueryContext ctx,
       List<ResolvedRelation> relations,
-      Map<ResourceId, TablePin> currentSnapshotPinCache,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
     if (relations == null || relations.isEmpty()) {
       return RelationPinSet.getDefaultInstance();
@@ -1592,7 +1594,8 @@ public class UserObjectBundleService {
     private final ArrayDeque<EagerBaseCursor> eagerBaseQueue = new ArrayDeque<>();
     private final Set<String> eagerBaseSeen = new HashSet<>();
     private final Map<RelationCacheKey, RelationInfo> relationInfoCache = new HashMap<>();
-    private final Map<ResourceId, TablePin> currentSnapshotPinCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache =
+        new ConcurrentHashMap<>();
     private final TimingAccumulator timings = new TimingAccumulator();
     private final PhaseDiagnostics diagnostics = diagnostics("get_user_objects");
     private final long streamStartNs = System.nanoTime();

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -94,6 +94,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -1591,7 +1592,7 @@ public class UserObjectBundleService {
     private final ArrayDeque<EagerBaseCursor> eagerBaseQueue = new ArrayDeque<>();
     private final Set<String> eagerBaseSeen = new HashSet<>();
     private final Map<RelationCacheKey, RelationInfo> relationInfoCache = new HashMap<>();
-    private final Map<ResourceId, TablePin> currentSnapshotPinCache = new HashMap<>();
+    private final Map<ResourceId, TablePin> currentSnapshotPinCache = new ConcurrentHashMap<>();
     private final TimingAccumulator timings = new TimingAccumulator();
     private final PhaseDiagnostics diagnostics = diagnostics("get_user_objects");
     private final long streamStartNs = System.nanoTime();

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1611,6 +1611,10 @@ public class UserObjectBundleService {
         new ConcurrentHashMap<>();
     private final ArrayDeque<EagerBaseCursor> eagerBaseQueue = new ArrayDeque<>();
     private final Set<String> eagerBaseSeen = new HashSet<>();
+    // Requested inputs selected for a chunk that filled before they could be emitted (a view ahead
+    // of them expanded into enough base tables to reach the cap). Emitted, in order, ahead of newly
+    // selected inputs in the next chunk — so a resolution's position never depends on chunk size.
+    private final ArrayDeque<PendingItem> resolvedSpillover = new ArrayDeque<>();
     private final Map<RelationCacheKey, RelationInfo> relationInfoCache = new HashMap<>();
     private final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache =
         new ConcurrentHashMap<>();
@@ -1720,15 +1724,33 @@ public class UserObjectBundleService {
 
     private void fillPending() {
       List<ResolvedRelation> toPin = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
+      // Carry-over first, in emit order: a prior view's undrained base tables, then requested
+      // inputs a prior chunk selected but could not fit.
       drainEagerBaseTables(toPin);
-      while (nextInputIndex < resolutionCount && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
-        PendingItem item = resolveNextResolution();
-        pending.add(item);
-        if (item instanceof PendingFound found) {
-          toPin.add(found.relation());
-          if (found.relation().node() instanceof ViewNode view && !view.baseRelations().isEmpty()) {
-            eagerBaseQueue.addLast(new EagerBaseCursor(view));
-            drainEagerBaseTables(toPin);
+      while (!resolvedSpillover.isEmpty() && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
+        gather(resolvedSpillover.removeFirst(), toPin);
+      }
+      // Then newly requested inputs, up to this chunk's remaining capacity. Selecting is separated
+      // from gathering so the select step can later run in parallel; today it is a serial loop.
+      int budget = MAX_RESOLUTIONS_PER_CHUNK - pending.size();
+      if (budget > 0 && nextInputIndex < resolutionCount) {
+        int planCount = Math.min(budget, resolutionCount - nextInputIndex);
+        List<PlannedInput> plan = new ArrayList<>(planCount);
+        for (int i = 0; i < planCount; i++) {
+          plan.add(planInput(nextInputIndex + i));
+        }
+        nextInputIndex += planCount;
+        List<PendingItem> selected = new ArrayList<>(plan.size());
+        for (PlannedInput planned : plan) {
+          selected.add(selectOne(planned));
+        }
+        for (PendingItem item : selected) {
+          // A view gathered earlier in this loop can fill the chunk via its base tables; the
+          // remaining already-selected inputs wait for the next chunk (their nodes are cached).
+          if (pending.size() >= MAX_RESOLUTIONS_PER_CHUNK) {
+            resolvedSpillover.addLast(item);
+          } else {
+            gather(item, toPin);
           }
         }
       }
@@ -1763,6 +1785,27 @@ public class UserObjectBundleService {
     private void cancel() {
       cancelled.set(true);
       publishStreamTelemetry("cancelled");
+    }
+
+    /**
+     * Append one selected resolution to the chunk on the driver thread: tally its found/not-found
+     * count, queue a FOUND table for pinning, and — for a FOUND view — drain its base tables right
+     * after it so bases follow their view in the emitted order. ERROR resolutions count toward
+     * neither found nor not-found, matching the end-chunk contract.
+     */
+    private void gather(PendingItem item, List<ResolvedRelation> toPin) {
+      pending.add(item);
+      if (item instanceof PendingFound found) {
+        foundCount++;
+        toPin.add(found.relation());
+        if (found.relation().node() instanceof ViewNode view && !view.baseRelations().isEmpty()) {
+          eagerBaseQueue.addLast(new EagerBaseCursor(view));
+          drainEagerBaseTables(toPin);
+        }
+      } else if (item instanceof PendingResolved resolved
+          && resolved.resolution().getStatus() == ResolutionStatus.RESOLUTION_STATUS_NOT_FOUND) {
+        notFoundCount++;
+      }
     }
 
     /**
@@ -1824,30 +1867,42 @@ public class UserObjectBundleService {
       return cursor.nextBaseIndex >= baseRelations.size();
     }
 
-    private PendingItem resolveNextResolution() {
+    /** A requested input paired with its normalized candidates, ready to select against. */
+    private record PlannedInput(
+        int inputIndex, TableReferenceCandidate candidate, List<QueryInput> normalized) {}
+
+    /** Normalize one requested input's candidates. Pure with respect to resolution state. */
+    private PlannedInput planInput(int inputIndex) {
+      TableReferenceCandidate candidate = tables.get(inputIndex);
+      if (LOG.isTraceEnabled()) {
+        LOG.tracef(
+            "Planning candidate query_id=%s input_index=%d candidate_count=%d",
+            ctx.getQueryId(), inputIndex, candidate.getCandidatesCount());
+      }
+      long normalizeStartNs = System.nanoTime();
+      try {
+        List<QueryInput> normalized =
+            normalizeCandidates(correlationId, candidate, this::defaultCatalogName);
+        return new PlannedInput(inputIndex, candidate, normalized);
+      } finally {
+        normalizeNanos += System.nanoTime() - normalizeStartNs;
+      }
+    }
+
+    /**
+     * Resolve one planned input to a {@link PendingItem} (FOUND, NOT_FOUND, or ERROR), without
+     * touching found/not-found counters or chunk order — the driver's {@link #gather} owns those.
+     */
+    private PendingItem selectOne(PlannedInput planned) {
+      int inputIndex = planned.inputIndex();
       long resolveStartNs = System.nanoTime();
       try {
-        TableReferenceCandidate candidate = tables.get(nextInputIndex);
-        int inputIndex = nextInputIndex;
-        nextInputIndex++;
-        if (LOG.isTraceEnabled()) {
-          LOG.tracef(
-              "Resolving candidate query_id=%s input_index=%d candidate_count=%d",
-              ctx.getQueryId(), inputIndex, candidate.getCandidatesCount());
-        }
-        List<QueryInput> normalized;
-        long normalizeStartNs = System.nanoTime();
-        try {
-          normalized = normalizeCandidates(correlationId, candidate, this::defaultCatalogName);
-        } finally {
-          normalizeNanos += System.nanoTime() - normalizeStartNs;
-        }
         try {
           long selectStartNs = System.nanoTime();
           Optional<ResolvedRelation> resolved =
-              selectResolvedRelationTimed(correlationId, candidate, normalized, selectStartNs);
+              selectResolvedRelationTimed(
+                  correlationId, planned.candidate(), planned.normalized(), selectStartNs);
           if (resolved.isPresent()) {
-            foundCount++;
             if (LOG.isTraceEnabled()) {
               LOG.tracef(
                   "Resolved candidate query_id=%s input_index=%d relation=%s",
@@ -1867,7 +1922,7 @@ public class UserObjectBundleService {
                   .setMessage("relation resolved but missing from graph")
                   .putDetails("resource_id", e.relationId().getId())
                   .putDetails("default_catalog", defaultCatalogForDiagnostics())
-                  .addAllAttempted(normalized)
+                  .addAllAttempted(planned.normalized())
                   .build();
           return new PendingResolved(
               RelationResolution.newBuilder()
@@ -1876,19 +1931,18 @@ public class UserObjectBundleService {
                   .setFailure(failure)
                   .build());
         }
-        notFoundCount++;
         if (LOG.isTraceEnabled()) {
           LOG.tracef(
               "Candidate not found query_id=%s input_index=%d attempted=%d",
-              ctx.getQueryId(), inputIndex, normalized.size());
+              ctx.getQueryId(), inputIndex, planned.normalized().size());
         }
         ResolutionFailure failure =
             ResolutionFailure.newBuilder()
                 .setCode("catalog_bundle.relation_not_found")
                 .setMessage("relation not found")
-                .putDetails("candidate_count", Integer.toString(normalized.size()))
+                .putDetails("candidate_count", Integer.toString(planned.normalized().size()))
                 .putDetails("default_catalog", defaultCatalogForDiagnostics())
-                .addAllAttempted(normalized)
+                .addAllAttempted(planned.normalized())
                 .build();
         return new PendingResolved(
             RelationResolution.newBuilder()

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -1740,6 +1740,7 @@ public class UserObjectBundleService {
           plan.add(planInput(nextInputIndex + i));
         }
         nextInputIndex += planCount;
+        seedNameResolutions(plan);
         List<PendingItem> selected = new ArrayList<>(plan.size());
         for (PlannedInput planned : plan) {
           selected.add(selectOne(planned));
@@ -1870,6 +1871,34 @@ public class UserObjectBundleService {
     /** A requested input paired with its normalized candidates, ready to select against. */
     private record PlannedInput(
         int inputIndex, TableReferenceCandidate candidate, List<QueryInput> normalized) {}
+
+    /**
+     * Resolve every NAME candidate of the plan in one batch, seeding the name memo. Names sharing a
+     * catalog/namespace resolve their scope once here instead of once per candidate during select,
+     * and the memo turns each candidate's later resolveNameCached into a hit. Already-cached names
+     * (e.g. from a prior chunk's base-table drain) are left as they are.
+     */
+    private void seedNameResolutions(List<PlannedInput> plan) {
+      List<NameRef> refs = new ArrayList<>();
+      for (PlannedInput planned : plan) {
+        for (QueryInput candidate : planned.normalized()) {
+          if (candidate.getTargetCase() == QueryInput.TargetCase.NAME) {
+            refs.add(candidate.getName());
+          }
+        }
+      }
+      if (refs.isEmpty()) {
+        return;
+      }
+      long startNs = System.nanoTime();
+      try {
+        overlay
+            .resolveNames(correlationId, refs)
+            .forEach((ref, id) -> nameResolutionCache.putIfAbsent(normalizedNameRef(ref), id));
+      } finally {
+        nameResolveNanos += System.nanoTime() - startNs;
+      }
+    }
 
     /** Normalize one requested input's candidates. Pure with respect to resolution state. */
     private PlannedInput planInput(int inputIndex) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -94,10 +94,12 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.Config;
@@ -110,6 +112,13 @@ public class UserObjectBundleService {
 
   private static final int MAX_RESOLUTIONS_PER_CHUNK = 25;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
+
+  private static void throwIfCancelled(BooleanSupplier cancelled) {
+    if (cancelled.getAsBoolean()) {
+      throw new CancellationException("GetUserObjects stream cancelled");
+    }
+  }
+
   private static final Set<String> LOCAL_FLIGHT_HOSTS = Set.of("localhost", "127.0.0.1", "0.0.0.0");
   private static final String SYSTEM_FLIGHT_ENDPOINTS_PREFIX = "floedb.system-flight.endpoints.";
   private static final String RELATION_HINT_PERSIST_NANOS_KEY =
@@ -270,7 +279,7 @@ public class UserObjectBundleService {
                   .onFailure()
                   .invoke(ignored -> iterator.publishStreamTelemetry("failed"))
                   .onTermination()
-                  .invoke(() -> iterator.publishStreamTelemetry("cancelled"));
+                  .invoke(iterator::cancel);
             });
   }
 
@@ -351,7 +360,9 @@ public class UserObjectBundleService {
       QueryContext ctx,
       List<ResolvedRelation> relations,
       ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-      PhaseDiagnostics diagnostics) {
+      PhaseDiagnostics diagnostics,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
     if (relations == null || relations.isEmpty()) {
       return RelationPinSet.getDefaultInstance();
     }
@@ -381,8 +392,10 @@ public class UserObjectBundleService {
             asOfDefault,
             Optional.of(ctx.getQueryDefaultCatalogId()),
             currentSnapshotPinCache,
-            diagnostics);
+            diagnostics,
+            cancelled);
     diagnostics.nanos("pin.resolver", System.nanoTime() - resolverStartNs);
+    throwIfCancelled(cancelled);
     RelationPinSet incoming = resolution.relationPinSet();
     RelationPinSet pins = incoming == null ? RelationPinSet.getDefaultInstance() : incoming;
     diagnostics.add("pin.output_pins", pins.getPinsCount());
@@ -1610,6 +1623,7 @@ public class UserObjectBundleService {
     private boolean headerEmitted = false;
     private boolean endEmitted = false;
     private final AtomicBoolean telemetryPublished = new AtomicBoolean(false);
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
     private boolean defaultCatalogResolved = false;
     private String defaultCatalogName = "";
     private long resolveNanos = 0L;
@@ -1666,6 +1680,7 @@ public class UserObjectBundleService {
 
     @Override
     public UserObjectsBundleChunk next() {
+      throwIfCancelled(this::isCancelled);
       if (!headerEmitted) {
         headerEmitted = true;
         if (LOG.isDebugEnabled()) {
@@ -1714,7 +1729,14 @@ public class UserObjectBundleService {
         long pinStartNs = System.nanoTime();
         try {
           RelationPinSet chunkPins =
-              collectChunkPins(correlationId, ctx, toPin, currentSnapshotPinCache, diagnostics);
+              collectChunkPins(
+                  correlationId,
+                  ctx,
+                  toPin,
+                  currentSnapshotPinCache,
+                  diagnostics,
+                  this::isCancelled);
+          throwIfCancelled(this::isCancelled);
           long accumulateStartNs = System.nanoTime();
           try {
             accumulateChunkPins(chunkPins);
@@ -1725,6 +1747,15 @@ public class UserObjectBundleService {
           pinCollectNanos += System.nanoTime() - pinStartNs;
         }
       }
+    }
+
+    private boolean isCancelled() {
+      return cancelled.get();
+    }
+
+    private void cancel() {
+      cancelled.set(true);
+      publishStreamTelemetry("cancelled");
     }
 
     /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
@@ -32,9 +32,9 @@ import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class QueryInputMetadataAssembler {
@@ -81,7 +81,7 @@ public class QueryInputMetadataAssembler {
                       inputs,
                       asOfDefault,
                       Optional.of(defaultCatalogId),
-                      new LinkedHashMap<>(),
+                      new ConcurrentHashMap<>(),
                       diagnostics));
       diagnostics.put("resolved_inputs", resolution.resolved().size());
       RelationPinSet relationPinSet = resolution.relationPinSet();

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.query.rpc.ExpansionMap;
 import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TableObligations;
+import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.resolver.ObligationsResolver;
 import ai.floedb.floecat.service.query.resolver.QueryInputResolver;
@@ -34,6 +35,7 @@ import jakarta.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
@@ -81,7 +83,7 @@ public class QueryInputMetadataAssembler {
                       inputs,
                       asOfDefault,
                       Optional.of(defaultCatalogId),
-                      new ConcurrentHashMap<>(),
+                      new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                       diagnostics));
       diagnostics.put("resolved_inputs", resolution.resolved().size());
       RelationPinSet relationPinSet = resolution.relationPinSet();

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.jboss.logging.Logger;
 
 /**
@@ -118,7 +119,8 @@ public class QuerySchemaServiceImpl extends BaseServiceImpl implements QuerySche
                                     request.getInputsList(),
                                     asOfDefault,
                                     Optional.of(ctx.getQueryDefaultCatalogId()),
-                                    new java.util.concurrent.ConcurrentHashMap<>(),
+                                    new java.util.concurrent.ConcurrentHashMap<
+                                        ResourceId, CompletableFuture<TablePin>>(),
                                     diagnostics));
                     diagnostics.put("resolved_inputs", rr.resolved().size());
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
@@ -118,7 +118,7 @@ public class QuerySchemaServiceImpl extends BaseServiceImpl implements QuerySche
                                     request.getInputsList(),
                                     asOfDefault,
                                     Optional.of(ctx.getQueryDefaultCatalogId()),
-                                    new java.util.LinkedHashMap<>(),
+                                    new java.util.concurrent.ConcurrentHashMap<>(),
                                     diagnostics));
                     diagnostics.put("resolved_inputs", rr.resolved().size());
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -430,14 +430,17 @@ public class QueryInputResolver {
       Map<NameRef, Optional<ResourceId>> resolvedNames) {
     AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
     ResolutionState taskState = state.withDiagnostics(taskDiagnostics);
-    List<InputPlan> plans =
-        BoundedFanout.mapOrdered(
-            inputs,
-            maxParallelInputResolutions,
-            blockingExecutor,
-            in -> planInput(taskState, in, resolvedNames));
-    taskDiagnostics.flushInto(state.diagnostics);
-    return plans;
+    try {
+      return BoundedFanout.mapOrdered(
+          inputs,
+          maxParallelInputResolutions,
+          blockingExecutor,
+          in -> planInput(taskState, in, resolvedNames));
+    } finally {
+      // A failed or cancelled sibling can still leave completed tasks' pin work in this
+      // accumulator. Preserve those counters for the request's failure telemetry too.
+      taskDiagnostics.flushInto(state.diagnostics);
+    }
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -222,38 +222,24 @@ public class QueryInputResolver {
     Map<NameRef, Optional<ResourceId>> resolvedNames =
         nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
 
+    // Resolve each input to its id and the table pins it contributes (a table yields its own pin; a
+    // view yields its base tables' pins). planInput reads the metadata graph and the shared
+    // current-snapshot cache; it does not touch `resolved` or `pinByTableId`.
+    List<InputPlan> plans = new ArrayList<>(inputs.size());
     for (QueryInput in : inputs) {
-      diag.count("pin.resolver_inputs");
-      SnapshotRef override = in.getSnapshot();
+      plans.add(planInput(state, in, resolvedNames));
+    }
 
-      switch (in.getTargetCase()) {
-        case NAME -> {
-          diag.count("pin.name_inputs");
-          long nameResolveStartNs = System.nanoTime();
-          ResourceId rid =
-              resolvedNames
-                  .getOrDefault(in.getName(), Optional.empty())
-                  .orElseThrow(
-                      () ->
-                          GrpcErrors.notFound(
-                              correlationId,
-                              QUERY_INPUT_UNRESOLVED,
-                              Map.of("name", in.getName().toString())));
-          diag.nanos("pin.input_name_resolve", System.nanoTime() - nameResolveStartNs);
-          addResolvedAndPins(state, rid, override);
-        }
-
-        case TABLE_ID -> {
-          diag.count("pin.table_id_inputs");
-          addResolvedAndPins(state, in.getTableId(), override);
-        }
-
-        case VIEW_ID -> {
-          diag.count("pin.view_id_inputs");
-          addResolvedAndPins(state, in.getViewId(), override);
-        }
-
-        default -> throw GrpcErrors.invalidArgument(correlationId, QUERY_INPUT_INVALID, Map.of());
+    // Merge the plans into the pin set in input order. Order decides two things: `resolved` mirrors
+    // the request order, and mergePin keeps the first pin seen for a table (rooting its blobs)
+    // while
+    // raising QUERY_TABLE_PIN_CONFLICT when a later reference pins the same table with an
+    // incompatible snapshot/as-of. Every kept pin is GC-rooted here, before resolveInputs returns
+    // and therefore before the caller reads any schema/stats or persists the context.
+    for (InputPlan plan : plans) {
+      state.resolved.add(plan.resolvedId());
+      for (TablePin pin : plan.pins()) {
+        mergePin(state.pinByTableId, pin, state.queryId, state.correlationId);
       }
     }
 
@@ -270,22 +256,66 @@ public class QueryInputResolver {
   // Pin resolution
   // =============================================================================
 
-  private void addResolvedAndPins(ResolutionState state, ResourceId rid, SnapshotRef override) {
-    state.resolved.add(rid);
+  /**
+   * One input's resolution: the id recorded in {@code resolved}, and the table pins it contributes,
+   * ordered. A view's id is recorded but the pins are its base tables'; a table records its id and
+   * its own single pin.
+   */
+  private record InputPlan(ResourceId resolvedId, List<TablePin> pins) {}
 
+  /**
+   * Resolve one input to its {@link InputPlan}, reading the metadata graph and the shared
+   * current-snapshot cache. Does not read or write {@code state.resolved} or {@code
+   * state.pinByTableId}; the caller merges the returned pins.
+   */
+  private InputPlan planInput(
+      ResolutionState state, QueryInput in, Map<NameRef, Optional<ResourceId>> resolvedNames) {
+    state.diagnostics.count("pin.resolver_inputs");
+    SnapshotRef override = in.getSnapshot();
+    ResourceId rid =
+        switch (in.getTargetCase()) {
+          case NAME -> {
+            state.diagnostics.count("pin.name_inputs");
+            long nameResolveStartNs = System.nanoTime();
+            ResourceId resolved =
+                resolvedNames
+                    .getOrDefault(in.getName(), Optional.empty())
+                    .orElseThrow(
+                        () ->
+                            GrpcErrors.notFound(
+                                state.correlationId,
+                                QUERY_INPUT_UNRESOLVED,
+                                Map.of("name", in.getName().toString())));
+            state.diagnostics.nanos(
+                "pin.input_name_resolve", System.nanoTime() - nameResolveStartNs);
+            yield resolved;
+          }
+          case TABLE_ID -> {
+            state.diagnostics.count("pin.table_id_inputs");
+            yield in.getTableId();
+          }
+          case VIEW_ID -> {
+            state.diagnostics.count("pin.view_id_inputs");
+            yield in.getViewId();
+          }
+          default ->
+              throw GrpcErrors.invalidArgument(state.correlationId, QUERY_INPUT_INVALID, Map.of());
+        };
+
+    List<TablePin> pins = new ArrayList<>();
     if (rid.getKind() == ResourceKind.RK_VIEW) {
       // Views are not pinned directly. We only pin their base tables.
       // Reject snapshot_id overrides for views; allow AS-OF and apply it to dependency pins.
       validateViewOverride(state.correlationId, rid, override);
-      collectBaseTables(state, rid, effectiveAsOf(override, state.asOfDefault), new HashSet<>());
-      return;
+      collectBaseTablePins(
+          state, rid, effectiveAsOf(override, state.asOfDefault), new HashSet<>(), pins);
+    } else {
+      TablePin pin = pinForResource(state, rid, override, state.asOfDefault);
+      if (pin != null) {
+        pins.add(pin);
+      }
     }
-
-    mergePin(
-        state.pinByTableId,
-        pinForResource(state, rid, override, state.asOfDefault),
-        state.queryId,
-        state.correlationId);
+    return new InputPlan(rid, pins);
   }
 
   private TablePin pinForResource(
@@ -403,21 +433,27 @@ public class QueryInputResolver {
         && pin.getOriginalAsOf().equals(asOf.get());
   }
 
-  private void collectBaseTables(
+  /**
+   * Append the table pins reachable from {@code relationId} to {@code out} in dependency order: a
+   * table contributes its own pin; a view is expanded through its base relations. {@code seen}
+   * guards against reference cycles. Appends rather than merging, so the caller decides ordering
+   * and deduplication.
+   */
+  private void collectBaseTablePins(
       ResolutionState state,
       ResourceId relationId,
       Optional<Timestamp> effectiveAsOf,
-      Set<String> seen) {
+      Set<String> seen,
+      List<TablePin> out) {
     String key = QueryPins.pinKey(relationId);
     if (!seen.add(key)) {
       return;
     }
     if (relationId.getKind() == ResourceKind.RK_TABLE) {
-      mergePin(
-          state.pinByTableId,
-          pinForResource(state, relationId, null, effectiveAsOf),
-          state.queryId,
-          state.correlationId);
+      TablePin pin = pinForResource(state, relationId, null, effectiveAsOf);
+      if (pin != null) {
+        out.add(pin);
+      }
       return;
     }
     long viewResolveStartNs = System.nanoTime();
@@ -450,7 +486,7 @@ public class QueryInputResolver {
             state.diagnostics.count("pin.view_base_name_resolutions");
             baseIds
                 .getOrDefault(baseRef, Optional.empty())
-                .ifPresent(rid -> collectBaseTables(state, rid, effectiveAsOf, seen));
+                .ifPresent(rid -> collectBaseTablePins(state, rid, effectiveAsOf, seen, out));
           }
         });
   }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -34,9 +34,13 @@ import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.ViewContextUtils;
+import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -46,6 +50,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Semaphore;
+import org.eclipse.microprofile.context.ManagedExecutor;
 
 /**
  * QueryInputResolver
@@ -81,12 +92,20 @@ import java.util.Set;
 @ApplicationScoped
 public class QueryInputResolver {
 
+  // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
+  // store reads; a small fan-out overlaps their round-trips without flooding the store or executor.
+  private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
+
   private final CatalogOverlay metadataGraph;
 
   // Registers each resolved pin's blobs as a transient GC root at construction time (see
   // QueryContextStore.registerResolvingPinBlobs). Null in unit tests that construct the resolver
   // without a store — registration is simply skipped then.
   private final QueryContextStore queryStore;
+
+  // Runs per-input resolution off the request thread. The Quarkus ManagedExecutor is injected in
+  // init(); tests (and any wiring without one) fall back to the common pool.
+  private volatile Executor blockingExecutor = ForkJoinPool.commonPool();
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -97,6 +116,13 @@ public class QueryInputResolver {
   /** Test-only constructor: no store (no pin-root registration). */
   public QueryInputResolver(CatalogOverlay metadataGraph) {
     this(metadataGraph, null);
+  }
+
+  @Inject
+  void init(Instance<ManagedExecutor> managedExecutors) {
+    if (managedExecutors != null) {
+      managedExecutors.stream().findFirst().ifPresent(e -> blockingExecutor = e);
+    }
   }
 
   // =============================================================================
@@ -155,6 +181,23 @@ public class QueryInputResolver {
       this.currentSnapshotPinCache = currentSnapshotPinCache;
       this.resolvingPinRoots = resolvingPinRoots;
       this.diagnostics = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
+    }
+
+    /**
+     * A view of this state that reports to {@code taskDiagnostics} instead of the shared
+     * diagnostics, for resolving one input off the request thread. Shares the read-only fields and
+     * the current-snapshot cache (which must be thread-safe); its own {@code resolved} / {@code
+     * pinByTableId} are unused, since off-thread resolution only computes pins and never merges.
+     */
+    ResolutionState withDiagnostics(PhaseDiagnostics taskDiagnostics) {
+      return new ResolutionState(
+          queryId,
+          correlationId,
+          asOfDefault,
+          defaultCatalog,
+          currentSnapshotPinCache,
+          resolvingPinRoots,
+          taskDiagnostics);
     }
   }
 
@@ -221,7 +264,7 @@ public class QueryInputResolver {
       Optional<Timestamp> asOfDefault,
       Optional<ResourceId> defaultCatalogId) {
     return resolveInputs(
-        "", correlationId, inputs, asOfDefault, defaultCatalogId, new LinkedHashMap<>(), null);
+        "", correlationId, inputs, asOfDefault, defaultCatalogId, new ConcurrentHashMap<>(), null);
   }
 
   /**
@@ -284,10 +327,12 @@ public class QueryInputResolver {
       Map<NameRef, Optional<ResourceId>> resolvedNames =
           nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
 
-      // Resolve and merge in input order. A later malformed input must not mask a conflict that
-      // was already established by an earlier pair.
-      for (QueryInput in : inputs) {
-        mergePlan(state, planInput(state, in, resolvedNames));
+      List<InputPlan> plans =
+          inputs.size() > 1
+              ? planInputsConcurrently(state, inputs, resolvedNames)
+              : planInputsSerially(state, inputs, resolvedNames);
+      for (InputPlan plan : plans) {
+        mergePlan(state, plan);
       }
 
       RelationPinSet relationPinSet =
@@ -322,6 +367,79 @@ public class QueryInputResolver {
     state.resolved.add(plan.resolvedId());
     for (TablePin pin : plan.pins()) {
       mergePin(state, pin);
+    }
+  }
+
+  /**
+   * Resolve the inputs one at a time on the calling thread, reporting to the shared diagnostics.
+   */
+  private List<InputPlan> planInputsSerially(
+      ResolutionState state,
+      List<QueryInput> inputs,
+      Map<NameRef, Optional<ResourceId>> resolvedNames) {
+    List<InputPlan> plans = new ArrayList<>(inputs.size());
+    for (QueryInput in : inputs) {
+      plans.add(planInput(state, in, resolvedNames));
+    }
+    return plans;
+  }
+
+  /**
+   * Resolve the inputs across the blocking executor and gather their plans in input order. Tasks
+   * report to a shared thread-safe accumulator instead of the request's diagnostics (which is not
+   * guaranteed thread-safe); its per-key totals — snapshot-lookup calls and time, cache hits/misses
+   * — are flushed to the real diagnostics once resolution has joined. The result is the per-RPC
+   * aggregate of those counters, not a per-relation breakdown; the coarse phase timings are
+   * measured by the caller around this call regardless. One task state is shared by all tasks
+   * because everything they touch is immutable or thread-safe (the current-snapshot cache and the
+   * accumulator). Gathering plans in input order keeps the caller's merge deterministic
+   * (first-touch-wins, conflict detection).
+   */
+  private List<InputPlan> planInputsConcurrently(
+      ResolutionState state,
+      List<QueryInput> inputs,
+      Map<NameRef, Optional<ResourceId>> resolvedNames) {
+    Semaphore gate = new Semaphore(MAX_PARALLEL_INPUT_RESOLUTIONS);
+    Context otelContext = Context.current();
+    AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
+    ResolutionState taskState = state.withDiagnostics(taskDiagnostics);
+    List<CompletableFuture<InputPlan>> futures =
+        inputs.stream()
+            .map(
+                in ->
+                    CompletableFuture.supplyAsync(
+                        () -> {
+                          gate.acquireUninterruptibly();
+                          try (Scope ignored = otelContext.makeCurrent()) {
+                            return planInput(taskState, in, resolvedNames);
+                          } finally {
+                            gate.release();
+                          }
+                        },
+                        blockingExecutor))
+            .toList();
+
+    List<InputPlan> plans = new ArrayList<>(inputs.size());
+    for (CompletableFuture<InputPlan> future : futures) {
+      plans.add(joinUnwrapped(future));
+    }
+    taskDiagnostics.flushInto(state.diagnostics);
+    return plans;
+  }
+
+  /** Join a resolution task, surfacing its original (unwrapped) failure rather than a wrapper. */
+  private static InputPlan joinUnwrapped(CompletableFuture<InputPlan> future) {
+    try {
+      return future.join();
+    } catch (CompletionException ce) {
+      Throwable cause = ce.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error e) {
+        throw e;
+      }
+      throw new IllegalStateException("unexpected checked exception from input resolution", cause);
     }
   }
 
@@ -404,21 +522,33 @@ public class QueryInputResolver {
       SnapshotRef override,
       Optional<Timestamp> asOfDefault) {
     if (usesCurrentSnapshotFallback(override, asOfDefault)) {
-      TablePin cached = state.currentSnapshotPinCache.get(rid);
-      if (cached != null) {
-        state.diagnostics.count("pin.current_snapshot_cache_hits");
-        state.resolvingPinRoots.register(cached);
-        return cached;
-      }
-      state.diagnostics.count("pin.current_snapshot_cache_misses");
-      long snapshotPinStartNs = System.nanoTime();
-      TablePin resolved =
-          metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
-      state.diagnostics.count("pin.snapshot_calls");
-      state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
-      state.resolvingPinRoots.register(resolved);
-      state.currentSnapshotPinCache.put(rid, resolved);
-      return resolved;
+      // Single-flight per table: two references to the same table's CURRENT snapshot must freeze
+      // the
+      // SAME snapshot even when they resolve on different threads, or an ingest landing between two
+      // independent lookups would give them different snapshots and turn a compatible pair into a
+      // pin conflict. computeIfAbsent runs the lookup once per table id; concurrent callers for
+      // that
+      // id wait for and share its result. (Requires a thread-safe cache — see resolveInputs.)
+      boolean[] resolvedHere = {false};
+      TablePin pin =
+          state.currentSnapshotPinCache.computeIfAbsent(
+              rid,
+              id -> {
+                resolvedHere[0] = true;
+                long snapshotPinStartNs = System.nanoTime();
+                TablePin resolved =
+                    metadataGraph.tablePinFor(state.correlationId, id, override, asOfDefault);
+                state.resolvingPinRoots.register(resolved);
+                state.diagnostics.count("pin.snapshot_calls");
+                state.diagnostics.nanos(
+                    "pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
+                return resolved;
+              });
+      state.diagnostics.count(
+          resolvedHere[0]
+              ? "pin.current_snapshot_cache_misses"
+              : "pin.current_snapshot_cache_hits");
+      return pin;
     }
     state.diagnostics.count(
         "pin.explicit_snapshot_pins", override != null && override.hasSnapshotId());

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
@@ -218,6 +219,7 @@ public class QueryInputResolver {
     private final QueryContextStore queryStore;
     private final String queryId;
     private final Map<TablePin, List<String>> rootsByPin = new IdentityHashMap<>();
+    private boolean terminal;
 
     ResolvingPinRoots(QueryContextStore queryStore, String queryId) {
       this.queryStore = queryStore;
@@ -229,7 +231,7 @@ public class QueryInputResolver {
      * callers propagate the failure without attempting a compensating release.
      */
     synchronized void register(TablePin pin) {
-      if (queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
+      if (terminal || queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
         return;
       }
       if (rootsByPin.containsKey(pin)) {
@@ -248,6 +250,9 @@ public class QueryInputResolver {
      * store failure retains ownership so a later failure cleanup can retry the release.
      */
     synchronized void discard(TablePin pin) {
+      if (terminal) {
+        return;
+      }
       List<String> roots = rootsByPin.get(pin);
       if (roots != null) {
         queryStore.releaseResolvingPinBlobs(queryId, roots);
@@ -260,6 +265,9 @@ public class QueryInputResolver {
      * and propagates to the caller, which retains the original resolution failure.
      */
     synchronized void releaseAll() {
+      // Cancellation can return from the fan-out before an uninterruptible task reaches register.
+      // Close ownership first so such a late task cannot add roots after this cleanup sweep.
+      terminal = true;
       var iterator = rootsByPin.entrySet().iterator();
       while (iterator.hasNext()) {
         Map.Entry<TablePin, List<String>> entry = iterator.next();
@@ -284,7 +292,13 @@ public class QueryInputResolver {
       Optional<Timestamp> asOfDefault,
       Optional<ResourceId> defaultCatalogId) {
     return resolveInputs(
-        "", correlationId, inputs, asOfDefault, defaultCatalogId, new ConcurrentHashMap<>(), null);
+        "",
+        correlationId,
+        inputs,
+        asOfDefault,
+        defaultCatalogId,
+        new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+        null);
   }
 
   /**
@@ -324,6 +338,50 @@ public class QueryInputResolver {
   }
 
   /**
+   * Backward-compatible overload for callers compiled against the original cache contract.
+   *
+   * <p>The legacy cache stores completed pins and is not required to be concurrent. Copy it into a
+   * concurrent single-flight cache for this call, then copy successfully resolved pins back on the
+   * calling thread. Worker tasks therefore never mutate a caller-owned plain {@link Map}.
+   */
+  public ResolutionResult resolveInputs(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      Map<ResourceId, TablePin> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics) {
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
+        new ConcurrentHashMap<>();
+    synchronized (currentSnapshotPinCache) {
+      currentSnapshotPinCache.forEach(
+          (tableId, pin) -> singleFlightCache.put(tableId, CompletableFuture.completedFuture(pin)));
+    }
+    try {
+      return resolveInputs(
+          queryId,
+          correlationId,
+          inputs,
+          asOfDefault,
+          defaultCatalogId,
+          singleFlightCache,
+          diagnostics);
+    } finally {
+      synchronized (currentSnapshotPinCache) {
+        singleFlightCache.forEach(
+            (tableId, pinFuture) -> {
+              if (pinFuture.isDone()
+                  && !pinFuture.isCompletedExceptionally()
+                  && !pinFuture.isCancelled()) {
+                currentSnapshotPinCache.put(tableId, Futures.join(pinFuture));
+              }
+            });
+      }
+    }
+  }
+
+  /**
    * As {@link #resolveInputs(String, String, List, Optional, Optional, ConcurrentMap,
    * PhaseDiagnostics)}, but stops before additional metadata work and interrupts fan-out tasks when
    * {@code cancelled} becomes true.
@@ -348,7 +406,8 @@ public class QueryInputResolver {
       long defaultCatalogStartNs = System.nanoTime();
       try {
         defaultCatalog =
-            metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName);
+            withMetadataGraph(
+                () -> metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName));
       } finally {
         diag.nanos("pin.default_catalog_resolve", System.nanoTime() - defaultCatalogStartNs);
       }
@@ -374,7 +433,9 @@ public class QueryInputResolver {
               .map(QueryInput::getName)
               .toList();
       Map<NameRef, Optional<ResourceId>> resolvedNames =
-          nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
+          nameInputs.isEmpty()
+              ? Map.of()
+              : withMetadataGraph(() -> metadataGraph.resolveNames(correlationId, nameInputs));
       throwIfCancelled(cancelled);
 
       // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
@@ -480,6 +541,20 @@ public class QueryInputResolver {
   }
 
   /**
+   * CatalogOverlay predates parallel resolution and does not require implementations to be
+   * thread-safe. Keep its callbacks serialized while allowing the rest of input planning to run
+   * concurrently.
+   */
+  private <T> T withMetadataGraph(Supplier<T> operation) {
+    if (metadataGraph.supportsConcurrentResolution()) {
+      return operation.get();
+    }
+    synchronized (metadataGraph) {
+      return operation.get();
+    }
+  }
+
+  /**
    * Resolve one input to its {@link InputPlan}, reading the metadata graph and the shared
    * current-snapshot cache. Does not read or write {@code state.resolved} or {@code
    * state.pinByTableId}; the caller merges the returned pins.
@@ -574,7 +649,9 @@ public class QueryInputResolver {
       if (inflight == null) {
         try {
           long snapshotPinStartNs = System.nanoTime();
-          pin = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+          pin =
+              withMetadataGraph(
+                  () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
           state.resolvingPinRoots.register(pin);
           state.diagnostics.count("pin.snapshot_calls");
           state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -589,6 +666,7 @@ public class QueryInputResolver {
         state.diagnostics.count("pin.current_snapshot_cache_misses");
       } else {
         pin = Futures.join(inflight);
+        state.resolvingPinRoots.register(pin);
         state.diagnostics.count("pin.current_snapshot_cache_hits");
       }
       return pin;
@@ -621,7 +699,9 @@ public class QueryInputResolver {
       }
     }
     long snapshotPinStartNs = System.nanoTime();
-    TablePin resolved = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+    TablePin resolved =
+        withMetadataGraph(
+            () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
     state.resolvingPinRoots.register(resolved);
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -696,10 +776,12 @@ public class QueryInputResolver {
     }
     long viewResolveStartNs = System.nanoTime();
     Optional<ViewNode> view =
-        metadataGraph
-            .resolve(relationId)
-            .filter(ViewNode.class::isInstance)
-            .map(ViewNode.class::cast);
+        withMetadataGraph(
+            () ->
+                metadataGraph
+                    .resolve(relationId)
+                    .filter(ViewNode.class::isInstance)
+                    .map(ViewNode.class::cast));
     state.diagnostics.nanos("pin.view_node_resolve", System.nanoTime() - viewResolveStartNs);
     view.ifPresent(
         resolvedView -> {
@@ -717,7 +799,7 @@ public class QueryInputResolver {
           }
           long baseNameStartNs = System.nanoTime();
           Map<NameRef, Optional<ResourceId>> baseIds =
-              metadataGraph.resolveNames(state.correlationId, baseRefs);
+              withMetadataGraph(() -> metadataGraph.resolveNames(state.correlationId, baseRefs));
           state.diagnostics.nanos(
               "pin.view_base_name_resolve", System.nanoTime() - baseNameStartNs);
           for (NameRef baseRef : baseRefs) {

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -40,6 +40,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +134,8 @@ public class QueryInputResolver {
     final Map<ResourceId, TablePin> pinByTableId = new LinkedHashMap<>();
     // Request-local cache for current-snapshot table pins (no override, no as-of).
     final Map<ResourceId, TablePin> currentSnapshotPinCache;
+    // Transient roots owned by this resolution attempt until the pins are committed or discarded.
+    final ResolvingPinRoots resolvingPinRoots;
     final PhaseDiagnostics diagnostics;
 
     ResolutionState(
@@ -141,13 +144,63 @@ public class QueryInputResolver {
         Optional<Timestamp> asOfDefault,
         Optional<String> defaultCatalog,
         Map<ResourceId, TablePin> currentSnapshotPinCache,
+        ResolvingPinRoots resolvingPinRoots,
         PhaseDiagnostics diagnostics) {
       this.queryId = queryId;
       this.correlationId = correlationId;
       this.asOfDefault = asOfDefault;
       this.defaultCatalog = defaultCatalog;
       this.currentSnapshotPinCache = currentSnapshotPinCache;
+      this.resolvingPinRoots = resolvingPinRoots;
       this.diagnostics = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
+    }
+  }
+
+  /**
+   * Owns transient registrations made while one resolution attempt constructs pins. Retained pins
+   * remain rooted until their query context is committed; compatible duplicates and failed
+   * resolutions release only the roots registered by this attempt.
+   */
+  private static final class ResolvingPinRoots {
+    private final QueryContextStore queryStore;
+    private final String queryId;
+    private final Map<TablePin, List<String>> rootsByPin = new IdentityHashMap<>();
+
+    ResolvingPinRoots(QueryContextStore queryStore, String queryId) {
+      this.queryStore = queryStore;
+      this.queryId = queryId;
+    }
+
+    synchronized void register(TablePin pin) {
+      if (queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
+        return;
+      }
+      if (rootsByPin.containsKey(pin)) {
+        return;
+      }
+      List<String> roots = QueryPins.gcRootUris(pin);
+      if (roots.isEmpty()) {
+        return;
+      }
+      queryStore.registerResolvingPinBlobs(queryId, roots);
+      rootsByPin.put(pin, roots);
+    }
+
+    synchronized void discard(TablePin pin) {
+      List<String> roots = rootsByPin.get(pin);
+      if (roots != null) {
+        queryStore.releaseResolvingPinBlobs(queryId, roots);
+        rootsByPin.remove(pin);
+      }
+    }
+
+    synchronized void releaseAll() {
+      var iterator = rootsByPin.entrySet().iterator();
+      while (iterator.hasNext()) {
+        Map.Entry<TablePin, List<String>> entry = iterator.next();
+        queryStore.releaseResolvingPinBlobs(queryId, entry.getValue());
+        iterator.remove();
+      }
     }
   }
 
@@ -210,46 +263,46 @@ public class QueryInputResolver {
 
     var state =
         new ResolutionState(
-            queryId, correlationId, asOfDefault, defaultCatalog, currentSnapshotPinCache, diag);
+            queryId,
+            correlationId,
+            asOfDefault,
+            defaultCatalog,
+            currentSnapshotPinCache,
+            new ResolvingPinRoots(queryStore, queryId),
+            diag);
 
-    // Batch-resolve all NAME inputs up front: names sharing a catalog/namespace resolve their
-    // scope once instead of once per input.
-    List<NameRef> nameInputs =
-        inputs.stream()
-            .filter(in -> in.getTargetCase() == QueryInput.TargetCase.NAME)
-            .map(QueryInput::getName)
-            .toList();
-    Map<NameRef, Optional<ResourceId>> resolvedNames =
-        nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
+    try {
+      // Batch-resolve all NAME inputs up front: names sharing a catalog/namespace resolve their
+      // scope once instead of once per input.
+      List<NameRef> nameInputs =
+          inputs.stream()
+              .filter(in -> in.getTargetCase() == QueryInput.TargetCase.NAME)
+              .map(QueryInput::getName)
+              .toList();
+      Map<NameRef, Optional<ResourceId>> resolvedNames =
+          nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
 
-    // Resolve each input to its id and the table pins it contributes (a table yields its own pin; a
-    // view yields its base tables' pins). planInput reads the metadata graph and the shared
-    // current-snapshot cache; it does not touch `resolved` or `pinByTableId`.
-    List<InputPlan> plans = new ArrayList<>(inputs.size());
-    for (QueryInput in : inputs) {
-      plans.add(planInput(state, in, resolvedNames));
-    }
-
-    // Merge the plans into the pin set in input order. Order decides two things: `resolved` mirrors
-    // the request order, and mergePin keeps the first pin seen for a table (rooting its blobs)
-    // while
-    // raising QUERY_TABLE_PIN_CONFLICT when a later reference pins the same table with an
-    // incompatible snapshot/as-of. Every kept pin is GC-rooted here, before resolveInputs returns
-    // and therefore before the caller reads any schema/stats or persists the context.
-    for (InputPlan plan : plans) {
-      state.resolved.add(plan.resolvedId());
-      for (TablePin pin : plan.pins()) {
-        mergePin(state.pinByTableId, pin, state.queryId, state.correlationId);
+      // Resolve and merge in input order. A later malformed input must not mask a conflict that
+      // was already established by an earlier pair.
+      for (QueryInput in : inputs) {
+        mergePlan(state, planInput(state, in, resolvedNames));
       }
-    }
 
-    RelationPinSet relationPinSet =
-        RelationPinSet.newBuilder()
-            .addAllPins(state.pinByTableId.values().stream().map(QueryPins::ofTable).toList())
-            .build();
-    diag.add("pin.resolver_output_pins", relationPinSet.getPinsCount());
-    return new ResolutionResult(
-        state.resolved, relationPinSet, asOfDefault.map(Timestamp::toByteArray).orElse(null));
+      RelationPinSet relationPinSet =
+          RelationPinSet.newBuilder()
+              .addAllPins(state.pinByTableId.values().stream().map(QueryPins::ofTable).toList())
+              .build();
+      diag.add("pin.resolver_output_pins", relationPinSet.getPinsCount());
+      return new ResolutionResult(
+          state.resolved, relationPinSet, asOfDefault.map(Timestamp::toByteArray).orElse(null));
+    } catch (RuntimeException | Error e) {
+      try {
+        state.resolvingPinRoots.releaseAll();
+      } catch (RuntimeException | Error cleanupFailure) {
+        e.addSuppressed(cleanupFailure);
+      }
+      throw e;
+    }
   }
 
   // =============================================================================
@@ -262,6 +315,13 @@ public class QueryInputResolver {
    * its own single pin.
    */
   private record InputPlan(ResourceId resolvedId, List<TablePin> pins) {}
+
+  private void mergePlan(ResolutionState state, InputPlan plan) {
+    state.resolved.add(plan.resolvedId());
+    for (TablePin pin : plan.pins()) {
+      mergePin(state, pin);
+    }
+  }
 
   /**
    * Resolve one input to its {@link InputPlan}, reading the metadata graph and the shared
@@ -345,6 +405,7 @@ public class QueryInputResolver {
       TablePin cached = state.currentSnapshotPinCache.get(rid);
       if (cached != null) {
         state.diagnostics.count("pin.current_snapshot_cache_hits");
+        state.resolvingPinRoots.register(cached);
         return cached;
       }
       state.diagnostics.count("pin.current_snapshot_cache_misses");
@@ -353,6 +414,7 @@ public class QueryInputResolver {
           metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
       state.diagnostics.count("pin.snapshot_calls");
       state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
+      state.resolvingPinRoots.register(resolved);
       state.currentSnapshotPinCache.put(rid, resolved);
       return resolved;
     }
@@ -387,6 +449,7 @@ public class QueryInputResolver {
     TablePin resolved = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
+    state.resolvingPinRoots.register(resolved);
     return resolved;
   }
 
@@ -491,34 +554,18 @@ public class QueryInputResolver {
         });
   }
 
-  private void mergePin(
-      Map<ResourceId, TablePin> pinByTableId, TablePin pin, String queryId, String correlationId) {
+  private void mergePin(ResolutionState state, TablePin pin) {
     if (pin == null) {
       return;
     }
-    TablePin existing = pinByTableId.get(pin.getTableId());
+    TablePin existing = state.pinByTableId.get(pin.getTableId());
     if (existing == null) {
-      // First touch: this is the pin the context will store. Root its blobs as a transient GC root
-      // the instant it is constructed — before any downstream expansion/obligations/schema/stats or
-      // persistence — so a concurrent table change plus blob GC cannot delete a just-resolved blob.
-      // Keyed by the stable query id so the committing RPC releases it by the same key regardless
-      // of
-      // which RPC's correlation id resolved. Registering only the kept pin (not a compatible
-      // incoming
-      // pin that reconcile then discards) avoids rooting a discarded pin's possibly-different table
-      // blob, which the commit — comparing against the kept pin — would never unroot.
-      if (queryStore != null) {
-        // The SAME uri set the committed context will root (QueryPins.gcRootUris) — critically
-        // including the pinned ROOT, whose chain expansion is what protects the manifest pages;
-        // omitting it left the whole chain sweepable during the resolving window.
-        queryStore.registerResolvingPinBlobs(queryId, QueryPins.gcRootUris(pin));
-      }
-      pinByTableId.put(pin.getTableId(), pin);
+      state.pinByTableId.put(pin.getTableId(), pin);
       return;
     }
-    // First-touch wins: reuse the existing (already-rooted) pin when compatible; conflicting
-    // temporal
-    // intents for the same table fail planning rather than silently depending on resolution order.
-    QueryPins.reconcile(existing, pin, correlationId);
+    QueryPins.reconcile(existing, pin, state.correlationId);
+    if (existing != pin) {
+      state.resolvingPinRoots.discard(pin);
+    }
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -49,11 +49,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.BooleanSupplier;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
@@ -109,7 +111,7 @@ public class QueryInputResolver {
   // worker pool: the driver blocks joining this fan-out and must not contend with it for the same
   // pool. The semaphore in BoundedFanout bounds concurrency; OTel context is re-established per
   // task.
-  private final Executor blockingExecutor = Executors.newVirtualThreadPerTaskExecutor();
+  private final ExecutorService blockingExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -310,6 +312,32 @@ public class QueryInputResolver {
       Optional<ResourceId> defaultCatalogId,
       ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
+    return resolveInputs(
+        queryId,
+        correlationId,
+        inputs,
+        asOfDefault,
+        defaultCatalogId,
+        currentSnapshotPinCache,
+        diagnostics,
+        () -> false);
+  }
+
+  /**
+   * As {@link #resolveInputs(String, String, List, Optional, Optional, ConcurrentMap,
+   * PhaseDiagnostics)}, but stops before additional metadata work and interrupts fan-out tasks when
+   * {@code cancelled} becomes true.
+   */
+  public ResolutionResult resolveInputs(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
     PhaseDiagnostics diag = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
 
     // Resolve catalog display-name once up-front — used to fill in blank catalog fields in
@@ -325,6 +353,7 @@ public class QueryInputResolver {
         diag.nanos("pin.default_catalog_resolve", System.nanoTime() - defaultCatalogStartNs);
       }
     }
+    throwIfCancelled(cancelled);
 
     var state =
         new ResolutionState(
@@ -346,27 +375,17 @@ public class QueryInputResolver {
               .toList();
       Map<NameRef, Optional<ResourceId>> resolvedNames =
           nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
+      throwIfCancelled(cancelled);
 
       // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
       // a view yields its base tables' pins). planInput reads the metadata graph and the shared
       // current-snapshot cache; it does not touch `resolved` or `pinByTableId`. Inputs resolve
       // independently, so with more than one they are fanned out; the results are gathered in input
       // order for the merge below.
-      List<InputPlan> plans =
-          inputs.size() > 1
-              ? planInputsConcurrently(state, inputs, resolvedNames)
-              : planInputsSerially(state, inputs, resolvedNames);
-
-      // Merge the plans into the pin set in input order. Order decides two things: `resolved`
-      // mirrors the request order, and mergePin keeps the first pin seen for a table while raising
-      // QUERY_TABLE_PIN_CONFLICT when a later reference pins the same table with an incompatible
-      // snapshot/as-of. Every kept pin is already GC-rooted at construction, before the caller
-      // reads any schema/stats or persists the context.
-      for (InputPlan plan : plans) {
-        state.resolved.add(plan.resolvedId());
-        for (TablePin pin : plan.pins()) {
-          mergePin(state, pin);
-        }
+      if (inputs.size() > 1) {
+        planInputsConcurrently(state, inputs, resolvedNames, cancelled);
+      } else {
+        planInputsSerially(state, inputs, resolvedNames, cancelled);
       }
 
       RelationPinSet relationPinSet =
@@ -397,18 +416,26 @@ public class QueryInputResolver {
    */
   private record InputPlan(ResourceId resolvedId, List<TablePin> pins) {}
 
+  /** Merge one completed plan on the request thread, preserving request-order semantics. */
+  private void mergePlan(ResolutionState state, InputPlan plan) {
+    state.resolved.add(plan.resolvedId());
+    for (TablePin pin : plan.pins()) {
+      mergePin(state, pin);
+    }
+  }
+
   /**
    * Resolve the inputs one at a time on the calling thread, reporting to the shared diagnostics.
    */
-  private List<InputPlan> planInputsSerially(
+  private void planInputsSerially(
       ResolutionState state,
       List<QueryInput> inputs,
-      Map<NameRef, Optional<ResourceId>> resolvedNames) {
-    List<InputPlan> plans = new ArrayList<>(inputs.size());
+      Map<NameRef, Optional<ResourceId>> resolvedNames,
+      BooleanSupplier cancelled) {
     for (QueryInput in : inputs) {
-      plans.add(planInput(state, in, resolvedNames));
+      throwIfCancelled(cancelled);
+      mergePlan(state, planInput(state, in, resolvedNames));
     }
-    return plans;
   }
 
   /**
@@ -424,22 +451,31 @@ public class QueryInputResolver {
    * Gathering plans in input order keeps the caller's merge deterministic (first-touch-wins,
    * conflict detection).
    */
-  private List<InputPlan> planInputsConcurrently(
+  private void planInputsConcurrently(
       ResolutionState state,
       List<QueryInput> inputs,
-      Map<NameRef, Optional<ResourceId>> resolvedNames) {
+      Map<NameRef, Optional<ResourceId>> resolvedNames,
+      BooleanSupplier cancelled) {
     AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
     ResolutionState taskState = state.withDiagnostics(taskDiagnostics);
     try {
-      return BoundedFanout.mapOrdered(
+      BoundedFanout.forEachOrdered(
           inputs,
           maxParallelInputResolutions,
           blockingExecutor,
-          in -> planInput(taskState, in, resolvedNames));
+          in -> planInput(taskState, in, resolvedNames),
+          plan -> mergePlan(state, plan),
+          cancelled);
     } finally {
       // A failed or cancelled sibling can still leave completed tasks' pin work in this
       // accumulator. Preserve those counters for the request's failure telemetry too.
       taskDiagnostics.flushInto(state.diagnostics);
+    }
+  }
+
+  private static void throwIfCancelled(BooleanSupplier cancelled) {
+    if (cancelled.getAsBoolean()) {
+      throw new CancellationException("input resolution cancelled");
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -30,6 +30,7 @@ import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
@@ -37,8 +38,6 @@ import ai.floedb.floecat.service.query.ViewContextUtils;
 import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -50,12 +49,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Semaphore;
 import org.eclipse.microprofile.context.ManagedExecutor;
 
 /**
@@ -399,48 +395,16 @@ public class QueryInputResolver {
       ResolutionState state,
       List<QueryInput> inputs,
       Map<NameRef, Optional<ResourceId>> resolvedNames) {
-    Semaphore gate = new Semaphore(MAX_PARALLEL_INPUT_RESOLUTIONS);
-    Context otelContext = Context.current();
     AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
     ResolutionState taskState = state.withDiagnostics(taskDiagnostics);
-    List<CompletableFuture<InputPlan>> futures =
-        inputs.stream()
-            .map(
-                in ->
-                    CompletableFuture.supplyAsync(
-                        () -> {
-                          gate.acquireUninterruptibly();
-                          try (Scope ignored = otelContext.makeCurrent()) {
-                            return planInput(taskState, in, resolvedNames);
-                          } finally {
-                            gate.release();
-                          }
-                        },
-                        blockingExecutor))
-            .toList();
-
-    List<InputPlan> plans = new ArrayList<>(inputs.size());
-    for (CompletableFuture<InputPlan> future : futures) {
-      plans.add(joinUnwrapped(future));
-    }
+    List<InputPlan> plans =
+        BoundedFanout.mapOrdered(
+            inputs,
+            MAX_PARALLEL_INPUT_RESOLUTIONS,
+            blockingExecutor,
+            in -> planInput(taskState, in, resolvedNames));
     taskDiagnostics.flushInto(state.diagnostics);
     return plans;
-  }
-
-  /** Join a resolution task, surfacing its original (unwrapped) failure rather than a wrapper. */
-  private static InputPlan joinUnwrapped(CompletableFuture<InputPlan> future) {
-    try {
-      return future.join();
-    } catch (CompletionException ce) {
-      Throwable cause = ce.getCause();
-      if (cause instanceof RuntimeException re) {
-        throw re;
-      }
-      if (cause instanceof Error e) {
-        throw e;
-      }
-      throw new IllegalStateException("unexpected checked exception from input resolution", cause);
-    }
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.service.concurrent.BoundedFanout;
+import ai.floedb.floecat.service.concurrent.Futures;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
@@ -39,7 +40,6 @@ import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -49,10 +49,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
-import org.eclipse.microprofile.context.ManagedExecutor;
+import java.util.concurrent.Executors;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
  * QueryInputResolver
@@ -89,8 +91,12 @@ import org.eclipse.microprofile.context.ManagedExecutor;
 public class QueryInputResolver {
 
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
-  // store reads; a small fan-out overlaps their round-trips without flooding the store or executor.
-  private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
+  // store reads; a small fan-out overlaps their round-trips without flooding the store. Shared with
+  // the catalog bundle's relation fan-out via the same config property. Per-request bound only: the
+  // virtual-thread executor has no shared-pool ceiling. Read once here via ConfigProvider (not a
+  // @ConfigProperty ctor param) so the new-constructed test call sites keep compiling while prod
+  // still honors config.
+  private final int maxParallelInputResolutions;
 
   private final CatalogOverlay metadataGraph;
 
@@ -99,26 +105,30 @@ public class QueryInputResolver {
   // without a store — registration is simply skipped then.
   private final QueryContextStore queryStore;
 
-  // Runs per-input resolution off the request thread. The Quarkus ManagedExecutor is injected in
-  // init(); tests (and any wiring without one) fall back to the common pool.
-  private volatile Executor blockingExecutor = ForkJoinPool.commonPool();
+  // Runs per-input resolution off the request thread on virtual threads, not the shared Quarkus
+  // worker pool: the driver blocks joining this fan-out and must not contend with it for the same
+  // pool. The semaphore in BoundedFanout bounds concurrency; OTel context is re-established per
+  // task.
+  private final Executor blockingExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
     this.metadataGraph = metadataGraph;
     this.queryStore = queryStore;
+    // Clamp to >=1: a 0/negative permit count would wedge the fan-out's permit wait forever.
+    // UserObjectBundleService warns on this same config key; clamp silently here to avoid a
+    // duplicate warning.
+    this.maxParallelInputResolutions =
+        Math.max(
+            1,
+            ConfigProvider.getConfig()
+                .getOptionalValue("floecat.catalog.bundle.max_parallel_relations", Integer.class)
+                .orElse(8));
   }
 
   /** Test-only constructor: no store (no pin-root registration). */
   public QueryInputResolver(CatalogOverlay metadataGraph) {
     this(metadataGraph, null);
-  }
-
-  @Inject
-  void init(Instance<ManagedExecutor> managedExecutors) {
-    if (managedExecutors != null) {
-      managedExecutors.stream().findFirst().ifPresent(e -> blockingExecutor = e);
-    }
   }
 
   // =============================================================================
@@ -157,8 +167,8 @@ public class QueryInputResolver {
     // Keep insertion order (matching input order) while deduplicating by table ID.
     final Map<ResourceId, TablePin> pinByTableId = new LinkedHashMap<>();
     // Request-local cache for current-snapshot table pins (no override, no as-of).
-    final Map<ResourceId, TablePin> currentSnapshotPinCache;
-    // Transient roots owned by this resolution attempt until the pins are committed or discarded.
+    final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache;
+    // Tracks transient roots owned by this resolution attempt until they are retained or discarded.
     final ResolvingPinRoots resolvingPinRoots;
     final PhaseDiagnostics diagnostics;
 
@@ -167,7 +177,7 @@ public class QueryInputResolver {
         String correlationId,
         Optional<Timestamp> asOfDefault,
         Optional<String> defaultCatalog,
-        Map<ResourceId, TablePin> currentSnapshotPinCache,
+        ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
         ResolvingPinRoots resolvingPinRoots,
         PhaseDiagnostics diagnostics) {
       this.queryId = queryId;
@@ -198,9 +208,9 @@ public class QueryInputResolver {
   }
 
   /**
-   * Owns transient registrations made while one resolution attempt constructs pins. Retained pins
-   * remain rooted until their query context is committed; compatible duplicates and failed
-   * resolutions release only the roots registered by this attempt.
+   * Owns the transient registrations made while one {@link #resolveInputs} call constructs pins. A
+   * retained pin stays registered until its context commit makes it durable; a discarded pin or
+   * failed resolution releases only the registration this attempt created.
    */
   private static final class ResolvingPinRoots {
     private final QueryContextStore queryStore;
@@ -212,6 +222,10 @@ public class QueryInputResolver {
       this.queryId = queryId;
     }
 
+    /**
+     * Register a pin's roots once for this attempt. A store failure leaves the pin untracked so
+     * callers propagate the failure without attempting a compensating release.
+     */
     synchronized void register(TablePin pin) {
       if (queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
         return;
@@ -227,6 +241,10 @@ public class QueryInputResolver {
       rootsByPin.put(pin, roots);
     }
 
+    /**
+     * Release this attempt's registration for a compatible pin that lost ordered first-touch. A
+     * store failure retains ownership so a later failure cleanup can retry the release.
+     */
     synchronized void discard(TablePin pin) {
       List<String> roots = rootsByPin.get(pin);
       if (roots != null) {
@@ -235,6 +253,10 @@ public class QueryInputResolver {
       }
     }
 
+    /**
+     * Release every registration still owned by this failed attempt. A store failure stops release
+     * and propagates to the caller, which retains the original resolution failure.
+     */
     synchronized void releaseAll() {
       var iterator = rootsByPin.entrySet().iterator();
       while (iterator.hasNext()) {
@@ -276,7 +298,9 @@ public class QueryInputResolver {
    *
    * <p>{@code defaultCatalogId} is used only when expanding view base relations: if a base-relation
    * {@link NameRef} has a blank catalog or empty path it is enriched with the query's default
-   * catalog / creation search-path before resolution. Non-view inputs are unaffected.
+   * catalog / creation search-path before resolution. Non-view inputs are unaffected. {@code
+   * currentSnapshotPinCache} is shared by concurrent input tasks, so it must provide atomic {@link
+   * ConcurrentMap#putIfAbsent} and conditional removal.
    */
   public ResolutionResult resolveInputs(
       String queryId,
@@ -284,7 +308,7 @@ public class QueryInputResolver {
       List<QueryInput> inputs,
       Optional<Timestamp> asOfDefault,
       Optional<ResourceId> defaultCatalogId,
-      Map<ResourceId, TablePin> currentSnapshotPinCache,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
     PhaseDiagnostics diag = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
 
@@ -323,12 +347,26 @@ public class QueryInputResolver {
       Map<NameRef, Optional<ResourceId>> resolvedNames =
           nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
 
+      // Resolve each input to its id and the table pins it contributes (a table yields its own pin;
+      // a view yields its base tables' pins). planInput reads the metadata graph and the shared
+      // current-snapshot cache; it does not touch `resolved` or `pinByTableId`. Inputs resolve
+      // independently, so with more than one they are fanned out; the results are gathered in input
+      // order for the merge below.
       List<InputPlan> plans =
           inputs.size() > 1
               ? planInputsConcurrently(state, inputs, resolvedNames)
               : planInputsSerially(state, inputs, resolvedNames);
+
+      // Merge the plans into the pin set in input order. Order decides two things: `resolved`
+      // mirrors the request order, and mergePin keeps the first pin seen for a table while raising
+      // QUERY_TABLE_PIN_CONFLICT when a later reference pins the same table with an incompatible
+      // snapshot/as-of. Every kept pin is already GC-rooted at construction, before the caller
+      // reads any schema/stats or persists the context.
       for (InputPlan plan : plans) {
-        mergePlan(state, plan);
+        state.resolved.add(plan.resolvedId());
+        for (TablePin pin : plan.pins()) {
+          mergePin(state, pin);
+        }
       }
 
       RelationPinSet relationPinSet =
@@ -359,13 +397,6 @@ public class QueryInputResolver {
    */
   private record InputPlan(ResourceId resolvedId, List<TablePin> pins) {}
 
-  private void mergePlan(ResolutionState state, InputPlan plan) {
-    state.resolved.add(plan.resolvedId());
-    for (TablePin pin : plan.pins()) {
-      mergePin(state, pin);
-    }
-  }
-
   /**
    * Resolve the inputs one at a time on the calling thread, reporting to the shared diagnostics.
    */
@@ -388,8 +419,10 @@ public class QueryInputResolver {
    * aggregate of those counters, not a per-relation breakdown; the coarse phase timings are
    * measured by the caller around this call regardless. One task state is shared by all tasks
    * because everything they touch is immutable or thread-safe (the current-snapshot cache and the
-   * accumulator). Gathering plans in input order keeps the caller's merge deterministic
-   * (first-touch-wins, conflict detection).
+   * accumulator). Keep off-thread diagnostics to counters and durations only; one-shot put/emit
+   * values must stay on the request thread because the accumulator intentionally drops them.
+   * Gathering plans in input order keeps the caller's merge deterministic (first-touch-wins,
+   * conflict detection).
    */
   private List<InputPlan> planInputsConcurrently(
       ResolutionState state,
@@ -400,7 +433,7 @@ public class QueryInputResolver {
     List<InputPlan> plans =
         BoundedFanout.mapOrdered(
             inputs,
-            MAX_PARALLEL_INPUT_RESOLUTIONS,
+            maxParallelInputResolutions,
             blockingExecutor,
             in -> planInput(taskState, in, resolvedNames));
     taskDiagnostics.flushInto(state.diagnostics);
@@ -490,28 +523,35 @@ public class QueryInputResolver {
       // the
       // SAME snapshot even when they resolve on different threads, or an ingest landing between two
       // independent lookups would give them different snapshots and turn a compatible pair into a
-      // pin conflict. computeIfAbsent runs the lookup once per table id; concurrent callers for
-      // that
-      // id wait for and share its result. (Requires a thread-safe cache — see resolveInputs.)
-      boolean[] resolvedHere = {false};
-      TablePin pin =
-          state.currentSnapshotPinCache.computeIfAbsent(
-              rid,
-              id -> {
-                resolvedHere[0] = true;
-                long snapshotPinStartNs = System.nanoTime();
-                TablePin resolved =
-                    metadataGraph.tablePinFor(state.correlationId, id, override, asOfDefault);
-                state.resolvingPinRoots.register(resolved);
-                state.diagnostics.count("pin.snapshot_calls");
-                state.diagnostics.nanos(
-                    "pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
-                return resolved;
-              });
-      state.diagnostics.count(
-          resolvedHere[0]
-              ? "pin.current_snapshot_cache_misses"
-              : "pin.current_snapshot_cache_hits");
+      // pin conflict. A CompletableFuture placeholder gives that single-flight WITHOUT
+      // computeIfAbsent
+      // holding the map's bin lock across the store round-trip — which would serialize unrelated
+      // table ids that hash to the same bin. The winner (whoever inserts the incomplete future)
+      // runs
+      // the one lookup; concurrent same-id callers await its result.
+      CompletableFuture<TablePin> holder = new CompletableFuture<>();
+      CompletableFuture<TablePin> inflight = state.currentSnapshotPinCache.putIfAbsent(rid, holder);
+      TablePin pin;
+      if (inflight == null) {
+        try {
+          long snapshotPinStartNs = System.nanoTime();
+          pin = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+          state.resolvingPinRoots.register(pin);
+          state.diagnostics.count("pin.snapshot_calls");
+          state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
+        } catch (RuntimeException | Error e) {
+          // Never cache a failure: drop the placeholder so a retry re-resolves, and release any
+          // callers already awaiting this id with the same error.
+          state.currentSnapshotPinCache.remove(rid, holder);
+          holder.completeExceptionally(e);
+          throw e;
+        }
+        holder.complete(pin);
+        state.diagnostics.count("pin.current_snapshot_cache_misses");
+      } else {
+        pin = Futures.join(inflight);
+        state.diagnostics.count("pin.current_snapshot_cache_hits");
+      }
       return pin;
     }
     state.diagnostics.count(
@@ -543,9 +583,9 @@ public class QueryInputResolver {
     }
     long snapshotPinStartNs = System.nanoTime();
     TablePin resolved = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+    state.resolvingPinRoots.register(resolved);
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
-    state.resolvingPinRoots.register(resolved);
     return resolved;
   }
 
@@ -659,6 +699,7 @@ public class QueryInputResolver {
       state.pinByTableId.put(pin.getTableId(), pin);
       return;
     }
+    // First-touch wins: compatible later pins relinquish only their own provisional roots.
     QueryPins.reconcile(existing, pin, state.correlationId);
     if (existing != pin) {
       state.resolvingPinRoots.discard(pin);

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -74,7 +74,9 @@ import java.util.Set;
  *       view-creation time, regardless of the current query search-path.
  * </ol>
  *
- * <p>No side effects: this class only computes resolution, it does not mutate or persist anything.
+ * <p>This resolver does not persist query context. While resolving, it registers each constructed
+ * pin as a transient GC root and releases discarded or abandoned registrations when the resolution
+ * attempt ends.
  */
 @ApplicationScoped
 public class QueryInputResolver {

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -19,7 +19,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -87,5 +96,116 @@ class BoundedFanoutTest {
                     }))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("boom");
+  }
+
+  @Test
+  void submissionFailureWaitsForAlreadySubmittedTasks() throws Exception {
+    CountDownLatch taskStarted = new CountDownLatch(1);
+    CountDownLatch allowTaskCompletion = new CountDownLatch(1);
+    CountDownLatch mapReturned = new CountDownLatch(1);
+    AtomicInteger submissions = new AtomicInteger();
+    Executor rejectSecondSubmission =
+        command -> {
+          if (submissions.getAndIncrement() == 0) {
+            CompletableFuture.runAsync(command);
+            return;
+          }
+          throw new RejectedExecutionException("executor saturated");
+        };
+
+    CompletableFuture<Throwable> result =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                BoundedFanout.mapOrdered(
+                    List.of(1, 2),
+                    2,
+                    rejectSecondSubmission,
+                    ignored -> {
+                      taskStarted.countDown();
+                      try {
+                        allowTaskCompletion.await();
+                      } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError("task interrupted", e);
+                      }
+                      return ignored;
+                    });
+                return null;
+              } catch (Throwable failure) {
+                return failure;
+              } finally {
+                mapReturned.countDown();
+              }
+            });
+
+    assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(mapReturned.await(100, TimeUnit.MILLISECONDS)).isFalse();
+    allowTaskCompletion.countDown();
+    assertThat(result.join())
+        .isInstanceOf(RejectedExecutionException.class)
+        .hasMessage("executor saturated");
+  }
+
+  @Test
+  void cancellationInterruptsRunningTaskAndReturnsWithoutWaitingForIt() throws Exception {
+    CountDownLatch taskStarted = new CountDownLatch(1);
+    CountDownLatch taskInterrupted = new CountDownLatch(1);
+    CountDownLatch allowTaskCompletion = new CountDownLatch(1);
+    AtomicBoolean cancelled = new AtomicBoolean();
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      CompletableFuture<Throwable> result =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  BoundedFanout.mapOrdered(
+                      List.of(1, 2),
+                      2,
+                      executor,
+                      ignored -> {
+                        taskStarted.countDown();
+                        try {
+                          allowTaskCompletion.await();
+                        } catch (InterruptedException e) {
+                          taskInterrupted.countDown();
+                          Thread.currentThread().interrupt();
+                          throw new CancellationException("task interrupted");
+                        }
+                        return ignored;
+                      },
+                      cancelled::get);
+                  return null;
+                } catch (Throwable failure) {
+                  return failure;
+                }
+              });
+
+      assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+      cancelled.set(true);
+      try {
+        assertThat(result.get(250, TimeUnit.MILLISECONDS))
+            .isInstanceOf(CancellationException.class)
+            .hasMessage("fan-out cancelled");
+        assertThat(taskInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
+      } finally {
+        allowTaskCompletion.countDown();
+      }
+    }
+  }
+
+  @Test
+  void rejectsZeroAndNegativePermits() {
+    // A 0/negative permit count would hand out no permits, blocking every task forever on an
+    // uninterruptible acquire while the caller blocks joining — a permanent hang. Fail fast.
+    for (int badPermits : new int[] {0, -1, -8}) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.mapOrdered(
+                      List.of(1, 2, 3), badPermits, ForkJoinPool.commonPool(), i -> i))
+          .as("permits=%d", badPermits)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("permits must be >= 1");
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -81,6 +81,43 @@ class BoundedFanoutTest {
   }
 
   @Test
+  void submitsOnlyTheRollingWindowWhileTheFirstResultIsBlocked() throws Exception {
+    CountDownLatch firstStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirst = new CountDownLatch(1);
+    AtomicInteger submissions = new AtomicInteger();
+    Executor countingExecutor =
+        command -> {
+          submissions.incrementAndGet();
+          CompletableFuture.runAsync(command);
+        };
+
+    CompletableFuture<List<Integer>> result =
+        CompletableFuture.supplyAsync(
+            () ->
+                BoundedFanout.mapOrdered(
+                    IntStream.range(0, 100).boxed().toList(),
+                    3,
+                    countingExecutor,
+                    value -> {
+                      if (value == 0) {
+                        firstStarted.countDown();
+                        try {
+                          releaseFirst.await();
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError(e);
+                        }
+                      }
+                      return value;
+                    }));
+
+    assertThat(firstStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(submissions.get()).isEqualTo(3);
+    releaseFirst.countDown();
+    assertThat(result.get(1, TimeUnit.SECONDS)).hasSize(100);
+  }
+
+  @Test
   void taskFailureSurfacesUnwrapped() {
     assertThatThrownBy(
             () ->

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class BoundedFanoutTest {
+
+  @Test
+  void resultsAreReturnedInInputOrder() {
+    List<Integer> inputs = IntStream.range(0, 50).boxed().toList();
+    // Reverse the completion order (later items sleep less) to prove ordering is by input, not
+    // completion.
+    List<Integer> out =
+        BoundedFanout.mapOrdered(
+            inputs,
+            8,
+            ForkJoinPool.commonPool(),
+            i -> {
+              try {
+                Thread.sleep((50 - i) % 5);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return i * 10;
+            });
+    assertThat(out).isEqualTo(inputs.stream().map(i -> i * 10).toList());
+  }
+
+  @Test
+  void neverRunsMoreThanPermitsAtOnce() {
+    int permits = 3;
+    AtomicInteger inFlight = new AtomicInteger();
+    AtomicInteger peak = new AtomicInteger();
+    BoundedFanout.mapOrdered(
+        IntStream.range(0, 40).boxed().toList(),
+        permits,
+        ForkJoinPool.commonPool(),
+        i -> {
+          int now = inFlight.incrementAndGet();
+          peak.accumulateAndGet(now, Math::max);
+          try {
+            Thread.sleep(2);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            inFlight.decrementAndGet();
+          }
+          return i;
+        });
+    assertThat(peak.get()).isLessThanOrEqualTo(permits);
+  }
+
+  @Test
+  void taskFailureSurfacesUnwrapped() {
+    assertThatThrownBy(
+            () ->
+                BoundedFanout.mapOrdered(
+                    List.of(1, 2, 3),
+                    4,
+                    ForkJoinPool.commonPool(),
+                    i -> {
+                      if (i == 2) {
+                        throw new IllegalStateException("boom");
+                      }
+                      return i;
+                    }))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("boom");
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.jboss.logging.MDC;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Off-thread propagation is the whole point of {@link PropagatedContext}: a fan-out worker never
+ * inherits the request thread's thread-locals, so without re-establishing them the ambient reads
+ * ({@code engineContext()}, the log MDC) read empty — which is how an engine-gated multi-input
+ * batch silently misclassified before this existed (eng-floe/floecat#361). These tests capture on a
+ * context-bearing thread and assert the body sees that context on a plain executor thread that
+ * carries none of its own.
+ */
+class PropagatedContextTest {
+
+  private static ResolvedCallContext resolvedWithEngine(String engineKind) {
+    return new ResolvedCallContext(
+        PrincipalContext.getDefaultInstance(),
+        "query-1",
+        "corr-1",
+        EngineContext.of(engineKind, "16.0"),
+        null,
+        null);
+  }
+
+  @Test
+  void reEstablishesAmbientContextOnAForeignThread() throws Exception {
+    ResolvedCallContext resolved = resolvedWithEngine("duckdb");
+    // A single-thread pool that never saw the request: its thread-locals are empty until supply()
+    // re-establishes them, so a wrong read here would be the real regression.
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    try {
+      String engineKind =
+          ResolvedCallContexts.callWith(
+              resolved,
+              () -> {
+                PropagatedContext captured = PropagatedContext.capture();
+                return foreign
+                    .submit(
+                        () ->
+                            captured.supply(
+                                () -> {
+                                  ResolvedCallContext seen = ResolvedCallContexts.currentOrNull();
+                                  assertThat(seen).isNotNull();
+                                  // MDC is derived from the call context, so off-thread log lines
+                                  // carry the request's ids too.
+                                  assertThat(MDC.get("floecat_engine_kind")).isEqualTo("duckdb");
+                                  assertThat(MDC.get("correlation_id")).isEqualTo("corr-1");
+                                  return seen.engineContext().engineKind();
+                                }))
+                    .get();
+              });
+      assertThat(engineKind).isEqualTo("duckdb");
+    } finally {
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
+  void clearsMdcAfterTheBodySoAPooledThreadDoesNotLeakIt() throws Exception {
+    ResolvedCallContext resolved = resolvedWithEngine("spark");
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    try {
+      // MDC.get is typed Object, so keep the carrier Object too rather than casting.
+      Object mdcAfterBody =
+          ResolvedCallContexts.callWith(
+              resolved,
+              () -> {
+                PropagatedContext captured = PropagatedContext.capture();
+                return foreign
+                    .submit(
+                        () -> {
+                          captured.run(
+                              () -> assertThat(MDC.get("floecat_engine_kind")).isEqualTo("spark"));
+                          // Same pooled thread, outside the body: the request's ids must be gone so
+                          // the next unrelated task cannot inherit them.
+                          return MDC.get("floecat_engine_kind");
+                        })
+                    .get();
+              });
+      assertThat(mdcAfterBody).isNull();
+    } finally {
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
+  void offAnyRequestTheBodyStillRuns() {
+    // Captured with no ambient request (startup, unit tests): supply must run the body rather than
+    // fail, and no context is fabricated.
+    PropagatedContext captured = PropagatedContext.capture();
+    assertThat(captured.supply(() -> "ran")).isEqualTo("ran");
+    assertThat(ResolvedCallContexts.currentOrNull()).isNull();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
@@ -108,6 +108,30 @@ class PropagatedContextTest {
   }
 
   @Test
+  void restoresExistingMdcAfterAnInlineNestedScope() {
+    MDC.put("floecat_component", "outer-component");
+    MDC.put("floecat_operation", "outer-operation");
+    MDC.put("correlation_id", "outer-correlation");
+    try {
+      ResolvedCallContexts.callWith(
+          resolvedWithEngine("spark"),
+          () -> {
+            PropagatedContext.capture()
+                .run(() -> assertThat(MDC.get("floecat_engine_kind")).isEqualTo("spark"));
+            return null;
+          });
+
+      assertThat(MDC.get("floecat_component")).isEqualTo("outer-component");
+      assertThat(MDC.get("floecat_operation")).isEqualTo("outer-operation");
+      assertThat(MDC.get("correlation_id")).isEqualTo("outer-correlation");
+    } finally {
+      MDC.remove("floecat_component");
+      MDC.remove("floecat_operation");
+      MDC.remove("correlation_id");
+    }
+  }
+
+  @Test
   void offAnyRequestTheBodyStillRuns() {
     // Captured with no ambient request (startup, unit tests): supply must run the body rather than
     // fail, and no context is fabricated.

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -1309,6 +1309,27 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void successfulLeadingCandidateDoesNotResolveLaterNameFallback() {
+    // Candidate order is semantic: once the table id succeeds, the later NAME fallback must not
+    // be resolved. In particular, that avoids surfacing an irrelevant name-resolution failure.
+    NameRef unusedFallback =
+        NameRef.newBuilder().setCatalog("cat").setName("unused_fallback").build();
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .addCandidates(QueryInput.newBuilder().setName(unusedFallback))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    RelationResolution resolution = chunks.get(1).getResolutions().getItems(0);
+    assertThat(resolution.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(resolution.getRelation().getRelationId()).isEqualTo(TABLE_A);
+    assertThat(overlay.resolveNameCount(unusedFallback)).isZero();
+  }
+
+  @Test
   void appliesDefaultCatalogWhenNameMissingCatalog() {
     TableReferenceCandidate candidate =
         TableReferenceCandidate.newBuilder()

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -77,6 +77,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -801,7 +803,7 @@ class UserObjectBundleServiceTest {
               List<QueryInput> inputs,
               Optional<Timestamp> asOfDefault,
               Optional<ResourceId> defaultCatalogId,
-              Map<ResourceId, TablePin> currentSnapshotPinCache,
+              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
               PhaseDiagnostics diagnostics) {
             return new ResolutionResult(
                 List.of(inputs.get(0).getTableId()), RelationPinSet.getDefaultInstance(), null);

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -2155,16 +2155,24 @@ class UserObjectBundleServiceTest {
 
   @Test
   void requestedInputAfterAnOverflowingViewSpillsToTheNextChunkInOrder() {
-    // Input 0 is a view whose eager base tables overflow one chunk; input 1 is a plain table.
-    // The base tables fill chunk 1 after the view, so the requested table cannot be emitted there
-    // and must appear in chunk 2 — after the view's remaining bases — with its input index intact.
+    assertRequestedInputAfterViewSpillsToNextChunk(30);
+  }
+
+  @Test
+  void requestedInputAfterAChunkFillingViewSpillsToTheNextChunkInOrder() {
+    assertRequestedInputAfterViewSpillsToNextChunk(24);
+  }
+
+  /** Verify that a requested relation after a view's eager bases retains its input position. */
+  private void assertRequestedInputAfterViewSpillsToNextChunk(int baseCount) {
+    // Input 0 is a view whose eager base tables fill chunk 1; input 1 is a plain table selected in
+    // the same batch and must be emitted in chunk 2.
     ResourceId viewId =
         ResourceId.newBuilder()
             .setAccountId("acct")
             .setId("WIDE_VIEW")
             .setKind(ResourceKind.RK_VIEW)
             .build();
-    int baseCount = 30; // > MAX_RESOLUTIONS_PER_CHUNK (25) so the bases span two chunks
     List<NameRef> baseRefs = new ArrayList<>(baseCount);
     for (int i = 0; i < baseCount; i++) {
       ResourceId baseId =
@@ -2216,7 +2224,6 @@ class UserObjectBundleServiceTest {
             .await()
             .indefinitely();
 
-    // header + two resolution chunks (bases span the cap) + end.
     List<RelationResolution> all =
         chunks.stream()
             .filter(UserObjectsBundleChunk::hasResolutions)
@@ -2228,7 +2235,7 @@ class UserObjectBundleServiceTest {
         .filter(UserObjectsBundleChunk::hasResolutions)
         .forEach(c -> assertThat(c.getResolutions().getItemsCount()).isLessThanOrEqualTo(25));
 
-    // The view (index 0) comes first, the requested table (index 1) last, with 30 synthetic bases
+    // The view (index 0) comes first, the requested table (index 1) last, with its synthetic bases
     // (index -1) in between — i.e. the table spilled past the bases but kept its request position.
     assertThat(all.get(0).getInputIndex()).isEqualTo(0);
     assertThat(all.get(0).getRelation().getRelationId()).isEqualTo(viewId);

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.query.catalog;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ai.floedb.floecat.catalog.rpc.TableValueStats;
 import ai.floedb.floecat.common.rpc.NameRef;
@@ -2155,16 +2156,22 @@ class UserObjectBundleServiceTest {
 
   @Test
   void requestedInputAfterAnOverflowingViewSpillsToTheNextChunkInOrder() {
-    assertRequestedInputAfterViewSpillsToNextChunk(30);
+    assertRequestedInputAfterViewSpillsToNextChunk(30, false);
   }
 
   @Test
   void requestedInputAfterAChunkFillingViewSpillsToTheNextChunkInOrder() {
-    assertRequestedInputAfterViewSpillsToNextChunk(24);
+    assertRequestedInputAfterViewSpillsToNextChunk(24, false);
+  }
+
+  @Test
+  void failureAfterAChunkFillingViewIsDeferredUntilTheNextPull() {
+    assertRequestedInputAfterViewSpillsToNextChunk(24, true);
   }
 
   /** Verify that a requested relation after a view's eager bases retains its input position. */
-  private void assertRequestedInputAfterViewSpillsToNextChunk(int baseCount) {
+  private void assertRequestedInputAfterViewSpillsToNextChunk(
+      int baseCount, boolean trailingCandidateFails) {
     // Input 0 is a view whose eager base tables fill chunk 1; input 1 is a plain table selected in
     // the same batch and must be emitted in chunk 2.
     ResourceId viewId =
@@ -2212,13 +2219,38 @@ class UserObjectBundleServiceTest {
         TableReferenceCandidate.newBuilder()
             .addCandidates(QueryInput.newBuilder().setViewId(viewId))
             .build();
-    TableReferenceCandidate tableCandidate =
-        TableReferenceCandidate.newBuilder()
-            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
-            .build();
+    TableReferenceCandidate trailingCandidate =
+        trailingCandidateFails
+            ? TableReferenceCandidate.getDefaultInstance()
+            : TableReferenceCandidate.newBuilder()
+                .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+                .build();
+
+    if (trailingCandidateFails) {
+      List<UserObjectsBundleChunk> emitted = new ArrayList<>();
+      assertThatThrownBy(
+              () ->
+                  service.stream("cid", ctx, List.of(viewCandidate, trailingCandidate))
+                      .onItem()
+                      .invoke(emitted::add)
+                      .collect()
+                      .asList()
+                      .await()
+                      .indefinitely())
+          .isInstanceOf(RuntimeException.class);
+      assertThat(emitted).hasSize(2);
+      assertThat(emitted.get(1).getResolutions().getItemsCount()).isEqualTo(25);
+      assertThat(emitted.get(1).getResolutions().getItems(0).getInputIndex()).isZero();
+      assertThat(
+              emitted.get(1).getResolutions().getItemsList().stream()
+                  .filter(item -> item.getInputIndex() == -1)
+                  .count())
+          .isEqualTo(24);
+      return;
+    }
 
     List<UserObjectsBundleChunk> chunks =
-        service.stream("cid", ctx, List.of(viewCandidate, tableCandidate))
+        service.stream("cid", ctx, List.of(viewCandidate, trailingCandidate))
             .collect()
             .asList()
             .await()

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -805,6 +805,23 @@ class UserObjectBundleServiceTest {
               Optional<ResourceId> defaultCatalogId,
               ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
               PhaseDiagnostics diagnostics) {
+            return emptyPinResolution(inputs);
+          }
+
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+              PhaseDiagnostics diagnostics,
+              java.util.function.BooleanSupplier cancelled) {
+            return emptyPinResolution(inputs);
+          }
+
+          private ResolutionResult emptyPinResolution(List<QueryInput> inputs) {
             return new ResolutionResult(
                 List.of(inputs.get(0).getTableId()), RelationPinSet.getDefaultInstance(), null);
           }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -735,6 +735,48 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void concurrentSelectPreservesInputOrderAndCountsAcrossChunks() {
+    // Many mixed found/not-found inputs spanning multiple chunks: resolved concurrently, they must
+    // still emit strictly in request order, each input index once, with exact end counts.
+    int total = 40; // > 25 so it spans two chunks
+    List<TableReferenceCandidate> candidates = new ArrayList<>(total);
+    int expectedFound = 0;
+    for (int i = 0; i < total; i++) {
+      if (i % 2 == 0) {
+        candidates.add(
+            TableReferenceCandidate.newBuilder()
+                .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+                .build());
+        expectedFound++;
+      } else {
+        candidates.add(
+            TableReferenceCandidate.newBuilder()
+                .addCandidates(
+                    QueryInput.newBuilder()
+                        .setName(NameRef.newBuilder().setCatalog("cat").setName("missing_" + i)))
+                .build());
+      }
+    }
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, candidates).collect().asList().await().indefinitely();
+
+    List<Integer> emittedIndices =
+        chunks.stream()
+            .filter(UserObjectsBundleChunk::hasResolutions)
+            .flatMap(c -> c.getResolutions().getItemsList().stream())
+            .map(RelationResolution::getInputIndex)
+            .toList();
+    List<Integer> expectedIndices = java.util.stream.IntStream.range(0, total).boxed().toList();
+    assertThat(emittedIndices).isEqualTo(expectedIndices);
+
+    UserObjectsBundleChunk end = chunks.get(chunks.size() - 1);
+    assertThat(end.getEnd().getResolutionCount()).isEqualTo(total);
+    assertThat(end.getEnd().getFoundCount()).isEqualTo(expectedFound);
+    assertThat(end.getEnd().getNotFoundCount()).isEqualTo(total - expectedFound);
+  }
+
+  @Test
   void largeRequestSpansMultipleChunksInOrder() {
     int totalCandidates = 30;
     List<TableReferenceCandidate> candidates = new ArrayList<>(totalCandidates);

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -2091,6 +2091,98 @@ class UserObjectBundleServiceTest {
   }
 
   @Test
+  void requestedInputAfterAnOverflowingViewSpillsToTheNextChunkInOrder() {
+    // Input 0 is a view whose eager base tables overflow one chunk; input 1 is a plain table.
+    // The base tables fill chunk 1 after the view, so the requested table cannot be emitted there
+    // and must appear in chunk 2 — after the view's remaining bases — with its input index intact.
+    ResourceId viewId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("WIDE_VIEW")
+            .setKind(ResourceKind.RK_VIEW)
+            .build();
+    int baseCount = 30; // > MAX_RESOLUTIONS_PER_CHUNK (25) so the bases span two chunks
+    List<NameRef> baseRefs = new ArrayList<>(baseCount);
+    for (int i = 0; i < baseCount; i++) {
+      ResourceId baseId =
+          ResourceId.newBuilder()
+              .setAccountId("acct")
+              .setId("WB_BASE_" + i)
+              .setKind(ResourceKind.RK_TABLE)
+              .build();
+      NameRef baseRef = NameRef.newBuilder().setCatalog("cat").setName("wb_base_" + i).build();
+      overlay.registerTable(baseId, UserObjectBundleTestSupport.schemaFor("c" + i), baseRef);
+      baseRefs.add(baseRef);
+    }
+    ViewNode viewNode =
+        new ViewNode(
+            viewId,
+            "blob://test/wide",
+            DEFAULT_CATALOG,
+            ResourceId.getDefaultInstance(),
+            "wide_view",
+            "SELECT 1",
+            "spark",
+            List.of(SchemaColumn.newBuilder().setName("c0").setNullable(true).build()),
+            baseRefs,
+            List.of(),
+            GraphNodeOrigin.USER,
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            Map.of());
+    overlay.registerRelation(
+        viewId,
+        viewNode,
+        UserObjectBundleTestSupport.schemaFor("c0"),
+        NameRef.newBuilder().setCatalog("cat").setName("wide_view").build());
+
+    TableReferenceCandidate viewCandidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setViewId(viewId))
+            .build();
+    TableReferenceCandidate tableCandidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(viewCandidate, tableCandidate))
+            .collect()
+            .asList()
+            .await()
+            .indefinitely();
+
+    // header + two resolution chunks (bases span the cap) + end.
+    List<RelationResolution> all =
+        chunks.stream()
+            .filter(UserObjectsBundleChunk::hasResolutions)
+            .flatMap(c -> c.getResolutions().getItemsList().stream())
+            .toList();
+
+    // Every resolution chunk respects the cap.
+    chunks.stream()
+        .filter(UserObjectsBundleChunk::hasResolutions)
+        .forEach(c -> assertThat(c.getResolutions().getItemsCount()).isLessThanOrEqualTo(25));
+
+    // The view (index 0) comes first, the requested table (index 1) last, with 30 synthetic bases
+    // (index -1) in between — i.e. the table spilled past the bases but kept its request position.
+    assertThat(all.get(0).getInputIndex()).isEqualTo(0);
+    assertThat(all.get(0).getRelation().getRelationId()).isEqualTo(viewId);
+    RelationResolution last = all.get(all.size() - 1);
+    assertThat(last.getInputIndex()).isEqualTo(1);
+    assertThat(last.getRelation().getRelationId()).isEqualTo(TABLE_A);
+    long bases = all.stream().filter(r -> r.getInputIndex() == -1).count();
+    assertThat(bases).isEqualTo(baseCount);
+
+    // End counts only the two requested inputs.
+    UserObjectsBundleChunk end = chunks.get(chunks.size() - 1);
+    assertThat(end.getEnd().getResolutionCount()).isEqualTo(2);
+    assertThat(end.getEnd().getFoundCount()).isEqualTo(2);
+    assertThat(end.getEnd().getNotFoundCount()).isZero();
+  }
+
+  @Test
   void viewAsOfOverrideKeepsAsOfPinForEagerBaseTable() throws Exception {
     ResourceId viewId =
         ResourceId.newBuilder()

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -35,6 +35,7 @@ import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.impl.QueryContext;
@@ -76,7 +77,9 @@ public final class UserObjectBundleTestSupport {
     private final Map<String, NameRef> names = new HashMap<>();
     private final Map<String, CatalogNode> catalogs = new HashMap<>();
     private final Set<String> hidden = new HashSet<>();
+    private final Set<String> schemaFailures = new HashSet<>();
     private final Map<String, Integer> resolveCalls = new ConcurrentHashMap<>();
+    private final Map<NameRef, Integer> resolveNameCalls = new ConcurrentHashMap<>();
 
     public void clear() {
       nodes.clear();
@@ -84,7 +87,16 @@ public final class UserObjectBundleTestSupport {
       names.clear();
       catalogs.clear();
       hidden.clear();
+      schemaFailures.clear();
       resolveCalls.clear();
+      resolveNameCalls.clear();
+    }
+
+    /**
+     * Make {@link #tableSchema} throw for this relation, to exercise per-relation build failures.
+     */
+    public void failSchemaFor(ResourceId id) {
+      schemaFailures.add(id.getId());
     }
 
     public void registerTable(
@@ -197,10 +209,22 @@ public final class UserObjectBundleTestSupport {
 
     @Override
     public Optional<ResourceId> resolveName(String correlationId, NameRef ref) {
+      resolveNameCalls.merge(ref, 1, Integer::sum);
       return names.entrySet().stream()
           .filter(entry -> entry.getValue().equals(ref))
           .map(entry -> nodes.get(entry.getKey()).id())
           .findFirst();
+    }
+
+    @Override
+    public Optional<ResourceId> resolveName(
+        String correlationId, NameRef ref, EngineContext engineContext) {
+      return resolveName(correlationId, ref);
+    }
+
+    /** How many times {@link #resolveName} ran for the exact ref (batch loop included). */
+    public int resolveNameCount(NameRef ref) {
+      return resolveNameCalls.getOrDefault(ref, 0);
     }
 
     @Override
@@ -309,6 +333,9 @@ public final class UserObjectBundleTestSupport {
 
     @Override
     public List<ai.floedb.floecat.query.rpc.SchemaColumn> tableSchema(ResourceId tableId) {
+      if (schemaFailures.contains(tableId.getId())) {
+        throw new RuntimeException("schema unavailable for " + tableId.getId());
+      }
       return schemas.getOrDefault(tableId.getId(), List.of());
     }
   }
@@ -382,7 +409,8 @@ public final class UserObjectBundleTestSupport {
         List<QueryInput> inputs,
         Optional<Timestamp> asOfDefault,
         Optional<ResourceId> defaultCatalogId,
-        Map<ResourceId, TablePin> currentSnapshotPinCache,
+        java.util.concurrent.ConcurrentMap<ResourceId, CompletableFuture<TablePin>>
+            currentSnapshotPinCache,
         PhaseDiagnostics diagnostics) {
       List<ResourceId> resolved = new ArrayList<>(inputs.size());
       RelationPinSet.Builder pins = RelationPinSet.newBuilder();

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -99,6 +100,39 @@ public class QueryInputResolverTest {
             org.mockito.ArgumentMatchers.eq("q1"),
             org.mockito.ArgumentMatchers.argThat(
                 uris -> uris.contains("s3://T1/table.pb") && uris.contains("s3://T1/snap.pb")));
+  }
+
+  @Test
+  void rootsCompletedPinsBeforePlanningLaterInputs() {
+    var store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var withStore = new QueryInputResolver(metadataGraph, store);
+    ResourceId first = rid("ROOTED_FIRST");
+    ResourceId second = rid("LATER_INPUT");
+    boolean[] observedBeforeLaterPlan = {false};
+    metadataGraph.beforeTablePin(
+        tableId -> {
+          if (tableId.equals(second)) {
+            org.mockito.Mockito.verify(store)
+                .registerResolvingPinBlobs(
+                    org.mockito.ArgumentMatchers.eq("q1"),
+                    org.mockito.ArgumentMatchers.argThat(
+                        uris -> uris.contains("s3://ROOTED_FIRST/table.pb")));
+            observedBeforeLaterPlan[0] = true;
+          }
+        });
+
+    withStore.resolveInputs(
+        "q1",
+        "cid",
+        List.of(
+            QueryInput.newBuilder().setTableId(first).build(),
+            QueryInput.newBuilder().setTableId(second).build()),
+        Optional.empty(),
+        Optional.empty(),
+        new java.util.LinkedHashMap<>(),
+        null);
+
+    assertTrue(observedBeforeLaterPlan[0]);
   }
 
   /** Resolving a name that maps only to a table should return the table id. */
@@ -864,6 +898,32 @@ public class QueryInputResolverTest {
   }
 
   @Test
+  void earlier_pin_conflict_precedes_a_later_malformed_input() {
+    ResourceId table = rid("CONFLICT_PRECEDENCE");
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                resolver.resolveInputs(
+                    "cid",
+                    List.of(
+                        QueryInput.newBuilder()
+                            .setTableId(table)
+                            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(888))
+                            .build(),
+                        QueryInput.newBuilder()
+                            .setTableId(table)
+                            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(999))
+                            .build(),
+                        QueryInput.getDefaultInstance()),
+                    Optional.empty(),
+                    Optional.empty()));
+
+    assertEquals(io.grpc.Status.Code.FAILED_PRECONDITION, failure.getStatus().getCode());
+  }
+
+  @Test
   void conflicting_asof_and_explicit_snapshot_for_same_table_fail() {
     // An AS_OF reference resolves to a concrete snapshot; if a later explicit-snapshot reference to
     // the same table names a different snapshot, the two temporal intents conflict and planning
@@ -1044,6 +1104,7 @@ public class QueryInputResolverTest {
     private final Map<String, Long> asOfSnapshots = new HashMap<>();
     private final List<PinCall> pinCalls = new ArrayList<>();
     private final Map<ResourceId, String> catalogNames = new HashMap<>();
+    private Consumer<ResourceId> beforeTablePin = ignored -> {};
 
     FakeGraph() {}
 
@@ -1092,6 +1153,7 @@ public class QueryInputResolverTest {
         SnapshotRef override,
         Optional<Timestamp> asOfDefault) {
 
+      beforeTablePin.accept(tableId);
       pinCalls.add(new PinCall(correlationId, tableId, override, asOfDefault));
 
       TablePin.Builder builder =
@@ -1139,6 +1201,10 @@ public class QueryInputResolverTest {
 
     void setAsOfSnapshot(ResourceId id, long snapshotId) {
       asOfSnapshots.put(id.getId(), snapshotId);
+    }
+
+    void beforeTablePin(Consumer<ResourceId> callback) {
+      beforeTablePin = callback;
     }
 
     List<PinCall> pinCalls() {

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.PinKind;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
 import com.google.protobuf.Timestamp;
@@ -40,7 +41,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -90,7 +95,7 @@ public class QueryInputResolverTest {
         List.of(QueryInput.newBuilder().setName(n).build()),
         Optional.empty(),
         Optional.empty(),
-        new java.util.LinkedHashMap<>(),
+        new ConcurrentHashMap<>(),
         null);
 
     // Registered under the stable query id (not the per-RPC correlation id), so the committing RPC
@@ -102,37 +107,70 @@ public class QueryInputResolverTest {
                 uris -> uris.contains("s3://T1/table.pb") && uris.contains("s3://T1/snap.pb")));
   }
 
+  /** A completed parallel input roots its pin while another input is still resolving. */
   @Test
-  void rootsCompletedPinsBeforePlanningLaterInputs() {
+  void rootsCompletedParallelPinBeforeSlowerInputReturns() throws Exception {
+    var blockingGraph = new BlockingPinGraph("SLOW");
     var store = org.mockito.Mockito.mock(QueryContextStore.class);
-    var withStore = new QueryInputResolver(metadataGraph, store);
-    ResourceId first = rid("ROOTED_FIRST");
-    ResourceId second = rid("LATER_INPUT");
-    boolean[] observedBeforeLaterPlan = {false};
-    metadataGraph.beforeTablePin(
-        tableId -> {
-          if (tableId.equals(second)) {
-            org.mockito.Mockito.verify(store)
-                .registerResolvingPinBlobs(
-                    org.mockito.ArgumentMatchers.eq("q1"),
-                    org.mockito.ArgumentMatchers.argThat(
-                        uris -> uris.contains("s3://ROOTED_FIRST/table.pb")));
-            observedBeforeLaterPlan[0] = true;
-          }
-        });
+    var withStore = new QueryInputResolver(blockingGraph, store);
+    ResourceId slow = rid("SLOW");
+    ResourceId fast = rid("FAST");
 
-    withStore.resolveInputs(
-        "q1",
-        "cid",
-        List.of(
-            QueryInput.newBuilder().setTableId(first).build(),
-            QueryInput.newBuilder().setTableId(second).build()),
-        Optional.empty(),
-        Optional.empty(),
-        new java.util.LinkedHashMap<>(),
-        null);
+    CompletableFuture<Void> resolution =
+        CompletableFuture.runAsync(
+            () ->
+                withStore.resolveInputs(
+                    "q-parallel",
+                    "cid",
+                    List.of(
+                        QueryInput.newBuilder().setTableId(slow).build(),
+                        QueryInput.newBuilder().setTableId(fast).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new java.util.concurrent.ConcurrentHashMap<>(),
+                    null));
 
-    assertTrue(observedBeforeLaterPlan[0]);
+    try {
+      assertTrue(blockingGraph.slowPinStarted.await(1, TimeUnit.SECONDS));
+      org.mockito.Mockito.verify(store, org.mockito.Mockito.timeout(1_000))
+          .registerResolvingPinBlobs(
+              org.mockito.ArgumentMatchers.eq("q-parallel"),
+              org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
+    } finally {
+      blockingGraph.allowSlowPin.countDown();
+    }
+    resolution.join();
+  }
+
+  /** A failed parallel plan releases every provisional root it constructed. */
+  @Test
+  void releasesCompletedParallelPinWhenSiblingPlanningFails() {
+    var failingGraph = new FailingAfterFastPinGraph();
+    var store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var withStore = new QueryInputResolver(failingGraph, store);
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-failure",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(rid("FAIL")).build(),
+                    QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                Optional.empty(),
+                Optional.empty(),
+                new java.util.concurrent.ConcurrentHashMap<>(),
+                null));
+
+    org.mockito.Mockito.verify(store)
+        .registerResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-failure"),
+            org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
+    org.mockito.Mockito.verify(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-failure"),
+            org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
   }
 
   /** Resolving a name that maps only to a table should return the table id. */
@@ -331,7 +369,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new java.util.LinkedHashMap<>(),
+                new ConcurrentHashMap<>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -397,7 +435,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new java.util.LinkedHashMap<>(),
+                new ConcurrentHashMap<>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -452,7 +490,7 @@ public class QueryInputResolverTest {
             List.of(qi),
             Optional.<com.google.protobuf.Timestamp>empty(),
             Optional.<ResourceId>empty(),
-            new java.util.LinkedHashMap<>(),
+            new ConcurrentHashMap<>(),
             null)
         .snapshotSet();
 
@@ -952,32 +990,6 @@ public class QueryInputResolverTest {
   }
 
   @Test
-  void earlier_pin_conflict_precedes_a_later_malformed_input() {
-    ResourceId table = rid("CONFLICT_PRECEDENCE");
-
-    StatusRuntimeException failure =
-        assertThrows(
-            StatusRuntimeException.class,
-            () ->
-                resolver.resolveInputs(
-                    "cid",
-                    List.of(
-                        QueryInput.newBuilder()
-                            .setTableId(table)
-                            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(888))
-                            .build(),
-                        QueryInput.newBuilder()
-                            .setTableId(table)
-                            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(999))
-                            .build(),
-                        QueryInput.getDefaultInstance()),
-                    Optional.empty(),
-                    Optional.empty()));
-
-    assertEquals(io.grpc.Status.Code.FAILED_PRECONDITION, failure.getStatus().getCode());
-  }
-
-  @Test
   void conflicting_asof_and_explicit_snapshot_for_same_table_fail() {
     // An AS_OF reference resolves to a concrete snapshot; if a later explicit-snapshot reference to
     // the same table names a different snapshot, the two temporal intents conflict and planning
@@ -1040,7 +1052,7 @@ public class QueryInputResolverTest {
     ResourceId tableId = rid("CACHE_TABLE");
     metadataGraph.setCurrentSnapshot(tableId, 1234L);
     QueryInput input = QueryInput.newBuilder().setTableId(tableId).build();
-    Map<ResourceId, TablePin> cache = new HashMap<>();
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
 
     resolver.resolveInputs(
         "", "cid-a", List.of(input), Optional.empty(), Optional.empty(), cache, null);
@@ -1150,7 +1162,7 @@ public class QueryInputResolverTest {
   // Helpers / test doubles (Composition, not inheritance)
   // ----------------------------------------------------------------------
 
-  static final class FakeGraph extends TestCatalogOverlay {
+  static class FakeGraph extends TestCatalogOverlay {
 
     private final Map<NameRef, ResourceId> nameBindings = new HashMap<>();
     private final Map<NameRef, RuntimeException> failures = new HashMap<>();
@@ -1160,7 +1172,6 @@ public class QueryInputResolverTest {
     private final List<PinCall> pinCalls =
         java.util.Collections.synchronizedList(new ArrayList<>());
     private final Map<ResourceId, String> catalogNames = new HashMap<>();
-    private Consumer<ResourceId> beforeTablePin = ignored -> {};
 
     FakeGraph() {}
 
@@ -1203,13 +1214,18 @@ public class QueryInputResolverTest {
     }
 
     @Override
+    public Optional<ResourceId> resolveName(
+        String correlationId, NameRef ref, EngineContext engineContext) {
+      return resolveName(correlationId, ref);
+    }
+
+    @Override
     public TablePin tablePinFor(
         String correlationId,
         ResourceId tableId,
         SnapshotRef override,
         Optional<Timestamp> asOfDefault) {
 
-      beforeTablePin.accept(tableId);
       pinCalls.add(new PinCall(correlationId, tableId, override, asOfDefault));
 
       TablePin.Builder builder =
@@ -1259,10 +1275,6 @@ public class QueryInputResolverTest {
       asOfSnapshots.put(id.getId(), snapshotId);
     }
 
-    void beforeTablePin(Consumer<ResourceId> callback) {
-      beforeTablePin = callback;
-    }
-
     List<PinCall> pinCalls() {
       return pinCalls;
     }
@@ -1272,6 +1284,66 @@ public class QueryInputResolverTest {
         ResourceId tableId,
         SnapshotRef override,
         Optional<Timestamp> asOfDefault) {}
+  }
+
+  /** Blocks one table-pin lookup until the test releases it. */
+  static final class BlockingPinGraph extends FakeGraph {
+    private final String blockedTableId;
+    final CountDownLatch slowPinStarted = new CountDownLatch(1);
+    final CountDownLatch allowSlowPin = new CountDownLatch(1);
+
+    BlockingPinGraph(String blockedTableId) {
+      this.blockedTableId = blockedTableId;
+    }
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      if (blockedTableId.equals(tableId.getId())) {
+        slowPinStarted.countDown();
+        try {
+          if (!allowSlowPin.await(1, TimeUnit.SECONDS)) {
+            throw new AssertionError("test did not release the slow pin lookup");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError("slow pin lookup interrupted", e);
+        }
+      }
+      return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+  }
+
+  /** Fails one lookup only after the sibling's pin has been constructed. */
+  static final class FailingAfterFastPinGraph extends FakeGraph {
+    private final CountDownLatch fastPinCompleted = new CountDownLatch(1);
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      if ("FAIL".equals(tableId.getId())) {
+        try {
+          if (!fastPinCompleted.await(1, TimeUnit.SECONDS)) {
+            throw new AssertionError("fast pin lookup did not complete");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError("failing pin lookup interrupted", e);
+        }
+        throw new IllegalStateException("planned failure");
+      }
+      TablePin pin = super.tablePinFor(correlationId, tableId, override, asOfDefault);
+      if ("FAST".equals(tableId.getId())) {
+        fastPinCompleted.countDown();
+      }
+      return pin;
+    }
   }
 
   private static NameRef nameRef(ResourceId id) {

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -173,6 +173,35 @@ public class QueryInputResolverTest {
             org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
   }
 
+  /** Completed sibling work still contributes pin diagnostics when another parallel plan fails. */
+  @Test
+  void flushesParallelPinDiagnosticsWhenSiblingPlanningFails() {
+    var failingGraph = new FailingAfterFastPinGraph();
+    var withStore = new QueryInputResolver(failingGraph);
+    var diagnostics = org.mockito.Mockito.mock(ai.floedb.floecat.telemetry.PhaseDiagnostics.class);
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-diagnostics-failure",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(rid("FAIL")).build(),
+                    QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                Optional.empty(),
+                Optional.empty(),
+                new java.util.concurrent.ConcurrentHashMap<>(),
+                diagnostics));
+
+    org.mockito.Mockito.verify(diagnostics).add("pin.snapshot_calls", 1L);
+    org.mockito.Mockito.verify(diagnostics).add("pin.current_snapshot_cache_misses", 1L);
+    org.mockito.Mockito.verify(diagnostics)
+        .nanos(
+            org.mockito.ArgumentMatchers.eq("pin.snapshot_lookup"),
+            org.mockito.ArgumentMatchers.anyLong());
+  }
+
   /** Resolving a name that maps only to a table should return the table id. */
   @Test
   void resolve_table_only() {

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -95,7 +95,7 @@ public class QueryInputResolverTest {
         List.of(QueryInput.newBuilder().setName(n).build()),
         Optional.empty(),
         Optional.empty(),
-        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
         null);
 
     // Registered under the stable query id (not the per-RPC correlation id), so the committing RPC
@@ -127,7 +127,8 @@ public class QueryInputResolverTest {
                         QueryInput.newBuilder().setTableId(fast).build()),
                     Optional.empty(),
                     Optional.empty(),
-                    new java.util.concurrent.ConcurrentHashMap<>(),
+                    new java.util.concurrent.ConcurrentHashMap<
+                        ResourceId, CompletableFuture<TablePin>>(),
                     null));
 
     try {
@@ -160,7 +161,7 @@ public class QueryInputResolverTest {
                         QueryInput.newBuilder().setTableId(rid("FAST")).build()),
                     Optional.empty(),
                     Optional.empty(),
-                    new ConcurrentHashMap<>(),
+                    new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                     null,
                     cancelled::get);
                 return null;
@@ -198,7 +199,8 @@ public class QueryInputResolverTest {
                     QueryInput.newBuilder().setTableId(rid("FAST")).build()),
                 Optional.empty(),
                 Optional.empty(),
-                new java.util.concurrent.ConcurrentHashMap<>(),
+                new java.util.concurrent.ConcurrentHashMap<
+                    ResourceId, CompletableFuture<TablePin>>(),
                 null));
 
     org.mockito.Mockito.verify(store)
@@ -229,7 +231,8 @@ public class QueryInputResolverTest {
                     QueryInput.newBuilder().setTableId(rid("FAST")).build()),
                 Optional.empty(),
                 Optional.empty(),
-                new java.util.concurrent.ConcurrentHashMap<>(),
+                new java.util.concurrent.ConcurrentHashMap<
+                    ResourceId, CompletableFuture<TablePin>>(),
                 diagnostics));
 
     org.mockito.Mockito.verify(diagnostics).add("pin.snapshot_calls", 1L);
@@ -436,7 +439,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new ConcurrentHashMap<>(),
+                new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -502,7 +505,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new ConcurrentHashMap<>(),
+                new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -557,7 +560,7 @@ public class QueryInputResolverTest {
             List.of(qi),
             Optional.<com.google.protobuf.Timestamp>empty(),
             Optional.<ResourceId>empty(),
-            new ConcurrentHashMap<>(),
+            new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
             null)
         .snapshotSet();
 
@@ -1267,6 +1270,11 @@ public class QueryInputResolverTest {
     private final Map<ResourceId, String> catalogNames = new HashMap<>();
 
     FakeGraph() {}
+
+    @Override
+    public boolean supportsConcurrentResolution() {
+      return true;
+    }
 
     void setCatalogName(ResourceId id, String name) {
       catalogNames.put(id, name);

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -201,6 +201,60 @@ public class QueryInputResolverTest {
                 Optional.empty()));
   }
 
+  /**
+   * Two references to the same table's CURRENT snapshot in one batch resolve the snapshot once,
+   * even though the inputs are resolved concurrently. Without single-flight the two references
+   * could resolve independently and, if an ingest landed between them, freeze different snapshots.
+   */
+  @Test
+  void currentSnapshotForRepeatedTableIsResolvedOnce() {
+    ResourceId tableId = rid("T1");
+    NameRef a = name("c", "ns", "a");
+    NameRef b = name("c", "ns", "b");
+    metadataGraph.bind(a, tableId);
+    metadataGraph.bind(b, tableId);
+    metadataGraph.setCurrentSnapshot(tableId, 55);
+
+    var result =
+        resolver.resolveInputs(
+            "cid",
+            List.of(
+                QueryInput.newBuilder().setName(a).build(),
+                QueryInput.newBuilder().setName(b).build()),
+            Optional.empty(),
+            Optional.empty());
+
+    long pinsForT1 =
+        result.snapshotSet().getPinsList().stream()
+            .filter(p -> p.getTableId().getId().equals("T1"))
+            .count();
+    assertEquals(1, pinsForT1, "the two references must merge into one pin");
+
+    long tablePinCallsForT1 =
+        metadataGraph.pinCalls().stream().filter(c -> c.tableId().equals(tableId)).count();
+    assertEquals(1, tablePinCallsForT1, "CURRENT snapshot for a table must be resolved once");
+  }
+
+  /** A batch of distinct relations resolves every one, preserving request order. */
+  @Test
+  void batchResolvesEveryInputInRequestOrder() {
+    List<QueryInput> inputs = new ArrayList<>();
+    List<String> expectedOrder = new ArrayList<>();
+    for (int i = 0; i < 12; i++) {
+      NameRef n = name("c", "ns", "t" + i);
+      ResourceId id = rid("T" + i);
+      metadataGraph.bind(n, id);
+      metadataGraph.setCurrentSnapshot(id, 100 + i);
+      inputs.add(QueryInput.newBuilder().setName(n).build());
+      expectedOrder.add("T" + i);
+    }
+
+    var result = resolver.resolveInputs("cid", inputs, Optional.empty(), Optional.empty());
+
+    assertEquals(expectedOrder, result.resolved().stream().map(ResourceId::getId).toList());
+    assertEquals(12, result.snapshotSet().getPinsCount());
+  }
+
   /** When a QueryInput specifies a snapshot_id override, the resolver must use it verbatim. */
   @Test
   void snapshot_override_id() {
@@ -1102,7 +1156,9 @@ public class QueryInputResolverTest {
     private final Map<NameRef, RuntimeException> failures = new HashMap<>();
     private final Map<String, Long> currentSnapshots = new HashMap<>();
     private final Map<String, Long> asOfSnapshots = new HashMap<>();
-    private final List<PinCall> pinCalls = new ArrayList<>();
+    // Written from resolution tasks, which may run in parallel; keep it thread-safe.
+    private final List<PinCall> pinCalls =
+        java.util.Collections.synchronizedList(new ArrayList<>());
     private final Map<ResourceId, String> catalogNames = new HashMap<>();
     private Consumer<ResourceId> beforeTablePin = ignored -> {};
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -142,6 +142,44 @@ public class QueryInputResolverTest {
     resolution.join();
   }
 
+  @Test
+  void cancellationInterruptsBlockedParallelPinResolution() throws Exception {
+    var blockingGraph = new BlockingPinGraph("SLOW");
+    var withStore = new QueryInputResolver(blockingGraph);
+    var cancelled = new java.util.concurrent.atomic.AtomicBoolean();
+
+    CompletableFuture<Throwable> resolution =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                withStore.resolveInputs(
+                    "q-cancel",
+                    "cid",
+                    List.of(
+                        QueryInput.newBuilder().setTableId(rid("SLOW")).build(),
+                        QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new ConcurrentHashMap<>(),
+                    null,
+                    cancelled::get);
+                return null;
+              } catch (Throwable failure) {
+                return failure;
+              }
+            });
+
+    try {
+      assertTrue(blockingGraph.slowPinStarted.await(1, TimeUnit.SECONDS));
+      cancelled.set(true);
+      assertTrue(
+          resolution.get(250, TimeUnit.MILLISECONDS)
+              instanceof java.util.concurrent.CancellationException);
+    } finally {
+      blockingGraph.allowSlowPin.countDown();
+    }
+  }
+
   /** A failed parallel plan releases every provisional root it constructed. */
   @Test
   void releasesCompletedParallelPinWhenSiblingPlanningFails() {
@@ -1016,6 +1054,32 @@ public class QueryInputResolverTest {
                         .build()),
                 Optional.empty(),
                 Optional.empty()));
+  }
+
+  @Test
+  void earlier_pin_conflict_precedes_a_later_malformed_input() {
+    ResourceId table = rid("CONFLICT_PRECEDENCE");
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                resolver.resolveInputs(
+                    "cid",
+                    List.of(
+                        QueryInput.newBuilder()
+                            .setTableId(table)
+                            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(888))
+                            .build(),
+                        QueryInput.newBuilder()
+                            .setTableId(table)
+                            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(999))
+                            .build(),
+                        QueryInput.getDefaultInstance()),
+                    Optional.empty(),
+                    Optional.empty()));
+
+    assertEquals(io.grpc.Status.Code.FAILED_PRECONDITION, failure.getStatus().getCode());
   }
 
   @Test

--- a/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
+++ b/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.telemetry;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * A thread-safe {@link PhaseDiagnostics} that sums counts and durations per key, for reporting
+ * diagnostics from work spread across threads. Concurrent tasks share one instance; the request
+ * thread then calls {@link #flushInto} once to emit the totals to the real (not necessarily
+ * thread-safe) diagnostics.
+ *
+ * <p>Only counters and durations aggregate meaningfully, so those are the only calls kept: {@code
+ * count}/{@code add} sum, {@code timer}/{@code nanos} sum the elapsed time, and each summed key is
+ * flushed once as a single {@code add} / {@code nanos}. The per-key values (e.g. total snapshot
+ * lookups and the total time spent in them) are the per-request aggregate; per-item ordering and
+ * one-shot fields ({@code put}, {@code emit}) are not represented and are dropped — a caller that
+ * needs them should record on the request thread.
+ */
+public final class AggregatingPhaseDiagnostics implements PhaseDiagnostics {
+
+  private final Map<String, LongAdder> counts = new ConcurrentHashMap<>();
+  private final Map<String, LongAdder> nanosByKey = new ConcurrentHashMap<>();
+
+  @Override
+  public Timer timer(String key) {
+    long startNanos = System.nanoTime();
+    return () -> nanos(key, System.nanoTime() - startNanos);
+  }
+
+  @Override
+  public void nanos(String key, long nanos) {
+    nanosByKey.computeIfAbsent(key, k -> new LongAdder()).add(nanos);
+  }
+
+  @Override
+  public void count(String key) {
+    add(key, 1L);
+  }
+
+  @Override
+  public void add(String key, long amount) {
+    counts.computeIfAbsent(key, k -> new LongAdder()).add(amount);
+  }
+
+  // One-shot values do not aggregate across items; callers that need them report on the request
+  // thread, not through this accumulator.
+  @Override
+  public void put(String key, String value) {}
+
+  @Override
+  public void put(String key, long value) {}
+
+  @Override
+  public void put(String key, double value) {}
+
+  @Override
+  public void put(String key, boolean value) {}
+
+  @Override
+  public void emit(String eventName) {}
+
+  /**
+   * Emit the accumulated totals to {@code target}: one {@code add} per counter, one summed {@code
+   * nanos} per timed key.
+   */
+  public void flushInto(PhaseDiagnostics target) {
+    counts.forEach((key, adder) -> target.add(key, adder.sum()));
+    nanosByKey.forEach((key, adder) -> target.nanos(key, adder.sum()));
+  }
+}

--- a/telemetry-hub/core/src/test/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnosticsTest.java
+++ b/telemetry-hub/core/src/test/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnosticsTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class AggregatingPhaseDiagnosticsTest {
+
+  /** Records the totals flushed to it, so aggregation can be asserted. */
+  private static final class CapturingDiagnostics implements PhaseDiagnostics {
+    final Map<String, Long> added = new LinkedHashMap<>();
+    final Map<String, Long> nanos = new LinkedHashMap<>();
+
+    @Override
+    public Timer timer(String key) {
+      return Timer.NOOP;
+    }
+
+    @Override
+    public void nanos(String key, long value) {
+      nanos.merge(key, value, Long::sum);
+    }
+
+    @Override
+    public void count(String key) {
+      add(key, 1L);
+    }
+
+    @Override
+    public void add(String key, long amount) {
+      added.merge(key, amount, Long::sum);
+    }
+
+    @Override
+    public void put(String key, String value) {}
+
+    @Override
+    public void put(String key, long value) {}
+
+    @Override
+    public void put(String key, double value) {}
+
+    @Override
+    public void put(String key, boolean value) {}
+
+    @Override
+    public void emit(String eventName) {}
+  }
+
+  @Test
+  void flushSumsCountsAndDurationsPerKey() {
+    AggregatingPhaseDiagnostics agg = new AggregatingPhaseDiagnostics();
+    agg.count("pin.snapshot_calls");
+    agg.count("pin.snapshot_calls");
+    agg.add("pin.current_snapshot_cache_hits", 3);
+    agg.nanos("pin.snapshot_lookup", 10);
+    agg.nanos("pin.snapshot_lookup", 25);
+
+    CapturingDiagnostics target = new CapturingDiagnostics();
+    agg.flushInto(target);
+
+    assertThat(target.added).containsEntry("pin.snapshot_calls", 2L);
+    assertThat(target.added).containsEntry("pin.current_snapshot_cache_hits", 3L);
+    assertThat(target.nanos).containsEntry("pin.snapshot_lookup", 35L);
+  }
+
+  @Test
+  void oneShotAndEmitAreDropped() {
+    AggregatingPhaseDiagnostics agg = new AggregatingPhaseDiagnostics();
+    agg.put("k", "v");
+    agg.put("n", 1L);
+    agg.emit("event");
+
+    CapturingDiagnostics target = new CapturingDiagnostics();
+    agg.flushInto(target);
+
+    assertThat(target.added).isEmpty();
+    assertThat(target.nanos).isEmpty();
+  }
+
+  @Test
+  void concurrentWritersAllAggregate() {
+    AggregatingPhaseDiagnostics agg = new AggregatingPhaseDiagnostics();
+    int writers = 64;
+    CompletableFuture<?>[] futures =
+        IntStream.range(0, writers)
+            .mapToObj(
+                i ->
+                    CompletableFuture.runAsync(
+                        () -> {
+                          agg.count("pin.snapshot_calls");
+                          agg.nanos("pin.snapshot_lookup", 5);
+                        }))
+            .toArray(CompletableFuture[]::new);
+    CompletableFuture.allOf(futures).join();
+
+    CapturingDiagnostics target = new CapturingDiagnostics();
+    agg.flushInto(target);
+
+    assertThat(target.added).containsEntry("pin.snapshot_calls", (long) writers);
+    assertThat(target.nanos).containsEntry("pin.snapshot_lookup", (long) writers * 5);
+  }
+
+  @Test
+  void timerSumsElapsedIntoItsKey() {
+    AggregatingPhaseDiagnostics agg = new AggregatingPhaseDiagnostics();
+    try (PhaseDiagnostics.Timer ignored = agg.timer("pin.snapshot_lookup")) {
+      // close records the elapsed
+    }
+
+    CapturingDiagnostics target = new CapturingDiagnostics();
+    agg.flushInto(target);
+
+    assertThat(target.nanos).containsKey("pin.snapshot_lookup");
+    assertThat(target.nanos.get("pin.snapshot_lookup")).isGreaterThanOrEqualTo(0L);
+  }
+}


### PR DESCRIPTION
## Summary

Restructure chunk filling into plan, select, and gather stages. 
Select inputs concurrently while preserving candidate fallback order, deterministic output ordering,
and spillover across chunk boundaries.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
