### PR TITLE
resolver: resolve a query's pins concurrently and safely

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/spi/decorator/EngineMetadataDecorator.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/spi/decorator/EngineMetadataDecorator.java
@@ -24,7 +24,11 @@ import java.util.Set;
  * ai.floedb.floecat.service.query.catalog.UserObjectBundleService}.
  *
  * <p>Implementations are invoked during bundle construction and receive normalized engine kind +
- * version. Decoration remains optional and is not part of scanner implementations.
+ * version. GetUserObjects invokes relation/view/column decoration synchronously on its
+ * bundle-producer thread, preserving caller-thread state. Implementations that perform blocking I/O
+ * must enforce their own downstream deadlines; stream cancellation is observed between callbacks
+ * but does not interrupt an active callback. Decoration remains optional and is not part of scanner
+ * implementations.
  */
 public interface EngineMetadataDecorator {
 

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogOverlay.java
@@ -194,6 +194,24 @@ public interface CatalogOverlay {
   }
 
   /**
+   * Whether independent resolution callbacks may run concurrently on this overlay instance.
+   *
+   * <p>The default preserves compatibility for existing overlays, whose lifecycle state may be tied
+   * to one request thread. Implementations backed by thread-safe services may opt in to concurrent
+   * resolution. Opting in permits {@link #catalog}, {@link #resolve}, {@code resolveName(s)}, and
+   * {@link #tablePinFor} callbacks to execute concurrently and off the caller thread, together with
+   * overlay-owned schema/name callbacks used while assembling GetUserObjects relations ({@link
+   * #schemaFor}, {@link #tableSchema}, {@link #tableName}, and {@link #viewName}). It does not
+   * change the caller-thread contract of separately injected stats, pin-validation, or
+   * engine-decoration collaborators. Implementations opting in must make the listed overlay
+   * callbacks thread-safe and must not depend on custom caller-thread state that service context
+   * propagation does not capture.
+   */
+  default boolean supportsConcurrentResolution() {
+    return false;
+  }
+
+  /**
    * Resolves a relation (table or view) by name reference using an explicit engine context.
    *
    * <p>Prefer this overload wherever the caller already holds the request's engine context — see

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/StatsProvider.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/StatsProvider.java
@@ -21,7 +21,14 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-/** Shared provider that surfaces table/column stats to metadata consumers. */
+/**
+ * Shared provider that surfaces table/column stats to metadata consumers.
+ *
+ * <p>GetUserObjects invokes these callbacks synchronously on its bundle-producer thread so provider
+ * implementations may retain caller-thread state. Implementations that perform blocking I/O must
+ * enforce their own downstream deadlines; stream cancellation is observed between callbacks but
+ * does not interrupt an active provider callback.
+ */
 public interface StatsProvider {
 
   default Optional<TableStatsView> tableStats(ResourceId tableId) {

--- a/docs/service.md
+++ b/docs/service.md
@@ -204,7 +204,7 @@ Notable `application.properties` keys:
 | `floecat.kv` / `floecat.blob` | Select pointer/blob store implementation (`memory`, `dynamodb`, `s3`). |
 | `floecat.query.*` | Default TTL, grace period, max cache size, safety expiry for query contexts. |
 | `floecat.query.resolver.max_parallel_inputs` | Per-request query-input pin-resolution fan-out. Defaults to `8`; values are clamped to `1`–`16`. |
-| `floecat.query.metadata-io.max-concurrency` | Process-wide admission bound for blocking metadata I/O shared by all requests. Defaults to `64`; missing, malformed, blank, or out-of-range values fail startup. |
+| `floecat.query.metadata-io.max-concurrency` | Process-wide admission bound for blocking metadata I/O shared by all requests. Missing values use `64`; present malformed, blank, or out-of-range values fail startup. |
 | `floecat.gc.idempotency.*` | Cadence, page size, batch limit, slice duration for idempotency GC. |
 | `floecat.gc.cas.*` | Cadence, page size, min-age, tick slice settings for CAS blob GC. |
 | `floecat.gc.pointer.*` | Cadence, page size, min-age, tick slice settings for pointer GC. |

--- a/docs/service.md
+++ b/docs/service.md
@@ -203,6 +203,8 @@ Notable `application.properties` keys:
 | `floecat.seed.enabled` | Enable demo data seeding. |
 | `floecat.kv` / `floecat.blob` | Select pointer/blob store implementation (`memory`, `dynamodb`, `s3`). |
 | `floecat.query.*` | Default TTL, grace period, max cache size, safety expiry for query contexts. |
+| `floecat.query.resolver.max_parallel_inputs` | Per-request query-input pin-resolution fan-out. Defaults to `8`; values are clamped to `1`–`16`. |
+| `floecat.query.metadata_io.max_concurrency` | Process-wide admission bound for blocking metadata I/O shared by all requests. Defaults to `64`; values are clamped to `1`–`256`. |
 | `floecat.gc.idempotency.*` | Cadence, page size, batch limit, slice duration for idempotency GC. |
 | `floecat.gc.cas.*` | Cadence, page size, min-age, tick slice settings for CAS blob GC. |
 | `floecat.gc.pointer.*` | Cadence, page size, min-age, tick slice settings for pointer GC. |

--- a/docs/service.md
+++ b/docs/service.md
@@ -204,7 +204,7 @@ Notable `application.properties` keys:
 | `floecat.kv` / `floecat.blob` | Select pointer/blob store implementation (`memory`, `dynamodb`, `s3`). |
 | `floecat.query.*` | Default TTL, grace period, max cache size, safety expiry for query contexts. |
 | `floecat.query.resolver.max_parallel_inputs` | Per-request query-input pin-resolution fan-out. Defaults to `8`; values are clamped to `1`–`16`. |
-| `floecat.query.metadata_io.max_concurrency` | Process-wide admission bound for blocking metadata I/O shared by all requests. Defaults to `64`; values are clamped to `1`–`256`. |
+| `floecat.query.metadata-io.max-concurrency` | Process-wide admission bound for blocking metadata I/O shared by all requests. Defaults to `64`; missing, malformed, blank, or out-of-range values fail startup. |
 | `floecat.gc.idempotency.*` | Cadence, page size, batch limit, slice duration for idempotency GC. |
 | `floecat.gc.cas.*` | Cadence, page size, min-age, tick slice settings for CAS blob GC. |
 | `floecat.gc.pointer.*` | Cadence, page size, min-age, tick slice settings for pointer GC. |

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/Futures.java
@@ -15,10 +15,28 @@
  */
 package ai.floedb.floecat.service.concurrent;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
 /** Unwrapping helpers for failures surfaced from async tasks. */
 public final class Futures {
 
   private Futures() {}
+
+  /**
+   * Join {@code future}, unwrapping the {@link CompletionException} so the caller sees the task's
+   * original {@link RuntimeException} or {@link Error} rather than a wrapper — what {@code
+   * QueryInputResolver} needs when it collects a shared pin future, so a pin failure surfaces as
+   * the store error that caused it. A checked-exception cause is a should-never-happen (these tasks
+   * throw only unchecked) and surfaces as an {@link IllegalStateException}.
+   */
+  public static <T> T join(CompletableFuture<T> future) {
+    try {
+      return future.join();
+    } catch (CompletionException ce) {
+      throw propagate(ce.getCause(), "unexpected checked exception from async task");
+    }
+  }
 
   /**
    * The {@link RuntimeException} to {@code throw} for an unwrapped async failure: the original

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoRunner.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataIoRunner.java
@@ -96,9 +96,9 @@ public class MetadataIoRunner {
   }
 
   /**
-   * Run one leaf store read. Request cancellation or caller interruption abandons the wait with
-   * {@link java.util.concurrent.CancellationException}; the task keeps its permit until the store
-   * call exits, and operation failures propagate unchanged.
+   * Run one metadata-store operation. Request cancellation or caller interruption abandons the wait
+   * with {@link java.util.concurrent.CancellationException}; the task keeps its permit until the
+   * store call exits, and operation failures propagate unchanged.
    */
   <T> T call(
       BooleanSupplier cancelled,
@@ -108,7 +108,7 @@ public class MetadataIoRunner {
         permits, cancelled, operation, failureMessages, saturationSink);
   }
 
-  /** Run one leaf read using the current request's cancellation signal when one is bound. */
+  /** Run one operation using the current request's cancellation signal when one is bound. */
   <T> T callWithCurrentCancellation(
       Supplier<T> operation, CancellableCallRunner.FailureMessages failureMessages) {
     BooleanSupplier cancelled = PropagatedContext.currentCancellation();
@@ -118,9 +118,9 @@ public class MetadataIoRunner {
   }
 
   /**
-   * Run one leaf store read without polling request cancellation. Caller interruption abandons the
-   * wait with {@link java.util.concurrent.CancellationException}; the task keeps its permit until
-   * the store call exits, and operation failures propagate unchanged.
+   * Run one metadata-store operation without polling request cancellation. Caller interruption
+   * abandons the wait with {@link java.util.concurrent.CancellationException}; the task keeps its
+   * permit until the store call exits, and operation failures propagate unchanged.
    */
   <T> T callWithoutCancellation(
       Supplier<T> operation, CancellableCallRunner.FailureMessages failureMessages) {

--- a/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataResourceReader.java
+++ b/service/src/main/java/ai/floedb/floecat/service/concurrent/MetadataResourceReader.java
@@ -21,7 +21,7 @@ import jakarta.inject.Inject;
 import java.util.function.Supplier;
 
 /**
- * Admission policy for one leaf metadata-store read.
+ * Admission policy for one metadata-store operation.
  *
  * <p>The current {@link ai.floedb.floecat.service.context.PropagatedContext} supplies cooperative
  * request cancellation when available. Cancellation may abandon the waiting caller, while the
@@ -42,7 +42,7 @@ public class MetadataResourceReader implements RepositoryReads.ReadPolicy {
     this.admission = admission;
   }
 
-  /** Execute one leaf read under process-wide admission and propagated request cancellation. */
+  /** Execute one operation under process-wide admission and propagated request cancellation. */
   @Override
   public <T> T read(Supplier<T> operation) {
     return admission.callWithCurrentCancellation(operation, FAILURES);

--- a/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
+++ b/service/src/main/java/ai/floedb/floecat/service/context/impl/ResolvedCallContexts.java
@@ -52,10 +52,10 @@ import org.jboss.logging.MDC;
  *       io.grpc.Context} directly (unit tests, non-Vert.x threads).
  * </ol>
  *
- * <p>History: mirroring only the principal onto the duplicated context moved the context-loss
- * failure from a loud {@code PERMISSION_DENIED} into a silent engine-gated {@code NOT_FOUND}
- * (eng-floe/floecat#361). Carrying the whole {@link ResolvedCallContext} on one channel keeps the
- * principal, correlation id, and engine context from ever diverging again.
+ * <p>Mirroring only the principal onto the duplicated context turns context loss from a loud {@code
+ * PERMISSION_DENIED} into a silent engine-gated {@code NOT_FOUND} (eng-floe/floecat#361). Carrying
+ * the whole {@link ResolvedCallContext} on one channel keeps the principal, correlation id, and
+ * engine context from ever diverging.
  */
 public final class ResolvedCallContexts {
 

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/MetaGraph.java
@@ -94,6 +94,11 @@ public final class MetaGraph implements CatalogOverlay, TopologyGraph {
     return ctx != null ? ctx : fallback.get();
   }
 
+  @Override
+  public boolean supportsConcurrentResolution() {
+    return true;
+  }
+
   /**
    * Resolves a graph node by ID, checking system graph first, then user graph.
    *

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -25,6 +25,8 @@ import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.concurrent.BoundedFanout;
+import ai.floedb.floecat.service.concurrent.MetadataFanout;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
@@ -32,19 +34,13 @@ import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.telemetry.Observability;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Semaphore;
 import java.util.function.Supplier;
-import org.eclipse.microprofile.context.ManagedExecutor;
 
 /**
  * Repository-backed name resolution helpers.
@@ -70,7 +66,7 @@ public final class NameResolver {
   // Dependencies
   // ----------------------------------------------------------------------
 
-  /** Max concurrent DynamoDB namespace scans per top-level listing call. */
+  /** Max concurrent DynamoDB namespace scans per top-level listing call (tier-1 fan-out width). */
   static final int MAX_PARALLEL_NS_SCANS = 8;
 
   private final CatalogRepository catalogRepository;
@@ -78,7 +74,6 @@ public final class NameResolver {
   private final TableRepository tableRepository;
   private final ViewRepository viewRepository;
   @Inject Observability observability;
-  private volatile Executor blockingExecutor = ForkJoinPool.commonPool();
 
   @Inject
   public NameResolver(
@@ -86,18 +81,10 @@ public final class NameResolver {
       NamespaceRepository namespaceRepository,
       TableRepository tableRepository,
       ViewRepository viewRepository) {
-
     this.catalogRepository = catalogRepository;
     this.namespaceRepository = namespaceRepository;
     this.tableRepository = tableRepository;
     this.viewRepository = viewRepository;
-  }
-
-  @Inject
-  void init(Instance<ManagedExecutor> managedExecutors) {
-    if (managedExecutors != null) {
-      managedExecutors.stream().findFirst().ifPresent(e -> blockingExecutor = e);
-    }
   }
 
   // ----------------------------------------------------------------------
@@ -400,41 +387,20 @@ public final class NameResolver {
   }
 
   /**
-   * Fans out per-namespace work across up to {@value #MAX_PARALLEL_NS_SCANS} concurrent tasks on
-   * the injected blocking executor. Each namespace is an independent DynamoDB scan; parallel
-   * execution reduces wall-clock time from O(N) to O(1) for warm DynamoDB connections.
+   * Fans out per-namespace work across up to {@value #MAX_PARALLEL_NS_SCANS} concurrent tasks and
+   * flattens the per-namespace results. Each namespace is an independent DynamoDB scan; warm
+   * connections complete in bounded waves instead of one serial scan per namespace. The scans run
+   * through {@link MetadataFanout} as the per-caller (tier-1) bound; each scan's repository read is
+   * held under the process-wide (tier-2) ceiling automatically at the store, so aggregate load
+   * stays bounded without this fan-out wiring any admission itself.
    */
   private <T> List<T> parallelScan(
       List<ResourceId> nsIds, java.util.function.Function<ResourceId, List<T>> task) {
-    Semaphore gate = new Semaphore(MAX_PARALLEL_NS_SCANS);
-    io.opentelemetry.context.Context otelContext = io.opentelemetry.context.Context.current();
-    List<CompletableFuture<List<T>>> futures =
-        nsIds.stream()
-            .<CompletableFuture<List<T>>>map(
-                ns ->
-                    CompletableFuture.<List<T>>supplyAsync(
-                        () -> {
-                          gate.acquireUninterruptibly();
-                          try (io.opentelemetry.context.Scope ignored = otelContext.makeCurrent()) {
-                            return task.apply(ns);
-                          } finally {
-                            gate.release();
-                          }
-                        },
-                        blockingExecutor))
-            .toList();
-    List<T> out = new ArrayList<>();
-    for (CompletableFuture<List<T>> f : futures) {
-      try {
-        out.addAll(f.join());
-      } catch (java.util.concurrent.CompletionException ce) {
-        Throwable cause = ce.getCause();
-        if (cause instanceof RuntimeException re) throw re;
-        if (cause instanceof Error e) throw e;
-        throw new IllegalStateException("unexpected checked exception from async task", cause);
-      }
-    }
-    return out;
+    return MetadataFanout.mapOrdered(
+            nsIds, MAX_PARALLEL_NS_SCANS, true, task, BoundedFanout.NEVER_CANCELLED)
+        .stream()
+        .flatMap(List::stream)
+        .toList();
   }
 
   private ResourceId requireCanonicalTableId(ResourceId tableId) {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -25,7 +25,6 @@ import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
-import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.concurrent.MetadataFanout;
 import ai.floedb.floecat.service.context.PropagatedContext;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
@@ -399,15 +398,12 @@ public final class NameResolver {
   private <T> List<T> parallelScan(
       List<ResourceId> nsIds, java.util.function.Function<ResourceId, List<T>> task) {
     BooleanSupplier cancelled = PropagatedContext.currentCancellation();
-    return MetadataFanout.mapOrdered(
-            nsIds,
-            MAX_PARALLEL_NS_SCANS,
-            true,
-            task,
-            cancelled == null ? BoundedFanout.NEVER_CANCELLED : cancelled)
-        .stream()
-        .flatMap(List::stream)
-        .toList();
+    MetadataFanout fanout = MetadataFanout.concurrent(MAX_PARALLEL_NS_SCANS);
+    List<List<T>> results =
+        cancelled == null
+            ? fanout.mapOrdered(nsIds, task)
+            : fanout.mapOrdered(nsIds, task, cancelled);
+    return results.stream().flatMap(List::stream).toList();
   }
 
   private ResourceId requireCanonicalTableId(ResourceId tableId) {

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/resolver/NameResolver.java
@@ -27,6 +27,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.concurrent.MetadataFanout;
+import ai.floedb.floecat.service.context.PropagatedContext;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
@@ -40,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 /**
@@ -396,8 +398,13 @@ public final class NameResolver {
    */
   private <T> List<T> parallelScan(
       List<ResourceId> nsIds, java.util.function.Function<ResourceId, List<T>> task) {
+    BooleanSupplier cancelled = PropagatedContext.currentCancellation();
     return MetadataFanout.mapOrdered(
-            nsIds, MAX_PARALLEL_NS_SCANS, true, task, BoundedFanout.NEVER_CANCELLED)
+            nsIds,
+            MAX_PARALLEL_NS_SCANS,
+            true,
+            task,
+            cancelled == null ? BoundedFanout.NEVER_CANCELLED : cancelled)
         .stream()
         .flatMap(List::stream)
         .toList();

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
@@ -30,6 +30,7 @@ import ai.floedb.floecat.query.rpc.PinKind;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.service.catalog.impl.StatsVisibilityGate;
 import ai.floedb.floecat.service.catalog.impl.TableRootCommitter;
+import ai.floedb.floecat.service.concurrent.BoundMetadataIo;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph.SchemaResolution;
 import ai.floedb.floecat.service.query.PinValidator;
@@ -113,6 +114,7 @@ public class SnapshotHelper {
    * pair to keep in step. A legacy table's root is synthesized at first touch ({@code ensureRoot}),
    * so pre-existing data needs no migration step.
    */
+  @BoundMetadataIo
   public TablePin tablePinFor(
       String cid, ResourceId tableId, SnapshotRef override, Optional<Timestamp> asOfDefault) {
 

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
@@ -30,7 +30,6 @@ import ai.floedb.floecat.query.rpc.PinKind;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.service.catalog.impl.StatsVisibilityGate;
 import ai.floedb.floecat.service.catalog.impl.TableRootCommitter;
-import ai.floedb.floecat.service.concurrent.BoundMetadataIo;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph.SchemaResolution;
 import ai.floedb.floecat.service.query.PinValidator;
@@ -114,7 +113,6 @@ public class SnapshotHelper {
    * pair to keep in step. A legacy table's root is synthesized at first touch ({@code ensureRoot}),
    * so pre-existing data needs no migration step.
    */
-  @BoundMetadataIo
   public TablePin tablePinFor(
       String cid, ResourceId tableId, SnapshotRef override, Optional<Timestamp> asOfDefault) {
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -58,7 +58,9 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.scanner.spi.MetadataResolutionContext;
 import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.concurrent.MetadataIoExecutors;
 import ai.floedb.floecat.service.context.EngineContextProvider;
+import ai.floedb.floecat.service.context.PropagatedContext;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.PinValidator;
 import ai.floedb.floecat.service.query.QueryContextStore;
@@ -81,6 +83,7 @@ import ai.floedb.floecat.types.LogicalType;
 import ai.floedb.floecat.types.LogicalTypeProtoAdapter;
 import io.opentelemetry.api.trace.Span;
 import io.smallrye.mutiny.Multi;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayDeque;
@@ -95,7 +98,16 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.microprofile.config.Config;
@@ -107,7 +119,95 @@ import org.jboss.logging.Logger;
 public class UserObjectBundleService {
 
   private static final int MAX_RESOLUTIONS_PER_CHUNK = 25;
+  private static final long EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
+  private static final BooleanSupplier NEVER_CANCELLED = () -> false;
   private static final Logger LOG = Logger.getLogger(UserObjectBundleService.class);
+
+  private static void throwIfCancelled(BooleanSupplier cancelled) {
+    if (cancelled.getAsBoolean()) {
+      throw new CancellationException("GetUserObjects stream cancelled");
+    }
+  }
+
+  /** Arbitrates the single terminal telemetry outcome against producer activity. */
+  static final class StreamTelemetryGate {
+    /** The terminal outcome whose sole telemetry publication a gate transition may grant. */
+    enum Publication {
+      NONE,
+      COMPLETION,
+      FAILURE,
+      CANCELLATION
+    }
+
+    /** Whether this cancellation is duplicate, owns teardown, or also publishes immediately. */
+    enum CancellationDecision {
+      IGNORED,
+      ACCEPTED,
+      PUBLISH
+    }
+
+    private boolean producerActive;
+    private boolean cancellationPending;
+    private boolean publicationClaimed;
+
+    /** Begin one producer step unless cancellation already won. */
+    synchronized void begin(BooleanSupplier cancelled) {
+      throwIfCancelled(cancelled);
+      producerActive = true;
+    }
+
+    /**
+     * Atomically expose cancellation to request work and terminal-outcome arbitration. The caller
+     * owns teardown unless another cancellation already won.
+     */
+    synchronized CancellationDecision cancel(AtomicBoolean cancelled) {
+      if (!cancelled.compareAndSet(false, true)) {
+        return CancellationDecision.IGNORED;
+      }
+      cancellationPending = true;
+      if (producerActive) {
+        return CancellationDecision.ACCEPTED;
+      }
+      cancellationPending = false;
+      return claimInternal() ? CancellationDecision.PUBLISH : CancellationDecision.ACCEPTED;
+    }
+
+    /**
+     * Finish a producer step with {@link Publication#NONE}, {@link Publication#COMPLETION}, or
+     * {@link Publication#FAILURE}. Failure takes precedence over racing cancellation, and
+     * cancellation takes precedence over completion. A non-{@code NONE} return grants ownership of
+     * the stream's sole terminal telemetry publication.
+     */
+    synchronized Publication finish(Publication terminalOutcome) {
+      boolean publishFailure = terminalOutcome == Publication.FAILURE && claimInternal();
+      producerActive = false;
+      boolean publishCancellation = !publishFailure && cancellationPending && claimInternal();
+      cancellationPending = false;
+      if (publishFailure) {
+        return Publication.FAILURE;
+      }
+      if (publishCancellation) {
+        return Publication.CANCELLATION;
+      }
+      return terminalOutcome == Publication.COMPLETION && claimInternal()
+          ? Publication.COMPLETION
+          : Publication.NONE;
+    }
+
+    /** Claim publication from a non-racing terminal path. */
+    synchronized boolean claim() {
+      return claimInternal();
+    }
+
+    private boolean claimInternal() {
+      if (publicationClaimed) {
+        return false;
+      }
+      publicationClaimed = true;
+      return true;
+    }
+  }
+
   private static final Set<String> LOCAL_FLIGHT_HOSTS = Set.of("localhost", "127.0.0.1", "0.0.0.0");
   private static final String SYSTEM_FLIGHT_ENDPOINTS_PREFIX = "floedb.system-flight.endpoints.";
   private static final String RELATION_HINT_PERSIST_NANOS_KEY =
@@ -129,8 +229,25 @@ public class UserObjectBundleService {
   private final long slowRpcMs;
   private final LogicalSchemaMapper logicalSchemaMapper = new LogicalSchemaMapper();
   private final FlightEndpointRef floecatFlightEndpoint;
-
+  // Cancellation can be signalled by a transport thread; release its store roots on a managed
+  // virtual-thread executor instead of blocking that termination callback.
+  private final ExecutorService cancellationTeardownExecutor =
+      Executors.newVirtualThreadPerTaskExecutor();
   @Inject Observability observability;
+
+  /** Stop cancellation teardown work without owning the resolver's shared metadata executor. */
+  @PreDestroy
+  void closeCancellationTeardownExecutor() {
+    shutdownExecutor(cancellationTeardownExecutor);
+  }
+
+  /** Bound bean destruction even if a store call ignores interruption during shutdown. */
+  private static void shutdownExecutor(ExecutorService executor) {
+    if (!MetadataIoExecutors.shutdownNowAndAwait(
+        executor, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      LOG.warn("bundle cancellation teardown executor did not terminate before shutdown timeout");
+    }
+  }
 
   private static void warnFlightHost(String flightHost, String quarkusProfile) {
     if (flightHost == null) {
@@ -269,9 +386,15 @@ public class UserObjectBundleService {
               return Multi.createFrom()
                   .iterable(() -> iterator)
                   .onFailure()
-                  .invoke(ignored -> iterator.publishStreamTelemetry("failed"))
-                  .onTermination()
-                  .invoke(() -> iterator.publishStreamTelemetry("cancelled"));
+                  .invoke(
+                      failure -> {
+                        if (!(failure instanceof CancellationException)) {
+                          iterator.publishStreamTelemetry("failed");
+                        }
+                        iterator.cancel();
+                      })
+                  .onCancellation()
+                  .invoke(iterator::cancel);
             });
   }
 
@@ -347,12 +470,19 @@ public class UserObjectBundleService {
     }
   }
 
+  /**
+   * Resolve canonical inputs for one chunk and transfer transient-root ownership to the iterator.
+   * Cancellation after resolution releases the returned pins before propagating instead of leaving
+   * an uncommitted root behind.
+   */
   private RelationPinSet collectChunkPins(
       String correlationId,
       QueryContext ctx,
       List<ResolvedRelation> relations,
-      Map<ResourceId, TablePin> currentSnapshotPinCache,
-      PhaseDiagnostics diagnostics) {
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
     if (relations == null || relations.isEmpty()) {
       return RelationPinSet.getDefaultInstance();
     }
@@ -382,12 +512,22 @@ public class UserObjectBundleService {
             asOfDefault,
             Optional.of(ctx.getQueryDefaultCatalogId()),
             currentSnapshotPinCache,
-            diagnostics);
+            diagnostics,
+            cancelled);
     diagnostics.nanos("pin.resolver", System.nanoTime() - resolverStartNs);
     RelationPinSet incoming = resolution.relationPinSet();
     RelationPinSet pins = incoming == null ? RelationPinSet.getDefaultInstance() : incoming;
-    diagnostics.add("pin.output_pins", pins.getPinsCount());
-    return pins;
+    boolean handedOff = false;
+    try {
+      throwIfCancelled(cancelled);
+      diagnostics.add("pin.output_pins", pins.getPinsCount());
+      handedOff = true;
+      return pins;
+    } finally {
+      if (!handedOff) {
+        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(pins));
+      }
+    }
   }
 
   private UserObjectsBundleChunk headerChunk(String queryId, int seq) {
@@ -509,7 +649,24 @@ public class UserObjectBundleService {
           + decorateColumnsNanos
           + decorateCompleteNanos;
     }
+
+    /** Merge one completed build task's isolated timings on the stream producer thread. */
+    private void addFrom(TimingAccumulator other) {
+      statsLookupNanos += other.statsLookupNanos;
+      decorateRelationNanos += other.decorateRelationNanos;
+      decorateViewNanos += other.decorateViewNanos;
+      decorateColumnsNanos += other.decorateColumnsNanos;
+      decorateColumnInvokeNanos += other.decorateColumnInvokeNanos;
+      decorateCompleteNanos += other.decorateCompleteNanos;
+      decoratePersistRelationNanos += other.decoratePersistRelationNanos;
+      decoratePersistColumnsNanos += other.decoratePersistColumnsNanos;
+      decorateColumnWarmHits += other.decorateColumnWarmHits;
+    }
   }
+
+  /** One relation payload and the task-local timing measurements produced while building it. */
+  private record BuiltRelation(
+      RelationInfo info, boolean identityOnly, long buildNanos, TimingAccumulator timings) {}
 
   /**
    * True when the payload built for this candidate carries the relation's complete column set (no
@@ -533,9 +690,8 @@ public class UserObjectBundleService {
   private Optional<PinIdentitySource> pinIdentityFor(
       String correlationId, ResolvedRelation relation, QueryContext queryContext) {
     // Only a USER table carries a per-query snapshot pin; route it through the pin's identity.
-    // Views AND system tables have no query pin, so they take the derived content token below —
-    // previously system tables fell into the pin branch and emitted no identity at all, so
-    // clients could never cache them despite that being the whole point of the content token.
+    // Views AND system tables have no query pin, so they take the derived content token below;
+    // system tables need that token for clients to cache them.
     // Discriminate on kind+origin (a system table is also a TABLE node, and a view may be USER
     // origin) rather than the concrete node class, so the routing holds for every node backing.
     if (relation.node().kind() == GraphNodeKind.TABLE
@@ -747,7 +903,8 @@ public class UserObjectBundleService {
       Optional<RelationPinIdentity> scopedIdentity,
       StatsProvider statsProvider,
       Set<String> knownBlobVersions,
-      TimingAccumulator timings) {
+      TimingAccumulator timings,
+      BooleanSupplier cancelled) {
     // The token is the engine-scoped payload token (scopedIdentity), not the bare content version,
     // so a client that proved possession under a different engine cannot be served identity-only.
     // A blank version can never prove possession: a user table whose definition blob had no etag
@@ -768,6 +925,7 @@ public class UserObjectBundleService {
     long statsLookupStartNs = System.nanoTime();
     attachTableStats(slim, relation.relationId(), statsProvider);
     timings.addStatsLookupNanos(System.nanoTime() - statsLookupStartNs);
+    throwIfCancelled(cancelled);
     return slim.build();
   }
 
@@ -804,7 +962,9 @@ public class UserObjectBundleService {
       MetadataResolutionContext resolutionContext,
       StatsProvider statsProvider,
       TimingAccumulator timings,
-      Optional<RelationPinIdentity> scopedIdentity) {
+      Optional<RelationPinIdentity> scopedIdentity,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
     if (LOG.isTraceEnabled()) {
       LOG.tracef(
           "Building relation bundle query_id=%s relation=%s kind=%s origin=%s",
@@ -830,13 +990,15 @@ public class UserObjectBundleService {
                     logicalSchemaForRelation(
                             correlationId, relation.relationId(), userTable, queryContext)
                         .getColumnsList())
-                : overlay.tableSchema(relation.node().id());
+                : Optional.ofNullable(overlay.tableSchema(relation.node().id()))
+                    .orElseGet(List::of);
 
     List<SchemaColumn> pruned =
         UserObjectBundleUtils.pruneSchema(schemaColumns, relation.candidate(), correlationId);
 
     List<ColumnInfo> columns =
         UserObjectBundleUtils.columnsFor(schemaColumns, pruned, origin, correlationId);
+    throwIfCancelled(cancelled);
 
     RelationInfo.Builder builder = baseRelationInfo(relation);
 
@@ -863,6 +1025,7 @@ public class UserObjectBundleService {
     long statsLookupStartNs = System.nanoTime();
     attachTableStats(builder, relation.relationId(), statsProvider);
     timings.addStatsLookupNanos(System.nanoTime() - statsLookupStartNs);
+    throwIfCancelled(cancelled);
 
     // If this is a view, keep a mutable builder around for decoration.
     ViewDefinition.Builder viewBuilder = null;
@@ -871,9 +1034,9 @@ public class UserObjectBundleService {
       builder.setViewDefinition(viewBuilder);
     }
 
-    // The engine captured at iterator construction, not a live provider re-read: this runs on
-    // executor threads where the request context is unreliable, and a silently empty engine would
-    // skip engine-specific decoration with no log line (eng-floe/floecat#361).
+    // Use the engine captured at iterator construction. Overlay reads may cross executor boundaries
+    // before decoration resumes here, so re-reading ambient request context is fragile and a
+    // silently empty engine would skip engine-specific decoration (eng-floe/floecat#361).
     EngineContext ctx = resolutionContext.engineContext();
     boolean decorationRequired = decorationRequired(ctx);
     Optional<EngineMetadataDecorator> decorator = currentDecorator(ctx);
@@ -899,12 +1062,16 @@ public class UserObjectBundleService {
               resolutionContext);
 
       try {
+        throwIfCancelled(cancelled);
         long decorateRelationStartNs = System.nanoTime();
         try {
           decorator.get().decorateRelation(ctx, relationDecoration);
         } finally {
           timings.addDecorateRelationNanos(System.nanoTime() - decorateRelationStartNs);
         }
+        throwIfCancelled(cancelled);
+      } catch (CancellationException e) {
+        throw e;
       } catch (RuntimeException e) {
         relationDecorationSucceeded = false;
         LOG.debugf(
@@ -924,12 +1091,16 @@ public class UserObjectBundleService {
                 builder, viewBuilder, relation.relationId(), relation.node(), resolutionContext);
 
         try {
+          throwIfCancelled(cancelled);
           long decorateViewStartNs = System.nanoTime();
           try {
             decorator.get().decorateView(ctx, viewDecoration);
           } finally {
             timings.addDecorateViewNanos(System.nanoTime() - decorateViewStartNs);
           }
+          throwIfCancelled(cancelled);
+        } catch (CancellationException e) {
+          throw e;
         } catch (RuntimeException e) {
           viewDecorationSucceeded = false;
           LOG.debugf(
@@ -950,7 +1121,9 @@ public class UserObjectBundleService {
             ctx,
             decorationRequired,
             relation.relationId(),
-            timings);
+            timings,
+            cancelled);
+    throwIfCancelled(cancelled);
     long relationWarmHitCount = decorationCounter(relationDecoration, COLUMN_WARM_HIT_COUNT_KEY);
     timings.addDecorateColumnWarmHits(relationWarmHitCount);
 
@@ -970,6 +1143,7 @@ public class UserObjectBundleService {
             readyColumnIds.size());
       }
       try {
+        throwIfCancelled(cancelled);
         long decorateCompleteStartNs = System.nanoTime();
         try {
           decorator
@@ -983,6 +1157,9 @@ public class UserObjectBundleService {
           timings.addDecoratePersistColumnsNanos(
               decorationTimingNanos(relationDecoration, COLUMN_HINT_PERSIST_NANOS_KEY));
         }
+        throwIfCancelled(cancelled);
+      } catch (CancellationException e) {
+        throw e;
       } catch (RuntimeException e) {
         completeRelationSucceeded = false;
         LOG.debugf(
@@ -1015,8 +1192,8 @@ public class UserObjectBundleService {
     // constraints_ref_version)
     //     is a property of the pinned relation, not of the served payload shape. Callers rely on it
     //     to tell a current pin from a historical one and to skip the constraints RPC, so it is
-    //     stamped UNCONDITIONALLY whenever the relation is pinned — including on projected or
-    //     decoration-incomplete replies, which previously lost it entirely.
+    //     stamped UNCONDITIONALLY whenever the relation is pinned, including on projected or
+    //     decoration-incomplete replies.
     //
     //   - The possession token (table_blob_version) is payload-scoped: a client that advertises it
     //     is later served identity-only and reuses its cached payload verbatim. It is kept only
@@ -1119,7 +1296,8 @@ public class UserObjectBundleService {
         ctx,
         decorationRequired,
         relationId,
-        new TimingAccumulator());
+        new TimingAccumulator(),
+        NEVER_CANCELLED);
   }
 
   private List<ColumnResult> decorateColumns(
@@ -1130,7 +1308,8 @@ public class UserObjectBundleService {
       EngineContext ctx,
       boolean decorationRequired,
       ResourceId relationId,
-      TimingAccumulator timings) {
+      TimingAccumulator timings,
+      BooleanSupplier cancelled) {
 
     if (pruned == null || pruned.size() != columns.size()) {
       String msg =
@@ -1181,6 +1360,7 @@ public class UserObjectBundleService {
 
     List<ColumnResult> decorated = new ArrayList<>(columns.size());
     for (int i = 0; i < columns.size(); i++) {
+      throwIfCancelled(cancelled);
       long decorateColumnTotalStartNs = System.nanoTime();
       ColumnInfo column = columns.get(i);
       SchemaColumn schema = pruned.get(i);
@@ -1196,6 +1376,7 @@ public class UserObjectBundleService {
         } finally {
           timings.addDecorateColumnInvokeNanos(System.nanoTime() - decorateColumnInvokeStartNs);
         }
+        throwIfCancelled(cancelled);
         ColumnInfo decoratedColumn = columnDecoration.builder().build();
         if (hasRequiredEnginePayload(decoratedColumn, ctx)) {
           decorated.add(readyColumn(decoratedColumn));
@@ -1218,6 +1399,8 @@ public class UserObjectBundleService {
                       "engine_kind", safe(ctx == null ? null : ctx.normalizedKind()),
                       "engine_version", safe(ctx == null ? null : ctx.normalizedVersion()))));
         }
+      } catch (CancellationException e) {
+        throw e;
       } catch (RuntimeException e) {
         ColumnFailure failure = mapFailure(e, ctx);
         LOG.debugf(
@@ -1489,6 +1672,7 @@ public class UserObjectBundleService {
     return logicalSchemaMapper.map(resolved.table(), resolved.schemaJson());
   }
 
+  /** Read canonical names directly from the graph; production overlays serve these from memory. */
   private NameRef canonicalName(ResourceId id, GraphNode node) {
     return switch (node.kind()) {
       case TABLE ->
@@ -1596,12 +1780,20 @@ public class UserObjectBundleService {
     private final ArrayDeque<EagerBaseCursor> eagerBaseQueue = new ArrayDeque<>();
     private final Set<String> eagerBaseSeen = new HashSet<>();
     private final Map<RelationCacheKey, RelationInfo> relationInfoCache = new HashMap<>();
-    private final Map<ResourceId, TablePin> currentSnapshotPinCache = new HashMap<>();
+    private final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache =
+        new ConcurrentHashMap<>();
     private final TimingAccumulator timings = new TimingAccumulator();
     private final PhaseDiagnostics diagnostics = diagnostics("get_user_objects");
     private final long streamStartNs = System.nanoTime();
     private final Span parentSpan = Span.current();
+    // Coordinates the resolving-root handoff. Cancellation can arrive on a different thread than
+    // chunk production, so it must neither release pins being committed nor miss pins accumulated
+    // after its cleanup pass. Store I/O always happens outside this lock.
+    private final Object pendingChunkPinsLock = new Object();
     private RelationPinSet pendingChunkPins = RelationPinSet.getDefaultInstance();
+    // A teardown may publish only after the active next() call has finished mutating iterator
+    // diagnostics and caches; a real failure wins when cancellation races that final step.
+    private final StreamTelemetryGate telemetryGate = new StreamTelemetryGate();
 
     private int seq = 1;
     private int nextInputIndex = 0;
@@ -1610,7 +1802,7 @@ public class UserObjectBundleService {
     private int emittedResolutionChunks = 0;
     private boolean headerEmitted = false;
     private boolean endEmitted = false;
-    private final AtomicBoolean telemetryPublished = new AtomicBoolean(false);
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
     private boolean defaultCatalogResolved = false;
     private String defaultCatalogName = "";
     private long resolveNanos = 0L;
@@ -1667,41 +1859,57 @@ public class UserObjectBundleService {
 
     @Override
     public UserObjectsBundleChunk next() {
-      if (!headerEmitted) {
-        headerEmitted = true;
-        if (LOG.isDebugEnabled()) {
-          LOG.debugf("Emitting header chunk query_id=%s seq=%d", ctx.getQueryId(), seq);
+      beginProducerStep();
+      StreamTelemetryGate.Publication terminalOutcome = StreamTelemetryGate.Publication.NONE;
+      // Reads in this step are auto-admitted at the repository layer; bind the request-scoped
+      // cancellation token so each one (on this thread or a fan-out worker) can abort on cancel.
+      try (var cancellationScope = PropagatedContext.bindCancellation(this::isCancelled)) {
+        if (!headerEmitted) {
+          headerEmitted = true;
+          if (LOG.isDebugEnabled()) {
+            LOG.debugf("Emitting header chunk query_id=%s seq=%d", ctx.getQueryId(), seq);
+          }
+          return headerChunk(ctx.getQueryId(), seq++);
         }
-        return headerChunk(ctx.getQueryId(), seq++);
-      }
 
-      if (pending.isEmpty() && (nextInputIndex < resolutionCount || !eagerBaseQueue.isEmpty())) {
-        fillPending();
-      }
-
-      if (!pending.isEmpty()) {
-        return flushResolutionChunk();
-      }
-
-      if (!endEmitted) {
-        endEmitted = true;
-        publishStreamTelemetry("completed");
-        if (LOG.isDebugEnabled()) {
-          LOG.debugf(
-              "Emitting end chunk query_id=%s seq=%d resolutions=%d found=%d not_found=%d",
-              ctx.getQueryId(), seq, resolutionCount, foundCount, notFoundCount);
+        if (pending.isEmpty() && (nextInputIndex < resolutionCount || !eagerBaseQueue.isEmpty())) {
+          fillPending();
         }
-        return endChunk(ctx.getQueryId(), seq++, resolutionCount, foundCount, notFoundCount);
-      }
 
-      throw new NoSuchElementException();
+        if (!pending.isEmpty()) {
+          return flushResolutionChunk();
+        }
+
+        if (!endEmitted) {
+          endEmitted = true;
+          terminalOutcome = StreamTelemetryGate.Publication.COMPLETION;
+          if (LOG.isDebugEnabled()) {
+            LOG.debugf(
+                "Emitting end chunk query_id=%s seq=%d resolutions=%d found=%d not_found=%d",
+                ctx.getQueryId(), seq, resolutionCount, foundCount, notFoundCount);
+          }
+          return endChunk(ctx.getQueryId(), seq++, resolutionCount, foundCount, notFoundCount);
+        }
+
+        throw new NoSuchElementException();
+      } catch (RuntimeException | Error failure) {
+        if (!(failure instanceof CancellationException)) {
+          terminalOutcome = StreamTelemetryGate.Publication.FAILURE;
+        }
+        throw failure;
+      } finally {
+        finishProducerStep(terminalOutcome);
+      }
     }
 
     private void fillPending() {
+      throwIfCancelled(this::isCancelled);
       List<ResolvedRelation> toPin = new ArrayList<>(MAX_RESOLUTIONS_PER_CHUNK);
       drainEagerBaseTables(toPin);
       while (nextInputIndex < resolutionCount && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
+        throwIfCancelled(this::isCancelled);
         PendingItem item = resolveNextResolution();
+        throwIfCancelled(this::isCancelled);
         pending.add(item);
         if (item instanceof PendingFound found) {
           toPin.add(found.relation());
@@ -1715,16 +1923,146 @@ public class UserObjectBundleService {
         long pinStartNs = System.nanoTime();
         try {
           RelationPinSet chunkPins =
-              collectChunkPins(correlationId, ctx, toPin, currentSnapshotPinCache, diagnostics);
-          long accumulateStartNs = System.nanoTime();
+              collectChunkPins(
+                  correlationId,
+                  ctx,
+                  toPin,
+                  currentSnapshotPinCache,
+                  diagnostics,
+                  this::isCancelled);
+          boolean pinsAccumulated = false;
           try {
-            accumulateChunkPins(chunkPins);
+            throwIfCancelled(this::isCancelled);
+            long accumulateStartNs = System.nanoTime();
+            try {
+              pinsAccumulated = accumulateChunkPins(chunkPins);
+            } finally {
+              diagnostics.nanos("pin.accumulate", System.nanoTime() - accumulateStartNs);
+            }
           } finally {
-            diagnostics.nanos("pin.accumulate", System.nanoTime() - accumulateStartNs);
+            if (!pinsAccumulated) {
+              queryStore.releaseResolvingPinBlobs(
+                  ctx.getQueryId(), QueryPins.gcRootUris(chunkPins));
+            }
           }
         } finally {
           pinCollectNanos += System.nanoTime() - pinStartNs;
         }
+      }
+    }
+
+    private boolean isCancelled() {
+      return cancelled.get();
+    }
+
+    /**
+     * Mark the iterator cancelled, detach pending pins, publish only stable telemetry, and offload
+     * root release so a transport/event-loop termination callback never performs store I/O.
+     */
+    private void cancel() {
+      StreamTelemetryGate.CancellationDecision cancellation = telemetryGate.cancel(cancelled);
+      if (cancellation != StreamTelemetryGate.CancellationDecision.IGNORED) {
+        RelationPinSet toRelease;
+        synchronized (pendingChunkPinsLock) {
+          toRelease = pendingChunkPins;
+          pendingChunkPins = RelationPinSet.getDefaultInstance();
+        }
+        if (cancellation == StreamTelemetryGate.CancellationDecision.PUBLISH) {
+          // No producer is mutating diagnostics or caches, but the RPC span may end as soon as
+          // this termination callback returns. Emit while it is still recording.
+          publishClaimedTelemetrySafely("cancelled");
+        }
+        // onTermination may run on a transport/event-loop thread. Root release can perform store
+        // I/O, so teardown runs on a managed executor. Telemetry is published only after the
+        // producer reports that no mutable iterator state remains active.
+        try {
+          cancellationTeardownExecutor.submit(
+              () -> {
+                try {
+                  queryStore.releaseResolvingPinBlobs(
+                      ctx.getQueryId(), QueryPins.gcRootUris(toRelease));
+                } catch (RuntimeException releaseFailure) {
+                  LOG.warnf(
+                      releaseFailure,
+                      "Failed to release cancelled stream pin roots query_id=%s",
+                      ctx.getQueryId());
+                }
+              });
+        } catch (RejectedExecutionException shutdown) {
+          LOG.warnf(
+              shutdown,
+              "Cancellation teardown executor stopped before pin-root release query_id=%s",
+              ctx.getQueryId());
+        }
+      }
+    }
+
+    /** Claim mutable iterator state for one producer step unless cancellation already won. */
+    private void beginProducerStep() {
+      telemetryGate.begin(this::isCancelled);
+    }
+
+    /**
+     * Release producer ownership and publish exactly one terminal outcome, giving a real failure
+     * precedence over cancellation that raced the active step.
+     */
+    private void finishProducerStep(StreamTelemetryGate.Publication terminalOutcome) {
+      StreamTelemetryGate.Publication publication = telemetryGate.finish(terminalOutcome);
+      switch (publication) {
+        case COMPLETION -> publishClaimedTelemetrySafely("completed");
+        case FAILURE -> publishClaimedTelemetrySafely("failed");
+        case CANCELLATION -> publishClaimedTelemetrySafely("cancelled");
+        case NONE -> {}
+      }
+    }
+
+    /**
+     * Assemble one relation on the producer thread. Only overlay-owned repository reads cross the
+     * metadata runner; stats, validation, and decorator callbacks retain their caller-thread
+     * contract. Cancellation is checked between those synchronous callbacks; each collaborator owns
+     * any deadline needed for its active call. The local timing accumulator is merged only after a
+     * successful build.
+     */
+    private BuiltRelation buildRelationWithCancellationChecks(
+        PendingFound found,
+        QueryContext liveContext,
+        Optional<RelationPinIdentity> scopedIdentity) {
+      TimingAccumulator taskTimings = new TimingAccumulator();
+      long buildStartNs = System.nanoTime();
+      RelationInfo identityOnly =
+          identityOnlyOrNull(
+              found.relation(),
+              scopedIdentity,
+              statsProvider,
+              knownBlobVersions,
+              taskTimings,
+              this::isCancelled);
+      if (identityOnly != null) {
+        return new BuiltRelation(identityOnly, true, System.nanoTime() - buildStartNs, taskTimings);
+      }
+      RelationInfo full =
+          buildRelation(
+              correlationId,
+              found.relation(),
+              liveContext,
+              resolutionContext,
+              statsProvider,
+              taskTimings,
+              scopedIdentity,
+              this::isCancelled);
+      return new BuiltRelation(full, false, System.nanoTime() - buildStartNs, taskTimings);
+    }
+
+    /** Publish a claimed outcome without allowing telemetry failure to mask stream termination. */
+    private void publishClaimedTelemetrySafely(String outcome) {
+      try {
+        publishClaimedStreamTelemetry(outcome);
+      } catch (RuntimeException telemetryFailure) {
+        LOG.warnf(
+            telemetryFailure,
+            "Failed to publish %s stream telemetry query_id=%s",
+            outcome,
+            ctx.getQueryId());
       }
     }
 
@@ -1739,6 +2077,7 @@ public class UserObjectBundleService {
      */
     private void drainEagerBaseTables(List<ResolvedRelation> toPin) {
       while (pending.size() < MAX_RESOLUTIONS_PER_CHUNK && !eagerBaseQueue.isEmpty()) {
+        throwIfCancelled(this::isCancelled);
         EagerBaseCursor cursor = eagerBaseQueue.peekFirst();
         if (cursor == null) {
           break;
@@ -1753,6 +2092,7 @@ public class UserObjectBundleService {
       List<NameRef> baseRelations = cursor.view.baseRelations();
       while (cursor.nextBaseIndex < baseRelations.size()
           && pending.size() < MAX_RESOLUTIONS_PER_CHUNK) {
+        throwIfCancelled(this::isCancelled);
         NameRef baseRef = baseRelations.get(cursor.nextBaseIndex++);
         long resolveStartNs = System.nanoTime();
         try {
@@ -1788,6 +2128,7 @@ public class UserObjectBundleService {
     }
 
     private PendingItem resolveNextResolution() {
+      throwIfCancelled(this::isCancelled);
       long resolveStartNs = System.nanoTime();
       try {
         TableReferenceCandidate candidate = tables.get(nextInputIndex);
@@ -1865,21 +2206,24 @@ public class UserObjectBundleService {
     }
 
     private UserObjectsBundleChunk flushResolutionChunk() {
+      throwIfCancelled(this::isCancelled);
       List<PendingItem> chunkItems = new ArrayList<>(pending);
       pending.clear();
       if (LOG.isDebugEnabled()) {
         LOG.debugf(
             "Flushing resolution chunk query_id=%s seq=%d pending_items=%d pending_pins=%d",
-            ctx.getQueryId(), seq, chunkItems.size(), pendingChunkPins.getPinsCount());
+            ctx.getQueryId(), seq, chunkItems.size(), pendingChunkPinCount());
       }
       // Ensure pins are durable before accessing stats (which expect the QueryContext to be
       // pinned).
+      throwIfCancelled(this::isCancelled);
       long pinCommitStartNs = System.nanoTime();
       commitChunkPins();
       pinCommitNanos += System.nanoTime() - pinCommitStartNs;
       QueryContext liveCtx = null;
       List<RelationResolution> resolutions = new ArrayList<>(chunkItems.size());
       for (PendingItem item : chunkItems) {
+        throwIfCancelled(this::isCancelled);
         if (item instanceof PendingResolved resolved) {
           resolutions.add(resolved.resolution());
           continue;
@@ -1896,9 +2240,6 @@ public class UserObjectBundleService {
                   .build());
           continue;
         }
-        long statsBeforeNanos = timings.statsLookupNanos();
-        long decorationBeforeNanos = timings.decorationTotalNanos();
-        long buildStartNs = System.nanoTime();
         if (liveCtx == null) {
           liveCtx = queryStore.get(ctx.getQueryId()).orElse(ctx);
         }
@@ -1911,47 +2252,31 @@ public class UserObjectBundleService {
         Optional<RelationPinIdentity> scopedIdentity =
             scopedPinIdentity(
                 correlationId, found.relation(), liveCtx, resolutionContext.engineContext());
-        /* Identity-only fast path: never cached — the info cache must only
-         * ever hold full payloads, or a later request that did NOT prove
-         * possession would be served a payload-less relation. */
-        RelationInfo slim =
-            identityOnlyOrNull(
-                found.relation(), scopedIdentity, statsProvider, knownBlobVersions, timings);
-        if (slim != null) {
-          // Account the slim path symmetric with the full path below: its stats time already landed
-          // in timings via identityOnlyOrNull; fold the remaining (identity-build) time into
-          // relationBuildNanos so identity-only resolutions are not invisible to the summary event.
-          long buildNanos = System.nanoTime() - buildStartNs;
-          long statsDeltaNanos = timings.statsLookupNanos() - statsBeforeNanos;
-          relationBuildNanos += Math.max(0L, buildNanos - statsDeltaNanos);
+        BuiltRelation built = buildRelationWithCancellationChecks(found, liveCtx, scopedIdentity);
+        TimingAccumulator buildTimings = built.timings();
+        timings.addFrom(buildTimings);
+        long statsNanos = buildTimings.statsLookupNanos();
+        long buildDecorationNanos = buildTimings.decorationTotalNanos();
+        if (built.identityOnly()) {
+          // Identity-only responses are not cached: the cache must hold full payloads for later
+          // requests that did not prove possession.
+          relationBuildNanos += Math.max(0L, built.buildNanos() - statsNanos);
           resolutions.add(
               RelationResolution.newBuilder()
                   .setInputIndex(found.inputIndex())
                   .setStatus(ResolutionStatus.RESOLUTION_STATUS_FOUND)
-                  .setRelation(slim)
+                  .setRelation(built.info())
                   .build());
           continue;
         }
-        RelationInfo info =
-            buildRelation(
-                correlationId,
-                found.relation(),
-                liveCtx,
-                resolutionContext,
-                statsProvider,
-                timings,
-                scopedIdentity);
-        long buildNanos = System.nanoTime() - buildStartNs;
-        long statsDeltaNanos = timings.statsLookupNanos() - statsBeforeNanos;
-        long decorationDeltaNanos = timings.decorationTotalNanos() - decorationBeforeNanos;
-        relationBuildNanos += Math.max(0L, buildNanos - statsDeltaNanos - decorationDeltaNanos);
-        decorationNanos += Math.max(0L, decorationDeltaNanos);
-        relationInfoCache.put(cacheKey, info);
+        relationBuildNanos += Math.max(0L, built.buildNanos() - statsNanos - buildDecorationNanos);
+        decorationNanos += Math.max(0L, buildDecorationNanos);
+        relationInfoCache.put(cacheKey, built.info());
         resolutions.add(
             RelationResolution.newBuilder()
                 .setInputIndex(found.inputIndex())
                 .setStatus(ResolutionStatus.RESOLUTION_STATUS_FOUND)
-                .setRelation(info)
+                .setRelation(built.info())
                 .build());
       }
       emittedResolutionChunks++;
@@ -1975,9 +2300,14 @@ public class UserObjectBundleService {
     }
 
     private void publishStreamTelemetry(String outcome) {
-      if (!telemetryPublished.compareAndSet(false, true)) {
+      if (!telemetryGate.claim()) {
         return;
       }
+      publishClaimedStreamTelemetry(outcome);
+    }
+
+    /** Publish after the telemetry gate has atomically selected this terminal outcome. */
+    private void publishClaimedStreamTelemetry(String outcome) {
       long totalNanos = System.nanoTime() - streamStartNs;
       long schedulingNanos =
           Math.max(
@@ -2268,31 +2598,44 @@ public class UserObjectBundleService {
       }
     }
 
-    // Track every pin that must be durable before the next chunk is emitted.
-    private void accumulateChunkPins(RelationPinSet incomingPins) {
+    /** Merge pins into pending commit ownership unless cancellation already detached that state. */
+    private boolean accumulateChunkPins(RelationPinSet incomingPins) {
       if (incomingPins == null || incomingPins.getPinsCount() == 0) {
-        return;
+        return true;
       }
-      try {
+      synchronized (pendingChunkPinsLock) {
+        if (isCancelled()) {
+          return false;
+        }
         pendingChunkPins = QueryPins.mergeSets(pendingChunkPins, incomingPins, correlationId);
-      } catch (RuntimeException | Error e) {
-        queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(incomingPins));
-        throw e;
+        return true;
       }
     }
 
+    /**
+     * Atomically detach pending pins, commit them as durable query roots, and release their
+     * transient roots on every failed or missing-context outcome. Store I/O runs outside the
+     * cancellation lock so termination cannot block behind the update.
+     */
     private void commitChunkPins() {
-      if (pendingChunkPins.getPinsCount() == 0) {
-        return;
+      RelationPinSet toCommit;
+      synchronized (pendingChunkPinsLock) {
+        throwIfCancelled(this::isCancelled);
+        if (pendingChunkPins.getPinsCount() == 0) {
+          return;
+        }
+        if (LOG.isDebugEnabled()) {
+          LOG.debugf(
+              "Committing chunk pins query_id=%s pin_count=%d",
+              ctx.getQueryId(), pendingChunkPins.getPinsCount());
+        }
+        toCommit = pendingChunkPins;
+        pendingChunkPins = RelationPinSet.getDefaultInstance();
       }
-      if (LOG.isDebugEnabled()) {
-        LOG.debugf(
-            "Committing chunk pins query_id=%s pin_count=%d",
-            ctx.getQueryId(), pendingChunkPins.getPinsCount());
-      }
-      RelationPinSet toCommit = pendingChunkPins;
-      // The resolver registered these pins' blobs as transient GC roots at resolution, so they are
-      // protected across the collect→commit window; this update makes the context a durable root.
+
+      // A concurrent cancellation sees this set as in-flight and leaves it to this method: a
+      // successful update establishes the durable root; a failed update releases the transient
+      // root below. That avoids both the GC window and blocking cancellation on store I/O.
       Optional<QueryContext> updated;
       try {
         updated =
@@ -2302,7 +2645,6 @@ public class UserObjectBundleService {
         queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
         throw e;
       }
-      pendingChunkPins = RelationPinSet.getDefaultInstance();
       if (updated.isEmpty()) {
         queryStore.releaseResolvingPinBlobs(ctx.getQueryId(), QueryPins.gcRootUris(toCommit));
         LOG.warnf(
@@ -2312,6 +2654,12 @@ public class UserObjectBundleService {
       }
       if (LOG.isDebugEnabled()) {
         LOG.debugf("Committed chunk pins query_id=%s", ctx.getQueryId());
+      }
+    }
+
+    private int pendingChunkPinCount() {
+      synchronized (pendingChunkPinsLock) {
+        return pendingChunkPins.getPinsCount();
       }
     }
   }

--- a/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleService.java
@@ -58,7 +58,6 @@ import ai.floedb.floecat.scanner.spi.CatalogOverlay;
 import ai.floedb.floecat.scanner.spi.MetadataResolutionContext;
 import ai.floedb.floecat.scanner.spi.StatsProvider;
 import ai.floedb.floecat.scanner.utils.EngineContext;
-import ai.floedb.floecat.service.concurrent.MetadataIoExecutors;
 import ai.floedb.floecat.service.context.EngineContextProvider;
 import ai.floedb.floecat.service.context.PropagatedContext;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
@@ -243,8 +242,15 @@ public class UserObjectBundleService {
 
   /** Bound bean destruction even if a store call ignores interruption during shutdown. */
   private static void shutdownExecutor(ExecutorService executor) {
-    if (!MetadataIoExecutors.shutdownNowAndAwait(
-        executor, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+    executor.shutdownNow();
+    boolean terminated;
+    try {
+      terminated = executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      terminated = false;
+    }
+    if (!terminated) {
       LOG.warn("bundle cancellation teardown executor did not terminate before shutdown timeout");
     }
   }

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QueryInputMetadataAssembler.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.query.rpc.ExpansionMap;
 import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TableObligations;
+import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.resolver.ObligationsResolver;
 import ai.floedb.floecat.service.query.resolver.QueryInputResolver;
@@ -32,9 +33,10 @@ import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class QueryInputMetadataAssembler {
@@ -81,7 +83,7 @@ public class QueryInputMetadataAssembler {
                       inputs,
                       asOfDefault,
                       Optional.of(defaultCatalogId),
-                      new LinkedHashMap<>(),
+                      new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                       diagnostics));
       diagnostics.put("resolved_inputs", resolution.resolved().size());
       RelationPinSet relationPinSet = resolution.relationPinSet();

--- a/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/impl/QuerySchemaServiceImpl.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.jboss.logging.Logger;
 
 /**
@@ -119,7 +120,8 @@ public class QuerySchemaServiceImpl extends BaseServiceImpl implements QuerySche
                                     request.getInputsList(),
                                     asOfDefault,
                                     Optional.of(ctx.getQueryDefaultCatalogId()),
-                                    new java.util.LinkedHashMap<>(),
+                                    new java.util.concurrent.ConcurrentHashMap<
+                                        ResourceId, CompletableFuture<TablePin>>(),
                                     diagnostics));
                     diagnostics.put("resolved_inputs", rr.resolved().size());
 

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/CurrentSnapshotCacheOwnership.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/CurrentSnapshotCacheOwnership.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.query.resolver;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.query.rpc.TablePin;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Owns the single-flight cache entries inserted by one input-resolution attempt. Failure evicts
+ * only this attempt's entries, while terminal cleanup prevents late workers from publishing an
+ * unrooted pin after the attempt has ended.
+ */
+final class CurrentSnapshotCacheOwnership {
+  private final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache;
+  private final Map<ResourceId, CompletableFuture<TablePin>> owned = new LinkedHashMap<>();
+  private boolean terminal;
+
+  CurrentSnapshotCacheOwnership(ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache) {
+    this.cache = cache;
+  }
+
+  /** Claim a newly inserted holder, or discard it when terminal cleanup already won. */
+  synchronized boolean claim(ResourceId tableId, CompletableFuture<TablePin> holder) {
+    if (terminal) {
+      synchronized (holder) {
+        cache.remove(tableId, holder);
+        holder.completeExceptionally(
+            new CancellationException("input resolution no longer active"));
+      }
+      return false;
+    }
+    owned.put(tableId, holder);
+    return true;
+  }
+
+  /** Forget a holder that its lookup failure already evicted from the shared cache. */
+  synchronized void forget(ResourceId tableId, CompletableFuture<TablePin> holder) {
+    owned.remove(tableId, holder);
+  }
+
+  /**
+   * Replace a compatible losing CURRENT holder with the pin retained by ordered first-touch. A
+   * waiter that observed the old holder retries against the replacement before using the loser.
+   */
+  synchronized void replaceCompatiblePin(TablePin losingPin, TablePin retainedPin) {
+    if (terminal) {
+      return;
+    }
+    ResourceId tableId = losingPin.getTableId();
+    CompletableFuture<TablePin> holder = cache.get(tableId);
+    if (holder == null
+        || !holder.isDone()
+        || holder.isCompletedExceptionally()
+        || holder.isCancelled()) {
+      return;
+    }
+    synchronized (holder) {
+      if (cache.get(tableId) != holder || holder.getNow(null) != losingPin) {
+        return;
+      }
+      CompletableFuture<TablePin> replacement = CompletableFuture.completedFuture(retainedPin);
+      if (cache.replace(tableId, holder, replacement)) {
+        owned.remove(tableId, holder);
+        owned.put(tableId, replacement);
+      }
+    }
+  }
+
+  /** Evict and fail every holder still owned by this failed resolution attempt. */
+  synchronized void closeAndEvict() {
+    terminal = true;
+    owned.forEach(
+        (tableId, holder) -> {
+          synchronized (holder) {
+            cache.remove(tableId, holder);
+            holder.completeExceptionally(new CancellationException("input resolution failed"));
+          }
+        });
+    owned.clear();
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -31,7 +31,6 @@ import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
-import ai.floedb.floecat.service.concurrent.BoundedFanout;
 import ai.floedb.floecat.service.concurrent.Futures;
 import ai.floedb.floecat.service.concurrent.MetadataFanout;
 import ai.floedb.floecat.service.context.PropagatedContext;
@@ -42,6 +41,7 @@ import ai.floedb.floecat.service.query.ViewContextUtils;
 import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
+import io.grpc.Context;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
@@ -441,7 +441,7 @@ public class QueryInputResolver {
     }
     return withResolutionInvocation(
         currentSnapshotPinCache,
-        BoundedFanout.NEVER_CANCELLED,
+        Context.current()::isCancelled,
         () ->
             resolveViaLegacyOverride(
                 queryId,
@@ -491,7 +491,7 @@ public class QueryInputResolver {
             defaultCatalogId,
             singleFlightCache,
             diagnostics,
-            BoundedFanout.NEVER_CANCELLED);
+            Context.current()::isCancelled);
     try {
       completedPins(singleFlightCache)
           .forEach(

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -766,13 +766,14 @@ public class QueryInputResolver {
       List<QueryInput> inputs,
       Map<NameRef, Optional<ResourceId>> resolvedNames,
       BooleanSupplier cancelled) {
-    boolean concurrent = metadataGraph.supportsConcurrentResolution();
+    MetadataFanout fanout =
+        metadataGraph.supportsConcurrentResolution()
+            ? MetadataFanout.concurrent(maxParallelInputResolutions)
+            : MetadataFanout.serial();
     AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
     try {
-      MetadataFanout.forEachOrdered(
+      fanout.forEachOrdered(
           inputs,
-          maxParallelInputResolutions,
-          concurrent,
           in -> planInput(state.withDiagnostics(taskDiagnostics), in, resolvedNames),
           plan -> mergePlan(state, plan),
           cancelled);

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.PinKind;
@@ -30,10 +31,15 @@ import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotSet;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.service.concurrent.BoundedFanout;
+import ai.floedb.floecat.service.concurrent.Futures;
+import ai.floedb.floecat.service.concurrent.MetadataFanout;
+import ai.floedb.floecat.service.context.PropagatedContext;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.ViewContextUtils;
+import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -46,6 +52,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
 
 /**
  * QueryInputResolver
@@ -81,6 +99,17 @@ import java.util.Set;
 @ApplicationScoped
 public class QueryInputResolver {
 
+  private static final Logger LOG = Logger.getLogger(QueryInputResolver.class);
+  private static final int DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS = 8;
+  private static final int MAX_PARALLEL_INPUT_RESOLUTIONS = 16;
+  private static final long SNAPSHOT_WAIT_POLL_MILLIS = 10;
+
+  // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
+  // store reads; a small fan-out overlaps their round-trips without flooding the store. This is a
+  // per-request bound only; the process-wide store-read ceiling is enforced separately at the
+  // repository layer. ConfigProvider keeps construction dependent on graph/store collaborators
+  // while production still reads the deployment setting once per resolver.
+  private final int maxParallelInputResolutions;
   private final CatalogOverlay metadataGraph;
 
   // Registers each resolved pin's blobs as a transient GC root at construction time (see
@@ -88,15 +117,35 @@ public class QueryInputResolver {
   // without a store — registration is simply skipped then.
   private final QueryContextStore queryStore;
 
+  // Carries cancellable single-flight state through the overridable completed-pin Map seam.
+  private final ThreadLocal<ResolutionInvocation> resolutionInvocation = new ThreadLocal<>();
+
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
     this.metadataGraph = metadataGraph;
     this.queryStore = queryStore;
+    this.maxParallelInputResolutions = configuredMaxParallelInputResolutions();
   }
 
   /** Test-only constructor: no store (no pin-root registration). */
   public QueryInputResolver(CatalogOverlay metadataGraph) {
     this(metadataGraph, null);
+  }
+
+  /** Read and clamp the per-request fan-out width so invalid deployment values remain safe. */
+  private static int configuredMaxParallelInputResolutions() {
+    int configured =
+        ConfigProvider.getConfig()
+            .getOptionalValue("floecat.query.resolver.max_parallel_inputs", Integer.class)
+            .orElse(DEFAULT_MAX_PARALLEL_INPUT_RESOLUTIONS);
+    int clamped = Math.max(1, Math.min(MAX_PARALLEL_INPUT_RESOLUTIONS, configured));
+    if (configured != clamped) {
+      LOG.warnf(
+          "floecat.query.resolver.max_parallel_inputs must be between 1 and %d; using %d"
+              + " instead of %d",
+          MAX_PARALLEL_INPUT_RESOLUTIONS, clamped, configured);
+    }
+    return clamped;
   }
 
   // =============================================================================
@@ -135,46 +184,156 @@ public class QueryInputResolver {
     // Keep insertion order (matching input order) while deduplicating by table ID.
     final Map<ResourceId, TablePin> pinByTableId = new LinkedHashMap<>();
     // Request-local cache for current-snapshot table pins (no override, no as-of).
-    final Map<ResourceId, TablePin> currentSnapshotPinCache;
-    // Transient roots owned by this resolution attempt until the pins are committed or discarded.
+    final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache;
+    // Entries inserted into the caller cache by this attempt, for conditional eviction on failure.
+    final CurrentSnapshotCacheOwnership currentSnapshotCacheOwnership;
+    // Tracks transient roots owned by this resolution attempt until they are retained or discarded.
     final ResolvingPinRoots resolvingPinRoots;
     final PhaseDiagnostics diagnostics;
+    final BooleanSupplier cancelled;
 
     ResolutionState(
         String queryId,
         String correlationId,
         Optional<Timestamp> asOfDefault,
         Optional<String> defaultCatalog,
-        Map<ResourceId, TablePin> currentSnapshotPinCache,
+        ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+        CurrentSnapshotCacheOwnership currentSnapshotCacheOwnership,
         ResolvingPinRoots resolvingPinRoots,
-        PhaseDiagnostics diagnostics) {
+        PhaseDiagnostics diagnostics,
+        BooleanSupplier cancelled) {
       this.queryId = queryId;
       this.correlationId = correlationId;
       this.asOfDefault = asOfDefault;
       this.defaultCatalog = defaultCatalog;
       this.currentSnapshotPinCache = currentSnapshotPinCache;
+      this.currentSnapshotCacheOwnership = currentSnapshotCacheOwnership;
       this.resolvingPinRoots = resolvingPinRoots;
       this.diagnostics = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
+      this.cancelled = cancelled;
+    }
+
+    /**
+     * A view of this state that reports to {@code taskDiagnostics} instead of the shared
+     * diagnostics, for resolving one input off the request thread. Shares the read-only fields and
+     * the current-snapshot cache (which must be thread-safe); its own {@code resolved} / {@code
+     * pinByTableId} are unused, since off-thread resolution only computes pins and never merges.
+     */
+    ResolutionState withDiagnostics(PhaseDiagnostics taskDiagnostics) {
+      return new ResolutionState(
+          queryId,
+          correlationId,
+          asOfDefault,
+          defaultCatalog,
+          currentSnapshotPinCache,
+          currentSnapshotCacheOwnership,
+          resolvingPinRoots,
+          taskDiagnostics,
+          cancelled);
     }
   }
 
   /**
-   * Owns transient registrations made while one resolution attempt constructs pins. Retained pins
-   * remain rooted until their query context is committed; compatible duplicates and failed
-   * resolutions release only the roots registered by this attempt.
+   * Tracks single-flight holders inserted by one resolution attempt. A failed attempt evicts only
+   * its own holders, leaving entries supplied by earlier or concurrent owners untouched. Closing is
+   * terminal: a late task that records after cancellation removes and fails its holder instead of
+   * publishing an unrooted pin after cleanup has completed.
+   */
+  private static final class CurrentSnapshotCacheOwnership {
+    private final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache;
+    private final Map<ResourceId, CompletableFuture<TablePin>> owned = new LinkedHashMap<>();
+    private boolean terminal;
+
+    CurrentSnapshotCacheOwnership(ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache) {
+      this.cache = cache;
+    }
+
+    /** Claim a newly inserted holder, or discard it when failure cleanup already won. */
+    synchronized boolean claim(ResourceId tableId, CompletableFuture<TablePin> holder) {
+      if (terminal) {
+        synchronized (holder) {
+          cache.remove(tableId, holder);
+          holder.completeExceptionally(
+              new CancellationException("input resolution no longer active"));
+        }
+        return false;
+      }
+      owned.put(tableId, holder);
+      return true;
+    }
+
+    /** Forget a holder that its lookup failure already evicted from the caller cache. */
+    synchronized void forget(ResourceId tableId, CompletableFuture<TablePin> holder) {
+      owned.remove(tableId, holder);
+    }
+
+    /**
+     * Replace a compatible losing CURRENT holder with the pin retained by ordered first-touch. A
+     * waiter that already observed the old holder fails its run-if-current check and retries
+     * against this replacement before using the losing pin.
+     */
+    synchronized void replaceCompatiblePin(TablePin losingPin, TablePin retainedPin) {
+      if (terminal) {
+        return;
+      }
+      ResourceId tableId = losingPin.getTableId();
+      CompletableFuture<TablePin> holder = cache.get(tableId);
+      if (holder == null
+          || !holder.isDone()
+          || holder.isCompletedExceptionally()
+          || holder.isCancelled()) {
+        return;
+      }
+      synchronized (holder) {
+        if (cache.get(tableId) != holder || holder.getNow(null) != losingPin) {
+          return;
+        }
+        CompletableFuture<TablePin> replacement = CompletableFuture.completedFuture(retainedPin);
+        if (cache.replace(tableId, holder, replacement)) {
+          owned.remove(tableId, holder);
+          // This attempt changed shared cache state. Failure cleanup must evict the replacement
+          // before releasing the retained pin's transient roots.
+          owned.put(tableId, replacement);
+        }
+      }
+    }
+
+    /** Evict and fail every holder still owned by this failed resolution attempt. */
+    synchronized void closeAndEvict() {
+      terminal = true;
+      owned.forEach(
+          (tableId, holder) -> {
+            synchronized (holder) {
+              cache.remove(tableId, holder);
+              holder.completeExceptionally(new CancellationException("input resolution failed"));
+            }
+          });
+      owned.clear();
+    }
+  }
+
+  /**
+   * Owns the transient registrations made while one {@link #resolveInputs} call constructs pins. A
+   * retained pin stays registered until its context commit makes it durable; a discarded pin or
+   * failed resolution releases only the registration this attempt created.
    */
   private static final class ResolvingPinRoots {
     private final QueryContextStore queryStore;
     private final String queryId;
     private final Map<TablePin, List<String>> rootsByPin = new IdentityHashMap<>();
+    private boolean terminal;
 
     ResolvingPinRoots(QueryContextStore queryStore, String queryId) {
       this.queryStore = queryStore;
       this.queryId = queryId;
     }
 
+    /**
+     * Register a pin's roots once for this attempt. A store failure leaves the pin untracked so
+     * callers propagate the failure without attempting a compensating release.
+     */
     synchronized void register(TablePin pin) {
-      if (queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
+      if (terminal || queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
         return;
       }
       if (rootsByPin.containsKey(pin)) {
@@ -188,7 +347,14 @@ public class QueryInputResolver {
       rootsByPin.put(pin, roots);
     }
 
+    /**
+     * Release this attempt's registration for a compatible pin that lost ordered first-touch. A
+     * store failure retains ownership so a later failure cleanup can retry the release.
+     */
     synchronized void discard(TablePin pin) {
+      if (terminal) {
+        return;
+      }
       List<String> roots = rootsByPin.get(pin);
       if (roots != null) {
         queryStore.releaseResolvingPinBlobs(queryId, roots);
@@ -196,7 +362,14 @@ public class QueryInputResolver {
       }
     }
 
+    /**
+     * Release every registration still owned by this failed attempt. A store failure stops release
+     * and propagates to the caller, which retains the original resolution failure.
+     */
     synchronized void releaseAll() {
+      // Cancellation can return from the fan-out before an uninterruptible task reaches register.
+      // Close ownership first so such a late task cannot add roots after this cleanup sweep.
+      terminal = true;
       var iterator = rootsByPin.entrySet().iterator();
       while (iterator.hasNext()) {
         Map.Entry<TablePin, List<String>> entry = iterator.next();
@@ -221,7 +394,13 @@ public class QueryInputResolver {
       Optional<Timestamp> asOfDefault,
       Optional<ResourceId> defaultCatalogId) {
     return resolveInputs(
-        "", correlationId, inputs, asOfDefault, defaultCatalogId, new LinkedHashMap<>(), null);
+        "",
+        correlationId,
+        inputs,
+        asOfDefault,
+        defaultCatalogId,
+        new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+        null);
   }
 
   /**
@@ -237,7 +416,47 @@ public class QueryInputResolver {
    *
    * <p>{@code defaultCatalogId} is used only when expanding view base relations: if a base-relation
    * {@link NameRef} has a blank catalog or empty path it is enriched with the query's default
-   * catalog / creation search-path before resolution. Non-view inputs are unaffected.
+   * catalog / creation search-path before resolution. Non-view inputs are unaffected. {@code
+   * currentSnapshotPinCache} is shared by concurrent input tasks, so it must provide atomic {@link
+   * ConcurrentMap#putIfAbsent} and conditional removal.
+   */
+  public ResolutionResult resolveInputs(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics) {
+    ResolutionInvocation invocation = resolutionInvocation.get();
+    if (invocation != null) {
+      return resolveViaLegacyOverride(
+          queryId,
+          correlationId,
+          inputs,
+          asOfDefault,
+          defaultCatalogId,
+          invocation.currentSnapshotPinCache(),
+          diagnostics);
+    }
+    return withResolutionInvocation(
+        currentSnapshotPinCache,
+        BoundedFanout.NEVER_CANCELLED,
+        () ->
+            resolveViaLegacyOverride(
+                queryId,
+                correlationId,
+                inputs,
+                asOfDefault,
+                defaultCatalogId,
+                currentSnapshotPinCache,
+                diagnostics));
+  }
+
+  /**
+   * Compatibility overload for callers and subclasses using the completed-pin cache contract. Plain
+   * maps are copied into the concurrent single-flight representation before fan-out and are updated
+   * only after successful resolution on the calling thread.
    */
   public ResolutionResult resolveInputs(
       String queryId,
@@ -247,63 +466,256 @@ public class QueryInputResolver {
       Optional<ResourceId> defaultCatalogId,
       Map<ResourceId, TablePin> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
-    PhaseDiagnostics diag = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
-
-    // Resolve catalog display-name once up-front — used to fill in blank catalog fields in
-    // view base-relation NameRefs so they re-resolve exactly as they did at view-creation time.
-    Optional<String> defaultCatalog = Optional.empty();
-    if (metadataGraph != null && defaultCatalogId.isPresent()) {
-      diag.count("pin.default_catalog_lookups");
-      long defaultCatalogStartNs = System.nanoTime();
-      try {
-        defaultCatalog =
-            metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName);
-      } finally {
-        diag.nanos("pin.default_catalog_resolve", System.nanoTime() - defaultCatalogStartNs);
-      }
+    ResolutionInvocation invocation = resolutionInvocation.get();
+    if (invocation != null) {
+      return resolveInputsCore(
+          queryId,
+          correlationId,
+          inputs,
+          asOfDefault,
+          defaultCatalogId,
+          invocation.currentSnapshotPinCache(),
+          diagnostics,
+          invocation.cancelled());
     }
 
-    var state =
-        new ResolutionState(
+    Map<ResourceId, TablePin> initialCache = new LinkedHashMap<>(currentSnapshotPinCache);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
+        toSingleFlightCache(initialCache);
+    ResolutionResult result =
+        resolveInputsCore(
             queryId,
             correlationId,
+            inputs,
             asOfDefault,
-            defaultCatalog,
-            currentSnapshotPinCache,
-            new ResolvingPinRoots(queryStore, queryId),
-            diag);
-
+            defaultCatalogId,
+            singleFlightCache,
+            diagnostics,
+            BoundedFanout.NEVER_CANCELLED);
     try {
-      // Batch-resolve all NAME inputs up front: names sharing a catalog/namespace resolve their
-      // scope once instead of once per input.
-      List<NameRef> nameInputs =
-          inputs.stream()
-              .filter(in -> in.getTargetCase() == QueryInput.TargetCase.NAME)
-              .map(QueryInput::getName)
-              .toList();
-      Map<NameRef, Optional<ResourceId>> resolvedNames =
-          nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
-
-      // Resolve and merge in input order. A later malformed input must not mask a conflict that
-      // was already established by an earlier pair.
-      for (QueryInput in : inputs) {
-        mergePlan(state, planInput(state, in, resolvedNames));
-      }
-
-      RelationPinSet relationPinSet =
-          RelationPinSet.newBuilder()
-              .addAllPins(state.pinByTableId.values().stream().map(QueryPins::ofTable).toList())
-              .build();
-      diag.add("pin.resolver_output_pins", relationPinSet.getPinsCount());
-      return new ResolutionResult(
-          state.resolved, relationPinSet, asOfDefault.map(Timestamp::toByteArray).orElse(null));
-    } catch (RuntimeException | Error e) {
+      completedPins(singleFlightCache)
+          .forEach(
+              (tableId, pin) -> {
+                if (!initialCache.containsKey(tableId)
+                    || !java.util.Objects.equals(initialCache.get(tableId), pin)) {
+                  currentSnapshotPinCache.put(tableId, pin);
+                }
+              });
+    } catch (RuntimeException | Error copyFailure) {
+      boolean restored = false;
       try {
-        state.resolvingPinRoots.releaseAll();
-      } catch (RuntimeException | Error cleanupFailure) {
-        e.addSuppressed(cleanupFailure);
+        if (!currentSnapshotPinCache.equals(initialCache)) {
+          currentSnapshotPinCache.clear();
+          currentSnapshotPinCache.putAll(initialCache);
+        }
+        restored = currentSnapshotPinCache.equals(initialCache);
+      } catch (RuntimeException | Error rollbackFailure) {
+        copyFailure.addSuppressed(rollbackFailure);
       }
-      throw e;
+      if (restored && queryStore != null && queryId != null && !queryId.isEmpty()) {
+        try {
+          queryStore.releaseResolvingPinBlobs(
+              queryId, QueryPins.gcRootUris(result.relationPinSet()));
+        } catch (RuntimeException | Error cleanupFailure) {
+          copyFailure.addSuppressed(cleanupFailure);
+        }
+      }
+      throw copyFailure;
+    }
+    return result;
+  }
+
+  /**
+   * As {@link #resolveInputs(String, String, List, Optional, Optional, ConcurrentMap,
+   * PhaseDiagnostics)}, but stops before additional metadata work and interrupts fan-out tasks when
+   * {@code cancelled} becomes true. The supplier may be read concurrently by the caller and worker
+   * threads, so it must be non-blocking and thread-safe (typically {@link AtomicBoolean#get}).
+   * Observed cancellation throws {@link CancellationException}.
+   */
+  public ResolutionResult resolveInputs(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
+    return withResolutionInvocation(
+        currentSnapshotPinCache,
+        cancelled,
+        () ->
+            resolveInputs(
+                queryId,
+                correlationId,
+                inputs,
+                asOfDefault,
+                defaultCatalogId,
+                currentSnapshotPinCache,
+                diagnostics));
+  }
+
+  /** Invoke the completed-pin compatibility seam and publish its successful cache entries. */
+  private ResolutionResult resolveViaLegacyOverride(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics) {
+    Map<ResourceId, TablePin> completedPinCache = completedPins(currentSnapshotPinCache);
+    ResolutionResult result =
+        resolveInputs(
+            queryId,
+            correlationId,
+            inputs,
+            asOfDefault,
+            defaultCatalogId,
+            completedPinCache,
+            diagnostics);
+    completedPinCache.forEach(
+        (tableId, pin) ->
+            currentSnapshotPinCache.putIfAbsent(tableId, CompletableFuture.completedFuture(pin)));
+    return result;
+  }
+
+  /** Install one invocation while retaining any outer invocation on the same request thread. */
+  private <T> T withResolutionInvocation(
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      BooleanSupplier cancelled,
+      Supplier<T> operation) {
+    ResolutionInvocation previous = resolutionInvocation.get();
+    resolutionInvocation.set(new ResolutionInvocation(currentSnapshotPinCache, cancelled));
+    try {
+      return operation.get();
+    } finally {
+      if (previous == null) {
+        resolutionInvocation.remove();
+      } else {
+        resolutionInvocation.set(previous);
+      }
+    }
+  }
+
+  /** Convert completed pins to the concurrent placeholder representation used during fan-out. */
+  private static ConcurrentMap<ResourceId, CompletableFuture<TablePin>> toSingleFlightCache(
+      Map<ResourceId, TablePin> completedPinCache) {
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
+        new ConcurrentHashMap<>();
+    completedPinCache.forEach(
+        (tableId, pin) -> singleFlightCache.put(tableId, CompletableFuture.completedFuture(pin)));
+    return singleFlightCache;
+  }
+
+  /** Snapshot successfully completed placeholders without waiting for active lookups. */
+  private static Map<ResourceId, TablePin> completedPins(
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache) {
+    Map<ResourceId, TablePin> completed = new LinkedHashMap<>();
+    singleFlightCache.forEach(
+        (tableId, pinFuture) -> {
+          if (pinFuture.isDone()
+              && !pinFuture.isCompletedExceptionally()
+              && !pinFuture.isCancelled()) {
+            completed.put(tableId, Futures.join(pinFuture));
+          }
+        });
+    return completed;
+  }
+
+  /** Per-thread state carried through the completed-pin override seam. */
+  private record ResolutionInvocation(
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      BooleanSupplier cancelled) {}
+
+  /** Run the shared resolution implementation for cancellable and non-cancellable callers. */
+  private ResolutionResult resolveInputsCore(
+      String queryId,
+      String correlationId,
+      List<QueryInput> inputs,
+      Optional<Timestamp> asOfDefault,
+      Optional<ResourceId> defaultCatalogId,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      PhaseDiagnostics diagnostics,
+      BooleanSupplier cancelled) {
+    throwIfCancelled(cancelled);
+    PhaseDiagnostics diag = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
+
+    // Bind the request's cancellation token for the whole resolution so every auto-admitted store
+    // read — including reads on fan-out workers — can abort its admission wait when this request
+    // cancels. Closing the scope restores the prior binding and never throws.
+    try (var cancellationScope = PropagatedContext.bindCancellation(cancelled)) {
+      // Resolve catalog display-name once up-front — used to fill in blank catalog fields in
+      // view base-relation NameRefs so they re-resolve exactly as they did at view-creation time.
+      Optional<String> defaultCatalog = Optional.empty();
+      if (metadataGraph != null && defaultCatalogId.isPresent()) {
+        diag.count("pin.default_catalog_lookups");
+        long defaultCatalogStartNs = System.nanoTime();
+        try {
+          defaultCatalog =
+              metadataGraph.catalog(defaultCatalogId.get()).map(CatalogNode::displayName);
+        } finally {
+          diag.nanos("pin.default_catalog_resolve", System.nanoTime() - defaultCatalogStartNs);
+        }
+      }
+      throwIfCancelled(cancelled);
+
+      var state =
+          new ResolutionState(
+              queryId,
+              correlationId,
+              asOfDefault,
+              defaultCatalog,
+              currentSnapshotPinCache,
+              new CurrentSnapshotCacheOwnership(currentSnapshotPinCache),
+              new ResolvingPinRoots(queryStore, queryId),
+              diag,
+              cancelled);
+
+      try {
+        // Batch-resolve all NAME inputs up front: names sharing a catalog/namespace resolve their
+        // scope once instead of once per input.
+        List<NameRef> nameInputs =
+            inputs.stream()
+                .filter(in -> in.getTargetCase() == QueryInput.TargetCase.NAME)
+                .map(QueryInput::getName)
+                .toList();
+        Map<NameRef, Optional<ResourceId>> resolvedNames =
+            nameInputs.isEmpty() ? Map.of() : metadataGraph.resolveNames(correlationId, nameInputs);
+        throwIfCancelled(cancelled);
+
+        // Resolve each input to its id and the table pins it contributes (a table yields its own
+        // pin; a view yields its base tables' pins). planInput reads the metadata graph and the
+        // shared current-snapshot cache; it does not touch `resolved` or `pinByTableId`. Inputs
+        // resolve independently, so overlays that explicitly support concurrent resolution fan them
+        // out. An overlay that opts out may retain request-thread-confined lifecycle state, so its
+        // entire planning loop remains on the caller thread. Results always merge in input order.
+        planInputs(state, inputs, resolvedNames, cancelled);
+        throwIfCancelled(cancelled);
+
+        RelationPinSet relationPinSet =
+            RelationPinSet.newBuilder()
+                .addAllPins(state.pinByTableId.values().stream().map(QueryPins::ofTable).toList())
+                .build();
+        diag.add("pin.resolver_output_pins", relationPinSet.getPinsCount());
+        return new ResolutionResult(
+            state.resolved, relationPinSet, asOfDefault.map(Timestamp::toByteArray).orElse(null));
+      } catch (RuntimeException | Error e) {
+        try {
+          // Evict attempt-owned cache entries before releasing their transient roots, so another
+          // resolve call cannot observe an unrooted completed pin in between those operations.
+          state.currentSnapshotCacheOwnership.closeAndEvict();
+        } catch (RuntimeException | Error cleanupFailure) {
+          e.addSuppressed(cleanupFailure);
+        }
+        try {
+          state.resolvingPinRoots.releaseAll();
+        } catch (RuntimeException | Error cleanupFailure) {
+          e.addSuppressed(cleanupFailure);
+        }
+        throw e;
+      }
     }
   }
 
@@ -314,10 +726,12 @@ public class QueryInputResolver {
   /**
    * One input's resolution: the id recorded in {@code resolved}, and the table pins it contributes,
    * ordered. A view's id is recorded but the pins are its base tables'; a table records its id and
-   * its own single pin.
+   * its own single pin. A view may retain a successfully resolved dependency prefix plus a terminal
+   * failure; ordered merge consumes that prefix before rethrowing the deferred failure.
    */
   private record InputPlan(ResourceId resolvedId, List<TablePin> pins, Throwable terminalFailure) {}
 
+  /** Merge one completed plan on the request thread, preserving request-order semantics. */
   private void mergePlan(ResolutionState state, InputPlan plan) {
     state.resolved.add(plan.resolvedId());
     for (TablePin pin : plan.pins()) {
@@ -328,6 +742,50 @@ public class QueryInputResolver {
     }
     if (plan.terminalFailure() instanceof Error error) {
       throw error;
+    }
+  }
+
+  /**
+   * Resolve each input to its id and pins and merge the plans in input order. Inputs are
+   * independent, so an overlay that supports concurrent resolution fans them out (a single input
+   * stays on the caller thread); an overlay that owns request-thread-confined state runs serially.
+   * {@link MetadataFanout} owns that choice and delivers plans in input order (each unit's store
+   * reads are admitted at the repository layer), so the merge stays deterministic
+   * (first-touch-wins, conflict detection). Each input gets its own state view so mutable per-plan
+   * fields never become shared task state; only immutable resolution context and the explicitly
+   * thread-safe single-flight cache, root tracker, and diagnostics accumulator are shared.
+   *
+   * <p>Tasks report to a shared thread-safe accumulator instead of the request's diagnostics (not
+   * guaranteed thread-safe); its per-key totals are flushed to the real diagnostics once resolution
+   * has joined, even on a failed/cancelled sibling. The accumulator keeps counters and durations
+   * only (it omits one-shot put/emit values that cannot be combined across inputs), and its task
+   * timing keys are aggregate work time, so they may exceed the enclosing wall-clock phase.
+   */
+  private void planInputs(
+      ResolutionState state,
+      List<QueryInput> inputs,
+      Map<NameRef, Optional<ResourceId>> resolvedNames,
+      BooleanSupplier cancelled) {
+    boolean concurrent = metadataGraph.supportsConcurrentResolution();
+    AggregatingPhaseDiagnostics taskDiagnostics = new AggregatingPhaseDiagnostics();
+    try {
+      MetadataFanout.forEachOrdered(
+          inputs,
+          maxParallelInputResolutions,
+          concurrent,
+          in -> planInput(state.withDiagnostics(taskDiagnostics), in, resolvedNames),
+          plan -> mergePlan(state, plan),
+          cancelled);
+    } finally {
+      // A failed or cancelled sibling can still leave completed tasks' pin work in the accumulator.
+      // Preserve those counters for the request's failure telemetry too.
+      taskDiagnostics.flushInto(state.diagnostics);
+    }
+  }
+
+  private static void throwIfCancelled(BooleanSupplier cancelled) {
+    if (cancelled.getAsBoolean()) {
+      throw new CancellationException("input resolution cancelled");
     }
   }
 
@@ -411,43 +869,76 @@ public class QueryInputResolver {
     };
   }
 
+  /**
+   * Resolve one table pin. CURRENT lookups use a single-flight holder whose owner constructs and
+   * roots the pin before publication; failures evict the holder and wake waiters. Explicit and
+   * AS-OF requests reuse an exactly matching committed pin or construct and root a fresh one.
+   */
   private TablePin pinForTable(
       ResolutionState state,
       ResourceId rid,
       SnapshotRef override,
       Optional<Timestamp> asOfDefault) {
-    if (usesCurrentSnapshotFallback(override, asOfDefault)) {
-      TablePin cached = state.currentSnapshotPinCache.get(rid);
-      if (cached != null) {
-        state.diagnostics.count("pin.current_snapshot_cache_hits");
-        state.resolvingPinRoots.register(cached);
-        return cached;
+    Optional<Timestamp> effectiveAsOfDefault =
+        isExplicitCurrentSnapshot(override) ? Optional.empty() : asOfDefault;
+    if (usesCurrentSnapshotFallback(override, effectiveAsOfDefault)) {
+      // Single-flight per table: two references to the same table's CURRENT snapshot must freeze
+      // the same snapshot even when they resolve on different threads. Otherwise, an ingest between
+      // independent lookups can turn a compatible pair into a conflict. A CompletableFuture
+      // placeholder provides single-flight without holding a map-bin lock across the store call:
+      // the task that inserts the placeholder performs the lookup, and same-table tasks await it.
+      while (true) {
+        CompletableFuture<TablePin> holder = new CompletableFuture<>();
+        CompletableFuture<TablePin> inflight =
+            state.currentSnapshotPinCache.putIfAbsent(rid, holder);
+        TablePin pin;
+        if (inflight == null) {
+          if (!state.currentSnapshotCacheOwnership.claim(rid, holder)) {
+            throw new CancellationException("input resolution no longer active");
+          }
+          try {
+            long snapshotPinStartNs = System.nanoTime();
+            pin =
+                metadataGraph.tablePinFor(state.correlationId, rid, override, effectiveAsOfDefault);
+            state.resolvingPinRoots.register(pin);
+            state.diagnostics.count("pin.snapshot_calls");
+            state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
+          } catch (RuntimeException | Error e) {
+            // Never cache a failure: drop the placeholder so a retry re-resolves, and release any
+            // callers already awaiting this id with the same error.
+            state.currentSnapshotPinCache.remove(rid, holder);
+            state.currentSnapshotCacheOwnership.forget(rid, holder);
+            holder.completeExceptionally(e);
+            throw e;
+          }
+          holder.complete(pin);
+          state.diagnostics.count("pin.current_snapshot_cache_misses");
+          return pin;
+        }
+
+        pin = awaitCurrentSnapshot(state, inflight);
+        // Failed owners remove the holder under this same lock before releasing their root. A
+        // waiter therefore either installs its own root while the holder remains published or
+        // retries against the replacement entry without using a retired pin.
+        synchronized (inflight) {
+          if (state.currentSnapshotPinCache.get(rid) == inflight) {
+            state.resolvingPinRoots.register(pin);
+            state.diagnostics.count("pin.current_snapshot_cache_hits");
+            return pin;
+          }
+        }
+        throwIfCancelled(state.cancelled);
       }
-      state.diagnostics.count("pin.current_snapshot_cache_misses");
-      long snapshotPinStartNs = System.nanoTime();
-      TablePin resolved =
-          metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
-      state.diagnostics.count("pin.snapshot_calls");
-      state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
-      state.resolvingPinRoots.register(resolved);
-      state.currentSnapshotPinCache.put(rid, resolved);
-      return resolved;
     }
     state.diagnostics.count(
         "pin.explicit_snapshot_pins", override != null && override.hasSnapshotId());
     state.diagnostics.count(
         "pin.asof_snapshot_pins",
         (override != null && override.hasAsOf()) || asOfDefault.isPresent());
-    // Before re-resolving against the LIVE root (which throws once the pinned snapshot has left the
-    // manifest — deleted or expired), reuse the query's existing committed pin if it already froze
-    // THIS same request, mirroring the CURRENT path's per-request cache and the first-touch-wins
-    // rule. A snapshot pinned at BeginQuery keeps its blobs GC-rooted for the query's lifetime, so
-    // a
-    // later DescribeInputs restating the same request must get the pin back — not a spurious
-    // NOT_FOUND or a QUERY_TABLE_PIN_CONFLICT from resolving a different snapshot at the same time.
-    // Covers explicit snapshot_id AND AS_OF (incl. an asOfDefault): both resolve deterministically
-    // to one frozen snapshot. Only a genuinely different request (other id / other as-of)
-    // re-resolves.
+    // Reuse a committed pin that froze this exact explicit or AS-OF request. The committed query
+    // keeps its blobs rooted even after the live manifest no longer contains that snapshot, and
+    // first-touch semantics require subsequent resolution to return the same frozen pin. A
+    // different snapshot id or timestamp still resolves against the live root.
     if (queryStore != null) {
       Optional<TablePin> reused =
           queryStore
@@ -464,18 +955,49 @@ public class QueryInputResolver {
     }
     long snapshotPinStartNs = System.nanoTime();
     TablePin resolved = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+    state.resolvingPinRoots.register(resolved);
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
-    state.resolvingPinRoots.register(resolved);
     return resolved;
+  }
+
+  /** Await a single-flight winner without stranding a cancelled waiter on the executor. */
+  private TablePin awaitCurrentSnapshot(
+      ResolutionState state, CompletableFuture<TablePin> inflight) {
+    while (true) {
+      throwIfCancelled(state.cancelled);
+      if (Thread.currentThread().isInterrupted()) {
+        throw new CancellationException("interrupted while awaiting current snapshot pin");
+      }
+      try {
+        return inflight.get(SNAPSHOT_WAIT_POLL_MILLIS, TimeUnit.MILLISECONDS);
+      } catch (TimeoutException ignored) {
+        // A bounded wait lets the next loop observe cancellation or an executor interrupt.
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new CancellationException("interrupted while awaiting current snapshot pin");
+      } catch (ExecutionException e) {
+        throw Futures.propagate(e.getCause(), "unexpected checked exception from async task");
+      }
+    }
   }
 
   private boolean usesCurrentSnapshotFallback(
       SnapshotRef override, Optional<Timestamp> asOfDefault) {
+    if (isExplicitCurrentSnapshot(override)) {
+      return true;
+    }
     if (override != null && override.getWhichCase() != SnapshotRef.WhichCase.WHICH_NOT_SET) {
       return false;
     }
     return asOfDefault.isEmpty();
+  }
+
+  /** An explicit CURRENT selector takes precedence over a request-wide AS-OF default. */
+  private boolean isExplicitCurrentSnapshot(SnapshotRef override) {
+    return override != null
+        && override.getWhichCase() == SnapshotRef.WhichCase.SPECIAL
+        && override.getSpecial() == SpecialSnapshot.SS_CURRENT;
   }
 
   private void validateViewOverride(String correlationId, ResourceId viewId, SnapshotRef override) {
@@ -485,8 +1007,14 @@ public class QueryInputResolver {
     }
   }
 
-  // Helper method to compute effective as-of timestamp for dependency pinning
+  /**
+   * Selects dependency pinning time: explicit CURRENT clears the request default, explicit AS-OF
+   * replaces it, and an input without either selector inherits the request default.
+   */
   private Optional<Timestamp> effectiveAsOf(SnapshotRef override, Optional<Timestamp> asOfDefault) {
+    if (isExplicitCurrentSnapshot(override)) {
+      return Optional.empty();
+    }
     if (override != null && override.hasAsOf()) {
       return Optional.of(override.getAsOf());
     }
@@ -580,9 +1108,19 @@ public class QueryInputResolver {
       state.pinByTableId.put(pin.getTableId(), pin);
       return;
     }
+    // First-touch wins: compatible later pins relinquish only their own provisional roots.
     QueryPins.reconcile(existing, pin, state.correlationId);
     if (existing != pin) {
-      state.resolvingPinRoots.discard(pin);
+      discardCompatiblePin(state, existing, pin);
     }
+  }
+
+  /**
+   * Rebind a compatible CURRENT cache entry before releasing the losing pin's provisional roots.
+   */
+  private void discardCompatiblePin(
+      ResolutionState state, TablePin retainedPin, TablePin losingPin) {
+    state.currentSnapshotCacheOwnership.replaceCompatiblePin(losingPin, retainedPin);
+    state.resolvingPinRoots.discard(losingPin);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -38,6 +38,7 @@ import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.ViewContextUtils;
+import ai.floedb.floecat.service.repo.util.RepositoryReads;
 import ai.floedb.floecat.telemetry.AggregatingPhaseDiagnostics;
 import ai.floedb.floecat.telemetry.PhaseDiagnostics;
 import com.google.protobuf.Timestamp;
@@ -104,11 +105,14 @@ public class QueryInputResolver {
 
   // Cap on inputs resolved concurrently. Each is an independent, mostly-blocking chain of metadata
   // store reads; a small fan-out overlaps their round-trips without flooding the store. This is a
-  // per-request bound only; the process-wide store-read ceiling is enforced separately at the
-  // repository layer. ConfigProvider keeps construction dependent on graph/store collaborators
-  // while production still reads the deployment setting once per resolver.
+  // per-request bound only; each table-pin chain also passes through pinResolutionReads so all
+  // requests share the process-wide metadata-I/O ceiling. ConfigProvider keeps construction
+  // dependent on graph/store collaborators while production reads the deployment setting once.
   private final int maxParallelInputResolutions;
   private final CatalogOverlay metadataGraph;
+  // Admits one complete table-pin chain. Its root/snapshot repositories intentionally stay direct;
+  // admitting their leaves too would acquire the same process gate twice for one operation.
+  private final RepositoryReads.ReadPolicy pinResolutionReads;
 
   // Registers each resolved pin's blobs as a transient GC root at construction time (see
   // QueryContextStore.registerResolvingPinBlobs). Null in unit tests that construct the resolver
@@ -116,10 +120,19 @@ public class QueryInputResolver {
   private final QueryContextStore queryStore;
 
   @Inject
-  public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
+  public QueryInputResolver(
+      CatalogOverlay metadataGraph,
+      QueryContextStore queryStore,
+      RepositoryReads.ReadPolicy pinResolutionReads) {
     this.metadataGraph = metadataGraph;
     this.queryStore = queryStore;
+    this.pinResolutionReads = pinResolutionReads;
     this.maxParallelInputResolutions = configuredMaxParallelInputResolutions();
+  }
+
+  /** Compatibility constructor for direct callers that own their metadata execution policy. */
+  public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
+    this(metadataGraph, queryStore, RepositoryReads.directPolicy());
   }
 
   /** Test-only constructor: no store (no pin-root registration). */
@@ -160,62 +173,25 @@ public class QueryInputResolver {
   // Per-call accumulation state
   // =============================================================================
 
-  /**
-   * Mutable accumulation state for a single {@link #resolveInputs} call.
-   *
-   * <p>Bundles the values that are constant across the entire resolution pass ({@code
-   * correlationId}, {@code asOfDefault}, {@code defaultCatalog}) together with the two collections
-   * that are built up incrementally ({@code resolved}, {@code pinByTableId}). Passing a single
-   * state object instead of individual parameters keeps the private helper signatures concise.
-   */
-  private static final class ResolutionState {
-    // Stable per-query id under which resolved pins are registered as transient GC roots, so the
-    // committing RPC can release them by the same key (its correlation id changes across RPCs).
-    final String queryId;
-    final String correlationId;
-    final Optional<Timestamp> asOfDefault;
-    final Optional<String> defaultCatalog;
-    final List<ResourceId> resolved = new ArrayList<>();
-    // Keep insertion order (matching input order) while deduplicating by table ID.
-    final Map<ResourceId, TablePin> pinByTableId = new LinkedHashMap<>();
-    // Request-local cache for current-snapshot table pins (no override, no as-of).
-    final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache;
-    // Entries inserted into the caller cache by this attempt, for conditional eviction on failure.
-    final CurrentSnapshotCacheOwnership currentSnapshotCacheOwnership;
-    // Tracks transient roots owned by this resolution attempt until they are retained or discarded.
-    final ResolvingPinRoots resolvingPinRoots;
-    final PhaseDiagnostics diagnostics;
-    final BooleanSupplier cancelled;
+  /** Context shared by input-planning workers; every mutable collaborator is thread-safe. */
+  private record ResolutionWork(
+      String queryId,
+      String correlationId,
+      Optional<Timestamp> asOfDefault,
+      Optional<String> defaultCatalog,
+      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+      CurrentSnapshotCacheOwnership currentSnapshotCacheOwnership,
+      ResolvingPinRoots resolvingPinRoots,
+      PhaseDiagnostics diagnostics,
+      BooleanSupplier cancelled) {
 
-    ResolutionState(
-        String queryId,
-        String correlationId,
-        Optional<Timestamp> asOfDefault,
-        Optional<String> defaultCatalog,
-        ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-        CurrentSnapshotCacheOwnership currentSnapshotCacheOwnership,
-        ResolvingPinRoots resolvingPinRoots,
-        PhaseDiagnostics diagnostics,
-        BooleanSupplier cancelled) {
-      this.queryId = queryId;
-      this.correlationId = correlationId;
-      this.asOfDefault = asOfDefault;
-      this.defaultCatalog = defaultCatalog;
-      this.currentSnapshotPinCache = currentSnapshotPinCache;
-      this.currentSnapshotCacheOwnership = currentSnapshotCacheOwnership;
-      this.resolvingPinRoots = resolvingPinRoots;
-      this.diagnostics = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
-      this.cancelled = cancelled;
+    ResolutionWork {
+      diagnostics = diagnostics == null ? PhaseDiagnostics.NOOP : diagnostics;
     }
 
-    /**
-     * A view of this state that reports to {@code taskDiagnostics} instead of the shared
-     * diagnostics, for resolving one input off the request thread. Shares the read-only fields and
-     * the current-snapshot cache (which must be thread-safe); its own {@code resolved} / {@code
-     * pinByTableId} are unused, since off-thread resolution only computes pins and never merges.
-     */
-    ResolutionState withDiagnostics(PhaseDiagnostics taskDiagnostics) {
-      return new ResolutionState(
+    /** Keep all shared ownership while directing one worker's metrics to its accumulator. */
+    ResolutionWork withDiagnostics(PhaseDiagnostics taskDiagnostics) {
+      return new ResolutionWork(
           queryId,
           correlationId,
           asOfDefault,
@@ -225,6 +201,18 @@ public class QueryInputResolver {
           resolvingPinRoots,
           taskDiagnostics,
           cancelled);
+    }
+  }
+
+  /** Request-thread-only ordered accumulation for one resolution call. */
+  private static final class ResolutionState {
+    final ResolutionWork work;
+    final List<ResourceId> resolved = new ArrayList<>();
+    // Keep insertion order (matching input order) while deduplicating by table ID.
+    final Map<ResourceId, TablePin> pinByTableId = new LinkedHashMap<>();
+
+    ResolutionState(ResolutionWork work) {
+      this.work = work;
     }
   }
 
@@ -433,15 +421,16 @@ public class QueryInputResolver {
 
       var state =
           new ResolutionState(
-              queryId,
-              correlationId,
-              asOfDefault,
-              defaultCatalog,
-              currentSnapshotPinCache,
-              new CurrentSnapshotCacheOwnership(currentSnapshotPinCache),
-              new ResolvingPinRoots(queryStore, queryId),
-              diag,
-              cancelled);
+              new ResolutionWork(
+                  queryId,
+                  correlationId,
+                  asOfDefault,
+                  defaultCatalog,
+                  currentSnapshotPinCache,
+                  new CurrentSnapshotCacheOwnership(currentSnapshotPinCache),
+                  new ResolvingPinRoots(queryStore, queryId),
+                  diag,
+                  cancelled));
 
       try {
         // Batch-resolve all NAME inputs up front: names sharing a catalog/namespace resolve their
@@ -475,12 +464,12 @@ public class QueryInputResolver {
         try {
           // Evict attempt-owned cache entries before releasing their transient roots, so another
           // resolve call cannot observe an unrooted completed pin in between those operations.
-          state.currentSnapshotCacheOwnership.closeAndEvict();
+          state.work.currentSnapshotCacheOwnership().closeAndEvict();
         } catch (RuntimeException | Error cleanupFailure) {
           e.addSuppressed(cleanupFailure);
         }
         try {
-          state.resolvingPinRoots.releaseAll();
+          state.work.resolvingPinRoots().releaseAll();
         } catch (RuntimeException | Error cleanupFailure) {
           e.addSuppressed(cleanupFailure);
         }
@@ -519,11 +508,11 @@ public class QueryInputResolver {
    * Resolve each input to its id and pins and merge the plans in input order. Inputs are
    * independent, so an overlay that supports concurrent resolution fans them out (a single input
    * stays on the caller thread); an overlay that owns request-thread-confined state runs serially.
-   * {@link MetadataFanout} owns that choice and delivers plans in input order (each unit's store
-   * reads are admitted at the repository layer), so the merge stays deterministic
-   * (first-touch-wins, conflict detection). Each input gets its own state view so mutable per-plan
-   * fields never become shared task state; only immutable resolution context and the explicitly
-   * thread-safe single-flight cache, root tracker, and diagnostics accumulator are shared.
+   * {@link MetadataFanout} owns that choice and delivers plans in input order (each table-pin chain
+   * is admitted as one metadata operation), so the merge stays deterministic (first-touch-wins,
+   * conflict detection). Each input gets its own state view so mutable per-plan fields never become
+   * shared task state; only immutable resolution context and the explicitly thread-safe
+   * single-flight cache, root tracker, and diagnostics accumulator are shared.
    *
    * <p>Tasks report to a shared thread-safe accumulator instead of the request's diagnostics (not
    * guaranteed thread-safe); its per-key totals are flushed to the real diagnostics once resolution
@@ -544,13 +533,13 @@ public class QueryInputResolver {
     try {
       fanout.forEachOrdered(
           inputs,
-          in -> planInput(state.withDiagnostics(taskDiagnostics), in, resolvedNames),
+          in -> planInput(state.work.withDiagnostics(taskDiagnostics), in, resolvedNames),
           plan -> mergePlan(state, plan),
           cancelled);
     } finally {
       // A failed or cancelled sibling can still leave completed tasks' pin work in the accumulator.
       // Preserve those counters for the request's failure telemetry too.
-      taskDiagnostics.flushInto(state.diagnostics);
+      taskDiagnostics.flushInto(state.work.diagnostics);
     }
   }
 
@@ -567,7 +556,7 @@ public class QueryInputResolver {
    * serially unless those cache and diagnostics collaborators are thread-safe.
    */
   private InputPlan planInput(
-      ResolutionState state, QueryInput in, Map<NameRef, Optional<ResourceId>> resolvedNames) {
+      ResolutionWork state, QueryInput in, Map<NameRef, Optional<ResourceId>> resolvedNames) {
     state.diagnostics.count("pin.resolver_inputs");
     SnapshotRef override = in.getSnapshot();
     ResourceId rid =
@@ -623,10 +612,7 @@ public class QueryInputResolver {
   }
 
   private TablePin pinForResource(
-      ResolutionState state,
-      ResourceId rid,
-      SnapshotRef override,
-      Optional<Timestamp> asOfDefault) {
+      ResolutionWork state, ResourceId rid, SnapshotRef override, Optional<Timestamp> asOfDefault) {
     return switch (rid.getKind()) {
       case RK_TABLE -> pinForTable(state, rid, override, asOfDefault);
       case RK_VIEW -> {
@@ -646,10 +632,7 @@ public class QueryInputResolver {
    * AS-OF requests reuse an exactly matching committed pin or construct and root a fresh one.
    */
   private TablePin pinForTable(
-      ResolutionState state,
-      ResourceId rid,
-      SnapshotRef override,
-      Optional<Timestamp> asOfDefault) {
+      ResolutionWork state, ResourceId rid, SnapshotRef override, Optional<Timestamp> asOfDefault) {
     Optional<Timestamp> effectiveAsOfDefault =
         isExplicitCurrentSnapshot(override) ? Optional.empty() : asOfDefault;
     if (usesCurrentSnapshotFallback(override, effectiveAsOfDefault)) {
@@ -670,7 +653,10 @@ public class QueryInputResolver {
           try {
             long snapshotPinStartNs = System.nanoTime();
             pin =
-                metadataGraph.tablePinFor(state.correlationId, rid, override, effectiveAsOfDefault);
+                pinResolutionReads.read(
+                    () ->
+                        metadataGraph.tablePinFor(
+                            state.correlationId, rid, override, effectiveAsOfDefault));
             state.resolvingPinRoots.register(pin);
             state.diagnostics.count("pin.snapshot_calls");
             state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -725,7 +711,9 @@ public class QueryInputResolver {
       }
     }
     long snapshotPinStartNs = System.nanoTime();
-    TablePin resolved = metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault);
+    TablePin resolved =
+        pinResolutionReads.read(
+            () -> metadataGraph.tablePinFor(state.correlationId, rid, override, asOfDefault));
     state.resolvingPinRoots.register(resolved);
     state.diagnostics.count("pin.snapshot_calls");
     state.diagnostics.nanos("pin.snapshot_lookup", System.nanoTime() - snapshotPinStartNs);
@@ -734,7 +722,7 @@ public class QueryInputResolver {
 
   /** Await a single-flight winner without stranding a cancelled waiter on the executor. */
   private TablePin awaitCurrentSnapshot(
-      ResolutionState state, CompletableFuture<TablePin> inflight) {
+      ResolutionWork state, CompletableFuture<TablePin> inflight) {
     while (true) {
       throwIfCancelled(state.cancelled);
       if (Thread.currentThread().isInterrupted()) {
@@ -819,7 +807,7 @@ public class QueryInputResolver {
    * and deduplication.
    */
   private void collectBaseTablePins(
-      ResolutionState state,
+      ResolutionWork state,
       ResourceId relationId,
       Optional<Timestamp> effectiveAsOf,
       Set<String> seen,
@@ -880,7 +868,7 @@ public class QueryInputResolver {
       return;
     }
     // First-touch wins: compatible later pins relinquish only their own provisional roots.
-    QueryPins.reconcile(existing, pin, state.correlationId);
+    QueryPins.reconcile(existing, pin, state.work.correlationId);
     if (existing != pin) {
       discardCompatiblePin(state, existing, pin);
     }
@@ -891,7 +879,7 @@ public class QueryInputResolver {
    */
   private void discardCompatiblePin(
       ResolutionState state, TablePin retainedPin, TablePin losingPin) {
-    state.currentSnapshotCacheOwnership.replaceCompatiblePin(losingPin, retainedPin);
-    state.resolvingPinRoots.discard(losingPin);
+    state.work.currentSnapshotCacheOwnership.replaceCompatiblePin(losingPin, retainedPin);
+    state.work.resolvingPinRoots.discard(losingPin);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/QueryInputResolver.java
@@ -46,7 +46,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +60,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
@@ -116,9 +114,6 @@ public class QueryInputResolver {
   // QueryContextStore.registerResolvingPinBlobs). Null in unit tests that construct the resolver
   // without a store — registration is simply skipped then.
   private final QueryContextStore queryStore;
-
-  // Carries cancellable single-flight state through the overridable completed-pin Map seam.
-  private final ThreadLocal<ResolutionInvocation> resolutionInvocation = new ThreadLocal<>();
 
   @Inject
   public QueryInputResolver(CatalogOverlay metadataGraph, QueryContextStore queryStore) {
@@ -233,152 +228,6 @@ public class QueryInputResolver {
     }
   }
 
-  /**
-   * Tracks single-flight holders inserted by one resolution attempt. A failed attempt evicts only
-   * its own holders, leaving entries supplied by earlier or concurrent owners untouched. Closing is
-   * terminal: a late task that records after cancellation removes and fails its holder instead of
-   * publishing an unrooted pin after cleanup has completed.
-   */
-  private static final class CurrentSnapshotCacheOwnership {
-    private final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache;
-    private final Map<ResourceId, CompletableFuture<TablePin>> owned = new LinkedHashMap<>();
-    private boolean terminal;
-
-    CurrentSnapshotCacheOwnership(ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache) {
-      this.cache = cache;
-    }
-
-    /** Claim a newly inserted holder, or discard it when failure cleanup already won. */
-    synchronized boolean claim(ResourceId tableId, CompletableFuture<TablePin> holder) {
-      if (terminal) {
-        synchronized (holder) {
-          cache.remove(tableId, holder);
-          holder.completeExceptionally(
-              new CancellationException("input resolution no longer active"));
-        }
-        return false;
-      }
-      owned.put(tableId, holder);
-      return true;
-    }
-
-    /** Forget a holder that its lookup failure already evicted from the caller cache. */
-    synchronized void forget(ResourceId tableId, CompletableFuture<TablePin> holder) {
-      owned.remove(tableId, holder);
-    }
-
-    /**
-     * Replace a compatible losing CURRENT holder with the pin retained by ordered first-touch. A
-     * waiter that already observed the old holder fails its run-if-current check and retries
-     * against this replacement before using the losing pin.
-     */
-    synchronized void replaceCompatiblePin(TablePin losingPin, TablePin retainedPin) {
-      if (terminal) {
-        return;
-      }
-      ResourceId tableId = losingPin.getTableId();
-      CompletableFuture<TablePin> holder = cache.get(tableId);
-      if (holder == null
-          || !holder.isDone()
-          || holder.isCompletedExceptionally()
-          || holder.isCancelled()) {
-        return;
-      }
-      synchronized (holder) {
-        if (cache.get(tableId) != holder || holder.getNow(null) != losingPin) {
-          return;
-        }
-        CompletableFuture<TablePin> replacement = CompletableFuture.completedFuture(retainedPin);
-        if (cache.replace(tableId, holder, replacement)) {
-          owned.remove(tableId, holder);
-          // This attempt changed shared cache state. Failure cleanup must evict the replacement
-          // before releasing the retained pin's transient roots.
-          owned.put(tableId, replacement);
-        }
-      }
-    }
-
-    /** Evict and fail every holder still owned by this failed resolution attempt. */
-    synchronized void closeAndEvict() {
-      terminal = true;
-      owned.forEach(
-          (tableId, holder) -> {
-            synchronized (holder) {
-              cache.remove(tableId, holder);
-              holder.completeExceptionally(new CancellationException("input resolution failed"));
-            }
-          });
-      owned.clear();
-    }
-  }
-
-  /**
-   * Owns the transient registrations made while one {@link #resolveInputs} call constructs pins. A
-   * retained pin stays registered until its context commit makes it durable; a discarded pin or
-   * failed resolution releases only the registration this attempt created.
-   */
-  private static final class ResolvingPinRoots {
-    private final QueryContextStore queryStore;
-    private final String queryId;
-    private final Map<TablePin, List<String>> rootsByPin = new IdentityHashMap<>();
-    private boolean terminal;
-
-    ResolvingPinRoots(QueryContextStore queryStore, String queryId) {
-      this.queryStore = queryStore;
-      this.queryId = queryId;
-    }
-
-    /**
-     * Register a pin's roots once for this attempt. A store failure leaves the pin untracked so
-     * callers propagate the failure without attempting a compensating release.
-     */
-    synchronized void register(TablePin pin) {
-      if (terminal || queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
-        return;
-      }
-      if (rootsByPin.containsKey(pin)) {
-        return;
-      }
-      List<String> roots = QueryPins.gcRootUris(pin);
-      if (roots.isEmpty()) {
-        return;
-      }
-      queryStore.registerResolvingPinBlobs(queryId, roots);
-      rootsByPin.put(pin, roots);
-    }
-
-    /**
-     * Release this attempt's registration for a compatible pin that lost ordered first-touch. A
-     * store failure retains ownership so a later failure cleanup can retry the release.
-     */
-    synchronized void discard(TablePin pin) {
-      if (terminal) {
-        return;
-      }
-      List<String> roots = rootsByPin.get(pin);
-      if (roots != null) {
-        queryStore.releaseResolvingPinBlobs(queryId, roots);
-        rootsByPin.remove(pin);
-      }
-    }
-
-    /**
-     * Release every registration still owned by this failed attempt. A store failure stops release
-     * and propagates to the caller, which retains the original resolution failure.
-     */
-    synchronized void releaseAll() {
-      // Cancellation can return from the fan-out before an uninterruptible task reaches register.
-      // Close ownership first so such a late task cannot add roots after this cleanup sweep.
-      terminal = true;
-      var iterator = rootsByPin.entrySet().iterator();
-      while (iterator.hasNext()) {
-        Map.Entry<TablePin, List<String>> entry = iterator.next();
-        queryStore.releaseResolvingPinBlobs(queryId, entry.getValue());
-        iterator.remove();
-      }
-    }
-  }
-
   // =============================================================================
   // Main resolution entrypoint
   // =============================================================================
@@ -428,29 +277,15 @@ public class QueryInputResolver {
       Optional<ResourceId> defaultCatalogId,
       ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
-    ResolutionInvocation invocation = resolutionInvocation.get();
-    if (invocation != null) {
-      return resolveViaLegacyOverride(
-          queryId,
-          correlationId,
-          inputs,
-          asOfDefault,
-          defaultCatalogId,
-          invocation.currentSnapshotPinCache(),
-          diagnostics);
-    }
-    return withResolutionInvocation(
+    return resolveInputsCore(
+        queryId,
+        correlationId,
+        inputs,
+        asOfDefault,
+        defaultCatalogId,
         currentSnapshotPinCache,
-        Context.current()::isCancelled,
-        () ->
-            resolveViaLegacyOverride(
-                queryId,
-                correlationId,
-                inputs,
-                asOfDefault,
-                defaultCatalogId,
-                currentSnapshotPinCache,
-                diagnostics));
+        diagnostics,
+        Context.current()::isCancelled);
   }
 
   /**
@@ -466,19 +301,6 @@ public class QueryInputResolver {
       Optional<ResourceId> defaultCatalogId,
       Map<ResourceId, TablePin> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics) {
-    ResolutionInvocation invocation = resolutionInvocation.get();
-    if (invocation != null) {
-      return resolveInputsCore(
-          queryId,
-          correlationId,
-          inputs,
-          asOfDefault,
-          defaultCatalogId,
-          invocation.currentSnapshotPinCache(),
-          diagnostics,
-          invocation.cancelled());
-    }
-
     Map<ResourceId, TablePin> initialCache = new LinkedHashMap<>(currentSnapshotPinCache);
     ConcurrentMap<ResourceId, CompletableFuture<TablePin>> singleFlightCache =
         toSingleFlightCache(initialCache);
@@ -541,62 +363,15 @@ public class QueryInputResolver {
       ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
       PhaseDiagnostics diagnostics,
       BooleanSupplier cancelled) {
-    throwIfCancelled(cancelled);
-    return withResolutionInvocation(
+    return resolveInputsCore(
+        queryId,
+        correlationId,
+        inputs,
+        asOfDefault,
+        defaultCatalogId,
         currentSnapshotPinCache,
-        cancelled,
-        () ->
-            resolveInputs(
-                queryId,
-                correlationId,
-                inputs,
-                asOfDefault,
-                defaultCatalogId,
-                currentSnapshotPinCache,
-                diagnostics));
-  }
-
-  /** Invoke the completed-pin compatibility seam and publish its successful cache entries. */
-  private ResolutionResult resolveViaLegacyOverride(
-      String queryId,
-      String correlationId,
-      List<QueryInput> inputs,
-      Optional<Timestamp> asOfDefault,
-      Optional<ResourceId> defaultCatalogId,
-      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-      PhaseDiagnostics diagnostics) {
-    Map<ResourceId, TablePin> completedPinCache = completedPins(currentSnapshotPinCache);
-    ResolutionResult result =
-        resolveInputs(
-            queryId,
-            correlationId,
-            inputs,
-            asOfDefault,
-            defaultCatalogId,
-            completedPinCache,
-            diagnostics);
-    completedPinCache.forEach(
-        (tableId, pin) ->
-            currentSnapshotPinCache.putIfAbsent(tableId, CompletableFuture.completedFuture(pin)));
-    return result;
-  }
-
-  /** Install one invocation while retaining any outer invocation on the same request thread. */
-  private <T> T withResolutionInvocation(
-      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-      BooleanSupplier cancelled,
-      Supplier<T> operation) {
-    ResolutionInvocation previous = resolutionInvocation.get();
-    resolutionInvocation.set(new ResolutionInvocation(currentSnapshotPinCache, cancelled));
-    try {
-      return operation.get();
-    } finally {
-      if (previous == null) {
-        resolutionInvocation.remove();
-      } else {
-        resolutionInvocation.set(previous);
-      }
-    }
+        diagnostics,
+        cancelled);
   }
 
   /** Convert completed pins to the concurrent placeholder representation used during fan-out. */
@@ -623,11 +398,6 @@ public class QueryInputResolver {
         });
     return completed;
   }
-
-  /** Per-thread state carried through the completed-pin override seam. */
-  private record ResolutionInvocation(
-      ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-      BooleanSupplier cancelled) {}
 
   /** Run the shared resolution implementation for cancellable and non-cancellable callers. */
   private ResolutionResult resolveInputsCore(

--- a/service/src/main/java/ai/floedb/floecat/service/query/resolver/ResolvingPinRoots.java
+++ b/service/src/main/java/ai/floedb/floecat/service/query/resolver/ResolvingPinRoots.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.query.resolver;
+
+import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.service.query.QueryContextStore;
+import ai.floedb.floecat.service.query.QueryPins;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Owns transient GC-root registrations created during one input-resolution attempt. Retained pins
+ * stay registered until the caller commits them; discarded pins and failed attempts release only
+ * the registrations created by this owner.
+ */
+final class ResolvingPinRoots {
+  private final QueryContextStore queryStore;
+  private final String queryId;
+  private final Map<TablePin, List<String>> rootsByPin = new IdentityHashMap<>();
+  private boolean terminal;
+
+  ResolvingPinRoots(QueryContextStore queryStore, String queryId) {
+    this.queryStore = queryStore;
+    this.queryId = queryId;
+  }
+
+  /** Register a pin once; a store failure leaves it untracked for normal propagation. */
+  synchronized void register(TablePin pin) {
+    if (terminal || queryStore == null || queryId == null || queryId.isEmpty() || pin == null) {
+      return;
+    }
+    if (rootsByPin.containsKey(pin)) {
+      return;
+    }
+    List<String> roots = QueryPins.gcRootUris(pin);
+    if (roots.isEmpty()) {
+      return;
+    }
+    queryStore.registerResolvingPinBlobs(queryId, roots);
+    rootsByPin.put(pin, roots);
+  }
+
+  /** Release the registration for a compatible pin that lost ordered first-touch. */
+  synchronized void discard(TablePin pin) {
+    if (terminal) {
+      return;
+    }
+    List<String> roots = rootsByPin.get(pin);
+    if (roots != null) {
+      queryStore.releaseResolvingPinBlobs(queryId, roots);
+      rootsByPin.remove(pin);
+    }
+  }
+
+  /**
+   * Close ownership and release all remaining registrations. Closing first prevents a late worker
+   * from adding roots after the cleanup sweep.
+   */
+  synchronized void releaseAll() {
+    terminal = true;
+    var iterator = rootsByPin.entrySet().iterator();
+    while (iterator.hasNext()) {
+      Map.Entry<TablePin, List<String>> entry = iterator.next();
+      queryStore.releaseResolvingPinBlobs(queryId, entry.getValue());
+      iterator.remove();
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/RepositoryReads.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/RepositoryReads.java
@@ -36,15 +36,17 @@ public record RepositoryReads(Pointers pointers, Blobs blobs) {
 
   /** Build read capabilities that invoke each supplied store on the calling thread. */
   public static RepositoryReads direct(PointerStore pointers, BlobStore blobs) {
-    return bind(
-        pointers,
-        blobs,
-        new ReadPolicy() {
-          @Override
-          public <T> T read(Supplier<T> operation) {
-            return operation.get();
-          }
-        });
+    return bind(pointers, blobs, directPolicy());
+  }
+
+  /** Build an execution policy that invokes a metadata operation on the calling thread. */
+  public static ReadPolicy directPolicy() {
+    return new ReadPolicy() {
+      @Override
+      public <T> T read(Supplier<T> operation) {
+        return operation.get();
+      }
+    };
   }
 
   /**
@@ -92,7 +94,7 @@ public record RepositoryReads(Pointers pointers, Blobs blobs) {
         });
   }
 
-  /** Defines how one leaf store read is executed and how its failure reaches the repository. */
+  /** Defines how one metadata read operation is executed and how its failure reaches the caller. */
   public interface ReadPolicy {
     /** Execute one backend operation, preserving its result type and runtime failure. */
     <T> T read(Supplier<T> operation);

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -207,8 +207,8 @@ floecat.reconciler.capture-now.max-wait=${FLOECAT_RECONCILER_CAPTURE_NOW_MAX_WAI
 # Covers catalog, namespace, table, and view reads. Saturated calls wait for a permit; a wedged store
 # holds its permit until it returns, and a WARN naming the caller is logged after 30 seconds.
 #
-# Snapshot, stats, current-snapshot-pointer, and table-root reads use their own local concurrency
-# bounds independently of this process gate.
+# Resolver table-pin chains are admitted once around their snapshot/table-root work. Other snapshot,
+# stats, current-snapshot-pointer, and table-root reads use their own local concurrency bounds.
 #
 # Watch floecat.service.metadata_io.permits.in_use against .permits.capacity to see whether this
 # ceiling is the constraint, and .admission.waiters for the queue behind it.

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -40,6 +40,8 @@ quarkus.http.port=${FLOECAT_HTTP_PORT:9100}
 quarkus.grpc.clients.floecat.host=${FLOECAT_GRPC_HOST:127.0.0.1}
 quarkus.grpc.clients.floecat.port=${FLOECAT_GRPC_PORT:9100}
 quarkus.grpc.clients.floecat.plain-text=true
+## Process-wide query metadata I/O admission
+floecat.query.metadata_io.max_concurrency=${FLOECAT_QUERY_METADATA_IO_MAX_CONCURRENCY:64}
 ## Floecat repository seeding
 floecat.seed.enabled=${FLOECAT_SEED_ENABLED:true}
 floecat.seed.mode=${FLOECAT_SEED_MODE:fake}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -40,8 +40,6 @@ quarkus.http.port=${FLOECAT_HTTP_PORT:9100}
 quarkus.grpc.clients.floecat.host=${FLOECAT_GRPC_HOST:127.0.0.1}
 quarkus.grpc.clients.floecat.port=${FLOECAT_GRPC_PORT:9100}
 quarkus.grpc.clients.floecat.plain-text=true
-## Process-wide query metadata I/O admission
-floecat.query.metadata_io.max_concurrency=${FLOECAT_QUERY_METADATA_IO_MAX_CONCURRENCY:64}
 ## Floecat repository seeding
 floecat.seed.enabled=${FLOECAT_SEED_ENABLED:true}
 floecat.seed.mode=${FLOECAT_SEED_MODE:fake}

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/FuturesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/FuturesTest.java
@@ -15,13 +15,38 @@
  */
 package ai.floedb.floecat.service.concurrent;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 
 /** Pins the unwrapping contract the fan-out relies on to surface a task's original failure. */
 class FuturesTest {
+
+  @Test
+  void joinSurfacesTheTasksOwnRuntimeExceptionUnwrapped() {
+    IllegalStateException original = new IllegalStateException("store error");
+
+    // Not the CompletionException wrapper CompletableFuture.join() would otherwise expose.
+    assertThatThrownBy(() -> Futures.join(CompletableFuture.failedFuture(original)))
+        .isSameAs(original);
+  }
+
+  @Test
+  void joinWrapsAnImpossibleCheckedCauseAsIllegalState() {
+    IOException checked = new IOException("impossible here: these tasks throw only unchecked");
+
+    assertThatThrownBy(() -> Futures.join(CompletableFuture.failedFuture(checked)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasCause(checked);
+  }
+
+  @Test
+  void joinReturnsTheValueOfACompletedFuture() {
+    assertThat(Futures.join(CompletableFuture.completedFuture("ok"))).isEqualTo("ok");
+  }
 
   @Test
   void propagateReturnsTheOriginalUncheckedFailureForTheCallerToThrow() {

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/MetadataIoAdmissionWiringTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/MetadataIoAdmissionWiringTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.query.resolver.QueryInputResolver;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
@@ -27,6 +28,7 @@ import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.service.repo.model.CatalogKey;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.util.MetadataRepositoryFactory;
+import ai.floedb.floecat.service.repo.util.RepositoryReads;
 import ai.floedb.floecat.service.testsupport.ConcurrentTestSupport;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import io.quarkus.test.junit.QuarkusTest;
@@ -67,6 +69,13 @@ class MetadataIoAdmissionWiringTest {
                   assertThat(constructor.getParameterTypes())
                       .contains(MetadataRepositoryFactory.class));
     }
+
+    assertThat(injectedConstructors(QueryInputResolver.class))
+        .singleElement()
+        .satisfies(
+            constructor ->
+                assertThat(constructor.getParameterTypes())
+                    .contains(RepositoryReads.ReadPolicy.class));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/QueryInputResolverAdmissionTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/QueryInputResolverAdmissionTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.QueryInput;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.query.rpc.PinKind;
+import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.service.query.resolver.QueryInputResolver;
+import ai.floedb.floecat.service.testsupport.ConcurrentTestSupport;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+/** Verifies query-input pin chains share the process metadata-I/O admission gate. */
+class QueryInputResolverAdmissionTest {
+
+  @Test
+  void pinResolutionWaitsForProcessAdmissionBeforeStartingTheBackend() throws Exception {
+    MetadataIoRunner admission = new MetadataIoRunner(1);
+    MetadataResourceReader admittedReads = new MetadataResourceReader(admission);
+    CatalogOverlay graph = mock(CatalogOverlay.class);
+    ResourceId tableId =
+        ResourceId.newBuilder()
+            .setAccountId("account")
+            .setId("table")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    TablePin expected =
+        TablePin.newBuilder()
+            .setTableId(tableId)
+            .setPinKind(PinKind.PIN_KIND_CURRENT)
+            .setSnapshotId(1)
+            .build();
+    AtomicBoolean backendStarted = new AtomicBoolean();
+    when(graph.tablePinFor(anyString(), eq(tableId), nullable(SnapshotRef.class), any()))
+        .thenAnswer(
+            ignored -> {
+              backendStarted.set(true);
+              return expected;
+            });
+    QueryInputResolver resolver = new QueryInputResolver(graph, null, admittedReads);
+
+    CountDownLatch holderEntered = new CountDownLatch(1);
+    CountDownLatch releaseHolder = new CountDownLatch(1);
+    try (ExecutorService workers = Executors.newVirtualThreadPerTaskExecutor()) {
+      CompletableFuture<Void> holder =
+          CompletableFuture.runAsync(
+              () ->
+                  admittedReads.read(
+                      () -> {
+                        holderEntered.countDown();
+                        ConcurrentTestSupport.awaitUninterruptibly(releaseHolder);
+                        return null;
+                      }),
+              workers);
+      assertThat(holderEntered.await(2, TimeUnit.SECONDS)).isTrue();
+
+      CompletableFuture<QueryInputResolver.ResolutionResult> resolution =
+          CompletableFuture.supplyAsync(
+              () ->
+                  resolver.resolveInputs(
+                      "query",
+                      "correlation",
+                      List.of(QueryInput.newBuilder().setTableId(tableId).build()),
+                      Optional.empty(),
+                      Optional.empty(),
+                      new ConcurrentHashMap<>(),
+                      null,
+                      () -> false),
+              workers);
+      try {
+        ConcurrentTestSupport.await(() -> admission.admissionWaiters() == 1, Duration.ofSeconds(2));
+        assertThat(backendStarted).isFalse();
+
+        releaseHolder.countDown();
+        assertThat(resolution.get(2, TimeUnit.SECONDS).relationPinSet().getPinsCount()).isOne();
+        assertThat(backendStarted).isTrue();
+      } finally {
+        releaseHolder.countDown();
+        holder.get(2, TimeUnit.SECONDS);
+      }
+      ConcurrentTestSupport.await(() -> admission.permitsInUse() == 0, Duration.ofSeconds(2));
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/resolver/NameResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/resolver/NameResolverTest.java
@@ -26,12 +26,22 @@ import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.context.PropagatedContext;
+import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.testsupport.UserRepositoryTestSupport.FakeCatalogRepository;
 import ai.floedb.floecat.service.testsupport.UserRepositoryTestSupport.FakeNamespaceRepository;
 import ai.floedb.floecat.service.testsupport.UserRepositoryTestSupport.FakeTableRepository;
 import ai.floedb.floecat.service.testsupport.UserRepositoryTestSupport.FakeViewRepository;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -157,6 +167,84 @@ class NameResolverTest {
   }
 
   @Test
+  void listTableIdsPassesTheRequestCancellationToTheNamespaceFanout() {
+    ResourceId catalogId = rid("account", "cat", ResourceKind.RK_CATALOG);
+    ResourceId ns2Id = rid("account", "ns2", ResourceKind.RK_NAMESPACE);
+    namespaceRepository.put(
+        Namespace.newBuilder()
+            .setResourceId(ns2Id)
+            .setCatalogId(catalogId)
+            .setDisplayName("ns2")
+            .build());
+    AtomicBoolean cancelled = new AtomicBoolean(true);
+
+    try (var ignored = PropagatedContext.bindCancellation(cancelled::get)) {
+      assertThatThrownBy(() -> resolver.listTableIds("account", "cat"))
+          .isInstanceOf(CancellationException.class);
+    }
+  }
+
+  @Test
+  void listTableIdsCancellationStopsQueuedNamespaceScans() throws Exception {
+    ResourceId catalogId = rid("account", "cat", ResourceKind.RK_CATALOG);
+    for (int i = 2; i <= 9; i++) {
+      ResourceId namespaceId = rid("account", "ns" + i, ResourceKind.RK_NAMESPACE);
+      namespaceRepository.put(
+          Namespace.newBuilder()
+              .setResourceId(namespaceId)
+              .setCatalogId(catalogId)
+              .setDisplayName("ns" + i)
+              .build());
+    }
+    CountDownLatch started = new CountDownLatch(8);
+    CountDownLatch release = new CountDownLatch(1);
+    CountDownLatch stopped = new CountDownLatch(8);
+    AtomicInteger scans = new AtomicInteger();
+    TableRepository blockingTableRepository =
+        new TableRepository(new InMemoryPointerStore(), new InMemoryBlobStore()) {
+          @Override
+          public List<Table> list(
+              String accountId,
+              String catalogId,
+              String namespaceId,
+              int limit,
+              String pageToken,
+              StringBuilder nextOut) {
+            scans.incrementAndGet();
+            started.countDown();
+            try {
+              awaitUninterruptibly(release);
+              return List.of();
+            } finally {
+              stopped.countDown();
+            }
+          }
+        };
+    NameResolver blockingResolver =
+        new NameResolver(
+            catalogRepository, namespaceRepository, blockingTableRepository, viewRepository);
+    AtomicBoolean cancelled = new AtomicBoolean();
+    CompletableFuture<List<ResourceId>> result =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try (var ignored = PropagatedContext.bindCancellation(cancelled::get)) {
+                return blockingResolver.listTableIds("account", "cat");
+              }
+            });
+
+    assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+    cancelled.set(true);
+    try {
+      assertThatThrownBy(() -> result.get(5, TimeUnit.SECONDS))
+          .hasCauseInstanceOf(CancellationException.class);
+      assertThat(scans.get()).isEqualTo(8);
+    } finally {
+      release.countDown();
+    }
+    assertThat(stopped.await(5, TimeUnit.SECONDS)).isTrue();
+  }
+
+  @Test
   void listViewIdsCollectsAcrossNamespaces() {
     ResourceId catalogId = rid("account", "cat", ResourceKind.RK_CATALOG);
 
@@ -235,5 +323,20 @@ class NameResolverTest {
 
   private static ResourceId rid(String account, String id, ResourceKind kind) {
     return ResourceId.newBuilder().setAccountId(account).setId(id).setKind(kind).build();
+  }
+
+  private static void awaitUninterruptibly(CountDownLatch latch) {
+    boolean interrupted = false;
+    while (true) {
+      try {
+        latch.await();
+        break;
+      } catch (InterruptedException ignored) {
+        interrupted = true;
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -839,6 +839,19 @@ class UserObjectBundleServiceTest {
             return emptyPinResolution(inputs);
           }
 
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+              PhaseDiagnostics diagnostics,
+              java.util.function.BooleanSupplier cancelled) {
+            return emptyPinResolution(inputs);
+          }
+
           private ResolutionResult emptyPinResolution(List<QueryInput> inputs) {
             return new ResolutionResult(
                 List.of(inputs.get(0).getTableId()), RelationPinSet.getDefaultInstance(), null);

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/UserObjectBundleServiceTest.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.metagraph.model.GraphNode;
 import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.ColumnFailureCode;
@@ -51,6 +52,7 @@ import ai.floedb.floecat.service.context.impl.InboundContextInterceptor;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.CancellingSubscriber;
+import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.CollectingSubscriber;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.FakeCatalogOverlay;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.TestQueryContextStore;
 import ai.floedb.floecat.service.query.catalog.testsupport.UserObjectBundleTestSupport.TestQueryInputResolver;
@@ -78,6 +80,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -250,6 +259,29 @@ class UserObjectBundleServiceTest {
     assertThat(relation.hasStats()).isTrue();
     assertThat(relation.getStats().getRowCount()).isEqualTo(stats.getRowCount());
     assertThat(relation.getStats().getTotalSizeBytes()).isEqualTo(0L);
+  }
+
+  @Test
+  void treatsANullOverlaySchemaAsAnEmptySchema() {
+    FakeCatalogOverlay nullSchemaOverlay =
+        new FakeCatalogOverlay() {
+          @Override
+          public List<SchemaColumn> tableSchema(ResourceId tableId) {
+            return null;
+          }
+        };
+    service = serviceWith(nullSchemaOverlay);
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    RelationResolution resolution = chunks.get(1).getResolutions().getItems(0);
+    assertThat(resolution.getStatus()).isEqualTo(ResolutionStatus.RESOLUTION_STATUS_FOUND);
+    assertThat(resolution.getRelation().getColumnsCount()).isZero();
   }
 
   @Test
@@ -804,6 +836,10 @@ class UserObjectBundleServiceTest {
               Optional<ResourceId> defaultCatalogId,
               Map<ResourceId, TablePin> currentSnapshotPinCache,
               PhaseDiagnostics diagnostics) {
+            return emptyPinResolution(inputs);
+          }
+
+          private ResolutionResult emptyPinResolution(List<QueryInput> inputs) {
             return new ResolutionResult(
                 List.of(inputs.get(0).getTableId()), RelationPinSet.getDefaultInstance(), null);
           }
@@ -1208,6 +1244,118 @@ class UserObjectBundleServiceTest {
     UserObjectsBundleChunk resolutionChunk = subscriber.items().get(1);
     assertThat(resolutionChunk.hasResolutions()).isTrue();
     assertThat(queryStore.updateCount()).isEqualTo(1);
+  }
+
+  @Test
+  void terminalFailureClaimWinsBeforeProducerBecomesIdle() {
+    var gate = new UserObjectBundleService.StreamTelemetryGate();
+    AtomicBoolean cancelled = new AtomicBoolean();
+    gate.begin(() -> false);
+
+    assertThat(gate.cancel(cancelled))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.CancellationDecision.ACCEPTED);
+    assertThat(gate.finish(UserObjectBundleService.StreamTelemetryGate.Publication.FAILURE))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.Publication.FAILURE);
+  }
+
+  @Test
+  void cancellationClaimWinsWhenItRacesFinalCompletion() {
+    var gate = new UserObjectBundleService.StreamTelemetryGate();
+    AtomicBoolean cancelled = new AtomicBoolean();
+    gate.begin(() -> false);
+
+    assertThat(gate.cancel(cancelled))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.CancellationDecision.ACCEPTED);
+    assertThat(cancelled).isTrue();
+    assertThat(gate.finish(UserObjectBundleService.StreamTelemetryGate.Publication.COMPLETION))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.Publication.CANCELLATION);
+  }
+
+  @Test
+  void completionClaimWinsWhenTheProducerFinishesBeforeCancellation() {
+    var gate = new UserObjectBundleService.StreamTelemetryGate();
+    AtomicBoolean cancelled = new AtomicBoolean();
+    gate.begin(() -> false);
+
+    assertThat(gate.finish(UserObjectBundleService.StreamTelemetryGate.Publication.COMPLETION))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.Publication.COMPLETION);
+    assertThat(gate.cancel(cancelled))
+        .isEqualTo(UserObjectBundleService.StreamTelemetryGate.CancellationDecision.ACCEPTED);
+  }
+
+  @Test
+  void threadConfinedOverlayLookupsStayOnTheStreamProducer() {
+    Thread producer = Thread.currentThread();
+    CallerThreadOnlyOverlay threadConfinedOverlay = new CallerThreadOnlyOverlay(producer);
+    service = serviceWith(threadConfinedOverlay);
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setName(NameRef.newBuilder().setName("a")))
+            .build();
+
+    List<UserObjectsBundleChunk> chunks =
+        service.stream("cid", ctx, List.of(candidate)).collect().asList().await().indefinitely();
+
+    assertThat(chunks).anyMatch(UserObjectsBundleChunk::hasResolutions);
+    assertThat(threadConfinedOverlay.callbackCount.get()).isGreaterThanOrEqualTo(3);
+  }
+
+  @Test
+  void cancellationAfterPinResolutionReleasesTransientRoots() {
+    /** Subscriber that exposes cancellation at the resolver-return ownership boundary. */
+    class CancelAfterResolutionSubscriber extends CollectingSubscriber {
+      void cancelNow() {
+        subscription.cancel();
+        completeSuccessfully();
+      }
+    }
+
+    AtomicReference<CancelAfterResolutionSubscriber> subscriberRef = new AtomicReference<>();
+    QueryInputResolver cancellingResolver =
+        new QueryInputResolver(null) {
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+              PhaseDiagnostics diagnostics,
+              java.util.function.BooleanSupplier cancelled) {
+            RelationPinSet pins =
+                SnapshotTestSupport.relationPins(
+                    SnapshotTestSupport.blobBackedPin(TABLE_A, TABLE_A_SNAPSHOT_ID));
+            queryStore.registerResolvingPinBlobs(queryId, QueryPins.gcRootUris(pins));
+            subscriberRef.get().cancelNow();
+            return new ResolutionResult(List.of(TABLE_A), pins, null);
+          }
+        };
+    service =
+        new UserObjectBundleService(
+            overlay,
+            cancellingResolver,
+            queryStore,
+            statsFactory,
+            decoratorProvider,
+            engineContextProvider,
+            false,
+            "localhost",
+            47470,
+            false,
+            "test");
+    TableReferenceCandidate candidate =
+        TableReferenceCandidate.newBuilder()
+            .addCandidates(QueryInput.newBuilder().setTableId(TABLE_A))
+            .build();
+    CancelAfterResolutionSubscriber subscriber = new CancelAfterResolutionSubscriber();
+    subscriberRef.set(subscriber);
+
+    service.stream("cid", ctx, List.of(candidate)).subscribe().withSubscriber(subscriber);
+    subscriber.await();
+
+    assertThat(queryStore.resolvingPinBlobUris()).isEmpty();
+    assertThat(queryStore.updateCount()).isZero();
   }
 
   @Test
@@ -2382,5 +2530,99 @@ class UserObjectBundleServiceTest {
                 .count())
         .isEqualTo(1);
     assertThat(allResolutions.stream().filter(r -> r.getInputIndex() == -1).count()).isEqualTo(30);
+  }
+
+  private UserObjectBundleService serviceWith(FakeCatalogOverlay testOverlay) {
+    testOverlay.registerTable(
+        TABLE_A,
+        UserObjectBundleTestSupport.schemaFor("id_a"),
+        NameRef.newBuilder().setCatalog("cat").setName("a").build());
+    testOverlay.registerCatalog(DEFAULT_CATALOG, "cat");
+    return new UserObjectBundleService(
+        testOverlay,
+        resolver,
+        queryStore,
+        statsFactory,
+        decoratorProvider,
+        engineContextProvider,
+        false,
+        "localhost",
+        47470,
+        false,
+        "test");
+  }
+
+  /** Fails when an overlay that opts out of concurrency is called away from its producer thread. */
+  private static final class CallerThreadOnlyOverlay extends FakeCatalogOverlay {
+    private final Thread producer;
+    private final AtomicInteger callbackCount = new AtomicInteger();
+
+    private CallerThreadOnlyOverlay(Thread producer) {
+      this.producer = producer;
+    }
+
+    @Override
+    public boolean supportsConcurrentResolution() {
+      return false;
+    }
+
+    @Override
+    public Optional<ai.floedb.floecat.metagraph.model.CatalogNode> catalog(ResourceId id) {
+      assertProducerThread();
+      return super.catalog(id);
+    }
+
+    @Override
+    public Optional<ResourceId> resolveName(
+        String correlationId, NameRef ref, EngineContext engineContext) {
+      assertProducerThread();
+      return super.resolveName(correlationId, ref, engineContext);
+    }
+
+    @Override
+    public Optional<GraphNode> resolve(ResourceId id) {
+      assertProducerThread();
+      return super.resolve(id);
+    }
+
+    private void assertProducerThread() {
+      if (Thread.currentThread() != producer) {
+        throw new AssertionError("thread-confined overlay callback left the stream producer");
+      }
+      callbackCount.incrementAndGet();
+    }
+  }
+
+  /** Requests stream items explicitly so cancellation can race one active iterator step. */
+  private static final class DemandSubscriber implements Subscriber<UserObjectsBundleChunk> {
+    private final CountDownLatch subscribed = new CountDownLatch(1);
+    private volatile Subscription subscription;
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+      this.subscription = subscription;
+      subscribed.countDown();
+    }
+
+    @Override
+    public void onNext(UserObjectsBundleChunk ignored) {}
+
+    @Override
+    public void onError(Throwable ignored) {}
+
+    @Override
+    public void onComplete() {}
+
+    boolean awaitSubscription() throws InterruptedException {
+      return subscribed.await(1, TimeUnit.SECONDS);
+    }
+
+    void request(long count) {
+      subscription.request(count);
+    }
+
+    void cancel() {
+      subscription.cancel();
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -54,8 +54,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
+import java.util.function.BooleanSupplier;
 import java.util.function.UnaryOperator;
 
 public final class UserObjectBundleTestSupport {
@@ -412,6 +414,20 @@ public final class UserObjectBundleTestSupport {
         Map<ResourceId, TablePin> currentSnapshotPinCache,
         PhaseDiagnostics diagnostics) {
       return resolveInputs(inputs);
+    }
+
+    @Override
+    public ResolutionResult resolveInputs(
+        String queryId,
+        String correlationId,
+        List<QueryInput> inputs,
+        Optional<Timestamp> asOfDefault,
+        Optional<ResourceId> defaultCatalogId,
+        ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+        PhaseDiagnostics diagnostics,
+        BooleanSupplier cancelled) {
+      return resolveInputs(
+          queryId, correlationId, inputs, asOfDefault, defaultCatalogId, Map.of(), diagnostics);
     }
 
     private ResolutionResult resolveInputs(List<QueryInput> inputs) {

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/testsupport/UserObjectBundleTestSupport.java
@@ -35,6 +35,7 @@ import ai.floedb.floecat.query.rpc.ScanHandle;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.query.rpc.UserObjectsBundleChunk;
 import ai.floedb.floecat.scanner.spi.CatalogOverlay;
+import ai.floedb.floecat.scanner.utils.EngineContext;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.service.query.QueryPins;
 import ai.floedb.floecat.service.query.impl.QueryContext;
@@ -69,14 +70,16 @@ public final class UserObjectBundleTestSupport {
             .build());
   }
 
-  public static final class FakeCatalogOverlay implements CatalogOverlay {
+  public static class FakeCatalogOverlay implements CatalogOverlay {
     private final Map<String, GraphNode> nodes = new HashMap<>();
     private final Map<String, List<ai.floedb.floecat.query.rpc.SchemaColumn>> schemas =
         new HashMap<>();
     private final Map<String, NameRef> names = new HashMap<>();
     private final Map<String, CatalogNode> catalogs = new HashMap<>();
     private final Set<String> hidden = new HashSet<>();
+    private final Set<String> schemaFailures = new HashSet<>();
     private final Map<String, Integer> resolveCalls = new ConcurrentHashMap<>();
+    private final Map<NameRef, Integer> resolveNameCalls = new ConcurrentHashMap<>();
 
     public void clear() {
       nodes.clear();
@@ -84,7 +87,16 @@ public final class UserObjectBundleTestSupport {
       names.clear();
       catalogs.clear();
       hidden.clear();
+      schemaFailures.clear();
       resolveCalls.clear();
+      resolveNameCalls.clear();
+    }
+
+    /**
+     * Make {@link #tableSchema} throw for this relation, to exercise per-relation build failures.
+     */
+    public void failSchemaFor(ResourceId id) {
+      schemaFailures.add(id.getId());
     }
 
     public void registerTable(
@@ -197,10 +209,22 @@ public final class UserObjectBundleTestSupport {
 
     @Override
     public Optional<ResourceId> resolveName(String correlationId, NameRef ref) {
+      resolveNameCalls.merge(ref, 1, Integer::sum);
       return names.entrySet().stream()
           .filter(entry -> entry.getValue().equals(ref))
           .map(entry -> nodes.get(entry.getKey()).id())
           .findFirst();
+    }
+
+    @Override
+    public Optional<ResourceId> resolveName(
+        String correlationId, NameRef ref, EngineContext engineContext) {
+      return resolveName(correlationId, ref);
+    }
+
+    /** How many times {@link #resolveName} ran for the exact ref (batch loop included). */
+    public int resolveNameCount(NameRef ref) {
+      return resolveNameCalls.getOrDefault(ref, 0);
     }
 
     @Override
@@ -309,6 +333,9 @@ public final class UserObjectBundleTestSupport {
 
     @Override
     public List<ai.floedb.floecat.query.rpc.SchemaColumn> tableSchema(ResourceId tableId) {
+      if (schemaFailures.contains(tableId.getId())) {
+        throw new RuntimeException("schema unavailable for " + tableId.getId());
+      }
       return schemas.getOrDefault(tableId.getId(), List.of());
     }
   }
@@ -384,6 +411,10 @@ public final class UserObjectBundleTestSupport {
         Optional<ResourceId> defaultCatalogId,
         Map<ResourceId, TablePin> currentSnapshotPinCache,
         PhaseDiagnostics diagnostics) {
+      return resolveInputs(inputs);
+    }
+
+    private ResolutionResult resolveInputs(List<QueryInput> inputs) {
       List<ResourceId> resolved = new ArrayList<>(inputs.size());
       RelationPinSet.Builder pins = RelationPinSet.newBuilder();
       for (QueryInput input : inputs) {
@@ -408,6 +439,7 @@ public final class UserObjectBundleTestSupport {
     private final Map<String, QueryContext> contexts = new HashMap<>();
     private final List<QueryContext> updates = new ArrayList<>();
     private final Map<String, ScanSession> scanSessions = new HashMap<>();
+    private final Set<String> resolvingPinBlobUris = ConcurrentHashMap.newKeySet();
 
     public void seed(QueryContext ctx) {
       contexts.put(ctx.getQueryId(), ctx);
@@ -415,6 +447,10 @@ public final class UserObjectBundleTestSupport {
 
     public int updateCount() {
       return updates.size();
+    }
+
+    public Set<String> resolvingPinBlobUris() {
+      return Set.copyOf(resolvingPinBlobUris);
     }
 
     @Override
@@ -464,12 +500,12 @@ public final class UserObjectBundleTestSupport {
     @Override
     public void registerResolvingPinBlobs(
         String correlationId, java.util.Collection<String> blobUris) {
-      // no-op: this fake does not model GC roots
+      resolvingPinBlobUris.addAll(blobUris);
     }
 
     @Override
     public void releaseResolvingPinBlobs(String queryId, java.util.Collection<String> blobUris) {
-      // no-op: this fake does not model GC roots
+      resolvingPinBlobUris.removeAll(blobUris);
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -465,8 +465,8 @@ public class QueryInputResolverTest {
   @Test
   void flushesParallelPinDiagnosticsWhenSiblingPlanningFails() {
     var failingGraph = new FailingAfterFastPinGraph();
-    var withStore = new QueryInputResolver(failingGraph);
     var diagnostics = org.mockito.Mockito.mock(ai.floedb.floecat.telemetry.PhaseDiagnostics.class);
+    var withStore = new QueryInputResolver(failingGraph);
 
     assertThrows(
         IllegalStateException.class,
@@ -475,8 +475,8 @@ public class QueryInputResolverTest {
                 "q-diagnostics-failure",
                 "cid",
                 List.of(
-                    QueryInput.newBuilder().setTableId(rid("FAIL")).build(),
-                    QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                    QueryInput.newBuilder().setTableId(rid("FAST")).build(),
+                    QueryInput.newBuilder().setTableId(rid("FAIL")).build()),
                 Optional.empty(),
                 Optional.empty(),
                 new java.util.concurrent.ConcurrentHashMap<

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -51,7 +51,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -354,7 +356,8 @@ public class QueryInputResolverTest {
   /** A failed parallel plan releases every provisional root it constructed. */
   @Test
   void releasesCompletedParallelPinWhenSiblingPlanningFails() {
-    var failingGraph = new FailingAfterFastPinGraph();
+    var currentSnapshotPinCache = new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>();
+    var failingGraph = new FailingAfterFastPinGraph(currentSnapshotPinCache);
     var store = org.mockito.Mockito.mock(QueryContextStore.class);
     var withStore = new QueryInputResolver(failingGraph, store);
 
@@ -369,8 +372,7 @@ public class QueryInputResolverTest {
                     QueryInput.newBuilder().setTableId(rid("FAST")).build()),
                 Optional.empty(),
                 Optional.empty(),
-                new java.util.concurrent.ConcurrentHashMap<
-                    ResourceId, CompletableFuture<TablePin>>(),
+                currentSnapshotPinCache,
                 null));
 
     org.mockito.Mockito.verify(store)
@@ -386,7 +388,8 @@ public class QueryInputResolverTest {
   /** Completed sibling work still contributes pin diagnostics when another parallel plan fails. */
   @Test
   void flushesParallelPinDiagnosticsWhenSiblingPlanningFails() {
-    var failingGraph = new FailingAfterFastPinGraph();
+    var currentSnapshotPinCache = new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>();
+    var failingGraph = new FailingAfterFastPinGraph(currentSnapshotPinCache);
     var diagnostics = org.mockito.Mockito.mock(ai.floedb.floecat.telemetry.PhaseDiagnostics.class);
     var withStore = new QueryInputResolver(failingGraph);
 
@@ -401,8 +404,7 @@ public class QueryInputResolverTest {
                     QueryInput.newBuilder().setTableId(rid("FAIL")).build()),
                 Optional.empty(),
                 Optional.empty(),
-                new java.util.concurrent.ConcurrentHashMap<
-                    ResourceId, CompletableFuture<TablePin>>(),
+                currentSnapshotPinCache,
                 diagnostics));
 
     org.mockito.Mockito.verify(diagnostics).add("pin.snapshot_calls", 1L);
@@ -2130,9 +2132,16 @@ public class QueryInputResolverTest {
     }
   }
 
-  /** Fails one lookup only after the sibling's pin has been constructed. */
+  /** Fails one lookup only after the sibling has published its fully processed pin. */
   static final class FailingAfterFastPinGraph extends FakeGraph {
     private final CountDownLatch fastPinCompleted = new CountDownLatch(1);
+    private final ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache;
+    private CompletableFuture<TablePin> fastPinHolder;
+
+    FailingAfterFastPinGraph(
+        ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache) {
+      this.currentSnapshotPinCache = currentSnapshotPinCache;
+    }
 
     @Override
     public TablePin tablePinFor(
@@ -2145,14 +2154,21 @@ public class QueryInputResolverTest {
           if (!fastPinCompleted.await(1, TimeUnit.SECONDS)) {
             throw new AssertionError("fast pin lookup did not complete");
           }
+          fastPinHolder.get(1, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           throw new AssertionError("failing pin lookup interrupted", e);
+        } catch (ExecutionException | TimeoutException e) {
+          throw new AssertionError("fast pin lookup did not publish successfully", e);
         }
         throw new IllegalStateException("planned failure");
       }
       TablePin pin = super.tablePinFor(correlationId, tableId, override, asOfDefault);
       if ("FAST".equals(tableId.getId())) {
+        fastPinHolder = currentSnapshotPinCache.get(tableId);
+        if (fastPinHolder == null) {
+          throw new AssertionError("fast pin lookup did not publish a cache holder");
+        }
         fastPinCompleted.countDown();
       }
       return pin;

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -31,7 +31,6 @@ import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.PinKind;
-import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.TablePin;
 import ai.floedb.floecat.scanner.utils.EngineContext;
@@ -68,83 +67,6 @@ public class QueryInputResolverTest {
   void init() {
     metadataGraph = new FakeGraph();
     resolver = new QueryInputResolver(metadataGraph);
-  }
-
-  @Test
-  void cancellableOverloadPreservesLegacyMapOverrideDispatch() {
-    AtomicBoolean legacyOverrideCalled = new AtomicBoolean();
-    QueryInputResolver legacySubclass =
-        new QueryInputResolver(metadataGraph) {
-          @Override
-          public ResolutionResult resolveInputs(
-              String queryId,
-              String correlationId,
-              List<QueryInput> inputs,
-              Optional<Timestamp> asOfDefault,
-              Optional<ResourceId> defaultCatalogId,
-              Map<ResourceId, TablePin> currentSnapshotPinCache,
-              ai.floedb.floecat.telemetry.PhaseDiagnostics diagnostics) {
-            legacyOverrideCalled.set(true);
-            ResourceId tableId = inputs.getFirst().getTableId();
-            TablePin pin =
-                metadataGraph.tablePinFor(
-                    correlationId, tableId, SnapshotRef.getDefaultInstance(), Optional.empty());
-            currentSnapshotPinCache.put(tableId, pin);
-            return new ResolutionResult(
-                List.of(tableId),
-                ai.floedb.floecat.query.rpc.RelationPinSet.newBuilder()
-                    .addPins(ai.floedb.floecat.service.query.QueryPins.ofTable(pin))
-                    .build(),
-                null);
-          }
-        };
-    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
-    ResourceId tableId = rid("LEGACY");
-
-    legacySubclass.resolveInputs(
-        "query",
-        "cid",
-        List.of(QueryInput.newBuilder().setTableId(tableId).build()),
-        Optional.empty(),
-        Optional.empty(),
-        cache,
-        null,
-        () -> false);
-
-    assertTrue(legacyOverrideCalled.get());
-    assertEquals(tableId, cache.get(tableId).join().getTableId());
-  }
-
-  @Test
-  void cancellableOverloadPreservesConcurrentMapOverrideDispatch() {
-    AtomicBoolean concurrentOverrideCalled = new AtomicBoolean();
-    QueryInputResolver concurrentSubclass =
-        new QueryInputResolver(metadataGraph) {
-          @Override
-          public ResolutionResult resolveInputs(
-              String queryId,
-              String correlationId,
-              List<QueryInput> inputs,
-              Optional<Timestamp> asOfDefault,
-              Optional<ResourceId> defaultCatalogId,
-              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
-              ai.floedb.floecat.telemetry.PhaseDiagnostics diagnostics) {
-            concurrentOverrideCalled.set(true);
-            return new ResolutionResult(List.of(), RelationPinSet.getDefaultInstance(), null);
-          }
-        };
-
-    concurrentSubclass.resolveInputs(
-        "query",
-        "cid",
-        List.of(),
-        Optional.empty(),
-        Optional.empty(),
-        new ConcurrentHashMap<>(),
-        null,
-        () -> false);
-
-    assertTrue(concurrentOverrideCalled.get());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/resolver/QueryInputResolverTest.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.query.resolver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -26,11 +27,15 @@ import ai.floedb.floecat.common.rpc.QueryInput;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.common.rpc.SnapshotRef;
+import ai.floedb.floecat.common.rpc.SpecialSnapshot;
 import ai.floedb.floecat.metagraph.model.GraphNodeOrigin;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.PinKind;
+import ai.floedb.floecat.query.rpc.RelationPinSet;
 import ai.floedb.floecat.query.rpc.SnapshotPin;
 import ai.floedb.floecat.query.rpc.TablePin;
+import ai.floedb.floecat.scanner.utils.EngineContext;
+import ai.floedb.floecat.service.concurrent.UninterruptibleBlocker;
 import ai.floedb.floecat.service.query.QueryContextStore;
 import ai.floedb.floecat.systemcatalog.util.TestCatalogOverlay;
 import com.google.protobuf.Timestamp;
@@ -42,6 +47,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +68,104 @@ public class QueryInputResolverTest {
   void init() {
     metadataGraph = new FakeGraph();
     resolver = new QueryInputResolver(metadataGraph);
+  }
+
+  @Test
+  void cancellableOverloadPreservesLegacyMapOverrideDispatch() {
+    AtomicBoolean legacyOverrideCalled = new AtomicBoolean();
+    QueryInputResolver legacySubclass =
+        new QueryInputResolver(metadataGraph) {
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              Map<ResourceId, TablePin> currentSnapshotPinCache,
+              ai.floedb.floecat.telemetry.PhaseDiagnostics diagnostics) {
+            legacyOverrideCalled.set(true);
+            ResourceId tableId = inputs.getFirst().getTableId();
+            TablePin pin =
+                metadataGraph.tablePinFor(
+                    correlationId, tableId, SnapshotRef.getDefaultInstance(), Optional.empty());
+            currentSnapshotPinCache.put(tableId, pin);
+            return new ResolutionResult(
+                List.of(tableId),
+                ai.floedb.floecat.query.rpc.RelationPinSet.newBuilder()
+                    .addPins(ai.floedb.floecat.service.query.QueryPins.ofTable(pin))
+                    .build(),
+                null);
+          }
+        };
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+    ResourceId tableId = rid("LEGACY");
+
+    legacySubclass.resolveInputs(
+        "query",
+        "cid",
+        List.of(QueryInput.newBuilder().setTableId(tableId).build()),
+        Optional.empty(),
+        Optional.empty(),
+        cache,
+        null,
+        () -> false);
+
+    assertTrue(legacyOverrideCalled.get());
+    assertEquals(tableId, cache.get(tableId).join().getTableId());
+  }
+
+  @Test
+  void cancellableOverloadPreservesConcurrentMapOverrideDispatch() {
+    AtomicBoolean concurrentOverrideCalled = new AtomicBoolean();
+    QueryInputResolver concurrentSubclass =
+        new QueryInputResolver(metadataGraph) {
+          @Override
+          public ResolutionResult resolveInputs(
+              String queryId,
+              String correlationId,
+              List<QueryInput> inputs,
+              Optional<Timestamp> asOfDefault,
+              Optional<ResourceId> defaultCatalogId,
+              ConcurrentMap<ResourceId, CompletableFuture<TablePin>> currentSnapshotPinCache,
+              ai.floedb.floecat.telemetry.PhaseDiagnostics diagnostics) {
+            concurrentOverrideCalled.set(true);
+            return new ResolutionResult(List.of(), RelationPinSet.getDefaultInstance(), null);
+          }
+        };
+
+    concurrentSubclass.resolveInputs(
+        "query",
+        "cid",
+        List.of(),
+        Optional.empty(),
+        Optional.empty(),
+        new ConcurrentHashMap<>(),
+        null,
+        () -> false);
+
+    assertTrue(concurrentOverrideCalled.get());
+  }
+
+  @Test
+  void legacyMapOverloadDoesNotRewriteAnExistingCacheHit() {
+    ResourceId tableId = rid("CACHED");
+    TablePin cachedPin =
+        metadataGraph.tablePinFor(
+            "cid", tableId, SnapshotRef.getDefaultInstance(), Optional.empty());
+
+    var result =
+        resolver.resolveInputs(
+            "",
+            "cid",
+            List.of(QueryInput.newBuilder().setTableId(tableId).build()),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of(tableId, cachedPin),
+            null);
+
+    assertEquals(tableId, result.resolved().getFirst());
+    assertEquals(cachedPin, result.relationPinSet().getPins(0).getTablePin());
   }
 
   NameRef name(String cat, String... parts) {
@@ -72,6 +183,36 @@ public class QueryInputResolverTest {
 
   ResourceId viewRid(String id) {
     return ResourceId.newBuilder().setId(id).setKind(ResourceKind.RK_VIEW).build();
+  }
+
+  /** Runs a cancellable resolution without coupling the test to the caller's executor. */
+  private static CompletableFuture<Throwable> resolveCancellable(Runnable resolution) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            resolution.run();
+            return null;
+          } catch (Throwable failure) {
+            return failure;
+          }
+        });
+  }
+
+  /** Verifies cancellation returns promptly even when the active metadata operation ignores it. */
+  private static void assertCancellationReturnsWhileBlocked(
+      CompletableFuture<Throwable> resolution,
+      java.util.concurrent.atomic.AtomicBoolean cancelled,
+      UninterruptibleBlocker blocker)
+      throws Exception {
+    try {
+      assertTrue(blocker.started.await(1, TimeUnit.SECONDS));
+      cancelled.set(true);
+      assertTrue(
+          resolution.get(250, TimeUnit.MILLISECONDS)
+              instanceof java.util.concurrent.CancellationException);
+    } finally {
+      blocker.release.countDown();
+    }
   }
 
   /**
@@ -92,7 +233,7 @@ public class QueryInputResolverTest {
         List.of(QueryInput.newBuilder().setName(n).build()),
         Optional.empty(),
         Optional.empty(),
-        new java.util.LinkedHashMap<>(),
+        new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
         null);
 
     // Registered under the stable query id (not the per-RPC correlation id), so the committing RPC
@@ -105,36 +246,249 @@ public class QueryInputResolverTest {
   }
 
   @Test
-  void rootsCompletedPinsBeforePlanningLaterInputs() {
+  void registersPinRootsOnTheMetadataWorkerBeforeResultHandoff() {
     var store = org.mockito.Mockito.mock(QueryContextStore.class);
     var withStore = new QueryInputResolver(metadataGraph, store);
-    ResourceId first = rid("ROOTED_FIRST");
-    ResourceId second = rid("LATER_INPUT");
-    boolean[] observedBeforeLaterPlan = {false};
-    metadataGraph.beforeTablePin(
-        tableId -> {
-          if (tableId.equals(second)) {
-            org.mockito.Mockito.verify(store)
-                .registerResolvingPinBlobs(
-                    org.mockito.ArgumentMatchers.eq("q1"),
-                    org.mockito.ArgumentMatchers.argThat(
-                        uris -> uris.contains("s3://ROOTED_FIRST/table.pb")));
-            observedBeforeLaterPlan[0] = true;
-          }
-        });
+    List<Thread> registrationThreads = java.util.Collections.synchronizedList(new ArrayList<>());
+    org.mockito.Mockito.doAnswer(
+            ignored -> {
+              registrationThreads.add(Thread.currentThread());
+              return null;
+            })
+        .when(store)
+        .registerResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyCollection());
 
     withStore.resolveInputs(
-        "q1",
+        "q-worker-registration",
         "cid",
-        List.of(
-            QueryInput.newBuilder().setTableId(first).build(),
-            QueryInput.newBuilder().setTableId(second).build()),
+        List.of(QueryInput.newBuilder().setTableId(rid("T1")).build()),
         Optional.empty(),
         Optional.empty(),
-        new java.util.LinkedHashMap<>(),
+        new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
         null);
 
-    assertTrue(observedBeforeLaterPlan[0]);
+    // Concurrent fan-out roots each pin on its off-request worker before handing the plan back to
+    // the caller for ordered merge, rather than inline on the request thread after the fact. Those
+    // workers are the shared virtual-thread fan-out pool, so registration runs off the caller.
+    assertEquals(1, registrationThreads.size());
+    assertTrue(registrationThreads.get(0).isVirtual());
+    assertTrue(registrationThreads.get(0) != Thread.currentThread());
+  }
+
+  /** A completed parallel input roots its pin while another input is still resolving. */
+  @Test
+  void rootsCompletedParallelPinBeforeSlowerInputReturns() throws Exception {
+    var blockingGraph = new BlockingPinGraph("SLOW");
+    var store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var withStore = new QueryInputResolver(blockingGraph, store);
+    ResourceId slow = rid("SLOW");
+    ResourceId fast = rid("FAST");
+
+    CompletableFuture<Void> resolution =
+        CompletableFuture.runAsync(
+            () ->
+                withStore.resolveInputs(
+                    "q-parallel",
+                    "cid",
+                    List.of(
+                        QueryInput.newBuilder().setTableId(slow).build(),
+                        QueryInput.newBuilder().setTableId(fast).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new java.util.concurrent.ConcurrentHashMap<
+                        ResourceId, CompletableFuture<TablePin>>(),
+                    null));
+
+    try {
+      assertTrue(blockingGraph.slowPinStarted.await(1, TimeUnit.SECONDS));
+      org.mockito.Mockito.verify(store, org.mockito.Mockito.timeout(1_000))
+          .registerResolvingPinBlobs(
+              org.mockito.ArgumentMatchers.eq("q-parallel"),
+              org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
+    } finally {
+      blockingGraph.allowSlowPin.countDown();
+    }
+    resolution.join();
+  }
+
+  @Test
+  void cancellationInterruptsBlockedParallelPinResolution() throws Exception {
+    var blockingGraph = new BlockingPinGraph("SLOW");
+    var withStore = new QueryInputResolver(blockingGraph);
+    var cancelled = new java.util.concurrent.atomic.AtomicBoolean();
+
+    CompletableFuture<Throwable> resolution =
+        resolveCancellable(
+            () ->
+                withStore.resolveInputs(
+                    "q-cancel",
+                    "cid",
+                    List.of(
+                        QueryInput.newBuilder().setTableId(rid("SLOW")).build(),
+                        QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                    null,
+                    cancelled::get));
+
+    try {
+      assertTrue(blockingGraph.slowPinStarted.await(1, TimeUnit.SECONDS));
+      cancelled.set(true);
+      assertTrue(
+          resolution.get(250, TimeUnit.MILLISECONDS)
+              instanceof java.util.concurrent.CancellationException);
+    } finally {
+      blockingGraph.allowSlowPin.countDown();
+    }
+  }
+
+  @Test
+  void cancellationReturnsWhileSingleInputPinLookupIgnoresInterrupts() throws Exception {
+    var blockingGraph = new BlockingPinGraph("SLOW");
+    var withStore = new QueryInputResolver(blockingGraph);
+    var cancelled = new java.util.concurrent.atomic.AtomicBoolean();
+
+    CompletableFuture<Throwable> resolution =
+        resolveCancellable(
+            () ->
+                withStore.resolveInputs(
+                    "q-cancel-single-pin",
+                    "cid",
+                    List.of(QueryInput.newBuilder().setTableId(rid("SLOW")).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                    null,
+                    cancelled::get));
+
+    assertCancellationReturnsWhileBlocked(resolution, cancelled, blockingGraph.slowPinBlocker);
+  }
+
+  @Test
+  void cancellationAfterFinalThreadConfinedPinLookupDoesNotReturnSuccess() throws Exception {
+    var blockingGraph = new BlockingThreadConfinedPinGraph();
+    var withStore = new QueryInputResolver(blockingGraph);
+    var cancelled = new AtomicBoolean();
+
+    CompletableFuture<Throwable> resolution =
+        resolveCancellable(
+            () ->
+                withStore.resolveInputs(
+                    "q-cancel-thread-confined-pin",
+                    "cid",
+                    List.of(QueryInput.newBuilder().setTableId(rid("SLOW")).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+                    null,
+                    cancelled::get));
+
+    assertTrue(blockingGraph.pinBlocker.started.await(1, TimeUnit.SECONDS));
+    cancelled.set(true);
+    blockingGraph.pinBlocker.release.countDown();
+    assertTrue(resolution.get(250, TimeUnit.MILLISECONDS) instanceof CancellationException);
+  }
+
+  @Test
+  void serialPlanningStaysOnTheCallerThreadWhenOverlayOptsOutOfConcurrency() {
+    Thread callerThread = Thread.currentThread();
+    var threadConfinedGraph = new CallerThreadOnlyGraph(callerThread);
+    var threadConfinedResolver = new QueryInputResolver(threadConfinedGraph);
+
+    threadConfinedResolver.resolveInputs(
+        "cid",
+        List.of(
+            QueryInput.newBuilder().setTableId(rid("ONE")).build(),
+            QueryInput.newBuilder().setTableId(rid("TWO")).build()),
+        Optional.empty(),
+        Optional.empty());
+
+    assertEquals(List.of(callerThread, callerThread), threadConfinedGraph.planningThreads());
+  }
+
+  @Test
+  void cancellableSerialPlanningStaysOnTheCallerThreadWhenOverlayOptsOutOfConcurrency() {
+    Thread callerThread = Thread.currentThread();
+    var threadConfinedGraph = new CallerThreadOnlyGraph(callerThread);
+    var threadConfinedResolver = new QueryInputResolver(threadConfinedGraph);
+
+    threadConfinedResolver.resolveInputs(
+        "q-thread-confined",
+        "cid",
+        List.of(
+            QueryInput.newBuilder().setTableId(rid("ONE")).build(),
+            QueryInput.newBuilder().setTableId(rid("TWO")).build()),
+        Optional.empty(),
+        Optional.empty(),
+        new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
+        null,
+        () -> false);
+
+    assertEquals(List.of(callerThread, callerThread), threadConfinedGraph.planningThreads());
+  }
+
+  /** A failed parallel plan releases every provisional root it constructed. */
+  @Test
+  void releasesCompletedParallelPinWhenSiblingPlanningFails() {
+    var failingGraph = new FailingAfterFastPinGraph();
+    var store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var withStore = new QueryInputResolver(failingGraph, store);
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-failure",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(rid("FAIL")).build(),
+                    QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                Optional.empty(),
+                Optional.empty(),
+                new java.util.concurrent.ConcurrentHashMap<
+                    ResourceId, CompletableFuture<TablePin>>(),
+                null));
+
+    org.mockito.Mockito.verify(store)
+        .registerResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-failure"),
+            org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
+    org.mockito.Mockito.verify(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-failure"),
+            org.mockito.ArgumentMatchers.argThat(uris -> uris.contains("s3://FAST/table.pb")));
+  }
+
+  /** Completed sibling work still contributes pin diagnostics when another parallel plan fails. */
+  @Test
+  void flushesParallelPinDiagnosticsWhenSiblingPlanningFails() {
+    var failingGraph = new FailingAfterFastPinGraph();
+    var withStore = new QueryInputResolver(failingGraph);
+    var diagnostics = org.mockito.Mockito.mock(ai.floedb.floecat.telemetry.PhaseDiagnostics.class);
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-diagnostics-failure",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(rid("FAIL")).build(),
+                    QueryInput.newBuilder().setTableId(rid("FAST")).build()),
+                Optional.empty(),
+                Optional.empty(),
+                new java.util.concurrent.ConcurrentHashMap<
+                    ResourceId, CompletableFuture<TablePin>>(),
+                diagnostics));
+
+    org.mockito.Mockito.verify(diagnostics).add("pin.snapshot_calls", 1L);
+    org.mockito.Mockito.verify(diagnostics).add("pin.current_snapshot_cache_misses", 1L);
+    org.mockito.Mockito.verify(diagnostics)
+        .nanos(
+            org.mockito.ArgumentMatchers.eq("pin.snapshot_lookup"),
+            org.mockito.ArgumentMatchers.anyLong());
   }
 
   /** Resolving a name that maps only to a table should return the table id. */
@@ -201,6 +555,84 @@ public class QueryInputResolverTest {
                 List.of(QueryInput.newBuilder().setName(n).build()),
                 Optional.empty(),
                 Optional.empty()));
+  }
+
+  /**
+   * Two references to the same table's CURRENT snapshot in one batch resolve the snapshot once,
+   * even though the inputs are resolved concurrently. Without single-flight the two references
+   * could resolve independently and, if an ingest landed between them, freeze different snapshots.
+   */
+  @Test
+  void currentSnapshotForRepeatedTableIsResolvedOnce() {
+    ResourceId tableId = rid("T1");
+    NameRef a = name("c", "ns", "a");
+    NameRef b = name("c", "ns", "b");
+    metadataGraph.bind(a, tableId);
+    metadataGraph.bind(b, tableId);
+    metadataGraph.setCurrentSnapshot(tableId, 55);
+
+    var result =
+        resolver.resolveInputs(
+            "cid",
+            List.of(
+                QueryInput.newBuilder().setName(a).build(),
+                QueryInput.newBuilder().setName(b).build()),
+            Optional.empty(),
+            Optional.empty());
+
+    long pinsForT1 =
+        result.snapshotSet().getPinsList().stream()
+            .filter(p -> p.getTableId().getId().equals("T1"))
+            .count();
+    assertEquals(1, pinsForT1, "the two references must merge into one pin");
+
+    long tablePinCallsForT1 =
+        metadataGraph.pinCalls().stream().filter(c -> c.tableId().equals(tableId)).count();
+    assertEquals(1, tablePinCallsForT1, "CURRENT snapshot for a table must be resolved once");
+  }
+
+  @Test
+  void explicitCurrentSnapshotForRepeatedTableIsResolvedOnce() {
+    ResourceId tableId = rid("EXPLICIT_CURRENT");
+    metadataGraph.setCurrentSnapshot(tableId, 55);
+    SnapshotRef current = SnapshotRef.newBuilder().setSpecial(SpecialSnapshot.SS_CURRENT).build();
+    Timestamp defaultAsOf = Timestamp.newBuilder().setSeconds(1_000).build();
+
+    var result =
+        resolver.resolveInputs(
+            "cid",
+            List.of(
+                QueryInput.newBuilder().setTableId(tableId).setSnapshot(current).build(),
+                QueryInput.newBuilder().setTableId(tableId).setSnapshot(current).build()),
+            Optional.of(defaultAsOf),
+            Optional.empty());
+
+    assertEquals(1, result.snapshotSet().getPinsCount());
+    assertEquals(55L, result.snapshotSet().getPins(0).getSnapshotId());
+    List<FakeGraph.PinCall> calls =
+        metadataGraph.pinCalls().stream().filter(call -> call.tableId().equals(tableId)).toList();
+    assertEquals(1, calls.size());
+    assertTrue(calls.get(0).asOfDefault().isEmpty());
+  }
+
+  /** A batch of distinct relations resolves every one, preserving request order. */
+  @Test
+  void batchResolvesEveryInputInRequestOrder() {
+    List<QueryInput> inputs = new ArrayList<>();
+    List<String> expectedOrder = new ArrayList<>();
+    for (int i = 0; i < 12; i++) {
+      NameRef n = name("c", "ns", "t" + i);
+      ResourceId id = rid("T" + i);
+      metadataGraph.bind(n, id);
+      metadataGraph.setCurrentSnapshot(id, 100 + i);
+      inputs.add(QueryInput.newBuilder().setName(n).build());
+      expectedOrder.add("T" + i);
+    }
+
+    var result = resolver.resolveInputs("cid", inputs, Optional.empty(), Optional.empty());
+
+    assertEquals(expectedOrder, result.resolved().stream().map(ResourceId::getId).toList());
+    assertEquals(12, result.snapshotSet().getPinsCount());
   }
 
   /** When a QueryInput specifies a snapshot_id override, the resolver must use it verbatim. */
@@ -279,7 +711,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new java.util.LinkedHashMap<>(),
+                new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -352,7 +784,7 @@ public class QueryInputResolverTest {
                 List.of(qi),
                 Optional.<com.google.protobuf.Timestamp>empty(),
                 Optional.<ResourceId>empty(),
-                new java.util.LinkedHashMap<>(),
+                new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
                 null)
             .snapshotSet()
             .getPins(0);
@@ -407,7 +839,7 @@ public class QueryInputResolverTest {
             List.of(qi),
             Optional.<com.google.protobuf.Timestamp>empty(),
             Optional.<ResourceId>empty(),
-            new java.util.LinkedHashMap<>(),
+            new ConcurrentHashMap<ResourceId, CompletableFuture<TablePin>>(),
             null)
         .snapshotSet();
 
@@ -839,6 +1271,33 @@ public class QueryInputResolverTest {
   }
 
   @Test
+  void view_with_explicit_current_override_ignores_asof_default_for_base_pins() {
+    ResourceId base = rid("BASE_EXPLICIT_CURRENT");
+    ResourceId viewId = viewRid("V_EXPLICIT_CURRENT");
+    metadataGraph.addNode(viewNode(viewId, List.of(nameRef(base))));
+    metadataGraph.setCurrentSnapshot(base, 101L);
+    metadataGraph.setAsOfSnapshot(base, 555L);
+    Timestamp defaultAsOf = Timestamp.newBuilder().setSeconds(202).build();
+
+    QueryInput input =
+        QueryInput.newBuilder()
+            .setViewId(viewId)
+            .setSnapshot(SnapshotRef.newBuilder().setSpecial(SpecialSnapshot.SS_CURRENT))
+            .build();
+
+    List<SnapshotPin> pins =
+        resolver
+            .resolveInputs("cid", List.of(input), Optional.of(defaultAsOf), Optional.empty())
+            .snapshotSet()
+            .getPinsList();
+
+    assertEquals(1, pins.size());
+    assertEquals(101L, pins.get(0).getSnapshotId());
+    FakeGraph.PinCall call = metadataGraph.pinCalls().get(metadataGraph.pinCalls().size() - 1);
+    assertTrue(call.asOfDefault().isEmpty());
+  }
+
+  @Test
   void view_with_snapshot_override_is_invalid() {
     ResourceId base = rid("BASE_INVALID");
     ResourceId viewId = viewRid("V_INVALID");
@@ -1026,7 +1485,7 @@ public class QueryInputResolverTest {
     ResourceId tableId = rid("CACHE_TABLE");
     metadataGraph.setCurrentSnapshot(tableId, 1234L);
     QueryInput input = QueryInput.newBuilder().setTableId(tableId).build();
-    Map<ResourceId, TablePin> cache = new HashMap<>();
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
 
     resolver.resolveInputs(
         "", "cid-a", List.of(input), Optional.empty(), Optional.empty(), cache, null);
@@ -1037,6 +1496,400 @@ public class QueryInputResolverTest {
         metadataGraph.pinCalls().stream().filter(call -> call.tableId().equals(tableId)).count();
     assertEquals(1L, tablePinCalls);
     assertEquals(1, cache.size());
+  }
+
+  @Test
+  void discardedCurrentPinRemainsCachedAfterItsProvisionalRootsAreReleased() {
+    ResourceId tableId = rid("DISCARDED_CURRENT_CACHE");
+    var graph =
+        new FakeGraph() {
+          @Override
+          public TablePin tablePinFor(
+              String correlationId,
+              ResourceId id,
+              SnapshotRef override,
+              Optional<Timestamp> asOfDefault) {
+            TablePin pin = super.tablePinFor(correlationId, id, override, asOfDefault);
+            return pin.toBuilder()
+                .setTableBlobUri("s3://" + id.getId() + "/table-" + pin.getSnapshotId() + ".pb")
+                .setSnapshotBlobUri("s3://" + id.getId() + "/snap-" + pin.getSnapshotId() + ".pb")
+                .build();
+          }
+        };
+    graph.setCurrentSnapshot(tableId, 20L);
+    QueryContextStore store = org.mockito.Mockito.mock(QueryContextStore.class);
+    var withStore = new QueryInputResolver(graph, store);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              assertTrue(cache.containsKey(tableId), "stream cache must outlive one resolution");
+              assertEquals(10L, cache.get(tableId).join().getSnapshotId());
+              return null;
+            })
+        .when(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-discarded-current"),
+            org.mockito.ArgumentMatchers.argThat(
+                roots -> roots.contains("s3://DISCARDED_CURRENT_CACHE/snap-20.pb")));
+
+    QueryInput explicit =
+        QueryInput.newBuilder()
+            .setTableId(tableId)
+            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(10L))
+            .build();
+    QueryInput current = QueryInput.newBuilder().setTableId(tableId).build();
+    withStore.resolveInputs(
+        "q-discarded-current",
+        "cid-first",
+        List.of(explicit, current),
+        Optional.empty(),
+        Optional.empty(),
+        cache,
+        null);
+
+    assertTrue(cache.containsKey(tableId));
+    org.mockito.Mockito.verify(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.eq("q-discarded-current"),
+            org.mockito.ArgumentMatchers.argThat(
+                roots -> roots.contains("s3://DISCARDED_CURRENT_CACHE/snap-20.pb")));
+    graph.setCurrentSnapshot(tableId, 30L);
+    TablePin refreshed =
+        withStore
+            .resolveInputs(
+                "q-discarded-current",
+                "cid-second",
+                List.of(current),
+                Optional.empty(),
+                Optional.empty(),
+                cache,
+                null)
+            .relationPinSet()
+            .getPins(0)
+            .getTablePin();
+
+    assertEquals(10L, refreshed.getSnapshotId());
+    assertEquals(
+        1L,
+        graph.pinCalls().stream()
+            .filter(
+                call ->
+                    call.tableId().equals(tableId)
+                        && (call.override() == null
+                            || call.override().getWhichCase()
+                                == SnapshotRef.WhichCase.WHICH_NOT_SET))
+            .count());
+  }
+
+  @Test
+  void concurrentPlanningKeepsCurrentHolderPublishedAcrossWaiters() throws Exception {
+    ResourceId shared = rid("DEFERRED_CURRENT_RETIREMENT");
+    ResourceId blocked = rid("DEFERRED_CURRENT_BLOCKER");
+    metadataGraph.setCurrentSnapshot(shared, 20L);
+    metadataGraph.setCurrentSnapshot(blocked, 30L);
+    CountDownLatch blockerEntered = new CountDownLatch(1);
+    CountDownLatch releaseBlocker = new CountDownLatch(1);
+    metadataGraph.beforeTablePin(
+        tableId -> {
+          if (!tableId.equals(blocked)) {
+            return;
+          }
+          blockerEntered.countDown();
+          try {
+            releaseBlocker.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new java.util.concurrent.CancellationException();
+          }
+        });
+
+    AtomicInteger removals = new AtomicInteger();
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache =
+        new ConcurrentHashMap<>() {
+          @Override
+          public boolean remove(Object key, Object value) {
+            boolean removed = super.remove(key, value);
+            if (removed && shared.equals(key)) {
+              removals.incrementAndGet();
+            }
+            return removed;
+          }
+        };
+    QueryInput explicit =
+        QueryInput.newBuilder()
+            .setTableId(shared)
+            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(10L))
+            .build();
+    QueryInput current = QueryInput.newBuilder().setTableId(shared).build();
+    QueryInput blocker = QueryInput.newBuilder().setTableId(blocked).build();
+
+    CompletableFuture<QueryInputResolver.ResolutionResult> resolution =
+        CompletableFuture.supplyAsync(
+            () ->
+                resolver.resolveInputs(
+                    "q-deferred-retirement",
+                    "cid",
+                    List.of(explicit, current, current, blocker),
+                    Optional.empty(),
+                    Optional.empty(),
+                    cache,
+                    null));
+
+    try {
+      assertTrue(blockerEntered.await(2, TimeUnit.SECONDS));
+      assertEquals(0, removals.get());
+    } finally {
+      releaseBlocker.countDown();
+    }
+    QueryInputResolver.ResolutionResult result = resolution.get(2, TimeUnit.SECONDS);
+
+    assertEquals(0, removals.get());
+    assertTrue(cache.containsKey(shared));
+    assertEquals(List.of(shared, shared, shared, blocked), result.resolved());
+    assertEquals(2, result.relationPinSet().getPinsCount());
+  }
+
+  @Test
+  void currentSnapshotWaiterRetriesWhenSharedHolderRetiresBeforeValidation() {
+    ResourceId shared = rid("RETIRED_CURRENT_WAITER");
+    metadataGraph.setCurrentSnapshot(shared, 30L);
+    TablePin retiredPin =
+        TablePin.newBuilder()
+            .setTableId(shared)
+            .setPinKind(PinKind.PIN_KIND_CURRENT)
+            .setSnapshotId(20L)
+            .setTableBlobUri("s3://RETIRED_CURRENT_WAITER/table-20.pb")
+            .setSnapshotBlobUri("s3://RETIRED_CURRENT_WAITER/snapshot-20.pb")
+            .build();
+    AtomicBoolean retireBeforeValidation = new AtomicBoolean(true);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache =
+        new ConcurrentHashMap<>() {
+          @Override
+          public CompletableFuture<TablePin> get(Object key) {
+            if (shared.equals(key) && retireBeforeValidation.compareAndSet(true, false)) {
+              super.remove(key);
+              return null;
+            }
+            return super.get(key);
+          }
+        };
+    cache.put(shared, CompletableFuture.completedFuture(retiredPin));
+
+    QueryInputResolver.ResolutionResult result =
+        resolver.resolveInputs(
+            "q-retired-current-waiter",
+            "cid",
+            List.of(QueryInput.newBuilder().setTableId(shared).build()),
+            Optional.empty(),
+            Optional.empty(),
+            cache,
+            null);
+
+    assertEquals(30L, result.relationPinSet().getPins(0).getTablePin().getSnapshotId());
+    assertEquals(
+        1L,
+        metadataGraph.pinCalls().stream().filter(call -> call.tableId().equals(shared)).count());
+    assertTrue(cache.containsKey(shared));
+  }
+
+  @Test
+  void concurrentCacheEvictsPinsOwnedByAFailedResolution() {
+    ResourceId successful = rid("CONCURRENT_CACHE_SUCCESS");
+    ResourceId failing = rid("CONCURRENT_CACHE_FAILURE");
+    var graph = new FakeGraph();
+    graph.failPinFor(failing);
+    var withStore =
+        new QueryInputResolver(graph, org.mockito.Mockito.mock(QueryContextStore.class));
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-concurrent-cache",
+                "cid",
+                List.of(
+                    QueryInput.newBuilder().setTableId(successful).build(),
+                    QueryInput.newBuilder().setTableId(failing).build()),
+                Optional.empty(),
+                Optional.empty(),
+                cache,
+                null));
+
+    assertTrue(cache.isEmpty());
+  }
+
+  @Test
+  void failedResolutionEvictsFirstTouchReplacementFromSharedCurrentCache() {
+    ResourceId shared = rid("FAILED_REPLACEMENT_CURRENT");
+    ResourceId failing = rid("FAILED_REPLACEMENT_ERROR");
+    var graph = new FakeGraph();
+    graph.setCurrentSnapshot(shared, 20L);
+    graph.failPinFor(failing);
+    var withStore =
+        new QueryInputResolver(graph, org.mockito.Mockito.mock(QueryContextStore.class));
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+    QueryInput explicit =
+        QueryInput.newBuilder()
+            .setTableId(shared)
+            .setSnapshot(SnapshotRef.newBuilder().setSnapshotId(10L))
+            .build();
+    QueryInput current = QueryInput.newBuilder().setTableId(shared).build();
+    QueryInput failure = QueryInput.newBuilder().setTableId(failing).build();
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-failed-replacement",
+                "cid",
+                List.of(explicit, current, failure),
+                Optional.empty(),
+                Optional.empty(),
+                cache,
+                null));
+
+    assertFalse(cache.containsKey(shared));
+  }
+
+  @Test
+  void failedResolutionPreservesConcurrentCacheEntriesOwnedByAnEarlierCall() {
+    ResourceId cached = rid("CONCURRENT_CACHE_EXISTING");
+    ResourceId failing = rid("CONCURRENT_CACHE_NEW_FAILURE");
+    var graph = new FakeGraph();
+    graph.failPinFor(failing);
+    var withStore =
+        new QueryInputResolver(graph, org.mockito.Mockito.mock(QueryContextStore.class));
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+
+    withStore.resolveInputs(
+        "q-concurrent-cache-existing",
+        "cid-first",
+        List.of(QueryInput.newBuilder().setTableId(cached).build()),
+        Optional.empty(),
+        Optional.empty(),
+        cache,
+        null);
+    CompletableFuture<TablePin> existing = cache.get(cached);
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            withStore.resolveInputs(
+                "q-concurrent-cache-existing",
+                "cid-second",
+                List.of(
+                    QueryInput.newBuilder().setTableId(cached).build(),
+                    QueryInput.newBuilder().setTableId(failing).build()),
+                Optional.empty(),
+                Optional.empty(),
+                cache,
+                null));
+
+    assertSame(existing, cache.get(cached));
+    assertEquals(Set.of(cached), cache.keySet());
+  }
+
+  @Test
+  void cacheWaiterRootsPinBeforeFailedOwnerCanReleaseIt() throws Exception {
+    ResourceId shared = rid("CONCURRENT_CACHE_HANDOFF");
+    ResourceId failing = rid("CONCURRENT_CACHE_HANDOFF_FAILURE");
+    CountDownLatch failingLookupStarted = new CountDownLatch(1);
+    CountDownLatch allowFailure = new CountDownLatch(1);
+    CountDownLatch waiterRegistrationStarted = new CountDownLatch(1);
+    CountDownLatch allowWaiterRegistration = new CountDownLatch(1);
+    CountDownLatch ownerReleasedRoot = new CountDownLatch(1);
+    AtomicInteger sharedRegistrations = new AtomicInteger();
+    var graph = new FakeGraph();
+    graph.failPinFor(failing);
+    graph.beforeTablePin(
+        tableId -> {
+          if (tableId.equals(failing)) {
+            failingLookupStarted.countDown();
+            try {
+              allowFailure.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new java.util.concurrent.CancellationException();
+            }
+          }
+        });
+    QueryContextStore store = org.mockito.Mockito.mock(QueryContextStore.class);
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              java.util.Collection<String> roots = invocation.getArgument(1);
+              if (roots.contains("s3://CONCURRENT_CACHE_HANDOFF/table.pb")
+                  && sharedRegistrations.incrementAndGet() == 2) {
+                waiterRegistrationStarted.countDown();
+                allowWaiterRegistration.await();
+              }
+              return null;
+            })
+        .when(store)
+        .registerResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              java.util.Collection<String> roots = invocation.getArgument(1);
+              if (roots.contains("s3://CONCURRENT_CACHE_HANDOFF/table.pb")) {
+                ownerReleasedRoot.countDown();
+              }
+              return null;
+            })
+        .when(store)
+        .releaseResolvingPinBlobs(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
+    var withStore = new QueryInputResolver(graph, store);
+    ConcurrentMap<ResourceId, CompletableFuture<TablePin>> cache = new ConcurrentHashMap<>();
+
+    CompletableFuture<Throwable> owner =
+        resolveCancellable(
+            () ->
+                withStore.resolveInputs(
+                    "q-cache-owner",
+                    "cid-owner",
+                    List.of(
+                        QueryInput.newBuilder().setTableId(shared).build(),
+                        QueryInput.newBuilder().setTableId(failing).build()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    cache,
+                    null));
+    try {
+      assertTrue(failingLookupStarted.await(1, TimeUnit.SECONDS));
+      for (int attempt = 0;
+          attempt < 100 && (cache.get(shared) == null || !cache.get(shared).isDone());
+          attempt++) {
+        Thread.sleep(10);
+      }
+      assertTrue(cache.get(shared).isDone());
+
+      CompletableFuture<QueryInputResolver.ResolutionResult> waiter =
+          CompletableFuture.supplyAsync(
+              () ->
+                  withStore.resolveInputs(
+                      "q-cache-waiter",
+                      "cid-waiter",
+                      List.of(QueryInput.newBuilder().setTableId(shared).build()),
+                      Optional.empty(),
+                      Optional.empty(),
+                      cache,
+                      null));
+      assertTrue(waiterRegistrationStarted.await(1, TimeUnit.SECONDS));
+
+      allowFailure.countDown();
+      assertFalse(ownerReleasedRoot.await(100, TimeUnit.MILLISECONDS));
+      allowWaiterRegistration.countDown();
+
+      assertEquals(shared, waiter.get(1, TimeUnit.SECONDS).resolved().getFirst());
+      assertTrue(owner.get(1, TimeUnit.SECONDS) instanceof StatusRuntimeException);
+      assertTrue(ownerReleasedRoot.await(1, TimeUnit.SECONDS));
+    } finally {
+      allowFailure.countDown();
+      allowWaiterRegistration.countDown();
+    }
   }
 
   // ----------------------------------------------------------------------
@@ -1136,18 +1989,25 @@ public class QueryInputResolverTest {
   // Helpers / test doubles (Composition, not inheritance)
   // ----------------------------------------------------------------------
 
-  static final class FakeGraph extends TestCatalogOverlay {
+  static class FakeGraph extends TestCatalogOverlay {
 
     private final Map<NameRef, ResourceId> nameBindings = new HashMap<>();
     private final Map<NameRef, RuntimeException> failures = new HashMap<>();
     private final Map<String, Long> currentSnapshots = new HashMap<>();
     private final Map<String, Long> asOfSnapshots = new HashMap<>();
+    // Written from resolution tasks, which may run in parallel; keep it thread-safe.
+    private final List<PinCall> pinCalls =
+        java.util.Collections.synchronizedList(new ArrayList<>());
     private final Set<ResourceId> failingPins = new HashSet<>();
-    private final List<PinCall> pinCalls = new ArrayList<>();
     private final Map<ResourceId, String> catalogNames = new HashMap<>();
     private Consumer<ResourceId> beforeTablePin = ignored -> {};
 
     FakeGraph() {}
+
+    @Override
+    public boolean supportsConcurrentResolution() {
+      return true;
+    }
 
     void setCatalogName(ResourceId id, String name) {
       catalogNames.put(id, name);
@@ -1185,6 +2045,12 @@ public class QueryInputResolverTest {
         return Optional.empty();
       }
       return Optional.of(id);
+    }
+
+    @Override
+    public Optional<ResourceId> resolveName(
+        String correlationId, NameRef ref, EngineContext engineContext) {
+      return resolveName(correlationId, ref);
     }
 
     @Override
@@ -1264,6 +2130,111 @@ public class QueryInputResolverTest {
         ResourceId tableId,
         SnapshotRef override,
         Optional<Timestamp> asOfDefault) {}
+  }
+
+  /** Blocks one table-pin lookup until the test releases it. */
+  static final class BlockingPinGraph extends FakeGraph {
+    private final String blockedTableId;
+    final UninterruptibleBlocker slowPinBlocker = new UninterruptibleBlocker();
+    final CountDownLatch slowPinStarted = slowPinBlocker.started;
+    final CountDownLatch allowSlowPin = slowPinBlocker.release;
+
+    BlockingPinGraph(String blockedTableId) {
+      this.blockedTableId = blockedTableId;
+    }
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      if (blockedTableId.equals(tableId.getId())) {
+        slowPinBlocker.await();
+      }
+      return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+  }
+
+  /** Blocks the final caller-thread pin callback so cancellation can race its return. */
+  static final class BlockingThreadConfinedPinGraph extends FakeGraph {
+    final UninterruptibleBlocker pinBlocker = new UninterruptibleBlocker();
+
+    @Override
+    public boolean supportsConcurrentResolution() {
+      return false;
+    }
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      pinBlocker.await();
+      return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+  }
+
+  /** Fails if a planning callback runs off the thread that began the request. */
+  static final class CallerThreadOnlyGraph extends FakeGraph {
+    private final Thread callerThread;
+    private final List<Thread> planningThreads = new ArrayList<>();
+
+    CallerThreadOnlyGraph(Thread callerThread) {
+      this.callerThread = callerThread;
+    }
+
+    @Override
+    public boolean supportsConcurrentResolution() {
+      return false;
+    }
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      if (Thread.currentThread() != callerThread) {
+        throw new AssertionError("planning callback escaped the request thread");
+      }
+      planningThreads.add(Thread.currentThread());
+      return super.tablePinFor(correlationId, tableId, override, asOfDefault);
+    }
+
+    List<Thread> planningThreads() {
+      return planningThreads;
+    }
+  }
+
+  /** Fails one lookup only after the sibling's pin has been constructed. */
+  static final class FailingAfterFastPinGraph extends FakeGraph {
+    private final CountDownLatch fastPinCompleted = new CountDownLatch(1);
+
+    @Override
+    public TablePin tablePinFor(
+        String correlationId,
+        ResourceId tableId,
+        SnapshotRef override,
+        Optional<Timestamp> asOfDefault) {
+      if ("FAIL".equals(tableId.getId())) {
+        try {
+          if (!fastPinCompleted.await(1, TimeUnit.SECONDS)) {
+            throw new AssertionError("fast pin lookup did not complete");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError("failing pin lookup interrupted", e);
+        }
+        throw new IllegalStateException("planned failure");
+      }
+      TablePin pin = super.tablePinFor(correlationId, tableId, override, asOfDefault);
+      if ("FAST".equals(tableId.getId())) {
+        fastPinCompleted.countDown();
+      }
+      return pin;
+    }
   }
 
   private static NameRef nameRef(ResourceId id) {

--- a/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
+++ b/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnostics.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.LongAdder;
  * count}/{@code add} sum, {@code timer}/{@code nanos} sum the elapsed time, and each summed key is
  * flushed once as a single {@code add} / {@code nanos}. The per-key values (e.g. total snapshot
  * lookups and the total time spent in them) are the per-request aggregate; per-item ordering and
- * one-shot fields ({@code put}, {@code emit}) are not represented and are dropped — a caller that
+ * one-shot fields ({@code put}, {@code emit}) are not representable and are omitted — a caller that
  * needs them should record on the request thread.
  */
 public final class AggregatingPhaseDiagnostics implements PhaseDiagnostics {
@@ -58,8 +58,8 @@ public final class AggregatingPhaseDiagnostics implements PhaseDiagnostics {
     counts.computeIfAbsent(key, k -> new LongAdder()).add(amount);
   }
 
-  // One-shot values do not aggregate across items; callers that need them report on the request
-  // thread, not through this accumulator.
+  // One-shot values do not aggregate across items. Unsupported telemetry must not turn concurrent
+  // request work into a failure.
   @Override
   public void put(String key, String value) {}
 

--- a/telemetry-hub/core/src/test/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnosticsTest.java
+++ b/telemetry-hub/core/src/test/java/ai/floedb/floecat/telemetry/AggregatingPhaseDiagnosticsTest.java
@@ -84,10 +84,12 @@ class AggregatingPhaseDiagnosticsTest {
   }
 
   @Test
-  void oneShotAndEmitAreDropped() {
+  void oneShotAndEmitAreOmitted() {
     AggregatingPhaseDiagnostics agg = new AggregatingPhaseDiagnostics();
     agg.put("k", "v");
     agg.put("n", 1L);
+    agg.put("ratio", 1.0d);
+    agg.put("enabled", true);
     agg.emit("event");
 
     CapturingDiagnostics target = new CapturingDiagnostics();


### PR DESCRIPTION
First consumer of the parallel metadata stage. Resolves a query's input pins concurrently instead of serially while preserving deterministic merge order, request cancellation, and the process-wide metadata-I/O ceiling introduced by PR #433 and wired by PR #434.

### Resolver concurrency

- **Ordered fan-out** — `QueryInputResolver` plans inputs through `MetadataFanout`, using concurrent virtual-thread units when the metadata graph supports concurrent resolution and an inline serial path for thread-confined overlays. Results always merge in request order.
- **Configured width** — `floecat.query.resolver.max_parallel_inputs` defaults to 8, is clamped to 1–16, and warns when clamped.
- **Process-wide admission** — each complete `metadataGraph.tablePinFor(...)` chain is admitted once through an injected `RepositoryReads.ReadPolicy`. Snapshot and table-root leaves remain direct within that chain, avoiding nested permits while ensuring concurrent resolver work waits behind `floecat.query.metadata-io.max-concurrency`.
- **Live cancellation** — the request cancellation signal is bound across planning and propagated into fan-out workers. A cancelled resolver abandons admission and pin waits without allowing queued backend work to start later.

### Pin ownership and state

- **`CurrentSnapshotPinCache`** — provides single-flight current-snapshot resolution per table, including safe ownership transfer, compatible-pin retirement, rollback, and transient GC-root cleanup.
- **Explicit worker context** — immutable/shared `ResolutionWork` is separated from request-thread `ResolutionState` accumulators, keeping worker ownership and merge ownership distinct.
- **Compatibility seams** — legacy completed-pin and cancellable overloads remain supported without bypassing the typed cache or cancellation behavior; test resolvers override the same production seam.
- **Deterministic diagnostics** — worker-local diagnostics are aggregated after fan-out, while the request-thread merge retains first-touch and conflict semantics.

### Supporting changes

- `Futures.join` unwraps pin failures so callers observe the underlying store error rather than `CompletionException`.
- `NameResolver`, `MetaGraph`, `StatsProvider`, and `CatalogOverlay` expose the concurrency capabilities needed by the resolver.
- Service configuration and operator documentation describe both the per-request fan-out and process-wide admission boundaries.

### Validation

- Saturation coverage proves pin resolution waits while the process-wide metadata gate is full.
- Resolver, cancellation, cache ownership, diagnostics, name resolution, bundle-service, and wiring regression tests pass.
- Full 35-module `make verify` succeeds.
- Final correctness and thermo-maintainability reviews report no actionable findings.

---

Part of the GetUserObjects parallel re-cut. Stacked on PR #434 (`mr-guo-3-auto-admission`).
