### PR TITLE
feat(catalog-access): add SPI and Iceberg REST provider (stack 8/10)

### DIFF
--- a/catalog-access/iceberg-rest/pom.xml
+++ b/catalog-access/iceberg-rest/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Yellowbrick Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.floedb.floecat</groupId>
+    <artifactId>floecat</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>floecat-catalog-access-iceberg-rest</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>ai.floedb.floecat</groupId>
+      <artifactId>floecat-catalog-access-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-aws</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
@@ -149,8 +149,7 @@ final class IcebergRestCatalogClient implements CatalogClient {
             .map(SQLViewRepresentation.class::cast)
             .map(
                 representation ->
-                    new CatalogViewDefinition(
-                        representation.sql(), representation.dialect()))
+                    new CatalogViewDefinition(representation.sql(), representation.dialect()))
             .toList();
     return new CatalogView(
         name,
@@ -196,8 +195,7 @@ final class IcebergRestCatalogClient implements CatalogClient {
     }
 
     Map<String, String> vended = filterVendedStorageProperties(selected.config());
-    if (!vended.containsKey("s3.access-key-id")
-        || !vended.containsKey("s3.secret-access-key")) {
+    if (!vended.containsKey("s3.access-key-id") || !vended.containsKey("s3.secret-access-key")) {
       return Optional.empty();
     }
     return Optional.of(

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
@@ -57,6 +57,8 @@ final class IcebergRestCatalogClient implements CatalogClient {
           "s3.region",
           "s3.endpoint",
           "s3.path-style-access");
+  private static final List<String> STORAGE_ROUTING_KEYS =
+      List.of("s3.region", "s3.endpoint", "s3.path-style-access");
   private static final String VENDED_EXPIRY_KEY = "s3.session-token-expires-at-ms";
   private static final CatalogCapabilities CAPABILITIES =
       CatalogCapabilities.of(
@@ -73,6 +75,7 @@ final class IcebergRestCatalogClient implements CatalogClient {
   private final SupportsNamespaces namespaceCatalog;
   private final ViewCatalog viewCatalog;
   private final Runnable closeHook;
+  private final Map<String, String> storageRoutingProperties;
   private final AtomicBoolean closed = new AtomicBoolean(false);
 
   IcebergRestCatalogClient(
@@ -80,10 +83,21 @@ final class IcebergRestCatalogClient implements CatalogClient {
       SupportsNamespaces namespaceCatalog,
       ViewCatalog viewCatalog,
       Runnable closeHook) {
+    this(catalog, namespaceCatalog, viewCatalog, closeHook, Map.of());
+  }
+
+  IcebergRestCatalogClient(
+      Catalog catalog,
+      SupportsNamespaces namespaceCatalog,
+      ViewCatalog viewCatalog,
+      Runnable closeHook,
+      Map<String, String> storageRoutingProperties) {
     this.catalog = Objects.requireNonNull(catalog, "catalog");
     this.namespaceCatalog = Objects.requireNonNull(namespaceCatalog, "namespaceCatalog");
     this.viewCatalog = Objects.requireNonNull(viewCatalog, "viewCatalog");
     this.closeHook = Objects.requireNonNull(closeHook, "closeHook");
+    this.storageRoutingProperties =
+        Map.copyOf(Objects.requireNonNull(storageRoutingProperties, "storageRoutingProperties"));
   }
 
   @Override
@@ -194,13 +208,14 @@ final class IcebergRestCatalogClient implements CatalogClient {
       return Optional.empty();
     }
 
-    Map<String, String> vended = filterVendedStorageProperties(selected.config());
+    Map<String, String> vended = new LinkedHashMap<>(storageRoutingProperties);
+    vended.putAll(filterVendedStorageProperties(selected.config()));
     if (!vended.containsKey("s3.access-key-id") || !vended.containsKey("s3.secret-access-key")) {
       return Optional.empty();
     }
     return Optional.of(
         new VendedStorageCredentials(
-            vended,
+            Map.copyOf(vended),
             Optional.ofNullable(selected.prefix()).orElse(""),
             Optional.ofNullable(parseVendedExpiry(selected.config()))));
   }
@@ -260,6 +275,17 @@ final class IcebergRestCatalogClient implements CatalogClient {
   private static Map<String, String> filterVendedStorageProperties(Map<String, String> source) {
     Map<String, String> filtered = new LinkedHashMap<>();
     for (String key : VENDED_STORAGE_KEYS) {
+      String value = source.get(key);
+      if (value != null && !value.isBlank()) {
+        filtered.put(key, value);
+      }
+    }
+    return Map.copyOf(filtered);
+  }
+
+  static Map<String, String> storageRoutingProperties(Map<String, String> source) {
+    Map<String, String> filtered = new LinkedHashMap<>();
+    for (String key : STORAGE_ROUTING_KEYS) {
       String value = source.get(key);
       if (value != null && !value.isBlank()) {
         filtered.put(key, value);

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest;
+
+import ai.floedb.floecat.catalog.access.CatalogCapabilities;
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.CatalogTable;
+import ai.floedb.floecat.catalog.access.CatalogView;
+import ai.floedb.floecat.catalog.access.CatalogViewDefinition;
+import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
+import org.apache.iceberg.view.SQLViewRepresentation;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewVersion;
+
+final class IcebergRestCatalogClient implements CatalogClient {
+  private static final List<String> VENDED_STORAGE_KEYS =
+      List.of(
+          "s3.access-key-id",
+          "s3.secret-access-key",
+          "s3.session-token",
+          "s3.region",
+          "s3.endpoint",
+          "s3.path-style-access");
+  private static final String VENDED_EXPIRY_KEY = "s3.session-token-expires-at-ms";
+  private static final CatalogCapabilities CAPABILITIES =
+      CatalogCapabilities.of(
+          CatalogCapability.VALIDATE,
+          CatalogCapability.LIST_NAMESPACES,
+          CatalogCapability.LIST_TABLES,
+          CatalogCapability.LOAD_TABLE,
+          CatalogCapability.LIST_VIEWS,
+          CatalogCapability.LOAD_VIEW,
+          CatalogCapability.VEND_STORAGE_CREDENTIALS,
+          CatalogCapability.STABLE_OBJECT_IDS);
+
+  private final Catalog catalog;
+  private final SupportsNamespaces namespaceCatalog;
+  private final ViewCatalog viewCatalog;
+  private final Runnable closeHook;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+
+  IcebergRestCatalogClient(
+      Catalog catalog,
+      SupportsNamespaces namespaceCatalog,
+      ViewCatalog viewCatalog,
+      Runnable closeHook) {
+    this.catalog = Objects.requireNonNull(catalog, "catalog");
+    this.namespaceCatalog = Objects.requireNonNull(namespaceCatalog, "namespaceCatalog");
+    this.viewCatalog = Objects.requireNonNull(viewCatalog, "viewCatalog");
+    this.closeHook = Objects.requireNonNull(closeHook, "closeHook");
+  }
+
+  @Override
+  public CatalogCapabilities capabilities() {
+    return CAPABILITIES;
+  }
+
+  @Override
+  public void validate() {
+    namespaceCatalog.listNamespaces(Namespace.empty());
+  }
+
+  @Override
+  public List<NamespacePath> listNamespaces(NamespacePath parent) {
+    Objects.requireNonNull(parent, "parent");
+    return namespaceCatalog.listNamespaces(toIcebergNamespace(parent)).stream()
+        .map(IcebergRestCatalogClient::fromIcebergNamespace)
+        .sorted()
+        .toList();
+  }
+
+  @Override
+  public List<CatalogObjectName> listTables(NamespacePath namespace) {
+    Objects.requireNonNull(namespace, "namespace");
+    return catalog.listTables(toIcebergNamespace(namespace)).stream()
+        .map(IcebergRestCatalogClient::fromTableIdentifier)
+        .sorted()
+        .toList();
+  }
+
+  @Override
+  public CatalogTable loadTable(CatalogObjectName name) {
+    Objects.requireNonNull(name, "name");
+    Table table = catalog.loadTable(toTableIdentifier(name));
+    TableMetadata metadata = tableMetadata(table);
+    return new CatalogTable(
+        name,
+        externalIdentity(name, metadata),
+        "ICEBERG",
+        metadataLocation(metadata),
+        Optional.ofNullable(table.location()).filter(location -> !location.isBlank()),
+        table.properties());
+  }
+
+  @Override
+  public List<CatalogObjectName> listViews(NamespacePath namespace) {
+    Objects.requireNonNull(namespace, "namespace");
+    return viewCatalog.listViews(toIcebergNamespace(namespace)).stream()
+        .map(IcebergRestCatalogClient::fromTableIdentifier)
+        .sorted()
+        .toList();
+  }
+
+  @Override
+  public CatalogView loadView(CatalogObjectName name) {
+    Objects.requireNonNull(name, "name");
+    View view = viewCatalog.loadView(toTableIdentifier(name));
+    ViewVersion currentVersion = Objects.requireNonNull(view.currentVersion(), "currentVersion");
+    Namespace defaultNamespace = currentVersion.defaultNamespace();
+    List<CatalogViewDefinition> definitions =
+        currentVersion.representations().stream()
+            .filter(SQLViewRepresentation.class::isInstance)
+            .map(SQLViewRepresentation.class::cast)
+            .map(
+                representation ->
+                    new CatalogViewDefinition(
+                        representation.sql(), representation.dialect()))
+            .toList();
+    return new CatalogView(
+        name,
+        Optional.ofNullable(view.uuid())
+            .map(Object::toString)
+            .map(ExternalObjectIdentity::stable)
+            .orElseGet(() -> ExternalObjectIdentity.pathFallback(name)),
+        SchemaParser.toJson(view.schema()),
+        definitions,
+        defaultNamespace == null ? name.namespace() : fromIcebergNamespace(defaultNamespace),
+        view.properties());
+  }
+
+  @Override
+  public Optional<VendedStorageCredentials> vendStorageCredentials(CatalogObjectName name) {
+    Objects.requireNonNull(name, "name");
+    Table table = catalog.loadTable(toTableIdentifier(name));
+    if (!(table.io() instanceof SupportsStorageCredentials credentialSource)) {
+      return Optional.empty();
+    }
+    List<StorageCredential> credentials = credentialSource.credentials();
+    if (credentials == null || credentials.isEmpty()) {
+      return Optional.empty();
+    }
+
+    String tableLocation = Optional.ofNullable(table.location()).orElse("");
+    StorageCredential selected = null;
+    for (StorageCredential candidate : credentials) {
+      if (candidate == null || candidate.config() == null || candidate.config().isEmpty()) {
+        continue;
+      }
+      String prefix = Optional.ofNullable(candidate.prefix()).orElse("");
+      if (!prefix.isEmpty() && !tableLocation.startsWith(prefix)) {
+        continue;
+      }
+      if (selected == null
+          || prefix.length() > Optional.ofNullable(selected.prefix()).orElse("").length()) {
+        selected = candidate;
+      }
+    }
+    if (selected == null) {
+      return Optional.empty();
+    }
+
+    Map<String, String> vended = filterVendedStorageProperties(selected.config());
+    if (!vended.containsKey("s3.access-key-id")
+        || !vended.containsKey("s3.secret-access-key")) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new VendedStorageCredentials(
+            vended,
+            Optional.ofNullable(selected.prefix()).orElse(""),
+            Optional.ofNullable(parseVendedExpiry(selected.config()))));
+  }
+
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      closeHook.run();
+    }
+  }
+
+  private static Namespace toIcebergNamespace(NamespacePath path) {
+    return path.segments().isEmpty()
+        ? Namespace.empty()
+        : Namespace.of(path.segments().toArray(String[]::new));
+  }
+
+  private static NamespacePath fromIcebergNamespace(Namespace namespace) {
+    return new NamespacePath(List.of(namespace.levels()));
+  }
+
+  private static CatalogObjectName fromTableIdentifier(TableIdentifier identifier) {
+    return new CatalogObjectName(fromIcebergNamespace(identifier.namespace()), identifier.name());
+  }
+
+  private static TableIdentifier toTableIdentifier(CatalogObjectName name) {
+    Namespace namespace = toIcebergNamespace(name.namespace());
+    return namespace.isEmpty()
+        ? TableIdentifier.of(name.name())
+        : TableIdentifier.of(namespace, name.name());
+  }
+
+  private static TableMetadata tableMetadata(Table table) {
+    if (!(table instanceof HasTableOperations hasOperations)) {
+      return null;
+    }
+    return hasOperations.operations().current();
+  }
+
+  private static ExternalObjectIdentity externalIdentity(
+      CatalogObjectName name, TableMetadata metadata) {
+    return Optional.ofNullable(metadata)
+        .map(TableMetadata::uuid)
+        .map(String::trim)
+        .filter(uuid -> !uuid.isEmpty())
+        .map(ExternalObjectIdentity::stable)
+        .orElseGet(() -> ExternalObjectIdentity.pathFallback(name));
+  }
+
+  private static Optional<String> metadataLocation(TableMetadata metadata) {
+    return Optional.ofNullable(metadata)
+        .map(TableMetadata::metadataFileLocation)
+        .map(String::trim)
+        .filter(location -> !location.isEmpty());
+  }
+
+  private static Map<String, String> filterVendedStorageProperties(Map<String, String> source) {
+    Map<String, String> filtered = new LinkedHashMap<>();
+    for (String key : VENDED_STORAGE_KEYS) {
+      String value = source.get(key);
+      if (value != null && !value.isBlank()) {
+        filtered.put(key, value);
+      }
+    }
+    return Map.copyOf(filtered);
+  }
+
+  private static Instant parseVendedExpiry(Map<String, String> properties) {
+    String raw = properties.get(VENDED_EXPIRY_KEY);
+    if (raw == null || raw.isBlank()) {
+      return null;
+    }
+    try {
+      return Instant.ofEpochMilli(Long.parseLong(raw.trim()));
+    } catch (NumberFormatException ignored) {
+      return null;
+    }
+  }
+}

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
@@ -189,19 +189,21 @@ final class IcebergRestCatalogClient implements CatalogClient {
       return Optional.empty();
     }
 
-    String tableLocation = Optional.ofNullable(table.location()).orElse("");
+    String tableLocation = normalizeS3Scheme(Optional.ofNullable(table.location()).orElse(""));
     StorageCredential selected = null;
+    int selectedPrefixLength = -1;
     for (StorageCredential candidate : credentials) {
-      if (candidate == null || candidate.config() == null || candidate.config().isEmpty()) {
+      if (candidate == null || !hasVendedKeyMaterial(candidate.config())) {
         continue;
       }
       String prefix = Optional.ofNullable(candidate.prefix()).orElse("");
-      if (!prefix.isEmpty() && !tableLocation.startsWith(prefix)) {
+      String normalizedPrefix = normalizeS3Scheme(prefix);
+      if (!normalizedPrefix.isEmpty() && !tableLocation.startsWith(normalizedPrefix)) {
         continue;
       }
-      if (selected == null
-          || prefix.length() > Optional.ofNullable(selected.prefix()).orElse("").length()) {
+      if (selected == null || normalizedPrefix.length() > selectedPrefixLength) {
         selected = candidate;
+        selectedPrefixLength = normalizedPrefix.length();
       }
     }
     if (selected == null) {
@@ -281,6 +283,31 @@ final class IcebergRestCatalogClient implements CatalogClient {
       }
     }
     return Map.copyOf(filtered);
+  }
+
+  private static boolean hasVendedKeyMaterial(Map<String, String> properties) {
+    return properties != null
+        && !properties.isEmpty()
+        && !isBlank(properties.get("s3.access-key-id"))
+        && !isBlank(properties.get("s3.secret-access-key"));
+  }
+
+  private static String normalizeS3Scheme(String location) {
+    int schemeEnd = location.indexOf("://");
+    if (schemeEnd < 0) {
+      return location;
+    }
+    String scheme = location.substring(0, schemeEnd);
+    if ("s3".equalsIgnoreCase(scheme)
+        || "s3a".equalsIgnoreCase(scheme)
+        || "s3n".equalsIgnoreCase(scheme)) {
+      return "s3" + location.substring(schemeEnd);
+    }
+    return location;
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
   }
 
   static Map<String, String> storageRoutingProperties(Map<String, String> source) {

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
@@ -89,7 +89,11 @@ public final class IcebergRestCatalogClientProvider implements CatalogClientProv
         throw new IllegalStateException("Iceberg REST catalog does not support namespaces");
       }
       return new IcebergRestCatalogClient(
-          catalog, namespaces, viewCatalog, () -> closeCatalog(sessionCatalog));
+          catalog,
+          namespaces,
+          viewCatalog,
+          () -> closeCatalog(sessionCatalog),
+          IcebergRestCatalogClient.storageRoutingProperties(properties));
     } catch (RuntimeException | Error e) {
       closeCatalog(sessionCatalog);
       throw e;

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest;
+
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogClientProvider;
+import ai.floedb.floecat.catalog.access.CatalogConnectionConfig;
+import ai.floedb.floecat.catalog.access.CatalogProtocol;
+import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
+import ai.floedb.floecat.catalog.iceberg.rest.auth.AwsCredentialScope;
+import ai.floedb.floecat.catalog.iceberg.rest.auth.CatalogSigV4AuthManager;
+import ai.floedb.floecat.catalog.iceberg.rest.auth.RefreshingAwsCredentialsRegistry;
+import ai.floedb.floecat.catalog.iceberg.rest.auth.RegistryBackedAwsCredentialsProvider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.rest.HTTPClient;
+import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.apache.iceberg.rest.RESTUtil;
+
+/** Opens Iceberg REST catalogs without any dependency on Connector resources or RPC contracts. */
+public final class IcebergRestCatalogClientProvider implements CatalogClientProvider {
+  private static final String DEFAULT_S3_FILE_IO = "org.apache.iceberg.aws.s3.S3FileIO";
+  private static final AwsCredentialKeys CATALOG_AWS_KEYS =
+      new AwsCredentialKeys(
+          RefreshingAwsCredentialsRegistry.CATALOG_PROVIDER_ID,
+          "rest",
+          "AWS SigV4 requires catalog access/secret keys or a renewable catalog provider");
+  private static final AwsCredentialKeys STORAGE_AWS_KEYS =
+      new AwsCredentialKeys(
+          RefreshingAwsCredentialsRegistry.STORAGE_PROVIDER_ID,
+          "s3",
+          "AWS storage credentials require both s3.access-key-id and s3.secret-access-key");
+  private static final Set<String> OAUTH_CREDENTIAL_PROPERTIES = Set.of("token", "credential");
+  private static final Set<String> AWS_CREDENTIAL_PROPERTIES =
+      Stream.of(CATALOG_AWS_KEYS, STORAGE_AWS_KEYS)
+          .flatMap(keys -> keys.propertyNames().stream())
+          .collect(Collectors.toUnmodifiableSet());
+  private static final Set<String> CONTROLLED_CONNECTION_PROPERTIES =
+      Stream.concat(
+              Stream.of("token", "credential", "rest.auth.type", "rest.sigv4-enabled"),
+              AWS_CREDENTIAL_PROPERTIES.stream())
+          .collect(Collectors.toUnmodifiableSet());
+
+  @Override
+  public CatalogProtocol protocol() {
+    return CatalogProtocol.ICEBERG_REST;
+  }
+
+  @Override
+  public CatalogClient open(
+      CatalogConnectionConfig config, ResolvedCatalogCredentials resolvedCredentials) {
+    if (config.protocol() != CatalogProtocol.ICEBERG_REST) {
+      throw new IllegalArgumentException(
+          "Iceberg REST provider cannot open protocol=" + config.protocol());
+    }
+
+    Map<String, String> properties = catalogProperties(config, resolvedCredentials);
+    RESTSessionCatalog sessionCatalog = createSessionCatalog(properties);
+    try {
+      SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+      Catalog catalog = sessionCatalog.asCatalog(context);
+      ViewCatalog viewCatalog = sessionCatalog.asViewCatalog(context);
+      if (!(catalog instanceof SupportsNamespaces namespaces)) {
+        throw new IllegalStateException("Iceberg REST catalog does not support namespaces");
+      }
+      return new IcebergRestCatalogClient(
+          catalog, namespaces, viewCatalog, () -> closeCatalog(sessionCatalog));
+    } catch (RuntimeException | Error e) {
+      closeCatalog(sessionCatalog);
+      throw e;
+    }
+  }
+
+  static Map<String, String> catalogProperties(
+      CatalogConnectionConfig config, ResolvedCatalogCredentials resolvedCredentials) {
+    String endpointScheme = config.endpoint().getScheme();
+    if (!"http".equalsIgnoreCase(endpointScheme) && !"https".equalsIgnoreCase(endpointScheme)) {
+      throw new IllegalArgumentException(
+          "Iceberg REST endpoint must use http or https: scheme=" + endpointScheme);
+    }
+    rejectResolvedOnlyProperties(config.properties());
+    rejectResolvedOnlyProperties(config.authentication().properties());
+    Map<String, String> properties = new HashMap<>(config.properties());
+
+    properties.putAll(config.authentication().properties());
+    properties.put(CatalogProperties.URI, config.endpoint().toString());
+    resolvedCredentials.headers().forEach((name, value) -> properties.put("header." + name, value));
+
+    switch (config.authentication().scheme()) {
+      case NONE -> {
+        if (!resolvedCredentials.isEmpty()) {
+          throw new IllegalArgumentException(
+              "Authentication scheme none does not accept resolved credentials");
+        }
+      }
+      case OAUTH2 -> {
+        Set<String> unsupportedCredentials =
+            resolvedCredentials.properties().keySet().stream()
+                .filter(name -> !OAUTH_CREDENTIAL_PROPERTIES.contains(name))
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        if (!unsupportedCredentials.isEmpty()) {
+          throw new IllegalArgumentException(
+              "Unsupported OAuth2 credential properties: " + unsupportedCredentials);
+        }
+        String token = resolvedCredentials.properties().get("token");
+        String credential = resolvedCredentials.properties().get("credential");
+        if ((token == null || token.isBlank()) && (credential == null || credential.isBlank())) {
+          throw new IllegalArgumentException(
+              "OAuth2 requires resolved token or credential material");
+        }
+        properties.put("rest.auth.type", "oauth2");
+        if (token != null && !token.isBlank()) {
+          properties.put("token", token);
+        }
+        if (credential != null && !credential.isBlank()) {
+          properties.put("credential", credential);
+        }
+      }
+      case AWS_SIGV4 -> applyAwsSigV4(properties, resolvedCredentials.properties());
+    }
+    return Map.copyOf(properties);
+  }
+
+  private static void applyAwsSigV4(
+      Map<String, String> properties, Map<String, String> credentialProperties) {
+    Set<String> unsupportedCredentials =
+        credentialProperties.keySet().stream()
+            .filter(name -> !AWS_CREDENTIAL_PROPERTIES.contains(name))
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    if (!unsupportedCredentials.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Unsupported AWS SigV4 credential properties: " + unsupportedCredentials);
+    }
+
+    AwsCredentialInput catalogCredentials =
+        AwsCredentialInput.from(credentialProperties, CATALOG_AWS_KEYS);
+    catalogCredentials.validate(true);
+    AwsCredentialInput storageCredentials =
+        AwsCredentialInput.from(credentialProperties, STORAGE_AWS_KEYS);
+    storageCredentials.validate(false);
+
+    properties.put("rest.auth.type", CatalogSigV4AuthManager.class.getName());
+    properties.putIfAbsent("rest.signing-name", properties.getOrDefault("signing-name", "glue"));
+    properties.putIfAbsent(
+        "rest.signing-region",
+        properties.getOrDefault(
+            "signing-region",
+            properties.getOrDefault(
+                "s3.region", properties.getOrDefault("client.region", "us-east-1"))));
+
+    if (catalogCredentials.renewable()) {
+      properties.put(
+          RefreshingAwsCredentialsRegistry.CATALOG_PROVIDER_ID, catalogCredentials.providerId());
+    } else {
+      catalogCredentials.copyStaticTo(properties);
+    }
+
+    if (storageCredentials.renewable()) {
+      properties.put(
+          RefreshingAwsCredentialsRegistry.STORAGE_PROVIDER_ID, storageCredentials.providerId());
+      properties.put(
+          "client.credentials-provider", RegistryBackedAwsCredentialsProvider.class.getName());
+      properties.put(
+          "client.credentials-provider.floecat-provider-id", storageCredentials.providerId());
+      properties.put(
+          "client.credentials-provider.floecat-credential-scope",
+          AwsCredentialScope.STORAGE.name());
+    } else {
+      storageCredentials.copyStaticTo(properties);
+    }
+    if (storageCredentials.configured()) {
+      properties.putIfAbsent("io-impl", DEFAULT_S3_FILE_IO);
+    }
+    normalizeAwsRegion(properties);
+  }
+
+  private static void rejectResolvedOnlyProperties(Map<String, String> properties) {
+    for (String name : properties.keySet()) {
+      if (name.startsWith("client.credentials-provider")) {
+        throw new IllegalArgumentException(
+            "client.credentials-provider is controlled by resolved credentials");
+      }
+      if (name.regionMatches(true, 0, "header.", 0, "header.".length())) {
+        throw new IllegalArgumentException(
+            "HTTP headers are controlled by resolved credentials, not connection properties");
+      }
+      if (CONTROLLED_CONNECTION_PROPERTIES.contains(name)) {
+        throw new IllegalArgumentException(
+            name
+                + " is controlled by authentication and resolved credentials, not connection"
+                + " properties");
+      }
+    }
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+
+  private static void normalizeAwsRegion(Map<String, String> properties) {
+    String region = properties.get("client.region");
+    if (isBlank(region)) {
+      region = properties.get("s3.region");
+    }
+    if (isBlank(region)) {
+      return;
+    }
+    properties.putIfAbsent("client.region", region);
+    properties.putIfAbsent("s3.region", region);
+  }
+
+  private static RESTSessionCatalog createSessionCatalog(Map<String, String> properties) {
+    RESTSessionCatalog catalog =
+        new RESTSessionCatalog(
+            config ->
+                HTTPClient.builder(config)
+                    .uri(config.get(CatalogProperties.URI))
+                    .withHeaders(RESTUtil.configHeaders(config))
+                    .build(),
+            null);
+    try {
+      catalog.initialize("floecat-catalog-access", properties);
+      return catalog;
+    } catch (RuntimeException | Error e) {
+      closeCatalog(catalog);
+      throw e;
+    }
+  }
+
+  private static void closeCatalog(RESTSessionCatalog catalog) {
+    try {
+      catalog.close();
+    } catch (Exception ignored) {
+    }
+  }
+
+  private record AwsCredentialKeys(
+      String providerIdProperty, String propertyPrefix, String incompleteMessage) {
+    private String accessKeyProperty() {
+      return propertyPrefix + ".access-key-id";
+    }
+
+    private String secretKeyProperty() {
+      return propertyPrefix + ".secret-access-key";
+    }
+
+    private String sessionTokenProperty() {
+      return propertyPrefix + ".session-token";
+    }
+
+    private Set<String> propertyNames() {
+      return Set.of(
+          providerIdProperty, accessKeyProperty(), secretKeyProperty(), sessionTokenProperty());
+    }
+  }
+
+  private record AwsCredentialInput(
+      AwsCredentialKeys keys,
+      String providerId,
+      String accessKey,
+      String secretKey,
+      String sessionToken) {
+    private static AwsCredentialInput from(Map<String, String> properties, AwsCredentialKeys keys) {
+      return new AwsCredentialInput(
+          keys,
+          properties.get(keys.providerIdProperty()),
+          properties.get(keys.accessKeyProperty()),
+          properties.get(keys.secretKeyProperty()),
+          properties.get(keys.sessionTokenProperty()));
+    }
+
+    private void validate(boolean required) {
+      boolean hasProvider = !isBlank(providerId);
+      boolean hasAccessKey = !isBlank(accessKey);
+      boolean hasSecretKey = !isBlank(secretKey);
+      boolean hasSessionToken = !isBlank(sessionToken);
+      boolean hasStaticCredential = hasAccessKey || hasSecretKey || hasSessionToken;
+
+      if (hasProvider && hasStaticCredential) {
+        throw new IllegalArgumentException(
+            "AWS credentials must use either a renewable provider or static credentials, not both");
+      }
+      if (hasProvider) {
+        return;
+      }
+      if ((required || hasStaticCredential) && (!hasAccessKey || !hasSecretKey)) {
+        throw new IllegalArgumentException(keys.incompleteMessage());
+      }
+    }
+
+    private boolean renewable() {
+      return !isBlank(providerId);
+    }
+
+    private boolean configured() {
+      return renewable() || (!isBlank(accessKey) && !isBlank(secretKey));
+    }
+
+    private void copyStaticTo(Map<String, String> properties) {
+      putIfPresent(properties, keys.accessKeyProperty(), accessKey);
+      putIfPresent(properties, keys.secretKeyProperty(), secretKey);
+      putIfPresent(properties, keys.sessionTokenProperty(), sessionToken);
+    }
+
+    private static void putIfPresent(Map<String, String> properties, String name, String value) {
+      if (!isBlank(value)) {
+        properties.put(name, value);
+      }
+    }
+  }
+}

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
@@ -41,6 +41,9 @@ import org.apache.iceberg.rest.RESTUtil;
 
 /** Opens Iceberg REST catalogs without any dependency on Connector resources or RPC contracts. */
 public final class IcebergRestCatalogClientProvider implements CatalogClientProvider {
+  private static final String ACCESS_DELEGATION_HEADER_PROPERTY =
+      "header.X-Iceberg-Access-Delegation";
+  private static final String VENDED_CREDENTIALS = "vended-credentials";
   private static final String DEFAULT_S3_FILE_IO = "org.apache.iceberg.aws.s3.S3FileIO";
   private static final AwsCredentialKeys CATALOG_AWS_KEYS =
       new AwsCredentialKeys(
@@ -107,6 +110,7 @@ public final class IcebergRestCatalogClientProvider implements CatalogClientProv
     properties.putAll(config.authentication().properties());
     properties.put(CatalogProperties.URI, config.endpoint().toString());
     resolvedCredentials.headers().forEach((name, value) -> properties.put("header." + name, value));
+    properties.put(ACCESS_DELEGATION_HEADER_PROPERTY, VENDED_CREDENTIALS);
 
     switch (config.authentication().scheme()) {
       case NONE -> {

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
@@ -41,8 +41,9 @@ import org.apache.iceberg.rest.RESTUtil;
 
 /** Opens Iceberg REST catalogs without any dependency on Connector resources or RPC contracts. */
 public final class IcebergRestCatalogClientProvider implements CatalogClientProvider {
+  private static final String ACCESS_DELEGATION_HEADER = "X-Iceberg-Access-Delegation";
   private static final String ACCESS_DELEGATION_HEADER_PROPERTY =
-      "header.X-Iceberg-Access-Delegation";
+      "header." + ACCESS_DELEGATION_HEADER;
   private static final String VENDED_CREDENTIALS = "vended-credentials";
   private static final String DEFAULT_S3_FILE_IO = "org.apache.iceberg.aws.s3.S3FileIO";
   private static final AwsCredentialKeys CATALOG_AWS_KEYS =
@@ -113,7 +114,16 @@ public final class IcebergRestCatalogClientProvider implements CatalogClientProv
 
     properties.putAll(config.authentication().properties());
     properties.put(CatalogProperties.URI, config.endpoint().toString());
-    resolvedCredentials.headers().forEach((name, value) -> properties.put("header." + name, value));
+    resolvedCredentials
+        .headers()
+        .forEach(
+            (name, value) -> {
+              if (ACCESS_DELEGATION_HEADER.equalsIgnoreCase(name)) {
+                throw new IllegalArgumentException(
+                    ACCESS_DELEGATION_HEADER + " is controlled by the Iceberg REST provider");
+              }
+              properties.put("header." + name, value);
+            });
     properties.put(ACCESS_DELEGATION_HEADER_PROPERTY, VENDED_CREDENTIALS);
 
     switch (config.authentication().scheme()) {
@@ -170,13 +180,9 @@ public final class IcebergRestCatalogClientProvider implements CatalogClientProv
     storageCredentials.validate(false);
 
     properties.put("rest.auth.type", CatalogSigV4AuthManager.class.getName());
-    properties.putIfAbsent("rest.signing-name", properties.getOrDefault("signing-name", "glue"));
-    properties.putIfAbsent(
-        "rest.signing-region",
-        properties.getOrDefault(
-            "signing-region",
-            properties.getOrDefault(
-                "s3.region", properties.getOrDefault("client.region", "us-east-1"))));
+    copyIfAbsent(properties, "rest.signing-name", "signing-name");
+    copyFirstIfAbsent(
+        properties, "rest.signing-region", "signing-region", "s3.region", "client.region");
 
     if (catalogCredentials.renewable()) {
       properties.put(
@@ -225,6 +231,25 @@ public final class IcebergRestCatalogClientProvider implements CatalogClientProv
 
   private static boolean isBlank(String value) {
     return value == null || value.isBlank();
+  }
+
+  private static void copyIfAbsent(Map<String, String> properties, String target, String source) {
+    if (!properties.containsKey(target) && properties.containsKey(source)) {
+      properties.put(target, properties.get(source));
+    }
+  }
+
+  private static void copyFirstIfAbsent(
+      Map<String, String> properties, String target, String... sources) {
+    if (properties.containsKey(target)) {
+      return;
+    }
+    for (String source : sources) {
+      if (properties.containsKey(source)) {
+        properties.put(target, properties.get(source));
+        return;
+      }
+    }
   }
 
   private static void normalizeAwsRegion(Map<String, String> properties) {

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/AwsCredentialScope.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/AwsCredentialScope.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest.auth;
+
+public enum AwsCredentialScope {
+  CATALOG,
+  STORAGE
+}

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/AwsCredentialValue.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/AwsCredentialValue.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest.auth;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/** One resolved AWS credential value. Its string representation never includes secrets. */
+public record AwsCredentialValue(
+    String accessKeyId, String secretAccessKey, String sessionToken, Instant expiresAt) {
+  public AwsCredentialValue {
+    accessKeyId = requireNonBlank(accessKeyId, "accessKeyId");
+    secretAccessKey = requireNonBlank(secretAccessKey, "secretAccessKey");
+  }
+
+  public boolean isSessionCredential() {
+    return sessionToken != null && !sessionToken.isBlank();
+  }
+
+  public boolean hasKnownExpiry() {
+    return expiresAt != null;
+  }
+
+  @Override
+  public String toString() {
+    return "AwsCredentialValue[accessKeyId=<redacted>, secretAccessKey=<redacted>, "
+        + "sessionToken="
+        + (isSessionCredential() ? "<redacted>" : "<absent>")
+        + ", expiresAt="
+        + expiresAt
+        + "]";
+  }
+
+  private static String requireNonBlank(String value, String field) {
+    value = Objects.requireNonNull(value, field).trim();
+    if (value.isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value;
+  }
+}

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/CatalogSigV4AuthManager.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/CatalogSigV4AuthManager.java
@@ -36,7 +36,7 @@ public final class CatalogSigV4AuthManager implements AuthManager {
   private final Aws4Signer signer = Aws4Signer.create();
   private final String name;
   private volatile AuthManager delegate;
-  private Map<String, String> catalogProperties = Map.of();
+  private volatile Map<String, String> catalogProperties = Map.of();
 
   public CatalogSigV4AuthManager(String name) {
     this.name = name;
@@ -53,7 +53,7 @@ public final class CatalogSigV4AuthManager implements AuthManager {
 
   @Override
   public AuthSession catalogSession(RESTClient sharedClient, Map<String, String> properties) {
-    catalogProperties = properties;
+    catalogProperties = Map.copyOf(properties);
     Map<String, String> authProperties = catalogAuthProperties(properties);
     return new RESTSigV4AuthSession(
         signer,

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/CatalogSigV4AuthManager.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/CatalogSigV4AuthManager.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest.auth;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.RESTSigV4AuthSession;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTUtil;
+import org.apache.iceberg.rest.auth.AuthManager;
+import org.apache.iceberg.rest.auth.AuthManagers;
+import org.apache.iceberg.rest.auth.AuthProperties;
+import org.apache.iceberg.rest.auth.AuthSession;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+
+/** Signs REST requests with catalog-scoped credentials, isolated from FileIO credentials. */
+public final class CatalogSigV4AuthManager implements AuthManager {
+  private final Aws4Signer signer = Aws4Signer.create();
+  private final String name;
+  private volatile AuthManager delegate;
+  private Map<String, String> catalogProperties = Map.of();
+
+  public CatalogSigV4AuthManager(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public AuthSession initSession(RESTClient initClient, Map<String, String> properties) {
+    Map<String, String> authProperties = catalogAuthProperties(properties);
+    return new RESTSigV4AuthSession(
+        signer,
+        delegate(properties).initSession(initClient, authProperties),
+        new AwsProperties(authProperties));
+  }
+
+  @Override
+  public AuthSession catalogSession(RESTClient sharedClient, Map<String, String> properties) {
+    catalogProperties = properties;
+    Map<String, String> authProperties = catalogAuthProperties(properties);
+    return new RESTSigV4AuthSession(
+        signer,
+        delegate(properties).catalogSession(sharedClient, authProperties),
+        new AwsProperties(authProperties));
+  }
+
+  @Override
+  public AuthSession contextualSession(SessionCatalog.SessionContext context, AuthSession parent) {
+    RESTSigV4AuthSession sigV4Parent = requireSigV4Parent(parent);
+    Map<String, String> contextProperties =
+        RESTUtil.merge(
+            catalogProperties,
+            RESTUtil.merge(
+                Optional.ofNullable(context.properties()).orElseGet(Map::of),
+                Optional.ofNullable(context.credentials()).orElseGet(Map::of)));
+    Map<String, String> authProperties = catalogAuthProperties(contextProperties);
+    return new RESTSigV4AuthSession(
+        signer,
+        delegate().contextualSession(context, sigV4Parent.delegate()),
+        new AwsProperties(authProperties));
+  }
+
+  @Override
+  public AuthSession tableSession(
+      TableIdentifier table, Map<String, String> properties, AuthSession parent) {
+    RESTSigV4AuthSession sigV4Parent = requireSigV4Parent(parent);
+    Map<String, String> authProperties =
+        catalogAuthProperties(RESTUtil.merge(catalogProperties, properties));
+    return new RESTSigV4AuthSession(
+        signer,
+        delegate().tableSession(table, properties, sigV4Parent.delegate()),
+        new AwsProperties(authProperties));
+  }
+
+  @Override
+  public void close() {
+    AuthManager current = delegate;
+    if (current != null) {
+      current.close();
+    }
+  }
+
+  static Map<String, String> catalogAuthProperties(Map<String, String> properties) {
+    Map<String, String> authProperties = new HashMap<>(properties);
+    authProperties.remove(RefreshingAwsCredentialsRegistry.CLIENT_PROVIDER);
+    authProperties
+        .keySet()
+        .removeIf(key -> key.startsWith(RefreshingAwsCredentialsRegistry.CLIENT_PROVIDER_PREFIX));
+    String providerId = authProperties.get(RefreshingAwsCredentialsRegistry.CATALOG_PROVIDER_ID);
+    if (providerId == null || providerId.isBlank()) {
+      return Map.copyOf(authProperties);
+    }
+    authProperties.put(
+        RefreshingAwsCredentialsRegistry.CLIENT_PROVIDER,
+        RegistryBackedAwsCredentialsProvider.class.getName());
+    authProperties.put(
+        RefreshingAwsCredentialsRegistry.CLIENT_PROVIDER_PREFIX
+            + RefreshingAwsCredentialsRegistry.PROVIDER_ID_PROPERTY,
+        providerId);
+    authProperties.put(
+        RefreshingAwsCredentialsRegistry.CLIENT_PROVIDER_PREFIX
+            + RefreshingAwsCredentialsRegistry.CREDENTIAL_SCOPE_PROPERTY,
+        AwsCredentialScope.CATALOG.name());
+    authProperties.remove("rest.access-key-id");
+    authProperties.remove("rest.secret-access-key");
+    authProperties.remove("rest.session-token");
+    return Map.copyOf(authProperties);
+  }
+
+  private AuthManager delegate(Map<String, String> properties) {
+    AuthManager current = delegate;
+    if (current != null) {
+      return current;
+    }
+    synchronized (this) {
+      current = delegate;
+      if (current == null) {
+        String delegateType =
+            properties.getOrDefault(
+                AuthProperties.SIGV4_DELEGATE_AUTH_TYPE,
+                AuthProperties.SIGV4_DELEGATE_AUTH_TYPE_DEFAULT);
+        if (AuthProperties.AUTH_TYPE_SIGV4.equals(delegateType)
+            || CatalogSigV4AuthManager.class.getName().equals(delegateType)) {
+          throw new IllegalArgumentException(
+              "Catalog SigV4 auth cannot delegate to " + delegateType);
+        }
+        Map<String, String> delegateProperties = new HashMap<>(properties);
+        delegateProperties.put(AuthProperties.AUTH_TYPE, delegateType);
+        current = AuthManagers.loadAuthManager(name, delegateProperties);
+        delegate = current;
+      }
+    }
+    return current;
+  }
+
+  private AuthManager delegate() {
+    AuthManager current = delegate;
+    if (current == null) {
+      throw new IllegalStateException("Catalog SigV4 auth manager is not initialized");
+    }
+    return current;
+  }
+
+  private static RESTSigV4AuthSession requireSigV4Parent(AuthSession parent) {
+    if (!(parent instanceof RESTSigV4AuthSession sigV4Parent)) {
+      throw new IllegalStateException("Parent session is not SigV4: " + parent);
+    }
+    return sigV4Parent;
+  }
+}

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistry.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistry.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest.auth;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+/** Process-local registry used by Iceberg and AWS SDK credential-provider reflection hooks. */
+public final class RefreshingAwsCredentialsRegistry {
+  private static final Logger LOG =
+      Logger.getLogger(RefreshingAwsCredentialsRegistry.class.getName());
+
+  public static final String STORAGE_PROVIDER_ID = "floecat.aws.credentials-provider-id";
+  public static final String CATALOG_PROVIDER_ID = "floecat.catalog.aws.credentials-provider-id";
+  static final String PROVIDER_ID_PROPERTY = "floecat-provider-id";
+  static final String CREDENTIAL_SCOPE_PROPERTY = "floecat-credential-scope";
+  static final String CLIENT_PROVIDER = "client.credentials-provider";
+  static final String CLIENT_PROVIDER_PREFIX = CLIENT_PROVIDER + ".";
+
+  private static final Duration DEFAULT_REFRESH_SKEW = Duration.ofMinutes(5);
+  private static final ConcurrentMap<String, Entry> REGISTRY = new ConcurrentHashMap<>();
+
+  private RefreshingAwsCredentialsRegistry() {}
+
+  public static Registration register(
+      AwsCredentialValue initialCredentials, Supplier<AwsCredentialValue> refresher) {
+    return register(
+        UUID.randomUUID().toString(),
+        initialCredentials,
+        refresher,
+        DEFAULT_REFRESH_SKEW,
+        Clock.systemUTC());
+  }
+
+  static Registration register(
+      String providerId,
+      AwsCredentialValue initialCredentials,
+      Supplier<AwsCredentialValue> refresher,
+      Duration refreshSkew) {
+    return register(providerId, initialCredentials, refresher, refreshSkew, Clock.systemUTC());
+  }
+
+  static Registration register(
+      String providerId,
+      AwsCredentialValue initialCredentials,
+      Supplier<AwsCredentialValue> refresher,
+      Duration refreshSkew,
+      Clock clock) {
+    String normalizedProviderId = requireNonBlank(providerId, "providerId");
+    Objects.requireNonNull(initialCredentials, "initialCredentials");
+    Objects.requireNonNull(refresher, "refresher");
+    Duration defaultRefreshSkew = normalizeRefreshSkew(refreshSkew);
+    Entry entry =
+        new Entry(
+            normalizedProviderId,
+            initialCredentials,
+            refresher,
+            defaultRefreshSkew,
+            Objects.requireNonNull(clock, "clock"));
+    Entry previous = REGISTRY.putIfAbsent(normalizedProviderId, entry);
+    if (previous != null) {
+      throw new IllegalStateException("AWS credentials provider id is already registered");
+    }
+    LOG.log(
+        Level.INFO,
+        "Registered catalog-access AWS credentials provider; providerRef={0}, expiresAt={1},"
+            + " refreshSkewMs={2}",
+        new Object[] {
+          entry.providerRef,
+          initialCredentials.expiresAt(),
+          entry.currentState.refreshSkew().toMillis()
+        });
+    return new Registration(normalizedProviderId);
+  }
+
+  public static AwsCredentials resolve(String providerId, AwsCredentialScope scope) {
+    Entry entry = REGISTRY.get(requireNonBlank(providerId, "providerId"));
+    if (entry == null) {
+      throw new IllegalStateException("Unknown AWS credentials provider id");
+    }
+    return entry.resolveCredentials(Objects.requireNonNull(scope, "scope"));
+  }
+
+  public static Map<String, String> propertiesFor(
+      Registration registration, AwsCredentialScope scope) {
+    Objects.requireNonNull(registration, "registration");
+    Objects.requireNonNull(scope, "scope");
+    return Map.of(
+        scope == AwsCredentialScope.CATALOG ? CATALOG_PROVIDER_ID : STORAGE_PROVIDER_ID,
+        registration.providerId());
+  }
+
+  public static Duration computeRefreshSkew(
+      AwsCredentialValue credentials, Duration defaultRefreshSkew) {
+    return computeRefreshSkew(credentials, normalizeRefreshSkew(defaultRefreshSkew), Instant.now());
+  }
+
+  private static Duration computeRefreshSkew(
+      AwsCredentialValue credentials, Duration baseline, Instant now) {
+    if (credentials == null || credentials.expiresAt() == null) {
+      return baseline;
+    }
+    if (!credentials.expiresAt().isAfter(now)) {
+      return Duration.ZERO;
+    }
+    Duration adaptive = Duration.between(now, credentials.expiresAt()).dividedBy(3L);
+    if (adaptive.isNegative()) {
+      return Duration.ZERO;
+    }
+    return adaptive.compareTo(baseline) < 0 ? adaptive : baseline;
+  }
+
+  private static Duration normalizeRefreshSkew(Duration refreshSkew) {
+    return refreshSkew == null || refreshSkew.isNegative() ? DEFAULT_REFRESH_SKEW : refreshSkew;
+  }
+
+  private static void unregister(String providerId) {
+    Entry removed = REGISTRY.remove(providerId);
+    if (removed != null) {
+      LOG.log(
+          Level.INFO,
+          "Unregistered catalog-access AWS credentials provider; providerRef={0},"
+              + " observedScopes={1}",
+          new Object[] {removed.providerRef, removed.observedScopes});
+    }
+  }
+
+  private static AwsCredentials toAwsCredentials(AwsCredentialValue resolved) {
+    Objects.requireNonNull(resolved, "resolved");
+    if (resolved.isSessionCredential()) {
+      return AwsSessionCredentials.create(
+          resolved.accessKeyId(), resolved.secretAccessKey(), resolved.sessionToken());
+    }
+    return AwsBasicCredentials.create(resolved.accessKeyId(), resolved.secretAccessKey());
+  }
+
+  private static boolean shouldRefresh(
+      AwsCredentialValue current, Duration refreshSkew, Instant now) {
+    if (current == null) {
+      return true;
+    }
+    if (!current.hasKnownExpiry()) {
+      return false;
+    }
+    return !now.isBefore(current.expiresAt().minus(refreshSkew));
+  }
+
+  private static String requireNonBlank(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(field + " must be non-blank");
+    }
+    return value.trim();
+  }
+
+  private static String providerRef(String providerId) {
+    return Integer.toUnsignedString(providerId.hashCode(), 16);
+  }
+
+  public static final class Registration implements AutoCloseable {
+    private final String providerId;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private Registration(String providerId) {
+      this.providerId = providerId;
+    }
+
+    String providerId() {
+      if (closed.get()) {
+        throw new IllegalStateException("AWS credentials registration is closed");
+      }
+      return providerId;
+    }
+
+    @Override
+    public void close() {
+      if (closed.compareAndSet(false, true)) {
+        unregister(providerId);
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "Registration[providerRef=" + providerRef(providerId) + ", closed=" + closed + "]";
+    }
+  }
+
+  private static final class Entry {
+    private final String providerRef;
+    private final Supplier<AwsCredentialValue> refresher;
+    private final Duration defaultRefreshSkew;
+    private final Clock clock;
+    private final Set<AwsCredentialScope> observedScopes = ConcurrentHashMap.newKeySet();
+    private volatile CredentialState currentState;
+    private volatile TerminalCredentialRefreshException terminalFailure;
+
+    private Entry(
+        String providerId,
+        AwsCredentialValue initialCredentials,
+        Supplier<AwsCredentialValue> refresher,
+        Duration defaultRefreshSkew,
+        Clock clock) {
+      this.providerRef = providerRef(providerId);
+      this.refresher = refresher;
+      this.defaultRefreshSkew = defaultRefreshSkew;
+      this.clock = clock;
+      this.currentState =
+          new CredentialState(
+              initialCredentials,
+              computeRefreshSkew(initialCredentials, defaultRefreshSkew, clock.instant()));
+    }
+
+    private AwsCredentials resolveCredentials(AwsCredentialScope scope) {
+      CredentialState snapshot = currentState;
+      if (observedScopes.add(scope)) {
+        LOG.log(
+            Level.INFO,
+            "Resolved catalog-access AWS credential scope; providerRef={0}, scope={1},"
+                + " expiresAt={2}",
+            new Object[] {providerRef, scope, snapshot.credentials().expiresAt()});
+      }
+      TerminalCredentialRefreshException terminal = terminalFailure;
+      if (terminal != null) {
+        throw terminal;
+      }
+      Instant now = clock.instant();
+      if (shouldRefresh(snapshot.credentials(), snapshot.refreshSkew(), now)) {
+        synchronized (this) {
+          terminal = terminalFailure;
+          if (terminal != null) {
+            throw terminal;
+          }
+          snapshot = currentState;
+          now = clock.instant();
+          if (shouldRefresh(snapshot.credentials(), snapshot.refreshSkew(), now)) {
+            try {
+              AwsCredentialValue refreshed =
+                  Objects.requireNonNull(refresher.get(), "refresher returned null");
+              toAwsCredentials(refreshed);
+              currentState =
+                  new CredentialState(
+                      refreshed,
+                      computeRefreshSkew(refreshed, defaultRefreshSkew, clock.instant()));
+              LOG.log(
+                  Level.INFO,
+                  "Refreshed catalog-access AWS credentials; providerRef={0}, scope={1},"
+                      + " previousExpiresAt={2}, newExpiresAt={3}, refreshSkewMs={4}",
+                  new Object[] {
+                    providerRef,
+                    scope,
+                    snapshot.credentials().expiresAt(),
+                    refreshed.expiresAt(),
+                    currentState.refreshSkew().toMillis()
+                  });
+            } catch (RuntimeException e) {
+              if (e instanceof TerminalCredentialRefreshException terminalRefresh) {
+                terminalFailure = terminalRefresh;
+                throw terminalRefresh;
+              }
+              if (snapshot.credentials().expiresAt() != null
+                  && now.isBefore(snapshot.credentials().expiresAt())) {
+                return toAwsCredentials(snapshot.credentials());
+              }
+              throw e;
+            }
+            snapshot = currentState;
+          }
+        }
+      }
+      return toAwsCredentials(snapshot.credentials());
+    }
+  }
+
+  private record CredentialState(AwsCredentialValue credentials, Duration refreshSkew) {}
+}

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistry.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistry.java
@@ -162,15 +162,14 @@ public final class RefreshingAwsCredentialsRegistry {
     return AwsBasicCredentials.create(resolved.accessKeyId(), resolved.secretAccessKey());
   }
 
-  private static boolean shouldRefresh(
-      AwsCredentialValue current, Duration refreshSkew, Instant now) {
-    if (current == null) {
+  private static boolean shouldRefresh(CredentialState state, Instant now) {
+    if (state == null || state.credentials() == null) {
       return true;
     }
-    if (!current.hasKnownExpiry()) {
-      return false;
+    if (!state.credentials().hasKnownExpiry()) {
+      return !now.isBefore(state.refreshedAt().plus(state.refreshSkew()));
     }
-    return !now.isBefore(current.expiresAt().minus(refreshSkew));
+    return !now.isBefore(state.credentials().expiresAt().minus(state.refreshSkew()));
   }
 
   private static String requireNonBlank(String value, String field) {
@@ -231,10 +230,12 @@ public final class RefreshingAwsCredentialsRegistry {
       this.refresher = refresher;
       this.defaultRefreshSkew = defaultRefreshSkew;
       this.clock = clock;
+      Instant registeredAt = clock.instant();
       this.currentState =
           new CredentialState(
               initialCredentials,
-              computeRefreshSkew(initialCredentials, defaultRefreshSkew, clock.instant()));
+              computeRefreshSkew(initialCredentials, defaultRefreshSkew, registeredAt),
+              registeredAt);
     }
 
     private AwsCredentials resolveCredentials(AwsCredentialScope scope) {
@@ -251,7 +252,7 @@ public final class RefreshingAwsCredentialsRegistry {
         throw terminal;
       }
       Instant now = clock.instant();
-      if (shouldRefresh(snapshot.credentials(), snapshot.refreshSkew(), now)) {
+      if (shouldRefresh(snapshot, now)) {
         synchronized (this) {
           terminal = terminalFailure;
           if (terminal != null) {
@@ -259,15 +260,17 @@ public final class RefreshingAwsCredentialsRegistry {
           }
           snapshot = currentState;
           now = clock.instant();
-          if (shouldRefresh(snapshot.credentials(), snapshot.refreshSkew(), now)) {
+          if (shouldRefresh(snapshot, now)) {
             try {
               AwsCredentialValue refreshed =
                   Objects.requireNonNull(refresher.get(), "refresher returned null");
               toAwsCredentials(refreshed);
+              Instant refreshedAt = clock.instant();
               currentState =
                   new CredentialState(
                       refreshed,
-                      computeRefreshSkew(refreshed, defaultRefreshSkew, clock.instant()));
+                      computeRefreshSkew(refreshed, defaultRefreshSkew, refreshedAt),
+                      refreshedAt);
               LOG.log(
                   Level.INFO,
                   "Refreshed catalog-access AWS credentials; providerRef={0}, scope={1},"
@@ -298,5 +301,6 @@ public final class RefreshingAwsCredentialsRegistry {
     }
   }
 
-  private record CredentialState(AwsCredentialValue credentials, Duration refreshSkew) {}
+  private record CredentialState(
+      AwsCredentialValue credentials, Duration refreshSkew, Instant refreshedAt) {}
 }

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RegistryBackedAwsCredentialsProvider.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RegistryBackedAwsCredentialsProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest.auth;
+
+import java.util.Locale;
+import java.util.Map;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+/** AWS SDK reflection entry point backed by {@link RefreshingAwsCredentialsRegistry}. */
+public final class RegistryBackedAwsCredentialsProvider implements AwsCredentialsProvider {
+  private final String providerId;
+  private final AwsCredentialScope scope;
+
+  public RegistryBackedAwsCredentialsProvider(String providerId, AwsCredentialScope scope) {
+    if (providerId == null || providerId.isBlank()) {
+      throw new IllegalArgumentException("providerId must be non-blank");
+    }
+    this.providerId = providerId.trim();
+    this.scope = scope;
+  }
+
+  public static AwsCredentialsProvider create(Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      throw new IllegalArgumentException("provider properties must include a provider id");
+    }
+    String providerId = properties.get(RefreshingAwsCredentialsRegistry.PROVIDER_ID_PROPERTY);
+    String rawScope =
+        properties.getOrDefault(
+            RefreshingAwsCredentialsRegistry.CREDENTIAL_SCOPE_PROPERTY,
+            AwsCredentialScope.STORAGE.name());
+    AwsCredentialScope scope = AwsCredentialScope.valueOf(rawScope.trim().toUpperCase(Locale.ROOT));
+    return new RegistryBackedAwsCredentialsProvider(providerId, scope);
+  }
+
+  @Override
+  public AwsCredentials resolveCredentials() {
+    return RefreshingAwsCredentialsRegistry.resolve(providerId, scope);
+  }
+}

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/TerminalCredentialRefreshException.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/TerminalCredentialRefreshException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest.auth;
+
+/** Signals that refreshing credentials cannot succeed for the current catalog session. */
+public final class TerminalCredentialRefreshException extends RuntimeException {
+  public TerminalCredentialRefreshException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/catalog-access/iceberg-rest/src/main/resources/META-INF/services/ai.floedb.floecat.catalog.access.CatalogClientProvider
+++ b/catalog-access/iceberg-rest/src/main/resources/META-INF/services/ai.floedb.floecat.catalog.access.CatalogClientProvider
@@ -1,0 +1,15 @@
+# Copyright 2026 Yellowbrick Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ai.floedb.floecat.catalog.iceberg.rest.IcebergRestCatalogClientProvider

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProviderTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProviderTest.java
@@ -33,6 +33,7 @@ import ai.floedb.floecat.catalog.iceberg.rest.auth.RefreshingAwsCredentialsRegis
 import ai.floedb.floecat.catalog.iceberg.rest.auth.RegistryBackedAwsCredentialsProvider;
 import java.net.URI;
 import java.util.Map;
+import org.apache.iceberg.rest.RESTUtil;
 import org.junit.jupiter.api.Test;
 
 class IcebergRestCatalogClientProviderTest {
@@ -45,6 +46,10 @@ class IcebergRestCatalogClientProviderTest {
 
     assertEquals("https://catalog.example/v1", properties.get("uri"));
     assertEquals("sales", properties.get("warehouse"));
+    assertEquals("vended-credentials", properties.get("header.X-Iceberg-Access-Delegation"));
+    assertEquals(
+        "vended-credentials",
+        RESTUtil.configHeaders(properties).get("X-Iceberg-Access-Delegation"));
     assertFalse(properties.containsKey("token"));
   }
 
@@ -63,6 +68,20 @@ class IcebergRestCatalogClientProviderTest {
     assertEquals("oauth2", properties.get("rest.auth.type"));
     assertEquals("secret-token", properties.get("token"));
     assertEquals("tenant-a", properties.get("header.X-Tenant"));
+  }
+
+  @Test
+  void accessDelegationCannotBeDowngradedByResolvedHeaders() {
+    Map<String, String> properties =
+        IcebergRestCatalogClientProvider.catalogProperties(
+            config(
+                new CatalogAuthentication(CatalogAuthenticationScheme.OAUTH2, Map.of()), Map.of()),
+            new ResolvedCatalogCredentials(
+                Map.of("token", "secret-token"),
+                Map.of("X-Iceberg-Access-Delegation", "remote-signing"),
+                null));
+
+    assertEquals("vended-credentials", properties.get("header.X-Iceberg-Access-Delegation"));
   }
 
   @Test

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProviderTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProviderTest.java
@@ -71,17 +71,43 @@ class IcebergRestCatalogClientProviderTest {
   }
 
   @Test
-  void accessDelegationCannotBeDowngradedByResolvedHeaders() {
-    Map<String, String> properties =
-        IcebergRestCatalogClientProvider.catalogProperties(
-            config(
-                new CatalogAuthentication(CatalogAuthenticationScheme.OAUTH2, Map.of()), Map.of()),
-            new ResolvedCatalogCredentials(
-                Map.of("token", "secret-token"),
-                Map.of("X-Iceberg-Access-Delegation", "remote-signing"),
-                null));
+  void rejectsCallerControlledAccessDelegationHeader() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                IcebergRestCatalogClientProvider.catalogProperties(
+                    config(
+                        new CatalogAuthentication(CatalogAuthenticationScheme.OAUTH2, Map.of()),
+                        Map.of()),
+                    new ResolvedCatalogCredentials(
+                        Map.of("token", "secret-token"),
+                        Map.of("X-Iceberg-Access-Delegation", "remote-signing"),
+                        null)));
 
-    assertEquals("vended-credentials", properties.get("header.X-Iceberg-Access-Delegation"));
+    assertEquals(
+        "X-Iceberg-Access-Delegation is controlled by the Iceberg REST provider",
+        error.getMessage());
+  }
+
+  @Test
+  void rejectsDifferentlyCasedCallerControlledAccessDelegationHeader() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                IcebergRestCatalogClientProvider.catalogProperties(
+                    config(
+                        new CatalogAuthentication(CatalogAuthenticationScheme.OAUTH2, Map.of()),
+                        Map.of()),
+                    new ResolvedCatalogCredentials(
+                        Map.of("token", "secret-token"),
+                        Map.of("x-iceberg-access-delegation", "remote-signing"),
+                        null)));
+
+    assertEquals(
+        "X-Iceberg-Access-Delegation is controlled by the Iceberg REST provider",
+        error.getMessage());
   }
 
   @Test
@@ -194,6 +220,24 @@ class IcebergRestCatalogClientProviderTest {
     assertEquals("storage-secret", properties.get("s3.secret-access-key"));
     assertEquals("org.apache.iceberg.aws.s3.S3FileIO", properties.get("io-impl"));
     assertEquals("us-west-2", properties.get("client.region"));
+  }
+
+  @Test
+  void leavesSigV4ServiceAndRegionUnsetForIcebergDefaults() {
+    Map<String, String> properties =
+        IcebergRestCatalogClientProvider.catalogProperties(
+            config(
+                new CatalogAuthentication(CatalogAuthenticationScheme.AWS_SIGV4, Map.of()),
+                Map.of()),
+            new ResolvedCatalogCredentials(
+                Map.of(
+                    "rest.access-key-id", "catalog-access",
+                    "rest.secret-access-key", "catalog-secret"),
+                Map.of(),
+                null));
+
+    assertFalse(properties.containsKey("rest.signing-name"));
+    assertFalse(properties.containsKey("rest.signing-region"));
   }
 
   @Test

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProviderTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProviderTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.floedb.floecat.catalog.access.CatalogAuthentication;
+import ai.floedb.floecat.catalog.access.CatalogAuthenticationScheme;
+import ai.floedb.floecat.catalog.access.CatalogClientFactory;
+import ai.floedb.floecat.catalog.access.CatalogConnectionConfig;
+import ai.floedb.floecat.catalog.access.CatalogProtocol;
+import ai.floedb.floecat.catalog.access.ResolvedCatalogCredentials;
+import ai.floedb.floecat.catalog.iceberg.rest.auth.AwsCredentialScope;
+import ai.floedb.floecat.catalog.iceberg.rest.auth.AwsCredentialValue;
+import ai.floedb.floecat.catalog.iceberg.rest.auth.CatalogSigV4AuthManager;
+import ai.floedb.floecat.catalog.iceberg.rest.auth.RefreshingAwsCredentialsRegistry;
+import ai.floedb.floecat.catalog.iceberg.rest.auth.RegistryBackedAwsCredentialsProvider;
+import java.net.URI;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class IcebergRestCatalogClientProviderTest {
+  @Test
+  void buildsAnonymousPropertiesWithoutCredentials() {
+    Map<String, String> properties =
+        IcebergRestCatalogClientProvider.catalogProperties(
+            config(CatalogAuthentication.none(), Map.of("warehouse", "sales")),
+            ResolvedCatalogCredentials.none());
+
+    assertEquals("https://catalog.example/v1", properties.get("uri"));
+    assertEquals("sales", properties.get("warehouse"));
+    assertFalse(properties.containsKey("token"));
+  }
+
+  @Test
+  void injectsOauthSecretsOnlyAtOpenBoundary() {
+    Map<String, String> properties =
+        IcebergRestCatalogClientProvider.catalogProperties(
+            config(
+                new CatalogAuthentication(
+                    CatalogAuthenticationScheme.OAUTH2,
+                    Map.of("oauth2-server-uri", "https://identity.example/token")),
+                Map.of()),
+            new ResolvedCatalogCredentials(
+                Map.of("token", "secret-token"), Map.of("X-Tenant", "tenant-a"), null));
+
+    assertEquals("oauth2", properties.get("rest.auth.type"));
+    assertEquals("secret-token", properties.get("token"));
+    assertEquals("tenant-a", properties.get("header.X-Tenant"));
+  }
+
+  @Test
+  void rejectsSecretsInPersistableConnectionConfig() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                IcebergRestCatalogClientProvider.catalogProperties(
+                    config(CatalogAuthentication.none(), Map.of("token", "must-not-persist")),
+                    ResolvedCatalogCredentials.none()));
+
+    assertEquals(
+        "connection properties must not contain secret key: token",
+        error.getMessage());
+  }
+
+  @Test
+  void rejectsHeadersInPersistableConnectionConfig() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                IcebergRestCatalogClientProvider.catalogProperties(
+                    config(
+                        CatalogAuthentication.none(),
+                        Map.of("header.Authorization", "Bearer must-not-persist")),
+                    ResolvedCatalogCredentials.none()));
+
+    assertEquals(
+        "connection properties must not contain secret key: header.Authorization",
+        error.getMessage());
+  }
+
+  @Test
+  void rejectsResolvedHeadersForAnonymousAuthentication() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                IcebergRestCatalogClientProvider.catalogProperties(
+                    config(CatalogAuthentication.none(), Map.of()),
+                    new ResolvedCatalogCredentials(
+                        Map.of(), Map.of("Authorization", "secret"), null)));
+
+    assertEquals(
+        "Authentication scheme none does not accept resolved credentials", error.getMessage());
+  }
+
+  @Test
+  void rejectsNonHttpRestEndpoints() {
+    CatalogConnectionConfig config =
+        new CatalogConnectionConfig(
+            CatalogProtocol.ICEBERG_REST,
+            URI.create("s3://bucket/catalog"),
+            Map.of(),
+            CatalogAuthentication.none());
+
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                IcebergRestCatalogClientProvider.catalogProperties(
+                    config, ResolvedCatalogCredentials.none()));
+
+    assertEquals(
+        "Iceberg REST endpoint must use http or https: scheme=s3", error.getMessage());
+  }
+
+  @Test
+  void providerIsDiscoverableWithoutConnectorServiceLoading() {
+    CatalogConnectionConfig config =
+        new CatalogConnectionConfig(
+            CatalogProtocol.ICEBERG_REST,
+            URI.create("s3://bucket/catalog"),
+            Map.of(),
+            CatalogAuthentication.none());
+
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CatalogClientFactory.load().open(config, ResolvedCatalogCredentials.none()));
+
+    assertEquals(
+        "Iceberg REST endpoint must use http or https: scheme=s3", error.getMessage());
+  }
+
+  @Test
+  void buildsStaticSigV4CatalogAndStorageCredentialsInSeparateLanes() {
+    Map<String, String> properties =
+        IcebergRestCatalogClientProvider.catalogProperties(
+            config(
+                new CatalogAuthentication(
+                    CatalogAuthenticationScheme.AWS_SIGV4,
+                    Map.of("signing-name", "glue", "signing-region", "us-west-2")),
+                Map.of("warehouse", "warehouse-a", "s3.region", "us-west-2")),
+            new ResolvedCatalogCredentials(
+                Map.of(
+                    "rest.access-key-id", "catalog-access",
+                    "rest.secret-access-key", "catalog-secret",
+                    "rest.session-token", "catalog-token",
+                    "s3.access-key-id", "storage-access",
+                    "s3.secret-access-key", "storage-secret",
+                    "s3.session-token", "storage-token"),
+                Map.of(),
+                null));
+
+    assertEquals(CatalogSigV4AuthManager.class.getName(), properties.get("rest.auth.type"));
+    assertEquals("glue", properties.get("rest.signing-name"));
+    assertEquals("us-west-2", properties.get("rest.signing-region"));
+    assertEquals("catalog-access", properties.get("rest.access-key-id"));
+    assertEquals("catalog-secret", properties.get("rest.secret-access-key"));
+    assertEquals("storage-access", properties.get("s3.access-key-id"));
+    assertEquals("storage-secret", properties.get("s3.secret-access-key"));
+    assertEquals("org.apache.iceberg.aws.s3.S3FileIO", properties.get("io-impl"));
+    assertEquals("us-west-2", properties.get("client.region"));
+  }
+
+  @Test
+  void configuresDifferentRenewableProvidersForCatalogAndStorage() {
+    try (var catalogRegistration =
+            RefreshingAwsCredentialsRegistry.register(
+                credentials("catalog"), () -> credentials("catalog-refreshed"));
+        var storageRegistration =
+            RefreshingAwsCredentialsRegistry.register(
+                credentials("storage"), () -> credentials("storage-refreshed"))) {
+      Map<String, String> resolvedProperties = new java.util.HashMap<>();
+      resolvedProperties.putAll(
+          RefreshingAwsCredentialsRegistry.propertiesFor(
+              catalogRegistration, AwsCredentialScope.CATALOG));
+      resolvedProperties.putAll(
+          RefreshingAwsCredentialsRegistry.propertiesFor(
+              storageRegistration, AwsCredentialScope.STORAGE));
+
+      Map<String, String> properties =
+          IcebergRestCatalogClientProvider.catalogProperties(
+              config(
+                  new CatalogAuthentication(CatalogAuthenticationScheme.AWS_SIGV4, Map.of()),
+                  Map.of()),
+              new ResolvedCatalogCredentials(resolvedProperties, Map.of(), null));
+
+      assertEquals(
+          resolvedProperties.get(RefreshingAwsCredentialsRegistry.CATALOG_PROVIDER_ID),
+          properties.get(RefreshingAwsCredentialsRegistry.CATALOG_PROVIDER_ID));
+      assertEquals(
+          RegistryBackedAwsCredentialsProvider.class.getName(),
+          properties.get("client.credentials-provider"));
+      assertEquals(
+          resolvedProperties.get(RefreshingAwsCredentialsRegistry.STORAGE_PROVIDER_ID),
+          properties.get("client.credentials-provider.floecat-provider-id"));
+      assertEquals(
+          AwsCredentialScope.STORAGE.name(),
+          properties.get("client.credentials-provider.floecat-credential-scope"));
+    }
+  }
+
+  @Test
+  void rejectsSigV4WithoutCatalogCredentials() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                IcebergRestCatalogClientProvider.catalogProperties(
+                    config(
+                        new CatalogAuthentication(CatalogAuthenticationScheme.AWS_SIGV4, Map.of()),
+                        Map.of()),
+                    ResolvedCatalogCredentials.none()));
+
+    assertEquals(
+        "AWS SigV4 requires catalog access/secret keys or a renewable catalog provider",
+        error.getMessage());
+  }
+
+  @Test
+  void rejectsIncompleteStaticStorageCredentials() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                IcebergRestCatalogClientProvider.catalogProperties(
+                    config(
+                        new CatalogAuthentication(CatalogAuthenticationScheme.AWS_SIGV4, Map.of()),
+                        Map.of()),
+                    new ResolvedCatalogCredentials(
+                        Map.of(
+                            "rest.access-key-id", "catalog-access",
+                            "rest.secret-access-key", "catalog-secret",
+                            "s3.access-key-id", "storage-access"),
+                        Map.of(),
+                        null)));
+
+    assertEquals(
+        "AWS storage credentials require both s3.access-key-id and s3.secret-access-key",
+        error.getMessage());
+  }
+
+  @Test
+  void rejectsStorageSessionTokenWithoutStaticKeys() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                IcebergRestCatalogClientProvider.catalogProperties(
+                    config(
+                        new CatalogAuthentication(CatalogAuthenticationScheme.AWS_SIGV4, Map.of()),
+                        Map.of()),
+                    new ResolvedCatalogCredentials(
+                        Map.of(
+                            "rest.access-key-id", "catalog-access",
+                            "rest.secret-access-key", "catalog-secret",
+                            "s3.session-token", "orphan-storage-token"),
+                        Map.of(),
+                        null)));
+
+    assertEquals(
+        "AWS storage credentials require both s3.access-key-id and s3.secret-access-key",
+        error.getMessage());
+  }
+
+  private static AwsCredentialValue credentials(String suffix) {
+    return new AwsCredentialValue("access-" + suffix, "secret-" + suffix, "token-" + suffix, null);
+  }
+
+  private static CatalogConnectionConfig config(
+      CatalogAuthentication authentication, Map<String, String> properties) {
+    return new CatalogConnectionConfig(
+        CatalogProtocol.ICEBERG_REST,
+        URI.create("https://catalog.example/v1"),
+        properties,
+        authentication);
+  }
+}

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProviderTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProviderTest.java
@@ -75,9 +75,7 @@ class IcebergRestCatalogClientProviderTest {
                     config(CatalogAuthentication.none(), Map.of("token", "must-not-persist")),
                     ResolvedCatalogCredentials.none()));
 
-    assertEquals(
-        "connection properties must not contain secret key: token",
-        error.getMessage());
+    assertEquals("connection properties must not contain secret key: token", error.getMessage());
   }
 
   @Test
@@ -128,8 +126,7 @@ class IcebergRestCatalogClientProviderTest {
                 IcebergRestCatalogClientProvider.catalogProperties(
                     config, ResolvedCatalogCredentials.none()));
 
-    assertEquals(
-        "Iceberg REST endpoint must use http or https: scheme=s3", error.getMessage());
+    assertEquals("Iceberg REST endpoint must use http or https: scheme=s3", error.getMessage());
   }
 
   @Test
@@ -146,8 +143,7 @@ class IcebergRestCatalogClientProviderTest {
             IllegalArgumentException.class,
             () -> CatalogClientFactory.load().open(config, ResolvedCatalogCredentials.none()));
 
-    assertEquals(
-        "Iceberg REST endpoint must use http or https: scheme=s3", error.getMessage());
+    assertEquals("Iceberg REST endpoint must use http or https: scheme=s3", error.getMessage());
   }
 
   @Test

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.withSettings;
 
 import ai.floedb.floecat.catalog.access.CatalogCapability;
 import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
 import ai.floedb.floecat.catalog.access.NamespacePath;
 import java.time.Instant;
 import java.util.List;
@@ -99,7 +100,7 @@ class IcebergRestCatalogClientTest {
     var loaded = client.loadTable(name);
 
     assertEquals(name, loaded.name());
-    assertEquals("production.sales.orders", loaded.identity().value());
+    assertEquals(ExternalObjectIdentity.pathFallback(name), loaded.identity());
     assertFalse(loaded.identity().stable());
     assertEquals("ICEBERG", loaded.format());
     assertEquals("s3://warehouse/sales/orders", loaded.storageLocation().orElseThrow());
@@ -222,6 +223,60 @@ class IcebergRestCatalogClientTest {
     assertEquals("us-east-1", properties.get("s3.region"));
     assertEquals("true", properties.get("s3.path-style-access"));
     assertEquals("vended-access", properties.get("s3.access-key-id"));
+  }
+
+  @Test
+  void ignoresLongerRoutingOnlyCredentialCandidates() {
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/",
+                    Map.of(
+                        "s3.access-key-id", "usable-access",
+                        "s3.secret-access-key", "usable-secret")),
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/", Map.of("s3.region", "us-west-2"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    var vended = client().vendStorageCredentials(name).orElseThrow();
+
+    assertEquals("usable-access", vended.properties().get("s3.access-key-id"));
+    assertEquals("s3://warehouse/", vended.scopePrefix());
+  }
+
+  @Test
+  void matchesS3aLocationsToS3CredentialPrefixes() {
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3a://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "vended-access",
+                        "s3.secret-access-key", "vended-secret"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    var vended = client().vendStorageCredentials(name).orElseThrow();
+
+    assertEquals("vended-access", vended.properties().get("s3.access-key-id"));
+    assertEquals("s3://warehouse/sales/orders/", vended.scopePrefix());
   }
 
   @Test

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
@@ -187,6 +187,44 @@ class IcebergRestCatalogClientTest {
   }
 
   @Test
+  void carriesConfiguredStorageRoutingWithProtocolVendedCredentials() {
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/",
+                    Map.of(
+                        "s3.access-key-id", "vended-access",
+                        "s3.secret-access-key", "vended-secret"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+    var client =
+        new IcebergRestCatalogClient(
+            catalog,
+            namespaces,
+            views,
+            () -> {},
+            Map.of(
+                "s3.endpoint", "http://localstack:4566",
+                "s3.region", "us-east-1",
+                "s3.path-style-access", "true"));
+
+    var properties = client.vendStorageCredentials(name).orElseThrow().properties();
+
+    assertEquals("http://localstack:4566", properties.get("s3.endpoint"));
+    assertEquals("us-east-1", properties.get("s3.region"));
+    assertEquals("true", properties.get("s3.path-style-access"));
+    assertEquals("vended-access", properties.get("s3.access-key-id"));
+  }
+
+  @Test
   void doesNotTreatOrdinaryFileIoPropertiesAsProtocolVendedCredentials() {
     CatalogObjectName name =
         new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.SQLViewRepresentation;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewVersion;
+import org.junit.jupiter.api.Test;
+
+class IcebergRestCatalogClientTest {
+  private final Catalog catalog = mock(Catalog.class);
+  private final SupportsNamespaces namespaces = mock(SupportsNamespaces.class);
+  private final ViewCatalog views = mock(ViewCatalog.class);
+
+  @Test
+  void listsAndSortsStructuredNamespaces() {
+    when(namespaces.listNamespaces(Namespace.of("production")))
+        .thenReturn(
+            List.of(Namespace.of("production", "sales"), Namespace.of("production", "finance")));
+    IcebergRestCatalogClient client = client();
+
+    assertEquals(
+        List.of(NamespacePath.of("production", "finance"), NamespacePath.of("production", "sales")),
+        client.listNamespaces(NamespacePath.of("production")));
+  }
+
+  @Test
+  void listsTablesWithTheirFullNamespace() {
+    when(catalog.listTables(Namespace.of("production", "sales")))
+        .thenReturn(
+            List.of(
+                TableIdentifier.of(Namespace.of("production", "sales"), "orders"),
+                TableIdentifier.of(Namespace.of("production", "sales"), "customers")));
+    IcebergRestCatalogClient client = client();
+
+    assertEquals(
+        List.of(
+            new CatalogObjectName(NamespacePath.of("production", "sales"), "customers"),
+            new CatalogObjectName(NamespacePath.of("production", "sales"), "orders")),
+        client.listTables(NamespacePath.of("production", "sales")));
+  }
+
+  @Test
+  void loadsProviderNeutralTableMetadataWithExplicitPathFallbackIdentity() {
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders");
+    when(table.properties()).thenReturn(Map.of("owner", "sales-team"));
+    when(catalog.loadTable(TableIdentifier.of(Namespace.of("production", "sales"), "orders")))
+        .thenReturn(table);
+    IcebergRestCatalogClient client = client();
+
+    var loaded = client.loadTable(name);
+
+    assertEquals(name, loaded.name());
+    assertEquals("production.sales.orders", loaded.identity().value());
+    assertFalse(loaded.identity().stable());
+    assertEquals("ICEBERG", loaded.format());
+    assertEquals("s3://warehouse/sales/orders", loaded.storageLocation().orElseThrow());
+    assertEquals(Map.of("owner", "sales-team"), loaded.properties());
+  }
+
+  @Test
+  void listsAndLoadsViewsWithProviderMetadata() {
+    Namespace namespace = Namespace.of("production", "sales");
+    TableIdentifier identifier = TableIdentifier.of(namespace, "monthly_sales");
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "monthly_sales");
+    View view = mock(View.class);
+    ViewVersion version = mock(ViewVersion.class);
+    SQLViewRepresentation representation = mock(SQLViewRepresentation.class);
+    when(views.listViews(namespace)).thenReturn(List.of(identifier));
+    when(views.loadView(identifier)).thenReturn(view);
+    when(view.uuid()).thenReturn(UUID.fromString("22398561-563c-4e4a-b90c-2a275264d40c"));
+    when(view.schema())
+        .thenReturn(new Schema(Types.NestedField.required(1, "total", Types.LongType.get())));
+    when(view.currentVersion()).thenReturn(version);
+    when(version.defaultNamespace()).thenReturn(Namespace.of("production", "shared"));
+    when(version.representations()).thenReturn(List.of(representation));
+    when(representation.sql()).thenReturn("select sum(amount) as total from sales");
+    when(representation.dialect()).thenReturn("spark");
+    when(view.properties()).thenReturn(Map.of("owner", "finance"));
+    IcebergRestCatalogClient client = client();
+
+    assertEquals(List.of(name), client.listViews(NamespacePath.of("production", "sales")));
+    var loaded = client.loadView(name);
+
+    assertEquals(name, loaded.name());
+    assertEquals("22398561-563c-4e4a-b90c-2a275264d40c", loaded.identity().value());
+    assertTrue(loaded.identity().stable());
+    assertTrue(loaded.outputSchemaJson().contains("total"));
+    assertEquals("select sum(amount) as total from sales", loaded.definitions().getFirst().sql());
+    assertEquals("spark", loaded.definitions().getFirst().dialect());
+    assertEquals(NamespacePath.of("production", "shared"), loaded.defaultNamespace());
+    assertEquals(Map.of("owner", "finance"), loaded.properties());
+    assertTrue(client.capabilities().supports(CatalogCapability.LIST_VIEWS));
+    assertTrue(client.capabilities().supports(CatalogCapability.LOAD_VIEW));
+  }
+
+  @Test
+  void returnsOnlyDedicatedProtocolVendedCredentialsForTheLongestMatchingPrefix() {
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier =
+        TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/",
+                    Map.of(
+                        "s3.access-key-id", "broad-access",
+                        "s3.secret-access-key", "broad-secret")),
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "table-access",
+                        "s3.secret-access-key", "table-secret",
+                        "s3.session-token", "table-token",
+                        "s3.session-token-expires-at-ms", "1786000000000",
+                        "token", "catalog-token-must-not-leak"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+    IcebergRestCatalogClient client = client();
+
+    var vended = client.vendStorageCredentials(name).orElseThrow();
+
+    assertEquals("table-access", vended.properties().get("s3.access-key-id"));
+    assertEquals("table-secret", vended.properties().get("s3.secret-access-key"));
+    assertFalse(vended.properties().containsKey("token"));
+    assertEquals("s3://warehouse/sales/orders/", vended.scopePrefix());
+    assertEquals(Instant.ofEpochMilli(1786000000000L), vended.expiresAt().orElseThrow());
+    assertFalse(vended.toString().contains("table-secret"));
+    assertTrue(client.capabilities().supports(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+
+    client.vendStorageCredentials(name);
+    verify(catalog, times(2)).loadTable(identifier);
+  }
+
+  @Test
+  void doesNotTreatOrdinaryFileIoPropertiesAsProtocolVendedCredentials() {
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io = mock(FileIO.class);
+    when(table.io()).thenReturn(io);
+    when(io.properties())
+        .thenReturn(
+            Map.of(
+                "s3.access-key-id", "configured-access",
+                "s3.secret-access-key", "configured-secret"));
+    when(catalog.loadTable(TableIdentifier.of(Namespace.of("production", "sales"), "orders")))
+        .thenReturn(table);
+
+    assertTrue(client().vendStorageCredentials(name).isEmpty());
+  }
+
+  @Test
+  void prefersStableIcebergTableUuidWhenMetadataExposesIt() {
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    Table table = mock(Table.class, withSettings().extraInterfaces(HasTableOperations.class));
+    TableOperations operations = mock(TableOperations.class);
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(((HasTableOperations) table).operations()).thenReturn(operations);
+    when(operations.current()).thenReturn(metadata);
+    when(metadata.uuid()).thenReturn("6d4fe3f7-4615-4bc5-b9ae-62c691d6ba7e");
+    when(metadata.metadataFileLocation()).thenReturn("s3://warehouse/metadata/v2.json");
+    when(table.location()).thenReturn("s3://warehouse/sales/orders");
+    when(table.properties()).thenReturn(Map.of());
+    when(catalog.loadTable(TableIdentifier.of(Namespace.of("production", "sales"), "orders")))
+        .thenReturn(table);
+    IcebergRestCatalogClient client = client();
+
+    var loaded = client.loadTable(name);
+
+    assertEquals("6d4fe3f7-4615-4bc5-b9ae-62c691d6ba7e", loaded.identity().value());
+    assertTrue(loaded.identity().stable());
+    assertEquals("s3://warehouse/metadata/v2.json", loaded.metadataLocation().orElseThrow());
+    assertTrue(client.capabilities().supports(CatalogCapability.STABLE_OBJECT_IDS));
+  }
+
+  @Test
+  void validatesWithARealCatalogOperation() {
+    IcebergRestCatalogClient client = client();
+
+    client.validate();
+
+    verify(namespaces, times(1)).listNamespaces(Namespace.empty());
+  }
+
+  @Test
+  void closesProviderSessionOnlyOnce() {
+    AtomicInteger closes = new AtomicInteger();
+    IcebergRestCatalogClient client =
+        new IcebergRestCatalogClient(catalog, namespaces, views, closes::incrementAndGet);
+
+    client.close();
+    client.close();
+
+    assertEquals(1, closes.get());
+  }
+
+  private IcebergRestCatalogClient client() {
+    return new IcebergRestCatalogClient(catalog, namespaces, views, () -> {});
+  }
+}

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
@@ -38,11 +38,11 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.io.SupportsStorageCredentials;
@@ -147,8 +147,7 @@ class IcebergRestCatalogClientTest {
   void returnsOnlyDedicatedProtocolVendedCredentialsForTheLongestMatchingPrefix() {
     CatalogObjectName name =
         new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
-    TableIdentifier identifier =
-        TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
     Table table = mock(Table.class);
     FileIO io =
         mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/CatalogSigV4AuthManagerTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/CatalogSigV4AuthManagerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.Map;
+import org.apache.iceberg.rest.auth.AuthManager;
+import org.apache.iceberg.rest.auth.AuthManagers;
+import org.junit.jupiter.api.Test;
+
+class CatalogSigV4AuthManagerTest {
+  @Test
+  void canBeLoadedByIcebergWithoutConnectorClasses() {
+    AuthManager manager =
+        AuthManagers.loadAuthManager(
+            "test-catalog", Map.of("rest.auth.type", CatalogSigV4AuthManager.class.getName()));
+    try {
+      assertInstanceOf(CatalogSigV4AuthManager.class, manager);
+    } finally {
+      manager.close();
+    }
+  }
+
+  @Test
+  void catalogProviderReplacesStorageProviderForSigningOnly() {
+    Map<String, String> properties =
+        Map.of(
+            RefreshingAwsCredentialsRegistry.CATALOG_PROVIDER_ID,
+            "catalog-provider",
+            RefreshingAwsCredentialsRegistry.STORAGE_PROVIDER_ID,
+            "storage-provider",
+            "client.credentials-provider",
+            "storage-provider-class",
+            "client.credentials-provider.floecat-provider-id",
+            "storage-provider");
+
+    Map<String, String> catalogProperties =
+        CatalogSigV4AuthManager.catalogAuthProperties(properties);
+
+    assertEquals(
+        RegistryBackedAwsCredentialsProvider.class.getName(),
+        catalogProperties.get("client.credentials-provider"));
+    assertEquals(
+        "catalog-provider",
+        catalogProperties.get("client.credentials-provider.floecat-provider-id"));
+    assertEquals(
+        AwsCredentialScope.CATALOG.name(),
+        catalogProperties.get("client.credentials-provider.floecat-credential-scope"));
+    assertFalse(catalogProperties.containsValue("storage-provider-class"));
+  }
+}

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/CatalogSigV4AuthManagerTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/CatalogSigV4AuthManagerTest.java
@@ -19,13 +19,22 @@ package ai.floedb.floecat.catalog.iceberg.rest.auth;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import java.util.Map;
 import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
 import org.junit.jupiter.api.Test;
 
 class CatalogSigV4AuthManagerTest {
+  @Test
+  void safelyPublishesCatalogPropertiesToRequestThreads() throws NoSuchFieldException {
+    assertTrue(
+        Modifier.isVolatile(
+            CatalogSigV4AuthManager.class.getDeclaredField("catalogProperties").getModifiers()));
+  }
+
   @Test
   void canBeLoadedByIcebergWithoutConnectorClasses() {
     AuthManager manager =

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistryTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistryTest.java
@@ -162,6 +162,36 @@ class RefreshingAwsCredentialsRegistryTest {
     }
   }
 
+  @Test
+  void periodicallyRefreshesCredentialsWithoutKnownExpiry() {
+    Instant start = Instant.parse("2026-08-05T12:00:00Z");
+    MutableClock clock = new MutableClock(start);
+    AtomicInteger refreshes = new AtomicInteger();
+    try (var registration =
+        RefreshingAwsCredentialsRegistry.register(
+            "unknown-expiry-test",
+            credentials("old", null),
+            () -> credentials("new-" + refreshes.incrementAndGet(), null),
+            Duration.ofMinutes(5),
+            clock)) {
+      var initial =
+          RefreshingAwsCredentialsRegistry.resolve(
+              registration.providerId(), AwsCredentialScope.CATALOG);
+      clock.advance(Duration.ofMinutes(5));
+      var refreshed =
+          RefreshingAwsCredentialsRegistry.resolve(
+              registration.providerId(), AwsCredentialScope.CATALOG);
+      var cached =
+          RefreshingAwsCredentialsRegistry.resolve(
+              registration.providerId(), AwsCredentialScope.CATALOG);
+
+      assertEquals("access-old", initial.accessKeyId());
+      assertEquals("access-new-1", refreshed.accessKeyId());
+      assertEquals("access-new-1", cached.accessKeyId());
+      assertEquals(1, refreshes.get());
+    }
+  }
+
   private static Map<String, String> providerProperties(
       RefreshingAwsCredentialsRegistry.Registration registration, AwsCredentialScope scope) {
     String providerId =

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistryTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistryTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.iceberg.rest.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+class RefreshingAwsCredentialsRegistryTest {
+  @Test
+  void refreshesExpiredSessionCredentialsOnce() {
+    AtomicInteger refreshes = new AtomicInteger();
+    try (var registration =
+        RefreshingAwsCredentialsRegistry.register(
+            "refresh-test",
+            credentials("old", Instant.now().minusSeconds(1)),
+            () -> {
+              refreshes.incrementAndGet();
+              return credentials("new", Instant.now().plusSeconds(3600));
+            },
+            Duration.ZERO)) {
+      var first =
+          RefreshingAwsCredentialsRegistry.resolve(
+              registration.providerId(), AwsCredentialScope.CATALOG);
+      var second =
+          RefreshingAwsCredentialsRegistry.resolve(
+              registration.providerId(), AwsCredentialScope.CATALOG);
+
+      assertEquals("access-new", first.accessKeyId());
+      assertEquals("access-new", second.accessKeyId());
+      assertEquals("token-new", ((AwsSessionCredentials) first).sessionToken());
+      assertEquals(1, refreshes.get());
+    }
+  }
+
+  @Test
+  void cachesTerminalRefreshFailure() {
+    AtomicInteger refreshes = new AtomicInteger();
+    TerminalCredentialRefreshException terminal =
+        new TerminalCredentialRefreshException("lease lost", new IllegalStateException("stale"));
+    try (var registration =
+        RefreshingAwsCredentialsRegistry.register(
+            "terminal-test",
+            credentials("old", Instant.now().minusSeconds(1)),
+            () -> {
+              refreshes.incrementAndGet();
+              throw terminal;
+            },
+            Duration.ZERO)) {
+      assertSame(
+          terminal,
+          assertThrows(
+              TerminalCredentialRefreshException.class,
+              () ->
+                  RefreshingAwsCredentialsRegistry.resolve(
+                      registration.providerId(), AwsCredentialScope.CATALOG)));
+      assertSame(
+          terminal,
+          assertThrows(
+              TerminalCredentialRefreshException.class,
+              () ->
+                  RefreshingAwsCredentialsRegistry.resolve(
+                      registration.providerId(), AwsCredentialScope.CATALOG)));
+      assertEquals(1, refreshes.get());
+    }
+  }
+
+  @Test
+  void closedRegistrationCanNoLongerResolve() {
+    var registration =
+        RefreshingAwsCredentialsRegistry.register(
+            credentials("active", null), () -> credentials("unused", null));
+    String providerId = registration.providerId();
+
+    registration.close();
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> RefreshingAwsCredentialsRegistry.resolve(providerId, AwsCredentialScope.STORAGE));
+  }
+
+  @Test
+  void credentialAndRegistrationStringsDoNotExposeSecretsOrProviderIds() {
+    AwsCredentialValue credentials = credentials("private", null);
+    try (var registration =
+        RefreshingAwsCredentialsRegistry.register(credentials, () -> credentials)) {
+      assertFalse(credentials.toString().contains("access-private"));
+      assertFalse(credentials.toString().contains("secret-private"));
+      assertFalse(credentials.toString().contains("token-private"));
+      assertFalse(registration.toString().contains(registration.providerId()));
+    }
+  }
+
+  @Test
+  void reflectionProviderResolvesTheConfiguredCredentialScope() {
+    try (var catalogRegistration =
+            RefreshingAwsCredentialsRegistry.register(
+                credentials("catalog", null), () -> credentials("unused-catalog", null));
+        var storageRegistration =
+            RefreshingAwsCredentialsRegistry.register(
+                credentials("storage", null), () -> credentials("unused-storage", null))) {
+      var catalogProvider =
+          RegistryBackedAwsCredentialsProvider.create(
+              providerProperties(catalogRegistration, AwsCredentialScope.CATALOG));
+      var storageProvider =
+          RegistryBackedAwsCredentialsProvider.create(
+              providerProperties(storageRegistration, AwsCredentialScope.STORAGE));
+
+      assertEquals("access-catalog", catalogProvider.resolveCredentials().accessKeyId());
+      assertEquals("access-storage", storageProvider.resolveCredentials().accessKeyId());
+    }
+  }
+
+  @Test
+  void recomputesAdaptiveSkewAfterRefreshChangesCredentialLifetime() {
+    Instant start = Instant.parse("2026-08-05T12:00:00Z");
+    MutableClock clock = new MutableClock(start);
+    AtomicInteger refreshes = new AtomicInteger();
+    try (var registration =
+        RefreshingAwsCredentialsRegistry.register(
+            "adaptive-skew-test",
+            credentials("old", start.plus(Duration.ofHours(1))),
+            () ->
+                credentials(
+                    "new-" + refreshes.incrementAndGet(),
+                    clock.instant().plus(Duration.ofMinutes(2))),
+            Duration.ofMinutes(5),
+            clock)) {
+      clock.advance(Duration.ofMinutes(56));
+
+      RefreshingAwsCredentialsRegistry.resolve(
+          registration.providerId(), AwsCredentialScope.CATALOG);
+      RefreshingAwsCredentialsRegistry.resolve(
+          registration.providerId(), AwsCredentialScope.CATALOG);
+
+      assertEquals(1, refreshes.get());
+    }
+  }
+
+  private static Map<String, String> providerProperties(
+      RefreshingAwsCredentialsRegistry.Registration registration, AwsCredentialScope scope) {
+    String providerId =
+        RefreshingAwsCredentialsRegistry.propertiesFor(registration, scope)
+            .values()
+            .iterator()
+            .next();
+    return Map.of(
+        RefreshingAwsCredentialsRegistry.PROVIDER_ID_PROPERTY,
+        providerId,
+        RefreshingAwsCredentialsRegistry.CREDENTIAL_SCOPE_PROPERTY,
+        scope.name());
+  }
+
+  private static AwsCredentialValue credentials(String suffix, Instant expiresAt) {
+    return new AwsCredentialValue(
+        "access-" + suffix, "secret-" + suffix, "token-" + suffix, expiresAt);
+  }
+
+  private static final class MutableClock extends Clock {
+    private Instant current;
+
+    private MutableClock(Instant current) {
+      this.current = current;
+    }
+
+    private void advance(Duration duration) {
+      current = current.plus(duration);
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return Clock.fixed(current, zone);
+    }
+
+    @Override
+    public Instant instant() {
+      return current;
+    }
+  }
+}

--- a/core/catalog-access-spi/pom.xml
+++ b/core/catalog-access-spi/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Yellowbrick Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.floedb.floecat</groupId>
+    <artifactId>floecat</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>floecat-catalog-access-spi</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogAuthentication.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogAuthentication.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.Map;
+import java.util.Objects;
+
+/** Non-secret authentication configuration. Resolved secret material is supplied separately. */
+public record CatalogAuthentication(
+    CatalogAuthenticationScheme scheme, Map<String, String> properties) {
+  public CatalogAuthentication {
+    scheme = Objects.requireNonNull(scheme, "scheme");
+    properties = Map.copyOf(Objects.requireNonNull(properties, "properties"));
+    NonSecretCatalogConfig.validateProperties(properties, "authentication properties");
+  }
+
+  public static CatalogAuthentication none() {
+    return new CatalogAuthentication(CatalogAuthenticationScheme.NONE, Map.of());
+  }
+
+  @Override
+  public String toString() {
+    return "CatalogAuthentication[scheme="
+        + scheme
+        + ", propertyKeys="
+        + NonSecretCatalogConfig.propertyKeys(properties)
+        + "]";
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogAuthenticationScheme.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogAuthenticationScheme.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+/** Supported authentication contracts for upstream catalog connections. */
+public enum CatalogAuthenticationScheme {
+  NONE,
+  OAUTH2,
+  AWS_SIGV4
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogCapabilities.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogCapabilities.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.Set;
+
+public record CatalogCapabilities(Set<CatalogCapability> supported) {
+  public CatalogCapabilities {
+    supported = Set.copyOf(supported);
+  }
+
+  public static CatalogCapabilities of(CatalogCapability... capabilities) {
+    return new CatalogCapabilities(Set.of(capabilities));
+  }
+
+  public boolean supports(CatalogCapability capability) {
+    return supported.contains(capability);
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogCapability.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogCapability.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+public enum CatalogCapability {
+  VALIDATE,
+  LIST_NAMESPACES,
+  LIST_TABLES,
+  LOAD_TABLE,
+  LIST_VIEWS,
+  LOAD_VIEW,
+  VEND_STORAGE_CREDENTIALS,
+  STABLE_OBJECT_IDS
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogClient.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogClient.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Discovery and metadata access to one upstream catalog connection. */
+public interface CatalogClient extends AutoCloseable {
+  CatalogCapabilities capabilities();
+
+  void validate();
+
+  List<NamespacePath> listNamespaces(NamespacePath parent);
+
+  List<CatalogObjectName> listTables(NamespacePath namespace);
+
+  CatalogTable loadTable(CatalogObjectName table);
+
+  List<CatalogObjectName> listViews(NamespacePath namespace);
+
+  CatalogView loadView(CatalogObjectName view);
+
+  /**
+   * Re-loads the table through the upstream protocol and returns only credentials from its
+   * dedicated vending channel. Call again when credentials expire; an absent expiry must not be
+   * treated as non-expiring.
+   */
+  Optional<VendedStorageCredentials> vendStorageCredentials(CatalogObjectName table);
+
+  @Override
+  void close();
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogClientFactory.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogClientFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+/** Resolves catalog clients by protocol without depending on Connector resources or RPC types. */
+public final class CatalogClientFactory {
+  private final Map<CatalogProtocol, CatalogClientProvider> providers;
+
+  public CatalogClientFactory(Collection<CatalogClientProvider> providers) {
+    Objects.requireNonNull(providers, "providers");
+    Map<CatalogProtocol, CatalogClientProvider> indexed = new EnumMap<>(CatalogProtocol.class);
+    for (CatalogClientProvider provider : providers) {
+      CatalogClientProvider previous = indexed.put(provider.protocol(), provider);
+      if (previous != null) {
+        throw new IllegalArgumentException(
+            "Multiple CatalogClientProviders for protocol=" + provider.protocol());
+      }
+    }
+    this.providers = Map.copyOf(indexed);
+  }
+
+  public static CatalogClientFactory load() {
+    return new CatalogClientFactory(
+        ServiceLoader.load(CatalogClientProvider.class, CatalogClientFactory.class.getClassLoader())
+            .stream()
+            .map(ServiceLoader.Provider::get)
+            .toList());
+  }
+
+  public CatalogClient open(
+      CatalogConnectionConfig config, ResolvedCatalogCredentials resolvedCredentials) {
+    Objects.requireNonNull(config, "config");
+    Objects.requireNonNull(resolvedCredentials, "resolvedCredentials");
+    CatalogClientProvider provider = providers.get(config.protocol());
+    if (provider == null) {
+      throw new IllegalStateException("No CatalogClientProvider for protocol=" + config.protocol());
+    }
+    return provider.open(config, resolvedCredentials);
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogClientProvider.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogClientProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+public interface CatalogClientProvider {
+  CatalogProtocol protocol();
+
+  CatalogClient open(
+      CatalogConnectionConfig config, ResolvedCatalogCredentials resolvedCredentials);
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogConnectionConfig.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogConnectionConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable, non-secret configuration for opening an upstream catalog. */
+public record CatalogConnectionConfig(
+    CatalogProtocol protocol,
+    URI endpoint,
+    Map<String, String> properties,
+    CatalogAuthentication authentication) {
+  public CatalogConnectionConfig {
+    protocol = Objects.requireNonNull(protocol, "protocol");
+    endpoint = Objects.requireNonNull(endpoint, "endpoint");
+    if (!endpoint.isAbsolute()) {
+      throw new IllegalArgumentException("endpoint must be absolute");
+    }
+    if (endpoint.getRawUserInfo() != null) {
+      throw new IllegalArgumentException("endpoint must not contain user-info");
+    }
+    NonSecretCatalogConfig.validateEndpoint(endpoint);
+    properties = Map.copyOf(Objects.requireNonNull(properties, "properties"));
+    NonSecretCatalogConfig.validateProperties(properties, "connection properties");
+    authentication = Objects.requireNonNull(authentication, "authentication");
+  }
+
+  @Override
+  public String toString() {
+    return "CatalogConnectionConfig[protocol="
+        + protocol
+        + ", endpoint="
+        + NonSecretCatalogConfig.safeEndpoint(endpoint)
+        + ", propertyKeys="
+        + NonSecretCatalogConfig.propertyKeys(properties)
+        + ", authentication="
+        + authentication
+        + "]";
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogObjectName.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogObjectName.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.Objects;
+
+public record CatalogObjectName(NamespacePath namespace, String name)
+    implements Comparable<CatalogObjectName> {
+  public CatalogObjectName {
+    namespace = Objects.requireNonNull(namespace, "namespace");
+    name = Objects.requireNonNull(name, "name").trim();
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException("name must not be blank");
+    }
+  }
+
+  @Override
+  public int compareTo(CatalogObjectName other) {
+    int namespaceComparison = namespace.compareTo(other.namespace);
+    return namespaceComparison == 0 ? name.compareTo(other.name) : namespaceComparison;
+  }
+
+  @Override
+  public String toString() {
+    return namespace.segments().isEmpty() ? name : namespace + "." + name;
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogProtocol.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogProtocol.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+/** The upstream catalog protocol or provider. This is deliberately not a table format. */
+public enum CatalogProtocol {
+  ICEBERG_REST,
+  UNITY_CATALOG,
+  AWS_GLUE
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogTable.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogTable.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Provider-neutral table discovery metadata. This is not the captured Floecat table resource. */
+public record CatalogTable(
+    CatalogObjectName name,
+    ExternalObjectIdentity identity,
+    String format,
+    Optional<String> metadataLocation,
+    Optional<String> storageLocation,
+    Map<String, String> properties) {
+  public CatalogTable {
+    name = Objects.requireNonNull(name, "name");
+    identity = Objects.requireNonNull(identity, "identity");
+    format = Objects.requireNonNull(format, "format").trim();
+    if (format.isEmpty()) {
+      throw new IllegalArgumentException("format must not be blank");
+    }
+    metadataLocation = Objects.requireNonNull(metadataLocation, "metadataLocation");
+    storageLocation = Objects.requireNonNull(storageLocation, "storageLocation");
+    properties = Map.copyOf(Objects.requireNonNull(properties, "properties"));
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogView.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogView.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Provider-neutral view discovery metadata. */
+public record CatalogView(
+    CatalogObjectName name,
+    ExternalObjectIdentity identity,
+    String outputSchemaJson,
+    List<CatalogViewDefinition> definitions,
+    NamespacePath defaultNamespace,
+    Map<String, String> properties) {
+  public CatalogView {
+    name = Objects.requireNonNull(name, "name");
+    identity = Objects.requireNonNull(identity, "identity");
+    outputSchemaJson = Objects.requireNonNull(outputSchemaJson, "outputSchemaJson").trim();
+    if (outputSchemaJson.isEmpty()) {
+      throw new IllegalArgumentException("outputSchemaJson must not be blank");
+    }
+    definitions = List.copyOf(Objects.requireNonNull(definitions, "definitions"));
+    defaultNamespace = Objects.requireNonNull(defaultNamespace, "defaultNamespace");
+    properties = Map.copyOf(Objects.requireNonNull(properties, "properties"));
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogViewDefinition.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogViewDefinition.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.Objects;
+
+/** One provider-native SQL representation of a view. */
+public record CatalogViewDefinition(String sql, String dialect) {
+  public CatalogViewDefinition {
+    sql = Objects.requireNonNull(sql, "sql");
+    dialect = Objects.requireNonNull(dialect, "dialect");
+    if (sql.isBlank()) {
+      throw new IllegalArgumentException("sql must not be blank");
+    }
+    if (dialect.isBlank()) {
+      throw new IllegalArgumentException("dialect must not be blank");
+    }
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/ExternalObjectIdentity.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/ExternalObjectIdentity.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.Objects;
+
+/**
+ * Provider identity for a captured object. Path-derived identities are explicitly marked unstable.
+ */
+public record ExternalObjectIdentity(String value, boolean stable) {
+  public ExternalObjectIdentity {
+    value = Objects.requireNonNull(value, "value").trim();
+    if (value.isEmpty()) {
+      throw new IllegalArgumentException("value must not be blank");
+    }
+  }
+
+  public static ExternalObjectIdentity pathFallback(CatalogObjectName name) {
+    return new ExternalObjectIdentity(name.toString(), false);
+  }
+
+  public static ExternalObjectIdentity stable(String value) {
+    return new ExternalObjectIdentity(value, true);
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/ExternalObjectIdentity.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/ExternalObjectIdentity.java
@@ -30,10 +30,18 @@ public record ExternalObjectIdentity(String value, boolean stable) {
   }
 
   public static ExternalObjectIdentity pathFallback(CatalogObjectName name) {
-    return new ExternalObjectIdentity(name.toString(), false);
+    Objects.requireNonNull(name, "name");
+    StringBuilder encoded = new StringBuilder("path:v1:");
+    name.namespace().segments().forEach(segment -> appendSegment(encoded, segment));
+    appendSegment(encoded, name.name());
+    return new ExternalObjectIdentity(encoded.toString(), false);
   }
 
   public static ExternalObjectIdentity stable(String value) {
     return new ExternalObjectIdentity(value, true);
+  }
+
+  private static void appendSegment(StringBuilder encoded, String segment) {
+    encoded.append(segment.length()).append(':').append(segment);
   }
 }

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/NamespacePath.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/NamespacePath.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.util.List;
+import java.util.Objects;
+
+/** A case-preserving namespace path ordered from catalog root to namespace leaf. */
+public record NamespacePath(List<String> segments) implements Comparable<NamespacePath> {
+  private static final NamespacePath ROOT = new NamespacePath(List.of());
+
+  public NamespacePath {
+    segments =
+        Objects.requireNonNull(segments, "segments").stream()
+            .map(segment -> Objects.requireNonNull(segment, "segment").trim())
+            .peek(
+                segment -> {
+                  if (segment.isEmpty()) {
+                    throw new IllegalArgumentException("namespace segments must not be blank");
+                  }
+                })
+            .toList();
+  }
+
+  public static NamespacePath root() {
+    return ROOT;
+  }
+
+  public static NamespacePath of(String... segments) {
+    return new NamespacePath(List.of(segments));
+  }
+
+  @Override
+  public int compareTo(NamespacePath other) {
+    int shared = Math.min(segments.size(), other.segments.size());
+    for (int i = 0; i < shared; i++) {
+      int compared = segments.get(i).compareTo(other.segments.get(i));
+      if (compared != 0) {
+        return compared;
+      }
+    }
+    return Integer.compare(segments.size(), other.segments.size());
+  }
+
+  @Override
+  public String toString() {
+    return String.join(".", segments);
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/NonSecretCatalogConfig.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/NonSecretCatalogConfig.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Validation and safe rendering for configuration that may be persisted or logged. */
+final class NonSecretCatalogConfig {
+  private static final Set<String> FORBIDDEN_KEYS =
+      Set.of(
+          "authorization",
+          "bearer",
+          "token",
+          "access_token",
+          "refresh_token",
+          "session_token",
+          "id_token",
+          "client_secret",
+          "secret",
+          "password",
+          "access_key",
+          "access_key_id",
+          "secret_key",
+          "secret_access_key",
+          "private_key",
+          "private_key_pem",
+          "api_key",
+          "assertion",
+          "credential",
+          "credentials",
+          "jwt",
+          "cookie",
+          "signature",
+          "sig");
+
+  private NonSecretCatalogConfig() {}
+
+  static void validateProperties(Map<String, String> properties, String fieldName) {
+    for (String key : properties.keySet()) {
+      if (isSecretKey(key)) {
+        throw new IllegalArgumentException(fieldName + " must not contain secret key: " + key);
+      }
+    }
+  }
+
+  static void validateEndpoint(URI endpoint) {
+    if (endpoint.getRawFragment() != null) {
+      throw new IllegalArgumentException("endpoint must not contain a fragment");
+    }
+    String query = endpoint.getRawQuery();
+    if (query == null || query.isBlank()) {
+      return;
+    }
+    for (String parameter : query.split("[&;]")) {
+      String rawKey = parameter.split("=", 2)[0];
+      String key = URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
+      if (isSecretKey(key)) {
+        throw new IllegalArgumentException("endpoint query must not contain secret key: " + key);
+      }
+    }
+  }
+
+  static String propertyKeys(Map<String, String> properties) {
+    return properties.keySet().stream().sorted().collect(Collectors.joining(", ", "[", "]"));
+  }
+
+  static String safeEndpoint(URI endpoint) {
+    if (endpoint.getRawQuery() == null) {
+      return endpoint.toString();
+    }
+    return endpoint.toString().substring(0, endpoint.toString().indexOf('?')) + "?<redacted>";
+  }
+
+  static boolean isSecretKey(String key) {
+    String canonical = canonicalKey(key);
+    if (canonical.isEmpty()) {
+      return false;
+    }
+    if (FORBIDDEN_KEYS.contains(canonical)
+        || canonical.contains("private_key")
+        || canonical.startsWith("header_")) {
+      return true;
+    }
+    String[] parts = canonical.split("_");
+    return containsPhrase(parts, "authorization")
+        || containsPhrase(parts, "bearer")
+        || containsPhrase(parts, "token")
+        || containsPhrase(parts, "secret")
+        || containsPhrase(parts, "password")
+        || containsPhrase(parts, "credential")
+        || containsPhrase(parts, "credentials")
+        || containsPhrase(parts, "assertion")
+        || containsPhrase(parts, "jwt")
+        || containsPhrase(parts, "cookie")
+        || containsPhrase(parts, "signature")
+        || containsPhrase(parts, "access", "key")
+        || containsPhrase(parts, "secret", "key")
+        || containsPhrase(parts, "private", "key")
+        || containsPhrase(parts, "api", "key");
+  }
+
+  private static boolean containsPhrase(String[] parts, String... phrase) {
+    for (int i = 0; i <= parts.length - phrase.length; i++) {
+      if (Arrays.equals(Arrays.copyOfRange(parts, i, i + phrase.length), phrase)) {
+        if (phrase.length == 1
+            && phrase[0].equals("token")
+            && i + 1 < parts.length
+            && parts[i + 1].equals("type")) {
+          continue;
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String canonicalKey(String key) {
+    if (key == null || key.isBlank()) {
+      return "";
+    }
+    return key.trim()
+        .replaceAll("([a-z0-9])([A-Z])", "$1_$2")
+        .toLowerCase(java.util.Locale.ROOT)
+        .replaceAll("[^a-z0-9]+", "_")
+        .replaceAll("^_+|_+$", "");
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/NonSecretCatalogConfig.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/NonSecretCatalogConfig.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 /** Validation and safe rendering for configuration that may be persisted or logged. */
 final class NonSecretCatalogConfig {
+  private static final Set<String> ALLOWED_TOKEN_KEYS = Set.of("token_refresh_enabled");
   private static final Set<String> FORBIDDEN_KEYS =
       Set.of(
           "authorization",
@@ -94,6 +95,9 @@ final class NonSecretCatalogConfig {
   static boolean isSecretKey(String key) {
     String canonical = canonicalKey(key);
     if (canonical.isEmpty()) {
+      return false;
+    }
+    if (ALLOWED_TOKEN_KEYS.contains(canonical)) {
       return false;
     }
     if (FORBIDDEN_KEYS.contains(canonical)

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/ResolvedCatalogCredentials.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/ResolvedCatalogCredentials.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/** In-memory resolved credentials. Its string representation never includes secret material. */
+public final class ResolvedCatalogCredentials {
+  private static final ResolvedCatalogCredentials NONE =
+      new ResolvedCatalogCredentials(Map.of(), Map.of(), null);
+
+  private final Map<String, String> properties;
+  private final Map<String, String> headers;
+  private final Instant expiresAt;
+
+  public ResolvedCatalogCredentials(
+      Map<String, String> properties, Map<String, String> headers, Instant expiresAt) {
+    this.properties = Map.copyOf(Objects.requireNonNull(properties, "properties"));
+    this.headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
+    this.expiresAt = expiresAt;
+  }
+
+  public static ResolvedCatalogCredentials none() {
+    return NONE;
+  }
+
+  public Map<String, String> properties() {
+    return properties;
+  }
+
+  public Map<String, String> headers() {
+    return headers;
+  }
+
+  public Optional<Instant> expiresAt() {
+    return Optional.ofNullable(expiresAt);
+  }
+
+  public boolean isEmpty() {
+    return properties.isEmpty() && headers.isEmpty();
+  }
+
+  @Override
+  public String toString() {
+    return "ResolvedCatalogCredentials[properties=<redacted:"
+        + properties.size()
+        + ">, headers=<redacted:"
+        + headers.size()
+        + ">, expiresAt="
+        + expiresAt
+        + "]";
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/VendedStorageCredentials.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/VendedStorageCredentials.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Short-lived, table-scoped credentials returned by an upstream catalog protocol. */
+public record VendedStorageCredentials(
+    Map<String, String> properties, String scopePrefix, Optional<Instant> expiresAt) {
+  public VendedStorageCredentials {
+    properties = Map.copyOf(Objects.requireNonNull(properties, "properties"));
+    if (properties.isEmpty()) {
+      throw new IllegalArgumentException("properties must not be empty");
+    }
+    scopePrefix = Objects.requireNonNull(scopePrefix, "scopePrefix");
+    expiresAt = Objects.requireNonNull(expiresAt, "expiresAt");
+  }
+
+  @Override
+  public String toString() {
+    return "VendedStorageCredentials[propertyKeys="
+        + NonSecretCatalogConfig.propertyKeys(properties)
+        + ", scopePrefix=<redacted>"
+        + ", expiresAt="
+        + expiresAt
+        + "]";
+  }
+}

--- a/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/CatalogClientFactoryTest.java
+++ b/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/CatalogClientFactoryTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CatalogClientFactoryTest {
+  @Test
+  void routesByCatalogProtocol() {
+    StubClient client = new StubClient();
+    CatalogClientProvider provider = provider(CatalogProtocol.ICEBERG_REST, client);
+    CatalogClientFactory factory = new CatalogClientFactory(List.of(provider));
+
+    CatalogClient opened =
+        factory.open(config(CatalogProtocol.ICEBERG_REST), ResolvedCatalogCredentials.none());
+
+    assertSame(client, opened);
+  }
+
+  @Test
+  void rejectsDuplicateProviders() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new CatalogClientFactory(
+                List.of(
+                    provider(CatalogProtocol.ICEBERG_REST, new StubClient()),
+                    provider(CatalogProtocol.ICEBERG_REST, new StubClient()))));
+  }
+
+  @Test
+  void reportsMissingProvider() {
+    CatalogClientFactory factory = new CatalogClientFactory(List.of());
+
+    IllegalStateException error =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                factory.open(
+                    config(CatalogProtocol.UNITY_CATALOG), ResolvedCatalogCredentials.none()));
+
+    assertEquals("No CatalogClientProvider for protocol=UNITY_CATALOG", error.getMessage());
+  }
+
+  @Test
+  void credentialsNeverRenderSecretValues() {
+    ResolvedCatalogCredentials credentials =
+        new ResolvedCatalogCredentials(
+            Map.of("token", "secret-token"),
+            Map.of("Authorization", "Bearer secret-token"),
+            Instant.parse("2026-08-05T12:00:00Z"));
+
+    assertFalse(credentials.toString().contains("secret-token"));
+    assertFalse(credentials.toString().contains("Bearer"));
+  }
+
+  @Test
+  void rejectsEndpointUserInfoFromPersistableConfiguration() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new CatalogConnectionConfig(
+                    CatalogProtocol.ICEBERG_REST,
+                    URI.create("https://user:secret@catalog.example/v1"),
+                    Map.of(),
+                    CatalogAuthentication.none()));
+
+    assertEquals("endpoint must not contain user-info", error.getMessage());
+  }
+
+  private static CatalogConnectionConfig config(CatalogProtocol protocol) {
+    return new CatalogConnectionConfig(
+        protocol, URI.create("https://catalog.example/v1"), Map.of(), CatalogAuthentication.none());
+  }
+
+  private static CatalogClientProvider provider(CatalogProtocol protocol, CatalogClient client) {
+    return new CatalogClientProvider() {
+      @Override
+      public CatalogProtocol protocol() {
+        return protocol;
+      }
+
+      @Override
+      public CatalogClient open(
+          CatalogConnectionConfig config, ResolvedCatalogCredentials resolvedCredentials) {
+        return client;
+      }
+    };
+  }
+
+  private static final class StubClient implements CatalogClient {
+    @Override
+    public CatalogCapabilities capabilities() {
+      return CatalogCapabilities.of();
+    }
+
+    @Override
+    public void validate() {}
+
+    @Override
+    public List<NamespacePath> listNamespaces(NamespacePath parent) {
+      return List.of();
+    }
+
+    @Override
+    public List<CatalogObjectName> listTables(NamespacePath namespace) {
+      return List.of();
+    }
+
+    @Override
+    public CatalogTable loadTable(CatalogObjectName table) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<CatalogObjectName> listViews(NamespacePath namespace) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CatalogView loadView(CatalogObjectName view) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.util.Optional<VendedStorageCredentials> vendStorageCredentials(
+        CatalogObjectName table) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/CatalogConnectionConfigTest.java
+++ b/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/CatalogConnectionConfigTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CatalogConnectionConfigTest {
+  @Test
+  void rejectsSecretBearingConnectionAndAuthenticationProperties() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> config(URI.create("https://catalog.example/v1"), Map.of("dbPassword", "secret")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new CatalogAuthentication(
+                CatalogAuthenticationScheme.OAUTH2, Map.of("client_secret", "secret")));
+  }
+
+  @Test
+  void rejectsSecretBearingEndpointComponents() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> config(URI.create("https://catalog.example/v1?access_token=secret"), Map.of()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> config(URI.create("https://catalog.example/v1?X-Amz-Signature=secret"), Map.of()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> config(URI.create("https://catalog.example/v1#secret"), Map.of()));
+  }
+
+  @Test
+  void stringRepresentationsNeverIncludePropertyOrQueryValues() {
+    CatalogAuthentication authentication =
+        new CatalogAuthentication(
+            CatalogAuthenticationScheme.OAUTH2, Map.of("scope", "internal-scope"));
+    CatalogConnectionConfig config =
+        new CatalogConnectionConfig(
+            CatalogProtocol.ICEBERG_REST,
+            URI.create("https://catalog.example/v1?warehouse=private-warehouse"),
+            Map.of("warehouse", "private-warehouse"),
+            authentication);
+
+    assertTrue(config.toString().contains("warehouse"));
+    assertFalse(config.toString().contains("private-warehouse"));
+    assertFalse(authentication.toString().contains("internal-scope"));
+  }
+
+  private static CatalogConnectionConfig config(URI endpoint, Map<String, String> properties) {
+    return new CatalogConnectionConfig(
+        CatalogProtocol.ICEBERG_REST,
+        endpoint,
+        properties,
+        CatalogAuthentication.none());
+  }
+}

--- a/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/CatalogConnectionConfigTest.java
+++ b/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/CatalogConnectionConfigTest.java
@@ -69,9 +69,6 @@ class CatalogConnectionConfigTest {
 
   private static CatalogConnectionConfig config(URI endpoint, Map<String, String> properties) {
     return new CatalogConnectionConfig(
-        CatalogProtocol.ICEBERG_REST,
-        endpoint,
-        properties,
-        CatalogAuthentication.none());
+        CatalogProtocol.ICEBERG_REST, endpoint, properties, CatalogAuthentication.none());
   }
 }

--- a/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/CatalogConnectionConfigTest.java
+++ b/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/CatalogConnectionConfigTest.java
@@ -67,6 +67,14 @@ class CatalogConnectionConfigTest {
     assertFalse(authentication.toString().contains("internal-scope"));
   }
 
+  @Test
+  void acceptsIcebergTokenRefreshSettingWithoutWeakeningTokenDetection() {
+    config(URI.create("https://catalog.example/v1"), Map.of("token-refresh-enabled", "true"));
+
+    assertFalse(NonSecretCatalogConfig.isSecretKey("token-refresh-enabled"));
+    assertTrue(NonSecretCatalogConfig.isSecretKey("token-refresh-secret"));
+  }
+
   private static CatalogConnectionConfig config(URI endpoint, Map<String, String> properties) {
     return new CatalogConnectionConfig(
         CatalogProtocol.ICEBERG_REST, endpoint, properties, CatalogAuthentication.none());

--- a/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/ExternalObjectIdentityTest.java
+++ b/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/ExternalObjectIdentityTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ExternalObjectIdentityTest {
+  @Test
+  void pathFallbackPreservesNamespaceSegmentBoundaries() {
+    ExternalObjectIdentity dottedSegment =
+        ExternalObjectIdentity.pathFallback(new CatalogObjectName(NamespacePath.of("a.b"), "c"));
+    ExternalObjectIdentity separateSegments =
+        ExternalObjectIdentity.pathFallback(new CatalogObjectName(NamespacePath.of("a", "b"), "c"));
+
+    assertNotEquals(dottedSegment, separateSegments);
+    assertFalse(dottedSegment.stable());
+    assertFalse(separateSegments.stable());
+  }
+
+  @Test
+  void pathFallbackPreservesTableNameBoundary() {
+    ExternalObjectIdentity dottedName =
+        ExternalObjectIdentity.pathFallback(new CatalogObjectName(NamespacePath.of("a"), "b.c"));
+    ExternalObjectIdentity nestedNamespace =
+        ExternalObjectIdentity.pathFallback(new CatalogObjectName(NamespacePath.of("a", "b"), "c"));
+
+    assertNotEquals(dottedName, nestedNamespace);
+    assertEquals(
+        dottedName,
+        ExternalObjectIdentity.pathFallback(new CatalogObjectName(NamespacePath.of("a"), "b.c")));
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,8 @@ The following modules compose the system (see linked docs for deep dives):
 | Component | Responsibility |
 |-----------|----------------|
 | [`proto/`](proto.md) | All protobuf/gRPC contracts (catalog, query lifecycle, execution scans, connectors, statistics, types). |
+| [`core/catalog-access-spi/`](catalog-access-spi.md) | Connector-independent upstream catalog access contracts. |
+| `catalog-access/iceberg-rest/` | Iceberg REST discovery and metadata provider for the catalog-access SPI. |
 | [`service/`](service.md) | Quarkus runtime, resource repositories, query lifecycle service, GC, security, metrics. |
 | [`client-cli/`](client-cli.md) | Interactive shell for humans; exercises every public RPC. |
 | [`core/connectors/spi/`](connectors-spi.md) | Connector interfaces, stats engines, NDV helpers, auth shims. |

--- a/docs/catalog-access-spi.md
+++ b/docs/catalog-access-spi.md
@@ -1,0 +1,120 @@
+# Catalog Access SPI
+
+The catalog-access SPI is the Connector-independent boundary for communicating with upstream
+catalogs. Catalog Integrations will use this boundary for connection validation, discovery, and
+provider metadata access without creating or reading legacy Connector resources.
+
+The SPI and its first provider are separate Maven modules:
+
+| Module | Responsibility |
+| --- | --- |
+| `core/catalog-access-spi` | Provider-neutral connection, authentication, credentials, capabilities, namespace, table, view, and client contracts. |
+| `catalog-access/iceberg-rest` | Iceberg REST client provider and ServiceLoader registration. |
+
+Neither module depends on Connector protobufs or `FloecatConnector`.
+
+## Connection boundary
+
+`CatalogConnectionConfig` contains only persistable, non-secret configuration: protocol, endpoint,
+properties, and `CatalogAuthentication`. Secret material is resolved immediately before opening a
+client and supplied separately as `ResolvedCatalogCredentials`. Its `toString()` implementation
+redacts property and header values.
+
+```java
+CatalogConnectionConfig config =
+    new CatalogConnectionConfig(
+        CatalogProtocol.ICEBERG_REST,
+        URI.create("https://catalog.example/v1"),
+        Map.of("warehouse", "sales"),
+        new CatalogAuthentication(CatalogAuthenticationScheme.OAUTH2, Map.of()));
+
+ResolvedCatalogCredentials credentials =
+    new ResolvedCatalogCredentials(Map.of("token", token), Map.of(), expiresAt);
+
+try (CatalogClient client = CatalogClientFactory.load().open(config, credentials)) {
+  client.validate();
+  List<NamespacePath> namespaces = client.listNamespaces(NamespacePath.root());
+}
+```
+
+Provider lookup is by `CatalogProtocol`, which describes the catalog protocol/provider rather than
+the table format. Missing and duplicate providers fail explicitly.
+
+## Iceberg REST slice
+
+The Iceberg REST provider currently supports:
+
+- anonymous, OAuth2, and AWS SigV4 connections;
+- connection validation through a real namespace-list operation;
+- structured, case-preserving namespace discovery;
+- table enumeration and provider-neutral table metadata;
+- view enumeration and provider-neutral output schema, SQL dialect, default namespace, properties,
+  and identity metadata;
+- metadata and storage locations when exposed by Iceberg;
+- table-scoped storage credentials obtained only from Iceberg's dedicated protocol vending channel;
+  and
+- idempotent ownership of the underlying REST session.
+
+`vendStorageCredentials` performs a fresh `loadTable` request on every call, selects the
+longest-prefix credential matching the table location, and copies only the S3 storage credential
+allowlist. Callers reacquire credentials at the returned expiry. A missing or invalid expiry means
+the result must not be cached. Catalog tokens and ordinary FileIO properties are never treated as
+vended storage credentials, so a server that does not vend returns an empty result instead of
+falling back to catalog authentication, configured storage keys, or Connector behavior.
+
+### Renewable AWS credentials
+
+SigV4 catalog signing and storage/FileIO access are separate credential scopes. Either scope can
+use static resolved keys or a renewable registration. Renewable registrations are process-local,
+opaque, and owned by the caller:
+
+```java
+try (var catalogRegistration =
+        RefreshingAwsCredentialsRegistry.register(initialCatalogCredentials, catalogRefresher);
+    var storageRegistration =
+        RefreshingAwsCredentialsRegistry.register(initialStorageCredentials, storageRefresher)) {
+  Map<String, String> resolved = new HashMap<>();
+  resolved.putAll(
+      RefreshingAwsCredentialsRegistry.propertiesFor(
+          catalogRegistration, AwsCredentialScope.CATALOG));
+  resolved.putAll(
+      RefreshingAwsCredentialsRegistry.propertiesFor(
+          storageRegistration, AwsCredentialScope.STORAGE));
+
+  try (CatalogClient client =
+      factory.open(config, new ResolvedCatalogCredentials(resolved, Map.of(), null))) {
+    client.validate();
+  }
+}
+```
+
+The registry refreshes expiring credentials with adaptive skew, serializes concurrent refresh for a
+registration, retains still-valid credentials after a transient refresh failure, caches terminal
+refresh failures, and stops resolving a registration after it is closed. Logs and object string
+representations use hashed provider references and never include keys or tokens.
+
+The Iceberg REST auth manager replaces storage provider configuration with the catalog-scoped
+provider only while signing REST requests. FileIO retains the separately configured storage scope,
+including credentials vended through later Iceberg table configuration.
+
+Iceberg REST tables use the Iceberg table UUID as their stable external identity when table metadata
+exposes it. Tables without an available UUID use a path-derived, explicitly unstable fallback; a
+rename of such a table is interpreted as deletion plus creation.
+
+OAuth secrets, AWS keys, renewable-provider IDs, and Iceberg credential-provider hooks are rejected
+in persistable connection configuration and accepted only through `ResolvedCatalogCredentials`.
+Persisted secret-bearing properties, HTTP headers, endpoint user-info, endpoint fragments, and
+secret-bearing endpoint query parameters are rejected. Configuration string representations print
+property names but redact their values and query values. Unsupported authentication schemes,
+incomplete or unknown credential properties, and endpoint protocols fail instead of falling back
+to Connector behavior.
+
+## Current boundary
+
+This first slice is discovery infrastructure. It does not add Integration credentials or validation
+RPCs, schedule reconciliation, write captured resources, or change the existing Iceberg Connector.
+The legacy Connector and its existing SigV4/refresh implementation remain operational and unchanged;
+their removal is a later migration step. The neutral implementation does not import or call them.
+
+See [Catalog Integration Architecture Decisions](catalog-integration-design.md) for ownership,
+mapping, reconciliation, and migration decisions.

--- a/docs/catalog-access-spi.md
+++ b/docs/catalog-access-spi.md
@@ -88,7 +88,8 @@ try (var catalogRegistration =
 }
 ```
 
-The registry refreshes expiring credentials with adaptive skew, serializes concurrent refresh for a
+The registry refreshes expiring credentials with adaptive skew and refreshes credentials without a
+reported expiry on the configured refresh cadence. It serializes concurrent refresh for a
 registration, retains still-valid credentials after a transient refresh failure, caches terminal
 refresh failures, and stops resolving a registration after it is closed. Logs and object string
 representations use hashed provider references and never include keys or tokens.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
   - Catalog and Metadata:
       - Catalog Integration Architecture and Delivery Plan: catalog-integration-design.md
       - Catalog Integrations and Overlays: catalog-integrations.md
+      - Catalog Access SPI: catalog-access-spi.md
       - Metadata Graph: metadata-graph.md
       - System Objects: system-objects.md
       - System Scans: system-scans.md

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
       <module>core/metadata-admission-runtime</module>
       <module>core/stats</module>
       <module>core/catalog</module>
+      <module>core/catalog-access-spi</module>
       <module>core/scanner</module>
       <module>core/metagraph</module>
       <module>core/connectors/spi</module>
@@ -110,6 +111,9 @@
       <module>core/storage-spi</module>
       <module>core/reconciler-spi</module>
       <module>core/arrow</module>
+
+      <!-- Catalog access -->
+      <module>catalog-access/iceberg-rest</module>
       
       <!-- Connectors -->
       <module>connectors/catalogs/iceberg</module>


### PR DESCRIPTION
## Summary

Introduces a connector-independent catalog access SPI and an Iceberg REST implementation. It includes provider discovery, typed connection and authentication contracts, AWS SigV4 support with refreshable credentials, first-class view access, protocol-vended storage credentials, unit coverage, module wiring, and architecture documentation.

The existing Connector path remains intact. The new SPI does not fall back to Connector or ambient credentials, and persisted catalog configuration rejects secret-bearing values.

## Type of Change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [x] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Focused Catalog Access SPI/provider tests passed.

- [x] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Stack position: **8/10**. Base: `mc-catalog-integrations-cli`. This remains draft while the lower stack is reviewed; review the SPI/provider abstraction independently from the resource APIs.

