### PR TITLE
Ali vending cred

### DIFF
--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
@@ -77,6 +77,15 @@ public class ServerSideStorageConfigResolver {
   private static final Metadata.Key<String> CORRELATION_ID =
       Metadata.Key.of("x-correlation-id", Metadata.ASCII_STRING_MARSHALLER);
 
+  /**
+   * Iceberg REST access-delegation header, as it appears in connector properties.
+   *
+   * <p>Set on a connector with {@code --props header.X-Iceberg-Access-Delegation=vended-credentials}.
+   * Read here rather than from the derived catalog properties because this runs before the connector
+   * factory builds them; {@code IcebergConnectorFactory} reads the same key downstream.
+   */
+  private static final String ICEBERG_ACCESS_DELEGATION_PROP = "header.X-Iceberg-Access-Delegation";
+
   private final Optional<String> headerName;
 
   @GrpcClient("floecat")
@@ -253,6 +262,19 @@ public class ServerSideStorageConfigResolver {
       Connector connector,
       ConnectorConfig config,
       boolean refreshableExecutionCredentials) {
+    // A catalog that vends its own credentials needs no storage authority: loadTable returns
+    // storage-credentials and the catalog client's FileIO uses them. Returning the config untouched
+    // is the same thing the null-locationPrefix branch below already does for non-S3 URIs, which is
+    // how GCS- and Azure-backed connectors run today without an authority -- this makes that
+    // existing path reachable for s3:// when the caller has explicitly asked for delegation.
+    //
+    // Deliberately not a fallback on vending failure: if delegation is declared we never call the
+    // authority service at all, so a missing authority cannot mask a catalog that silently ignored
+    // the header. The failure then surfaces from the catalog or the read itself.
+    if (isNonBlank(config.options().get(ICEBERG_ACCESS_DELEGATION_PROP))) {
+      return config;
+    }
+
     String locationPrefix = storageAuthorityLookupLocation(storageLocation, config);
     if (locationPrefix == null) {
       return config;

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
@@ -80,9 +80,10 @@ public class ServerSideStorageConfigResolver {
   /**
    * Iceberg REST access-delegation header, as it appears in connector properties.
    *
-   * <p>Set on a connector with {@code --props header.X-Iceberg-Access-Delegation=vended-credentials}.
-   * Read here rather than from the derived catalog properties because this runs before the connector
-   * factory builds them; {@code IcebergConnectorFactory} reads the same key downstream.
+   * <p>Set on a connector with {@code --props
+   * header.X-Iceberg-Access-Delegation=vended-credentials}. Read here rather than from the derived
+   * catalog properties because this runs before the connector factory builds them; {@code
+   * IcebergConnectorFactory} reads the same key downstream.
    */
   private static final String ICEBERG_ACCESS_DELEGATION_PROP = "header.X-Iceberg-Access-Delegation";
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
@@ -404,8 +404,7 @@ class ServerSideStorageConfigResolverTest {
         new ServerSideStorageConfigResolver(java.util.Optional.empty(), java.util.Optional.empty());
     resolver.storageAuthorities = mock(StorageAuthoritiesGrpc.StorageAuthoritiesBlockingStub.class);
 
-    ConnectorConfig resolved =
-        resolveWithStorageLocation(resolver, config).config();
+    ConnectorConfig resolved = resolveWithStorageLocation(resolver, config).config();
 
     verify(resolver.storageAuthorities, never()).vendStorageCredentials(any());
     assertEquals(config.options(), resolved.options());

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
@@ -391,6 +391,90 @@ class ServerSideStorageConfigResolverTest {
             java.util.Optional.empty(), config));
   }
 
+  /**
+   * A connector whose catalog vends its own credentials must not consult the storage authority
+   * service at all. Note the storage location IS present here -- without the delegation property
+   * this exact call vends (see the companion test below), so this asserts the property is what
+   * short-circuits it, not a missing location hint.
+   */
+  @Test
+  void delegatingRestConnectorSkipsStorageAuthorityVending() {
+    ConnectorConfig config = delegationTestConfig(true);
+    ServerSideStorageConfigResolver resolver =
+        new ServerSideStorageConfigResolver(java.util.Optional.empty(), java.util.Optional.empty());
+    resolver.storageAuthorities = mock(StorageAuthoritiesGrpc.StorageAuthoritiesBlockingStub.class);
+
+    ConnectorConfig resolved =
+        resolveWithStorageLocation(resolver, config).config();
+
+    verify(resolver.storageAuthorities, never()).vendStorageCredentials(any());
+    assertEquals(config.options(), resolved.options());
+  }
+
+  /**
+   * Guards the change above from being read as a blanket disable: the same connector without the
+   * delegation property still vends. If this ever stops failing when the property check is removed,
+   * the test above is proving nothing.
+   */
+  @Test
+  void nonDelegatingRestConnectorStillVendsStorageCredentials() {
+    ConnectorConfig config = delegationTestConfig(false);
+    ServerSideStorageConfigResolver resolver =
+        new ServerSideStorageConfigResolver(java.util.Optional.empty(), java.util.Optional.empty());
+    resolver.storageAuthorities = mock(StorageAuthoritiesGrpc.StorageAuthoritiesBlockingStub.class);
+    when(resolver.storageAuthorities.withInterceptors(any()))
+        .thenReturn(resolver.storageAuthorities);
+    when(resolver.storageAuthorities.vendStorageCredentials(any()))
+        .thenReturn(
+            ResolveStorageAuthorityResponse.newBuilder()
+                .addStorageCredentials(
+                    VendedStorageCredential.newBuilder()
+                        .setPrefix("s3://8c554103--table-s3/")
+                        .putConfig("s3.access-key-id", "vended-access")
+                        .putConfig("s3.secret-access-key", "vended-secret"))
+                .build());
+
+    resolveWithStorageLocation(resolver, config);
+
+    verify(resolver.storageAuthorities, times(1)).vendStorageCredentials(any());
+  }
+
+  private static ConnectorConfig delegationTestConfig(boolean withDelegation) {
+    var options = new java.util.LinkedHashMap<String, String>();
+    options.put("iceberg.source", "rest");
+    options.put("warehouse", "arn:aws:s3tables:us-east-1:000000000000:bucket/bench");
+    if (withDelegation) {
+      options.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
+    }
+    return new ConnectorConfig(
+        ConnectorConfig.Kind.ICEBERG,
+        "s3tables",
+        "https://s3tables.us-east-1.amazonaws.com/iceberg",
+        java.util.Map.copyOf(options),
+        new ConnectorConfig.Auth("aws-sigv4", Map.of(), Map.of()));
+  }
+
+  private static ServerSideStorageConfigResolver.ResolvedConnectorConfig resolveWithStorageLocation(
+      ServerSideStorageConfigResolver resolver, ConnectorConfig config) {
+    Connector connector =
+        Connector.newBuilder()
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setResourceId(
+                ResourceId.newBuilder()
+                    .setAccountId("acct")
+                    .setId("conn")
+                    .setKind(ResourceKind.RK_CONNECTOR))
+            .build();
+    return resolver.resolveManagedWithAuthorization(
+        java.util.Optional.empty(),
+        java.util.Optional.empty(),
+        java.util.Optional.empty(),
+        java.util.Optional.of("s3://8c554103--table-s3/data/f.parquet"),
+        java.util.Optional.empty(),
+        connector,
+        config);
+  }
+
   @Test
   void mergeResolvedStorageConfigAddsServerSideSecretsAndClientSafeProps() {
     ResolveStorageAuthorityResponse response =


### PR DESCRIPTION
## Summary

Describe what this PR changes and why.

## Type of Change

- [ ] feat (new functionality)
- [X ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [ X] `make fmt`
- [ ] `make verify`
- [X ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [ ] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

**The unproven half — please read before approving.** `PLAN_TABLE` runs in Java
against the Iceberg REST client, so delegated credentials should reach its
FileIO. `EXEC_FILE_GROUP` runs on the Rust remote worker, which cannot use a Java
FileIO and needs credentials handed to it explicitly. Skipping vending means the
config carries the connector's own credentials rather than authority-derived
ones, and whether that satisfies the worker is **untested**.

So this may fix metadata planning and still fail at capture, in which case it is
the first piece of a larger change rather than the whole fix. Anyone who knows
the worker's credential path can likely answer that in a minute; testing it takes
a preview image and a catalog that vends.

**Testing needs a catalog that actually vends.** Polaris supports the header, but
its `root` principal lacks `LOAD_TABLE_WITH_READ_DELEGATION`, so delegated
`loadTable` returns 403 until that is granted. S3 Tables may not honour the
header at all — a failure there would not distinguish this change being wrong
from AWS declining to vend. Neither is set up today, which is why this is
unproven rather than tested-and-working.

**Open question for reviewers: skip or fallback?** As written, declaring the
property means the authority service is never consulted. A fallback — try the
authority, use delegation only when none exists — would be safer for existing
connectors but would mask a catalog that silently ignores the header, surfacing
as an unexplained read failure well downstream. I preferred the loud version;
happy to change it.

**Why it matters.** Today every external catalog needs a role in the target
account, a trust policy naming FloeCat, and a matching `sts:AssumeRole` grant in
`module.irsa_floecat` — a stack shared with production. That makes onboarding a
tenant a production IAM change. If the catalog vends, it becomes a connector row.

It also removes the `--location-prefix` scaling problem for catalogs that vend.
S3 Tables gives each table its own generated `<uuid>--table-s3` bucket, so
authorities are per-table with names that cannot be known in advance; the current
workaround is a catch-all authority on `s3://`, which then becomes the fallback
for every unmatched path in the deployment.

**Context.** Found while validating FloeCat against Polaris, S3 Tables, Glue and
Glue+LakeFormation. Cross-account S3 Tables now works end to end in prod via the
storage-authority path (TPC-H SF10, 8 tables, 86,586,082 rows), so this is not
blocking that work — it is about what onboarding costs per customer.



