### PR TITLE
feat(cli): add catalog integration and overlay commands (stack 7/8)

### DIFF
--- a/client-cli/EMBEDDING.md
+++ b/client-cli/EMBEDDING.md
@@ -24,6 +24,8 @@ CliCommandExecutor executor = CliCommandExecutor.builder()
     .tables(TableServiceGrpc.newBlockingStub(channel))
     .viewService(ViewServiceGrpc.newBlockingStub(channel))
     .connectors(ConnectorsGrpc.newBlockingStub(channel))
+    .integrations(CatalogIntegrationsGrpc.newBlockingStub(channel))
+    .overlays(CatalogOverlaysGrpc.newBlockingStub(channel))
     .reconcileControl(ReconcileControlGrpc.newBlockingStub(channel))
     .snapshots(SnapshotServiceGrpc.newBlockingStub(channel))
     .statistics(TableStatisticsServiceGrpc.newBlockingStub(channel))
@@ -111,6 +113,8 @@ expected: `catalog create "my catalog"` becomes three tokens.
 | `table` / `tables` | `tables <ns>`, `table get <fq>`, `resolve <fq>`, `describe <fq>` |
 | `view` / `views` | `views <ns>`, `view get <fq>` |
 | `connector` / `connectors` | `connectors`, `connector create ...`, `connector trigger <id>` |
+| `integration` / `integrations` | `integrations`, `integration create <name> <type> <uri> --auth-type <type>` |
+| `overlay` / `overlays` | `overlays`, `overlay create <name> <integration>` |
 | `snapshot` / `snapshots` | `snapshots <table>`, `snapshot get <table> --snapshot <id>` |
 | `stats` / `analyze` | `stats table <fq>`, `stats columns <fq>`, `analyze <fq>` |
 | `constraints` | `constraints list <table>` |

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/CliCommandExecutor.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/CliCommandExecutor.java
@@ -28,6 +28,8 @@ import ai.floedb.floecat.catalog.rpc.TableStatisticsServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.ViewServiceGrpc;
 import ai.floedb.floecat.client.cli.util.CliUtils;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
