### PR TITLE
fix(test): relax bounded fanout scheduling waits

### DIFF
--- a/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/concurrent/BoundedFanoutTest.java
@@ -602,13 +602,13 @@ class BoundedFanoutTest {
                     cancelled::get);
               });
 
-      assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+      assertThat(taskStarted.await(5, TimeUnit.SECONDS)).isTrue();
       cancelled.set(true);
       try {
         assertThat(result.get(5, TimeUnit.SECONDS))
             .isInstanceOf(CancellationException.class)
             .hasMessage("fan-out cancelled");
-        assertThat(taskInterrupted.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(taskInterrupted.await(5, TimeUnit.SECONDS)).isTrue();
       } finally {
         allowTaskCompletion.countDown();
       }


### PR DESCRIPTION
## Summary

Increase the BoundedFanout cancellation test coordination waits from 1 second to 5 seconds. The failed assertion only showed that a task had not been scheduled within one second on a loaded CI runner; cancellation had not started yet.

## Testing

- Targeted BoundedFanoutTest cancellation method passed with upstream modules built.
- No integration or smoke tests were run.