### PR TITLE
concurrency: bounded ordered fan-out with request-context propagation

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
@@ -42,7 +42,6 @@ import com.google.protobuf.util.Timestamps;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.smallrye.mutiny.Multi;
@@ -92,19 +91,13 @@ public abstract class BaseServiceImpl {
   }
 
   /**
-   * The OTel context to re-activate inside a hopped body. Prefers the context current at method
-   * entry, but when that carries no valid span — the norm on this server, where the span is only
-   * current inside the innermost tracing interceptor's window and never at the method layer — it
-   * grafts on the span {@code SpanCaptureInterceptor} stashed on the per-call duplicated-context
-   * carrier. Without this, {@code Span.current()} inside the body is the invalid root span and
-   * every per-request decoration and diagnostic summary event silently no-ops.
+   * The OTel context to re-activate inside a hopped body: the entry context, with the call's gRPC
+   * server span grafted on when it carries none (the norm at the method layer). See {@link
+   * ResolvedCallContexts#withCurrentCallSpan} for why — the same rule {@code PropagatedContext}
+   * uses.
    */
   private static Context otelContextForBody(Context captured) {
-    if (Span.fromContext(captured).getSpanContext().isValid()) {
-      return captured;
-    }
-    Span carried = ResolvedCallContexts.currentCallSpanOrInvalid();
-    return carried.getSpanContext().isValid() ? captured.with(carried) : captured;
+    return ResolvedCallContexts.withCurrentCallSpan(captured);
   }
 
   protected <T> Uni<T> run(Supplier<T> body) {
@@ -119,7 +112,7 @@ public abstract class BaseServiceImpl {
             () ->
                 grpcCtx.call(
                     () ->
-                        ResolvedCallContexts.callWith(
+                        ResolvedCallContexts.callWithOrInherit(
                             callCtx,
                             () -> {
                               try (Scope ignored = otelCtx.makeCurrent()) {
@@ -147,7 +140,7 @@ public abstract class BaseServiceImpl {
             () ->
                 grpcCtx.call(
                     () ->
-                        ResolvedCallContexts.callWith(
+                        ResolvedCallContexts.callWithOrInherit(
                             callCtx,
                             () -> {
                               try (Scope ignored = otelCtx.makeCurrent()) {
@@ -168,7 +161,7 @@ public abstract class BaseServiceImpl {
             emitter ->
                 grpcCtx.run(
                     () ->
-                        ResolvedCallContexts.runWith(
+                        ResolvedCallContexts.runWithOrInherit(
                             callCtx,
                             () -> {
                               try (Scope ignored = otelCtx.makeCurrent()) {

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/BoundedFanout.java
@@ -1,0 +1,882 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import ai.floedb.floecat.service.context.PropagatedContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntConsumer;
+import org.jboss.logging.Logger;
+
+/**
+ * Runs independent, mostly-blocking tasks with a concurrency bound.
+ *
+ * <p>At most the configured number of tasks are submitted at a time. A completed task immediately
+ * opens one submission slot, independent of input order. Completed results are retained by index;
+ * mapping and ordered consumption deliver each contiguous input-order prefix as soon as it is
+ * available. Once that prefix exposes a failure, active siblings are cancelled or abandoned and the
+ * original failure returns without waiting for unrelated work.
+ *
+ * <p>This is orchestration only — it applies no I/O admission of its own. Its fan-out methods are
+ * package-private on purpose: an I/O-admission tier is meant to wrap them, so widening them to
+ * {@code public} would let a caller fan out per-unit store calls that bypass admission entirely.
+ * Keep them package-private.
+ *
+ * <p>{@code permits} bounds concurrency, not buffered results. The window refills past a
+ * still-running input-order head, so a completed later result is retained until the head lets the
+ * contiguous prefix advance. Undelivered results are therefore bounded by {@code items.size()}, not
+ * by {@code permits}: one slow head can hold every downstream result in heap at once. That is the
+ * deliberate trade for not stalling a fast later task behind a slow earlier one — size the batch
+ * (or the per-element footprint) accordingly rather than assuming a {@code permits}-sized buffer.
+ *
+ * <p>Return does not imply completion. Cancellation and failure <em>abandon</em> active siblings —
+ * {@code Future.cancel(true)} interrupts them but does not wait — so this class can return with
+ * tasks still running inside a non-interruptible store call (an S3/JDBC round trip that ignores the
+ * interrupt). This class holds no admission permit of its own.
+ *
+ * <p><b>Executor requirement:</b> {@code executor} must be able to run submitted tasks
+ * independently of the calling thread. The scheduler blocks the caller awaiting completions, so a
+ * bounded executor that the caller thread <em>itself</em> occupies deadlocks — the caller holds the
+ * only worker while its own submissions queue behind it, with no timeout. An unbounded or
+ * virtual-thread executor is always safe, as is any pool separate from the caller's. Use one of
+ * those. This cannot be detected here (the class does not know the caller's pool), so it is the
+ * caller's contract.
+ *
+ * <p>A same-pool {@link ForkJoinPool} is <b>no exemption at all</b>, despite {@link
+ * ForkJoinPool#managedBlock}. Compensation covers the <em>scheduler's</em> wait — one credit per
+ * managed block, and {@code tryCompensate} often satisfies it by lowering the active count rather
+ * than adding a worker. Nothing compensates for a submitted task that blocks, because that park is
+ * unmanaged, and mostly-blocking tasks are this class's whole premise. So the pool stops growing
+ * after a small constant and every later submission starves. Measured on a single-worker pool, with
+ * the pool capping at three threads: a cancellable caller stalls permanently with two blocking
+ * tasks, and {@link #NEVER_CANCELLED} stalls from three onward. Neither path is safe — the sentinel
+ * merely fails one task later. Do not dispatch to the pool the caller is running on.
+ *
+ * <p>{@code managedBlock} is still used, and still earns its keep for the supported topology: a
+ * scheduler running on an FJP worker that dispatches tasks <em>elsewhere</em> lends the pool a
+ * worker for the duration of its wait. Off an FJP it degrades to an ordinary block.
+ *
+ * <p>{@code executor} must also <b>run or reject</b> every task it accepts, never silently drop
+ * one. The scheduler's only exits from its wait are a completion notification, an observed
+ * cancellation, or an interrupt: a task accepted and then discarded never notifies, so {@code
+ * active} never drains and the calling thread parks. A rejection is fine (it surfaces through the
+ * ordered failure path); a {@link java.util.concurrent.ThreadPoolExecutor.DiscardPolicy} or {@code
+ * DiscardOldestPolicy} is not, and neither is calling {@code shutdownNow()} on the executor while a
+ * fan-out is in flight — that drains queued-but-unstarted tasks without running them. There is
+ * deliberately no wait deadline: any ceiling low enough to catch a wedged executor would also abort
+ * legitimately slow metadata reads, so this is a wiring contract rather than a timeout.
+ */
+final class BoundedFanout {
+
+  private static final Logger LOG = Logger.getLogger(BoundedFanout.class);
+
+  /**
+   * The canonical "never cancels" signal, shared so callers do not each define their own — and so
+   * they get the fast path: this scheduler recognizes <em>this exact instance</em> by identity and
+   * blocks for the next completion instead of waking every {@value #CANCELLATION_POLL_MILLIS} ms to
+   * re-read a signal that can never change. Passing an equivalent but distinct {@code () -> false}
+   * takes the polling path instead: correct on a conforming executor, but it pays that wakeup cost
+   * and does not share this path's incidental tolerance of a same-pool {@link ForkJoinPool} (see
+   * the class javadoc — that shape is unsupported either way). Pass this constant through rather
+   * than redeclaring it. Scheduling is otherwise identical: {@link #forEachOrdered} always installs
+   * the cancellation-aware runtime.
+   */
+  static final BooleanSupplier NEVER_CANCELLED = () -> false;
+
+  /**
+   * The shared cancellation-responsiveness budget (millis): this fan-out polls cancellation on this
+   * interval. Package-private so same-package callers share the one knob rather than each declaring
+   * their own.
+   */
+  static final long CANCELLATION_POLL_MILLIS = 10;
+
+  /**
+   * Shared no-op completion barrier used by production. A completion barrier is a test seam invoked
+   * with a slot's input index after its future is terminal but before the slot is enqueued, so a
+   * test can hold that notification and exercise the terminal-but-unnotified window. It runs on
+   * whichever thread completed the future ({@link FutureTask#done()}) — the task's worker, or the
+   * scheduler thread itself when that thread calls {@code cancel(true)} — so a test must only hold
+   * notifications for indices it is not itself waiting on. Tests inject their own barrier through
+   * the package-private {@code forEachOrdered} overload rather than mutating process-wide state.
+   */
+  private static final IntConsumer NO_COMPLETION_BARRIER = index -> {};
+
+  private BoundedFanout() {}
+
+  /**
+   * Apply {@code task} to each item on {@code executor}, at most {@code permits} running at once,
+   * and return the results in input order. Each task runs under the caller's request context
+   * (OpenTelemetry, engine/principal/correlation, MDC) re-established via {@link
+   * PropagatedContext}, so ambient reads behave off-thread as they do on the caller's thread. A
+   * task failure surfaces unwrapped — its original {@link RuntimeException} or {@link Error}, never
+   * an execution-wrapper exception. The first failure reachable in input order propagates
+   * immediately; active siblings are cancelled or abandoned rather than drained. {@code cancelled}
+   * must be non-blocking and thread-safe; observed cancellation throws {@link
+   * CancellationException} and abandons in-flight work rather than running every task to
+   * completion.
+   */
+  static <I, O> List<O> mapOrdered(
+      List<I> items,
+      int permits,
+      Executor executor,
+      Function<I, O> task,
+      BooleanSupplier cancelled) {
+    List<O> results = new ArrayList<>(items.size());
+    forEachOrdered(items, permits, executor, task, results::add, cancelled);
+    return results;
+  }
+
+  /**
+   * Cancellation-aware ordered result consumption. A consumer failure has the same ordered
+   * precedence as a task failure, while submitted work is cancelled promptly on failure or when
+   * cancellation is requested. {@code cancelled} may be read concurrently by the scheduler and
+   * workers, so it must be non-blocking and thread-safe (typically {@link
+   * java.util.concurrent.atomic.AtomicBoolean#get}). Observed cancellation throws {@link
+   * CancellationException}.
+   *
+   * <p>{@code consumer} runs synchronously on the scheduler thread between window refills, and the
+   * scheduler cannot observe cancellation while it runs — so the consumer <b>must not block</b>
+   * (e.g. on downstream backpressure). A blocked consumer stalls both cancellation polling and
+   * window refill until it returns; route streaming/backpressure outside the fan-out (collect here,
+   * emit after) rather than inside {@code consumer}.
+   */
+  static <I, O> void forEachOrdered(
+      List<I> items,
+      int permits,
+      Executor executor,
+      Function<I, O> task,
+      Consumer<? super O> consumer,
+      BooleanSupplier cancelled) {
+    forEachOrdered(items, permits, executor, task, consumer, cancelled, NO_COMPLETION_BARRIER);
+  }
+
+  /**
+   * {@link #forEachOrdered} with a per-invocation completion barrier — a test seam (see {@link
+   * #NO_COMPLETION_BARRIER}) injected without touching process-wide state. Package-private: every
+   * production path uses the six-arg overload’s no-op barrier.
+   */
+  static <I, O> void forEachOrdered(
+      List<I> items,
+      int permits,
+      Executor executor,
+      Function<I, O> task,
+      Consumer<? super O> consumer,
+      BooleanSupplier cancelled,
+      IntConsumer completionBarrier) {
+    // Before capture() or any allocation: an invalid bound should cost nothing and name itself.
+    validatePermits(permits);
+    List<TaskOutcome<O>> outcomes = emptyOutcomes(items.size());
+    OrderedOutcomeConsumer<O> ordered = new OrderedOutcomeConsumer<>(outcomes, consumer, cancelled);
+    completeAll(
+        items,
+        permits,
+        outcomes,
+        ordered,
+        new CancellableTaskRuntime<>(
+            executor, PropagatedContext.capture(), task, cancelled, completionBarrier));
+  }
+
+  /**
+   * Submit no more than {@code permits} tasks at once, recording each outcome as it completes so a
+   * fast later task immediately replenishes the window despite ordered result observation.
+   */
+  private static <I, O> void completeAll(
+      List<I> items,
+      int permits,
+      List<TaskOutcome<O>> outcomes,
+      OrderedOutcomeConsumer<O> ordered,
+      TaskRuntime<I, O> runtime) {
+    // Never more than items.size() slots are active at once, so do not let a large permits value
+    // pre-allocate memory independent of the actual workload.
+    List<CompletionSlot<O>> active = new ArrayList<>(Math.min(permits, items.size()));
+    int next = 0;
+    try {
+      next = fillWindow(items, permits, next, active, outcomes, ordered, runtime);
+      // Surface a failure a synchronous initial fill already made reachable before blocking on
+      // take(). Reconcile cancellation first, exactly as the main loop does: the fill's last task
+      // can set cancelled before returning, and an earlier recorded success must not be published
+      // to
+      // a stopped stream — a reachable failure still keeps precedence over the cancellation.
+      if (runtime.cancellationObserved()) {
+        surfaceSubmissionFailure(cancelled(), runtime, active, outcomes, ordered);
+      }
+      ordered.deliverReady();
+      while (!active.isEmpty()) {
+        CompletionSlot<O> slot;
+        try {
+          slot = runtime.take(active);
+        } catch (CancellationException cancellation) {
+          // take observed cancellation with nothing ready in its queue. A sibling may have reached
+          // a
+          // terminal failure whose notification is still pending (on the tail, fillWindow's loop
+          // body did not run, so nothing reconciled it). Reconcile through the same path as every
+          // other cancellation point so that reachable failure keeps precedence over the
+          // cancellation instead of being masked by it.
+          surfaceSubmissionFailure(cancellation, runtime, active, outcomes, ordered);
+          throw cancellation; // unreachable: surfaceSubmissionFailure always throws
+        }
+        outcomes.set(slot.index, runtime.outcome(slot));
+        active.remove(slot);
+        // Refill before delivering, so a burst of completions does not shrink the live window.
+        next = fillWindow(items, permits, next, active, outcomes, ordered, runtime);
+        // fillWindow's beforeSubmit does this recheck whenever work remains; the final (or sole)
+        // completion has no submit left to trip it, so repeat it here every iteration.
+        if (runtime.cancellationObserved()) {
+          surfaceSubmissionFailure(cancelled(), runtime, active, outcomes, ordered);
+        }
+        ordered.deliverReady();
+      }
+    } catch (RuntimeException | Error processingFailure) {
+      runtime.afterFailure(active, processingFailure);
+      throw processingFailure;
+    }
+  }
+
+  /**
+   * Submit inputs until the window holds {@code permits} tasks or inputs are exhausted, reconciling
+   * terminal completions and stopping before the next submission once a failure is reachable in
+   * input order. Reconciling between submissions keeps a synchronous executor safe — a task that
+   * failed during the preceding submit is surfaced before another is started, so later work never
+   * runs on the caller thread past a completed failure — and refills every slot a burst of
+   * completions reopened, so the configured parallelism is not silently collapsed to one. Returns
+   * the next unsubmitted index.
+   */
+  private static <I, O> int fillWindow(
+      List<I> items,
+      int permits,
+      int next,
+      List<CompletionSlot<O>> active,
+      List<TaskOutcome<O>> outcomes,
+      OrderedOutcomeConsumer<O> ordered,
+      TaskRuntime<I, O> runtime) {
+    // Cap this call at one window's worth of submissions. With a synchronous executor the just-
+    // submitted task completes inline, so recordTerminalCompletions empties active every iteration
+    // and active.size() alone would never reach permits — one call would submit the whole batch,
+    // suppress incremental delivery, and rescan a growing contiguous prefix (O(N^2)). The main loop
+    // reconciles and refills between deliveries, so bounding submissions per call restores both.
+    int submitted = 0;
+    while (submitted < permits && active.size() < permits && next < items.size()) {
+      // A sibling's terminal transition happens-before its queue notification, so record terminal
+      // slots directly before each submit: a failure that has completed but is not yet queued would
+      // otherwise stay unreachable here and let the fill proceed past it.
+      runtime.recordTerminalCompletions(active, outcomes);
+      if (ordered.earliestReachableFailure() != null) {
+        break;
+      }
+      try {
+        runtime.beforeSubmit(active);
+        active.add(runtime.submit(next, items.get(next)));
+        next++;
+        submitted++;
+      } catch (RuntimeException | Error submissionFailure) {
+        // A fill failure (cancellation or executor rejection) is reconciled against every terminal
+        // completion, so a store failure an earlier input already produced keeps first-reachable
+        // precedence over it.
+        surfaceSubmissionFailure(submissionFailure, runtime, active, outcomes, ordered);
+      }
+    }
+    return next;
+  }
+
+  /**
+   * Reconcile a submission failure — from {@code beforeSubmit}/{@code submit}, during initial fill
+   * or refill — against work already completed, then surface it (this method always throws). Every
+   * already-terminal completion is recorded into {@code outcomes} first — consulting each future
+   * directly, so a sibling that is terminal but whose queue notification has not yet landed still
+   * counts — so an earlier input's completion cannot leave a later input's failure unreachable in
+   * input order. A failure reachable in the contiguous prefix keeps first-failure precedence: on
+   * cancellation it is thrown in place of the cancellation (no success is published after
+   * cancellation); otherwise the contiguous prefix is delivered — a reachable failure throws here —
+   * before the submission failure itself is surfaced.
+   */
+  private static <O> void surfaceSubmissionFailure(
+      Throwable submissionFailure,
+      TaskRuntime<?, O> runtime,
+      List<CompletionSlot<O>> active,
+      List<TaskOutcome<O>> outcomes,
+      OrderedOutcomeConsumer<O> ordered) {
+    runtime.recordTerminalCompletions(active, outcomes);
+    if (submissionFailure instanceof CancellationException cancellation) {
+      Throwable reachable = ordered.earliestReachableFailure();
+      if (reachable instanceof RuntimeException reachableRuntime) {
+        throw reachableRuntime;
+      }
+      if (reachable instanceof Error reachableError) {
+        throw reachableError;
+      }
+      throw cancellation;
+    }
+    ordered.deliverReady();
+    if (submissionFailure instanceof RuntimeException runtimeFailure) {
+      throw runtimeFailure;
+    }
+    if (submissionFailure instanceof Error errorFailure) {
+      throw errorFailure;
+    }
+    // Structurally enforce the always-throws contract two callers rely on (completeAll's
+    // unreachable
+    // rethrow, fillWindow's catch that would otherwise retry the same index). Submission failures
+    // only ever arrive through catch (RuntimeException | Error), so a checked Throwable here is a
+    // programming error rather than a swallow-and-retry loop.
+    throw new AssertionError(
+        "unexpected throwable type from a submission failure", submissionFailure);
+  }
+
+  /**
+   * The task lifecycle protocol the bounded-window scheduler drives. One implementation today
+   * ({@link CancellableTaskRuntime}); the interface documents the terminal-vs-notified protocol as
+   * a contract rather than a two-implementation hierarchy.
+   */
+  private interface TaskRuntime<I, O> {
+    /** Validate scheduler state before submission without adding or removing active slots. */
+    void beforeSubmit(List<CompletionSlot<O>> active);
+
+    /**
+     * Whether cancellation has been observed. Checked after each completion is recorded and before
+     * it is delivered, so a cancellation that flips during a task's post-I/O work is reconciled
+     * even for the final/sole completion — which has no refill to trip {@link #beforeSubmit}. Must
+     * not throw or mutate state (unlike {@code beforeSubmit}).
+     */
+    boolean cancellationObserved();
+
+    /** Submit one indexed item and return the slot the scheduler owns until completion. */
+    CompletionSlot<O> submit(int index, I item);
+
+    /** Wait for and return one completed member of {@code active} without mutating that list. */
+    CompletionSlot<O> take(List<CompletionSlot<O>> active);
+
+    /**
+     * Whether this slot's future has reached its terminal state. This transition happens-before the
+     * slot's queue notification — a {@link FutureTask} publishes its state before running {@code
+     * done()} — so a reconciliation point must consult it directly rather than the notification
+     * queue, which lags behind it.
+     */
+    boolean isTerminal(CompletionSlot<O> slot);
+
+    /**
+     * Whether this slot's future was cancelled — i.e. abandoned by the scheduler's own cancellation
+     * rather than reaching its own terminal state. Three paths call {@code cancel(true)}: {@code
+     * checkCancelled}, {@code take}'s {@code InterruptedException} catch, and {@code afterFailure}.
+     * Such a slot carries no genuine outcome; recording its interrupt as a failure would mask the
+     * cancellation that caused it.
+     */
+    boolean isCancelled(CompletionSlot<O> slot);
+
+    /**
+     * Record every active slot whose future is already terminal into {@code outcomes}, removing it
+     * from {@code active}. Consults each future directly (see {@link #isTerminal}), so a sibling
+     * that completed but whose queue notification is still pending cannot leave its outcome — a
+     * failure in particular — unreachable in input order at a refill or submission-failure
+     * decision. Each such slot is marked consumed so its later queue notification is skipped by
+     * {@link #take}. A slot the scheduler cancelled contributes no outcome (see {@link
+     * #isCancelled}), so its interrupt cannot masquerade as a reachable failure and mask the
+     * cancellation.
+     *
+     * <p>Dropping a cancelled slot's outcome leaves a permanent {@code null} in {@code outcomes}
+     * while still removing it from {@code active}. That is safe only because every path that
+     * cancels slots then throws unconditionally — {@code checkCancelled}, {@code take}'s {@code
+     * InterruptedException} catch, and {@code afterFailure} from {@code completeAll}'s catch. If
+     * any of them were ever made to continue instead, {@code deliverReady} would stop at that null,
+     * {@code active} would drain, and {@code forEachOrdered} would return NORMALLY having silently
+     * delivered a truncated prefix. Keep the throw — and never leave an index null on a path that
+     * continues, which is why the racing-cancellation catch below records a failure for the slot
+     * instead of dropping it.
+     */
+    default void recordTerminalCompletions(
+        List<CompletionSlot<O>> active, List<TaskOutcome<O>> outcomes) {
+      for (Iterator<CompletionSlot<O>> it = active.iterator(); it.hasNext(); ) {
+        CompletionSlot<O> slot = it.next();
+        if (slot.consumed || !isTerminal(slot)) {
+          continue;
+        }
+        slot.consumed = true;
+        it.remove();
+        if (!isCancelled(slot)) {
+          try {
+            outcomes.set(slot.index, outcome(slot));
+          } catch (CancellationException racedCancellation) {
+            // Guard, not a known-live path: outcome() escapes only for a scheduler-cancelled
+            // future,
+            // and every cancel(true) call site runs on this same scheduler thread, so the
+            // interleaving should be impossible — but a raw CancellationException was observed
+            // escaping forEachOrdered through here in a contended run and never reproduced.
+            //
+            // Record it as this index's failure rather than dropping it. Dropping leaves a
+            // permanent
+            // null here while the slot is already out of active — exactly the truncation this
+            // method's javadoc warns about: deliverReady stops at the null, active drains, and
+            // forEachOrdered returns NORMALLY having delivered a short prefix. Silent data loss is
+            // worse than a surfaced cancellation. As a failure at its own index it obeys
+            // input-order
+            // precedence like any other, so an earlier store failure still wins.
+            CancellationException surfaced =
+                new CancellationException(
+                    "fan-out task " + slot.index + " was cancelled while its outcome was read");
+            surfaced.initCause(racedCancellation);
+            LOG.warn(surfaced.getMessage(), racedCancellation);
+            outcomes.set(slot.index, TaskOutcome.failure(surfaced));
+          }
+        }
+      }
+    }
+
+    /** Capture a completed slot as data; only scheduler cancellation may escape this method. */
+    TaskOutcome<O> outcome(CompletionSlot<O> slot);
+
+    /**
+     * Cancel or abandon active work after scheduler/consumer failure without waiting for it. The
+     * supplied failure remains the caller-visible outcome.
+     */
+    void afterFailure(List<CompletionSlot<O>> active, Throwable processingFailure);
+  }
+
+  /** Interruptible FutureTask lifecycle with cooperative request cancellation. */
+  private static final class CancellableTaskRuntime<I, O> implements TaskRuntime<I, O> {
+    private final Executor executor;
+    private final PropagatedContext context;
+    private final Function<I, O> task;
+    private final BooleanSupplier cancelled;
+    private final IntConsumer completionBarrier;
+    private final BlockingQueue<CompletionSlot<O>> completions = new LinkedBlockingQueue<>();
+
+    private CancellableTaskRuntime(
+        Executor executor,
+        PropagatedContext context,
+        Function<I, O> task,
+        BooleanSupplier cancelled,
+        IntConsumer completionBarrier) {
+      this.executor = executor;
+      this.context = context;
+      this.task = task;
+      this.cancelled = cancelled;
+      this.completionBarrier = completionBarrier;
+    }
+
+    @Override
+    public void beforeSubmit(List<CompletionSlot<O>> active) {
+      checkCancelled(cancelled, active);
+    }
+
+    @Override
+    public boolean cancellationObserved() {
+      return cancelled.getAsBoolean();
+    }
+
+    @Override
+    public CompletionSlot<O> submit(int index, I item) {
+      CompletionSlot<O> slot = new CompletionSlot<>(index);
+      FutureTask<O> submitted =
+          new FutureTask<O>(
+              () ->
+                  context.supply(
+                      () -> {
+                        if (cancelled.getAsBoolean()) {
+                          throw cancelled();
+                        }
+                        return task.apply(item);
+                      })) {
+            @Override
+            protected void done() {
+              // FutureTask publishes its terminal state before running done(); the barrier (a no-op
+              // in production) lets a test hold this notification while the slot is already
+              // terminal. Enqueue in a finally: a barrier that throws or is interrupted must not
+              // orphan the slot, which with a sole active slot would block take() forever on a
+              // future that is already terminal.
+              try {
+                completionBarrier.accept(slot.index);
+              } finally {
+                completions.add(slot);
+              }
+            }
+          };
+      slot.task = submitted;
+      executor.execute(submitted);
+      return slot;
+    }
+
+    @Override
+    public boolean isTerminal(CompletionSlot<O> slot) {
+      return slot.task.isDone();
+    }
+
+    @Override
+    public boolean isCancelled(CompletionSlot<O> slot) {
+      return slot.task.isCancelled();
+    }
+
+    @Override
+    public CompletionSlot<O> take(List<CompletionSlot<O>> active) {
+      // A caller that cannot cancel (NEVER_CANCELLED, by identity) blocks for the next completion
+      // instead of waking every CANCELLATION_POLL_MILLIS to poll a hard-false signal. That polling
+      // scales with request concurrency rather than work: ~100 wakeups/second per in-flight
+      // fan-out,
+      // which the sentinel avoids entirely. A wakeup cost on a conforming executor, nothing more —
+      // the two paths differ in liveness only on a same-pool ForkJoinPool, where both stall anyway
+      // (see the class javadoc), so neither is a way to make that shape work.
+      boolean cancellable = cancelled != NEVER_CANCELLED;
+      while (true) {
+        // Drain a completion that is already ready before observing cancellation, so a task that
+        // has
+        // finished (a failure at the next reachable index in particular) is recorded and keeps its
+        // first-failure precedence rather than being masked by a racing cancellation. Cancellation
+        // is observed only when nothing is ready — active work is still cancelled promptly then. A
+        // slot already recorded through recordTerminalCompletions is skipped: its outcome is set
+        // and it is no longer active, so this stale notification must not be redelivered. Under the
+        // current invariants a redelivery is value-identical — outcome() re-reads the same terminal
+        // future — so this guard is defensive rather than load-bearing, and is not pinned by a
+        // test.
+        // (Not because it lands below nextIndex: a later index recorded out of order while the head
+        // still runs is undelivered, so a redelivery can land at or above it.)
+        CompletionSlot<O> ready = completions.poll();
+        if (ready != null) {
+          if (!ready.consumed) {
+            return ready;
+          }
+          continue;
+        }
+        try {
+          CompletionSlot<O> slot;
+          if (cancellable) {
+            checkCancelled(cancelled, active);
+            slot = managedPoll(completions, CANCELLATION_POLL_MILLIS, TimeUnit.MILLISECONDS);
+          } else {
+            slot = managedTake(completions);
+          }
+          if (slot != null && !slot.consumed) {
+            return slot;
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          cancelSubmittedTasks(active);
+          throw cancelled();
+        }
+      }
+    }
+
+    @Override
+    public TaskOutcome<O> outcome(CompletionSlot<O> slot) {
+      try {
+        return TaskOutcome.success(terminalOutcome(slot.task));
+      } catch (CancellationException cancellation) {
+        // Escape ONLY for a future the scheduler itself abandoned (cancel(true)); that slot carries
+        // no outcome. A CancellationException the task BODY threw is recorded at its own index
+        // instead, so it cannot escape past still-unfinished predecessors and break input-order
+        // precedence. Reachable from recordTerminalCompletions when cancel(true) lands between its
+        // isCancelled pre-check and this read; that caller converts it back to "no outcome" rather
+        // than letting it escape.
+        if (slot.task.isCancelled()) {
+          throw cancellation;
+        }
+        return TaskOutcome.failure(cancellation);
+      } catch (RuntimeException | Error failure) {
+        return TaskOutcome.failure(failure);
+      }
+    }
+
+    @Override
+    public void afterFailure(List<CompletionSlot<O>> active, Throwable processingFailure) {
+      cancelSubmittedTasks(active);
+    }
+  }
+
+  /**
+   * Capture the outcome of an already-terminal future: its result, or its failure propagated
+   * unwrapped. Every caller reaches this with a terminal future — a slot dequeued from {@code
+   * completions} (enqueued only after {@code done()} fires) or one {@link TaskRuntime#isTerminal}
+   * confirmed — so {@code get()} does not wait on the task. The {@code InterruptedException} catch
+   * is unreachable rather than live interrupt handling: {@code FutureTask.awaitDone} yields while
+   * the state is {@code COMPLETING} and only tests {@code Thread.interrupted()} when the state is
+   * still {@code NEW}, which {@code isDone()} has already ruled out. It is kept so the contract
+   * does not depend on that internal detail.
+   */
+  private static <O> O terminalOutcome(Future<O> future) {
+    try {
+      return future.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw cancelled();
+    } catch (ExecutionException e) {
+      throw Futures.propagate(e.getCause(), "unexpected checked exception from fan-out");
+    }
+  }
+
+  private static <O> List<TaskOutcome<O>> emptyOutcomes(int size) {
+    return new ArrayList<>(Collections.nCopies(size, null));
+  }
+
+  /**
+   * Block indefinitely for the next completion without consuming an uncompensated ForkJoinPool
+   * worker when the scheduler and its tasks share that pool. Used only for non-cancellable callers,
+   * which have no signal to poll for.
+   */
+  // Not pinned by a test, deliberately. Its effect is FJP throughput for the supported topology (a
+  // scheduler on an FJP worker dispatching tasks elsewhere): replacing it with a bare queue.take()
+  // leaves the whole suite green, because FJP grows a worker for an external submission regardless
+  // of compensation, so no unit test can isolate it. Attempts to pin it via a same-pool pool only
+  // asserted an unsupported topology — see the class javadoc. Keep it: it is the documented,
+  // correct
+  // way for a ForkJoinWorkerThread to block, and costs nothing off an FJP.
+  private static <T> T managedTake(BlockingQueue<T> queue) throws InterruptedException {
+    QueueTakeBlocker<T> blocker = new QueueTakeBlocker<>(queue);
+    ForkJoinPool.managedBlock(blocker);
+    return blocker.result;
+  }
+
+  /**
+   * Block for a completion without consuming an uncompensated ForkJoinPool worker when the fan-out
+   * scheduler and its tasks share that pool.
+   */
+  private static <T> T managedPoll(BlockingQueue<T> queue, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    QueuePollBlocker<T> blocker = new QueuePollBlocker<>(queue, unit.toNanos(timeout));
+    ForkJoinPool.managedBlock(blocker);
+    return blocker.result;
+  }
+
+  /** Managed blocker for an unbounded completion-queue wait. */
+  private static final class QueueTakeBlocker<T> implements ForkJoinPool.ManagedBlocker {
+    private final BlockingQueue<T> queue;
+    private T result;
+
+    private QueueTakeBlocker(BlockingQueue<T> queue) {
+      this.queue = queue;
+    }
+
+    @Override
+    public boolean block() throws InterruptedException {
+      if (result == null) {
+        result = queue.take();
+      }
+      return true;
+    }
+
+    @Override
+    public boolean isReleasable() {
+      if (result == null) {
+        result = queue.poll();
+      }
+      return result != null;
+    }
+  }
+
+  /** Managed blocker for one bounded completion-queue poll. */
+  private static final class QueuePollBlocker<T> implements ForkJoinPool.ManagedBlocker {
+    private final BlockingQueue<T> queue;
+    private final long deadlineNanos;
+    private T result;
+    private boolean done;
+
+    private QueuePollBlocker(BlockingQueue<T> queue, long timeoutNanos) {
+      this.queue = queue;
+      this.deadlineNanos = System.nanoTime() + timeoutNanos;
+    }
+
+    @Override
+    public boolean block() throws InterruptedException {
+      if (!done) {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos > 0) {
+          result = queue.poll(remainingNanos, TimeUnit.NANOSECONDS);
+        }
+        done = true;
+      }
+      return true;
+    }
+
+    @Override
+    public boolean isReleasable() {
+      if (!done) {
+        result = queue.poll();
+        done = result != null || System.nanoTime() >= deadlineNanos;
+      }
+      return done;
+    }
+  }
+
+  /**
+   * Cancel every active task and fail the caller when its cooperative signal is set, or when the
+   * scheduler thread already carries an interrupt — the mechanism a container uses to unwind a
+   * worker, which must abandon pending work rather than let the batch run to completion.
+   */
+  private static void checkCancelled(
+      BooleanSupplier cancelled, List<? extends CompletionSlot<?>> active) {
+    if (cancelled.getAsBoolean() || Thread.currentThread().isInterrupted()) {
+      cancelSubmittedTasks(active);
+      throw cancelled();
+    }
+  }
+
+  /** Interrupt every submitted task, including work already inside a downstream call. */
+  private static void cancelSubmittedTasks(List<? extends CompletionSlot<?>> active) {
+    // cancel(true) runs FutureTask.finishCompletion -> done() -> the completion barrier, ON THIS
+    // thread. A throw from any one slot must not (a) leave the remaining siblings running, which is
+    // the opposite of this method's purpose, or (b) escape to replace the store failure the caller
+    // is being given — afterFailure runs inside completeAll's catch, just before it rethrows the
+    // original. Cancel every slot, and log any casualty rather than attaching it.
+    RuntimeException cancellationFault = null;
+    for (CompletionSlot<?> slot : active) {
+      if (slot.task == null) {
+        continue;
+      }
+      try {
+        slot.task.cancel(true);
+      } catch (RuntimeException | Error failure) {
+        if (cancellationFault == null) {
+          cancellationFault = new IllegalStateException("failed to cancel a fan-out task");
+        }
+        cancellationFault.addSuppressed(failure);
+      }
+    }
+    if (cancellationFault != null) {
+      // Every slot has been attempted by now. Log rather than throw: the caller's own failure (or
+      // cancellation) is the diagnosis they need, and this cannot be attached to it from here.
+      LOG.warnf(cancellationFault, "one or more fan-out tasks could not be cancelled");
+    }
+  }
+
+  /** Validate the concurrency bound before any tasks are submitted. */
+  private static void validatePermits(int permits) {
+    if (permits < 1) {
+      throw new IllegalArgumentException("BoundedFanout permits must be >= 1, got " + permits);
+    }
+  }
+
+  /** Build the canonical cancellation failure returned to a stopped stream driver. */
+  private static CancellationException cancelled() {
+    return new CancellationException("fan-out cancelled");
+  }
+
+  /** One submitted input and the future through which its completion is observed. */
+  private static final class CompletionSlot<O> {
+    private final int index;
+    private Future<O> task;
+    // Set once this slot's outcome has been recorded through recordTerminalCompletions, so the
+    // queue
+    // notification that lands after the future became terminal is skipped rather than recording —
+    // and
+    // redelivering — the same slot twice. Touched only by the single scheduler thread.
+    private boolean consumed;
+
+    private CompletionSlot(int index) {
+      this.index = index;
+    }
+  }
+
+  /** The successful result or unwrapped failure captured for one input. */
+  private record TaskOutcome<O>(O result, Throwable failure) {
+    private static <O> TaskOutcome<O> success(O result) {
+      return new TaskOutcome<>(result, null);
+    }
+
+    private static <O> TaskOutcome<O> failure(Throwable failure) {
+      return new TaskOutcome<>(null, failure);
+    }
+  }
+
+  /**
+   * Delivers completed results to a caller in input order without stalling the submission window.
+   */
+  private static final class OrderedOutcomeConsumer<O> {
+    private final List<TaskOutcome<O>> outcomes;
+    private final Consumer<? super O> consumer;
+    private final BooleanSupplier cancelled;
+    private int nextIndex;
+
+    private OrderedOutcomeConsumer(
+        List<TaskOutcome<O>> outcomes, Consumer<? super O> consumer, BooleanSupplier cancelled) {
+      this.outcomes = outcomes;
+      this.consumer = consumer;
+      this.cancelled = cancelled;
+    }
+
+    /** Deliver every newly contiguous outcome, stopping at the first unfinished input index. */
+    private void deliverReady() {
+      while (nextIndex < outcomes.size() && outcomes.get(nextIndex) != null) {
+        // Recheck before every publish, not just once per drain: a consumer callback can itself
+        // flip
+        // cancellation, and the rest of an already-ready prefix must not then be published to a
+        // stopped stream.
+        abortIfCancelled();
+        int delivered = nextIndex++;
+        TaskOutcome<O> outcome = outcomes.get(delivered);
+        // Release the delivered outcome from the list: a slot below nextIndex is never re-read, and
+        // null keeps its "not yet complete" meaning only for slots at/after nextIndex. This lets
+        // forEachOrdered stream — a consumed result becomes collectable instead of being pinned for
+        // the whole batch (mapOrdered still retains results in its own list). Memory behaviour
+        // only, so no test pins it; removing it is silently correct and silently retaining.
+        outcomes.set(delivered, null);
+        if (outcome.failure() != null) {
+          throw Futures.propagate(outcome.failure(), "unexpected checked exception from fan-out");
+        }
+        consumer.accept(outcome.result());
+      }
+      // And once after the last publish: with the window already drained, the scheduler's loop
+      // would
+      // otherwise exit and return normally on a cancellation the final callback raised.
+      abortIfCancelled();
+    }
+
+    /**
+     * Abandon the batch when the request has cancelled or the scheduler thread carries an interrupt
+     * — a completed task's queued result would otherwise let a pre-interrupted caller drain the
+     * whole batch without the interrupt ever taking effect. A failure already reachable in input
+     * order keeps precedence: it is the diagnosis the caller needs, and the cancellation merely
+     * raced it.
+     */
+    private void abortIfCancelled() {
+      if (!cancelled.getAsBoolean() && !Thread.currentThread().isInterrupted()) {
+        return;
+      }
+      Throwable reachable = earliestReachableFailure();
+      if (reachable instanceof RuntimeException reachableRuntime) {
+        throw reachableRuntime;
+      }
+      if (reachable instanceof Error reachableError) {
+        throw reachableError;
+      }
+      throw cancelled();
+    }
+
+    /**
+     * The earliest failure in the contiguous completed prefix from the next undelivered index, or
+     * {@code null} — without delivering any success. Lets a task failure already reachable in input
+     * order keep its precedence over an interrupting cancellation.
+     */
+    private Throwable earliestReachableFailure() {
+      for (int i = nextIndex; i < outcomes.size() && outcomes.get(i) != null; i++) {
+        Throwable failure = outcomes.get(i).failure();
+        if (failure != null) {
+          return failure;
+        }
+      }
+      return null;
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+/** Unwrapping helpers for failures surfaced from async tasks. */
+public final class Futures {
+
+  private Futures() {}
+
+  /**
+   * The {@link RuntimeException} to {@code throw} for an unwrapped async failure: the original
+   * unchecked exception, or an {@link IllegalStateException} wrapping an (impossible) checked one.
+   * An {@link Error} cannot be wrapped without losing its type, so it is rethrown <em>directly</em>
+   * from here rather than returned — on that one path the caller's own leading {@code throw} is
+   * unreachable, which is harmless. Always invoke as {@code throw Futures.propagate(...)}.
+   */
+  public static RuntimeException propagate(Throwable failure, String checkedFailureMessage) {
+    if (failure instanceof RuntimeException runtime) {
+      return runtime;
+    }
+    if (failure instanceof Error error) {
+      throw error;
+    }
+    return new IllegalStateException(checkedFailureMessage, failure);
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/PropagatedContext.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.context;
+
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Vertx;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.jboss.logging.MDC;
+
+/**
+ * An immutable snapshot of a thread's ambient request context, for re-establishing it on another
+ * thread. Request context does not follow a task across a thread hop on its own — it lives in
+ * thread-locals (OpenTelemetry's {@link Context}, the resolved call context's scope) — so work
+ * dispatched to an executor loses it, and ambient reads ({@code engineContext()}, principal,
+ * correlation, log MDC) silently read empty off-thread. That is how engine-gated system objects
+ * become unresolvable across a fan-out (eng-floe/floecat#361).
+ *
+ * <p>{@link #capture()} on the originating thread, {@link #supply} on the worker thread. Four
+ * carriers travel together: the OpenTelemetry context (with the call's server span grafted on), the
+ * caller's live {@code io.grpc.Context}, the {@link ResolvedCallContext}, and the log MDC. The
+ * {@code ResolvedCallContext} is the authoritative channel for engine, principal and correlation;
+ * the gRPC context still rides along because several readers consult only its keys
+ * (session/authorization tokens, and the principal/engine fallbacks), and because the inbound
+ * deadline lives there. Centralizing carriers here keeps every dispatch point that uses this
+ * snapshot on the same context set.
+ *
+ * <p>"Snapshot" describes the captured VALUES, not isolation from the request's fate. The gRPC
+ * carrier is a live reference on purpose: a later client cancellation or deadline expiry is visible
+ * to a body already running, which is what lets abandoned fan-out work stop instead of running on
+ * after the request is gone. Do not read this class as detaching the body from its request.
+ *
+ * <p><b>Relationship to {@code flight}'s {@code ContextSnapshot}:</b> the two do the same job for
+ * different dispatch points — {@code ContextSnapshot} serves the Flight producers, this serves
+ * service-layer executor dispatch — and both carry the gRPC context rather than detaching it. They
+ * differ deliberately on one point: {@code ContextSnapshot} calls {@code fork()}, which drops the
+ * cancellable ancestor, so its bodies have no deadline and never observe cancellation; this class
+ * carries the live context so a fan-out unit — work that belongs to the request and should die with
+ * it — still sees the inbound deadline and client cancellation. This one also adds the {@link
+ * ResolvedCallContext} scope (the channel that survives Quarkus's gRPC worker hops, see
+ * eng-floe/floecat#361) and the shared-carrier guard below. Prefer this class for service-layer
+ * dispatch, and change them together rather than letting a third behavior appear.
+ */
+public final class PropagatedContext {
+
+  private final Context otel;
+  private final io.grpc.Context grpc;
+  private final ResolvedCallContext call; // null off any request (e.g. unit tests, startup)
+  private final Map<String, Object> sourceMdc;
+
+  private PropagatedContext(
+      Context otel, io.grpc.Context grpc, ResolvedCallContext call, Map<String, Object> sourceMdc) {
+    this.otel = otel;
+    this.grpc = grpc;
+    this.call = call;
+    // Copy defensively: this snapshot is read concurrently by every worker running supply(), so the
+    // immutability the class promises has to hold at the boundary, not by convention. A later line
+    // stamping a per-task key would otherwise mutate a map being iterated on N threads. Null values
+    // are tolerated rather than fatal — Quarkus/SmallRye and OTel instrumentation write to the MDC
+    // too and can leave nulls, and Map.copyOf would turn that into an NPE on the request thread,
+    // failing the whole request over a logging concern (ContextSnapshot guards the same way).
+    this.sourceMdc = Collections.unmodifiableMap(new HashMap<>(sourceMdc));
+  }
+
+  /** Snapshot the calling thread's ambient context. Call on the request/driver thread. */
+  public static PropagatedContext capture() {
+    return new PropagatedContext(
+        ResolvedCallContexts.withCurrentCallSpan(Context.current()),
+        // The caller's LIVE gRPC context, deliberately not fork(): fork() builds a context with no
+        // cancellableAncestor, so getDeadline() returns null and isCancelled() is permanently false
+        // — the body would silently lose the inbound deadline and never observe client
+        // cancellation.
+        // Carrying the live context (rather than leaving the worker's own) is also what isolates
+        // the
+        // body: readers that consult only gRPC keys — AuthResolutionContexts' session/authorization
+        // tokens, PrincipalProvider/EngineContextProvider's fallbacks — see THIS request's values,
+        // and a body captured off-request carries an empty context instead of a foreign one.
+        io.grpc.Context.current(),
+        ResolvedCallContexts.currentOrNull(),
+        snapshotMdc());
+  }
+
+  /**
+   * Run {@code body} on the current thread with the captured context re-established for its
+   * duration and torn down afterward, so its ambient reads behave as they did on the capturing
+   * thread.
+   */
+  public <T> T supply(Supplier<T> body) {
+    // Refuse to run where the carriers are not ours: see requireThreadConfinedCarriers.
+    requireThreadConfinedCarriers();
+    try (Scope ignored = otel.makeCurrent()) {
+      io.grpc.Context priorGrpc = null;
+      Map<String, Object> priorMdc = null;
+      boolean attached = false;
+      try {
+        // Install the captured gRPC context for the body's duration, replacing whatever the worker
+        // carries, so the readers that consult only its keys see this request. Inside the try: an
+        // exception between attach and the body would otherwise skip the detach in the finally and
+        // strand this request's context on a pooled worker for every later task it runs.
+        priorGrpc = grpc.attach();
+        attached = true;
+        priorMdc = snapshotMdc();
+        replaceMdc(sourceMdc);
+        if (call == null) {
+          // Captured off-request: isolate the body from any foreign request the worker still
+          // carries
+          // through a fallback carrier (duplicated-context local, io.grpc.Context keys), rather
+          // than
+          // callWith(null, ...) which would let those carriers show through.
+          return ResolvedCallContexts.callWithoutRequestScope(body::get);
+        }
+        return ResolvedCallContexts.callWith(
+            call,
+            () -> {
+              InboundContextInterceptor.populateMdc(call);
+              return body.get();
+            });
+      } finally {
+        // Nested so the detach runs even if the MDC restore throws: otherwise this request's gRPC
+        // context stays attached to a pooled worker and every later task on it reads our identity.
+        try {
+          if (priorMdc != null) {
+            replaceMdc(priorMdc);
+          }
+        } finally {
+          if (attached) {
+            grpc.detach(priorGrpc);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Refuse to run where this thread's carriers are shared rather than ours. Under Quarkus a
+   * duplicated Vert.x context backs both the MDC map and the {@code io.grpc.Context} attach slot,
+   * so on such a context every concurrent task on it shares them.
+   *
+   * <p>This throws rather than degrading, because the degradation is not a logging concern.
+   * Skipping the MDC write alone would only mis-attribute log lines; but the gRPC context cannot be
+   * attached there either (its slot is last-writer-wins across overlapping tasks), and then the
+   * body runs with the captured {@link ResolvedCallContext}'s principal and engine while the
+   * readers that consult only gRPC keys — {@code AuthResolutionContexts}' session/authorization
+   * tokens — see whatever ambient request that thread carries. A body running under two requests'
+   * identities at once is a security failure, and a failed task is the better outcome.
+   *
+   * <p>This fires only for a context-propagating executor (a Quarkus {@code ManagedExecutor}, say)
+   * — a wiring mistake, and one whose message names the fix. Dispatching to a plain virtual- or
+   * platform-thread executor never trips it.
+   */
+  private static void requireThreadConfinedCarriers() {
+    io.vertx.core.Context ctx = Vertx.currentContext();
+    if (ctx == null || !VertxContext.isDuplicatedContext(ctx)) {
+      return;
+    }
+    throw new IllegalStateException(
+        "PropagatedContext.supply must run on a thread that owns its MDC and gRPC context, but a"
+            + " Vert.x duplicated context is current: both carriers are shared by every task on it,"
+            + " so propagating would corrupt their MDC and could run this body under a mix of two"
+            + " requests' identities. Dispatch this work to a virtual-/platform-thread executor that"
+            + " does not propagate the Vert.x context.");
+  }
+
+  /** Copy the complete MDC so extension-defined keys participate in isolation and restoration. */
+  private static Map<String, Object> snapshotMdc() {
+    Map<String, Object> values = MDC.getMap();
+    return values == null ? new HashMap<>() : new HashMap<>(values);
+  }
+
+  /**
+   * Replace, rather than merge, MDC state so pooled workers cannot leak foreign request keys.
+   *
+   * <p>Requires a thread-confined MDC store. Under Quarkus the MDC keys off the current Vert.x
+   * context and only falls back to a thread-local when there is none — so the executor must NOT be
+   * a context-propagating one (e.g. a Quarkus {@code ManagedExecutor} sharing a Vert.x context),
+   * where {@link MDC#clear()} would wipe state visible to every concurrent task on that context. A
+   * plain virtual- or platform-thread executor carries no Vert.x context, so the store is
+   * thread-local there; callers must dispatch to one of those.
+   */
+  private static void replaceMdc(Map<String, Object> values) {
+    MDC.clear();
+    for (Map.Entry<String, Object> entry : values.entrySet()) {
+      // Skip nulls: Quarkus's VertxMDC.putObject does requireNonNull on the value, so a null
+      // written
+      // by other instrumentation would throw here — at restore time — defeating the null-tolerant
+      // copy taken at capture.
+      if (entry.getValue() != null) {
+        MDC.put(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
@@ -20,9 +20,11 @@ import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.scanner.utils.EngineContext;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.jboss.logging.Logger;
 import org.jboss.logging.MDC;
@@ -34,9 +36,11 @@ import org.jboss.logging.MDC;
  * <p>The resolved context is carried on three channels, consulted in order of reliability:
  *
  * <ol>
- *   <li><b>Explicit scope</b> ({@link #callWith}/{@link #runWith}) — a thread-confined override for
- *       code that was handed the context by reference across an executor hop. This is the only
- *       channel that works on arbitrary executor threads.
+ *   <li><b>Explicit scope</b> ({@link #callWith}/{@link #runWith}, or the explicitly empty scope
+ *       {@link #callWithoutRequestScope} installs) — a thread-confined override for code that was
+ *       handed the context by reference across an executor hop. This is the only channel that works
+ *       on arbitrary executor threads, and the only one that can deliberately resolve to nothing:
+ *       an empty scope beats the two fallback channels below rather than deferring to them.
  *   <li><b>Vert.x duplicated-context local</b> ({@link #storeOnDuplicatedContext}) — written once
  *       by the inbound interceptor on the same per-call duplicated context that carries MDC. It
  *       survives Quarkus's gRPC dispatch worker hops and Mutiny's contextualized callbacks for
@@ -72,7 +76,10 @@ public final class ResolvedCallContexts {
    */
   private static final String SPAN_LOCAL = "floecat.call-span";
 
-  private static final ThreadLocal<ResolvedCallContext> SCOPE = new ThreadLocal<>();
+  // A present holder is an explicit scope; Optional.empty() is an explicitly empty scope (an
+  // off-request capture) that must win over the fallback carriers. A null value (thread-local
+  // absent) means no explicit scope, so the carriers are consulted.
+  private static final ThreadLocal<Optional<ResolvedCallContext>> SCOPE = new ThreadLocal<>();
 
   private ResolvedCallContexts() {}
 
@@ -142,14 +149,34 @@ public final class ResolvedCallContexts {
   }
 
   /**
+   * Graft the call's gRPC server span onto {@code captured} when {@code captured} carries no valid
+   * span. The server span is not current at the service-method layer — it lives on the
+   * duplicated-context carrier (see {@link #currentCallSpanOrInvalid}) — so without this a hopped
+   * or off-thread body would re-establish an invalid trace root and its spans would silently detach
+   * from the request trace. {@code BaseServiceImpl}'s hopped bodies (unary and both streaming
+   * forms, via {@code otelContextForBody}) and {@link
+   * ai.floedb.floecat.service.context.PropagatedContext} both route their OpenTelemetry context
+   * through here so the graft rule cannot diverge between them.
+   */
+  public static Context withCurrentCallSpan(Context captured) {
+    if (Span.fromContext(captured).getSpanContext().isValid()) {
+      return captured;
+    }
+    Span carried = currentCallSpanOrInvalid();
+    return carried.getSpanContext().isValid() ? captured.with(carried) : captured;
+  }
+
+  /**
    * Returns the resolved call context for the current thread, or {@code null} when no channel
    * carries one. Channels are consulted in reliability order: explicit scope, duplicated-context
-   * local, {@code io.grpc.Context} keys.
+   * local, {@code io.grpc.Context} keys. An explicit scope — including the explicitly empty one an
+   * off-request capture installs — short-circuits: it wins over the fallback carriers, so an
+   * isolated body cannot inherit a foreign request the worker's duplicated or gRPC context bears.
    */
   public static ResolvedCallContext currentOrNull() {
-    ResolvedCallContext scoped = SCOPE.get();
+    Optional<ResolvedCallContext> scoped = SCOPE.get();
     if (scoped != null) {
-      return scoped;
+      return scoped.orElse(null);
     }
     ResolvedCallContext fromDuplicatedContext = fromDuplicatedContext();
     if (fromDuplicatedContext != null) {
@@ -194,12 +221,14 @@ public final class ResolvedCallContexts {
   /**
    * Runs {@code body} with {@code resolved} as the current thread's call context. Use to carry the
    * context by reference across an executor hop: read the context once before the hop, then wrap
-   * the hopped body. Passing {@code null} is allowed and runs the body unscoped.
+   * the hopped body. {@code resolved} must be non-null — see {@link #runWithOrInherit} for the
+   * read-may-be-null case.
    */
   public static void runWith(ResolvedCallContext resolved, Runnable body) {
     Objects.requireNonNull(body, "body");
-    ResolvedCallContext previous = SCOPE.get();
-    SCOPE.set(resolved);
+    Objects.requireNonNull(resolved, "resolved");
+    Optional<ResolvedCallContext> previous = SCOPE.get();
+    SCOPE.set(Optional.of(resolved));
     try {
       body.run();
     } finally {
@@ -209,24 +238,82 @@ public final class ResolvedCallContexts {
 
   /**
    * Calls {@code body} with {@code resolved} as the current thread's call context and returns the
-   * result. Checked exceptions are wrapped in a {@link RuntimeException}.
+   * result. Checked exceptions are wrapped in a {@link RuntimeException}. {@code resolved} must be
+   * non-null — see {@link #callWithOrInherit} for the read-may-be-null case.
    */
   public static <T> T callWith(ResolvedCallContext resolved, Callable<T> body) {
     Objects.requireNonNull(body, "body");
-    ResolvedCallContext previous = SCOPE.get();
-    SCOPE.set(resolved);
+    Objects.requireNonNull(resolved, "resolved");
+    Optional<ResolvedCallContext> previous = SCOPE.get();
+    SCOPE.set(Optional.of(resolved));
+    try {
+      return runBody(body);
+    } finally {
+      restore(previous);
+    }
+  }
+
+  /**
+   * {@link #runWith} for a context read that may legitimately be {@code null} — a service method
+   * grafting a pre-hop read, where "no resolved context" means "inherit", not "isolate". A null
+   * {@code resolved} leaves the enclosing scope in force: with no enclosing scope {@link
+   * #currentOrNull()} still consults the fallback carriers, and inside a {@link
+   * #callWithoutRequestScope} body the isolation is preserved. Named rather than spelled {@code
+   * null} because the three scope states are genuinely distinct and a null used to mean the
+   * opposite of this one.
+   */
+  public static void runWithOrInherit(ResolvedCallContext resolved, Runnable body) {
+    Objects.requireNonNull(body, "body");
+    if (resolved == null) {
+      body.run();
+      return;
+    }
+    runWith(resolved, body);
+  }
+
+  /**
+   * {@link #callWith} for a context read that may legitimately be {@code null}; see {@link
+   * #runWithOrInherit}.
+   */
+  public static <T> T callWithOrInherit(ResolvedCallContext resolved, Callable<T> body) {
+    Objects.requireNonNull(body, "body");
+    if (resolved == null) {
+      return runBody(body);
+    }
+    return callWith(resolved, body);
+  }
+
+  /**
+   * Calls {@code body} under an explicitly empty call scope: {@link #currentOrNull()} returns
+   * {@code null} for its duration regardless of any fallback carrier (duplicated-context local,
+   * {@code io.grpc.Context} keys) the thread bears, and the prior scope is restored afterward. Use
+   * to isolate an off-request body — captured before an executor hop — from a foreign request the
+   * worker may still carry. Distinct from {@code callWith(null, ...)}, which leaves the enclosing
+   * scope in place and lets the carriers show through when there is none.
+   */
+  public static <T> T callWithoutRequestScope(Callable<T> body) {
+    Objects.requireNonNull(body, "body");
+    Optional<ResolvedCallContext> previous = SCOPE.get();
+    SCOPE.set(Optional.empty());
+    try {
+      return runBody(body);
+    } finally {
+      restore(previous);
+    }
+  }
+
+  /** Run {@code body}, wrapping any checked exception in a {@link RuntimeException}. */
+  private static <T> T runBody(Callable<T> body) {
     try {
       return body.call();
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new RuntimeException(e);
-    } finally {
-      restore(previous);
     }
   }
 
-  private static void restore(ResolvedCallContext previous) {
+  private static void restore(Optional<ResolvedCallContext> previous) {
     if (previous == null) {
       SCOPE.remove();
     } else {

--- a/service/src/main/java/ai/floedb/floecat/service/credentials/AuthResolutionContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/credentials/AuthResolutionContexts.java
@@ -17,16 +17,43 @@
 package ai.floedb.floecat.service.credentials;
 
 import ai.floedb.floecat.connector.spi.AuthResolutionContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
 import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
 
 public final class AuthResolutionContexts {
   private AuthResolutionContexts() {}
 
+  /**
+   * The current call's connector-auth tokens.
+   *
+   * <p>Prefers the resolved call context over the {@code io.grpc.Context} keys. Both carry the same
+   * two header values — the inbound interceptor reads the headers once and populates both — but the
+   * gRPC channel is the unreliable one: under Quarkus its attach slot is a shared last-writer-wins
+   * slot that threads of the same call race, so it can read back empty, or stale from a reused
+   * worker, while the resolved context still answers correctly (eng-floe/floecat#361). Reading the
+   * gRPC keys first is therefore how a body carried across an executor hop ends up resolving
+   * connector credentials with blank or another request's tokens while running as its own request.
+   *
+   * <p>A present resolved context is authoritative, including when a token is {@code null}: every
+   * production construction populates these fields from the headers, so {@code null} means the
+   * request did not carry that header rather than "not filled in". The gRPC keys are consulted only
+   * when no resolved context exists at all — non-Vert.x threads and callers that drive {@code
+   * io.grpc.Context} directly.
+   */
   public static AuthResolutionContext fromInboundContext() {
-    String sessionToken = InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get();
-    String authorizationToken = InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get();
+    ResolvedCallContext resolved = ResolvedCallContexts.currentOrNull();
+    if (resolved != null) {
+      return new AuthResolutionContext(
+          blankIfAbsent(resolved.sessionHeaderValue()),
+          blankIfAbsent(resolved.authorizationHeaderValue()));
+    }
     return new AuthResolutionContext(
-        sessionToken == null ? "" : sessionToken,
-        authorizationToken == null ? "" : authorizationToken);
+        blankIfAbsent(InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get()),
+        blankIfAbsent(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get()));
+  }
+
+  private static String blankIfAbsent(String headerValue) {
+    return headerValue == null ? "" : headerValue;
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -1,0 +1,1567 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+/** Verifies bounded scheduling, ordered delivery, fail-fast errors, and prompt cancellation. */
+class BoundedFanoutTest {
+
+  @Test
+  void resultsAreReturnedInInputOrder() {
+    List<Integer> inputs = IntStream.range(0, 50).boxed().toList();
+    // Reverse the completion order (later items sleep less) to prove ordering is by input, not
+    // completion. Needs a pool with real parallelism — on a 1-2 core agent commonPool() would run
+    // these serially in submission order, so there would be nothing to reorder.
+    try (ExecutorService pool = Executors.newFixedThreadPool(8)) {
+      List<Integer> out =
+          BoundedFanout.mapOrdered(
+              inputs,
+              8,
+              pool,
+              i -> {
+                try {
+                  Thread.sleep((50 - i) % 5);
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+                return i * 10;
+              },
+              () -> false);
+      assertThat(out).isEqualTo(inputs.stream().map(i -> i * 10).toList());
+    }
+  }
+
+  @Test
+  void nonCancellableCallerSchedulesThroughTheBlockingTakePath() throws Exception {
+    // Passing NEVER_CANCELLED by identity selects the blocking managedTake path (no cancellation to
+    // poll). Assert it still schedules, orders, and refills correctly across an async executor —
+    // reverse the completion order so a wrong take/refill would reorder results.
+    try (ExecutorService pool = Executors.newFixedThreadPool(4)) {
+      List<Integer> out =
+          BoundedFanout.mapOrdered(
+              IntStream.range(0, 30).boxed().toList(),
+              4,
+              pool,
+              i -> {
+                try {
+                  Thread.sleep((30 - i) % 3);
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+                return i * 2;
+              },
+              BoundedFanout.NEVER_CANCELLED);
+      assertThat(out).isEqualTo(IntStream.range(0, 30).map(i -> i * 2).boxed().toList());
+    }
+  }
+
+  @Test
+  void sameForkJoinPoolSchedulerSchedulesWhileAwaitingSubmittedTasks() throws Exception {
+    // Scheduling only, not compensation: these tasks never block, so the single worker runs them
+    // from its own deque and the scheduler never has to wait. Compensation on the polling path is
+    // in fact broken for a same-pool ForkJoinPool — see the class javadoc, which no longer claims
+    // that shape is supported.
+    ForkJoinPool executor = new ForkJoinPool(1);
+    try {
+      Future<List<Integer>> result =
+          executor.submit(
+              () ->
+                  BoundedFanout.mapOrdered(
+                      List.of(1, 2), 1, executor, value -> value, () -> false));
+
+      assertThat(result.get(5, TimeUnit.SECONDS)).containsExactly(1, 2);
+    } finally {
+      // See above: close() would hang on the regression this test catches.
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void neverRunsMoreThanPermitsAtOnce() {
+    // A pool with more threads than permits, rather than commonPool(): its parallelism is
+    // max(1, cores - 1), so on a 1-2 core CI agent peak could never exceed 1 and the upper bound
+    // would hold vacuously — a regression submitting the whole batch at once would still pass.
+    int permits = 3;
+    AtomicInteger inFlight = new AtomicInteger();
+    AtomicInteger peak = new AtomicInteger();
+    try (ExecutorService pool = Executors.newFixedThreadPool(permits * 3)) {
+      BoundedFanout.mapOrdered(
+          IntStream.range(0, 40).boxed().toList(),
+          permits,
+          pool,
+          i -> {
+            int now = inFlight.incrementAndGet();
+            peak.accumulateAndGet(now, Math::max);
+            try {
+              Thread.sleep(2);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            } finally {
+              inFlight.decrementAndGet();
+            }
+            return i;
+          },
+          () -> false);
+    }
+    assertThat(peak.get()).isLessThanOrEqualTo(permits);
+    // Lower bound so the upper bound cannot pass vacuously: with 40 tasks each sleeping 2ms on a
+    // 9-thread pool, genuine overlap must occur, which is what makes the bound above meaningful.
+    assertThat(peak.get()).as("the permit window must actually be exercised").isGreaterThan(1);
+  }
+
+  @Test
+  void refillsPermitsWhileTheFirstResultIsBlocked() throws Exception {
+    CountDownLatch firstStarted = new CountDownLatch(1);
+    CountDownLatch laterItemStarted = new CountDownLatch(1);
+    CountDownLatch initialWindowSubmitted = new CountDownLatch(1);
+    CountDownLatch releaseFirst = new CountDownLatch(1);
+    AtomicInteger submissions = new AtomicInteger();
+    LinkedBlockingQueue<Runnable> queuedTasks = new LinkedBlockingQueue<>();
+    Executor countingExecutor =
+        command -> {
+          if (submissions.incrementAndGet() == 3) {
+            initialWindowSubmitted.countDown();
+          }
+          queuedTasks.add(command);
+        };
+
+    CompletableFuture<List<Integer>> result =
+        CompletableFuture.supplyAsync(
+            () ->
+                BoundedFanout.mapOrdered(
+                    IntStream.range(0, 100).boxed().toList(),
+                    3,
+                    countingExecutor,
+                    value -> {
+                      if (value == 0) {
+                        firstStarted.countDown();
+                        try {
+                          releaseFirst.await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError(e);
+                        }
+                      } else if (value >= 3) {
+                        laterItemStarted.countDown();
+                      }
+                      return value;
+                    },
+                    () -> false));
+
+    // Before any submitted task completes, only the bounded window may reach the executor.
+    assertThat(initialWindowSubmitted.await(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(submissions.get()).isEqualTo(3);
+    ExecutorService workers = Executors.newFixedThreadPool(3);
+    try {
+      try {
+        for (int i = 0; i < 3; i++) {
+          workers.submit(
+              () -> {
+                try {
+                  while (!result.isDone()) {
+                    Runnable submitted = queuedTasks.poll(10, TimeUnit.MILLISECONDS);
+                    if (submitted != null) {
+                      submitted.run();
+                    }
+                  }
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+              });
+        }
+        assertThat(firstStarted.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(laterItemStarted.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(submissions.get()).isGreaterThan(3);
+      } finally {
+        releaseFirst.countDown();
+      }
+      assertThat(result.get(1, TimeUnit.SECONDS)).hasSize(100);
+    } finally {
+      workers.shutdownNow();
+    }
+  }
+
+  @Test
+  void refillsBeforeDeliveringCompletionToTheCaller() throws Exception {
+    CountDownLatch firstCompletionDelivered = new CountDownLatch(1);
+    CountDownLatch thirdTaskStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirstCompletion = new CountDownLatch(1);
+    CountDownLatch releaseSecondTask = new CountDownLatch(1);
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+      CompletableFuture<Void> result =
+          CompletableFuture.runAsync(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2),
+                      2,
+                      executor,
+                      value -> {
+                        if (value == 1) {
+                          try {
+                            releaseSecondTask.await(30, TimeUnit.SECONDS);
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new AssertionError(e);
+                          }
+                        }
+                        if (value == 2) {
+                          thirdTaskStarted.countDown();
+                        }
+                        return value;
+                      },
+                      value -> {
+                        if (value == 0) {
+                          firstCompletionDelivered.countDown();
+                          try {
+                            releaseFirstCompletion.await(30, TimeUnit.SECONDS);
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new AssertionError(e);
+                          }
+                        }
+                      },
+                      () -> false));
+
+      try {
+        assertThat(firstCompletionDelivered.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(thirdTaskStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      } finally {
+        releaseFirstCompletion.countDown();
+        releaseSecondTask.countDown();
+      }
+      result.get(1, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void orderedConsumerFailureCancelsActiveSiblingsAndReturnsPromptly() throws Exception {
+    AtomicInteger activeSiblingsStarted = new AtomicInteger();
+    CountDownLatch activeSiblingInterrupted = new CountDownLatch(1);
+    CountDownLatch activeSiblingRunning = new CountDownLatch(1);
+    AtomicInteger highestStarted = new AtomicInteger(-1);
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+      CompletableFuture<Throwable> result =
+          captureAsyncFailure(
+              () -> {
+                BoundedFanout.forEachOrdered(
+                    List.of(0, 1, 2, 3, 4),
+                    2,
+                    executor,
+                    value -> {
+                      highestStarted.accumulateAndGet(value, Math::max);
+                      if (value > 0) {
+                        activeSiblingsStarted.incrementAndGet();
+                        activeSiblingRunning.countDown();
+                        try {
+                          // Bounded so a cancellation regression fails fast instead of parking this
+                          // task — and ExecutorService.close() — for ~24h; the interrupt arrives
+                          // well
+                          // within this if cancellation works.
+                          new CountDownLatch(1).await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                          activeSiblingInterrupted.countDown();
+                          Thread.currentThread().interrupt();
+                          throw new CancellationException("active sibling interrupted");
+                        }
+                      }
+                      return value;
+                    },
+                    value -> {
+                      if (value == 0) {
+                        // Wait for a sibling to be genuinely running before failing, so the
+                        // cancellation this test is named for is always exercised. Without this the
+                        // sibling may not have been picked up yet on a low-core agent and the
+                        // assertion below had to be skipped, leaving the behaviour unasserted.
+                        awaitLatch(activeSiblingRunning);
+                        throw new IllegalStateException("ordered merge failed");
+                      }
+                    },
+                    () -> false);
+              });
+
+      assertThat(result.get(5, TimeUnit.SECONDS))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("ordered merge failed");
+      assertThat(activeSiblingsStarted.get())
+          .as("a sibling must have been running for this to test anything")
+          .isGreaterThan(0);
+      assertThat(activeSiblingInterrupted.await(5, TimeUnit.SECONDS))
+          .as("the consumer's failure must interrupt the active sibling")
+          .isTrue();
+      // Two separate claims. The upper bound is the real one: permits=2 must never let input 3 or
+      // 4 start. The lower bound asserts the run got far enough to mean anything — a vacuous
+      // isBetween(0, ...) would have passed even if only input 0 ever ran.
+      assertThat(highestStarted.get())
+          .as("permits=2 must not admit an input beyond index 2")
+          .isLessThanOrEqualTo(2);
+      assertThat(highestStarted.get())
+          .as("the window must have opened past the head for this to test the bound")
+          .isGreaterThanOrEqualTo(1);
+    }
+  }
+
+  @Test
+  void orderedTaskFailureDoesNotWaitForStalledSibling() throws Exception {
+    CountDownLatch siblingStarted = new CountDownLatch(1);
+    CountDownLatch releaseSibling = new CountDownLatch(1);
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+      CompletableFuture<Throwable> result =
+          captureAsyncFailure(
+              () -> {
+                BoundedFanout.forEachOrdered(
+                    List.of(0, 1),
+                    2,
+                    executor,
+                    value -> {
+                      if (value == 0) {
+                        try {
+                          siblingStarted.await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError(e);
+                        }
+                        throw new IllegalStateException("ordered task failed");
+                      }
+                      siblingStarted.countDown();
+                      while (releaseSibling.getCount() != 0) {
+                        try {
+                          releaseSibling.await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException ignored) {
+                          // Deliberately ignore interruption: the known ordered failure must still
+                          // return without waiting for this unrelated downstream call.
+                        }
+                      }
+                      return value;
+                    },
+                    ignored -> {},
+                    () -> false);
+              });
+
+      try {
+        // Inside the try: this assertion can fail, and the sibling below swallows interrupts, so a
+        // release that only ran on the happy path would park a pool worker until close() gives up.
+        assertThat(siblingStarted.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(result.get(5, TimeUnit.SECONDS))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("ordered task failed");
+      } finally {
+        releaseSibling.countDown();
+      }
+    }
+  }
+
+  @Test
+  void orderedMapFailureDoesNotWaitForStalledSibling() throws Exception {
+    CountDownLatch siblingStarted = new CountDownLatch(1);
+    CountDownLatch releaseSibling = new CountDownLatch(1);
+    // A dedicated 2-thread pool, not commonPool(): this scenario needs input 1 to run WHILE input 0
+    // waits on it, and commonPool parallelism is max(1, cores - 1). On a 1-2 core CI agent input 1
+    // would never get a worker, and input 0 — whose wait deliberately ignores interrupts to model a
+    // non-interruptible store call — would park a shared pool worker for the rest of the JVM,
+    // starving every later commonPool test.
+    ExecutorService siblingPool = Executors.newFixedThreadPool(2);
+
+    CompletableFuture<Throwable> result =
+        captureAsyncFailure(
+            () ->
+                BoundedFanout.mapOrdered(
+                    List.of(0, 1),
+                    2,
+                    siblingPool,
+                    value -> {
+                      if (value == 0) {
+                        try {
+                          siblingStarted.await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError(e);
+                        }
+                        throw new IllegalStateException("ordered task failed");
+                      }
+                      siblingStarted.countDown();
+                      while (releaseSibling.getCount() != 0) {
+                        try {
+                          releaseSibling.await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException ignored) {
+                          // CompletableFuture cancellation need not interrupt its running action.
+                        }
+                      }
+                      return value;
+                    },
+                    () -> false));
+
+    try {
+      // Inside the try, as above — and this pool is non-daemon, so a skipped shutdownNow would keep
+      // the surefire JVM alive forever rather than just failing the test.
+      assertThat(siblingStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(result.get(5, TimeUnit.SECONDS))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("ordered task failed");
+    } finally {
+      releaseSibling.countDown();
+      siblingPool.shutdownNow();
+      siblingPool.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void taskFailureSurfacesUnwrapped() {
+    assertThatThrownBy(
+            () ->
+                BoundedFanout.mapOrdered(
+                    List.of(1, 2, 3),
+                    4,
+                    ForkJoinPool.commonPool(),
+                    i -> {
+                      if (i == 2) {
+                        throw new IllegalStateException("boom");
+                      }
+                      return i;
+                    },
+                    () -> false))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("boom");
+  }
+
+  @Test
+  void submissionFailureDoesNotWaitForAlreadySubmittedTasks() throws Exception {
+    CountDownLatch allowTaskCompletion = new CountDownLatch(1);
+    CountDownLatch mapReturned = new CountDownLatch(1);
+    AtomicInteger submissions = new AtomicInteger();
+    Executor rejectSecondSubmission =
+        command -> {
+          if (submissions.getAndIncrement() == 0) {
+            CompletableFuture.runAsync(command);
+            return;
+          }
+          throw new RejectedExecutionException("executor saturated");
+        };
+
+    CompletableFuture<Throwable> result =
+        captureAsyncFailure(
+            () -> {
+              try {
+                BoundedFanout.mapOrdered(
+                    List.of(1, 2),
+                    2,
+                    rejectSecondSubmission,
+                    ignored -> {
+                      try {
+                        allowTaskCompletion.await(30, TimeUnit.SECONDS);
+                      } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError("task interrupted", e);
+                      }
+                      return ignored;
+                    },
+                    () -> false);
+              } finally {
+                mapReturned.countDown();
+              }
+            });
+
+    try {
+      assertThat(mapReturned.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(result.get(5, TimeUnit.SECONDS))
+          .isInstanceOf(RejectedExecutionException.class)
+          .hasMessage("executor saturated");
+    } finally {
+      allowTaskCompletion.countDown();
+    }
+  }
+
+  @Test
+  void refillSubmissionFailureDoesNotWaitForAlreadySubmittedTasks() throws Exception {
+    CountDownLatch blockingTaskStarted = new CountDownLatch(1);
+    CountDownLatch allowBlockingTaskCompletion = new CountDownLatch(1);
+    CountDownLatch mapReturned = new CountDownLatch(1);
+    AtomicInteger submissions = new AtomicInteger();
+    Executor rejectRefillSubmission =
+        command -> {
+          if (submissions.getAndIncrement() < 2) {
+            CompletableFuture.runAsync(command);
+            return;
+          }
+          throw new RejectedExecutionException("executor saturated during refill");
+        };
+
+    CompletableFuture<Throwable> result =
+        captureAsyncFailure(
+            () -> {
+              try {
+                BoundedFanout.mapOrdered(
+                    List.of(1, 2, 3),
+                    2,
+                    rejectRefillSubmission,
+                    value -> {
+                      if (value == 1) {
+                        try {
+                          blockingTaskStarted.await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError("first task interrupted", e);
+                        }
+                      }
+                      if (value == 2) {
+                        blockingTaskStarted.countDown();
+                        try {
+                          allowBlockingTaskCompletion.await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError("task interrupted", e);
+                        }
+                      }
+                      return value;
+                    },
+                    () -> false);
+              } finally {
+                mapReturned.countDown();
+              }
+            });
+
+    assertThat(blockingTaskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    try {
+      assertThat(mapReturned.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(result.get(5, TimeUnit.SECONDS))
+          .isInstanceOf(RejectedExecutionException.class)
+          .hasMessage("executor saturated during refill");
+    } finally {
+      allowBlockingTaskCompletion.countDown();
+    }
+  }
+
+  @Test
+  void cancellationInterruptsRunningTaskAndReturnsWithoutWaitingForIt() throws Exception {
+    CountDownLatch taskStarted = new CountDownLatch(1);
+    CountDownLatch taskInterrupted = new CountDownLatch(1);
+    CountDownLatch allowTaskCompletion = new CountDownLatch(1);
+    AtomicBoolean cancelled = new AtomicBoolean();
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      CompletableFuture<Throwable> result =
+          captureAsyncFailure(
+              () -> {
+                BoundedFanout.forEachOrdered(
+                    List.of(1, 2),
+                    2,
+                    executor,
+                    ignored -> {
+                      taskStarted.countDown();
+                      try {
+                        allowTaskCompletion.await(30, TimeUnit.SECONDS);
+                      } catch (InterruptedException e) {
+                        taskInterrupted.countDown();
+                        Thread.currentThread().interrupt();
+                        throw new CancellationException("task interrupted");
+                      }
+                      return ignored;
+                    },
+                    ignored -> {},
+                    cancelled::get);
+              });
+
+      assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+      cancelled.set(true);
+      try {
+        assertThat(result.get(5, TimeUnit.SECONDS))
+            .isInstanceOf(CancellationException.class)
+            .hasMessage("fan-out cancelled");
+        assertThat(taskInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
+      } finally {
+        allowTaskCompletion.countDown();
+      }
+    }
+  }
+
+  @Test
+  void aRejectedSubmissionSurfacesWhileActiveTasksAreInterrupted() throws Exception {
+    CountDownLatch taskStarted = new CountDownLatch(1);
+    CountDownLatch taskInterrupted = new CountDownLatch(1);
+    // Reject the second submission deterministically — only after the first task has signalled it
+    // started — so afterFailure's interruption of the active task cannot race ahead of taskStarted
+    // and leave the first task cancelled before it ever ran (the prior SynchronousQueue+AbortPolicy
+    // setup was timing-dependent and intermittently flaky).
+    RejectedExecutionHandler rejectAfterFirstStarted =
+        (r, exec) -> {
+          try {
+            taskStarted.await(1, TimeUnit.SECONDS);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          throw new RejectedExecutionException("second submission rejected");
+        };
+    try (ExecutorService executor =
+        new ThreadPoolExecutor(
+            1, 1, 0, TimeUnit.MILLISECONDS, new SynchronousQueue<>(), rejectAfterFirstStarted)) {
+      CompletableFuture<Throwable> result =
+          captureAsyncFailure(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(1, 2),
+                      2,
+                      executor,
+                      ignored -> {
+                        taskStarted.countDown();
+                        try {
+                          // Bounded so a cancellation regression fails fast instead of parking this
+                          // task — and ExecutorService.close() — for ~24h; the interrupt arrives
+                          // well
+                          // within this if cancellation works.
+                          new CountDownLatch(1).await(30, TimeUnit.SECONDS);
+                          return ignored;
+                        } catch (InterruptedException e) {
+                          taskInterrupted.countDown();
+                          Thread.currentThread().interrupt();
+                          throw new CancellationException("task interrupted");
+                        }
+                      },
+                      ignored -> {},
+                      () -> false));
+
+      Throwable failure = result.get(5, TimeUnit.SECONDS);
+      assertThat(failure)
+          .isInstanceOf(RejectedExecutionException.class)
+          .hasMessage("second submission rejected");
+      assertThat(taskInterrupted.await(5, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+
+  @Test
+  void cancellationDuringRefillDoesNotPublishTheCompletedValue() throws Exception {
+    // Task 0 completes and flips cancellation; the window then refills, whose beforeSubmit observes
+    // the cancellation. The already-completed value must NOT be delivered to the consumer after
+    // cancellation was observed — the stage throws CancellationException instead.
+    AtomicBoolean cancelled = new AtomicBoolean();
+    java.util.List<Integer> published = new java.util.ArrayList<>();
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      CompletableFuture<Throwable> result =
+          captureAsyncFailure(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1),
+                      1,
+                      executor,
+                      i -> {
+                        if (i == 0) {
+                          cancelled.set(true);
+                        }
+                        return i;
+                      },
+                      published::add,
+                      cancelled::get));
+      assertThat(result.get(1, TimeUnit.SECONDS)).isInstanceOf(CancellationException.class);
+      assertThat(published).isEmpty();
+    }
+  }
+
+  @Test
+  void aReachableFailureStopsTheRefillRatherThanRacingItsRejection() {
+    // The executor here would reject a third submission, but never sees one: once input 1's queued
+    // failure is reconciled it is reachable in input order, and fillWindow stops before submitting
+    // input 2. So a reachable failure cannot race a refill rejection at all -- it is prevented
+    // structurally rather than resolved by precedence. Asserting the submission count is what makes
+    // that claim testable; without it this reads as a rejection test that silently never rejects.
+    AtomicInteger submissions = new AtomicInteger();
+    try (ExecutorService rejectsAThirdSubmission =
+        countingDirectExecutor(submissions, 2, "submission rejected")) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2),
+                      2,
+                      rejectsAThirdSubmission,
+                      i -> {
+                        if (i == 1) {
+                          throw new IllegalStateException("store error on input 1");
+                        }
+                        return i;
+                      },
+                      ignored -> {},
+                      () -> false))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("store error on input 1");
+    }
+    assertThat(submissions.get())
+        .as("input 2 must never be submitted once input 1's failure is reachable")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void aRefillRejectionStillDeliversTheSuccessesAlreadyReadyBeforeIt() {
+    // The rejection path in surfaceSubmissionFailure delivers ready outcomes before rethrowing, so
+    // work that already succeeded is not silently dropped when the executor saturates mid-batch.
+    // Inputs 0 and 1 both succeed inline; the refill of input 2 is rejected. Both successes must
+    // reach the consumer, and only then the RejectedExecutionException.
+    AtomicInteger submissions = new AtomicInteger();
+    java.util.List<Integer> published = new java.util.ArrayList<>();
+    try (ExecutorService rejectsAThirdSubmission =
+        countingDirectExecutor(submissions, 2, "executor saturated")) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2),
+                      2,
+                      rejectsAThirdSubmission,
+                      i -> i,
+                      published::add,
+                      () -> false))
+          .isInstanceOf(RejectedExecutionException.class)
+          .hasMessage("executor saturated");
+    }
+    assertThat(published)
+        .as("successes ready before the rejection must still be delivered")
+        .containsExactly(0, 1);
+    assertThat(submissions.get()).isEqualTo(3);
+  }
+
+  @Test
+  void aQueuedFailureSurvivesACancellationWhileAnEarlierSuccessIsStillQueued() {
+    // As above, but cancellation is observed instead of a rejection. White-box: with the direct
+    // executor the poll sequence is [beforeSubmit0, task0, beforeSubmit1, task1,
+    // post-initial-fill-recheck] (take/outcome drain without reading the signal), so the signal
+    // flips at index 4 -- in completeAll, right after the initial fill. There is no refill poll:
+    // once input 1's queued failure is reconciled, fillWindow stops before submitting input 2.
+    // Draining input 0's queued success makes input 1's failure reachable and win over the
+    // cancellation.
+    AtomicInteger polls = new AtomicInteger();
+    BooleanSupplier cancelledAfterTheFailure = () -> polls.getAndIncrement() >= 4;
+    try (ExecutorService direct = directExecutorService()) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2),
+                      2,
+                      direct,
+                      i -> {
+                        if (i == 1) {
+                          throw new IllegalStateException("store error on input 1");
+                        }
+                        return i;
+                      },
+                      ignored -> {},
+                      cancelledAfterTheFailure))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("store error on input 1");
+    }
+  }
+
+  @Test
+  void aReachableFailureIsSurfacedWithoutSubmittingLaterWork() {
+    // Once recording a completion exposes a failure reachable in input order, the operation is
+    // terminal and no further task may be submitted: on an inline/caller-runs executor that submit
+    // would run the next task on the caller thread and could stall before the failure is ever
+    // surfaced; on an async executor it is wasted work. permits=1 runs input 0 inline (it fails),
+    // so the refill of input 1 must be skipped -- input 1's task never runs -- and input 0's
+    // failure surfaces immediately.
+    List<Integer> executed = new java.util.ArrayList<>();
+    try (ExecutorService inline = directExecutorService()) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1),
+                      1,
+                      inline,
+                      i -> {
+                        executed.add(i);
+                        if (i == 0) {
+                          throw new IllegalStateException("store error on input 0");
+                        }
+                        return i;
+                      },
+                      ignored -> {},
+                      () -> false))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("store error on input 0");
+    }
+    assertThat(executed).containsExactly(0);
+  }
+
+  @Test
+  void anInitialFillRejectionSurfacesWhenNoFailureIsReachableYet() throws Exception {
+    // The initial-fill rejection arm, which only runs when nothing has failed yet: input 0 blocks
+    // on an async executor so no outcome is reachable, and input 1's submission is rejected inside
+    // the initial-fill loop. The caller must see the RejectedExecutionException, and input 0 must
+    // be interrupted rather than abandoned to run on.
+    // (When a failure IS already reachable, fillWindow stops before this submit -- see
+    // aReachableFailureStopsTheRefillRatherThanRacingItsRejection. That is why this test blocks
+    // input 0 instead of failing it: a failing input 0 would mean no rejection ever fires.)
+    AtomicInteger submissions = new AtomicInteger();
+    CountDownLatch input0Started = new CountDownLatch(1);
+    CountDownLatch input0Interrupted = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    Executor rejectsTheSecondSubmission =
+        command -> {
+          if (submissions.getAndIncrement() >= 1) {
+            // Reject only once input 0 is genuinely running. Otherwise the rejection unwinds and
+            // cancels input 0 before the pool ever starts it, and the interrupt assertion below
+            // would be testing a task that never ran.
+            awaitLatch(input0Started);
+            throw new RejectedExecutionException("initial fill rejected");
+          }
+          pool.execute(command);
+        };
+    try {
+      CompletableFuture<Throwable> result =
+          captureAsyncFailure(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1),
+                      2,
+                      rejectsTheSecondSubmission,
+                      i -> {
+                        input0Started.countDown();
+                        try {
+                          new CountDownLatch(1).await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                          input0Interrupted.countDown();
+                          Thread.currentThread().interrupt();
+                          throw new CancellationException("input 0 interrupted");
+                        }
+                        return i;
+                      },
+                      ignored -> {},
+                      () -> false));
+
+      assertThat(result.get(5, TimeUnit.SECONDS))
+          .isInstanceOf(RejectedExecutionException.class)
+          .hasMessage("initial fill rejected");
+      assertThat(input0Interrupted.await(5, TimeUnit.SECONDS))
+          .as("the already-submitted sibling must be interrupted, not left running")
+          .isTrue();
+      assertThat(submissions.get())
+          .as("the rejection this test is named for must actually fire")
+          .isEqualTo(2);
+    } finally {
+      pool.shutdownNow();
+      pool.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void aTerminalUnnotifiedFailureBeatsACancellationOnTheFinalCompletion() throws Exception {
+    // Pins completeAll's post-completion reconciliation, and it is the only case that can: once
+    // every item has been submitted, fillWindow's loop (gated on next < items.size()) never runs,
+    // so it never reconciles. That leaves this recheck as the sole caller of
+    // recordTerminalCompletions before delivery.
+    //
+    // permits=2 submits both inputs, so no refill remains. Input 1 fails and its future goes
+    // terminal, but the barrier holds its queue notification. Input 0 then succeeds and flips
+    // cancellation. The reconciliation must pick up input 1's held failure so it beats the
+    // cancellation; without it, input 1's outcome is still unrecorded when deliverReady checks,
+    // earliestReachableFailure sees nothing, and the caller gets CancellationException — the store
+    // error masked by teardown, which is the failure mode this whole precedence rule exists to
+    // prevent.
+    var input1Terminal = new CountDownLatch(1);
+    var releaseInput1Notification = new CountDownLatch(1);
+    var cancelled = new AtomicBoolean(false);
+    IntConsumer barrier =
+        index -> {
+          if (index == 1) {
+            input1Terminal.countDown();
+            awaitLatch(releaseInput1Notification);
+          }
+        };
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1),
+                      2,
+                      pool,
+                      i -> {
+                        if (i == 1) {
+                          throw new IllegalStateException("store error on input 1");
+                        }
+                        awaitLatch(input1Terminal); // complete only once input 1 is terminal
+                        cancelled.set(true); // flips as input 0 finishes, before delivery
+                        return i;
+                      },
+                      ignored -> {},
+                      cancelled::get,
+                      barrier))
+          .as("the held store failure must beat the cancellation, not be masked by it")
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("store error on input 1");
+    } finally {
+      releaseInput1Notification.countDown();
+      pool.shutdownNow();
+      pool.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void cancellationRaisedByTheFinalConsumerCallbackStillAborts() {
+    // Pins deliverReady's trailing abortIfCancelled — the one after the publish loop. When the LAST
+    // outcome's callback raises cancellation there is no next publish to recheck before, and the
+    // window is already drained, so the scheduler's loop would exit and forEachOrdered would return
+    // NORMALLY on a cancelled request. (The per-publish check covers a callback that cancels
+    // mid-prefix; only the final callback reaches this one.)
+    var cancelled = new AtomicBoolean(false);
+    var published = new java.util.ArrayList<Integer>();
+    try (ExecutorService direct = directExecutorService()) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0),
+                      1,
+                      direct,
+                      i -> i,
+                      i -> {
+                        published.add(i);
+                        cancelled.set(true); // the final callback cancels
+                      },
+                      cancelled::get))
+          .isInstanceOf(CancellationException.class);
+    }
+    assertThat(published).containsExactly(0);
+  }
+
+  @Test
+  void aReachableFailureBeatsACancellationRaisedByAnEarlierConsumerCallback() {
+    // Pins abortIfCancelled's reachable-failure precedence (as opposed to a bare throw
+    // cancelled()).
+    // permits=3 with a direct executor: fillWindow reconciles before each submit, so input 1's
+    // failure is recorded — and stops the fill before input 2 — while input 0's success is still
+    // undelivered. deliverReady then publishes input 0, whose callback cancels, and the recheck
+    // before the next publish sees BOTH a set cancellation and input 1's reachable failure. The
+    // caller must get the store error, the actual diagnosis, not the cancellation that raced it.
+    var cancelled = new AtomicBoolean(false);
+    var published = new java.util.ArrayList<Integer>();
+    try (ExecutorService direct = directExecutorService()) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2),
+                      3,
+                      direct,
+                      i -> {
+                        if (i == 1) {
+                          throw new IllegalStateException("store error on input 1");
+                        }
+                        return i;
+                      },
+                      i -> {
+                        published.add(i);
+                        cancelled.set(true); // input 0's callback cancels
+                      },
+                      cancelled::get))
+          .as("a reachable failure must outrank the cancellation the callback raised")
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("store error on input 1");
+    }
+    assertThat(published).containsExactly(0);
+  }
+
+  @Test
+  void anInterruptRaisedMidDeliveryStopsTheRestOfTheReadyPrefix() throws Exception {
+    // Pins abortIfCancelled's interrupt disjunct specifically. The pre-interrupt test above aborts
+    // in checkCancelled, before delivery ever starts; here the interrupt arrives from input 0's
+    // callback, with input 1's success already recorded and ready. The cooperative signal is
+    // hard-false, so only the interrupt can stop the prefix — and it must, rather than draining the
+    // remaining ready results under a thread the container is unwinding.
+    // Runs on its own thread so the interrupt cannot leak into sibling tests.
+    var published = new java.util.ArrayList<Integer>();
+    var outcome = new java.util.concurrent.atomic.AtomicReference<Throwable>();
+    Thread scheduler =
+        new Thread(
+            () -> {
+              try (ExecutorService direct = directExecutorService()) {
+                BoundedFanout.forEachOrdered(
+                    List.of(0, 1, 2),
+                    3,
+                    direct,
+                    i -> i,
+                    i -> {
+                      published.add(i);
+                      if (i == 0) {
+                        Thread.currentThread().interrupt();
+                      }
+                    },
+                    BoundedFanout.NEVER_CANCELLED);
+              } catch (Throwable t) {
+                outcome.set(t);
+              }
+            });
+    scheduler.start();
+    scheduler.join(5_000);
+
+    assertThat(outcome.get())
+        .as("an interrupt mid-delivery must abort the batch")
+        .isInstanceOf(CancellationException.class);
+    assertThat(published)
+        .as("the already-ready sibling must not be published after the interrupt")
+        .containsExactly(0);
+  }
+
+  @Test
+  void aPreInterruptedSchedulerThreadAbortsInsteadOfDrainingTheBatch() throws Exception {
+    // Pins the Thread.isInterrupted() disjuncts in checkCancelled and abortIfCancelled. The
+    // cooperative signal is hard-false (NEVER_CANCELLED), so the interrupt is the only stop signal:
+    // a container unwinding this worker must not have the whole batch drained under it just because
+    // every task's result is already queued.
+    var completed = new java.util.concurrent.atomic.AtomicInteger();
+    var outcome = new java.util.concurrent.atomic.AtomicReference<Throwable>();
+    Thread scheduler =
+        new Thread(
+            () -> {
+              Thread.currentThread().interrupt(); // as a container unwind leaves it
+              try (ExecutorService direct = directExecutorService()) {
+                BoundedFanout.forEachOrdered(
+                    List.of(0, 1, 2),
+                    2,
+                    direct,
+                    i -> {
+                      completed.incrementAndGet();
+                      return i;
+                    },
+                    ignored -> {},
+                    BoundedFanout.NEVER_CANCELLED);
+              } catch (Throwable t) {
+                outcome.set(t);
+              }
+            });
+    scheduler.start();
+    scheduler.join(5_000);
+
+    assertThat(outcome.get())
+        .as("a pre-interrupted scheduler must abandon the batch")
+        .isInstanceOf(CancellationException.class);
+    // Exact, not a bound: checkCancelled runs at the very first beforeSubmit, so a pre-interrupted
+    // scheduler submits nothing at all. A looser assertion would also pass if that check were gone
+    // and the abort came from deliverReady instead — after the initial fill had already run
+    // permits-worth of store calls for a request that is already being torn down.
+    assertThat(completed.get())
+        .as("a pre-interrupted scheduler must submit no work at all")
+        .isEqualTo(0);
+  }
+
+  @Test
+  void aSoleTaskFailureKeepsPrecedenceOverCancellationFlippedBeforeItReturns() {
+    // The reconciliation must not blindly mask an already-recorded failure with the cancellation: a
+    // sole unit that both fails and flips cancellation surfaces its store failure, not
+    // CancellationException.
+    AtomicBoolean cancelled = new AtomicBoolean(false);
+    try (ExecutorService direct = directExecutorService()) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0),
+                      1,
+                      direct,
+                      i -> {
+                        cancelled.set(true);
+                        throw new IllegalStateException("store error on input " + i);
+                      },
+                      ignored -> {},
+                      cancelled::get))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("store error on input 0");
+    }
+  }
+
+  private static ExecutorService directExecutorService() {
+    return directExecutor(Integer.MAX_VALUE);
+  }
+
+  /**
+   * Same-thread executor: runs the first {@code runFirst} submissions inline and rejects the rest.
+   */
+  private static ExecutorService countingDirectExecutor(
+      AtomicInteger submissions, int runFirst, String rejectionMessage) {
+    return new java.util.concurrent.AbstractExecutorService() {
+      @Override
+      public void execute(Runnable command) {
+        if (submissions.getAndIncrement() >= runFirst) {
+          throw new RejectedExecutionException(rejectionMessage);
+        }
+        command.run();
+      }
+
+      @Override
+      public void shutdown() {}
+
+      @Override
+      public List<Runnable> shutdownNow() {
+        return List.of();
+      }
+
+      @Override
+      public boolean isShutdown() {
+        return false;
+      }
+
+      @Override
+      public boolean isTerminated() {
+        return false;
+      }
+
+      @Override
+      public boolean awaitTermination(long timeout, TimeUnit unit) {
+        return true;
+      }
+    };
+  }
+
+  private static ExecutorService directExecutor(int runFirst) {
+    return new java.util.concurrent.AbstractExecutorService() {
+      private final AtomicInteger submissions = new AtomicInteger();
+
+      @Override
+      public void execute(Runnable command) {
+        if (submissions.getAndIncrement() >= runFirst) {
+          throw new RejectedExecutionException("submission rejected");
+        }
+        command.run();
+      }
+
+      @Override
+      public void shutdown() {}
+
+      @Override
+      public List<Runnable> shutdownNow() {
+        return List.of();
+      }
+
+      @Override
+      public boolean isShutdown() {
+        return true;
+      }
+
+      @Override
+      public boolean isTerminated() {
+        return true;
+      }
+
+      @Override
+      public boolean awaitTermination(long timeout, TimeUnit unit) {
+        return true;
+      }
+    };
+  }
+
+  @Test
+  void rejectsZeroAndNegativePermits() {
+    // A 0/negative permit count would hand out no permits, blocking every task forever on an
+    // uninterruptible acquire while the caller blocks joining — a permanent hang. Fail fast.
+    for (int badPermits : new int[] {0, -1, -8}) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.mapOrdered(
+                      List.of(1, 2, 3), badPermits, ForkJoinPool.commonPool(), i -> i, () -> false))
+          .as("permits=%d", badPermits)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("permits must be >= 1");
+    }
+  }
+
+  @Test
+  void aTerminalButUnnotifiedFailureIsReconciledBeforeRefill() throws Exception {
+    // A sibling's future becomes terminal before its queue notification lands (FutureTask publishes
+    // its state before done()). At a refill decision that window must not let an already-completed
+    // failure look unreachable and admit more work. permits=2 runs inputs 0 (fails) and 1
+    // (succeeds); the barrier holds input 0's notification while its future is already terminal,
+    // and
+    // input 1 completes only once input 0 is terminal. Recording input 1 must then reconcile input
+    // 0's terminal failure and skip the refill of input 2. Without that reconciliation input 2 is
+    // submitted — and its task releases the held notification so the run finishes and the assertion
+    // fails cleanly instead of deadlocking.
+    var input0Terminal = new CountDownLatch(1);
+    var releaseInput0Notification = new CountDownLatch(1);
+    var input2Submitted = new AtomicBoolean(false);
+    IntConsumer barrier =
+        index -> {
+          if (index == 0) {
+            input0Terminal.countDown();
+            awaitLatch(releaseInput0Notification);
+          }
+        };
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2),
+                      2,
+                      pool,
+                      i -> {
+                        if (i == 0) {
+                          throw new IllegalStateException("store error on input 0");
+                        }
+                        if (i == 1) {
+                          awaitLatch(input0Terminal); // complete only once input 0 is terminal
+                        }
+                        if (i == 2) {
+                          input2Submitted.set(true);
+                          releaseInput0Notification.countDown(); // reached only on the buggy path
+                        }
+                        return i;
+                      },
+                      ignored -> {},
+                      () -> false,
+                      barrier))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("store error on input 0");
+      assertThat(input2Submitted.get())
+          .as("input 2 must not be submitted once input 0's failure has completed")
+          .isFalse();
+    } finally {
+      releaseInput0Notification.countDown();
+      pool.shutdownNow();
+      pool.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void aCancellationDuringTheInitialFillIsReconciledBeforeDelivery() {
+    // With more than one permit and a synchronous executor the initial fill records earlier
+    // successes while it continues. If the last filled task flips cancellation before returning,
+    // those successes must not be published — the initial delivery reconciles cancellation just as
+    // the main loop does, so a stopped stream sees nothing.
+    var cancelled = new AtomicBoolean(false);
+    var published = new java.util.ArrayList<Integer>();
+    try (ExecutorService inline = directExecutorService()) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1),
+                      2,
+                      inline,
+                      i -> {
+                        if (i == 1) {
+                          cancelled.set(true); // last filled task flips cancellation as it finishes
+                        }
+                        return i;
+                      },
+                      published::add,
+                      cancelled::get))
+          .isInstanceOf(CancellationException.class);
+    }
+    assertThat(published).isEmpty();
+  }
+
+  @Test
+  void aCancelledSiblingInterruptDoesNotMaskTheCancellation() {
+    // Input 0 succeeds; input 1 is blocked inside a store call when the request cancels. Cancelling
+    // the batch interrupts input 1, but reconciliation must not record input 1's cancelled future
+    // as
+    // a task failure and surface it in place of the request's cancellation.
+    var input1Started = new CountDownLatch(1);
+    var cancelled = new AtomicBoolean(false);
+    try (ExecutorService pool = Executors.newFixedThreadPool(2)) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2),
+                      2,
+                      pool,
+                      i -> {
+                        if (i == 0) {
+                          awaitLatch(input1Started); // let input 1 start blocking first
+                          cancelled.set(true); // request cancels while input 1 is in its store call
+                          return 0;
+                        }
+                        if (i == 1) {
+                          input1Started.countDown();
+                          try {
+                            new CountDownLatch(1).await(10, TimeUnit.SECONDS); // until interrupted
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException("interrupted store call on input 1");
+                          }
+                        }
+                        return i;
+                      },
+                      ignored -> {},
+                      cancelled::get))
+          .isInstanceOf(CancellationException.class)
+          .hasMessage("fan-out cancelled");
+    }
+  }
+
+  @Test
+  void anInlineInitialFillStopsAtAReachableFailure() {
+    // The initial fill must reconcile a task that failed inline during the preceding submit before
+    // starting the next. permits=2 on a direct executor runs input 0 inline (it fails); input 1
+    // must never be submitted — its side effect never runs — and input 0's failure surfaces.
+    var executed = new java.util.ArrayList<Integer>();
+    try (ExecutorService inline = directExecutorService()) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1),
+                      2,
+                      inline,
+                      i -> {
+                        executed.add(i);
+                        if (i == 0) {
+                          throw new IllegalStateException("store error on input 0");
+                        }
+                        return i;
+                      },
+                      ignored -> {},
+                      () -> false))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("store error on input 0");
+    }
+    assertThat(executed).containsExactly(0);
+  }
+
+  @Test
+  void aBurstOfCompletionsRefillsEveryReopenedSlot() throws Exception {
+    // recordTerminalCompletions can free several slots from a single consumed notification; the
+    // window must refill all of them, not one, or the run collapses to concurrency 1. permits=3
+    // submits inputs 0..2; inputs 1 and 2 finish and their notifications are held (terminal but not
+    // queued) while input 0 completes last as the only consumed notification. Recording input 0
+    // must
+    // then reopen and refill all three slots, so inputs 3, 4 and 5 all reach the executor together.
+    var input1Held = new CountDownLatch(1);
+    var input2Held = new CountDownLatch(1);
+    var releaseHeldNotifications = new CountDownLatch(1);
+    var laterTasksInFlight = new CountDownLatch(3);
+    var releaseLaterTasks = new CountDownLatch(1);
+    IntConsumer barrier =
+        index -> {
+          if (index == 1) {
+            input1Held.countDown();
+            awaitLatch(releaseHeldNotifications);
+          } else if (index == 2) {
+            input2Held.countDown();
+            awaitLatch(releaseHeldNotifications);
+          }
+        };
+    ExecutorService pool = Executors.newCachedThreadPool();
+    try {
+      CompletableFuture<Void> fanout =
+          CompletableFuture.runAsync(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2, 3, 4, 5),
+                      3,
+                      pool,
+                      i -> {
+                        if (i == 0) {
+                          awaitLatch(input1Held); // input 0 finishes only once 1 and 2 are terminal
+                          awaitLatch(input2Held);
+                        } else if (i >= 3) {
+                          laterTasksInFlight.countDown();
+                          awaitLatch(releaseLaterTasks);
+                        }
+                        return i;
+                      },
+                      ignored -> {},
+                      () -> false,
+                      barrier));
+      assertThat(laterTasksInFlight.await(5, TimeUnit.SECONDS))
+          .as("all three reopened slots must be refilled, not just one")
+          .isTrue();
+      releaseLaterTasks.countDown();
+      releaseHeldNotifications.countDown();
+      fanout.get(5, TimeUnit.SECONDS);
+    } finally {
+      releaseLaterTasks.countDown();
+      releaseHeldNotifications.countDown();
+      pool.shutdownNow();
+      pool.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void aTaskThrownCancellationDoesNotAbandonAnEarlierStillRunningTask() throws Exception {
+    // A task body throwing CancellationException is a task failure, not a scheduler cancellation of
+    // the batch. permits=2: input 1 throws it while input 0 is still running; input 0 must NOT be
+    // interrupted/abandoned — input 1's failure is recorded at its own index and surfaces only in
+    // input order, never by cancelling the earlier task.
+    var input1Threw = new CountDownLatch(1);
+    var releaseInput0 = new CountDownLatch(1);
+    var input0Interrupted = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      CompletableFuture<Void> fanout =
+          CompletableFuture.runAsync(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1),
+                      2,
+                      pool,
+                      i -> {
+                        if (i == 1) {
+                          input1Threw.countDown();
+                          throw new CancellationException("task cancel at input 1");
+                        }
+                        try {
+                          releaseInput0.await(5, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          input0Interrupted.countDown();
+                          throw new CancellationException("input 0 interrupted");
+                        }
+                        return 0;
+                      },
+                      ignored -> {},
+                      () -> false));
+      assertThat(input1Threw.await(5, TimeUnit.SECONDS)).isTrue();
+      // This asserts an absence, so it waits for the bad event rather than sleeping and looking
+      // afterwards: a regression that abandons input 0 interrupts it while it is blocked here and
+      // trips the latch at once (fast failure), while correct behaviour simply burns the timeout.
+      // A fixed sleep would have had the same floor with none of the fast failure.
+      assertThat(input0Interrupted.await(500, TimeUnit.MILLISECONDS))
+          .as("a later task's cancellation must not abandon an earlier still-running task")
+          .isFalse();
+      releaseInput0.countDown();
+      assertThatThrownBy(fanout::join)
+          .hasCauseInstanceOf(CancellationException.class)
+          .hasRootCauseMessage("task cancel at input 1");
+      assertThat(input0Interrupted.getCount())
+          .as("input 0 must still not have been interrupted once the batch has settled")
+          .isEqualTo(1);
+    } finally {
+      releaseInput0.countDown();
+      pool.shutdownNow();
+      pool.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void aSynchronousExecutorDeliversIncrementallyRatherThanRunningTheWholeBatchFirst() {
+    // With a same-thread executor, recordTerminalCompletions empties active every iteration;
+    // without
+    // a per-call submission cap, one fillWindow call would run the entire input before delivering
+    // any result (and rescan a growing prefix, O(N^2)). Assert the first result is delivered before
+    // the last input runs.
+    var events = new java.util.ArrayList<String>();
+    try (ExecutorService inline = directExecutorService()) {
+      BoundedFanout.forEachOrdered(
+          List.of(0, 1, 2, 3, 4, 5),
+          2,
+          inline,
+          i -> {
+            events.add("run " + i);
+            return i;
+          },
+          i -> events.add("deliver " + i),
+          () -> false);
+    }
+    assertThat(events.indexOf("deliver 0"))
+        .as("the first result must be delivered before the last input runs")
+        .isLessThan(events.indexOf("run 5"));
+  }
+
+  @Test
+  void aThrowingCompletionBarrierDoesNotOrphanTheTerminalSlot() {
+    // The barrier runs in done() before the slot is enqueued. If a throw skipped that enqueue, a
+    // sole-slot fan-out would wait forever on a future that is already terminal — no sibling
+    // notification exists to wake it. The slot must be enqueued regardless, so the scheduler still
+    // makes progress and delivers the completed result.
+    IntConsumer throwingBarrier =
+        index -> {
+          throw new IllegalStateException("barrier failed for index " + index);
+        };
+    List<Integer> delivered = new java.util.ArrayList<>();
+    try (ExecutorService pool = Executors.newFixedThreadPool(1)) {
+      assertTimeoutPreemptively(
+          Duration.ofSeconds(5),
+          () ->
+              BoundedFanout.forEachOrdered(
+                  List.of(0), 1, pool, i -> i, delivered::add, () -> false, throwingBarrier),
+          "a barrier failure must not orphan the slot and hang take()");
+    }
+    assertThat(delivered).containsExactly(0);
+  }
+
+  @Test
+  void cancellationRaisedByAConsumerCallbackStopsTheRestOfTheReadyPrefix() {
+    // A whole prefix can be ready at once (here: an inline executor runs every task before delivery
+    // begins). If the first callback cancels, the remaining already-ready values must not be
+    // published to the now-stopped stream, and the call must not return normally just because the
+    // window is already drained.
+    var cancelled = new AtomicBoolean(false);
+    var published = new java.util.ArrayList<Integer>();
+    try (ExecutorService inline = directExecutorService()) {
+      assertThatThrownBy(
+              () ->
+                  BoundedFanout.forEachOrdered(
+                      List.of(0, 1, 2, 3),
+                      4,
+                      inline,
+                      i -> i,
+                      i -> {
+                        published.add(i);
+                        cancelled.set(true); // the first delivery stops the stream
+                      },
+                      cancelled::get))
+          .isInstanceOf(CancellationException.class);
+    }
+    assertThat(published)
+        .as("no further ready result may be published after the consumer cancelled")
+        .containsExactly(0);
+  }
+
+  private static void awaitLatch(CountDownLatch latch) {
+    try {
+      // Bounded so a test regression that never releases the latch fails fast rather than parking a
+      // worker task — and the managing ExecutorService.close() — for up to a day.
+      if (!latch.await(30, TimeUnit.SECONDS)) {
+        throw new AssertionError("timed out waiting for a test coordination latch");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CancellationException("interrupted");
+    }
+  }
+
+  /** Run one assertion scenario asynchronously and expose its terminal failure as a value. */
+  private static CompletableFuture<Throwable> captureAsyncFailure(Runnable scenario) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            scenario.run();
+            return null;
+          } catch (Throwable failure) {
+            return failure;
+          }
+        });
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/FuturesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/FuturesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/** Pins the unwrapping contract the fan-out relies on to surface a task's original failure. */
+class FuturesTest {
+
+  @Test
+  void propagateReturnsTheOriginalUncheckedFailureForTheCallerToThrow() {
+    IllegalStateException original = new IllegalStateException("store error");
+
+    assertThatThrownBy(
+            () -> {
+              throw Futures.propagate(original, "unused");
+            })
+        .isSameAs(original);
+  }
+
+  @Test
+  void propagateWrapsAnImpossibleCheckedCauseAsIllegalState() {
+    IOException checked = new IOException("impossible here: fan-out tasks throw only unchecked");
+
+    assertThatThrownBy(
+            () -> {
+              throw Futures.propagate(checked, "unexpected checked exception from fan-out");
+            })
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("unexpected checked exception from fan-out")
+        .hasCause(checked);
+  }
+
+  @Test
+  void propagateRethrowsAnErrorDirectlyRatherThanWrappingIt() {
+    // An Error cannot be wrapped without losing its type, so propagate throws it from inside rather
+    // than returning it — the documented asymmetry that makes callers' leading `throw` unreachable
+    // on this one path.
+    OutOfMemoryError error = new OutOfMemoryError("heap");
+
+    assertThatThrownBy(() -> Futures.propagate(error, "unused")).isSameAs(error);
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/PropagatedContextTest.java
@@ -1,0 +1,681 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.connector.spi.AuthResolutionContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
+import ai.floedb.floecat.service.context.impl.ResolvedCallContexts;
+import ai.floedb.floecat.service.credentials.AuthResolutionContexts;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Vertx;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.jboss.logging.MDC;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Off-thread propagation is the whole point of {@link PropagatedContext}: a fan-out worker never
+ * inherits the request thread's thread-locals, so without re-establishing them the ambient reads
+ * ({@code engineContext()}, the log MDC) read empty. These tests capture on a context-bearing
+ * thread and assert the body sees that context on a plain executor thread that carries none of its
+ * own.
+ */
+class PropagatedContextTest {
+
+  private static final java.util.concurrent.ScheduledExecutorService deadlineScheduler =
+      java.util.concurrent.Executors.newSingleThreadScheduledExecutor(
+          r -> {
+            Thread t = new Thread(r, "test-deadline");
+            t.setDaemon(true);
+            return t;
+          });
+
+  @Test
+  void aThrowingBodyStillRestoresEveryCarrier() throws Exception {
+    // supply()'s try/finally nesting is justified only in comments — that an exception between the
+    // gRPC attach and the body must not skip the detach, and that the detach must run even if the
+    // MDC restore throws. Nothing asserted it. Run on a pooled thread deliberately left carrying a
+    // foreign gRPC context and a stale MDC key, so a missed restore is visible.
+    ExecutorService worker = Executors.newSingleThreadExecutor();
+    try {
+      ResolvedCallContext resolved = resolvedWithEngine("spark");
+      PropagatedContext captured =
+          ResolvedCallContexts.callWith(resolved, PropagatedContext::capture);
+      io.grpc.Context foreign =
+          io.grpc.Context.current()
+              .withValue(
+                  InboundContextInterceptor.PC_KEY,
+                  PrincipalContext.newBuilder().setSubject("foreign").build());
+
+      Object[] after =
+          worker
+              .submit(
+                  () -> {
+                    MDC.put("leftover", "stale");
+                    io.grpc.Context priorGrpc = foreign.attach();
+                    try {
+                      assertThatThrownBy(
+                              () ->
+                                  captured.supply(
+                                      () -> {
+                                        throw new IllegalStateException("body failed");
+                                      }))
+                          .isInstanceOf(IllegalStateException.class)
+                          .hasMessage("body failed");
+                      return new Object[] {
+                        InboundContextInterceptor.PC_KEY.get().getSubject(),
+                        MDC.get("leftover"),
+                        MDC.get("floecat_engine_kind")
+                      };
+                    } finally {
+                      foreign.detach(priorGrpc);
+                      MDC.clear();
+                    }
+                  })
+              .get(5, TimeUnit.SECONDS);
+
+      assertThat(after[0])
+          .as("the worker's own gRPC context must be reattached after a throwing body")
+          .isEqualTo("foreign");
+      assertThat(after[1]).as("the worker's own MDC must be restored").isEqualTo("stale");
+      assertThat(after[2]).as("no captured MDC key may leak past the body").isNull();
+    } finally {
+      worker.shutdownNow();
+    }
+  }
+
+  @Test
+  void propagatesTheOtelSpanToTheWorkerSoOffThreadTracesStayAttached() throws Exception {
+    // The class promises to re-establish OpenTelemetry context across the hop; assert span identity
+    // on the worker, which no other test did. (capture()'s other half — grafting the call span when
+    // the captured context has none — needs a Vert.x duplicated context. The graft helper itself is
+    // pinned by ResolvedCallContextsSpanTest; capture()'s CALL of it is not covered here.)
+    SpanContext spanContext =
+        SpanContext.create(
+            "00000000000000000000000000000abc",
+            "0000000000000abc",
+            TraceFlags.getSampled(),
+            TraceState.getDefault());
+    Span span = Span.wrap(spanContext);
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    try (Scope ignored = Context.current().with(span).makeCurrent()) {
+      PropagatedContext captured = PropagatedContext.capture();
+      String seenSpanId =
+          foreign
+              .submit(() -> captured.supply(() -> Span.current().getSpanContext().getSpanId()))
+              .get();
+      assertThat(seenSpanId).isEqualTo("0000000000000abc");
+    } finally {
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
+  void anEmptyCaptureIsolatesFromAForeignScopeOnTheExecutionThread() throws Exception {
+    // Captured off any request, so the captured call context is null. When that body later runs on
+    // a thread already bearing a foreign request scope, it must not inherit that scope's principal
+    // or engine — supply() installs an explicitly empty scope for the body and restores the foreign
+    // one afterward.
+    PropagatedContext captured = PropagatedContext.capture();
+    ResolvedCallContext foreign = resolvedWithEngine("spark");
+    ExecutorService worker = Executors.newSingleThreadExecutor();
+    try {
+      worker
+          .submit(
+              () ->
+                  ResolvedCallContexts.callWith(
+                      foreign,
+                      () -> {
+                        ResolvedCallContext seenInBody =
+                            captured.supply(ResolvedCallContexts::currentOrNull);
+                        assertThat(seenInBody)
+                            .as("off-request body must not inherit the worker's foreign scope")
+                            .isNull();
+                        assertThat(ResolvedCallContexts.currentOrNull())
+                            .as("the foreign scope is restored after supply")
+                            .isSameAs(foreign);
+                        return null;
+                      }))
+          .get();
+    } finally {
+      worker.shutdownNow();
+    }
+  }
+
+  @Test
+  void anEmptyCaptureIsolatesFromAFallbackCarrierNotJustAnExplicitScope() throws Exception {
+    // The worker bears a foreign request only through a fallback carrier (io.grpc.Context keys),
+    // not
+    // an explicit scope. An off-request capture must still isolate: the explicitly empty scope that
+    // supply() installs wins over the fallback, so the body observes no foreign principal or
+    // engine.
+    PropagatedContext captured = PropagatedContext.capture(); // off-request: call == null
+    io.grpc.Context grpcWithForeignRequest =
+        io.grpc.Context.current()
+            .withValue(
+                InboundContextInterceptor.PC_KEY,
+                PrincipalContext.newBuilder().setSubject("foreign-subject").build());
+    grpcWithForeignRequest.call(
+        () -> {
+          // Premise of the test: the fallback carrier really does resolve, and to the foreign
+          // request. A bare isNotNull() here would also pass if it resolved to something else,
+          // leaving the isolation assertion below testing nothing in particular.
+          assertThat(ResolvedCallContexts.currentOrNull())
+              .isNotNull()
+              .extracting(c -> c.principalContext().getSubject())
+              .isEqualTo("foreign-subject");
+          ResolvedCallContext seenInBody = captured.supply(ResolvedCallContexts::currentOrNull);
+          assertThat(seenInBody)
+              .as("an off-request body must not inherit a foreign request from a fallback carrier")
+              .isNull();
+          return null;
+        });
+  }
+
+  @Test
+  void anOnRequestCaptureCarriesTheGrpcContextKeysIntoTheBody() throws Exception {
+    // The counterpart to the isolation test below: several readers consult ONLY gRPC keys — the
+    // session/authorization tokens AuthResolutionContexts reads, and the principal/engine fallbacks
+    // —
+    // so the captured context has to travel, not be detached. Detaching it would hand fan-out tasks
+    // empty credentials, breaking connector credential resolution while every ResolvedCallContext
+    // assertion still passed.
+    PrincipalContext principal =
+        PrincipalContext.newBuilder().setAccountId("acct-1").setSubject("subject-1").build();
+    io.grpc.Context inbound =
+        io.grpc.Context.current()
+            .withValue(InboundContextInterceptor.PC_KEY, principal)
+            .withValue(
+                InboundContextInterceptor.ENGINE_CONTEXT_KEY, EngineContext.of("duckdb", "1"))
+            .withValue(InboundContextInterceptor.SESSION_HEADER_VALUE_KEY, "session-token")
+            .withValue(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY, "Bearer real");
+    ExecutorService worker = Executors.newSingleThreadExecutor();
+    try {
+      PropagatedContext captured = inbound.call(PropagatedContext::capture);
+      worker
+          .submit(
+              () ->
+                  captured.supply(
+                      () -> {
+                        assertThat(InboundContextInterceptor.SESSION_HEADER_VALUE_KEY.get())
+                            .as("the request's session token must reach the worker")
+                            .isEqualTo("session-token");
+                        assertThat(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get())
+                            .as("and its authorization token")
+                            .isEqualTo("Bearer real");
+                        assertThat(InboundContextInterceptor.PC_KEY.get()).isEqualTo(principal);
+                        return null;
+                      }))
+          .get();
+    } finally {
+      worker.shutdownNow();
+    }
+  }
+
+  @Test
+  void theInboundDeadlineAndCancellationReachTheBody() throws Exception {
+    // The captured gRPC context must keep its cancellable ancestor. Context.fork() drops it, and
+    // then getDeadline() returns null and isCancelled() is permanently false — the body silently
+    // loses the request's deadline and can never observe client cancellation, which for
+    // non-interruptible store work means it keeps running after the request is gone.
+    io.grpc.Context.CancellableContext cancellable =
+        io.grpc.Context.current().withDeadlineAfter(30, TimeUnit.SECONDS, deadlineScheduler);
+    ExecutorService worker = Executors.newSingleThreadExecutor();
+    try {
+      PropagatedContext captured = cancellable.call(PropagatedContext::capture);
+      io.grpc.Deadline inboundDeadline = cancellable.getDeadline();
+      assertThat(inboundDeadline).isNotNull();
+
+      worker
+          .submit(
+              () ->
+                  captured.supply(
+                      () -> {
+                        assertThat(io.grpc.Context.current().getDeadline())
+                            .as("the worker must see the inbound deadline, not a fresh one")
+                            .isSameAs(inboundDeadline);
+                        assertThat(io.grpc.Context.current().isCancelled()).isFalse();
+                        return null;
+                      }))
+          .get();
+
+      cancellable.cancel(new RuntimeException("client went away"));
+      worker
+          .submit(
+              () ->
+                  captured.supply(
+                      () -> {
+                        assertThat(io.grpc.Context.current().isCancelled())
+                            .as("client cancellation must be observable in the body")
+                            .isTrue();
+                        return null;
+                      }))
+          .get();
+    } finally {
+      cancellable.close();
+      worker.shutdownNow();
+    }
+  }
+
+  @Test
+  void anEmptyCaptureIsolatesTheGrpcContextFallbackReadersToo() throws Exception {
+    // The empty call scope only makes ResolvedCallContexts.currentOrNull() null. Several readers
+    // bypass it and fall back straight to io.grpc.Context keys — PrincipalProvider.get(),
+    // EngineContextProvider.engineContext(), the inbound session/authorization keys — so without
+    // detaching that context an off-request body would read the FOREIGN request's principal and
+    // engine through its own supposedly-isolated scope. This is the cross-request leak the scope
+    // alone does not close.
+    PropagatedContext captured = PropagatedContext.capture(); // off-request: call == null
+    PrincipalContext foreignPrincipal =
+        PrincipalContext.newBuilder()
+            .setAccountId("other-acct")
+            .setSubject("other-subject")
+            .build();
+    io.grpc.Context foreignRequest =
+        io.grpc.Context.current()
+            .withValue(InboundContextInterceptor.PC_KEY, foreignPrincipal)
+            .withValue(InboundContextInterceptor.ENGINE_CONTEXT_KEY, EngineContext.of("spark", "3"))
+            .withValue(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY, "Bearer foreign");
+    var principals = new PrincipalProvider();
+    var engines = new EngineContextProvider();
+
+    foreignRequest.call(
+        () -> {
+          // Sanity: on this thread the foreign request really is visible through the fallbacks.
+          assertThat(principals.get().getSubject()).isEqualTo("other-subject");
+
+          captured.supply(
+              () -> {
+                assertThat(principals.get().getSubject())
+                    .as("an off-request body must not inherit the foreign principal")
+                    .isEmpty();
+                assertThat(engines.engineContext().engineKind())
+                    .as("nor the foreign engine — an isolated body resolves to no engine at all")
+                    .isEmpty();
+                assertThat(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY.get())
+                    .as("nor the foreign authorization token")
+                    .isNull();
+                return null;
+              });
+
+          // The foreign context is restored for the caller afterward.
+          assertThat(principals.get().getSubject()).isEqualTo("other-subject");
+          return null;
+        });
+  }
+
+  @Test
+  void supplyRefusesToRunWhereTheCarriersAreSharedRatherThanOwned() throws Exception {
+    // On a Quarkus duplicated Vert.x context both the MDC map and the gRPC attach slot are shared
+    // by
+    // every task on it. Propagating there would corrupt their MDC AND — because the gRPC context
+    // cannot be attached either — run the body under the captured principal while the key-only
+    // readers (session/authorization tokens) see whatever ambient request the thread carries. That
+    // mixed identity is worse than a failed task, so this fails fast. No production path reaches
+    // it:
+    // supply runs on the fan-out's virtual threads or the admission pool's platform threads.
+    MDC.put("floecat_component", "ambient-component");
+    PropagatedContext captured = PropagatedContext.capture();
+    Vertx vertx = Vertx.vertx();
+    try {
+      assertThatThrownBy(
+              () ->
+                  onDuplicatedContext(
+                      vertx,
+                      () -> {
+                        MDC.put("floecat_component", "shared-context-owner");
+                        return captured.supply(() -> "unreachable");
+                      }))
+          .cause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("owns its MDC and gRPC context");
+
+      // And it refuses BEFORE touching either carrier: the shared context's MDC is left intact.
+      String ambient =
+          onDuplicatedContext(
+              vertx,
+              () -> {
+                MDC.put("floecat_component", "shared-context-owner");
+                try {
+                  captured.supply(() -> "unreachable");
+                } catch (IllegalStateException expected) {
+                  // fall through to read the MDC back
+                }
+                return String.valueOf(MDC.get("floecat_component"));
+              });
+      assertThat(ambient)
+          .as("the shared context's MDC must not be cleared or replaced")
+          .isEqualTo("shared-context-owner");
+    } finally {
+      vertx.close();
+      MDC.remove("floecat_component");
+    }
+  }
+
+  @Test
+  void captureGraftsTheCallSpanSoAWorkerStaysOnTheRequestTrace() throws Exception {
+    // capture()'s second half: the gRPC server span is not current at the service-method layer, it
+    // lives on the duplicated-context carrier. Without the graft a captured context has no valid
+    // span, the worker re-roots its trace, and off-thread spans silently detach from the request.
+    // ResolvedCallContextsSpanTest pins withCurrentCallSpan itself; this pins capture()'s use of
+    // it,
+    // which nothing did — removing the call left all 20 context tests green.
+    Span carried =
+        Span.wrap(
+            SpanContext.createFromRemoteParent(
+                "0af7651916cd43dd8448eb211c80319c",
+                "b7ad6b7169203331",
+                TraceFlags.getSampled(),
+                TraceState.getDefault()));
+    Vertx vertx = Vertx.vertx();
+    ExecutorService worker = Executors.newSingleThreadExecutor();
+    try {
+      PropagatedContext captured =
+          onDuplicatedContext(
+              vertx,
+              () -> {
+                ResolvedCallContexts.storeSpanOnDuplicatedContext(carried);
+                assertThat(Span.current().getSpanContext().isValid())
+                    .as("premise: no span is current at the capture point")
+                    .isFalse();
+                return PropagatedContext.capture();
+              });
+
+      String seenSpanId =
+          worker
+              .submit(() -> captured.supply(() -> Span.current().getSpanContext().getSpanId()))
+              .get(5, TimeUnit.SECONDS);
+
+      assertThat(seenSpanId)
+          .as("the worker must run under the request's server span, not a fresh trace root")
+          .isEqualTo("b7ad6b7169203331");
+    } finally {
+      worker.shutdownNow();
+      vertx.close();
+    }
+  }
+
+  @Test
+  void connectorCredentialsFollowTheResolvedContextNotTheGrpcCarrier() throws Exception {
+    // The #361 shape, end to end. Request A is captured with its tokens on the RESOLVED context
+    // while the raw io.grpc.Context carries none — the state the duplicated-context race produces.
+    // The body then runs on a pooled worker where foreign request B's gRPC keys are ambient.
+    //
+    // AuthResolutionContexts is the last reader of those tokens, and it used to read the gRPC keys
+    // only. That made a fan-out task resolve connector credentials with blank tokens (or, on a
+    // reused worker whose captured slot went stale, request B's) while every other part of the task
+    // ran as request A — the cross-request leak this class exists to prevent.
+    ResolvedCallContext requestA =
+        new ResolvedCallContext(
+            PrincipalContext.newBuilder().setSubject("subject-a").build(),
+            "query-a",
+            "corr-a",
+            EngineContext.of("duckdb", "1.0"),
+            "session-a",
+            "authorization-a");
+
+    PropagatedContext captured =
+        ResolvedCallContexts.callWith(requestA, PropagatedContext::capture);
+
+    io.grpc.Context foreignRequestB =
+        io.grpc.Context.current()
+            .withValue(
+                InboundContextInterceptor.PC_KEY,
+                PrincipalContext.newBuilder().setSubject("subject-b").build())
+            .withValue(InboundContextInterceptor.SESSION_HEADER_VALUE_KEY, "session-b")
+            .withValue(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY, "authorization-b");
+
+    ExecutorService worker = Executors.newSingleThreadExecutor();
+    try {
+      AuthResolutionContext seen =
+          worker
+              .submit(
+                  () -> {
+                    io.grpc.Context prior = foreignRequestB.attach();
+                    try {
+                      return captured.supply(AuthResolutionContexts::fromInboundContext);
+                    } finally {
+                      foreignRequestB.detach(prior);
+                    }
+                  })
+              .get(5, TimeUnit.SECONDS);
+
+      assertThat(seen.sessionToken())
+          .as(
+              "the worker must resolve credentials as request A, whose tokens only the resolved"
+                  + " context carries")
+          .isEqualTo("session-a");
+      assertThat(seen.authorizationToken()).isEqualTo("authorization-a");
+    } finally {
+      worker.shutdownNow();
+    }
+  }
+
+  @Test
+  void connectorCredentialsStillFallBackToTheGrpcKeysOffAnyResolvedContext() {
+    // The fallback branch: no resolved context at all (a non-Vert.x thread, or a caller driving
+    // io.grpc.Context directly). The gRPC keys remain the source there, so the preference above
+    // cannot blank out credentials for those callers.
+    io.grpc.Context onlyGrpcKeys =
+        io.grpc.Context.current()
+            .withValue(InboundContextInterceptor.SESSION_HEADER_VALUE_KEY, "session-legacy")
+            .withValue(InboundContextInterceptor.AUTHORIZATION_HEADER_VALUE_KEY, "auth-legacy");
+
+    AuthResolutionContext seen =
+        ResolvedCallContexts.callWithoutRequestScope(
+            () -> onlyGrpcKeys.call(AuthResolutionContexts::fromInboundContext));
+
+    assertThat(seen.sessionToken()).isEqualTo("session-legacy");
+    assertThat(seen.authorizationToken()).isEqualTo("auth-legacy");
+  }
+
+  /** Runs {@code body} on a fresh Vert.x duplicated context and returns its result. */
+  private static <T> T onDuplicatedContext(Vertx vertx, Supplier<T> body) throws Exception {
+    CompletableFuture<T> result = new CompletableFuture<>();
+    io.vertx.core.Context duplicated =
+        VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+    duplicated.runOnContext(
+        ignored -> {
+          try {
+            result.complete(body.get());
+          } catch (Throwable t) {
+            result.completeExceptionally(t);
+          }
+        });
+    return result.get(10, TimeUnit.SECONDS);
+  }
+
+  private static ResolvedCallContext resolvedWithEngine(String engineKind) {
+    return new ResolvedCallContext(
+        PrincipalContext.getDefaultInstance(),
+        "query-1",
+        "corr-1",
+        EngineContext.of(engineKind, "16.0"),
+        null,
+        null);
+  }
+
+  @Test
+  void reEstablishesAmbientContextOnAForeignThread() throws Exception {
+    ResolvedCallContext resolved = resolvedWithEngine("duckdb");
+    // A single-thread pool that never saw the request: its thread-locals are empty until supply()
+    // re-establishes them, so a wrong read here would be the real regression.
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    MDC.put("floecat_component", "query-resolver");
+    MDC.put("floecat_operation", "resolve-inputs");
+    try {
+      String engineKind =
+          ResolvedCallContexts.callWith(
+              resolved,
+              () -> {
+                PropagatedContext captured = PropagatedContext.capture();
+                return foreign
+                    .submit(
+                        () ->
+                            captured.supply(
+                                () -> {
+                                  ResolvedCallContext seen = ResolvedCallContexts.currentOrNull();
+                                  assertThat(seen)
+                                      .as("the captured call context must cross the thread hop")
+                                      .isSameAs(resolved);
+                                  // MDC is derived from the call context, so off-thread log lines
+                                  // carry the request's ids too.
+                                  assertThat(MDC.get("floecat_engine_kind")).isEqualTo("duckdb");
+                                  assertThat(MDC.get("correlation_id")).isEqualTo("corr-1");
+                                  assertThat(MDC.get("floecat_component"))
+                                      .isEqualTo("query-resolver");
+                                  assertThat(MDC.get("floecat_operation"))
+                                      .isEqualTo("resolve-inputs");
+                                  return seen.engineContext().engineKind();
+                                }))
+                    .get();
+              });
+      assertThat(engineKind).isEqualTo("duckdb");
+    } finally {
+      foreign.shutdownNow();
+      MDC.remove("floecat_component");
+      MDC.remove("floecat_operation");
+    }
+  }
+
+  @Test
+  void clearsMdcAfterTheBodySoAPooledThreadDoesNotLeakIt() throws Exception {
+    ResolvedCallContext resolved = resolvedWithEngine("spark");
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    try {
+      // MDC.get is typed Object, so keep the carrier Object too rather than casting.
+      Object mdcAfterBody =
+          ResolvedCallContexts.callWith(
+              resolved,
+              () -> {
+                PropagatedContext captured = PropagatedContext.capture();
+                return foreign
+                    .submit(
+                        () -> {
+                          captured.supply(
+                              () -> {
+                                assertThat(MDC.get("floecat_engine_kind")).isEqualTo("spark");
+                                return null;
+                              });
+                          // Same pooled thread, outside the body: the request's ids must be gone so
+                          // the next unrelated task cannot inherit them.
+                          return MDC.get("floecat_engine_kind");
+                        })
+                    .get();
+              });
+      assertThat(mdcAfterBody).isNull();
+    } finally {
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
+  void clearsExtensionMdcKeysAddedByTheBody() throws Exception {
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    try {
+      Object mdcAfterBody =
+          foreign
+              .submit(
+                  () -> {
+                    PropagatedContext.capture()
+                        .supply(
+                            () -> {
+                              MDC.put("extension_tenant", "tenant-a");
+                              return null;
+                            });
+                    return MDC.get("extension_tenant");
+                  })
+              .get();
+
+      assertThat(mdcAfterBody).isNull();
+    } finally {
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
+  void replacesForeignWorkerMdcWithTheCompleteCapturedMap() throws Exception {
+    ExecutorService foreign = Executors.newSingleThreadExecutor();
+    MDC.put("extension_tenant", "request-tenant");
+    try {
+      PropagatedContext captured = PropagatedContext.capture();
+      foreign.submit(() -> MDC.put("extension_tenant", "stale-worker-tenant")).get();
+
+      Object tenantSeenByBody =
+          foreign.submit(() -> captured.supply(() -> MDC.get("extension_tenant"))).get();
+      Object tenantRestoredAfterBody = foreign.submit(() -> MDC.get("extension_tenant")).get();
+
+      assertThat(tenantSeenByBody).isEqualTo("request-tenant");
+      assertThat(tenantRestoredAfterBody).isEqualTo("stale-worker-tenant");
+    } finally {
+      MDC.remove("extension_tenant");
+      foreign.shutdownNow();
+    }
+  }
+
+  @Test
+  void restoresExistingMdcAfterAnInlineNestedScope() {
+    MDC.put("floecat_component", "outer-component");
+    MDC.put("floecat_operation", "outer-operation");
+    MDC.put("correlation_id", "outer-correlation");
+    try {
+      ResolvedCallContexts.callWith(
+          resolvedWithEngine("spark"),
+          () -> {
+            PropagatedContext.capture()
+                .supply(
+                    () -> {
+                      assertThat(MDC.get("floecat_engine_kind")).isEqualTo("spark");
+                      return null;
+                    });
+            return null;
+          });
+
+      assertThat(MDC.get("floecat_component")).isEqualTo("outer-component");
+      assertThat(MDC.get("floecat_operation")).isEqualTo("outer-operation");
+      assertThat(MDC.get("correlation_id")).isEqualTo("outer-correlation");
+    } finally {
+      MDC.remove("floecat_component");
+      MDC.remove("floecat_operation");
+      MDC.remove("correlation_id");
+    }
+  }
+
+  @Test
+  void offAnyRequestTheBodyStillRuns() {
+    // Captured with no ambient request (startup, unit tests): supply must run the body rather than
+    // fail, and no context is fabricated.
+    PropagatedContext captured = PropagatedContext.capture();
+    assertThat(captured.supply(() -> "ran")).isEqualTo("ran");
+    assertThat(ResolvedCallContexts.currentOrNull()).isNull();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptorContextTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/InboundContextInterceptorContextTest.java
@@ -72,6 +72,23 @@ class InboundContextInterceptorContextTest {
     assertEquals(null, MDC.get("correlation_id"));
   }
 
+  @Test
+  void populateMdcOwnsOnlyTheRequestIdsNotTheDispatchDimensions() {
+    // PropagatedContext relies on this split: it re-establishes the dispatching work's
+    // component/operation from its captured MDC snapshot and then calls populateMdc for the
+    // call-derived request ids. If populateMdc ever grew to write component/operation it would
+    // clobber the fan-out's own dimensions with the inbound RPC's, so pin the boundary here.
+    MDC.clear();
+    MDC.put("floecat_component", "query-resolver");
+    MDC.put("floecat_operation", "resolve-inputs");
+
+    InboundContextInterceptor.populateMdc(sampleContext());
+
+    assertEquals("query-resolver", MDC.get("floecat_component"));
+    assertEquals("resolve-inputs", MDC.get("floecat_operation"));
+    InboundContextInterceptor.clearMdc();
+  }
+
   private static ResolvedCallContext sampleContext() {
     return new ResolvedCallContext(
         PrincipalContext.newBuilder().setAccountId("acct-1").setSubject("subject-1").build(),

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/ResolvedCallContextsScopeTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/ResolvedCallContextsScopeTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.context.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.flight.context.ResolvedCallContext;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the three states of the explicit call scope, which decide whose principal and engine a
+ * nested body sees. They are only distinguishable by reading {@code callWith}, {@code
+ * callWithoutRequestScope} and {@code currentOrNull} together, so each is asserted here rather than
+ * left to a reader to infer:
+ *
+ * <ul>
+ *   <li><b>absent</b> — no explicit scope; {@code currentOrNull} consults the fallback carriers.
+ *   <li><b>present</b> — {@code callWith(resolved, …)} overrides for the body's duration.
+ *   <li><b>explicitly empty</b> — {@code callWithoutRequestScope} makes {@code currentOrNull}
+ *       return null even when a fallback carrier could answer.
+ * </ul>
+ */
+class ResolvedCallContextsScopeTest {
+
+  @Test
+  void callWithOrInheritNullLeavesAnEnclosingScopeInForce() {
+    // The behaviour changed here: a null argument used to CLEAR an enclosing scope (falling back to
+    // the ambient carriers). It now leaves the enclosing scope alone, so a service body that grafts
+    // a possibly-null context read before a thread hop cannot accidentally drop the caller's scope.
+    ResolvedCallContext outer = resolved("duckdb");
+
+    ResolvedCallContexts.callWith(
+        outer,
+        () -> {
+          ResolvedCallContext seen =
+              ResolvedCallContexts.callWithOrInherit(null, ResolvedCallContexts::currentOrNull);
+          assertThat(seen)
+              .as("callWithOrInherit(null, ...) must not clear the scope its caller established")
+              .isSameAs(outer);
+          return null;
+        });
+  }
+
+  @Test
+  void runWithOrInheritNullAlsoLeavesAnEnclosingScopeInForce() {
+    // runWith is the void-returning twin of callWith and repeats the null check rather than
+    // delegating, so callWith's coverage does not extend to it: the two can drift apart silently.
+    ResolvedCallContext outer = resolved("trino");
+    AtomicReference<ResolvedCallContext> seen = new AtomicReference<>();
+
+    ResolvedCallContexts.callWith(
+        outer,
+        () -> {
+          ResolvedCallContexts.runWithOrInherit(
+              null, () -> seen.set(ResolvedCallContexts.currentOrNull()));
+          return null;
+        });
+
+    assertThat(seen.get())
+        .as("runWithOrInherit(null, ...) must not clear the scope its caller established")
+        .isSameAs(outer);
+  }
+
+  @Test
+  void callWithOrInheritNullOutsideAnyScopeLeavesTheFallbackCarriersVisible() {
+    // With no enclosing scope, a null argument installs nothing, so currentOrNull still consults
+    // the
+    // fallback carriers — what BaseServiceImpl.run relies on when its pre-hop read returned null.
+    io.grpc.Context withFallbackRequest =
+        io.grpc.Context.current()
+            .withValue(
+                InboundContextInterceptor.PC_KEY,
+                PrincipalContext.newBuilder().setSubject("from-grpc").build());
+
+    withFallbackRequest.run(
+        () -> {
+          ResolvedCallContext seen =
+              ResolvedCallContexts.callWithOrInherit(null, ResolvedCallContexts::currentOrNull);
+          assertThat(seen).isNotNull();
+          assertThat(seen.principalContext().getSubject()).isEqualTo("from-grpc");
+        });
+  }
+
+  @Test
+  void callWithoutRequestScopeHidesBothAnEnclosingScopeAndTheFallbackCarriers() {
+    // The explicitly-empty state: distinct from "absent", and the reason the thread-local holds an
+    // Optional rather than a bare context.
+    ResolvedCallContext outer = resolved("spark");
+    io.grpc.Context withFallbackRequest =
+        io.grpc.Context.current()
+            .withValue(
+                InboundContextInterceptor.PC_KEY,
+                PrincipalContext.newBuilder().setSubject("from-grpc").build());
+
+    withFallbackRequest.run(
+        () ->
+            ResolvedCallContexts.callWith(
+                outer,
+                () -> {
+                  ResolvedCallContext seen =
+                      ResolvedCallContexts.callWithoutRequestScope(
+                          ResolvedCallContexts::currentOrNull);
+                  assertThat(seen)
+                      .as(
+                          "an explicitly empty scope beats both the enclosing scope and the carrier")
+                      .isNull();
+                  assertThat(ResolvedCallContexts.currentOrNull())
+                      .as("and the enclosing scope is restored afterward")
+                      .isSameAs(outer);
+                  return null;
+                }));
+  }
+
+  @Test
+  void callWithAndRunWithRejectNullRatherThanSilentlyInheriting() {
+    // A null used to CLEAR the enclosing scope. Keeping it a silent convention on these two would
+    // mean an old caller's null flips from "isolate" to "inherit" with no error and leaks the
+    // caller's scope into the body. The inherit case is now a separately named method.
+    assertThatThrownBy(() -> ResolvedCallContexts.callWith(null, () -> null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> ResolvedCallContexts.runWith(null, () -> {}))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  private static ResolvedCallContext resolved(String engineKind) {
+    return new ResolvedCallContext(
+        PrincipalContext.getDefaultInstance(),
+        "query-1",
+        "corr-1",
+        EngineContext.of(engineKind, "1.0"),
+        null,
+        null);
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/context/impl/ResolvedCallContextsSpanTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/context/impl/ResolvedCallContextsSpanTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
 import java.util.concurrent.CompletableFuture;
@@ -84,6 +85,61 @@ class ResolvedCallContextsSpanTest {
   }
 
   @Test
+  void theCarriedCallSpanIsGraftedOntoAnOtelContextThatHasNone() throws Exception {
+    // The graft itself, which the store/read tests above do not reach: withCurrentCallSpan is what
+    // BaseServiceImpl's hopped bodies and PropagatedContext.capture() both rely on. The server span
+    // is not current at the service-method layer, so a captured context has no valid span; without
+    // the graft a hopped body re-roots its spans and they detach from the request trace.
+    Vertx vertx = Vertx.vertx();
+    try {
+      Span grafted =
+          onDuplicatedContext(
+              vertx,
+              () -> {
+                ResolvedCallContexts.storeSpanOnDuplicatedContext(SAMPLED_SPAN);
+                Context withNoSpan = Context.root();
+                assertFalse(
+                    Span.fromContext(withNoSpan).getSpanContext().isValid(),
+                    "premise: the captured context must carry no valid span");
+                return Span.fromContext(ResolvedCallContexts.withCurrentCallSpan(withNoSpan));
+              });
+      assertTrue(grafted.getSpanContext().isValid());
+      assertEquals(
+          SAMPLED_SPAN.getSpanContext().getTraceId(), grafted.getSpanContext().getTraceId());
+      assertEquals(SAMPLED_SPAN.getSpanContext().getSpanId(), grafted.getSpanContext().getSpanId());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
+  void anAlreadyValidSpanIsNotReplacedByTheCarriedOne() throws Exception {
+    // The graft must not override a context that already has a span: that context is the more
+    // specific one (a body that started its own span), and replacing it would reparent live spans.
+    Vertx vertx = Vertx.vertx();
+    try {
+      Span kept =
+          onDuplicatedContext(
+              vertx,
+              () -> {
+                ResolvedCallContexts.storeSpanOnDuplicatedContext(SAMPLED_SPAN);
+                Span own =
+                    Span.wrap(
+                        SpanContext.createFromRemoteParent(
+                            "11111111111111111111111111111111",
+                            "2222222222222222",
+                            TraceFlags.getSampled(),
+                            TraceState.getDefault()));
+                return Span.fromContext(
+                    ResolvedCallContexts.withCurrentCallSpan(Context.root().with(own)));
+              });
+      assertEquals("2222222222222222", kept.getSpanContext().getSpanId());
+    } finally {
+      vertx.close().toCompletionStage().toCompletableFuture().get();
+    }
+  }
+
+  @Test
   void anInvalidSpanIsNotCarried() throws Exception {
     Vertx vertx = Vertx.vertx();
     try {
@@ -94,10 +150,17 @@ class ResolvedCallContextsSpanTest {
           onDuplicatedContext(
               vertx,
               () -> {
+                // Store a valid span first: if the invalid store were NOT a no-op it would
+                // overwrite this, so reading back the valid span proves the skip. Asserting only
+                // that the result is invalid would pass either way.
+                ResolvedCallContexts.storeSpanOnDuplicatedContext(SAMPLED_SPAN);
                 ResolvedCallContexts.storeSpanOnDuplicatedContext(Span.getInvalid());
                 return ResolvedCallContexts.currentCallSpanOrInvalid();
               });
-      assertFalse(readBack.getSpanContext().isValid());
+      assertTrue(
+          readBack.getSpanContext().isValid(), "the invalid store must not have overwritten it");
+      assertEquals(
+          SAMPLED_SPAN.getSpanContext().getSpanId(), readBack.getSpanContext().getSpanId());
     } finally {
       vertx.close().toCompletionStage().toCompletableFuture().get();
     }

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionsServiceImplTest.java
@@ -165,8 +165,55 @@ class TransactionsServiceImplTest {
   void commitAppliedResyncsTheTouchedTableRoots() throws Exception {
     var service = newService();
     var rootWriter = Mockito.mock(ai.floedb.floecat.service.catalog.impl.TableRootWriter.class);
+    var rootResyncQueue =
+        Mockito.mock(ai.floedb.floecat.service.catalog.impl.RootResyncQueue.class);
     inject(service, "rootWriter", rootWriter);
+    inject(service, "rootResyncQueue", rootResyncQueue);
+    when(rootWriter.resyncFromCommittedState(any())).thenReturn(true);
 
+    Transaction committed = commitTransactionTouchingTable1(service);
+
+    assertEquals(TransactionState.TS_APPLIED, committed.getState());
+    var expectedTable = resourceId("tbl-1", ResourceKind.RK_TABLE);
+    verify(rootWriter).resyncFromCommittedState(expectedTable);
+    Mockito.verifyNoMoreInteractions(rootWriter);
+    // The queue is the failure branch's job alone. Without this the success path would still pass
+    // if a regression enqueued a re-drive marker on every commit, quietly turning the GC's
+    // convergence backlog into a per-commit queue.
+    Mockito.verifyNoInteractions(rootResyncQueue);
+  }
+
+  @Test
+  void commitLeavesAReDriveMarkerWhenTheRootResyncFails() throws Exception {
+    // A table only ever touched by REST transactions has no other writer to converge its root, so a
+    // failed resync must leave a durable re-drive marker for the periodic transaction GC — the sole
+    // remaining convergence path. Losing the marker would strand such a table divergent until its
+    // next unrelated write, so verify the failure branch enqueues it exactly once.
+    var service = newService();
+    var rootWriter = Mockito.mock(ai.floedb.floecat.service.catalog.impl.TableRootWriter.class);
+    var rootResyncQueue =
+        Mockito.mock(ai.floedb.floecat.service.catalog.impl.RootResyncQueue.class);
+    inject(service, "rootWriter", rootWriter);
+    inject(service, "rootResyncQueue", rootResyncQueue);
+    when(rootWriter.resyncFromCommittedState(any())).thenReturn(false);
+
+    Transaction committed = commitTransactionTouchingTable1(service);
+
+    assertEquals(TransactionState.TS_APPLIED, committed.getState());
+    var expectedTable = resourceId("tbl-1", ResourceKind.RK_TABLE);
+    verify(rootWriter).resyncFromCommittedState(expectedTable);
+    verify(rootResyncQueue).enqueue(expectedTable);
+    Mockito.verifyNoMoreInteractions(rootResyncQueue);
+  }
+
+  /**
+   * Drive a commit whose transaction moves table {@code tbl-1}'s definition and current-snapshot
+   * pointers, so post-apply root reconciliation touches exactly {@code tbl-1}. Returns the
+   * committed transaction; the caller injects the root-writer/queue mocks and asserts the
+   * reconciliation.
+   */
+  private Transaction commitTransactionTouchingTable1(TransactionsServiceImpl service)
+      throws Exception {
     Transaction txn = preparedTxn();
     Transaction txnApplying = txn.toBuilder().setState(TransactionState.TS_APPLYING).build();
     // The applier moves this table's definition pointer AND its current-snapshot pointer by raw
@@ -209,17 +256,11 @@ class TransactionsServiceImplTest {
             anyLong()))
         .thenReturn(true);
 
-    Transaction committed =
-        invokeCommitPrivate(
-            service,
-            "acct",
-            CommitTransactionRequest.newBuilder().setTxId("tx-1").build(),
-            Timestamps.fromMillis(10));
-
-    assertEquals(TransactionState.TS_APPLIED, committed.getState());
-    var expectedTable = resourceId("tbl-1", ResourceKind.RK_TABLE);
-    verify(rootWriter).resyncFromCommittedState(expectedTable);
-    Mockito.verifyNoMoreInteractions(rootWriter);
+    return invokeCommitPrivate(
+        service,
+        "acct",
+        CommitTransactionRequest.newBuilder().setTxId("tx-1").build(),
+        Timestamps.fromMillis(10));
   }
 
   @Test


### PR DESCRIPTION
Foundation for parallelizing metadata work: the parallelism substrate plus the request-context carrier it needs. No domain wiring yet — the first production caller arrives in PR 4.

### What's here

- **`BoundedFanout`** — runs independent, mostly-blocking tasks under a concurrency bound: at most *N* in flight, a completed task immediately reopens a slot, results delivered in **input order**. The first failure reachable in input order propagates immediately; active siblings are cancelled or abandoned rather than drained. Fan-out methods are **package-private on purpose** — the narrow surface the later admission tier drives, so a per-unit store call cannot reach the store un-admitted.
- **`PropagatedContext`** — captures a request's ambient context and re-establishes it on worker threads. Four carriers travel together: the OpenTelemetry context (with the call's gRPC server span grafted on), the forked `io.grpc.Context`, the `ResolvedCallContext`, and the log MDC.
- **`ResolvedCallContexts`** — gains `withCurrentCallSpan` (the span-graft rule, previously duplicated verbatim in `BaseServiceImpl`, which now delegates) and `callWithoutRequestScope` (an explicitly-empty scope, distinct from "no scope").
- **`Futures.propagate`** — surfaces a task's original `RuntimeException`/`Error` instead of an execution wrapper.

### Contracts worth reviewing

These are the properties the scheduler actually promises, each stated in the class javadoc because each has a sharp edge:

- **First-failure precedence holds from the very first submit.** An initial-fill or refill submission failure (cancellation, executor rejection) is reconciled against every already-terminal task, so a real store failure always wins over a masking rejection. Reconciliation consults futures directly rather than the completion queue, because a future's terminal transition happens-before its queue notification.
- **`permits` bounds concurrency, not buffered results.** The window refills past a still-running input-order head, so undelivered results are bounded by `items.size()`, not by `permits`. Deliberate — the alternative stalls a fast later task behind a slow earlier one — but it means one slow head can hold every downstream result in heap.
- **Return does not imply completion.** Cancellation/failure *abandon* siblings (`cancel(true)` interrupts but does not wait), so a task may still be inside a non-interruptible store call when this returns. This class does not hold the store ceiling; an admitted call holds its permit until the call itself returns (PR 2).
- **Executor requirement.** The executor must run tasks independently of the caller, and must run-or-reject every task it accepts — never silently discard. There is deliberately no wait deadline: any ceiling low enough to catch a wedged executor would also abort legitimately slow metadata reads.

### Cross-request isolation

`PropagatedContext` forks and carries the caller's gRPC context rather than leaving the worker's own. That matters because several readers consult **only** gRPC keys — the session/authorization tokens `AuthResolutionContexts` reads, and `PrincipalProvider`/`EngineContextProvider`'s fallbacks. Carrying the captured context both delivers this request's credentials to fan-out tasks *and* isolates an off-request capture (it carries an empty context instead of inheriting whatever foreign request the worker happened to bear). This mirrors flight's `ContextSnapshot`, deliberately, so the two dispatch points agree on gRPC semantics.

MDC is handled separately: on a Quarkus duplicated Vert.x context the MDC is shared by every concurrent task, so `supply` skips MDC propagation there and warns once per JVM rather than corrupting it — a logging degradation instead of failing every task on a misconfigured executor.

**Tests:** `BoundedFanoutTest` (37), `PropagatedContextTest` (12), `FuturesTest` (3), plus a relocated invariant in `InboundContextInterceptorContextTest` pinning that `populateMdc` writes only the request ids and never the dispatch dimensions.

### Second commit
`test: cover transaction root resync` — adds the failure-branch test for `resyncRootOrLeaveMarker` (a failed resync must leave a durable re-drive marker, the only convergence path for REST-only tables). Unrelated to fan-out; folded here rather than blocking on its own PR.

---
Part of the GetUserObjects parallel re-cut. Supersedes #415–#418. Base: `main`.