@@ -78,6 +80,8 @@ public final class CliCommandExecutor {
   private final TableServiceGrpc.TableServiceBlockingStub tables;
   private final ViewServiceGrpc.ViewServiceBlockingStub viewService;
   private final ConnectorsGrpc.ConnectorsBlockingStub connectors;
+  private final CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations;
+  private final CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays;
   private final ReconcileControlGrpc.ReconcileControlBlockingStub reconcileControl;
   private final SnapshotServiceGrpc.SnapshotServiceBlockingStub snapshots;
   private final TableStatisticsServiceGrpc.TableStatisticsServiceBlockingStub statistics;
@@ -101,6 +105,8 @@ public final class CliCommandExecutor {
     this.tables = builder.tables;
     this.viewService = builder.viewService;
     this.connectors = builder.connectors;
+    this.integrations = builder.integrations;
+    this.overlays = builder.overlays;
     this.reconcileControl = builder.reconcileControl;
     this.snapshots = builder.snapshots;
     this.statistics = builder.statistics;
@@ -145,6 +151,8 @@ public final class CliCommandExecutor {
         .tables(TableServiceGrpc.newBlockingStub(channel))
         .viewService(ViewServiceGrpc.newBlockingStub(channel))
         .connectors(ConnectorsGrpc.newBlockingStub(channel))
+        .integrations(CatalogIntegrationsGrpc.newBlockingStub(channel))
+        .overlays(CatalogOverlaysGrpc.newBlockingStub(channel))
         .reconcileControl(ReconcileControlGrpc.newBlockingStub(channel))
         .snapshots(SnapshotServiceGrpc.newBlockingStub(channel))
         .statistics(TableStatisticsServiceGrpc.newBlockingStub(channel))
@@ -174,6 +182,8 @@ public final class CliCommandExecutor {
     private TableServiceGrpc.TableServiceBlockingStub tables;
     private ViewServiceGrpc.ViewServiceBlockingStub viewService;
     private ConnectorsGrpc.ConnectorsBlockingStub connectors;
+    private CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations;
+    private CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays;
     private ReconcileControlGrpc.ReconcileControlBlockingStub reconcileControl;
     private SnapshotServiceGrpc.SnapshotServiceBlockingStub snapshots;
     private TableStatisticsServiceGrpc.TableStatisticsServiceBlockingStub statistics;
@@ -227,6 +237,17 @@ public final class CliCommandExecutor {
 
     public Builder connectors(ConnectorsGrpc.ConnectorsBlockingStub connectors) {
       this.connectors = connectors;
+      return this;
+    }
+
+    public Builder integrations(
+        CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations) {
+      this.integrations = integrations;
+      return this;
+    }
+
+    public Builder overlays(CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays) {
+      this.overlays = overlays;
       return this;
     }
 
@@ -319,6 +340,8 @@ public final class CliCommandExecutor {
       Objects.requireNonNull(tables, "tables");
       Objects.requireNonNull(viewService, "viewService");
       Objects.requireNonNull(connectors, "connectors");
+      Objects.requireNonNull(integrations, "integrations");
+      Objects.requireNonNull(overlays, "overlays");
       Objects.requireNonNull(reconcileControl, "reconcileControl");
       Objects.requireNonNull(snapshots, "snapshots");
       Objects.requireNonNull(statistics, "statistics");
@@ -394,6 +417,9 @@ public final class CliCommandExecutor {
               snapshots,
               directory,
               getAccountId);
+      case "integrations", "integration", "overlays", "overlay" ->
+          IntegrationCliSupport.handle(
+              command, CliArgs.tail(tokens), out, integrations, overlays, getAccountId);
       case "snapshots", "snapshot" ->
           SnapshotCliSupport.handle(
               command,

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
@@ -1,0 +1,595 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package ai.floedb.floecat.client.cli;
+
+import ai.floedb.floecat.client.cli.util.CliUtils;
+import ai.floedb.floecat.client.cli.util.FQNameParserUtil;
+import ai.floedb.floecat.client.cli.util.Quotes;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.AwsAccessKeyAuthentication;
+import ai.floedb.floecat.integration.rpc.AwsAccessKeySecret;
+import ai.floedb.floecat.integration.rpc.AwsAssumeRoleAuthentication;
+import ai.floedb.floecat.integration.rpc.AwsDefaultAuthentication;
+import ai.floedb.floecat.integration.rpc.AwsSigV4Authentication;
+import ai.floedb.floecat.integration.rpc.BearerAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationSpec;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaySpec;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
+import ai.floedb.floecat.integration.rpc.NamespacePath;
+import ai.floedb.floecat.integration.rpc.OAuthClientCredentialsAuthentication;
+import ai.floedb.floecat.integration.rpc.SecretValue;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayRequest;
+import com.google.protobuf.FieldMask;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/** Small CRUD surface for catalog integrations and their catalog overlays. */
+final class IntegrationCliSupport {
+  private static final int DEFAULT_PAGE_SIZE = 100;
+
+  private IntegrationCliSupport() {}
+
+  static void handle(
+      String command,
+      List<String> args,
+      PrintStream out,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays,
+      Supplier<String> getCurrentAccountId) {
+    switch (command) {
+      case "integrations" -> listIntegrations(out, integrations);
+      case "integration" -> integrationCrud(args, out, integrations, getCurrentAccountId);
+      case "overlays" -> listOverlays(args, out, integrations, overlays, getCurrentAccountId);
+      case "overlay" -> overlayCrud(args, out, integrations, overlays, getCurrentAccountId);
+      default -> throw new IllegalArgumentException("Unsupported integration command: " + command);
+    }
+  }
+
+  private static void integrationCrud(
+      List<String> args,
+      PrintStream out,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      Supplier<String> accountId) {
+    if (args.isEmpty()) {
+      out.println("usage: integration <list|get|create|update|update-auth|delete> ...");
+      return;
+    }
+    switch (args.getFirst()) {
+      case "list" -> listIntegrations(out, integrations);
+      case "get" -> {
+        if (args.size() < 2) {
+          out.println("usage: integration get <name|id>");
+          return;
+        }
+        var row =
+            integrations
+                .getCatalogIntegration(
+                    GetCatalogIntegrationRequest.newBuilder()
+                        .setIntegrationId(resolveIntegration(args.get(1), integrations, accountId))
+                        .build())
+                .getIntegration();
+        printIntegrations(List.of(row), out);
+      }
+      case "create" -> {
+        if (args.size() < 4) {
+          out.println(
+              "usage: integration create <name> <iceberg-rest|unity> <uri>"
+                  + " --auth-type <type> [--auth k=v ...] [--cred k=v ...]");
+          return;
+        }
+        ParsedAuthentication parsedAuthentication = parseAuthentication(args);
+        CatalogIntegrationSpec spec =
+            integrationSpec(
+                Quotes.unquote(args.get(1)),
+                parseIntegrationType(Quotes.unquote(args.get(2))),
+                Quotes.unquote(args.get(3)),
+                parsedAuthentication.authentication());
+        var row =
+            integrations
+                .createCatalogIntegration(
+                    CreateCatalogIntegrationRequest.newBuilder()
+                        .setSpec(spec)
+                        .setCredentials(parsedAuthentication.credentials())
+                        .build())
+                .getIntegration();
+        printIntegrations(List.of(row), out);
+      }
+      case "update" -> {
+        if (args.size() < 2) {
+          out.println("usage: integration update <name|id> --display <name> [--etag <etag>]");
+          return;
+        }
+        ResourceId id = resolveIntegration(args.get(1), integrations, accountId);
+        FieldMask updateMask = integrationUpdateMask(args);
+        if (updateMask.getPathsCount() == 0) {
+          throw new IllegalArgumentException("No integration changes specified");
+        }
+        var request =
+            UpdateCatalogIntegrationRequest.newBuilder()
+                .setIntegrationId(id)
+                .setSpec(integrationUpdateSpec(args))
+                .setUpdateMask(updateMask);
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        printIntegrations(
+            List.of(integrations.updateCatalogIntegration(request.build()).getIntegration()), out);
+      }
+      case "update-auth" -> {
+        if (args.size() < 2) {
+          out.println(
+              "usage: integration update-auth <name|id> --auth-type <type>"
+                  + " [--auth k=v ...] [--cred k=v ...] [--etag <etag>]");
+          return;
+        }
+        ParsedAuthentication parsedAuthentication = parseAuthentication(args);
+        var request =
+            UpdateCatalogIntegrationAuthenticationRequest.newBuilder()
+                .setIntegrationId(resolveIntegration(args.get(1), integrations, accountId))
+                .setAuthentication(parsedAuthentication.authentication())
+                .setCredentials(parsedAuthentication.credentials());
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        printIntegrations(
+            List.of(
+                integrations
+                    .updateCatalogIntegrationAuthentication(request.build())
+                    .getIntegration()),
+            out);
+      }
+      case "delete" -> {
+        if (args.size() < 2) {
+          out.println("usage: integration delete <name|id> [--cascade] [--etag <etag>]");
+          return;
+        }
+        var request =
+            DeleteCatalogIntegrationRequest.newBuilder()
+                .setIntegrationId(resolveIntegration(args.get(1), integrations, accountId));
+        request.setCascade(args.contains("--cascade"));
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        integrations.deleteCatalogIntegration(request.build());
+        out.println("ok");
+      }
+      default -> out.println("unknown subcommand");
+    }
+  }
+
+  private static void overlayCrud(
+      List<String> args,
+      PrintStream out,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays,
+      Supplier<String> accountId) {
+    if (args.isEmpty()) {
+      out.println("usage: overlay <list|get|create|update|delete> ...");
+      return;
+    }
+    switch (args.getFirst()) {
+      case "list" -> listOverlays(args, out, integrations, overlays, accountId);
+      case "get" -> {
+        if (args.size() < 2) {
+          out.println("usage: overlay get <name|id>");
+          return;
+        }
+        var row =
+            overlays
+                .getCatalogOverlay(
+                    GetCatalogOverlayRequest.newBuilder()
+                        .setOverlayId(resolveOverlay(args.get(1), overlays, accountId))
+                        .build())
+                .getOverlay();
+        printOverlays(List.of(row), out);
+      }
+      case "create" -> {
+        if (args.size() < 3) {
+          out.println(
+              "usage: overlay create <name> <integration-name|id>"
+                  + " [--include a.b,c.d] [--exclude x.y]");
+          return;
+        }
+        var spec =
+            overlaySpec(
+                Quotes.unquote(args.get(1)),
+                resolveIntegration(args.get(2), integrations, accountId),
+                args);
+        var row =
+            overlays
+                .createCatalogOverlay(
+                    CreateCatalogOverlayRequest.newBuilder().setSpec(spec).build())
+                .getOverlay();
+        printOverlays(List.of(row), out);
+      }
+      case "update" -> {
+        if (args.size() < 2) {
+          out.println(
+              "usage: overlay update <name|id> [--display <name>] [--include a.b,c.d]"
+                  + " [--exclude x.y]"
+                  + " [--etag <etag>]");
+          return;
+        }
+        ResourceId id = resolveOverlay(args.get(1), overlays, accountId);
+        FieldMask updateMask = overlayUpdateMask(args);
+        if (updateMask.getPathsCount() == 0) {
+          throw new IllegalArgumentException("No overlay changes specified");
+        }
+        var request =
+            UpdateCatalogOverlayRequest.newBuilder()
+                .setOverlayId(id)
+                .setSpec(overlayUpdateSpec(args))
+                .setUpdateMask(updateMask);
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        printOverlays(List.of(overlays.updateCatalogOverlay(request.build()).getOverlay()), out);
+      }
+      case "delete" -> {
+        if (args.size() < 2) {
+          out.println("usage: overlay delete <name|id> [--etag <etag>]");
+          return;
+        }
+        var request =
+            DeleteCatalogOverlayRequest.newBuilder()
+                .setOverlayId(resolveOverlay(args.get(1), overlays, accountId));
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        overlays.deleteCatalogOverlay(request.build());
+        out.println("ok");
+      }
+      default -> out.println("unknown subcommand");
+    }
+  }
+
+  private static CatalogIntegrationSpec integrationSpec(
+      String name, CatalogIntegrationType type, String uri, CatalogAuthentication authentication) {
+    return CatalogIntegrationSpec.newBuilder()
+        .setDisplayName(name)
+        .setType(type)
+        .setCatalogUri(uri)
+        .setAuthentication(authentication)
+        .build();
+  }
+
+  private static ParsedAuthentication parseAuthentication(List<String> args) {
+    String authType = normalized(CliArgs.parseStringFlag(args, "--auth-type", ""));
+    if (authType.isBlank()) {
+      throw new IllegalArgumentException("Missing --auth-type");
+    }
+    Map<String, String> auth = new LinkedHashMap<>(CliUtils.parseKeyValueList(args, "--auth"));
+    Map<String, String> credentials =
+        new LinkedHashMap<>(CliUtils.parseKeyValueList(args, "--cred"));
+    var authentication = CatalogAuthentication.newBuilder();
+    var secret = CatalogIntegrationCredentials.newBuilder();
+
+    switch (authType) {
+      case "OAUTH_CLIENT_CREDENTIALS", "OAUTH-CLIENT-CREDENTIALS", "OAUTH2" -> {
+        var oauth =
+            OAuthClientCredentialsAuthentication.newBuilder()
+                .setClientId(require(auth, "client_id", "--auth"));
+        setOptional(auth, "token_uri", oauth::setTokenUri);
+        String scopes = take(auth, "scopes");
+        if (scopes != null) oauth.addAllScopes(CliUtils.csvList(scopes));
+        authentication.setOauthClientCredentials(oauth);
+        secret.setOauthClientSecret(
+            SecretValue.newBuilder().setValue(require(credentials, "client_secret", "--cred")));
+      }
+      case "BEARER" -> {
+        authentication.setBearer(BearerAuthentication.getDefaultInstance());
+        secret.setBearerToken(
+            SecretValue.newBuilder().setValue(require(credentials, "token", "--cred")));
+      }
+      case "AWS_ASSUME_ROLE", "AWS-ASSUME-ROLE" ->
+          authentication.setAwsAssumeRole(assumeRole(auth));
+      case "AWS_ACCESS_KEY", "AWS-ACCESS-KEY" -> {
+        authentication.setAwsAccessKey(
+            AwsAccessKeyAuthentication.newBuilder()
+                .setAccessKeyId(require(auth, "access_key_id", "--auth")));
+        secret.setAwsAccessKey(accessKeySecret(credentials));
+      }
+      case "AWS_SIGV4", "AWS-SIGV4" -> {
+        var sigv4 =
+            AwsSigV4Authentication.newBuilder().setRegion(require(auth, "region", "--auth"));
+        setOptional(auth, "signing_name", sigv4::setSigningName);
+        String source = normalized(require(auth, "credential_source", "--auth"));
+        switch (source) {
+          case "DEFAULT", "AWS_DEFAULT", "AWS-DEFAULT" ->
+              sigv4.setAwsDefault(AwsDefaultAuthentication.getDefaultInstance());
+          case "ASSUME_ROLE", "ASSUME-ROLE", "AWS_ASSUME_ROLE", "AWS-ASSUME-ROLE" ->
+              sigv4.setAwsAssumeRole(assumeRole(auth));
+          case "ACCESS_KEY", "ACCESS-KEY", "AWS_ACCESS_KEY", "AWS-ACCESS-KEY" -> {
+            sigv4.setAwsAccessKey(
+                AwsAccessKeyAuthentication.newBuilder()
+                    .setAccessKeyId(require(auth, "access_key_id", "--auth")));
+            secret.setAwsAccessKey(accessKeySecret(credentials));
+          }
+          default ->
+              throw new IllegalArgumentException("Unsupported --auth credential_source: " + source);
+        }
+        authentication.setAwsSigv4(sigv4);
+      }
+      default -> throw new IllegalArgumentException("Unsupported --auth-type: " + authType);
+    }
+
+    rejectUnknown(auth, "--auth");
+    rejectUnknown(credentials, "--cred");
+    return new ParsedAuthentication(authentication.build(), secret.build());
+  }
+
+  private static AwsAssumeRoleAuthentication.Builder assumeRole(Map<String, String> auth) {
+    var assumeRole =
+        AwsAssumeRoleAuthentication.newBuilder().setRoleArn(require(auth, "role_arn", "--auth"));
+    setOptional(auth, "external_id", assumeRole::setExternalId);
+    setOptional(auth, "role_session_name", assumeRole::setRoleSessionName);
+    return assumeRole;
+  }
+
+  private static AwsAccessKeySecret.Builder accessKeySecret(Map<String, String> credentials) {
+    var secret =
+        AwsAccessKeySecret.newBuilder()
+            .setSecretAccessKey(require(credentials, "secret_access_key", "--cred"));
+    setOptional(credentials, "session_token", secret::setSessionToken);
+    return secret;
+  }
+
+  private static String require(Map<String, String> values, String key, String flag) {
+    String value = take(values, key);
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("Missing " + flag + " " + key + "=...");
+    }
+    return value;
+  }
+
+  private static String take(Map<String, String> values, String key) {
+    String value = values.remove(key);
+    return value == null ? null : Quotes.unquote(value);
+  }
+
+  private static void setOptional(
+      Map<String, String> values, String key, java.util.function.Consumer<String> setter) {
+    String value = take(values, key);
+    if (value != null && !value.isBlank()) setter.accept(value);
+  }
+
+  private static void rejectUnknown(Map<String, String> values, String flag) {
+    if (!values.isEmpty()) {
+      throw new IllegalArgumentException("Unsupported " + flag + " keys: " + values.keySet());
+    }
+  }
+
+  private record ParsedAuthentication(
+      CatalogAuthentication authentication, CatalogIntegrationCredentials credentials) {}
+
+  private static CatalogIntegrationSpec integrationUpdateSpec(List<String> args) {
+    var b = CatalogIntegrationSpec.newBuilder();
+    if (args.contains("--display"))
+      b.setDisplayName(Quotes.unquote(CliArgs.parseStringFlag(args, "--display", "")));
+    return b.build();
+  }
+
+  private static FieldMask integrationUpdateMask(List<String> args) {
+    var paths = new ArrayList<String>();
+    addIfPresent(paths, args, "--display", "display_name");
+    return FieldMask.newBuilder().addAllPaths(paths).build();
+  }
+
+  private static CatalogOverlaySpec overlaySpec(
+      String name, ResourceId integrationId, List<String> args) {
+    return CatalogOverlaySpec.newBuilder()
+        .setDisplayName(name)
+        .setIntegrationId(integrationId)
+        .addAllIncludeNamespaces(paths(args, "--include"))
+        .addAllExcludeNamespaces(paths(args, "--exclude"))
+        .build();
+  }
+
+  private static CatalogOverlaySpec overlayUpdateSpec(List<String> args) {
+    var b = CatalogOverlaySpec.newBuilder();
+    if (args.contains("--display"))
+      b.setDisplayName(Quotes.unquote(CliArgs.parseStringFlag(args, "--display", "")));
+    if (args.contains("--include")) b.addAllIncludeNamespaces(paths(args, "--include"));
+    if (args.contains("--exclude")) b.addAllExcludeNamespaces(paths(args, "--exclude"));
+    return b.build();
+  }
+
+  private static FieldMask overlayUpdateMask(List<String> args) {
+    var paths = new ArrayList<String>();
+    addIfPresent(paths, args, "--display", "display_name");
+    addIfPresent(paths, args, "--include", "include_namespaces");
+    addIfPresent(paths, args, "--exclude", "exclude_namespaces");
+    return FieldMask.newBuilder().addAllPaths(paths).build();
+  }
+
+  private static List<NamespacePath> paths(List<String> args, String flag) {
+    String value = Quotes.unquote(CliArgs.parseStringFlag(args, flag, ""));
+    if (value.isBlank()) return List.of();
+    return CliUtils.csvList(value).stream()
+        .map(
+            path ->
+                NamespacePath.newBuilder().addAllSegments(FQNameParserUtil.segments(path)).build())
+        .toList();
+  }
+
+  private static void listIntegrations(
+      PrintStream out, CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations) {
+    printIntegrationHeader(out);
+    CliArgs.forEachPage(
+        DEFAULT_PAGE_SIZE,
+        page ->
+            integrations.listCatalogIntegrations(
+                ListCatalogIntegrationsRequest.newBuilder().setPage(page).build()),
+        response ->
+            response.getEntriesList().stream().map(entry -> entry.getIntegration()).toList(),
+        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
+        rows -> printIntegrationRows(rows, out));
+  }
+
+  private static void listOverlays(
+      List<String> args,
+      PrintStream out,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays,
+      Supplier<String> accountId) {
+    ResourceId filter = null;
+    if (args.contains("--integration")) {
+      filter =
+          resolveIntegration(
+              CliArgs.parseStringFlag(args, "--integration", ""), integrations, accountId);
+    }
+    ResourceId integrationFilter = filter;
+    printOverlayHeader(out);
+    CliArgs.forEachPage(
+        DEFAULT_PAGE_SIZE,
+        page -> {
+          var request = ListCatalogOverlaysRequest.newBuilder().setPage(page);
+          if (integrationFilter != null) request.setIntegrationId(integrationFilter);
+          return overlays.listCatalogOverlays(request.build());
+        },
+        response -> response.getEntriesList().stream().map(entry -> entry.getOverlay()).toList(),
+        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
+        rows -> printOverlayRows(rows, out));
+  }
+
+  private static ResourceId resolveIntegration(
+      String token,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      Supplier<String> accountId) {
+    String value = Quotes.unquote(token);
+    if (CliUtils.looksLikeUuid(value))
+      return rid(value, ResourceKind.RK_CATALOG_INTEGRATION, accountId);
+    var matches = new ArrayList<CatalogIntegration>();
+    CliArgs.forEachPage(
+        DEFAULT_PAGE_SIZE,
+        page ->
+            integrations.listCatalogIntegrations(
+                ListCatalogIntegrationsRequest.newBuilder().setPage(page).build()),
+        response ->
+            response.getEntriesList().stream().map(entry -> entry.getIntegration()).toList(),
+        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
+        rows ->
+            rows.stream()
+                .filter(row -> row.getDisplayName().equalsIgnoreCase(value))
+                .forEach(matches::add));
+    return uniqueId(
+        value,
+        "Catalog integration",
+        matches.stream().map(CatalogIntegration::getResourceId).toList());
+  }
+
+  private static ResourceId resolveOverlay(
+      String token,
+      CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays,
+      Supplier<String> accountId) {
+    String value = Quotes.unquote(token);
+    if (CliUtils.looksLikeUuid(value)) {
+      return rid(value, ResourceKind.RK_CATALOG_OVERLAY, accountId);
+    }
+    var matches = new ArrayList<CatalogOverlay>();
+    CliArgs.forEachPage(
+        DEFAULT_PAGE_SIZE,
+        page ->
+            overlays.listCatalogOverlays(
+                ListCatalogOverlaysRequest.newBuilder().setPage(page).build()),
+        response -> response.getEntriesList().stream().map(entry -> entry.getOverlay()).toList(),
+        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
+        rows ->
+            rows.stream()
+                .filter(row -> row.getDisplayName().equalsIgnoreCase(value))
+                .forEach(matches::add));
+    return uniqueId(
+        value, "Catalog overlay", matches.stream().map(CatalogOverlay::getResourceId).toList());
+  }
+
+  private static ResourceId uniqueId(String value, String label, List<ResourceId> ids) {
+    if (ids.size() == 1) return ids.getFirst();
+    if (ids.isEmpty()) throw new IllegalArgumentException(label + " not found: " + value);
+    throw new IllegalArgumentException(label + " name is ambiguous: " + value);
+  }
+
+  private static ResourceId rid(
+      String id, ResourceKind kind, Supplier<String> getCurrentAccountId) {
+    String accountId = getCurrentAccountId.get();
+    if (accountId == null || accountId.isBlank())
+      throw new IllegalStateException("No account set. Use: account <accountId>");
+    return ResourceId.newBuilder().setAccountId(accountId).setKind(kind).setId(id).build();
+  }
+
+  private static CatalogIntegrationType parseIntegrationType(String value) {
+    return switch (normalized(value)) {
+      case "ICEBERG_REST", "ICEBERG-REST", "ICEBERG" -> CatalogIntegrationType.CIT_ICEBERG_REST;
+      case "UNITY" -> CatalogIntegrationType.CIT_UNITY;
+      default -> throw new IllegalArgumentException("Unknown integration type: " + value);
+    };
+  }
+
+  private static String normalized(String value) {
+    return Quotes.unquote(value).trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static void addIfPresent(
+      List<String> paths, List<String> args, String flag, String path) {
+    if (args.contains(flag)) paths.add(path);
+  }
+
+  private static void printIntegrations(List<CatalogIntegration> rows, PrintStream out) {
+    printIntegrationHeader(out);
+    printIntegrationRows(rows, out);
+  }
+
+  private static void printIntegrationHeader(PrintStream out) {
+    out.printf("%-36s  %-24s  %-14s  %s%n", "INTEGRATION_ID", "NAME", "TYPE", "URI");
+  }
+
+  private static void printIntegrationRows(List<CatalogIntegration> rows, PrintStream out) {
+    for (var row : rows) {
+      out.printf(
+          "%-36s  %-24s  %-14s  %s%n",
+          CliUtils.rid(row.getResourceId()),
+          row.getDisplayName(),
+          row.getType().name().replaceFirst("^CIT_", ""),
+          row.getCatalogUri());
+    }
+  }
+
+  private static void printOverlays(List<CatalogOverlay> rows, PrintStream out) {
+    printOverlayHeader(out);
+    printOverlayRows(rows, out);
+  }
+
+  private static void printOverlayHeader(PrintStream out) {
+    out.printf("%-36s  %-24s  %-36s%n", "OVERLAY_ID", "NAME", "INTEGRATION_ID");
+  }
+
+  private static void printOverlayRows(List<CatalogOverlay> rows, PrintStream out) {
+    for (var row : rows) {
+      out.printf(
+          "%-36s  %-24s  %-36s%n",
+          CliUtils.rid(row.getResourceId()),
+          row.getDisplayName(),
+          CliUtils.rid(row.getIntegrationId()));
+    }
+  }
+}

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -31,6 +31,8 @@ import ai.floedb.floecat.catalog.rpc.ViewServiceGrpc;
 import ai.floedb.floecat.client.cli.util.AuthHeaderInterceptor;
 import ai.floedb.floecat.client.cli.util.OidcClientCredentialsTokenProvider;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
@@ -63,9 +65,12 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "floecat-shell",
     version = "floecat-shell 0.1",
-    description = "Interactive CLI to browse and manage catalogs/namespaces/tables/connectors")
+    description =
+        "Interactive CLI to manage catalogs, integrations, overlays, tables, and connectors")
 @jakarta.inject.Singleton
 public class Shell implements Runnable {
+
+  static final String SENSITIVE_HISTORY_PATTERN = "*--cred *:*--cred-head *";
 
   @CommandLine.Option(
       names = {"-h", "--help"},
@@ -185,6 +190,14 @@ public class Shell implements Runnable {
 
   @Inject
   @GrpcClient("floecat")
+  CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations;
+
+  @Inject
+  @GrpcClient("floecat")
+  CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays;
+
+  @Inject
+  @GrpcClient("floecat")
   ReconcileControlGrpc.ReconcileControlBlockingStub reconcileControl;
 
   @Inject
@@ -250,6 +263,8 @@ public class Shell implements Runnable {
               .tables(tables)
               .viewService(viewService)
               .connectors(connectors)
+              .integrations(integrations)
+              .overlays(overlays)
               .reconcileControl(reconcileControl)
               .snapshots(snapshots)
               .statistics(statistics)
@@ -282,6 +297,10 @@ public class Shell implements Runnable {
               "table",
               "connectors",
               "connector",
+              "integrations",
+              "integration",
+              "overlays",
+              "overlay",
               "resolve",
               "describe",
               "snapshots",
@@ -302,6 +321,7 @@ public class Shell implements Runnable {
               .parser(parser)
               .completer(completer)
               .variable(LineReader.HISTORY_FILE, historyPath)
+              .variable(LineReader.HISTORY_IGNORE, SENSITIVE_HISTORY_PATTERN)
               .option(LineReader.Option.HISTORY_TIMESTAMPED, true)
               .build();
       Runtime.getRuntime()
@@ -559,6 +579,21 @@ public class Shell implements Runnable {
          query end <query_id> [--commit|--abort]
          query get <query_id>
          query fetch-scan <query_id> <table_id>
+         integrations
+         integration get <name|id>
+         integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
+             [--auth k=v ...] [--cred k=v ...]
+         integration update <name|id> --display <name> [--etag <etag>]
+         integration update-auth <name|id> --auth-type <type>
+             [--auth k=v ...] [--cred k=v ...] [--etag <etag>]
+         integration delete <name|id> [--cascade] [--etag <etag>]
+         overlays [--integration <name|id>]
+         overlay get <name|id>
+         overlay create <name> <integration>
+             [--include ns[,ns...]] [--exclude ns[,ns...]]
+         overlay update <name|id> [--display <name>]
+             [--include ns[,ns...]] [--exclude ns[,ns...]] [--etag <etag>]
+         overlay delete <name|id> [--etag <etag>]
          connectors
          connector list [--kind <KIND>]
          connector get <display_name|id>
@@ -698,6 +733,8 @@ public class Shell implements Runnable {
     snapshots = SnapshotServiceGrpc.newBlockingStub(overrideChannel);
     viewService = ViewServiceGrpc.newBlockingStub(overrideChannel);
     connectors = ConnectorsGrpc.newBlockingStub(overrideChannel);
+    integrations = CatalogIntegrationsGrpc.newBlockingStub(overrideChannel);
+    overlays = CatalogOverlaysGrpc.newBlockingStub(overrideChannel);
     reconcileControl = ReconcileControlGrpc.newBlockingStub(overrideChannel);
     queries = QueryServiceGrpc.newBlockingStub(overrideChannel);
     queryScan = QueryScanServiceGrpc.newBlockingStub(overrideChannel);
@@ -880,6 +917,8 @@ public class Shell implements Runnable {
     snapshots = snapshots.withInterceptors(authInterceptor);
     viewService = viewService.withInterceptors(authInterceptor);
     connectors = connectors.withInterceptors(authInterceptor);
+    integrations = integrations.withInterceptors(authInterceptor);
+    overlays = overlays.withInterceptors(authInterceptor);
     reconcileControl = reconcileControl.withInterceptors(authInterceptor);
     queries = queries.withInterceptors(authInterceptor);
     queryScan = queryScan.withInterceptors(authInterceptor);

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/CliCommandExecutorTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/CliCommandExecutorTest.java
@@ -43,6 +43,12 @@ import ai.floedb.floecat.catalog.rpc.ViewServiceGrpc;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
 import ai.floedb.floecat.connector.rpc.ListConnectorsRequest;
 import ai.floedb.floecat.connector.rpc.ListConnectorsResponse;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysResponse;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
@@ -108,6 +114,22 @@ class CliCommandExecutorTest {
     try (Harness h = new Harness()) {
       assertTrue(h.executor.execute("connectors"));
       assertEquals(1, h.connectorService.listConnectorsCalls.get());
+    }
+  }
+
+  @Test
+  void integrationsRouted() throws Exception {
+    try (Harness h = new Harness()) {
+      assertTrue(h.executor.execute("integrations"));
+      assertEquals(1, h.integrationService.listIntegrationsCalls.get());
+    }
+  }
+
+  @Test
+  void overlaysRouted() throws Exception {
+    try (Harness h = new Harness()) {
+      assertTrue(h.executor.execute("overlays"));
+      assertEquals(1, h.overlayService.listOverlaysCalls.get());
     }
   }
 
@@ -231,6 +253,8 @@ class CliCommandExecutorTest {
     final MinimalTableService tableService = new MinimalTableService();
     final MinimalViewService viewService = new MinimalViewService();
     final MinimalConnectorService connectorService = new MinimalConnectorService();
+    final MinimalIntegrationService integrationService = new MinimalIntegrationService();
+    final MinimalOverlayService overlayService = new MinimalOverlayService();
     final MinimalAccountService accountService = new MinimalAccountService();
     final MinimalQueryService queryService = new MinimalQueryService();
     final MinimalStorageAuthorityService storageAuthorityService =
@@ -247,6 +271,8 @@ class CliCommandExecutorTest {
               .addService(tableService)
               .addService(viewService)
               .addService(connectorService)
+              .addService(integrationService)
+              .addService(overlayService)
               .addService(accountService)
               .addService(queryService)
               .addService(new NullSnapshotService())
@@ -277,6 +303,8 @@ class CliCommandExecutorTest {
           .tables(TableServiceGrpc.newBlockingStub(channel))
           .viewService(ViewServiceGrpc.newBlockingStub(channel))
           .connectors(ConnectorsGrpc.newBlockingStub(channel))
+          .integrations(CatalogIntegrationsGrpc.newBlockingStub(channel))
+          .overlays(CatalogOverlaysGrpc.newBlockingStub(channel))
           .reconcileControl(ReconcileControlGrpc.newBlockingStub(channel))
           .snapshots(SnapshotServiceGrpc.newBlockingStub(channel))
           .statistics(TableStatisticsServiceGrpc.newBlockingStub(channel))
@@ -354,6 +382,34 @@ class CliCommandExecutorTest {
         ListConnectorsRequest request, StreamObserver<ListConnectorsResponse> responseObserver) {
       listConnectorsCalls.incrementAndGet();
       responseObserver.onNext(ListConnectorsResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static final class MinimalIntegrationService
+      extends CatalogIntegrationsGrpc.CatalogIntegrationsImplBase {
+    final AtomicInteger listIntegrationsCalls = new AtomicInteger();
+
+    @Override
+    public void listCatalogIntegrations(
+        ListCatalogIntegrationsRequest request,
+        StreamObserver<ListCatalogIntegrationsResponse> responseObserver) {
+      listIntegrationsCalls.incrementAndGet();
+      responseObserver.onNext(ListCatalogIntegrationsResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static final class MinimalOverlayService
+      extends CatalogOverlaysGrpc.CatalogOverlaysImplBase {
+    final AtomicInteger listOverlaysCalls = new AtomicInteger();
+
+    @Override
+    public void listCatalogOverlays(
+        ListCatalogOverlaysRequest request,
+        StreamObserver<ListCatalogOverlaysResponse> responseObserver) {
+      listOverlaysCalls.incrementAndGet();
+      responseObserver.onNext(ListCatalogOverlaysResponse.getDefaultInstance());
       responseObserver.onCompleted();
     }
   }

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package ai.floedb.floecat.client.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationEntry;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
+import ai.floedb.floecat.integration.rpc.CatalogOverlayEntry;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayResponse;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayResponse;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.GetCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogOverlayResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysResponse;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationResponse;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayResponse;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IntegrationCliSupportTest {
+  private static final String INTEGRATION_ID = "00000000-0000-0000-0000-000000000011";
+  private static final String OVERLAY_ID = "00000000-0000-0000-0000-000000000012";
+
+  @Test
+  void createsIntegrationWithOAuthCredentials() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run(
+          "integration",
+          List.of(
+              "create",
+              "lakehouse",
+              "iceberg-rest",
+              "https://catalog.example/v1",
+              "--auth-type",
+              "oauth-client-credentials",
+              "--auth",
+              "client_id=floecat",
+              "token_uri=https://identity.example/token",
+              "scopes=catalog.read,catalog.write",
+              "--cred",
+              "client_secret=secret"));
+
+      var spec = h.integrations.lastCreate.getSpec();
+      assertEquals("lakehouse", spec.getDisplayName());
+      assertEquals(CatalogIntegrationType.CIT_ICEBERG_REST, spec.getType());
+      assertEquals("https://catalog.example/v1", spec.getCatalogUri());
+      assertEquals("floecat", spec.getAuthentication().getOauthClientCredentials().getClientId());
+      assertEquals(
+          List.of("catalog.read", "catalog.write"),
+          spec.getAuthentication().getOauthClientCredentials().getScopesList());
+      assertEquals(
+          "secret", h.integrations.lastCreate.getCredentials().getOauthClientSecret().getValue());
+    }
+  }
+
+  @Test
+  void createsIntegrationWithSigV4AccessKeyCredentials() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run(
+          "integration",
+          List.of(
+              "create",
+              "lakehouse",
+              "iceberg-rest",
+              "https://catalog.example/v1",
+              "--auth-type",
+              "aws-sigv4",
+              "--auth",
+              "region=us-east-1",
+              "credential_source=access-key",
+              "access_key_id=AKIAEXAMPLE",
+              "--cred",
+              "secret_access_key=secret",
+              "session_token=session"));
+
+      var auth = h.integrations.lastCreate.getSpec().getAuthentication().getAwsSigv4();
+      assertEquals("us-east-1", auth.getRegion());
+      assertEquals("AKIAEXAMPLE", auth.getAwsAccessKey().getAccessKeyId());
+      assertEquals(
+          "session",
+          h.integrations.lastCreate.getCredentials().getAwsAccessKey().getSessionToken());
+    }
+  }
+
+  @Test
+  void listsAndGetsIntegrationByName() throws Exception {
+    try (Harness h = new Harness()) {
+      assertTrue(h.run("integrations", List.of()).contains("lakehouse"));
+      assertTrue(h.run("integration", List.of("get", "lakehouse")).contains("lakehouse"));
+    }
+  }
+
+  @Test
+  void updatesAndDeletesIntegrationById() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run("integration", List.of("update", INTEGRATION_ID, "--display", "renamed"));
+      assertEquals(
+          List.of("display_name"), h.integrations.lastUpdate.getUpdateMask().getPathsList());
+      assertEquals("renamed", h.integrations.lastUpdate.getSpec().getDisplayName());
+
+      h.run("integration", List.of("delete", INTEGRATION_ID, "--cascade"));
+      assertEquals(INTEGRATION_ID, h.integrations.lastDelete.getIntegrationId().getId());
+      assertTrue(h.integrations.lastDelete.getCascade());
+    }
+  }
+
+  @Test
+  void rotatesIntegrationAuthentication() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run(
+          "integration",
+          List.of(
+              "update-auth",
+              INTEGRATION_ID,
+              "--auth-type",
+              "bearer",
+              "--cred",
+              "token=replacement",
+              "--etag",
+              "etag-1"));
+
+      assertEquals(INTEGRATION_ID, h.integrations.lastAuthUpdate.getIntegrationId().getId());
+      assertTrue(h.integrations.lastAuthUpdate.getAuthentication().hasBearer());
+      assertEquals(
+          "replacement",
+          h.integrations.lastAuthUpdate.getCredentials().getBearerToken().getValue());
+      assertEquals("etag-1", h.integrations.lastAuthUpdate.getPrecondition().getExpectedEtag());
+    }
+  }
+
+  @Test
+  void createsOverlayForIntegration() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run(
+          "overlay",
+          List.of("create", "sales", "lakehouse", "--include", "prod.sales,prod.reference"));
+
+      var spec = h.overlays.lastCreate.getSpec();
+      assertEquals(INTEGRATION_ID, spec.getIntegrationId().getId());
+      assertEquals(2, spec.getIncludeNamespacesCount());
+      assertEquals(List.of("prod", "sales"), spec.getIncludeNamespaces(0).getSegmentsList());
+    }
+  }
+
+  @Test
+  void listsAndGetsOverlayByName() throws Exception {
+    try (Harness h = new Harness()) {
+      assertTrue(h.run("overlays", List.of()).contains("sales"));
+      assertTrue(h.run("overlay", List.of("get", "sales")).contains("sales"));
+    }
+  }
+
+  @Test
+  void updatesAndDeletesOverlayById() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run("overlay", List.of("update", OVERLAY_ID, "--display", "renamed", "--exclude", "tmp"));
+      assertEquals(
+          List.of("display_name", "exclude_namespaces"),
+          h.overlays.lastUpdate.getUpdateMask().getPathsList());
+      assertEquals("renamed", h.overlays.lastUpdate.getSpec().getDisplayName());
+
+      h.run("overlay", List.of("delete", OVERLAY_ID));
+      assertEquals(OVERLAY_ID, h.overlays.lastDelete.getOverlayId().getId());
+    }
+  }
+
+  private static ResourceId id(String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("account").setId(id).setKind(kind).build();
+  }
+
+  private static final class Harness implements AutoCloseable {
+    final IntegrationService integrations = new IntegrationService();
+    final OverlayService overlays = new OverlayService();
+    final Server server;
+    final ManagedChannel channel;
+    final CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrationStub;
+    final CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlayStub;
+
+    Harness() throws Exception {
+      String name = InProcessServerBuilder.generateName();
+      server =
+          InProcessServerBuilder.forName(name)
+              .directExecutor()
+              .addService(integrations)
+              .addService(overlays)
+              .build()
+              .start();
+      channel = InProcessChannelBuilder.forName(name).directExecutor().build();
+      integrationStub = CatalogIntegrationsGrpc.newBlockingStub(channel);
+      overlayStub = CatalogOverlaysGrpc.newBlockingStub(channel);
+    }
+
+    String run(String command, List<String> args) {
+      var bytes = new ByteArrayOutputStream();
+      IntegrationCliSupport.handle(
+          command, args, new PrintStream(bytes), integrationStub, overlayStub, () -> "account");
+      return bytes.toString();
+    }
+
+    @Override
+    public void close() {
+      channel.shutdownNow();
+      server.shutdownNow();
+    }
+  }
+
+  private static final class IntegrationService
+      extends CatalogIntegrationsGrpc.CatalogIntegrationsImplBase {
+    final CatalogIntegration integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id(INTEGRATION_ID, ResourceKind.RK_CATALOG_INTEGRATION))
+            .setDisplayName("lakehouse")
+            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+            .setCatalogUri("https://catalog.example/v1")
+            .build();
+    CreateCatalogIntegrationRequest lastCreate;
+    UpdateCatalogIntegrationRequest lastUpdate;
+    UpdateCatalogIntegrationAuthenticationRequest lastAuthUpdate;
+    DeleteCatalogIntegrationRequest lastDelete;
+
+    @Override
+    public void listCatalogIntegrations(
+        ListCatalogIntegrationsRequest request,
+        StreamObserver<ListCatalogIntegrationsResponse> observer) {
+      respond(
+          observer,
+          ListCatalogIntegrationsResponse.newBuilder()
+              .addEntries(CatalogIntegrationEntry.newBuilder().setIntegration(integration))
+              .build());
+    }
+
+    @Override
+    public void getCatalogIntegration(
+        GetCatalogIntegrationRequest request,
+        StreamObserver<GetCatalogIntegrationResponse> observer) {
+      respond(
+          observer, GetCatalogIntegrationResponse.newBuilder().setIntegration(integration).build());
+    }
+
+    @Override
+    public void createCatalogIntegration(
+        CreateCatalogIntegrationRequest request,
+        StreamObserver<CreateCatalogIntegrationResponse> observer) {
+      lastCreate = request;
+      respond(
+          observer,
+          CreateCatalogIntegrationResponse.newBuilder()
+              .setIntegration(
+                  integration.toBuilder().setDisplayName(request.getSpec().getDisplayName()))
+              .build());
+    }
+
+    @Override
+    public void updateCatalogIntegration(
+        UpdateCatalogIntegrationRequest request,
+        StreamObserver<UpdateCatalogIntegrationResponse> observer) {
+      lastUpdate = request;
+      respond(
+          observer,
+          UpdateCatalogIntegrationResponse.newBuilder().setIntegration(integration).build());
+    }
+
+    @Override
+    public void updateCatalogIntegrationAuthentication(
+        UpdateCatalogIntegrationAuthenticationRequest request,
+        StreamObserver<UpdateCatalogIntegrationAuthenticationResponse> observer) {
+      lastAuthUpdate = request;
+      respond(
+          observer,
+          UpdateCatalogIntegrationAuthenticationResponse.newBuilder()
+              .setIntegration(integration)
+              .build());
+    }
+
+    @Override
+    public void deleteCatalogIntegration(
+        DeleteCatalogIntegrationRequest request,
+        StreamObserver<DeleteCatalogIntegrationResponse> observer) {
+      lastDelete = request;
+      respond(observer, DeleteCatalogIntegrationResponse.getDefaultInstance());
+    }
+  }
+
+  private static final class OverlayService extends CatalogOverlaysGrpc.CatalogOverlaysImplBase {
+    final CatalogOverlay overlay =
+        CatalogOverlay.newBuilder()
+            .setResourceId(id(OVERLAY_ID, ResourceKind.RK_CATALOG_OVERLAY))
+            .setDisplayName("sales")
+            .setIntegrationId(id(INTEGRATION_ID, ResourceKind.RK_CATALOG_INTEGRATION))
+            .build();
+    CreateCatalogOverlayRequest lastCreate;
+    UpdateCatalogOverlayRequest lastUpdate;
+    DeleteCatalogOverlayRequest lastDelete;
+
+    @Override
+    public void listCatalogOverlays(
+        ListCatalogOverlaysRequest request, StreamObserver<ListCatalogOverlaysResponse> observer) {
+      respond(
+          observer,
+          ListCatalogOverlaysResponse.newBuilder()
+              .addEntries(CatalogOverlayEntry.newBuilder().setOverlay(overlay))
+              .build());
+    }
+
+    @Override
+    public void getCatalogOverlay(
+        GetCatalogOverlayRequest request, StreamObserver<GetCatalogOverlayResponse> observer) {
+      respond(observer, GetCatalogOverlayResponse.newBuilder().setOverlay(overlay).build());
+    }
+
+    @Override
+    public void createCatalogOverlay(
+        CreateCatalogOverlayRequest request,
+        StreamObserver<CreateCatalogOverlayResponse> observer) {
+      lastCreate = request;
+      respond(
+          observer,
+          CreateCatalogOverlayResponse.newBuilder()
+              .setOverlay(overlay.toBuilder().setDisplayName(request.getSpec().getDisplayName()))
+              .build());
+    }
+
+    @Override
+    public void updateCatalogOverlay(
+        UpdateCatalogOverlayRequest request,
+        StreamObserver<UpdateCatalogOverlayResponse> observer) {
+      lastUpdate = request;
+      respond(observer, UpdateCatalogOverlayResponse.newBuilder().setOverlay(overlay).build());
+    }
+
+    @Override
+    public void deleteCatalogOverlay(
+        DeleteCatalogOverlayRequest request,
+        StreamObserver<DeleteCatalogOverlayResponse> observer) {
+      lastDelete = request;
+      respond(observer, DeleteCatalogOverlayResponse.getDefaultInstance());
+    }
+  }
+
+  private static <T> void respond(StreamObserver<T> observer, T value) {
+    observer.onNext(value);
+    observer.onCompleted();
+  }
+}

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellAuthInterceptorTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellAuthInterceptorTest.java
@@ -29,6 +29,12 @@ import ai.floedb.floecat.catalog.rpc.TableServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.TableStatisticsServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.ViewServiceGrpc;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysResponse;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
@@ -55,7 +61,7 @@ class ShellAuthInterceptorTest {
       Metadata.Key.of("x-floe-session", Metadata.ASCII_STRING_MARSHALLER);
 
   @Test
-  void applyAuthInterceptorsAlsoWrapsStorageAuthoritiesStub() throws Exception {
+  void applyAuthInterceptorsWrapsAdditionalServiceStubs() throws Exception {
     AtomicReference<String> observedSession = new AtomicReference<>();
     String serverName = InProcessServerBuilder.generateName();
     Server server =
@@ -63,6 +69,8 @@ class ShellAuthInterceptorTest {
             .directExecutor()
             .intercept(new CaptureSessionHeaderInterceptor(observedSession))
             .addService(new StorageAuthorityService())
+            .addService(new IntegrationService())
+            .addService(new OverlayService())
             .build()
             .start();
     ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
@@ -82,6 +90,8 @@ class ShellAuthInterceptorTest {
       shell.snapshots = SnapshotServiceGrpc.newBlockingStub(channel);
       shell.viewService = ViewServiceGrpc.newBlockingStub(channel);
       shell.connectors = ConnectorsGrpc.newBlockingStub(channel);
+      shell.integrations = CatalogIntegrationsGrpc.newBlockingStub(channel);
+      shell.overlays = CatalogOverlaysGrpc.newBlockingStub(channel);
       shell.reconcileControl = ReconcileControlGrpc.newBlockingStub(channel);
       shell.queries = QueryServiceGrpc.newBlockingStub(channel);
       shell.queryScan = QueryScanServiceGrpc.newBlockingStub(channel);
@@ -96,6 +106,15 @@ class ShellAuthInterceptorTest {
       shell.storageAuthorities.listStorageAuthorities(
           ListStorageAuthoritiesRequest.getDefaultInstance());
 
+      assertEquals("session-123", observedSession.get());
+
+      observedSession.set(null);
+      shell.integrations.listCatalogIntegrations(
+          ListCatalogIntegrationsRequest.getDefaultInstance());
+      assertEquals("session-123", observedSession.get());
+
+      observedSession.set(null);
+      shell.overlays.listCatalogOverlays(ListCatalogOverlaysRequest.getDefaultInstance());
       assertEquals("session-123", observedSession.get());
     } finally {
       channel.shutdownNow();
@@ -125,6 +144,27 @@ class ShellAuthInterceptorTest {
         ListStorageAuthoritiesRequest request,
         StreamObserver<ListStorageAuthoritiesResponse> responseObserver) {
       responseObserver.onNext(ListStorageAuthoritiesResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static final class IntegrationService
+      extends CatalogIntegrationsGrpc.CatalogIntegrationsImplBase {
+    @Override
+    public void listCatalogIntegrations(
+        ListCatalogIntegrationsRequest request,
+        StreamObserver<ListCatalogIntegrationsResponse> responseObserver) {
+      responseObserver.onNext(ListCatalogIntegrationsResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static final class OverlayService extends CatalogOverlaysGrpc.CatalogOverlaysImplBase {
+    @Override
+    public void listCatalogOverlays(
+        ListCatalogOverlaysRequest request,
+        StreamObserver<ListCatalogOverlaysResponse> responseObserver) {
+      responseObserver.onNext(ListCatalogOverlaysResponse.getDefaultInstance());
       responseObserver.onCompleted();
     }
   }

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellHistoryTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellHistoryTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package ai.floedb.floecat.client.cli;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jline.reader.impl.history.DefaultHistory;
+import org.junit.jupiter.api.Test;
+
+class ShellHistoryTest {
+
+  @Test
+  void credentialArgumentsAreExcludedFromPersistentHistory() {
+    var history = new TestHistory();
+
+    assertTrue(
+        history.matches(
+            Shell.SENSITIVE_HISTORY_PATTERN,
+            "integration create lakehouse iceberg-rest https://example --cred token=secret"));
+    assertTrue(
+        history.matches(
+            Shell.SENSITIVE_HISTORY_PATTERN,
+            "integration update-auth lakehouse --cred secret_access_key=secret"));
+    assertFalse(history.matches(Shell.SENSITIVE_HISTORY_PATTERN, "integration get lakehouse"));
+  }
+
+  private static final class TestHistory extends DefaultHistory {
+    boolean matches(String patterns, String line) {
+      return matchPatterns(patterns, line);
+    }
+  }
+}

--- a/core/proto/src/main/proto/floecat/catalog/catalog.proto
+++ b/core/proto/src/main/proto/floecat/catalog/catalog.proto
@@ -31,6 +31,10 @@ message Catalog {
   optional string connector_ref = 4;
   optional string policy_ref = 5;
   google.protobuf.Timestamp created_at = 6;
+  // Set when this catalog is owned by a catalog overlay. An owned catalog is listed and read like
+  // any other catalog, but is created, renamed, and deleted only through its overlay and rejects
+  // direct mutation. Unset for directly managed catalogs.
+  optional ai.floedb.floecat.common.ResourceId overlay_id = 7;
   map<string,string> properties = 99;
 }
 

--- a/core/proto/src/main/proto/floecat/common/common.proto
+++ b/core/proto/src/main/proto/floecat/common/common.proto
@@ -43,6 +43,7 @@ enum ResourceKind {
   RK_TRANSACTION = 15;
   RK_STORAGE_AUTHORITY = 16;
   RK_CATALOG_INTEGRATION = 17;
+  RK_CATALOG_OVERLAY = 18;
 }
 
 message ResourceId {

--- a/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
+++ b/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
@@ -177,6 +177,9 @@ message UpdateCatalogIntegrationAuthenticationResponse {
 message DeleteCatalogIntegrationRequest {
   ai.floedb.floecat.common.ResourceId integration_id = 1;
   ai.floedb.floecat.common.Precondition precondition = 2;
+  // Deletes dependent catalog overlays under a durable integration-deletion fence.
+  // Cascade additionally requires catalog-overlay.write permission.
+  bool cascade = 3;
 }
 message DeleteCatalogIntegrationResponse {
   ai.floedb.floecat.common.MutationMeta meta = 1;

--- a/core/proto/src/main/proto/floecat/integration/catalog_overlay.proto
+++ b/core/proto/src/main/proto/floecat/integration/catalog_overlay.proto
@@ -1,0 +1,124 @@
+// Copyright 2026 Yellowbrick Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package ai.floedb.floecat.integration;
+
+option java_multiple_files = true;
+option java_package = "ai.floedb.floecat.integration.rpc";
+
+import "floecat/common/common.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/timestamp.proto";
+
+// A namespace path ordered from the external catalog root to the namespace leaf.
+message NamespacePath {
+  repeated string segments = 1;
+}
+
+// A catalog overlay selects upstream namespaces from a catalog integration and owns the Floecat
+// catalog they are exposed beneath.
+message CatalogOverlay {
+  ai.floedb.floecat.common.ResourceId resource_id = 1;
+  string display_name = 2;
+  ai.floedb.floecat.common.ResourceId integration_id = 3;
+  // Selection paths are expressed in the external catalog's namespace space. An empty include
+  // list selects all namespaces. A selected path includes that namespace and all descendants.
+  // Paths are deduplicated and matched case-sensitively.
+  repeated NamespacePath include_namespaces = 4;
+  // Exclusions apply to the named namespace and all descendants and take precedence over includes.
+  repeated NamespacePath exclude_namespaces = 5;
+  google.protobuf.Timestamp created_at = 6;
+  google.protobuf.Timestamp updated_at = 7;
+  // The catalog this overlay owns, assigned by the server at create time. Selected upstream
+  // namespaces are exposed beneath it. Not settable through CatalogOverlaySpec.
+  ai.floedb.floecat.common.ResourceId catalog_id = 8;
+}
+
+message CatalogOverlaySpec {
+  optional string display_name = 1;
+  ai.floedb.floecat.common.ResourceId integration_id = 2;
+  // Selection paths are expressed in the external catalog's namespace space. An empty include
+  // list selects all namespaces. A selected path includes that namespace and all descendants.
+  // Paths are deduplicated and matched case-sensitively.
+  repeated NamespacePath include_namespaces = 3;
+  // Exclusions apply to the named namespace and all descendants and take precedence over includes.
+  repeated NamespacePath exclude_namespaces = 4;
+}
+
+message CatalogOverlayEntry {
+  CatalogOverlay overlay = 1;
+  ai.floedb.floecat.common.MutationMeta meta = 2;
+}
+
+message CreateCatalogOverlayRequest {
+  CatalogOverlaySpec spec = 1;
+  ai.floedb.floecat.common.IdempotencyKey idempotency = 2;
+  // Non-default modes replace the existing identity, or return the existing resource unchanged.
+  // Non-default modes cannot be combined with idempotency; replacement is itself state-idempotent.
+  ai.floedb.floecat.common.CreateMode create_mode = 3;
+}
+message CreateCatalogOverlayResponse {
+  CatalogOverlay overlay = 1;
+  ai.floedb.floecat.common.MutationMeta meta = 2;
+}
+
+message GetCatalogOverlayRequest {
+  oneof selector {
+    ai.floedb.floecat.common.ResourceId overlay_id = 1;
+    string display_name = 2;
+  }
+}
+message GetCatalogOverlayResponse {
+  CatalogOverlay overlay = 1;
+  ai.floedb.floecat.common.MutationMeta meta = 2;
+}
+
+message ListCatalogOverlaysRequest {
+  ai.floedb.floecat.common.PageRequest page = 1;
+  optional ai.floedb.floecat.common.ResourceId integration_id = 2;
+}
+message ListCatalogOverlaysResponse {
+  repeated CatalogOverlayEntry entries = 1;
+  ai.floedb.floecat.common.PageResponse page = 2;
+}
+
+message UpdateCatalogOverlayRequest {
+  ai.floedb.floecat.common.ResourceId overlay_id = 1;
+  // display_name and the namespace-selection lists are mutable. integration_id is immutable.
+  // A list selected by update_mask is replaced in full.
+  CatalogOverlaySpec spec = 2;
+  ai.floedb.floecat.common.Precondition precondition = 3;
+  google.protobuf.FieldMask update_mask = 4;
+}
+message UpdateCatalogOverlayResponse {
+  CatalogOverlay overlay = 1;
+  ai.floedb.floecat.common.MutationMeta meta = 2;
+}
+
+message DeleteCatalogOverlayRequest {
+  ai.floedb.floecat.common.ResourceId overlay_id = 1;
+  ai.floedb.floecat.common.Precondition precondition = 2;
+}
+message DeleteCatalogOverlayResponse {
+  ai.floedb.floecat.common.MutationMeta meta = 1;
+}
+
+service CatalogOverlays {
+  rpc GetCatalogOverlay(GetCatalogOverlayRequest) returns (GetCatalogOverlayResponse);
+  rpc ListCatalogOverlays(ListCatalogOverlaysRequest) returns (ListCatalogOverlaysResponse);
+  rpc CreateCatalogOverlay(CreateCatalogOverlayRequest) returns (CreateCatalogOverlayResponse);
+  rpc UpdateCatalogOverlay(UpdateCatalogOverlayRequest) returns (UpdateCatalogOverlayResponse);
+  rpc DeleteCatalogOverlay(DeleteCatalogOverlayRequest) returns (DeleteCatalogOverlayResponse);
+}

--- a/docs/_snippets/docs-by-area.md
+++ b/docs/_snippets/docs-by-area.md
@@ -1,4 +1,6 @@
 - **Core platform**: architecture, service, caching, metadata graph, reconciler
-- **Integrations**: [catalog integration design](catalog-integration-design.md), connectors (Iceberg, Delta), Arrow Flight, client CLI
+- **Integrations**: [catalog integration design](catalog-integration-design.md),
+  [catalog integrations and overlays](catalog-integrations.md), connectors (Iceberg, Delta), Arrow
+  Flight, client CLI
 - **Storage and security**: storage backends, secrets manager, external authentication
 - **Operations and observability**: operations, telemetry, troubleshooting

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@ Views, Snapshots, statistics, and query-lifecycle artifacts.
 ```
 Account
  ├── CatalogIntegration (external catalog identity)
+ │    └── CatalogOverlay (upstream namespace selection)
  └── Catalog (locally managed catalog)
       └── Namespace (hierarchical path)
            ├── Table (Iceberg/Delta metadata, upstream reference)
@@ -47,12 +48,20 @@ to the newest finalized snapshot at or before it instead, so logical metadata ca
 without exposing an unfinalized scan.
 
 The gRPC service (Quarkus) enforces tenancy, authorization, idempotency, and transactional CRUD for
-catalog integrations. Catalog integrations include typed, non-secret authentication
+catalog integrations and overlays. Catalog integrations include typed, non-secret authentication
 configuration plus write-only credential create/rotation primitives; secret payloads are stored
 separately and never returned. A typed credential-store resolver derives the internal secret key
 from integration identity and credential generation for follow-on clients. The resources remain operationally inert: this API does not perform
 connectivity validation, adapter selection, or reconciliation. Legacy connectors remain unchanged
-and are not part of the new contract.
+and are not part of either new contract.
+
+An overlay owns exactly one Catalog, created in the overlay's own pointer transaction and carrying
+the overlay's display name, so top-level name uniqueness is ordinary catalog name uniqueness. That
+catalog is listed and read like any other but is renamed and deleted only through its overlay.
+Overlay creation is conditioned on the current integration pointer version and advances a
+fixed integration dependency marker in the same transaction. Integration deletion checks both the
+strongly consistent dependent-overlay index and that marker, closing concurrent
+overlay-create/integration-delete races. Account deletion removes overlays before integrations.
 
 ## Components
 

--- a/docs/catalog-integrations.md
+++ b/docs/catalog-integrations.md
@@ -1,0 +1,81 @@
+# Catalog Integrations and Overlays
+
+Catalog integrations and overlays establish the resource, authentication, and SQL naming
+foundation for external-catalog connectivity:
+
+- A **catalog integration** records an upstream catalog type, URI, display name, and typed,
+  non-secret authentication configuration. Credential material is stored separately and is never
+  returned by the API.
+- A **catalog overlay** defines a top-level Floecat catalog backed by an integration and filtered
+  to selected upstream namespaces.
+
+```text
+CatalogIntegration (external catalog identity)
+ ├── CatalogOverlay "sales"
+ └── CatalogOverlay "finance"
+```
+
+These resources do not yet validate connectivity, refresh metadata, reconcile or capture tables,
+or affect query paths. The legacy `Connector` API and Shell commands remain the operational path
+for external catalog connectivity.
+
+## Shell workflow
+
+Create the integration record, then define a top-level overlay catalog:
+
+```text
+integration create lakehouse iceberg-rest https://catalog.example/v1 \
+  --auth-type oauth-client-credentials \
+  --auth client_id=floecat token_uri=https://identity.example/token \
+  --cred client_secret=secret
+overlay create sales-overlay lakehouse --include prod.sales,prod.reference
+```
+
+The overlay command accepts either a resource ID or display name for the integration.
+Namespace filters are comma-separated paths supplied with `--include` and `--exclude`. Omitting both
+selects the whole upstream namespace tree.
+
+The available commands are:
+
+```text
+integrations
+integration list
+integration get <name|id>
+integration create <name> <type> <uri> --auth-type <type> [--auth k=v ...] [--cred k=v ...]
+integration update <name|id> [options]
+integration update-auth <name|id> --auth-type <type> [--auth k=v ...] [--cred k=v ...]
+integration delete <name|id>
+
+overlays [--integration <name|id>]
+overlay list [--integration <name|id>]
+overlay get <name|id>
+overlay create <name> <integration-name|id> [options]
+overlay update <name|id> [options]
+overlay delete <name|id>
+```
+
+Authentication types and their properties are:
+
+| `--auth-type` | `--auth` properties | `--cred` properties |
+| --- | --- | --- |
+| `oauth-client-credentials` | `client_id`; optional `token_uri`, `scopes` CSV | `client_secret` |
+| `bearer` | none | `token` |
+| `aws-assume-role` | `role_arn`; optional `external_id`, `role_session_name` | none |
+| `aws-access-key` | `access_key_id` | `secret_access_key`; optional `session_token` |
+| `aws-sigv4` | `region`, `credential_source`; optional `signing_name`, plus source fields | source-dependent |
+
+For SigV4, `credential_source` is `default`, `assume-role`, or `access-key`. Assume-role uses the
+role properties above. Access-key uses the access-key properties above. The CLI rejects unknown
+properties instead of silently dropping them.
+
+## Lifecycle
+
+- Overlay creation requires an existing integration.
+- Overlay display names are unique within an account and identify the top-level catalog.
+- An integration cannot be deleted while overlays refer to it.
+- Integration deletion supports `--cascade` to delete dependent overlays.
+- Integration and overlay mutations support optimistic `--etag` preconditions.
+- Authentication replacement uses the dedicated `integration update-auth` command so credential
+  values remain write-only.
+
+The protobuf contracts are in `core/proto/src/main/proto/floecat/integration/`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,6 +81,25 @@ query end <query_id> [--commit|--abort]
 query get <query_id>
 query fetch-scan <query_id> <table_id>
 
+integrations
+integration list
+integration get <name|id>
+integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
+  [--auth k=v ...] [--cred k=v ...]
+integration update <name|id> --display <name> [--etag <etag>]
+integration update-auth <name|id> --auth-type <type>
+  [--auth k=v ...] [--cred k=v ...] [--etag <etag>]
+integration delete <name|id> [--cascade] [--etag <etag>]
+
+overlays [--integration <name|id>]
+overlay list [--integration <name|id>]
+overlay get <name|id>
+overlay create <name> <integration-name|id>
+    [--include ns[,ns...]] [--exclude ns[,ns...]]
+overlay update <name|id> [--display <name>]
+    [--include ns[,ns...]] [--exclude ns[,ns...]] [--etag <etag>]
+overlay delete <name|id> [--etag <etag>]
+
 connectors
 connector list [--kind <KIND>]
 connector get <display_name|id>

--- a/docs/client-cli.md
+++ b/docs/client-cli.md
@@ -4,7 +4,8 @@
 
 `client-cli/` packages a Picocli-based interactive shell backed by the same gRPC stubs used by the
 service. It is the quickest way for developers and operators to explore catalogs, namespaces, tables,
-connectors, storage authorities, and query-lifecycle workflows without writing bespoke clients.
+catalog integrations, overlays, legacy connectors, storage authorities, and query-lifecycle
+workflows without writing bespoke clients.
 
 The CLI runs as a Quarkus application, depends on generated RPC stubs, and includes helpers for
 fully-qualified name parsing (`FQNameParserUtil`) and CSV-like argument parsing for column lists
@@ -53,6 +54,10 @@ The CLI exposes commands documented at runtime via `help`. Highlights:
   while `query fetch-scan <query_id> <table_id>` requests the connector-provided `ScanFile` lists for
   an individual table.
 - `connectors` / `connector <subcommand>` – Manage connector definitions and reconciliation jobs.
+- `integrations` / `integration <subcommand>` – Manage upstream catalog identity, authentication,
+  and write-only credentials.
+- `overlays` / `overlay <subcommand>` – Define a top-level catalog backed by an integration,
+  optionally filtering namespaces.
 - `storage-authorities` / `storage-authority <subcommand>` – Manage storage credential authorities
   used by the Iceberg REST gateway to vend temporary object-store credentials.
 
@@ -87,6 +92,18 @@ User command → Picocli parser → Shell subcommand → gRPC stub call
 
 Commands run synchronously inside the REPL thread; long-running operations (for example connector
 reconciliation) show job IDs that can be polled via `connector job <id>`.
+
+Integration and overlay records currently provide CRUD configuration and credential lifecycle
+only. They do not connect to the upstream catalog, reconcile metadata, or affect query execution.
+To exercise the resource model from the Shell, create an integration and overlay:
+
+```text
+integration create lakehouse iceberg-rest https://catalog.example/v1 \
+  --auth-type bearer --cred token=secret
+overlay create sales-overlay lakehouse --include prod.sales
+```
+
+Legacy connector commands remain the operational path for external catalog connectivity.
 
 `connector jobs` shows a parent-job summary table by default. Use
 `connector jobs --child <parent-job-id>` to render the descendant job tree rooted at that job.

--- a/docs/fixed-roles.md
+++ b/docs/fixed-roles.md
@@ -8,14 +8,14 @@ Source of truth: `service/src/main/java/ai/floedb/floecat/service/security/RoleP
 
 | Role name | Purpose | Granted permissions |
 |-----------|---------|---------------------|
-| `default` | Baseline read-only tenant access. Used when no roles are provided in normal (`oidc`) mode. | `account.read`, `catalog.read`, `namespace.read`, `table.read`, `view.read`, `catalog-integration.read` |
-| `administrator` | Full tenant-scoped administration of metadata, catalog integrations, and legacy connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `system-objects.read`, `account.delete` |
-| `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `system-objects.read`, `account.delete` |
+| `default` | Baseline read-only tenant access. Used when no roles are provided in normal (`oidc`) mode. | `account.read`, `catalog.read`, `namespace.read`, `table.read`, `view.read`, `catalog-integration.read`, `catalog-overlay.read` |
+| `administrator` | Full tenant-scoped administration of metadata, catalog integrations, catalog overlays, and legacy connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write`, `system-objects.read`, `account.delete` |
+| `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write`, `system-objects.read`, `account.delete` |
 | `platform-admin` (or configured value of `floecat.auth.platform-admin.role`) | Platform-level account management role from IdP. | `account.read`, `account.write`, `account.delete` |
-| `init-account` | Bootstrap role used to initialize account + initial resources. | `account.read`, `account.write`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `connector.create`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use` |
+| `init-account` | Bootstrap role used to initialize account + initial resources. | `account.read`, `account.write`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `connector.create`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write` |
 | `delete-account` | Narrow internal role used to trigger account teardown. Floecat performs the implied cleanup internally. | `account.delete` |
 | `system-objects` | Minimal role for SystemObjects/GetSystemObjects access. | `system-objects.read` |
-| `reconcile-worker` | Dedicated machine principal for reconciler background gRPC work. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.use`, `system-objects.read`, `storage-authority.resolve-internal`, `reconcile-executor-control.internal` |
+| `reconcile-worker` | Dedicated machine principal for reconciler background gRPC work. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.use`, `catalog-overlay.read`, `system-objects.read`, `storage-authority.resolve-internal`, `reconcile-executor-control.internal` |
 
 ## Behavior Notes
 
@@ -28,6 +28,11 @@ Source of truth: `service/src/main/java/ai/floedb/floecat/service/security/RoleP
 - `init-account` also bypasses strict account existence validation during inbound context building.
 - `account.delete` is the dedicated destructive permission for account teardown. It is intentionally
   separate from broad catalog/table/connector management permissions.
-- `catalog-integration.write` administers integration records. `catalog-integration.use` is a
-  separate capability reserved for binding an integration from dependent resources without
-  granting integration-management authority.
+- `catalog-integration.write` administers integration records, while `catalog-integration.use`
+  permits an integration to be bound to an overlay without granting integration-management
+  authority. Cascading integration deletion additionally requires `catalog-overlay.write` because
+  it deletes the dependent overlay resources.
+- `catalog-overlay.write` administers overlay records. Creating an overlay additionally requires
+  `catalog-integration.use`. Creating, renaming, and deleting an overlay additionally requires
+  `catalog.write`, because each of those operations creates, renames, or deletes the Catalog the
+  overlay owns.

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -28,9 +28,9 @@ CLI, and reconciler.
   schemas also cover per-file statistics and index artifact metadata.
 - **`connector/connector.proto`** – Connector management RPCs plus reconciliation job tracking and
   validation routines.
-- **`integration/catalog_integration.proto`** – External catalog identity CRUD,
-  typed catalog authentication configuration, write-only credential payloads, non-secret
-  configured/generation state, and credential rotation. This contract is
+- **`integration/*.proto`** – External catalog identity and catalog overlay CRUD APIs,
+  including segment-based namespace filters, typed catalog authentication configuration, write-only
+  credential payloads, non-secret configured/generation state, and credential rotation. These contracts are
   independent of Connector and deliberately contain no connectivity-validation or reconciliation
   operations.
 - **`query/lifecycle.proto`** – Query lifecycle (`BeginQuery`, `RenewQuery`, `EndQuery`, `GetQuery`) and the
@@ -64,6 +64,7 @@ CLI, and reconciler.
 | `AccountService` | Account CRUD. |
 | `Connectors` | Connector CRUD, `ValidateConnector`, `StartCapture`, `GetReconcileJob`. |
 | `CatalogIntegrations` | Integration CRUD. |
+| `CatalogOverlays` | Overlay CRUD, including filtering by integration. |
 | `QueryService` | `BeginQuery`, `RenewQuery`, `EndQuery`, `GetQuery`. |
 | `QuerySchemaService` | `DescribeInputs`. |
 | `QueryScanService` | `InitScan`, `StreamDeleteFiles`, `StreamDataFiles`, `CloseScan`. |
@@ -74,9 +75,14 @@ CLI, and reconciler.
 | &nbsp;&nbsp;&nbsp;— Consumption pattern | | Clients read `UserObjectsBundleChunk` in three phases: 1) header chunk (cheap metadata), 2) zero or more `resolutions` chunk batches where each `RelationResolution` carries `input_index` + FOUND/NOT_FOUND/ERROR, and 3) a single end chunk with summary counts. Use `input_index` to map back to planner `TableReferenceCandidate`s and bind as soon as a `FOUND` arrives. For each `RelationInfo`, inspect `columns[*].status`: `COLUMN_STATUS_OK` exposes `columns[*].column`, while `COLUMN_STATUS_FAILED` exposes `columns[*].failure` with typed `ColumnFailureCode` plus details. Extension-defined failures must use `COLUMN_FAILURE_CODE_ENGINE_EXTENSION` and set `extension_code_value`; clients branch on `extension_code_value` inside the engine domain (for FloeDB, see `FloeDecorationFailureCode` in `extensions/floedb/src/main/proto/engine_floe.proto`). |
 | `SystemObjectsService` | `GetSystemObjects` | Returns the builtin catalog filtered by the `x-engine-kind` / `x-engine-version` headers supplied with the request. |
 
-Resource IDs supplied to integration RPCs must include an `account_id` matching the
+Resource IDs supplied to integration and overlay RPCs must include an `account_id` matching the
 authenticated principal's account. The service rejects blank or cross-account IDs before hitting
 repository storage.
+
+`NamespacePath` represents an upstream namespace as root-to-leaf path segments for overlay include
+and exclude filters. Empty includes select all namespaces; exclusions take precedence. Segment text
+is preserved exactly, paths are deduplicated and deterministically ordered, and matching is
+case-sensitive. Each path selects that namespace subtree.
 
 ### Planner Lifecycle & Execution Scan Schemas
 `query/lifecycle.proto` captures everything the planner needs to hold a lease:

--- a/docs/service.md
+++ b/docs/service.md
@@ -27,7 +27,7 @@ query lifecycle / scan bundle logic.
 │  ├─ Interceptors (context, localization, metering)                         │
 │  ├─ Security (PrincipalProvider, Authorizer)                               │
 │  ├─ Services (Catalog, Namespace, Table, View, Snapshot, Account,           │
-│  │       Directory, Statistics, Integrations, Connectors, QueryService)      │
+│  │      Directory, Statistics, Integrations, Overlays, Connectors, Query)   │
 │  ├─ QueryService (QueryContextStore, QueryServiceImpl)                     │
 │  ├─ Repositories (CatalogRepository, NamespaceRepository, TableRepository, │
 │  │                ViewRepository, SnapshotRepository, StatsRepository,     │
@@ -81,8 +81,9 @@ helpers like `randomResourceId` (UUIDv4). Highlights:
   reuses the graph’s ResolveFQ helpers for list/prefix pagination.
 - **AccountServiceImpl** – Administers accounts and enforces conventional permissions. Account
   deletion installs a durable write fence, then uses strongly consistent enumeration to remove
-  catalog integrations before legacy connectors and local catalog descendants. Retrying a
-  committed account delete resumes cleanup using the deletion record's original mutation metadata.
+  catalog overlays before their integrations, followed by legacy connectors and local catalog
+  descendants. Retrying a committed account delete resumes cleanup using the deletion record's
+  original mutation metadata.
 - **CatalogIntegrationsImpl** – Provides CRUD for external catalog identity records. The contract is
   intentionally independent of legacy Connectors. It persists typed non-secret authentication
   configuration for OAuth client credentials, bearer tokens, AWS assume-role/access-key, and AWS
@@ -99,7 +100,9 @@ helpers like `randomResourceId` (UUIDv4). Highlights:
   fragments. Type and endpoint are immutable through update. The API exposes `CM_REPLACE` and
   `CM_RETURN_EXISTING` as create-conflict primitives.
   Replacement publishes a new resource identity and atomically swaps the name pointer before the
-  old identity is removed. Idempotent creates publish the
+  old identity is removed. Integration replacement is rejected while overlays depend on the old
+  identity. Cascading delete uses a durable fence so retries resume dependent-overlay cleanup before
+  removing the integration, dependency marker, and fence together. Idempotent creates publish the
   immutable success receipt in the same pointer transaction as the resource, so a retry never
   rebuilds its response from subsequently mutable state. Creates carrying credentials support
   idempotency. Secret values are excluded from durable request fingerprints and receipts, so the
@@ -107,11 +110,28 @@ helpers like `randomResourceId` (UUIDv4). Highlights:
   happen before resource publication; definite publication failures remove the unpublished
   generation, and replaced credentials are deleted only after the resource CAS commits. If the
   publication acknowledgement is uncertain, the new secret is retained so a visible integration can
-  never reference a deleted secret. Durable cleanup records are drained after the generation is
-  provably superseded.
+  never reference a deleted secret. Durable cleanup records are drained by pointer GC once a
+  generation is provably superseded.
   Get accepts either resource ID or
   exact display name. Reads require
-  `catalog-integration.read`; writes require `catalog-integration.write`.
+  `catalog-integration.read`; writes require `catalog-integration.write`, and cascading deletion of
+  dependent overlays also requires `catalog-overlay.write`.
+- **CatalogOverlaysImpl** – Binds an integration and optional upstream namespace filters to the
+  Catalog the overlay owns. Creating an overlay creates that catalog in the same pointer
+  transaction, renaming the overlay renames it, and deleting the overlay deletes it, so the two are
+  never visible separately or under different names. Because the owned catalog is an ordinary
+  Catalog, top-level name uniqueness is the existing catalog by-name uniqueness. Creating an overlay atomically publishes its pointers while requiring the integration
+  pointer to remain at its validated version, and advances the integration dependency marker in the
+  same transaction. `CM_REPLACE` atomically swaps in a new overlay identity and may bind it to
+  another integration while advancing both dependency markers; `CM_RETURN_EXISTING`
+  returns the existing object. Get accepts either
+  resource ID or exact display name. An empty include list
+  selects all namespaces; paths select subtrees, exclusions
+  take precedence, and matching is case-sensitive. The integration binding is immutable through
+  update; updates only replace the selected include/exclude lists or rename the overlay. Reads require
+  `catalog-overlay.read`; writes require `catalog-overlay.write`, and creation also requires
+  `catalog-integration.use`. Connectivity and
+  reconciliation are deferred.
 - **ConnectorsImpl** – Manages connector lifecycle, validates `ConnectorSpec` via SPI factories,
   wires reconciliation job submission, and exposes `ValidateConnector` + `StartCapture`.
   `CaptureNow` maps to reconciler capture modes:

--- a/docs/storage-layout.md
+++ b/docs/storage-layout.md
@@ -27,6 +27,7 @@ Resource and transaction blobs:
 /accounts/{account_id}/views/{view_id}/view/{sha}.pb
 /accounts/{account_id}/connectors/{connector_id}/connector/{sha}.pb
 /accounts/{account_id}/catalog-integrations/{integration_id}/integration/{sha}.pb
+/accounts/{account_id}/catalog-overlays/{overlay_id}/overlay/{sha}.pb
 /accounts/{account_id}/transactions/{tx_id}/transaction/{sha}.pb
 /accounts/{account_id}/transactions/{tx_id}/intent/{sha}.pb
 /accounts/{account_id}/transactions/{tx_id}/objects/{sha}.bin
@@ -93,13 +94,20 @@ Catalog hierarchy, lookup indexes, and maintenance markers:
 /accounts/{account_id}/catalog-integrations/by-name/{integration_name}
 /accounts/{account_id}/catalog-integrations/overlays-marker/{integration_id}
 /accounts/{account_id}/catalog-integrations/deleting/{integration_id}
+/accounts/{account_id}/catalog-overlays/by-id/{overlay_id}
+/accounts/{account_id}/catalog-overlays/by-name/{overlay_name}
+/accounts/{account_id}/catalog-overlays/by-integration/{integration_id}/{overlay_id}
 /accounts/{account_id}/deleting
-/catalog-integration-credential-cleanup/{account_id}/{integration_id}/{generation}
 /accounts/{account_id}/catalogs/{catalog_id}/markers/children
 /accounts/{account_id}/namespaces/{namespace_id}/markers/children
 /accounts/{account_id}/gc/cas/generation-cursor
 /accounts/{account_id}/root-resyncs/by-table/{table_id}
 ```
+
+An overlay owns a Catalog whose display name is the overlay's own, so the ordinary
+`catalogs/by-name` pointer is what keeps top-level names unique. The owned catalog's pointer set is
+written, renamed, and deleted in the same transaction as the overlay's, so the two can never be
+visible under different names or outlive each other.
 
 Catalog integration secret payloads are stored outside the resource blob through SecretsManager:
 
@@ -110,8 +118,8 @@ accounts/{account_id}/catalog-integrations/{integration_id}:{credential_generati
 The key is derived internally from the persisted integration identity and credential generation; it
 is not present in the resource payload. A new secret is written before publishing the matching
 generation; an old secret is deleted only after the resource mutation commits. Definite failures
-delete an unpublished generation. Durable cleanup records retain other candidates until pointer GC
-can prove that their generation is no longer referenced.
+delete an unpublished generation. Durable cleanup records cover acknowledgement-uncertain failures
+and are drained once the generation is provably superseded.
 
 Transaction and idempotency pointers:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - Arrow Flight: arrow-flight.md
   - Catalog and Metadata:
       - Catalog Integration Architecture and Delivery Plan: catalog-integration-design.md
+      - Catalog Integrations and Overlays: catalog-integrations.md
       - Metadata Graph: metadata-graph.md
       - System Objects: system-objects.md
       - System Scans: system-scans.md

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -49,6 +49,7 @@ import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
@@ -82,6 +83,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
   @Inject AccountRepository accountRepo;
   @Inject CatalogRepository catalogRepo;
   @Inject CatalogIntegrationRepository catalogIntegrationRepo;
+  @Inject CatalogOverlayRepository catalogOverlayRepo;
   @Inject NamespaceRepository namespaceRepo;
   @Inject TableRepository tableRepo;
   @Inject TableRootRepository tableRootRepo;
@@ -499,12 +501,14 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     var summary = new AccountCleanupSummary(accountKey);
     CLEANUP_LOG.infof("account_delete_cleanup_start account_id=%s", accountKey);
     try {
+      cleanupCatalogOverlays(accountKey, summary);
       cleanupCatalogIntegrations(accountKey, summary);
       cleanupConnectors(accountKey, summary);
       cleanupCatalogs(accountKey, summary);
       CLEANUP_LOG.infof(
-          "account_delete_cleanup_complete account_id=%s catalog_integrations=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d snapshot_prefix_deletes=%d",
+          "account_delete_cleanup_complete account_id=%s catalog_overlays=%d catalog_integrations=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d snapshot_prefix_deletes=%d",
           summary.accountId,
+          summary.catalogOverlaysDeleted,
           summary.catalogIntegrationsDeleted,
           summary.connectorsDeleted,
           summary.credentialsDeleted,
@@ -516,6 +520,19 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     } catch (RuntimeException e) {
       CLEANUP_LOG.errorf(e, "account_delete_cleanup_failed account_id=%s", accountKey);
       throw e;
+    }
+  }
+
+  private void cleanupCatalogOverlays(String accountId, AccountCleanupSummary summary) {
+    for (var overlay :
+        listAllPages(
+            (token, next) -> catalogOverlayRepo.listConsistent(accountId, 200, token, next))) {
+      if (catalogOverlayRepo.delete(overlay.getResourceId())) {
+        summary.catalogOverlaysDeleted++;
+      } else if (catalogOverlayRepo.getById(overlay.getResourceId()).isPresent()) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "catalog overlay changed during account cleanup");
+      }
     }
   }
 
@@ -718,6 +735,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
   private static final class AccountCleanupSummary {
     private final String accountId;
     private int connectorsDeleted;
+    private int catalogOverlaysDeleted;
     private int catalogIntegrationsDeleted;
     private int credentialsDeleted;
     private int catalogsDeleted;

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImpl.java
@@ -393,7 +393,7 @@ public class CatalogServiceImpl extends BaseServiceImpl implements CatalogServic
   }
 
   private CatalogSurfaceWritePolicy catalogSurfaceWritePolicy() {
-    return new CatalogSurfaceWritePolicy(overlay);
+    return new CatalogSurfaceWritePolicy(overlay, catalogRepo);
   }
 
   private Catalog applyCatalogSpecPatch(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
@@ -621,7 +621,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
   }
 
   private CatalogSurfaceWritePolicy catalogSurfaceWritePolicy() {
-    return new CatalogSurfaceWritePolicy(overlay);
+    return new CatalogSurfaceWritePolicy(overlay, catalogRepo);
   }
 
   private static byte[] canonicalFingerprint(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
@@ -55,6 +55,7 @@ import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.common.PersistedSecretPropertyValidator;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
@@ -76,6 +77,7 @@ import org.jboss.logging.Logger;
 public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotService {
 
   @Inject SnapshotRepository snapshotRepo;
+  @Inject CatalogRepository catalogRepo;
   @Inject TableRepository tableRepo;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
@@ -129,7 +131,7 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
   }
 
   private void ensureTableWritable(ResourceId tableId, String corr) {
-    new CatalogSurfaceWritePolicy(overlay).requireWritableTable(tableId, corr);
+    new CatalogSurfaceWritePolicy(overlay, catalogRepo).requireWritableTable(tableId, corr);
   }
 
   private String schemaJsonForTable(String corr, ResourceId tableId) {

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableIndexServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableIndexServiceImpl.java
@@ -43,6 +43,7 @@ import ai.floedb.floecat.service.common.LogHelper;
 import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.IndexArtifactRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
@@ -63,6 +64,7 @@ import org.jboss.logging.Logger;
 public class TableIndexServiceImpl extends BaseServiceImpl implements TableIndexService {
 
   @Inject SnapshotRepository snapshots;
+  @Inject CatalogRepository catalogRepo;
   @Inject IndexArtifactRepository indexArtifacts;
   @Inject BlobStore blobStore;
   @Inject PrincipalProvider principal;
@@ -248,7 +250,8 @@ public class TableIndexServiceImpl extends BaseServiceImpl implements TableIndex
     var pc = principal.get();
     authz.require(pc, "table.write");
 
-    new CatalogSurfaceWritePolicy(overlay).requireWritableTable(state.tableId, correlationId());
+    new CatalogSurfaceWritePolicy(overlay, catalogRepo)
+        .requireWritableTable(state.tableId, correlationId());
 
     snapshots
         .getById(state.tableId, state.snapshotId)

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
@@ -50,6 +50,7 @@ import ai.floedb.floecat.service.common.PersistedSecretPropertyValidator;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
@@ -74,6 +75,7 @@ import org.jboss.logging.Logger;
 public class TableServiceImpl extends BaseServiceImpl implements TableService {
 
   @Inject TableRepository tableRepo;
+  @Inject CatalogRepository catalogRepo;
   @Inject SnapshotRepository snapshotRepo;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
@@ -111,7 +113,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
   }
 
   private CatalogSurfaceWritePolicy catalogSurfaceWritePolicy() {
-    return new CatalogSurfaceWritePolicy(overlay);
+    return new CatalogSurfaceWritePolicy(overlay, catalogRepo);
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
@@ -48,6 +48,7 @@ import ai.floedb.floecat.service.common.PersistedSecretPropertyValidator;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
@@ -69,6 +70,7 @@ import org.jboss.logging.Logger;
 public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
 
   @Inject ViewRepository viewRepo;
+  @Inject CatalogRepository catalogRepo;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
   @Inject IdempotencyRepository idempotencyStore;
@@ -96,7 +98,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
   }
 
   private CatalogSurfaceWritePolicy catalogSurfaceWritePolicy() {
-    return new CatalogSurfaceWritePolicy(overlay);
+    return new CatalogSurfaceWritePolicy(overlay, catalogRepo);
   }
 
   @Override

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceWritePolicy.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceWritePolicy.java
@@ -28,6 +28,7 @@ import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.scanner.spi.CatalogGraphView;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.systemcatalog.graph.SystemResourceIdGenerator;
 import io.grpc.StatusRuntimeException;
 import java.util.ArrayList;
@@ -41,9 +42,15 @@ public final class CatalogSurfaceWritePolicy {
   private static final String PATH_DELIM = "\u001F";
 
   private final CatalogGraphView overlay;
+  private final CatalogRepository catalogs;
 
   public CatalogSurfaceWritePolicy(CatalogGraphView overlay) {
+    this(overlay, null);
+  }
+
+  public CatalogSurfaceWritePolicy(CatalogGraphView overlay, CatalogRepository catalogs) {
     this.overlay = Objects.requireNonNull(overlay, "catalog overlay is required");
+    this.catalogs = catalogs;
   }
 
   /**
@@ -75,6 +82,7 @@ public final class CatalogSurfaceWritePolicy {
   public CatalogNode requireWritableCatalog(ResourceId catalogId, String field, String corr) {
     CatalogSurfaceSupport.ensureKind(catalogId, ResourceKind.RK_CATALOG, field, corr);
     rejectSystemId(catalogId, "catalog", corr);
+    rejectOverlayOwnedCatalog(catalogId, corr);
     return requireVisibleCatalog(catalogId, field, corr);
   }
 
@@ -93,6 +101,7 @@ public final class CatalogSurfaceWritePolicy {
     if (namespace.origin() == GraphNodeOrigin.SYSTEM) {
       throw systemObjectImmutable(corr, namespaceId, "namespace");
     }
+    rejectOverlayOwnedCatalog(namespace.catalogId(), corr);
     return namespace;
   }
 
@@ -106,6 +115,7 @@ public final class CatalogSurfaceWritePolicy {
   public void requireDeletableCatalog(ResourceId catalogId, String corr) {
     CatalogSurfaceSupport.ensureKind(catalogId, ResourceKind.RK_CATALOG, "catalog_id", corr);
     rejectSystemId(catalogId, "catalog", corr);
+    rejectOverlayOwnedCatalog(catalogId, corr);
   }
 
   /**
@@ -119,15 +129,18 @@ public final class CatalogSurfaceWritePolicy {
   public void requireDeletableNamespace(ResourceId namespaceId, String corr) {
     CatalogSurfaceSupport.ensureKind(namespaceId, ResourceKind.RK_NAMESPACE, "namespace_id", corr);
     rejectSystemId(namespaceId, "namespace", corr);
-    overlay
-        .resolve(namespaceId)
-        .filter(NamespaceNode.class::isInstance)
-        .map(NamespaceNode.class::cast)
+    var namespace =
+        overlay
+            .resolve(namespaceId)
+            .filter(NamespaceNode.class::isInstance)
+            .map(NamespaceNode.class::cast);
+    namespace
         .filter(ns -> ns.origin() == GraphNodeOrigin.SYSTEM)
         .ifPresent(
             ns -> {
               throw systemObjectImmutable(corr, namespaceId, "namespace");
             });
+    namespace.ifPresent(ns -> rejectOverlayOwnedCatalog(ns.catalogId(), corr));
   }
 
   public void requireNamespaceInCatalog(
@@ -239,7 +252,8 @@ public final class CatalogSurfaceWritePolicy {
   }
 
   private void enforceWritableTableNode(GraphNode node, ResourceId tableId, String corr) {
-    if (node instanceof UserTableNode) {
+    if (node instanceof UserTableNode userTable) {
+      rejectOverlayOwnedCatalog(userTable.catalogId(), corr);
       return;
     }
 
@@ -255,9 +269,28 @@ public final class CatalogSurfaceWritePolicy {
       if (isSystemViewNode(vn)) {
         throw systemObjectImmutable(corr, viewId, "view");
       }
+      rejectOverlayOwnedCatalog(vn.catalogId(), corr);
       return;
     }
     throw GrpcErrors.notFound(corr, VIEW, Map.of("id", viewId.getId()));
+  }
+
+  private void rejectOverlayOwnedCatalog(ResourceId catalogId, String corr) {
+    if (catalogs == null) {
+      return;
+    }
+    catalogs
+        .getById(catalogId)
+        .filter(catalog -> catalog.hasOverlayId())
+        .ifPresent(
+            catalog -> {
+              throw GrpcErrors.permissionDenied(
+                  corr,
+                  null,
+                  Map.of(
+                      "id", catalogId.getId(),
+                      "overlay_id", catalog.getOverlayId().getId()));
+            });
   }
 
   private List<NamespaceNode> listSystemNamespaces(ResourceId catalogId) {

--- a/service/src/main/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImpl.java
@@ -51,6 +51,7 @@ import ai.floedb.floecat.service.common.LogHelper;
 import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.ConstraintRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
@@ -73,6 +74,7 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
     implements TableConstraintsService {
 
   @Inject SnapshotRepository snapshots;
+  @Inject CatalogRepository catalogRepo;
   @Inject ConstraintRepository constraints;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
@@ -90,7 +92,7 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
   }
 
   private CatalogSurfaceWritePolicy catalogSurfaceWritePolicy() {
-    return new CatalogSurfaceWritePolicy(overlay);
+    return new CatalogSurfaceWritePolicy(overlay, catalogRepo);
   }
 
   /** Returns snapshot-scoped constraints for one table snapshot. */

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
@@ -741,6 +741,14 @@ public class CasBlobGc {
               storageEstimate);
       pointersScanned +=
           collectPointers(
+              Keys.catalogOverlayPointerByIdPrefix(accountId),
+              referenced,
+              null,
+              pageSize,
+              null,
+              storageEstimate);
+      pointersScanned +=
+          collectPointers(
               Keys.storageAuthorityPointerByIdPrefix(accountId),
               referenced,
               null,
@@ -1094,6 +1102,21 @@ public class CasBlobGc {
       blobsScanned += catalogIntegrations.scanned();
       blobsDeleted += catalogIntegrations.deleted();
       blobsRescued += catalogIntegrations.rescued();
+
+      var catalogOverlays =
+          deleteUnreferenced(
+              Keys.catalogOverlayRootPrefix(accountId),
+              referenced,
+              walkedPinRoots,
+              walkFailures,
+              key -> key.contains("/overlay/"),
+              null,
+              pageSize,
+              nowMs,
+              minAgeMs);
+      blobsScanned += catalogOverlays.scanned();
+      blobsDeleted += catalogOverlays.deleted();
+      blobsRescued += catalogOverlays.rescued();
 
       var storageAuthorities =
           deleteUnreferenced(

--- a/service/src/main/java/ai/floedb/floecat/service/gc/PointerGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/PointerGc.java
@@ -231,6 +231,37 @@ public class PointerGc {
     missingBlobs += integrationsByName.missingBlobs;
     staleSecondaries += integrationsByName.staleSecondaries;
 
+    Result overlaysById =
+        scanPrefix(
+            Keys.catalogOverlayPointerByIdPrefix(accountId),
+            pageSize,
+            deadlineMs,
+            blobCache,
+            p -> true,
+            nowMs,
+            minAgeMs);
+    scanned += overlaysById.scanned;
+    deleted += overlaysById.deleted;
+    missingBlobs += overlaysById.missingBlobs;
+    staleSecondaries += overlaysById.staleSecondaries;
+
+    Result overlaySecondaryPointers =
+        scanPrefix(
+            Keys.catalogOverlayRootPrefix(accountId),
+            pageSize,
+            deadlineMs,
+            blobCache,
+            p -> {
+              String key = p.getKey();
+              return key != null && (key.contains("/by-name/") || key.contains("/by-integration/"));
+            },
+            nowMs,
+            minAgeMs);
+    scanned += overlaySecondaryPointers.scanned;
+    deleted += overlaySecondaryPointers.deleted;
+    missingBlobs += overlaySecondaryPointers.missingBlobs;
+    staleSecondaries += overlaySecondaryPointers.staleSecondaries;
+
     Result catalogsByName =
         scanPrefix(
             Keys.catalogPointerByNamePrefix(accountId),
@@ -480,6 +511,10 @@ public class PointerGc {
         && parts.length >= 5
         && "integration".equals(parts[4])) {
       return Keys.catalogIntegrationPointerById(accountId, decode(parts[3]));
+    }
+
+    if ("catalog-overlays".equals(scope) && parts.length >= 5 && "overlay".equals(parts[4])) {
+      return Keys.catalogOverlayPointerById(accountId, decode(parts[3]));
     }
 
     return null;

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -35,6 +35,8 @@ import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.RolePermissions;
@@ -56,6 +58,8 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
   private static final Set<String> MUTABLE_PATHS = Set.of("display_name");
 
   @Inject CatalogIntegrationRepository integrations;
+  @Inject CatalogOverlayRepository overlays;
+  @Inject CatalogRepository catalogs;
   @Inject MarkerStore markerStore;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
@@ -304,6 +308,13 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
         throw GrpcErrors.alreadyExists(corr, null, Map.of("display_name", name));
       long markerVersion =
           markerStore.catalogIntegrationOverlaysMarkerVersion(current.value().getResourceId());
+      int dependents =
+          overlays.countByIntegration(
+              current.value().getResourceId().getAccountId(),
+              current.value().getResourceId().getId());
+      if (dependents > 0)
+        throw GrpcErrors.conflict(
+            corr, null, Map.of("dependent_overlays", Integer.toString(dependents)));
       var replacement =
           applyAuthentication(
                   CatalogIntegration.newBuilder()
@@ -321,7 +332,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
               current.value(), current.meta().getPointerVersion(), replacement, markerVersion);
       if (replaced.isEmpty()) {
         throw new BaseResourceRepository.AbortRetryableException(
-            "integration dependencies changed during replacement");
+            "integration or overlays changed during replacement");
       }
       credentialCleanup.cleanIfSuperseded(current.value());
       return new CreateOutcome(replaced.get(), true);
@@ -492,6 +503,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
             () -> {
               var pc = principal.get();
               authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
+              if (request.getCascade()) authz.require(pc, RolePermissions.CATALOG_OVERLAY_WRITE);
               String corr = pc.getCorrelationId();
               ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
               var current = integrations.getByIdWithMeta(id);
@@ -505,20 +517,76 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
               var meta = current.get().meta();
               MutationOps.BaseServiceChecks.enforcePreconditions(
                   corr, meta, request.getPrecondition());
+              if (request.getCascade()) {
+                credentialCleanup.schedule(current.get().value());
+                cascadeDeleteIntegration(id, meta);
+                credentialCleanup.cleanIfSuperseded(current.get().value());
+                return DeleteCatalogIntegrationResponse.newBuilder().setMeta(meta).build();
+              }
               if (integrations.cascadeDeletionFenceVersion(id) > 0L)
                 throw GrpcErrors.conflict(
                     corr, null, Map.of("reason", "cascade deletion in progress"));
               long markerVersion = markerStore.catalogIntegrationOverlaysMarkerVersion(id);
+              int dependents = overlays.countByIntegration(pc.getAccountId(), id.getId());
+              if (dependents > 0)
+                throw GrpcErrors.conflict(
+                    corr, null, Map.of("dependent_overlays", Integer.toString(dependents)));
               credentialCleanup.schedule(current.get().value());
               if (!integrations.deleteWithPreconditionAndOverlayMarker(
                   id, meta.getPointerVersion(), markerVersion)) {
                 throw new BaseResourceRepository.AbortRetryableException(
-                    "integration dependencies changed during deletion");
+                    "integration or overlays changed during deletion");
               }
               credentialCleanup.cleanIfSuperseded(current.get().value());
               return DeleteCatalogIntegrationResponse.newBuilder().setMeta(meta).build();
             }),
         correlationId());
+  }
+
+  private void cascadeDeleteIntegration(
+      ResourceId integrationId, ai.floedb.floecat.common.rpc.MutationMeta integrationMeta) {
+    if (!integrations.beginCascadeDeletion(integrationId, integrationMeta.getPointerVersion())) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "integration changed while cascade deletion was fenced");
+    }
+
+    while (true) {
+      var next = new StringBuilder();
+      var dependents =
+          overlays.listByIntegrationWithMetaConsistent(
+              integrationId.getAccountId(), integrationId.getId(), 100, "", next);
+      if (dependents.isEmpty()) break;
+      for (var dependent : dependents) {
+        if (!dependent.value().hasCatalogId()) {
+          throw new BaseResourceRepository.CorruptionException(
+              "overlay is missing its owned catalog: " + dependent.value().getResourceId().getId(),
+              null);
+        }
+        var ownedCatalogDeletes = catalogs.prepareDeleteOps(dependent.value().getCatalogId());
+        if (!overlays.deleteWithOwnedCatalog(
+            dependent.value().getResourceId(),
+            dependent.meta().getPointerVersion(),
+            ownedCatalogDeletes)) {
+          throw new BaseResourceRepository.AbortRetryableException(
+              "overlay changed during integration cascade deletion");
+        }
+      }
+    }
+
+    int remaining =
+        overlays.countByIntegration(integrationId.getAccountId(), integrationId.getId());
+    if (remaining != 0) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "overlays appeared during integration cascade deletion");
+    }
+    long markerVersion = markerStore.catalogIntegrationOverlaysMarkerVersion(integrationId);
+    long fenceVersion = integrations.cascadeDeletionFenceVersion(integrationId);
+    if (fenceVersion == 0L
+        || !integrations.deleteWithPreconditionAndOverlayMarkerAndFence(
+            integrationId, integrationMeta.getPointerVersion(), markerVersion, fenceVersion)) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "integration changed while cascade deletion completed");
+    }
   }
 
   private static FieldMask requiredMask(FieldMask mask, String corr) {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
@@ -1,0 +1,664 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.integration;
+
+import ai.floedb.floecat.catalog.rpc.Catalog;
+import ai.floedb.floecat.common.rpc.CreateMode;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
+import ai.floedb.floecat.integration.rpc.CatalogOverlayEntry;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaySpec;
+import ai.floedb.floecat.integration.rpc.CatalogOverlays;
+import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayResponse;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayResponse;
+import ai.floedb.floecat.integration.rpc.GetCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogOverlayResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysResponse;
+import ai.floedb.floecat.integration.rpc.NamespacePath;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayResponse;
+import ai.floedb.floecat.service.common.BaseServiceImpl;
+import ai.floedb.floecat.service.common.Canonicalizer;
+import ai.floedb.floecat.service.common.IdempotencyGuard;
+import ai.floedb.floecat.service.common.MutationOps;
+import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.MarkerStore;
+import ai.floedb.floecat.service.security.RolePermissions;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.Timestamp;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@GrpcService
+public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverlays {
+  private static final Set<String> MUTABLE_PATHS =
+      Set.of("display_name", "include_namespaces", "exclude_namespaces");
+
+  @Inject CatalogOverlayRepository overlays;
+  @Inject CatalogIntegrationRepository integrations;
+  @Inject CatalogRepository catalogs;
+  @Inject MarkerStore markerStore;
+  @Inject PrincipalProvider principal;
+  @Inject Authorizer authz;
+  @Inject IdempotencyRepository idempotencyStore;
+
+  @Override
+  public Uni<ListCatalogOverlaysResponse> listCatalogOverlays(ListCatalogOverlaysRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_OVERLAY_READ);
+              var page = MutationOps.pageIn(request.hasPage() ? request.getPage() : null);
+              var next = new StringBuilder();
+              List<
+                      ai.floedb.floecat.service.repo.util.GenericResourceRepository
+                              .ResourceWithMeta<
+                          CatalogOverlay>>
+                  rows;
+              int total;
+              if (request.hasIntegrationId()) {
+                ResourceId integrationId =
+                    scopedIntegrationId(pc.getAccountId(), request.getIntegrationId());
+                rows =
+                    overlays.listByIntegrationWithMeta(
+                        pc.getAccountId(),
+                        integrationId.getId(),
+                        Math.max(1, page.limit),
+                        page.token,
+                        next);
+                total = overlays.countByIntegration(pc.getAccountId(), integrationId.getId());
+              } else {
+                rows =
+                    overlays.listWithMeta(
+                        pc.getAccountId(), Math.max(1, page.limit), page.token, next);
+                total = overlays.count(pc.getAccountId());
+              }
+              var response = ListCatalogOverlaysResponse.newBuilder();
+              rows.forEach(
+                  row ->
+                      response.addEntries(
+                          CatalogOverlayEntry.newBuilder()
+                              .setOverlay(row.value())
+                              .setMeta(row.meta())));
+              return response.setPage(MutationOps.pageOut(next.toString(), total)).build();
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<GetCatalogOverlayResponse> getCatalogOverlay(GetCatalogOverlayRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_OVERLAY_READ);
+              if (!request.hasOverlayId() && !request.hasDisplayName())
+                throw GrpcErrors.invalidArgument(
+                    pc.getCorrelationId(), null, Map.of("field", "selector"));
+              var row =
+                  (request.hasOverlayId()
+                          ? overlays.getByIdWithMeta(
+                              scopedOverlayId(pc.getAccountId(), request.getOverlayId()))
+                          : request.hasDisplayName()
+                              ? overlays.getByNameWithMeta(
+                                  pc.getAccountId(),
+                                  normalizeName(
+                                      mustNonEmpty(
+                                          request.getDisplayName(),
+                                          "display_name",
+                                          pc.getCorrelationId())))
+                              : throwMissingOverlaySelector())
+                      .orElseThrow(
+                          () -> GrpcErrors.notFound(pc.getCorrelationId(), null, Map.of()));
+              return GetCatalogOverlayResponse.newBuilder()
+                  .setOverlay(row.value())
+                  .setMeta(row.meta())
+                  .build();
+            }),
+        correlationId());
+  }
+
+  private static java.util.Optional<
+          ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta<
+              CatalogOverlay>>
+      throwMissingOverlaySelector() {
+    throw new IllegalStateException("validated overlay selector missing");
+  }
+
+  @Override
+  public Uni<CreateCatalogOverlayResponse> createCatalogOverlay(
+      CreateCatalogOverlayRequest request) {
+    return mapFailures(
+        runWithRetry(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_OVERLAY_WRITE);
+              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_USE);
+              // Creating an overlay creates the catalog it owns.
+              authz.require(pc, RolePermissions.CATALOG_WRITE);
+              String corr = pc.getCorrelationId();
+              CatalogOverlaySpec spec = request.getSpec();
+              String name =
+                  normalizeName(mustNonEmpty(spec.getDisplayName(), "display_name", corr));
+              var createPolicy =
+                  CatalogCreatePolicy.validate(
+                      request.getCreateMode(),
+                      request.hasIdempotency() ? request.getIdempotency().getKey() : "",
+                      corr);
+              String key = createPolicy.idempotencyKey();
+              CreateMode mode = createPolicy.mode();
+              if (mode == CreateMode.CM_RETURN_EXISTING) {
+                var existing = overlays.getByNameWithMeta(pc.getAccountId(), name);
+                if (existing.isPresent()) {
+                  return CreateCatalogOverlayResponse.newBuilder()
+                      .setOverlay(existing.get().value())
+                      .setMeta(existing.get().meta())
+                      .build();
+                }
+              }
+              ResourceId integrationId =
+                  scopedIntegrationId(pc.getAccountId(), spec.getIntegrationId());
+              List<NamespacePath> includes =
+                  normalizePaths(spec.getIncludeNamespacesList(), "include_namespaces", corr);
+              List<NamespacePath> excludes =
+                  normalizePaths(spec.getExcludeNamespacesList(), "exclude_namespaces", corr);
+              byte[] fingerprint = canonicalFingerprint(name, integrationId, includes, excludes);
+              var now = nowTs();
+
+              if (key.isEmpty()) {
+                var created =
+                    createOrReplace(
+                        randomResourceId(pc.getAccountId(), ResourceKind.RK_CATALOG_OVERLAY),
+                        name,
+                        integrationId,
+                        includes,
+                        excludes,
+                        mode,
+                        false,
+                        null,
+                        now,
+                        corr);
+                return CreateCatalogOverlayResponse.newBuilder()
+                    .setOverlay(created.value())
+                    .setMeta(created.meta())
+                    .build();
+              }
+              var result =
+                  runIdempotentCreate(
+                      () ->
+                          MutationOps.createProtoRecoverable(
+                              pc.getAccountId(),
+                              "CreateCatalogOverlay",
+                              key,
+                              () -> fingerprint,
+                              () ->
+                                  randomResourceId(
+                                      pc.getAccountId(), ResourceKind.RK_CATALOG_OVERLAY),
+                              (reservedId, completion) -> {
+                                var recovered = overlays.getByIdWithMeta(reservedId);
+                                if (recovered.isPresent()) {
+                                  throw new BaseResourceRepository.AbortRetryableException(
+                                      "overlay exists before its idempotency receipt committed");
+                                }
+                                var created =
+                                    createOrReplace(
+                                        reservedId,
+                                        name,
+                                        integrationId,
+                                        includes,
+                                        excludes,
+                                        CreateMode.CM_ERROR_IF_EXISTS,
+                                        true,
+                                        completion,
+                                        now,
+                                        corr);
+                                return new IdempotencyGuard.CommittedCreate<>(
+                                    created.value(),
+                                    created.value().getResourceId(),
+                                    created.meta());
+                              },
+                              idempotencyStore,
+                              now,
+                              idempotencyTtlSeconds(),
+                              this::correlationId,
+                              CatalogOverlay::parseFrom));
+              return CreateCatalogOverlayResponse.newBuilder()
+                  .setOverlay(result.body)
+                  .setMeta(result.meta)
+                  .build();
+            }),
+        correlationId());
+  }
+
+  private ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta<
+          CatalogOverlay>
+      createOrReplace(
+          ResourceId overlayId,
+          String name,
+          ResourceId integrationId,
+          List<NamespacePath> includes,
+          List<NamespacePath> excludes,
+          CreateMode mode,
+          boolean reservedIdentity,
+          IdempotencyGuard.SuccessCommitter<CatalogOverlay> completion,
+          com.google.protobuf.Timestamp now,
+          String corr) {
+    String accountId = overlayId.getAccountId();
+    var integration =
+        integrations
+            .getByIdWithMeta(integrationId)
+            .orElseThrow(
+                () ->
+                    GrpcErrors.notFound(
+                        corr, null, Map.of("integration_id", integrationId.getId())));
+    long markerVersion = markerStore.catalogIntegrationOverlaysMarkerVersion(integrationId);
+    Map<String, Long> requiredVersions =
+        Map.of(
+            Keys.catalogIntegrationPointerById(accountId, integrationId.getId()),
+            integration.meta().getPointerVersion());
+    Set<String> requiredAbsent =
+        new java.util.HashSet<>(
+            Set.of(Keys.catalogIntegrationDeletionMarker(accountId, integrationId.getId())));
+    var existing = overlays.getByNameWithMeta(accountId, name);
+    if (existing.isPresent()) {
+      var current = existing.get();
+      if (reservedIdentity && current.value().getResourceId().equals(overlayId)) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "overlay exists before its idempotency receipt committed");
+      }
+      if (mode == CreateMode.CM_RETURN_EXISTING) return current;
+      if (mode != CreateMode.CM_REPLACE)
+        throw GrpcErrors.alreadyExists(corr, null, Map.of("display_name", name));
+
+      Map<String, Long> parentVersions = new java.util.HashMap<>(requiredVersions);
+      ResourceId oldIntegrationId = current.value().getIntegrationId();
+      if (!oldIntegrationId.equals(integrationId)) {
+        var oldIntegration =
+            integrations
+                .getByIdWithMeta(oldIntegrationId)
+                .orElseThrow(
+                    () ->
+                        new BaseResourceRepository.CorruptionException(
+                            "overlay references missing integration: " + oldIntegrationId.getId(),
+                            null));
+        parentVersions.put(
+            Keys.catalogIntegrationPointerById(accountId, oldIntegrationId.getId()),
+            oldIntegration.meta().getPointerVersion());
+        requiredAbsent.add(
+            Keys.catalogIntegrationDeletionMarker(accountId, oldIntegrationId.getId()));
+      }
+      Map<String, Long> markerVersions = new java.util.HashMap<>();
+      markerVersions.put(
+          Keys.catalogIntegrationOverlaysMarker(accountId, integrationId.getId()), markerVersion);
+      if (!oldIntegrationId.equals(integrationId)) {
+        markerVersions.put(
+            Keys.catalogIntegrationOverlaysMarker(accountId, oldIntegrationId.getId()),
+            markerStore.catalogIntegrationOverlaysMarkerVersion(oldIntegrationId));
+      }
+      var replacement =
+          CatalogOverlay.newBuilder()
+              .setResourceId(overlayId)
+              .setCatalogId(requireOwnedCatalogId(current.value()))
+              .setDisplayName(name)
+              .setIntegrationId(integrationId)
+              .addAllIncludeNamespaces(includes)
+              .addAllExcludeNamespaces(excludes)
+              .setCreatedAt(now)
+              .setUpdatedAt(now)
+              .build();
+      return overlays
+          .replaceIdentityAttachedWithMeta(
+              current.value(),
+              current.meta().getPointerVersion(),
+              replacement,
+              Map.copyOf(parentVersions),
+              Set.copyOf(requiredAbsent),
+              Map.copyOf(markerVersions),
+              ownedCatalogReplacementOps(current.value(), replacement))
+          .orElseThrow(
+              () ->
+                  new BaseResourceRepository.AbortRetryableException(
+                      "overlay or integration changed during replacement"));
+    }
+    CatalogOverlay overlay =
+        CatalogOverlay.newBuilder()
+            .setResourceId(overlayId)
+            .setDisplayName(name)
+            .setIntegrationId(integrationId)
+            .addAllIncludeNamespaces(includes)
+            .addAllExcludeNamespaces(excludes)
+            .setCreatedAt(now)
+            .setUpdatedAt(now)
+            .build();
+    // The catalog this overlay owns is created in the overlay's own pointer transaction, so the two
+    // become visible together. Its blob is content-addressed, so preparing operations for a batch
+    // that loses is wasted space rather than a reachable orphan.
+    Catalog ownedCatalog = ownedCatalogFor(overlay, now);
+    overlay = overlay.toBuilder().setCatalogId(ownedCatalog.getResourceId()).build();
+    ownedCatalog = ownedCatalog.toBuilder().setOverlayId(overlay.getResourceId()).build();
+    List<PointerStore.CasOp> catalogOps = catalogs.prepareCreateOps(ownedCatalog);
+    try {
+      return overlays
+          .createAttachedWithMetaAndCompanions(
+              overlay,
+              requiredVersions,
+              requiredAbsent,
+              markerVersion,
+              row -> {
+                List<PointerStore.CasOp> companions = new ArrayList<>(catalogOps);
+                if (completion != null) {
+                  companions.add(
+                      completion.prepare(
+                          new IdempotencyGuard.CommittedCreate<>(
+                              row.value(), row.value().getResourceId(), row.meta())));
+                }
+                return companions;
+              })
+          .orElseThrow(
+              () ->
+                  new BaseResourceRepository.AbortRetryableException(
+                      "overlay parent changed during creation"));
+    } catch (BaseResourceRepository.NameConflictException e) {
+      if (reservedIdentity) {
+        var recovered = overlays.getByIdWithMeta(overlayId);
+        if (recovered.isPresent())
+          throw new BaseResourceRepository.AbortRetryableException(
+              "overlay exists before its idempotency receipt committed");
+        var owner = overlays.getByNameWithMeta(accountId, name);
+        if (owner.isPresent() && owner.get().value().getResourceId().equals(overlayId)) {
+          throw new BaseResourceRepository.AbortRetryableException(
+              "overlay exists before its idempotency receipt committed");
+        }
+      }
+      var catalogOwner = catalogs.getByName(accountId, name);
+      if (catalogOwner.isPresent()
+          && (!catalogOwner.get().hasOverlayId()
+              || !catalogOwner.get().getOverlayId().equals(overlayId))) {
+        throw GrpcErrors.alreadyExists(corr, null, Map.of("display_name", name));
+      }
+      if (reservedIdentity) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "overlay create conflict not yet visible");
+      }
+      if (mode != CreateMode.CM_ERROR_IF_EXISTS)
+        throw new BaseResourceRepository.AbortRetryableException(
+            "overlay name owner changed during create");
+      throw GrpcErrors.alreadyExists(corr, null, Map.of("display_name", name));
+    }
+  }
+
+  @Override
+  public Uni<UpdateCatalogOverlayResponse> updateCatalogOverlay(
+      UpdateCatalogOverlayRequest request) {
+    return mapFailures(
+        runWithRetry(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_OVERLAY_WRITE);
+              String corr = pc.getCorrelationId();
+              ResourceId id = scopedOverlayId(pc.getAccountId(), request.getOverlayId());
+              requiredMask(request.hasUpdateMask() ? request.getUpdateMask() : null, corr);
+              var current =
+                  overlays
+                      .getByIdWithMeta(id)
+                      .orElseThrow(() -> GrpcErrors.notFound(corr, null, Map.of("id", id.getId())));
+              MutationOps.BaseServiceChecks.enforcePreconditions(
+                  corr, current.meta(), request.getPrecondition());
+              var desiredBuilder = current.value().toBuilder();
+              for (String path : request.getUpdateMask().getPathsList()) {
+                switch (path) {
+                  case "display_name" ->
+                      desiredBuilder.setDisplayName(
+                          normalizeName(
+                              mustNonEmpty(
+                                  request.getSpec().getDisplayName(), "display_name", corr)));
+                  case "include_namespaces" ->
+                      desiredBuilder
+                          .clearIncludeNamespaces()
+                          .addAllIncludeNamespaces(
+                              normalizePaths(
+                                  request.getSpec().getIncludeNamespacesList(), path, corr));
+                  case "exclude_namespaces" ->
+                      desiredBuilder
+                          .clearExcludeNamespaces()
+                          .addAllExcludeNamespaces(
+                              normalizePaths(
+                                  request.getSpec().getExcludeNamespacesList(), path, corr));
+                  default -> throw GrpcErrors.invalidArgument(corr, null, Map.of("field", path));
+                }
+              }
+              CatalogOverlay desired = desiredBuilder.setUpdatedAt(nowTs()).build();
+              boolean renamed = !desired.getDisplayName().equals(current.value().getDisplayName());
+              if (renamed) {
+                // Renaming an overlay renames the catalog it owns.
+                authz.require(pc, RolePermissions.CATALOG_WRITE);
+                if (catalogs.getByName(pc.getAccountId(), desired.getDisplayName()).isPresent()) {
+                  throw GrpcErrors.alreadyExists(
+                      corr, null, Map.of("display_name", desired.getDisplayName()));
+                }
+              }
+              // A rename moves the owned catalog's name pointer in the overlay's own transaction,
+              // so the two can never be left under different names.
+              List<PointerStore.CasOp> ownedCatalogOps =
+                  renamed ? ownedCatalogRenameOps(desired, corr) : List.of();
+              try {
+                var meta =
+                    overlays
+                        .updateWithMetaUnlessIntegrationDeleting(
+                            desired, current.meta().getPointerVersion(), ownedCatalogOps)
+                        .orElseThrow(() -> GrpcErrors.preconditionFailed(corr, null, Map.of()));
+                return UpdateCatalogOverlayResponse.newBuilder()
+                    .setOverlay(desired)
+                    .setMeta(meta)
+                    .build();
+              } catch (BaseResourceRepository.NameConflictException e) {
+                throw GrpcErrors.alreadyExists(
+                    corr, null, Map.of("display_name", desired.getDisplayName()));
+              }
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<DeleteCatalogOverlayResponse> deleteCatalogOverlay(
+      DeleteCatalogOverlayRequest request) {
+    return mapFailures(
+        runWithRetry(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_OVERLAY_WRITE);
+              // Deleting an overlay deletes the catalog it owns.
+              authz.require(pc, RolePermissions.CATALOG_WRITE);
+              String corr = pc.getCorrelationId();
+              ResourceId id = scopedOverlayId(pc.getAccountId(), request.getOverlayId());
+              var current = overlays.getByIdWithMeta(id);
+              if (current.isEmpty()) {
+                if (hasMeaningfulPrecondition(request.getPrecondition()))
+                  throw GrpcErrors.notFound(corr, null, Map.of("id", id.getId()));
+                return DeleteCatalogOverlayResponse.newBuilder()
+                    .setMeta(overlays.metaForSafe(id))
+                    .build();
+              }
+              var meta = current.get().meta();
+              MutationOps.BaseServiceChecks.enforcePreconditions(
+                  corr, meta, request.getPrecondition());
+              // Deleting the overlay deletes the catalog it owns in the same transaction. An
+              // already-absent catalog yields no operations, so a retried delete resumes rather
+              // than failing on work a previous attempt completed.
+              List<PointerStore.CasOp> ownedCatalogDeletes =
+                  catalogs.prepareDeleteOps(requireOwnedCatalogId(current.get().value()));
+              if (!overlays.deleteWithOwnedCatalog(
+                  id, meta.getPointerVersion(), ownedCatalogDeletes))
+                throw new BaseResourceRepository.AbortRetryableException(
+                    "overlay changed during deletion");
+              return DeleteCatalogOverlayResponse.newBuilder().setMeta(meta).build();
+            }),
+        correlationId());
+  }
+
+  /**
+   * Rename operations for the catalog an overlay owns, at the catalog's current pointer version.
+   * The version is asserted by the batch, so a catalog mutated between this read and the commit
+   * fails the transaction rather than being overwritten.
+   */
+  private List<PointerStore.CasOp> ownedCatalogRenameOps(CatalogOverlay desired, String corr) {
+    ResourceId catalogId = requireOwnedCatalogId(desired);
+    var owned =
+        catalogs
+            .getByIdWithMeta(catalogId)
+            .orElseThrow(
+                () ->
+                    new BaseResourceRepository.CorruptionException(
+                        "overlay references missing catalog: " + catalogId.getId(), null));
+    Catalog renamedCatalog =
+        owned.value().toBuilder().setDisplayName(desired.getDisplayName()).build();
+    return catalogs.prepareUpdateOps(renamedCatalog, owned.meta().getPointerVersion());
+  }
+
+  private List<PointerStore.CasOp> ownedCatalogReplacementOps(
+      CatalogOverlay current, CatalogOverlay replacement) {
+    ResourceId catalogId = requireOwnedCatalogId(current);
+    var owned =
+        catalogs
+            .getByIdWithMeta(catalogId)
+            .orElseThrow(
+                () ->
+                    new BaseResourceRepository.CorruptionException(
+                        "overlay references missing catalog: " + catalogId.getId(), null));
+    Catalog replacedOwner =
+        owned.value().toBuilder()
+            .setDisplayName(replacement.getDisplayName())
+            .setOverlayId(replacement.getResourceId())
+            .build();
+    return catalogs.prepareUpdateOps(replacedOwner, owned.meta().getPointerVersion());
+  }
+
+  private static ResourceId requireOwnedCatalogId(CatalogOverlay overlay) {
+    if (!overlay.hasCatalogId()) {
+      throw new BaseResourceRepository.CorruptionException(
+          "overlay is missing its owned catalog: " + overlay.getResourceId().getId(), null);
+    }
+    return overlay.getCatalogId();
+  }
+
+  /**
+   * The catalog an overlay owns. It carries the overlay's display name, so top-level name
+   * uniqueness is ordinary catalog name uniqueness, and its overlay_id marks it as reachable for
+   * mutation only through the overlay.
+   */
+  private Catalog ownedCatalogFor(CatalogOverlay overlay, Timestamp now) {
+    return Catalog.newBuilder()
+        .setResourceId(
+            randomResourceId(overlay.getResourceId().getAccountId(), ResourceKind.RK_CATALOG))
+        .setDisplayName(overlay.getDisplayName())
+        .setOverlayId(overlay.getResourceId())
+        .setCreatedAt(now)
+        .build();
+  }
+
+  private List<NamespacePath> normalizePaths(List<NamespacePath> paths, String field, String corr) {
+    LinkedHashMap<String, NamespacePath> unique = new LinkedHashMap<>();
+    for (NamespacePath path : paths) {
+      if (path.getSegmentsCount() == 0)
+        throw GrpcErrors.invalidArgument(corr, null, Map.of("field", field));
+      var normalized = NamespacePath.newBuilder();
+      for (String segment : path.getSegmentsList())
+        normalized.addSegments(mustNonEmpty(segment, field, corr));
+      NamespacePath value = normalized.build();
+      unique.putIfAbsent(canonicalNamespacePath(value), value);
+    }
+    var result = new ArrayList<>(unique.values());
+    result.sort(CatalogOverlaysImpl::compareNamespacePaths);
+    return List.copyOf(result);
+  }
+
+  private static int compareNamespacePaths(NamespacePath left, NamespacePath right) {
+    int common = Math.min(left.getSegmentsCount(), right.getSegmentsCount());
+    for (int i = 0; i < common; i++) {
+      int compared = left.getSegments(i).compareTo(right.getSegments(i));
+      if (compared != 0) return compared;
+    }
+    return Integer.compare(left.getSegmentsCount(), right.getSegmentsCount());
+  }
+
+  private static FieldMask requiredMask(FieldMask mask, String corr) {
+    if (mask == null
+        || mask.getPathsCount() == 0
+        || mask.getPathsList().stream().anyMatch(path -> !MUTABLE_PATHS.contains(path)))
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "update_mask"));
+    return mask;
+  }
+
+  private ResourceId scopedOverlayId(String accountId, ResourceId id) {
+    ensureKind(id, ResourceKind.RK_CATALOG_OVERLAY, "overlay_id", correlationId());
+    validateScopedAccount(accountId, id, "overlay_id");
+    return id.toBuilder().setAccountId(accountId).build();
+  }
+
+  private ResourceId scopedIntegrationId(String accountId, ResourceId id) {
+    ensureKind(id, ResourceKind.RK_CATALOG_INTEGRATION, "integration_id", correlationId());
+    validateScopedAccount(accountId, id, "integration_id");
+    return id.toBuilder().setAccountId(accountId).build();
+  }
+
+  private void validateScopedAccount(String accountId, ResourceId id, String field) {
+    mustNonEmpty(id.getAccountId(), field + ".account_id", correlationId());
+    mustNonEmpty(id.getId(), field + ".id", correlationId());
+    if (!accountId.equals(id.getAccountId()))
+      throw GrpcErrors.invalidArgument(
+          correlationId(), null, Map.of("field", field + ".account_id"));
+  }
+
+  private static byte[] canonicalFingerprint(
+      String name,
+      ResourceId integrationId,
+      List<NamespacePath> includes,
+      List<NamespacePath> excludes) {
+    var canonical =
+        new Canonicalizer()
+            .scalar("display_name", name)
+            .scalar("integration_id", integrationId.getId());
+    includes.forEach(
+        path -> canonical.scalar("include_namespaces[]", canonicalNamespacePath(path)));
+    excludes.forEach(
+        path -> canonical.scalar("exclude_namespaces[]", canonicalNamespacePath(path)));
+    return canonical.bytes();
+  }
+
+  static byte[] canonicalFingerprintForTest(
+      String name,
+      ResourceId integrationId,
+      List<NamespacePath> includes,
+      List<NamespacePath> excludes) {
+    return canonicalFingerprint(name, integrationId, includes, excludes);
+  }
+
+  private static String canonicalNamespacePath(NamespacePath path) {
+    return Base64.getEncoder().encodeToString(path.toByteArray());
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepository.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
+import ai.floedb.floecat.service.repo.model.CatalogOverlayKey;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.Schemas;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.PointerConditions;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta;
+import ai.floedb.floecat.storage.spi.BlobStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+@ApplicationScoped
+public class CatalogOverlayRepository {
+
+  private final GenericResourceRepository<CatalogOverlay, CatalogOverlayKey> repo;
+
+  @Inject
+  public CatalogOverlayRepository(PointerStore pointerStore, BlobStore blobStore) {
+    repo =
+        new GenericResourceRepository<>(
+            pointerStore,
+            blobStore,
+            Schemas.CATALOG_OVERLAY,
+            CatalogOverlay::parseFrom,
+            CatalogOverlay::toByteArray,
+            "application/x-protobuf");
+  }
+
+  public void create(CatalogOverlay overlay) {
+    repo.create(overlay);
+  }
+
+  public ResourceWithMeta<CatalogOverlay> createWithMeta(CatalogOverlay overlay) {
+    return repo.createWithMeta(overlay);
+  }
+
+  public boolean createAttached(
+      CatalogOverlay overlay,
+      Map<String, Long> requiredPointerVersions,
+      Set<String> requiredAbsentPointers,
+      long expectedIntegrationMarkerVersion) {
+    return createAttachedWithMeta(
+            overlay,
+            requiredPointerVersions,
+            requiredAbsentPointers,
+            expectedIntegrationMarkerVersion)
+        .isPresent();
+  }
+
+  public Optional<ResourceWithMeta<CatalogOverlay>> createAttachedWithMeta(
+      CatalogOverlay overlay,
+      Map<String, Long> requiredPointerVersions,
+      Set<String> requiredAbsentPointers,
+      long expectedIntegrationMarkerVersion) {
+    return createAttachedWithMetaAndCompanions(
+        overlay,
+        requiredPointerVersions,
+        requiredAbsentPointers,
+        expectedIntegrationMarkerVersion,
+        null);
+  }
+
+  /**
+   * Creates an overlay, advancing its integration's dependency marker and publishing the caller's
+   * companion operations in the same atomic pointer transaction. The companions carry the catalog
+   * the overlay owns, and an idempotency receipt when the create is keyed, so an overlay can never
+   * be visible without its catalog.
+   */
+  public Optional<ResourceWithMeta<CatalogOverlay>> createAttachedWithMetaAndCompanions(
+      CatalogOverlay overlay,
+      Map<String, Long> requiredPointerVersions,
+      Set<String> requiredAbsentPointers,
+      long expectedIntegrationMarkerVersion,
+      Function<ResourceWithMeta<CatalogOverlay>, List<PointerStore.CasOp>> companions) {
+    String integrationMarker =
+        Keys.catalogIntegrationOverlaysMarker(
+            overlay.getResourceId().getAccountId(), overlay.getIntegrationId().getId());
+    return repo.createWithMeta(
+        overlay,
+        new PointerConditions(
+            requiredPointerVersions,
+            requiredAbsentPointers,
+            Map.of(integrationMarker, expectedIntegrationMarkerVersion)),
+        companions);
+  }
+
+  /**
+   * Deletes an overlay and the catalog it owns in one atomic pointer transaction. The caller
+   * supplies the owned catalog's delete operations; an empty list means that catalog is already
+   * gone, which a retried cascade treats as work already done.
+   */
+  public boolean deleteWithOwnedCatalog(
+      ResourceId overlayId,
+      long expectedPointerVersion,
+      List<PointerStore.CasOp> ownedCatalogDeletes) {
+    return repo.deleteWithPreconditionAndCompanions(
+        key(overlayId), expectedPointerVersion, ownedCatalogDeletes);
+  }
+
+  public boolean update(CatalogOverlay overlay, long expectedPointerVersion) {
+    return repo.update(overlay, expectedPointerVersion);
+  }
+
+  public Optional<MutationMeta> updateWithMetaUnlessIntegrationDeleting(
+      CatalogOverlay overlay, long expectedPointerVersion) {
+    return updateWithMetaUnlessIntegrationDeleting(overlay, expectedPointerVersion, List.of());
+  }
+
+  /**
+   * Updates an overlay and publishes the caller's companion operations in the same transaction. A
+   * rename carries the owned catalog's rename operations here, so the overlay and its catalog can
+   * never end up under different names.
+   */
+  public Optional<MutationMeta> updateWithMetaUnlessIntegrationDeleting(
+      CatalogOverlay overlay, long expectedPointerVersion, List<PointerStore.CasOp> companions) {
+    String fence =
+        Keys.catalogIntegrationDeletionMarker(
+            overlay.getResourceId().getAccountId(), overlay.getIntegrationId().getId());
+    return repo.updateWithMetaWhilePointersMatchAndBumpMarkers(
+        overlay,
+        expectedPointerVersion,
+        new PointerConditions(Map.of(), Set.of(fence), Map.of()),
+        companions);
+  }
+
+  public Optional<ResourceWithMeta<CatalogOverlay>> replaceIdentityAttachedWithMeta(
+      CatalogOverlay current,
+      long expectedPointerVersion,
+      CatalogOverlay replacement,
+      Map<String, Long> requiredPointerVersions,
+      Set<String> requiredAbsentPointers,
+      Map<String, Long> integrationMarkerVersions,
+      List<PointerStore.CasOp> companions) {
+    return repo.replaceIdentityWithMeta(
+        current,
+        expectedPointerVersion,
+        replacement,
+        new PointerConditions(
+            requiredPointerVersions, requiredAbsentPointers, integrationMarkerVersions),
+        Map.of(),
+        companions);
+  }
+
+  public boolean deleteWithPrecondition(ResourceId overlayId, long expectedPointerVersion) {
+    return repo.deleteWithPrecondition(key(overlayId), expectedPointerVersion);
+  }
+
+  public boolean delete(ResourceId overlayId) {
+    return repo.delete(key(overlayId));
+  }
+
+  public Optional<CatalogOverlay> getById(ResourceId overlayId) {
+    return repo.getByKey(key(overlayId));
+  }
+
+  public Optional<ResourceWithMeta<CatalogOverlay>> getByIdWithMeta(ResourceId overlayId) {
+    return repo.getByKeyWithMeta(key(overlayId));
+  }
+
+  public Optional<CatalogOverlay> getByName(String accountId, String displayName) {
+    return repo.get(Keys.catalogOverlayPointerByName(accountId, displayName));
+  }
+
+  public Optional<ResourceWithMeta<CatalogOverlay>> getByNameWithMeta(
+      String accountId, String displayName) {
+    return repo.getWithMeta(Keys.catalogOverlayPointerByName(accountId, displayName));
+  }
+
+  public List<CatalogOverlay> list(
+      String accountId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefix(
+        Keys.catalogOverlayPointerByNamePrefix(accountId), limit, pageToken, nextOut);
+  }
+
+  public List<CatalogOverlay> listConsistent(
+      String accountId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefixConsistent(
+        Keys.catalogOverlayPointerByNamePrefix(accountId), limit, pageToken, nextOut);
+  }
+
+  public List<ResourceWithMeta<CatalogOverlay>> listWithMeta(
+      String accountId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefixWithMeta(
+        Keys.catalogOverlayPointerByNamePrefix(accountId), limit, pageToken, nextOut);
+  }
+
+  public List<CatalogOverlay> listByIntegration(
+      String accountId, String integrationId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefix(
+        Keys.catalogOverlayPointerByIntegrationPrefix(accountId, integrationId),
+        limit,
+        pageToken,
+        nextOut);
+  }
+
+  public List<ResourceWithMeta<CatalogOverlay>> listByIntegrationWithMeta(
+      String accountId, String integrationId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefixWithMeta(
+        Keys.catalogOverlayPointerByIntegrationPrefix(accountId, integrationId),
+        limit,
+        pageToken,
+        nextOut);
+  }
+
+  public List<ResourceWithMeta<CatalogOverlay>> listByIntegrationWithMetaConsistent(
+      String accountId, String integrationId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefixWithMetaConsistent(
+        Keys.catalogOverlayPointerByIntegrationPrefix(accountId, integrationId),
+        limit,
+        pageToken,
+        nextOut);
+  }
+
+  public int count(String accountId) {
+    return repo.countByPrefix(Keys.catalogOverlayPointerByNamePrefix(accountId));
+  }
+
+  public int countByIntegration(String accountId, String integrationId) {
+    return repo.countByPrefixConsistent(
+        Keys.catalogOverlayPointerByIntegrationPrefix(accountId, integrationId));
+  }
+
+  public MutationMeta metaFor(ResourceId overlayId) {
+    return repo.metaFor(key(overlayId));
+  }
+
+  public MutationMeta metaForSafe(ResourceId overlayId) {
+    return repo.metaForSafe(key(overlayId));
+  }
+
+  private static CatalogOverlayKey key(ResourceId id) {
+    return new CatalogOverlayKey(id.getAccountId(), id.getId());
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
@@ -90,6 +90,29 @@ public class CatalogRepository {
     return repo.listByPrefix(Keys.catalogPointerByNamePrefix(accountId), limit, pageToken, nextOut);
   }
 
+  /**
+   * Pointer operations that would create this catalog, for a caller that must commit it in the same
+   * atomic transaction as another resource. Overlay creation uses this so an overlay and the
+   * catalog it owns become visible together.
+   */
+  public List<PointerStore.CasOp> prepareCreateOps(Catalog catalog) {
+    return repo.prepareCreateOps(catalog);
+  }
+
+  /**
+   * Pointer operations that would rename or otherwise update this catalog, for a caller committing
+   * it alongside another resource. Overlay rename uses this so the overlay and the catalog it owns
+   * never carry different names.
+   */
+  public List<PointerStore.CasOp> prepareUpdateOps(Catalog catalog, long expectedPointerVersion) {
+    return repo.prepareUpdateOps(catalog, expectedPointerVersion);
+  }
+
+  /** Pointer operations that would delete this catalog, for an owning resource's cascade. */
+  public List<PointerStore.CasOp> prepareDeleteOps(ResourceId catalogId) {
+    return repo.prepareDeleteOps(new CatalogKey(catalogId.getAccountId(), catalogId.getId()));
+  }
+
   public List<Catalog> listConsistent(
       String accountId, int limit, String pageToken, StringBuilder nextOut) {
     return repo.listByPrefixConsistent(
@@ -98,6 +121,13 @@ public class CatalogRepository {
 
   public int count(String accountId) {
     return repo.countByPrefix(Keys.catalogPointerByNamePrefix(accountId));
+  }
+
+  /** Body and metadata resolved from the same canonical pointer version. */
+  public Optional<GenericResourceRepository.ResourceWithMeta<Catalog>> getByIdWithMeta(
+      ResourceId catalogResourceId) {
+    return repo.getByKeyWithMeta(
+        new CatalogKey(catalogResourceId.getAccountId(), catalogResourceId.getId()));
   }
 
   public MutationMeta metaFor(ResourceId catalogResourceId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/CatalogOverlayKey.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/CatalogOverlayKey.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package ai.floedb.floecat.service.repo.model;
+
+public record CatalogOverlayKey(String accountId, String overlayId, String sha256)
+    implements ResourceKey {
+  public CatalogOverlayKey(String accountId, String overlayId) {
+    this(accountId, overlayId, "");
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -1079,6 +1079,63 @@ public final class Keys {
         encode(tid), encode(iid), encode(sha));
   }
 
+  // ===== Catalog Overlay =====
+
+  public static String catalogOverlayPointerById(String accountId, String overlayId) {
+    String tid = req("account_id", accountId);
+    String oid = req("overlay_id", overlayId);
+    return "/accounts/" + encode(tid) + "/catalog-overlays/by-id/" + encode(oid);
+  }
+
+  public static String catalogOverlayPointerByIdPrefix(String accountId) {
+    String tid = req("account_id", accountId);
+    return "/accounts/" + encode(tid) + "/catalog-overlays/by-id/";
+  }
+
+  public static String catalogOverlayRootPrefix(String accountId) {
+    String tid = req("account_id", accountId);
+    return "/accounts/" + encode(tid) + "/catalog-overlays/";
+  }
+
+  public static String catalogOverlayPointerByName(String accountId, String displayName) {
+    String tid = req("account_id", accountId);
+    String name = req("display_name", displayName);
+    return "/accounts/" + encode(tid) + "/catalog-overlays/by-name/" + encode(name);
+  }
+
+  public static String catalogOverlayPointerByNamePrefix(String accountId) {
+    String tid = req("account_id", accountId);
+    return "/accounts/" + encode(tid) + "/catalog-overlays/by-name/";
+  }
+
+  public static String catalogOverlayPointerByIntegration(
+      String accountId, String integrationId, String overlayId) {
+    String tid = req("account_id", accountId);
+    String iid = req("integration_id", integrationId);
+    String oid = req("overlay_id", overlayId);
+    return "/accounts/"
+        + encode(tid)
+        + "/catalog-overlays/by-integration/"
+        + encode(iid)
+        + "/"
+        + encode(oid);
+  }
+
+  public static String catalogOverlayPointerByIntegrationPrefix(
+      String accountId, String integrationId) {
+    String tid = req("account_id", accountId);
+    String iid = req("integration_id", integrationId);
+    return "/accounts/" + encode(tid) + "/catalog-overlays/by-integration/" + encode(iid) + "/";
+  }
+
+  public static String catalogOverlayBlobUri(String accountId, String overlayId, String sha256) {
+    String tid = req("account_id", accountId);
+    String oid = req("overlay_id", overlayId);
+    String sha = req("sha256", sha256);
+    return String.format(
+        "/accounts/%s/catalog-overlays/%s/overlay/%s.pb", encode(tid), encode(oid), encode(sha));
+  }
+
   // ===== Idempotency =====
 
   public static String idempotencyKey(String accountId, String operation, String key) {
@@ -1903,6 +1960,10 @@ public final class Keys {
       case "catalog-integrations" ->
           seg.length == 6 && "integration".equals(seg[4])
               ? catalogIntegrationPointerById(account, percentDecode(seg[3]))
+              : null;
+      case "catalog-overlays" ->
+          seg.length == 6 && "overlay".equals(seg[4])
+              ? catalogOverlayPointerById(account, percentDecode(seg[3]))
               : null;
       case "tables" -> seg.length >= 6 ? tableBlobOwner(account, seg) : null;
       default -> null;

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Schemas.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Schemas.java
@@ -29,6 +29,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
 import ai.floedb.floecat.service.repo.util.ConstraintNormalizer;
 import ai.floedb.floecat.storage.rpc.StorageAuthority;
 import ai.floedb.floecat.transaction.rpc.Transaction;
@@ -288,6 +289,28 @@ public final class Schemas {
                         v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
                   })
               .withCasBlobs();
+
+  public static final ResourceSchema<CatalogOverlay, CatalogOverlayKey> CATALOG_OVERLAY =
+      ResourceSchema.<CatalogOverlay, CatalogOverlayKey>of(
+              "catalog-overlay",
+              key -> Keys.catalogOverlayPointerById(key.accountId(), key.overlayId()),
+              key -> Keys.catalogOverlayBlobUri(key.accountId(), key.overlayId(), key.sha256()),
+              v ->
+                  Map.of(
+                      "byName",
+                      Keys.catalogOverlayPointerByName(
+                          v.getResourceId().getAccountId(), v.getDisplayName()),
+                      "byIntegration",
+                      Keys.catalogOverlayPointerByIntegration(
+                          v.getResourceId().getAccountId(),
+                          v.getIntegrationId().getId(),
+                          v.getResourceId().getId())),
+              v -> {
+                var sha = Hashing.sha256Hex(v.toByteArray());
+                return new CatalogOverlayKey(
+                    v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
+              })
+          .withCasBlobs();
 
   public static final ResourceSchema<Transaction, TransactionKey> TRANSACTION =
       ResourceSchema.<Transaction, TransactionKey>of(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -180,10 +180,24 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
    */
   public List<ResourceWithMeta<T>> listByPrefixWithMeta(
       String prefix, int limit, String token, StringBuilder nextOut) {
+    return listByPrefixWithMeta(prefix, limit, token, nextOut, false);
+  }
+
+  /** Strongly consistent variant used by lifecycle scans whose emptiness is load-bearing. */
+  public List<ResourceWithMeta<T>> listByPrefixWithMetaConsistent(
+      String prefix, int limit, String token, StringBuilder nextOut) {
+    return listByPrefixWithMeta(prefix, limit, token, nextOut, true);
+  }
+
+  private List<ResourceWithMeta<T>> listByPrefixWithMeta(
+      String prefix, int limit, String token, StringBuilder nextOut, boolean consistentRead) {
     return observeRepository(
-        "list_by_prefix_with_meta",
+        consistentRead ? "list_by_prefix_with_meta_consistent" : "list_by_prefix_with_meta",
         () -> {
-          List<Pointer> pointers = pointerReads.list(prefix, Math.max(1, limit), token, nextOut);
+          List<Pointer> pointers =
+              consistentRead
+                  ? pointerReads.listConsistent(prefix, Math.max(1, limit), token, nextOut)
+                  : pointerReads.list(prefix, Math.max(1, limit), token, nextOut);
           List<ResourceWithMeta<T>> values = new ArrayList<>(pointers.size());
           Timestamp now = Timestamps.fromMillis(clock.millis());
           for (Pointer selectedPointer : pointers) {
@@ -1046,6 +1060,22 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       T replacementValue,
       PointerConditions conditions,
       Map<String, Long> pointerVersionsToDelete) {
+    return replaceIdentityWithMeta(
+        currentValue,
+        expectedCanonicalVersion,
+        replacementValue,
+        conditions,
+        pointerVersionsToDelete,
+        List.of());
+  }
+
+  public Optional<ResourceWithMeta<T>> replaceIdentityWithMeta(
+      T currentValue,
+      long expectedCanonicalVersion,
+      T replacementValue,
+      PointerConditions conditions,
+      Map<String, Long> pointerVersionsToDelete,
+      List<PointerStore.CasOp> companions) {
     Map<String, Long> requiredPointerVersions = conditions.requiredVersions();
     Set<String> requiredAbsentPointers = conditions.requiredAbsent();
     Map<String, Long> markerVersions = conditions.markerVersions();
@@ -1144,6 +1174,13 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
             ops.add(new PointerStore.CasCheckAbsent(accountDeletionMarker));
           }
           addMarkerAdvances(markerVersions, batchedKeys, ops, "replacement");
+          for (PointerStore.CasOp companion : companions) {
+            if (!batchedKeys.add(companion.key())) {
+              throw new IllegalArgumentException(
+                  "companion operation duplicates pointer: " + companion.key());
+            }
+            ops.add(companion);
+          }
 
           if (!mutationPointerStore.compareAndSetBatch(ops)) {
             return Optional.empty();

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/MarkerStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/MarkerStore.java
@@ -35,14 +35,14 @@ public class MarkerStore {
     return pointerStore.get(key).map(Pointer::getVersion).orElse(0L);
   }
 
-  public long catalogIntegrationOverlaysMarkerVersion(ResourceId integrationId) {
-    String key =
-        Keys.catalogIntegrationOverlaysMarker(integrationId.getAccountId(), integrationId.getId());
+  public long namespaceMarkerVersion(ResourceId namespaceId) {
+    String key = Keys.namespaceChildrenMarker(namespaceId.getAccountId(), namespaceId.getId());
     return pointerStore.get(key).map(Pointer::getVersion).orElse(0L);
   }
 
-  public long namespaceMarkerVersion(ResourceId namespaceId) {
-    String key = Keys.namespaceChildrenMarker(namespaceId.getAccountId(), namespaceId.getId());
+  public long catalogIntegrationOverlaysMarkerVersion(ResourceId integrationId) {
+    String key =
+        Keys.catalogIntegrationOverlaysMarker(integrationId.getAccountId(), integrationId.getId());
     return pointerStore.get(key).map(Pointer::getVersion).orElse(0L);
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
@@ -33,9 +33,12 @@ public final class RolePermissions {
       "storage-authority.resolve-internal";
   public static final String RECONCILE_EXECUTOR_CONTROL_INTERNAL =
       "reconcile-executor-control.internal";
+  public static final String CATALOG_WRITE = "catalog.write";
   public static final String CATALOG_INTEGRATION_READ = "catalog-integration.read";
   public static final String CATALOG_INTEGRATION_WRITE = "catalog-integration.write";
   public static final String CATALOG_INTEGRATION_USE = "catalog-integration.use";
+  public static final String CATALOG_OVERLAY_READ = "catalog-overlay.read";
+  public static final String CATALOG_OVERLAY_WRITE = "catalog-overlay.write";
   private static final List<String> READ_PERMS =
       List.of(
           "account.read",
@@ -43,12 +46,13 @@ public final class RolePermissions {
           "namespace.read",
           "table.read",
           "view.read",
-          CATALOG_INTEGRATION_READ);
+          CATALOG_INTEGRATION_READ,
+          CATALOG_OVERLAY_READ);
   private static final List<String> FULL_PERMS =
       List.of(
           "account.read",
           "catalog.read",
-          "catalog.write",
+          CATALOG_WRITE,
           "namespace.read",
           "namespace.write",
           "table.read",
@@ -59,6 +63,8 @@ public final class RolePermissions {
           CATALOG_INTEGRATION_READ,
           CATALOG_INTEGRATION_WRITE,
           CATALOG_INTEGRATION_USE,
+          CATALOG_OVERLAY_READ,
+          CATALOG_OVERLAY_WRITE,
           "system-objects.read",
           "account.delete");
   private static final List<String> PLATFORM_PERMS =
@@ -69,19 +75,21 @@ public final class RolePermissions {
           "account.read",
           "account.write",
           "catalog.read",
-          "catalog.write",
+          CATALOG_WRITE,
           "namespace.read",
           "namespace.write",
           "connector.create",
           CATALOG_INTEGRATION_READ,
           CATALOG_INTEGRATION_WRITE,
-          CATALOG_INTEGRATION_USE);
+          CATALOG_INTEGRATION_USE,
+          CATALOG_OVERLAY_READ,
+          CATALOG_OVERLAY_WRITE);
   private static final List<String> DELETE_ACCOUNT_PERMS = List.of("account.delete");
   private static final List<String> RECONCILE_WORKER_PERMS =
       List.of(
           "account.read",
           "catalog.read",
-          "catalog.write",
+          CATALOG_WRITE,
           "namespace.read",
           "namespace.write",
           "table.read",
@@ -91,6 +99,7 @@ public final class RolePermissions {
           "connector.manage",
           CATALOG_INTEGRATION_READ,
           CATALOG_INTEGRATION_USE,
+          CATALOG_OVERLAY_READ,
           "system-objects.read",
           STORAGE_AUTHORITY_RESOLVE_INTERNAL,
           RECONCILE_EXECUTOR_CONTROL_INTERNAL);

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImpl.java
@@ -49,6 +49,7 @@ import ai.floedb.floecat.service.common.LogHelper;
 import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
@@ -75,6 +76,7 @@ public class TableStatisticsServiceImpl extends BaseServiceImpl implements Table
   static final int LIST_FETCH_MAX_RECORDS = 1_000;
 
   @Inject SnapshotRepository snapshots;
+  @Inject CatalogRepository catalogRepo;
   @Inject StatsStore statsStore;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
@@ -347,7 +349,8 @@ public class TableStatisticsServiceImpl extends BaseServiceImpl implements Table
     var pc = principal.get();
     authz.require(pc, "table.write");
 
-    new CatalogSurfaceWritePolicy(overlay).requireWritableTable(state.tableId, correlationId());
+    new CatalogSurfaceWritePolicy(overlay, catalogRepo)
+        .requireWritableTable(state.tableId, correlationId());
 
     snapshots
         .getById(state.tableId, state.snapshotId)

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.scanner.spi.CatalogGraphView;
 import ai.floedb.floecat.service.catalog.impl.surface.CatalogSurfaceWritePolicy;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
@@ -87,6 +88,7 @@ public class TransactionIntentApplierSupport {
   @Inject PointerStore pointerStore;
   @Inject BlobStore blobStore;
   @Inject CatalogGraphView overlay;
+  @Inject CatalogRepository catalogRepo;
 
   public boolean isTableByIdPointer(String pointerKey) {
     return pointerKey != null && pointerKey.contains("/tables/by-id/");
@@ -690,7 +692,7 @@ public class TransactionIntentApplierSupport {
     }
 
     try {
-      var writePolicy = new CatalogSurfaceWritePolicy(overlay);
+      var writePolicy = new CatalogSurfaceWritePolicy(overlay, catalogRepo);
       if (checkExistingTable) {
         writePolicy.requireWritableTable(table.getResourceId(), "transaction-apply");
       }

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
@@ -54,6 +54,7 @@ import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.metagraph.resolver.NameResolver;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionRepository;
@@ -127,6 +128,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
   @Inject TransactionIntentRepository intentRepo;
   @Inject IdempotencyRepository idempotencyStore;
   @Inject ConnectorRepository connectorRepo;
+  @Inject CatalogRepository catalogRepo;
   @Inject ReconcileJobStore reconcileJobs;
   @Inject NameResolver nameResolver;
   @Inject Authorizer authz;
@@ -1670,7 +1672,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
   }
 
   private CatalogSurfaceWritePolicy catalogSurfaceWritePolicy() {
-    return new CatalogSurfaceWritePolicy(overlay);
+    return new CatalogSurfaceWritePolicy(overlay, catalogRepo);
   }
 
   private boolean looksLikeDeleteSentinelBlobUri(String accountId, String blobUri) {

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -20,7 +20,7 @@ import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
-import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.credentials.DefaultCredentialResolver;
 import ai.floedb.floecat.service.integration.CatalogIntegrationCredentialCleanup;
@@ -28,6 +28,7 @@ import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
@@ -57,6 +58,7 @@ class AccountServiceImplTest {
     service.accountRepo = mock(AccountRepository.class);
     service.catalogRepo = mock(CatalogRepository.class);
     service.catalogIntegrationRepo = mock(CatalogIntegrationRepository.class);
+    service.catalogOverlayRepo = mock(CatalogOverlayRepository.class);
     service.namespaceRepo = mock(NamespaceRepository.class);
     service.tableRepo = mock(TableRepository.class);
     service.tableRootRepo = mock(TableRootRepository.class);
@@ -90,21 +92,21 @@ class AccountServiceImplTest {
   @Test
   void descendantCleanupFailureRetriesBehindDurableDeletionFence() {
     MutationMeta meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
-    ResourceId connectorId =
+    ResourceId overlayId =
         ResourceId.newBuilder()
             .setAccountId("acct")
-            .setId("connector")
-            .setKind(ResourceKind.RK_CONNECTOR)
+            .setId("overlay")
+            .setKind(ResourceKind.RK_CATALOG_OVERLAY)
             .build();
-    Connector connector = Connector.newBuilder().setResourceId(connectorId).build();
+    CatalogOverlay overlay = CatalogOverlay.newBuilder().setResourceId(overlayId).build();
     when(service.accountRepo.metaFor(accountId))
         .thenReturn(meta)
         .thenThrow(new BaseResourceRepository.NotFoundException("deleted"));
     when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
-    when(service.connectorRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
-        .thenReturn(List.of(connector), List.of(connector));
-    when(service.connectorRepo.delete(connectorId)).thenReturn(false, true);
-    when(service.connectorRepo.getById(connectorId)).thenReturn(Optional.of(connector));
+    when(service.catalogOverlayRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
+        .thenReturn(List.of(overlay), List.of(overlay));
+    when(service.catalogOverlayRepo.delete(overlayId)).thenReturn(false, true);
+    when(service.catalogOverlayRepo.getById(overlayId)).thenReturn(Optional.of(overlay));
 
     var response =
         service
@@ -115,7 +117,7 @@ class AccountServiceImplTest {
     assertEquals(meta, response.getMeta());
     assertTrue(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
     verify(service.accountRepo).deleteWithPrecondition(accountId, 7L);
-    verify(service.connectorRepo, org.mockito.Mockito.times(2)).delete(connectorId);
+    verify(service.catalogOverlayRepo, org.mockito.Mockito.times(2)).delete(overlayId);
   }
 
   private static void installBasePrincipal(

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceWritePolicyTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/surface/CatalogSurfaceWritePolicyTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -36,6 +37,7 @@ import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.query.rpc.TableBackendKind;
 import ai.floedb.floecat.scanner.spi.CatalogGraphView;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
 import ai.floedb.floecat.systemcatalog.graph.model.SystemTableNode;
 import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
@@ -135,6 +137,48 @@ class CatalogSurfaceWritePolicyTest {
     assertStatus(
         Status.Code.PERMISSION_DENIED,
         () -> writePolicy.requireWritableView(viewId, CORRELATION_ID));
+  }
+
+  @Test
+  void requireWritableResourcesRejectOverlayOwnedCatalogAndDescendants() {
+    var catalogs = mock(CatalogRepository.class);
+    var policy = new CatalogSurfaceWritePolicy(overlay, catalogs);
+    var overlayId = id(ResourceKind.RK_CATALOG_OVERLAY, "overlay");
+    when(catalogs.getById(catalogId))
+        .thenReturn(
+            Optional.of(
+                Catalog.newBuilder()
+                    .setResourceId(catalogId)
+                    .setDisplayName("external")
+                    .setOverlayId(overlayId)
+                    .build()));
+    overlay.addNode(catalogNode(catalogId, "external"));
+    overlay.addNode(namespaceNode(namespaceId, "public", GraphNodeOrigin.USER));
+    overlay.addRelation(namespaceId, userTableNode(tableId));
+    overlay.addRelation(namespaceId, viewNode(viewId, GraphNodeOrigin.USER));
+
+    assertStatus(
+        Status.Code.PERMISSION_DENIED,
+        () -> policy.requireWritableCatalog(catalogId, CORRELATION_ID));
+    assertStatus(
+        Status.Code.PERMISSION_DENIED,
+        () -> policy.requireDeletableCatalog(catalogId, CORRELATION_ID));
+    assertStatus(
+        Status.Code.PERMISSION_DENIED,
+        () -> policy.requireWritableNamespace(namespaceId, CORRELATION_ID));
+    assertStatus(
+        Status.Code.PERMISSION_DENIED,
+        () -> policy.requireDeletableNamespace(namespaceId, CORRELATION_ID));
+    assertStatus(
+        Status.Code.PERMISSION_DENIED, () -> policy.requireWritableTable(tableId, CORRELATION_ID));
+    assertStatus(
+        Status.Code.PERMISSION_DENIED,
+        () -> policy.requireWritableTableForDelete(tableId, CORRELATION_ID, false));
+    assertStatus(
+        Status.Code.PERMISSION_DENIED, () -> policy.requireWritableView(viewId, CORRELATION_ID));
+    assertStatus(
+        Status.Code.PERMISSION_DENIED,
+        () -> policy.requireWritableViewForDelete(viewId, CORRELATION_ID, false));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
@@ -112,19 +112,24 @@ class CasBlobGcTest {
   }
 
   @Test
-  void keepsCurrentIntegrationBlobAndDeletesSupersededBlob() {
+  void keepsCurrentIntegrationAndOverlayBlobsAndDeletesSupersededBlobs() {
     String integrationCurrent =
         Keys.catalogIntegrationBlobUri(ACCOUNT_ID, "integration-1", "sha-current");
     String integrationOld = Keys.catalogIntegrationBlobUri(ACCOUNT_ID, "integration-1", "sha-old");
-    for (String blob : List.of(integrationCurrent, integrationOld)) {
+    String overlayCurrent = Keys.catalogOverlayBlobUri(ACCOUNT_ID, "overlay-1", "sha-current");
+    String overlayOld = Keys.catalogOverlayBlobUri(ACCOUNT_ID, "overlay-1", "sha-old");
+    for (String blob : List.of(integrationCurrent, integrationOld, overlayCurrent, overlayOld)) {
       blobs.put(blob, "data".getBytes(StandardCharsets.UTF_8), "application/x-protobuf");
     }
     putPointer(Keys.catalogIntegrationPointerById(ACCOUNT_ID, "integration-1"), integrationCurrent);
+    putPointer(Keys.catalogOverlayPointerById(ACCOUNT_ID, "overlay-1"), overlayCurrent);
 
     gc.runForAccount(ACCOUNT_ID);
 
     assertTrue(blobs.head(integrationCurrent).isPresent());
     assertFalse(blobs.head(integrationOld).isPresent());
+    assertTrue(blobs.head(overlayCurrent).isPresent());
+    assertFalse(blobs.head(overlayOld).isPresent());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/gc/PointerGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/PointerGcTest.java
@@ -117,6 +117,25 @@ class PointerGcTest {
     assertTrue(pointers.get(statsPtr).isEmpty());
   }
 
+  @Test
+  void deletesStaleCatalogOverlaySecondaryPointer() {
+    System.setProperty("floecat.gc.pointer.min-age-ms", "0");
+    String currentBlob = Keys.catalogOverlayBlobUri(ACCOUNT_ID, "overlay-1", "sha-current");
+    String staleBlob = Keys.catalogOverlayBlobUri(ACCOUNT_ID, "overlay-1", "sha-stale");
+    blobs.put(currentBlob, "current".getBytes(StandardCharsets.UTF_8), "text/plain");
+    blobs.put(staleBlob, "stale".getBytes(StandardCharsets.UTF_8), "text/plain");
+    String canonical = Keys.catalogOverlayPointerById(ACCOUNT_ID, "overlay-1");
+    String secondary =
+        Keys.catalogOverlayPointerByIntegration(ACCOUNT_ID, "integration-1", "overlay-1");
+    putPointer(canonical, currentBlob);
+    putPointer(secondary, staleBlob);
+
+    gc.runForAccount(ACCOUNT_ID, System.currentTimeMillis() + 5_000L);
+
+    assertTrue(pointers.get(canonical).isPresent());
+    assertTrue(pointers.get(secondary).isEmpty());
+  }
+
   private void putPointer(String key, String blobUri) {
     Pointer ptr = PointerReferences.blobPointer(key, blobUri, 1L);
     pointers.compareAndSet(key, 0L, ptr);

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -31,6 +32,7 @@ import ai.floedb.floecat.integration.rpc.CatalogIntegration;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationSpec;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
 import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationRequest;
 import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationRequest;
 import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationRequest;
@@ -40,6 +42,8 @@ import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationR
 import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta;
 import ai.floedb.floecat.service.repo.util.MarkerStore;
@@ -69,6 +73,8 @@ class CatalogIntegrationsImplTest {
   void setUp() {
     service = new CatalogIntegrationsImpl();
     service.integrations = mock(CatalogIntegrationRepository.class);
+    service.overlays = mock(CatalogOverlayRepository.class);
+    service.catalogs = mock(CatalogRepository.class);
     service.markerStore = mock(MarkerStore.class);
     service.principal = mock(PrincipalProvider.class);
     service.authz = mock(Authorizer.class);
@@ -891,6 +897,7 @@ class CatalogIntegrationsImplTest {
             Optional.of(
                 new ai.floedb.floecat.service.repo.util.GenericResourceRepository
                     .ResourceWithMeta<>(current, meta)));
+    when(service.overlays.countByIntegration("acct", "integration")).thenReturn(0);
     when(service.markerStore.catalogIntegrationOverlaysMarkerVersion(integrationId)).thenReturn(4L);
     when(service.integrations.deleteWithPreconditionAndOverlayMarker(integrationId, 7L, 4L))
         .thenReturn(true);
@@ -901,13 +908,119 @@ class CatalogIntegrationsImplTest {
         .await()
         .indefinitely();
 
-    verify(service.markerStore).catalogIntegrationOverlaysMarkerVersion(integrationId);
+    var dependencyReadOrder = inOrder(service.markerStore, service.overlays);
+    dependencyReadOrder
+        .verify(service.markerStore)
+        .catalogIntegrationOverlaysMarkerVersion(integrationId);
+    dependencyReadOrder.verify(service.overlays).countByIntegration("acct", "integration");
     verify(service.integrations).deleteWithPreconditionAndOverlayMarker(integrationId, 7L, 4L);
     verify(secretsManager)
         .deleteImmediately(
             "acct",
             CatalogIntegrationCredentialStore.SECRET_TYPE,
             CatalogIntegrationCredentialStore.reference(integrationId, 1L));
+  }
+
+  @Test
+  void dependentOverlayPreventsDelete() {
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var current = CatalogIntegration.newBuilder().setResourceId(integrationId).build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(7).build();
+    when(service.integrations.getByIdWithMeta(integrationId))
+        .thenReturn(
+            Optional.of(
+                new ai.floedb.floecat.service.repo.util.GenericResourceRepository
+                    .ResourceWithMeta<>(current, meta)));
+    when(service.overlays.countByIntegration("acct", "integration")).thenReturn(1);
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .deleteCatalogIntegration(
+                        DeleteCatalogIntegrationRequest.newBuilder()
+                            .setIntegrationId(integrationId)
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.ABORTED, error.getStatus().getCode());
+    verify(service.integrations, never())
+        .deleteWithPreconditionAndOverlayMarker(any(), anyLong(), anyLong());
+  }
+
+  @Test
+  void cascadeDeleteRequiresOverlayWriteBeforeReadingIntegration() {
+    service.authz = new Authorizer();
+    when(service.principal.get()).thenReturn(principal("catalog-integration.write"));
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .deleteCatalogIntegration(
+                        DeleteCatalogIntegrationRequest.newBuilder()
+                            .setIntegrationId(integrationId)
+                            .setCascade(true)
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.PERMISSION_DENIED, error.getStatus().getCode());
+    verify(service.integrations, never()).getByIdWithMeta(any());
+  }
+
+  @Test
+  void cascadeFencesDeletesDependentsAndAtomicallyCompletes() {
+    service.authz = new Authorizer();
+    when(service.principal.get())
+        .thenReturn(principal("catalog-integration.write", "catalog-overlay.write"));
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var integration = CatalogIntegration.newBuilder().setResourceId(integrationId).build();
+    var integrationMeta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    var overlayId = id("overlay", ResourceKind.RK_CATALOG_OVERLAY);
+    var catalogId = id("catalog", ResourceKind.RK_CATALOG);
+    var overlay =
+        CatalogOverlay.newBuilder()
+            .setResourceId(overlayId)
+            .setCatalogId(catalogId)
+            .setIntegrationId(integrationId)
+            .build();
+    var overlayMeta = MutationMeta.newBuilder().setPointerVersion(3L).build();
+    when(service.integrations.getByIdWithMeta(integrationId))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(integration, integrationMeta)));
+    when(service.integrations.beginCascadeDeletion(integrationId, 7L)).thenReturn(true);
+    when(service.overlays.listByIntegrationWithMetaConsistent(
+            eq("acct"), eq("integration"), eq(100), eq(""), any()))
+        .thenReturn(List.of(new ResourceWithMeta<>(overlay, overlayMeta)), List.of());
+    when(service.catalogs.prepareDeleteOps(catalogId)).thenReturn(List.of());
+    when(service.overlays.deleteWithOwnedCatalog(overlayId, 3L, List.of())).thenReturn(true);
+    when(service.overlays.countByIntegration("acct", "integration")).thenReturn(0);
+    when(service.markerStore.catalogIntegrationOverlaysMarkerVersion(integrationId)).thenReturn(4L);
+    when(service.integrations.cascadeDeletionFenceVersion(integrationId)).thenReturn(1L);
+    when(service.integrations.deleteWithPreconditionAndOverlayMarkerAndFence(
+            integrationId, 7L, 4L, 1L))
+        .thenReturn(true);
+
+    service
+        .deleteCatalogIntegration(
+            DeleteCatalogIntegrationRequest.newBuilder()
+                .setIntegrationId(integrationId)
+                .setCascade(true)
+                .build())
+        .await()
+        .indefinitely();
+
+    verify(service.integrations).beginCascadeDeletion(integrationId, 7L);
+    verify(service.catalogs).prepareDeleteOps(catalogId);
+    verify(service.overlays).deleteWithOwnedCatalog(overlayId, 3L, List.of());
+    verify(service.integrations)
+        .deleteWithPreconditionAndOverlayMarkerAndFence(integrationId, 7L, 4L, 1L);
+    verify(service.integrations, never())
+        .deleteWithPreconditionAndOverlayMarker(any(), anyLong(), anyLong());
   }
 
   private static PrincipalContext principal() {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
@@ -1,0 +1,680 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import ai.floedb.floecat.catalog.rpc.Catalog;
+import ai.floedb.floecat.common.rpc.CreateMode;
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.*;
+import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta;
+import ai.floedb.floecat.service.repo.util.MarkerStore;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.storage.rpc.IdempotencyRecord;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import com.google.protobuf.FieldMask;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class CatalogOverlaysImplTest {
+  private CatalogOverlaysImpl service;
+
+  @BeforeEach
+  void setUp() {
+    service = new CatalogOverlaysImpl();
+    service.overlays = mock(CatalogOverlayRepository.class);
+    service.integrations = mock(CatalogIntegrationRepository.class);
+    service.catalogs = mock(CatalogRepository.class);
+    service.markerStore = mock(MarkerStore.class);
+    service.principal = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.idempotencyStore = mock(IdempotencyRepository.class);
+    installBasePrincipal(service, service.principal);
+    when(service.principal.get()).thenReturn(principal());
+    var integration = CatalogIntegration.newBuilder().setResourceId(integrationId()).build();
+    when(service.integrations.getByIdWithMeta(integrationId()))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    integration, MutationMeta.newBuilder().setPointerVersion(5).build())));
+    when(service.catalogs.prepareCreateOps(any())).thenReturn(List.of());
+    when(service.overlays.createAttachedWithMetaAndCompanions(
+            any(), any(), any(), anyLong(), any()))
+        .thenAnswer(
+            invocation -> {
+              CatalogOverlay value = invocation.getArgument(0);
+              var meta = MutationMeta.newBuilder().setPointerVersion(1).build();
+              Function<ResourceWithMeta<CatalogOverlay>, List<PointerStore.CasOp>> companions =
+                  invocation.getArgument(4);
+              if (companions != null) {
+                companions.apply(new ResourceWithMeta<>(value, meta));
+              }
+              return Optional.of(new ResourceWithMeta<>(value, meta));
+            });
+  }
+
+  @Test
+  void overlayOwnsACatalogCarryingItsName() {
+    var response = create(CatalogOverlaySpec.newBuilder());
+
+    var overlayCaptor = ArgumentCaptor.forClass(CatalogOverlay.class);
+    verify(service.overlays)
+        .createAttachedWithMetaAndCompanions(
+            overlayCaptor.capture(), any(), any(), anyLong(), any());
+    var catalogCaptor = ArgumentCaptor.forClass(Catalog.class);
+    verify(service.catalogs).prepareCreateOps(catalogCaptor.capture());
+
+    assertEquals("sales", response.getOverlay().getDisplayName());
+    assertEquals(integrationId(), overlayCaptor.getValue().getIntegrationId());
+    // The overlay and the catalog it owns reference each other and share a name.
+    Catalog owned = catalogCaptor.getValue();
+    assertEquals("sales", owned.getDisplayName());
+    assertEquals(overlayCaptor.getValue().getResourceId(), owned.getOverlayId());
+    assertEquals(owned.getResourceId(), overlayCaptor.getValue().getCatalogId());
+  }
+
+  @Test
+  void createNormalizesOverlayNameBeforeLookupAndPersistence() {
+    var response =
+        service
+            .createCatalogOverlay(
+                CreateCatalogOverlayRequest.newBuilder()
+                    .setSpec(
+                        CatalogOverlaySpec.newBuilder()
+                            .setDisplayName("  sales  ")
+                            .setIntegrationId(integrationId()))
+                    .build())
+            .await()
+            .indefinitely();
+
+    var captured = ArgumentCaptor.forClass(CatalogOverlay.class);
+    verify(service.overlays).getByNameWithMeta("acct", "sales");
+    verify(service.overlays)
+        .createAttachedWithMetaAndCompanions(captured.capture(), any(), any(), anyLong(), any());
+    assertEquals("sales", captured.getValue().getDisplayName());
+    assertEquals("sales", response.getOverlay().getDisplayName());
+  }
+
+  @Test
+  void createRequiresOverlayWriteIntegrationUseAndCatalogWrite() {
+    service.authz = new Authorizer();
+    when(service.principal.get())
+        .thenReturn(principal("catalog-overlay.write", "catalog-integration.use", "catalog.write"));
+    create(CatalogOverlaySpec.newBuilder());
+    verify(service.integrations).getByIdWithMeta(integrationId());
+  }
+
+  @Test
+  void renamingAnOverlayRenamesTheCatalogItOwnsInTheSameTransaction() {
+    ResourceId catalogId = id("catalog", ResourceKind.RK_CATALOG);
+    var current =
+        CatalogOverlay.newBuilder()
+            .setResourceId(id("overlay", ResourceKind.RK_CATALOG_OVERLAY))
+            .setDisplayName("sales")
+            .setIntegrationId(integrationId())
+            .setCatalogId(catalogId)
+            .build();
+    when(service.overlays.getByIdWithMeta(id("overlay", ResourceKind.RK_CATALOG_OVERLAY)))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    current, MutationMeta.newBuilder().setPointerVersion(7).build())));
+    when(service.catalogs.getByIdWithMeta(catalogId))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    Catalog.newBuilder()
+                        .setResourceId(catalogId)
+                        .setDisplayName("sales")
+                        .setOverlayId(id("overlay", ResourceKind.RK_CATALOG_OVERLAY))
+                        .build(),
+                    MutationMeta.newBuilder().setPointerVersion(3).build())));
+    when(service.catalogs.prepareUpdateOps(any(), anyLong())).thenReturn(List.of());
+    when(service.overlays.updateWithMetaUnlessIntegrationDeleting(any(), eq(7L), any()))
+        .thenReturn(Optional.of(MutationMeta.newBuilder().setPointerVersion(8).build()));
+
+    service
+        .updateCatalogOverlay(
+            UpdateCatalogOverlayRequest.newBuilder()
+                .setOverlayId(id("overlay", ResourceKind.RK_CATALOG_OVERLAY))
+                .setUpdateMask(FieldMask.newBuilder().addPaths("display_name"))
+                .setSpec(CatalogOverlaySpec.newBuilder().setDisplayName("revenue"))
+                .build())
+        .await()
+        .indefinitely();
+
+    // The owned catalog is renamed from its own current pointer version, and those operations are
+    // handed to the overlay update so both names move in one transaction.
+    var renamed = ArgumentCaptor.forClass(Catalog.class);
+    verify(service.catalogs).prepareUpdateOps(renamed.capture(), eq(3L));
+    assertEquals("revenue", renamed.getValue().getDisplayName());
+    assertEquals(id("overlay", ResourceKind.RK_CATALOG_OVERLAY), renamed.getValue().getOverlayId());
+    verify(service.overlays).updateWithMetaUnlessIntegrationDeleting(any(), eq(7L), any());
+  }
+
+  @Test
+  void selectionOnlyUpdateLeavesTheOwnedCatalogAlone() {
+    var current =
+        CatalogOverlay.newBuilder()
+            .setResourceId(id("overlay", ResourceKind.RK_CATALOG_OVERLAY))
+            .setDisplayName("sales")
+            .setIntegrationId(integrationId())
+            .setCatalogId(id("catalog", ResourceKind.RK_CATALOG))
+            .build();
+    when(service.overlays.getByIdWithMeta(id("overlay", ResourceKind.RK_CATALOG_OVERLAY)))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    current, MutationMeta.newBuilder().setPointerVersion(7).build())));
+    when(service.overlays.updateWithMetaUnlessIntegrationDeleting(any(), eq(7L), any()))
+        .thenReturn(Optional.of(MutationMeta.newBuilder().setPointerVersion(8).build()));
+
+    service
+        .updateCatalogOverlay(
+            UpdateCatalogOverlayRequest.newBuilder()
+                .setOverlayId(id("overlay", ResourceKind.RK_CATALOG_OVERLAY))
+                .setUpdateMask(FieldMask.newBuilder().addPaths("include_namespaces"))
+                .setSpec(
+                    CatalogOverlaySpec.newBuilder()
+                        .addIncludeNamespaces(NamespacePath.newBuilder().addSegments("foo")))
+                .build())
+        .await()
+        .indefinitely();
+
+    verify(service.catalogs, never()).prepareUpdateOps(any(), anyLong());
+  }
+
+  @Test
+  void createRejectsNameReservedByCatalog() {
+    when(service.catalogs.getByName("acct", "sales"))
+        .thenReturn(
+            Optional.of(
+                Catalog.newBuilder()
+                    .setResourceId(id("catalog", ResourceKind.RK_CATALOG))
+                    .setDisplayName("sales")
+                    .build()));
+    // The owned catalog loses its name reservation inside the atomic batch; the repository reports
+    // that as a name conflict and the service renders it as ALREADY_EXISTS.
+    when(service.overlays.createAttachedWithMetaAndCompanions(
+            any(), any(), any(), anyLong(), any()))
+        .thenThrow(
+            new BaseResourceRepository.NameConflictException("companion pointer already reserved"));
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogOverlay(
+                        CreateCatalogOverlayRequest.newBuilder()
+                            .setSpec(
+                                CatalogOverlaySpec.newBuilder()
+                                    .setDisplayName("sales")
+                                    .setIntegrationId(integrationId()))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.ALREADY_EXISTS, error.getStatus().getCode());
+    verify(service.overlays)
+        .createAttachedWithMetaAndCompanions(any(), any(), any(), anyLong(), any());
+  }
+
+  @Test
+  void createRejectsUnknownConflictMode() {
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogOverlay(
+                        CreateCatalogOverlayRequest.newBuilder()
+                            .setCreateModeValue(99)
+                            .setSpec(
+                                CatalogOverlaySpec.newBuilder()
+                                    .setDisplayName("sales")
+                                    .setIntegrationId(integrationId()))
+                            .build())
+                    .await()
+                    .indefinitely());
+    assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+  }
+
+  @Test
+  void ifNotExistsReturnsExistingBeforeValidatingUnusedIntegrationBinding() {
+    var existing =
+        CatalogOverlay.newBuilder()
+            .setResourceId(id("existing", ResourceKind.RK_CATALOG_OVERLAY))
+            .setDisplayName("sales")
+            .setIntegrationId(integrationId())
+            .build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(9L).build();
+    when(service.overlays.getByNameWithMeta("acct", "sales"))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(existing, meta)));
+
+    var response =
+        service
+            .createCatalogOverlay(
+                CreateCatalogOverlayRequest.newBuilder()
+                    .setCreateMode(CreateMode.CM_RETURN_EXISTING)
+                    .setSpec(CatalogOverlaySpec.newBuilder().setDisplayName("sales"))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(existing, response.getOverlay());
+    assertEquals(meta, response.getMeta());
+    verify(service.integrations, never()).getByIdWithMeta(any());
+    verify(service.overlays, never())
+        .createAttachedWithMetaAndCompanions(any(), any(), any(), anyLong(), any());
+  }
+
+  @Test
+  void namespaceNamesAreExactAndPathsAreDeduplicatedDeterministically() {
+    create(
+        CatalogOverlaySpec.newBuilder()
+            .addIncludeNamespaces(path("z"))
+            .addIncludeNamespaces(path("a", "b"))
+            .addIncludeNamespaces(path("z")));
+    var captured = ArgumentCaptor.forClass(CatalogOverlay.class);
+    verify(service.overlays)
+        .createAttachedWithMetaAndCompanions(captured.capture(), any(), any(), anyLong(), any());
+    assertEquals(2, captured.getValue().getIncludeNamespacesCount());
+    assertEquals(path("a", "b"), captured.getValue().getIncludeNamespaces(0));
+  }
+
+  @Test
+  void idempotencyFingerprintPreservesPathBoundaries() {
+    byte[] one =
+        CatalogOverlaysImpl.canonicalFingerprintForTest(
+            "o", integrationId(), List.of(path("a", "b")), List.of());
+    byte[] two =
+        CatalogOverlaysImpl.canonicalFingerprintForTest(
+            "o", integrationId(), List.of(path("a"), path("b")), List.of());
+    assertFalse(Arrays.equals(one, two));
+  }
+
+  @Test
+  void updateCanReplaceNamespaceSelection() {
+    ResourceId overlayId = id("overlay", ResourceKind.RK_CATALOG_OVERLAY);
+    ResourceId catalogId = id("catalog", ResourceKind.RK_CATALOG);
+    var row =
+        CatalogOverlay.newBuilder()
+            .setResourceId(overlayId)
+            .setCatalogId(catalogId)
+            .setDisplayName("sales")
+            .setIntegrationId(integrationId())
+            .build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(7).build();
+    when(service.overlays.getByIdWithMeta(overlayId))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(row, meta)));
+    when(service.catalogs.getByIdWithMeta(catalogId))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    Catalog.newBuilder()
+                        .setResourceId(catalogId)
+                        .setDisplayName("sales")
+                        .setOverlayId(overlayId)
+                        .build(),
+                    MutationMeta.newBuilder().setPointerVersion(3L).build())));
+    when(service.catalogs.prepareUpdateOps(any(), eq(3L))).thenReturn(List.of());
+    when(service.overlays.updateWithMetaUnlessIntegrationDeleting(any(), eq(7L), any()))
+        .thenReturn(Optional.of(MutationMeta.newBuilder().setPointerVersion(8).build()));
+
+    var response =
+        service
+            .updateCatalogOverlay(
+                UpdateCatalogOverlayRequest.newBuilder()
+                    .setOverlayId(overlayId)
+                    .setSpec(CatalogOverlaySpec.newBuilder().addExcludeNamespaces(path("private")))
+                    .setUpdateMask(FieldMask.newBuilder().addPaths("exclude_namespaces"))
+                    .build())
+            .await()
+            .indefinitely();
+    assertEquals(path("private"), response.getOverlay().getExcludeNamespaces(0));
+    assertEquals(8L, response.getMeta().getPointerVersion());
+  }
+
+  @Test
+  void updateNormalizesSqlCatalogNameBeforeCollisionCheckAndPersistence() {
+    ResourceId overlayId = id("overlay", ResourceKind.RK_CATALOG_OVERLAY);
+    ResourceId catalogId = id("catalog", ResourceKind.RK_CATALOG);
+    var row =
+        CatalogOverlay.newBuilder()
+            .setResourceId(overlayId)
+            .setCatalogId(catalogId)
+            .setDisplayName("sales")
+            .setIntegrationId(integrationId())
+            .build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(7).build();
+    when(service.overlays.getByIdWithMeta(overlayId))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(row, meta)));
+    when(service.catalogs.getByIdWithMeta(catalogId))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    Catalog.newBuilder()
+                        .setResourceId(catalogId)
+                        .setDisplayName("sales")
+                        .setOverlayId(overlayId)
+                        .build(),
+                    MutationMeta.newBuilder().setPointerVersion(3L).build())));
+    when(service.catalogs.prepareUpdateOps(any(), eq(3L))).thenReturn(List.of());
+    when(service.overlays.updateWithMetaUnlessIntegrationDeleting(any(), eq(7L), any()))
+        .thenReturn(Optional.of(MutationMeta.newBuilder().setPointerVersion(8).build()));
+
+    var response =
+        service
+            .updateCatalogOverlay(
+                UpdateCatalogOverlayRequest.newBuilder()
+                    .setOverlayId(overlayId)
+                    .setSpec(CatalogOverlaySpec.newBuilder().setDisplayName("  revenue  "))
+                    .setUpdateMask(FieldMask.newBuilder().addPaths("display_name"))
+                    .build())
+            .await()
+            .indefinitely();
+
+    verify(service.catalogs).getByName("acct", "revenue");
+    var desired = ArgumentCaptor.forClass(CatalogOverlay.class);
+    verify(service.overlays)
+        .updateWithMetaUnlessIntegrationDeleting(desired.capture(), eq(7L), any());
+    assertEquals("revenue", desired.getValue().getDisplayName());
+    assertEquals("revenue", response.getOverlay().getDisplayName());
+  }
+
+  @Test
+  void legacyConnectorPermissionDoesNotAuthorizeCreate() {
+    service.authz = new Authorizer();
+    when(service.principal.get()).thenReturn(principal("connector.manage"));
+    var error =
+        assertThrows(StatusRuntimeException.class, () -> create(CatalogOverlaySpec.newBuilder()));
+    assertEquals(Status.Code.PERMISSION_DENIED, error.getStatus().getCode());
+  }
+
+  @Test
+  void createOrReplaceSwapsIdentityAndCanChangeIntegrationBinding() {
+    ResourceId overlayId = id("overlay", ResourceKind.RK_CATALOG_OVERLAY);
+    ResourceId catalogId = id("catalog", ResourceKind.RK_CATALOG);
+    ResourceId oldIntegrationId = id("old-integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var current =
+        CatalogOverlay.newBuilder()
+            .setResourceId(overlayId)
+            .setCatalogId(catalogId)
+            .setDisplayName("sales")
+            .setIntegrationId(oldIntegrationId)
+            .build();
+    when(service.overlays.getByNameWithMeta("acct", "sales"))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    current, MutationMeta.newBuilder().setPointerVersion(4L).build())));
+    when(service.catalogs.getByIdWithMeta(catalogId))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    Catalog.newBuilder()
+                        .setResourceId(catalogId)
+                        .setDisplayName("sales")
+                        .setOverlayId(overlayId)
+                        .build(),
+                    MutationMeta.newBuilder().setPointerVersion(8L).build())));
+    when(service.catalogs.prepareUpdateOps(any(), eq(8L))).thenReturn(List.of());
+    when(service.integrations.getByIdWithMeta(oldIntegrationId))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    CatalogIntegration.newBuilder().setResourceId(oldIntegrationId).build(),
+                    MutationMeta.newBuilder().setPointerVersion(6L).build())));
+    when(service.overlays.replaceIdentityAttachedWithMeta(
+            any(), eq(4L), any(), any(), any(), any(), any()))
+        .thenAnswer(
+            invocation ->
+                Optional.of(
+                    new ResourceWithMeta<>(
+                        invocation.getArgument(2),
+                        MutationMeta.newBuilder().setPointerVersion(1L).build())));
+
+    var response =
+        service
+            .createCatalogOverlay(
+                CreateCatalogOverlayRequest.newBuilder()
+                    .setCreateMode(CreateMode.CM_REPLACE)
+                    .setSpec(
+                        CatalogOverlaySpec.newBuilder()
+                            .setDisplayName("sales")
+                            .setIntegrationId(integrationId()))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertNotEquals(overlayId, response.getOverlay().getResourceId());
+    assertEquals(integrationId(), response.getOverlay().getIntegrationId());
+    assertEquals(1L, response.getMeta().getPointerVersion());
+    verify(service.overlays)
+        .replaceIdentityAttachedWithMeta(any(), eq(4L), any(), any(), any(), any(), any());
+    assertEquals(catalogId, response.getOverlay().getCatalogId());
+    var owner = ArgumentCaptor.forClass(Catalog.class);
+    verify(service.catalogs).prepareUpdateOps(owner.capture(), eq(8L));
+    assertEquals(response.getOverlay().getResourceId(), owner.getValue().getOverlayId());
+  }
+
+  @Test
+  void idempotentCreateRequiresAtomicReceiptWithResourcePublication() {
+    var receipt = new AtomicReference<IdempotencyRecord>();
+    when(service.idempotencyStore.get(any()))
+        .thenAnswer(invocation -> Optional.ofNullable(receipt.get()));
+    when(service.idempotencyStore.createPending(
+            any(), any(), any(), any(), any(ResourceId.class), any(), any()))
+        .thenReturn(true);
+    when(service.idempotencyStore.prepareSuccess(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              String opName = invocation.getArgument(2, String.class);
+              String requestHash = invocation.getArgument(3, String.class);
+              ResourceId resourceId = invocation.getArgument(4, ResourceId.class);
+              MutationMeta meta = invocation.getArgument(5, MutationMeta.class);
+              byte[] payload = invocation.getArgument(6, byte[].class);
+              com.google.protobuf.Timestamp createdAt =
+                  invocation.getArgument(7, com.google.protobuf.Timestamp.class);
+              com.google.protobuf.Timestamp expiresAt =
+                  invocation.getArgument(8, com.google.protobuf.Timestamp.class);
+              receipt.set(
+                  IdempotencyRecord.newBuilder()
+                      .setOpName(opName)
+                      .setRequestHash(requestHash)
+                      .setStatus(IdempotencyRecord.Status.SUCCEEDED)
+                      .setResourceId(resourceId)
+                      .setMeta(meta)
+                      .setPayload(com.google.protobuf.ByteString.copyFrom(payload))
+                      .setCreatedAt(createdAt)
+                      .setExpiresAt(expiresAt)
+                      .build());
+              return new PointerStore.CasUpsert(
+                  "receipt", 1L, Pointer.newBuilder().setKey("receipt").build());
+            });
+    when(service.overlays.createAttachedWithMetaAndCompanions(
+            any(), any(), any(), anyLong(), any()))
+        .thenAnswer(
+            invocation -> {
+              CatalogOverlay value = invocation.getArgument(0);
+              var row =
+                  new ResourceWithMeta<>(
+                      value, MutationMeta.newBuilder().setPointerVersion(1L).build());
+              Function<ResourceWithMeta<CatalogOverlay>, PointerStore.CasUpsert> completion =
+                  invocation.getArgument(4);
+              completion.apply(row);
+              return Optional.of(row);
+            });
+
+    var response =
+        service
+            .createCatalogOverlay(
+                CreateCatalogOverlayRequest.newBuilder()
+                    .setIdempotency(
+                        ai.floedb.floecat.common.rpc.IdempotencyKey.newBuilder().setKey("key"))
+                    .setSpec(
+                        CatalogOverlaySpec.newBuilder()
+                            .setDisplayName("sales")
+                            .setIntegrationId(integrationId()))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(receipt.get().getResourceId(), response.getOverlay().getResourceId());
+    verify(service.idempotencyStore)
+        .prepareSuccess(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    verify(service.idempotencyStore, never())
+        .finalizeSuccess(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    verify(service.idempotencyStore, never()).delete(any());
+  }
+
+  @Test
+  void idempotentCreateAdoptsReservedIdentityPublishedByConcurrentRetry() {
+    var reservedId = new AtomicReference<ResourceId>();
+    var requestHash = new AtomicReference<String>();
+    var createdAt = new AtomicReference<com.google.protobuf.Timestamp>();
+    var expiresAt = new AtomicReference<com.google.protobuf.Timestamp>();
+    var meta = MutationMeta.newBuilder().setPointerVersion(9L).build();
+    when(service.idempotencyStore.get(any()))
+        .thenAnswer(
+            invocation -> {
+              if (reservedId.get() == null) return Optional.empty();
+              var overlay =
+                  CatalogOverlay.newBuilder()
+                      .setResourceId(reservedId.get())
+                      .setDisplayName("sales")
+                      .setIntegrationId(integrationId())
+                      .build();
+              return Optional.of(
+                  IdempotencyRecord.newBuilder()
+                      .setOpName("CreateCatalogOverlay")
+                      .setRequestHash(requestHash.get())
+                      .setStatus(IdempotencyRecord.Status.SUCCEEDED)
+                      .setResourceId(reservedId.get())
+                      .setMeta(meta)
+                      .setPayload(overlay.toByteString())
+                      .setCreatedAt(createdAt.get())
+                      .setExpiresAt(expiresAt.get())
+                      .build());
+            });
+    when(service.idempotencyStore.createPending(
+            any(), any(), any(), any(), any(ResourceId.class), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              requestHash.set(invocation.getArgument(3));
+              reservedId.set(invocation.getArgument(4));
+              createdAt.set(invocation.getArgument(5));
+              expiresAt.set(invocation.getArgument(6));
+              return true;
+            });
+    when(service.overlays.getByNameWithMeta("acct", "sales"))
+        .thenAnswer(
+            invocation ->
+                Optional.of(
+                    new ResourceWithMeta<>(
+                        CatalogOverlay.newBuilder()
+                            .setResourceId(reservedId.get())
+                            .setDisplayName("sales")
+                            .setIntegrationId(integrationId())
+                            .build(),
+                        meta)));
+
+    var response =
+        service
+            .createCatalogOverlay(
+                CreateCatalogOverlayRequest.newBuilder()
+                    .setIdempotency(
+                        ai.floedb.floecat.common.rpc.IdempotencyKey.newBuilder().setKey("key"))
+                    .setSpec(
+                        CatalogOverlaySpec.newBuilder()
+                            .setDisplayName("sales")
+                            .setIntegrationId(integrationId()))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(reservedId.get(), response.getOverlay().getResourceId());
+    assertEquals(meta, response.getMeta());
+    verify(service.overlays, never())
+        .createAttachedWithMetaAndCompanions(any(), any(), any(), anyLong(), any());
+    verify(service.idempotencyStore, never())
+        .prepareSuccess(any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  private CreateCatalogOverlayResponse create(CatalogOverlaySpec.Builder spec) {
+    return service
+        .createCatalogOverlay(
+            CreateCatalogOverlayRequest.newBuilder()
+                .setSpec(spec.setDisplayName("sales").setIntegrationId(integrationId()))
+                .build())
+        .await()
+        .indefinitely();
+  }
+
+  private static PrincipalContext principal() {
+    return principal("catalog-overlay.read", "catalog-overlay.write", "catalog-integration.use");
+  }
+
+  private static PrincipalContext principal(String... permissions) {
+    return PrincipalContext.newBuilder()
+        .setAccountId("acct")
+        .setCorrelationId("corr")
+        .addAllPermissions(List.of(permissions))
+        .build();
+  }
+
+  private static NamespacePath path(String... segments) {
+    return NamespacePath.newBuilder().addAllSegments(List.of(segments)).build();
+  }
+
+  private static ResourceId integrationId() {
+    return id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+  }
+
+  private static ResourceId id(String value, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("acct").setId(value).setKind(kind).build();
+  }
+
+  private static void installBasePrincipal(
+      CatalogOverlaysImpl service, PrincipalProvider provider) {
+    try {
+      Field field =
+          ai.floedb.floecat.service.common.BaseServiceImpl.class.getDeclaredField("principal");
+      field.setAccessible(true);
+      field.set(service, provider);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepositoryTest.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.catalog.rpc.Catalog;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.rpc.IdempotencyRecord;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import com.google.protobuf.Timestamp;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class CatalogOverlayRepositoryTest {
+
+  @Test
+  void overlayAndItsOwnedCatalogCommitInOneTransaction() {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var catalogs = new CatalogRepository(pointers, blobs);
+    var overlays = new CatalogOverlayRepository(pointers, blobs);
+    ResourceId catalogId = id("catalog", ResourceKind.RK_CATALOG);
+    CatalogOverlay overlay = overlay("overlay").toBuilder().setCatalogId(catalogId).build();
+    Catalog owned =
+        Catalog.newBuilder()
+            .setResourceId(catalogId)
+            .setDisplayName(overlay.getDisplayName())
+            .setOverlayId(overlay.getResourceId())
+            .build();
+
+    assertTrue(
+        overlays
+            .createAttachedWithMetaAndCompanions(
+                overlay, Map.of(), Set.of(), 0L, row -> catalogs.prepareCreateOps(owned))
+            .isPresent());
+
+    assertEquals("sales", catalogs.getByName("account", "sales").orElseThrow().getDisplayName());
+    assertEquals(overlay.getResourceId(), catalogs.getById(catalogId).orElseThrow().getOverlayId());
+  }
+
+  @Test
+  void overlayCreateCommitsNothingWhenItsCatalogNameIsTaken() {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var catalogs = new CatalogRepository(pointers, blobs);
+    var overlays = new CatalogOverlayRepository(pointers, blobs);
+    catalogs.create(
+        Catalog.newBuilder()
+            .setResourceId(id("existing", ResourceKind.RK_CATALOG))
+            .setDisplayName("sales")
+            .build());
+
+    ResourceId catalogId = id("catalog", ResourceKind.RK_CATALOG);
+    CatalogOverlay overlay = overlay("overlay").toBuilder().setCatalogId(catalogId).build();
+    Catalog owned =
+        Catalog.newBuilder()
+            .setResourceId(catalogId)
+            .setDisplayName("sales")
+            .setOverlayId(overlay.getResourceId())
+            .build();
+
+    // The companion catalog loses its name reservation, so the whole batch commits nothing and the
+    // caller is told this is a name conflict rather than a transient one.
+    assertThrows(
+        BaseResourceRepository.NameConflictException.class,
+        () ->
+            overlays.createAttachedWithMetaAndCompanions(
+                overlay, Map.of(), Set.of(), 0L, row -> catalogs.prepareCreateOps(owned)));
+    assertTrue(overlays.getById(overlay.getResourceId()).isEmpty());
+    assertTrue(catalogs.getById(catalogId).isEmpty());
+  }
+
+  @Test
+  void deletingAnOverlayDeletesTheCatalogItOwns() {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var catalogs = new CatalogRepository(pointers, blobs);
+    var overlays = new CatalogOverlayRepository(pointers, blobs);
+    ResourceId catalogId = id("catalog", ResourceKind.RK_CATALOG);
+    CatalogOverlay overlay = overlay("overlay").toBuilder().setCatalogId(catalogId).build();
+    Catalog owned =
+        Catalog.newBuilder()
+            .setResourceId(catalogId)
+            .setDisplayName(overlay.getDisplayName())
+            .setOverlayId(overlay.getResourceId())
+            .build();
+    overlays.createAttachedWithMetaAndCompanions(
+        overlay, Map.of(), Set.of(), 0L, row -> catalogs.prepareCreateOps(owned));
+
+    long version = overlays.metaFor(overlay.getResourceId()).getPointerVersion();
+    assertTrue(
+        overlays.deleteWithOwnedCatalog(
+            overlay.getResourceId(), version, catalogs.prepareDeleteOps(catalogId)));
+
+    assertTrue(overlays.getById(overlay.getResourceId()).isEmpty());
+    assertTrue(catalogs.getById(catalogId).isEmpty());
+    assertTrue(catalogs.getByName("account", "sales").isEmpty());
+  }
+
+  @Test
+  void indexesOverlayAndDeletesAllPointersAtomically() {
+    var repo = new CatalogOverlayRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    var overlay = overlay("overlay");
+    repo.create(overlay);
+
+    assertEquals(overlay, repo.getById(overlay.getResourceId()).orElseThrow());
+    assertEquals(overlay, repo.getByName("account", "sales").orElseThrow());
+    assertEquals(1, repo.countByIntegration("account", "integration"));
+
+    assertTrue(repo.deleteWithPrecondition(overlay.getResourceId(), 1L));
+    assertFalse(repo.getById(overlay.getResourceId()).isPresent());
+    assertFalse(repo.getByName("account", "sales").isPresent());
+    assertEquals(0, repo.countByIntegration("account", "integration"));
+  }
+
+  @Test
+  void integrationMayHaveMultipleOverlays() {
+    var repo = new CatalogOverlayRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    repo.create(overlay("overlay"));
+
+    repo.create(overlay("other").toBuilder().setDisplayName("other").build());
+    assertEquals(2, repo.countByIntegration("account", "integration"));
+  }
+
+  @Test
+  void createChecksParentsAndAdvancesIntegrationMarkerAtomically() {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var integrations = new CatalogIntegrationRepository(pointers, blobs);
+    var overlays = new CatalogOverlayRepository(pointers, blobs);
+    CatalogOverlay overlay = overlay("overlay");
+    ResourceId integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    ResourceId catalogId = id("catalog", ResourceKind.RK_CATALOG);
+    integrations.create(
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setDisplayName("integration")
+            .build());
+    long integrationVersion = integrations.metaFor(integrationId).getPointerVersion();
+
+    assertTrue(
+        overlays.createAttached(
+            overlay,
+            Map.of(
+                Keys.catalogIntegrationPointerById("account", "integration"), integrationVersion),
+            Set.of(),
+            0L));
+    assertEquals(
+        1L,
+        pointers
+            .get(Keys.catalogIntegrationOverlaysMarker("account", "integration"))
+            .orElseThrow()
+            .getVersion());
+
+    assertFalse(
+        integrations.deleteWithPreconditionAndOverlayMarker(integrationId, integrationVersion, 0L));
+
+    long overlayVersion = overlays.metaFor(overlay.getResourceId()).getPointerVersion();
+    assertTrue(overlays.deleteWithPrecondition(overlay.getResourceId(), overlayVersion));
+    assertTrue(
+        integrations.deleteWithPreconditionAndOverlayMarker(integrationId, integrationVersion, 1L));
+    assertFalse(integrations.getById(integrationId).isPresent());
+    assertFalse(
+        pointers.get(Keys.catalogIntegrationOverlaysMarker("account", "integration")).isPresent());
+  }
+
+  @Test
+  void identityReplacementMovesIntegrationIndexAndAdvancesBothMarkersAtomically() {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var integrations = new CatalogIntegrationRepository(pointers, blobs);
+    var overlays = new CatalogOverlayRepository(pointers, blobs);
+    ResourceId oldId = id("old", ResourceKind.RK_CATALOG_INTEGRATION);
+    ResourceId nextId = id("next", ResourceKind.RK_CATALOG_INTEGRATION);
+    integrations.create(
+        CatalogIntegration.newBuilder().setResourceId(oldId).setDisplayName("old").build());
+    integrations.create(
+        CatalogIntegration.newBuilder().setResourceId(nextId).setDisplayName("next").build());
+    CatalogOverlay original = overlay("overlay").toBuilder().setIntegrationId(oldId).build();
+    long oldVersion = integrations.metaFor(oldId).getPointerVersion();
+    long nextVersion = integrations.metaFor(nextId).getPointerVersion();
+    assertTrue(
+        overlays.createAttached(
+            original,
+            Map.of(Keys.catalogIntegrationPointerById("account", "old"), oldVersion),
+            Set.of(),
+            0L));
+
+    CatalogOverlay replacement =
+        original.toBuilder()
+            .setResourceId(id("replacement", ResourceKind.RK_CATALOG_OVERLAY))
+            .setIntegrationId(nextId)
+            .build();
+    var replaced =
+        overlays
+            .replaceIdentityAttachedWithMeta(
+                original,
+                1L,
+                replacement,
+                Map.of(
+                    Keys.catalogIntegrationPointerById("account", "old"), oldVersion,
+                    Keys.catalogIntegrationPointerById("account", "next"), nextVersion),
+                Set.of(
+                    Keys.catalogIntegrationDeletionMarker("account", "old"),
+                    Keys.catalogIntegrationDeletionMarker("account", "next")),
+                Map.of(
+                    Keys.catalogIntegrationOverlaysMarker("account", "old"), 1L,
+                    Keys.catalogIntegrationOverlaysMarker("account", "next"), 0L),
+                List.of())
+            .orElseThrow();
+
+    assertEquals(1L, replaced.meta().getPointerVersion());
+    assertFalse(overlays.getById(original.getResourceId()).isPresent());
+    assertEquals(replacement, overlays.getById(replacement.getResourceId()).orElseThrow());
+    assertEquals(0, overlays.countByIntegration("account", "old"));
+    assertEquals(1, overlays.countByIntegration("account", "next"));
+    assertEquals(
+        2L,
+        pointers
+            .get(Keys.catalogIntegrationOverlaysMarker("account", "old"))
+            .orElseThrow()
+            .getVersion());
+    assertEquals(
+        1L,
+        pointers
+            .get(Keys.catalogIntegrationOverlaysMarker("account", "next"))
+            .orElseThrow()
+            .getVersion());
+  }
+
+  @Test
+  void cascadeDeletionFenceAtomicallyRejectsANewOverlayAttachment() {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var integrations = new CatalogIntegrationRepository(pointers, blobs);
+    var overlays = new CatalogOverlayRepository(pointers, blobs);
+    ResourceId integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    integrations.create(
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setDisplayName("integration")
+            .build());
+    long integrationVersion = integrations.metaFor(integrationId).getPointerVersion();
+    assertTrue(integrations.beginCascadeDeletion(integrationId, integrationVersion));
+
+    assertFalse(
+        overlays.createAttached(
+            overlay("overlay"),
+            Map.of(
+                Keys.catalogIntegrationPointerById("account", "integration"), integrationVersion),
+            Set.of(Keys.catalogIntegrationDeletionMarker("account", "integration")),
+            0L));
+    assertFalse(overlays.getById(id("overlay", ResourceKind.RK_CATALOG_OVERLAY)).isPresent());
+  }
+
+  @Test
+  void idempotencyReceiptAndOverlayPointerSetBothCommitWhenAcknowledgementIsLost()
+      throws Exception {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var integrations = new CatalogIntegrationRepository(pointers, blobs);
+    ResourceId integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    integrations.create(
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setDisplayName("integration")
+            .build());
+    long integrationVersion = integrations.metaFor(integrationId).getPointerVersion();
+    var commitThenFail = new RepoTestPointerStores.CommitThenFailBatchPointerStore(pointers);
+    var overlays = new CatalogOverlayRepository(commitThenFail, blobs);
+    var idempotency = new IdempotencyRepositoryImpl(commitThenFail, blobs);
+    CatalogOverlay overlay = overlay("overlay");
+    String operation = "CreateCatalogOverlay";
+    String key = Keys.idempotencyKey("account", operation, "request-1");
+    Timestamp createdAt = timestamp(1L);
+    Timestamp expiresAt = timestamp(2L);
+    var committedMeta = new AtomicReference<ai.floedb.floecat.common.rpc.MutationMeta>();
+    assertTrue(
+        idempotency.createPending(
+            "account",
+            key,
+            operation,
+            "request-hash",
+            overlay.getResourceId(),
+            createdAt,
+            expiresAt));
+
+    assertThrows(
+        RepoTestPointerStores.CommitThenFailBatchPointerStore.InjectedAcknowledgementFailure.class,
+        () ->
+            overlays.createAttachedWithMetaAndCompanions(
+                overlay,
+                Map.of(
+                    Keys.catalogIntegrationPointerById("account", "integration"),
+                    integrationVersion),
+                Set.of(Keys.catalogIntegrationDeletionMarker("account", "integration")),
+                0L,
+                row -> {
+                  committedMeta.set(row.meta());
+                  return List.of(
+                      (PointerStore.CasOp)
+                          idempotency.prepareSuccess(
+                              "account",
+                              key,
+                              operation,
+                              "request-hash",
+                              row.value().getResourceId(),
+                              row.meta(),
+                              row.value().toByteArray(),
+                              createdAt,
+                              expiresAt));
+                }));
+
+    var receipt = idempotency.get(key).orElseThrow();
+    assertEquals(IdempotencyRecord.Status.SUCCEEDED, receipt.getStatus());
+    assertEquals(committedMeta.get(), receipt.getMeta());
+    assertEquals(overlay, CatalogOverlay.parseFrom(receipt.getPayload()));
+    assertEquals(overlay, overlays.getById(overlay.getResourceId()).orElseThrow());
+    assertEquals(overlay, overlays.getByName("account", "sales").orElseThrow());
+    assertEquals(1, overlays.countByIntegration("account", "integration"));
+    assertEquals(
+        1L,
+        pointers
+            .get(Keys.catalogIntegrationOverlaysMarker("account", "integration"))
+            .orElseThrow()
+            .getVersion());
+  }
+
+  @Test
+  void idempotencyReceiptAndOverlayPointerSetBothRemainUncommittedWhenBatchFails() {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var integrations = new CatalogIntegrationRepository(pointers, blobs);
+    ResourceId integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    integrations.create(
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setDisplayName("integration")
+            .build());
+    long integrationVersion = integrations.metaFor(integrationId).getPointerVersion();
+    var failing = new RepoTestPointerStores.FailingBatchPointerStore(pointers);
+    var overlays = new CatalogOverlayRepository(failing, blobs);
+    var idempotency = new IdempotencyRepositoryImpl(failing, blobs);
+    CatalogOverlay overlay = overlay("overlay");
+    String operation = "CreateCatalogOverlay";
+    String key = Keys.idempotencyKey("account", operation, "request-1");
+    Timestamp createdAt = timestamp(1L);
+    Timestamp expiresAt = timestamp(2L);
+    assertTrue(
+        idempotency.createPending(
+            "account",
+            key,
+            operation,
+            "request-hash",
+            overlay.getResourceId(),
+            createdAt,
+            expiresAt));
+
+    assertThrows(
+        RepoTestPointerStores.FailingBatchPointerStore.InjectedBatchFailure.class,
+        () ->
+            overlays.createAttachedWithMetaAndCompanions(
+                overlay,
+                Map.of(
+                    Keys.catalogIntegrationPointerById("account", "integration"),
+                    integrationVersion),
+                Set.of(Keys.catalogIntegrationDeletionMarker("account", "integration")),
+                0L,
+                row ->
+                    List.of(
+                        (PointerStore.CasOp)
+                            idempotency.prepareSuccess(
+                                "account",
+                                key,
+                                operation,
+                                "request-hash",
+                                row.value().getResourceId(),
+                                row.meta(),
+                                row.value().toByteArray(),
+                                createdAt,
+                                expiresAt))));
+
+    assertTrue(overlays.getById(overlay.getResourceId()).isEmpty());
+    assertTrue(overlays.getByName("account", "sales").isEmpty());
+    assertEquals(0, overlays.countByIntegration("account", "integration"));
+    assertTrue(
+        pointers.get(Keys.catalogIntegrationOverlaysMarker("account", "integration")).isEmpty());
+    assertEquals(IdempotencyRecord.Status.PENDING, idempotency.get(key).orElseThrow().getStatus());
+  }
+
+  private static Timestamp timestamp(long seconds) {
+    return Timestamp.newBuilder().setSeconds(seconds).build();
+  }
+
+  private static CatalogOverlay overlay(String overlayId) {
+    return CatalogOverlay.newBuilder()
+        .setResourceId(id(overlayId, ResourceKind.RK_CATALOG_OVERLAY))
+        .setDisplayName("sales")
+        .setIntegrationId(id("integration", ResourceKind.RK_CATALOG_INTEGRATION))
+        .build();
+  }
+
+  private static ResourceId id(String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("account").setId(id).setKind(kind).build();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
@@ -183,6 +183,9 @@ class KeysTest {
         Keys.catalogIntegrationPointerById("a c", "int 1"),
         Keys.ownerPointerKeyForBlob(Keys.catalogIntegrationBlobUri("a c", "int 1", "sha")));
     assertEquals(
+        Keys.catalogOverlayPointerById("a c", "over 1"),
+        Keys.ownerPointerKeyForBlob(Keys.catalogOverlayBlobUri("a c", "over 1", "sha")));
+    assertEquals(
         Keys.tableRootByTable("a c", "tbl 1"),
         Keys.ownerPointerKeyForBlob(Keys.tableRootBlobUri("a c", "tbl 1", "sha")));
     assertEquals(

--- a/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
@@ -30,7 +30,8 @@ class RolePermissionsTest {
           "namespace.read",
           "table.read",
           "view.read",
-          RolePermissions.CATALOG_INTEGRATION_READ);
+          RolePermissions.CATALOG_INTEGRATION_READ,
+          RolePermissions.CATALOG_OVERLAY_READ);
   private static final List<String> FULL_PERMS =
       List.of(
           "account.read",
@@ -46,6 +47,8 @@ class RolePermissionsTest {
           RolePermissions.CATALOG_INTEGRATION_READ,
           RolePermissions.CATALOG_INTEGRATION_WRITE,
           RolePermissions.CATALOG_INTEGRATION_USE,
+          RolePermissions.CATALOG_OVERLAY_READ,
+          RolePermissions.CATALOG_OVERLAY_WRITE,
           "system-objects.read",
           "account.delete");
   private static final List<String> INIT_ACCOUNT_PERMS =
@@ -59,7 +62,9 @@ class RolePermissionsTest {
           "connector.create",
           RolePermissions.CATALOG_INTEGRATION_READ,
           RolePermissions.CATALOG_INTEGRATION_WRITE,
-          RolePermissions.CATALOG_INTEGRATION_USE);
+          RolePermissions.CATALOG_INTEGRATION_USE,
+          RolePermissions.CATALOG_OVERLAY_READ,
+          RolePermissions.CATALOG_OVERLAY_WRITE);
   private static final List<String> DELETE_ACCOUNT_PERMS = List.of("account.delete");
   private static final List<String> PLATFORM_PERMS =
       List.of("account.read", "account.write", "account.delete");
@@ -77,6 +82,7 @@ class RolePermissionsTest {
           "connector.manage",
           RolePermissions.CATALOG_INTEGRATION_READ,
           RolePermissions.CATALOG_INTEGRATION_USE,
+          RolePermissions.CATALOG_OVERLAY_READ,
           "system-objects.read",
           RolePermissions.STORAGE_AUTHORITY_RESOLVE_INTERNAL,
           RolePermissions.RECONCILE_EXECUTOR_CONTROL_INTERNAL);


### PR DESCRIPTION
## Summary

Adds catalog integration and overlay commands to the client CLI, along with command execution support, shell wiring, history/auth coverage, CLI reference material, and an operator-facing catalog integrations guide.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

- Focused CLI suite: 29 tests passed.
- `make test-site`

- [x] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Stack position: **7/8**. Base: `mc-catalog-overlays-api`. This PR is limited to client/CLI and user documentation over the APIs below it.
