### PR TITLE
docs(integrations): finalize catalog integration design (stack 1/10)

### DIFF
--- a/docs/_snippets/docs-by-area.md
+++ b/docs/_snippets/docs-by-area.md
@@ -1,4 +1,4 @@
 - **Core platform**: architecture, service, caching, metadata graph, reconciler
-- **Integrations**: connectors (Iceberg, Delta), Arrow Flight, client CLI
+- **Integrations**: [catalog integration design](catalog-integration-design.md), connectors (Iceberg, Delta), Arrow Flight, client CLI
 - **Storage and security**: storage backends, secrets manager, external authentication
 - **Operations and observability**: operations, telemetry, troubleshooting

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -5,7 +5,7 @@ implemented in the current PR stack.
 
 This document records both the target architecture and the boundary of each stacked change. It is
 aligned with the Catalog Integration and Catalog Overlay SQL specification. It distinguishes code
-already present below this change, code in the following PR, and work that remains deferred.
+implemented in the following stacked changes from work that remains deferred.
 
 ## Stack implementation map
 
@@ -13,7 +13,7 @@ already present below this change, code in the following PR, and work that remai
 | --- | --- | --- |
 | #424, Catalog Integration and Overlay APIs | CRUD resources, typed authentication, write-only credential storage and rotation, shared SQL catalog-name reservation, idempotency, optimistic concurrency, dependencies, cascade deletion, and atomic persistence primitives | Upstream connectivity, provider discovery, validation RPCs, capture, reconciliation, and query visibility |
 | #425, Shell CLI | Integration and Overlay CRUD commands, typed authentication input, write-only credential input, authentication rotation, pagination, name resolution, namespace filters, cascade, and etag preconditions | Connectivity validation, discovery, capture, reconciliation, and query visibility |
-| #439, this document | Architecture decisions and delivery boundaries | Production behavior |
+| #446, this document | Architecture decisions and delivery boundaries | Production behavior |
 | #440, catalog-access SPI | Connector-independent catalog client SPI plus an Iceberg REST provider with validation, discovery, table loading, OAuth2, SigV4, and renewable AWS credential support | Wiring Catalog Integration resources to the SPI, Integration validation/listing RPCs, persistence, scheduling, and capture |
 
 ## Goals
@@ -231,8 +231,8 @@ or authentication combinations must fail explicitly.
    idempotency, dependency, cascade, and cleanup primitives.
 2. **Complete — #425:** CLI coverage for those APIs, including typed authentication and write-only
    credential input for create and rotation commands.
-3. **This change — #439:** keep the architecture and delivery record aligned with implemented code.
-4. **Implemented in the following PR — #440:** neutral catalog-access SPI and Iceberg REST vertical
+3. **This change — #446:** keep the architecture and delivery record aligned with implemented code.
+4. **Implemented later in the stack — #440:** neutral catalog-access SPI and Iceberg REST vertical
    slice.
 5. **Next:** Integration-to-SPI adapter and SQL-required validation/discovery RPCs.
 6. **Later:** canonical capture/bindings, scheduling, query visibility, garbage collection,

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -1,0 +1,245 @@
+# Catalog Integration Architecture Decisions
+
+Status: accepted for implementation after the inert Integration and Overlay CRUD foundation.
+
+This document defines the target architecture for catalog integrations. It is intentionally a
+design boundary: it fixes resource ownership, namespace mapping, capture identity, scheduling, and
+lifecycle semantics before those behaviors are added to the production APIs.
+
+## Goals
+
+The catalog integration model will provide a simpler way to:
+
+- authenticate Floecat to an upstream catalog;
+- map upstream catalog namespaces into SQL-visible Floecat catalogs and namespaces;
+- define freshness and retention requirements; and
+- capture external metadata once while exposing it through one or more overlays.
+
+The new path does not use, wrap, synthesize, or fall back to Connector resources. Connectors remain
+a separate legacy path during migration and will eventually be deprecated.
+
+## Resource and ownership model
+
+The target model has three distinct layers:
+
+```text
+CatalogIntegration                 connection, authentication, canonical upstream identity
+ ├── captured namespace/table      shared metadata, snapshots, file groups, and statistics
+ ├── CatalogOverlay                mappings, visibility, and freshness demand
+ │    └── existing Catalog         SQL-visible placement; not owned by the overlay
+ └── CatalogOverlay
+      └── existing Catalog
+```
+
+### Catalog integration
+
+`CatalogIntegration` owns the upstream catalog protocol, endpoint, authentication configuration,
+credential lifecycle, and canonical identity of captured external objects. Its immutable resource
+ID is used by capture and reconciliation; display names are never operational identity.
+
+The integration type identifies a catalog protocol or provider, such as Iceberg REST, Unity
+Catalog, or AWS Glue. It does not identify the table format. A provider can expose more than one
+table format, and format-specific behavior belongs to the discovered table metadata and catalog
+client capabilities.
+
+Secret values are stored outside the integration protobuf. Reads expose only the configured
+authentication scheme, non-secret options, whether credentials are configured, and a credential
+generation. Credential writes use a dedicated request that never returns secret material.
+
+### Catalog overlay
+
+`CatalogOverlay` is a non-owning, read-only projection of one integration into one existing
+Floecat `Catalog`. It owns namespace mappings, visibility state, and refresh/retention demand. It
+does not create, rename, empty, lock, or delete its target catalog.
+
+Initially, at most one overlay may target a catalog. This keeps name resolution and collision
+reporting deterministic while still allowing several catalogs to expose different projections of
+the same integration. Supporting overlay composition within one catalog requires a separate design
+decision.
+
+The target catalog remains a normal catalog. Users may create local namespaces and views in it,
+and views may reference overlay-bound tables. Captured namespaces and relations are read-only.
+Local and overlay objects never shadow one another: an exposed-name collision prevents that binding
+from becoming visible and puts the overlay into a degraded condition until the conflict is fixed.
+
+## Namespace selection and mapping
+
+The current include/exclude paths are sufficient for inert CRUD but not for the target product.
+The behavioral contract replaces them with explicit source-to-target prefix mappings:
+
+```proto
+message NamespaceMapping {
+  NamespacePath source_prefix = 1;
+  NamespacePath target_prefix = 2;
+  bool recursive = 3;
+}
+
+message CatalogOverlaySpec {
+  ResourceId integration_id = 3;
+  ResourceId catalog_id = 4;
+  repeated NamespaceMapping namespace_mappings = 5;
+  repeated NamespacePath exclude_namespaces = 6;
+  CatalogOverlayState state = 7;
+  CatalogOverlayPolicy policy = 8;
+}
+```
+
+The protobuf above is illustrative. The inert CRUD field numbers remain contiguous; numbering for
+new fields and request separation are finalized when the contract is implemented. The semantics
+are fixed:
+
+- Paths are ordered from catalog root to namespace leaf, trimmed, and matched case-sensitively.
+- A recursive mapping maps every descendant by appending its suffix to `target_prefix`.
+- A non-recursive mapping exposes only the exact source namespace.
+- Exclusions are expressed in upstream namespace space and take precedence over mappings.
+- Newly discovered namespaces that match an active mapping become visible automatically.
+- Empty source or target prefixes represent the corresponding catalog root.
+- Source mappings within one overlay may not overlap. Target prefixes may not overlap. Rejecting
+  ambiguity is preferable to order-dependent precedence.
+- Two overlays may expose the same canonical table under different catalogs or names without
+  duplicating captured metadata.
+
+For example, mapping `production.sales` to `sales` recursively exposes
+`production.sales.orders` as `sales.orders`. An exclusion for
+`production.sales.private` suppresses that namespace and all descendants.
+
+## Shared captured metadata
+
+External metadata is captured once per integration and is not stored as catalog-owned table copies.
+A canonical captured object key consists of:
+
+```text
+(account_id, integration_id, object_kind, upstream_object_id)
+```
+
+Provider-stable object IDs are preferred. When a provider has no stable ID, the normalized full
+upstream path is the fallback identity and an upstream rename is observed as delete plus create.
+Display names and overlay mappings are never part of canonical identity.
+
+Canonical tables own their schemas, snapshots, manifests, file groups, and statistics. An overlay
+binding is lightweight state that associates a canonical object with an exposed catalog/namespace
+path. Its identity includes the overlay ID, canonical object ID, and exposed path. Query resolution
+returns the canonical table identity plus the binding through which it was resolved, so several
+names can safely share one captured object and one set of statistics.
+
+This requires an explicit replacement for the current connector-rooted `UpstreamRef`; adding an
+integration ID beside a connector ID would create two competing identities. The integration path
+will use a new canonical external-object reference. Connector-backed tables retain their existing
+reference until the explicit migration phase.
+
+## Catalog access boundary
+
+Catalog connectivity is extracted behind a neutral library before integration-driven capture is
+implemented. The boundary uses catalog concepts rather than Connector RPC concepts. Its expected
+shape is:
+
+```text
+CatalogConnectionConfig
+CatalogAuthentication
+ResolvedCatalogCredentials
+CatalogClient
+CatalogClientProvider
+CatalogClientFactory
+CatalogCapabilities
+```
+
+No type in this boundary imports Connector protobufs or carries a Connector resource ID. The first
+vertical slice is Iceberg REST. The existing Iceberg Connector may delegate catalog access to this
+library during transition, but Integration code never delegates to a Connector resource or service.
+Unity Catalog and Glue support follow as separate provider implementations.
+
+The client boundary covers connection validation, namespace and relation enumeration, stable
+identity lookup, and provider metadata access. Capture planning, scheduling, Floecat persistence,
+overlay binding, and query resolution remain outside the catalog client.
+
+## Refresh and reconciliation ownership
+
+Overlays state user-facing freshness and retention requirements; integrations own upstream work.
+For all active overlays on an active integration, the scheduler computes one effective capture
+plan:
+
+- capture scope is the union of namespaces selected by active overlays;
+- refresh interval is the shortest requested interval;
+- retained history is sufficient for the longest requested retention; and
+- pausing an overlay removes its visibility and policy demand, while pausing an integration stops
+  all new upstream work for it.
+
+Changing connection configuration or credentials advances an integration configuration generation.
+Changing mappings, policy, or overlay state advances the effective capture-plan generation. Every
+planned and leased job carries both generations. Publishing captured data or bindings is conditional
+on those generations still being current. A stale job may finish external I/O, but it cannot publish
+results or repopulate a changed or deleted overlay.
+
+Reconciliation jobs and deduplication keys use integration and canonical external-object identity.
+There is no Connector fallback if an integration provider is unavailable or unsupported; the
+integration reports an actionable validation or reconciliation error.
+
+## Lifecycle and garbage collection
+
+Lifecycle operations have the following effects:
+
+| Operation | Required behavior |
+| --- | --- |
+| Pause overlay | Hide its bindings and remove its policy demand; retain shared captures. |
+| Delete overlay | Fence its jobs, remove bindings and policy demand, and leave its catalog untouched. |
+| Drop target catalog | Reject while an overlay references it unless an explicit cascade removes the overlay first. |
+| Pause integration | Stop new work and fence publication from work planned before the pause. |
+| Rotate credentials | Atomically advance the credential/configuration generation; never expose the old or new secret. |
+| Delete integration | Reject while overlays exist unless explicit cascade was requested. |
+| Cascade integration delete | Delete overlays, cancel/fence jobs, delete credentials, then make unreferenced captures GC-eligible. |
+
+Captured metadata becomes eligible for garbage collection only when no active or retained overlay
+binding references it, no query pin protects it, no in-flight current-generation job can publish to
+it, and the configured retention grace period has elapsed. Deleting an overlay never immediately
+deletes shared snapshots or statistics used by another overlay.
+
+## Proposed API evolution
+
+The inert CRUD resources remain the foundation. Behavioral implementation evolves them with:
+
+1. A typed, integration-owned catalog connection and authentication contract, dedicated credential
+   mutation, validation/capabilities RPCs, and credential generations.
+2. Namespace mappings and overlay refresh/retention policy, replacing selection-only filters.
+3. Canonical captured-resource and overlay-binding contracts independent of Connector protos.
+4. Configuration and capture-plan generations used by every reconciliation job and publish step.
+5. Explicit cascade requests, dependency reporting, job fencing, credential cleanup, and retained
+   metadata garbage collection.
+
+Because backwards compatibility is not a project requirement at this stage, fields should be
+replaced where the semantics differ rather than preserving aliases or hidden fallback behavior.
+
+## Legacy Connector disposition
+
+Connectors remain operational as a separate legacy API while the new path is built. This is a
+temporary coexistence decision, not a compatibility layer:
+
+- Integration and Overlay services do not create or read Connector resources.
+- Integration validation and reconciliation do not call Connector RPCs.
+- New integration contracts and neutral catalog-access types do not import Connector protos.
+- Existing Connector-backed tables and jobs continue to work unchanged until an explicit migration.
+- Migration maps connectivity and authentication to integrations and placement/filtering to
+  overlays, then retires Connector APIs and persisted state in a separately reviewed change.
+
+There is deliberately no runtime fallback from an Integration to a Connector. Silent fallback would
+make ownership, credentials, scheduling, and failure semantics impossible to reason about.
+
+## Implementation sequence
+
+The next changes should retain clear review boundaries:
+
+1. Introduce the neutral catalog-access SPI and an Iceberg REST implementation; adapt the legacy
+   Iceberg Connector to use it internally.
+2. Add integration authentication, secret persistence, credential rotation, capability discovery,
+   validation, and their CLI surface. Do not schedule reconciliation yet.
+3. Add integration-scoped canonical capture identity and lightweight overlay bindings, including
+   collision and name-resolution tests.
+4. Move scheduling and job identity to integrations with generation fencing. Do not add Connector
+   fallback.
+5. Complete query visibility, cascade lifecycle, garbage collection, migration, and finally
+   Connector deprecation/removal in separate changes.
+
+The Integration/Overlay CLI currently resolves display names by listing the corresponding resource
+type, so its integration and overlay helpers contain similar pagination and ambiguity handling.
+That duplication is small and isolated. It should remain in the inert CLI change rather than
+expanding the earlier API PR. A generic resource resolver is worthwhile only when the Directory API
+supports these resource kinds or another CLI resource needs the same behavior.

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -40,6 +40,7 @@ hierarchy, a second table identity, or a second name-resolution path.
 | Catalog Overlay API | Overlay CRUD, overlay-owned catalog lifecycle, namespace selection, dependencies, cascade deletion, idempotency, and optimistic concurrency | Capture, reconciliation, and query visibility |
 | Shell CLI | Integration and Overlay CRUD commands, typed authentication input, write-only credential input, authentication rotation, pagination, name resolution, namespace filters, cascade, and etag preconditions | Connectivity validation, discovery, capture, reconciliation, and query visibility |
 | Catalog-access SPI | Connector-independent catalog client SPI plus an Iceberg REST provider with validation, discovery, table and view loading, OAuth2, SigV4, and renewable AWS credential support | Wiring Catalog Integration resources to the SPI, Integration validation/listing RPCs, persistence, scheduling, and capture |
+| Integration validation and discovery | Wire persisted Integration credentials to the SPI; validate catalog authentication, credential vending, and storage access; lazily list upstream namespaces, tables, and views | Persistence of discovery results, Overlay reconciliation, scheduling, and capture |
 | Overlay metadata reconciliation | A synchronous Overlay RPC wires persisted Integration credentials to the SPI and materializes selected namespaces, table definitions, and views with generation fencing and explicit lifecycle cleanup | Durable scheduling, snapshot/file capture, validation, and statistics |
 
 ## Goals
@@ -249,8 +250,9 @@ The service adapter translates OAuth client credentials, bearer tokens, and expl
 SigV4 credentials from the Integration protobuf and `CatalogIntegrationCredentialStore` onto the
 SPI's authentication schemes. Ambient and assume-role AWS resolution are not yet wired into this
 adapter and fail explicitly. Integration authentication is required, so the adapter never selects
-the SPI's `NONE` scheme. Dedicated Integration validation/listing RPCs and scheduling remain
-deferred; synchronous Overlay reconciliation performs validation and discovery internally.
+the SPI's `NONE` scheme. Dedicated Integration RPCs validate the catalog and storage credential
+boundaries and provide paginated, read-only upstream namespace and object listing. Scheduling
+remains deferred.
 
 The catalog client owns external I/O only. Capture planning, Floecat persistence, scheduling, and
 name resolution remain outside it.
@@ -445,12 +447,11 @@ on an overlay, and the type and URI on an integration.
 
 After the initial delivery, follow-on changes will:
 
-1. Wire Integration resources and the typed credential resolver to the catalog-access SPI and add
-   synchronous, generation-fenced Overlay metadata reconciliation. This is the first follow-on and
-   materializes namespaces, table definitions, and views, but not snapshots or files.
-2. Add validation, capability, namespace-listing, and object-listing RPCs. Validation exercises both
+1. Add validation, capability, namespace-listing, and object-listing RPCs. Validation exercises both
    catalog authentication and usable storage-credential vending; object listing distinguishes
    namespaces, tables, and views.
+2. Add synchronous, generation-fenced Overlay metadata reconciliation. This materializes namespaces,
+   table definitions, and views, but not snapshots or files.
 3. Extend the durable reconciler with Integration/Overlay-rooted jobs and capture `Snapshot`, file,
    validation, and statistics state beneath the already materialized tables.
 4. Add overlay policy and state, table validation-error persistence, visibility and override

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -1,93 +1,131 @@
 # Catalog Integration Architecture and Delivery Plan
 
-Status: accepted; the resource, authentication, CLI, and first catalog-access layers are
-implemented in the current PR stack.
+Status: proposed architecture and delivery plan for Catalog Integration.
 
-This document records both the target architecture and the boundary of each stacked change. It is
-aligned with the Catalog Integration and Catalog Overlay SQL specification. It distinguishes code
-implemented in the following stacked changes from work that remains deferred.
+This document defines the target architecture and planned boundary of each delivery phase. It is
+aligned with the Catalog Integration and Catalog Overlay SQL specification. It separates the
+initial delivery scope from work that remains deferred.
 
-## Stack implementation map
+## Planned delivery boundaries
 
-| Change | Implemented boundary | Explicitly not implemented |
+| Change | Planned boundary | Explicitly deferred |
 | --- | --- | --- |
-| #424, Catalog Integration and Overlay APIs | CRUD resources, typed authentication, write-only credential storage and rotation, shared SQL catalog-name reservation, idempotency, optimistic concurrency, dependencies, cascade deletion, and atomic persistence primitives | Upstream connectivity, provider discovery, validation RPCs, capture, reconciliation, and query visibility |
-| #425, Shell CLI | Integration and Overlay CRUD commands, typed authentication input, write-only credential input, authentication rotation, pagination, name resolution, namespace filters, cascade, and etag preconditions | Connectivity validation, discovery, capture, reconciliation, and query visibility |
-| #446, this document | Architecture decisions and delivery boundaries | Production behavior |
-| #440, catalog-access SPI | Connector-independent catalog client SPI plus an Iceberg REST provider with validation, discovery, table loading, OAuth2, SigV4, and renewable AWS credential support | Wiring Catalog Integration resources to the SPI, Integration validation/listing RPCs, persistence, scheduling, and capture |
+| This document | Architecture decisions and delivery boundaries | Production behavior |
+| Catalog Integration and Overlay APIs | CRUD resources, typed authentication, write-only credential storage and rotation, shared SQL catalog-name reservation, idempotency, optimistic concurrency, dependencies, cascade deletion, and atomic persistence primitives | Upstream connectivity, provider discovery, validation RPCs, capture, reconciliation, and query visibility |
+| Shell CLI | Integration and Overlay CRUD commands, typed authentication input, write-only credential input, authentication rotation, pagination, name resolution, namespace filters, cascade, and etag preconditions | Connectivity validation, discovery, capture, reconciliation, and query visibility |
+| Catalog-access SPI | Connector-independent catalog client SPI plus an Iceberg REST provider with validation, discovery, table and view loading, OAuth2, SigV4, and renewable AWS credential support | Wiring Catalog Integration resources to the SPI, Integration validation/listing RPCs, persistence, scheduling, and capture |
 
 ## Goals
 
-The catalog integration model provides a SQL-compatible way to:
+The catalog integration model will provide a SQL-compatible way to:
 
 - authenticate Floecat to an upstream catalog;
 - select upstream namespaces beneath a read-only SQL catalog name;
-- discover and validate upstream objects without depending on Connector resources; and
+- discover and validate upstream namespaces, tables, and views without depending on Connector
+  resources; and
 - eventually capture external metadata once while exposing it through one or more overlays.
 
-The Integration path does not use, wrap, synthesize, or fall back to Connector resources.
-Connectors currently remain a separate operational path and are retired through an explicit later
-migration, not through runtime fallback.
+The Integration path will not use, wrap, synthesize, or fall back to Connector resources.
+Connectors will remain a separate operational path until they are retired through an explicit
+later migration, not through runtime fallback.
 
 ## Resource and ownership model
 
 ```text
 CatalogIntegration                 connection and authentication
- ├── captured namespace/table      future shared metadata and statistics
+ ├── captured namespace/table/view future shared metadata and statistics
  ├── CatalogOverlay "sales"        top-level SQL catalog and namespace selection
  └── CatalogOverlay "finance"      another projection of the same integration
 ```
 
 ### Catalog integration
 
-`CatalogIntegration` owns the upstream protocol, HTTP(S) endpoint, non-secret authentication
+`CatalogIntegration` will own the upstream protocol, HTTP(S) endpoint, non-secret authentication
 configuration, credential lifecycle, and eventually the canonical identity of captured external
 objects. Its immutable resource ID is operational identity; its display name is mutable SQL-facing
 metadata.
 
-The API currently supports Iceberg REST and Unity integration types. Authentication is required and
-is represented by typed protobuf messages for OAuth client credentials, bearer tokens, AWS assume
-role, AWS access keys, and AWS SigV4. Unity currently accepts only OAuth client credentials or
-bearer authentication. The base service validates structural compatibility; endpoint/provider
-support is intentionally left to the catalog-access adapter and provider.
+The API will initially support Iceberg REST and Unity integration types. Authentication will be
+required and represented by typed protobuf messages for OAuth client credentials, bearer tokens,
+AWS assume role, AWS access keys, and AWS SigV4. Unity will initially accept only OAuth client
+credentials or bearer authentication. The base service will validate structural compatibility;
+endpoint/provider support will remain the responsibility of the catalog-access adapter and
+provider.
 
-Type and catalog URI are immutable through update. `CREATE OR REPLACE` creates a new resource
-identity. It is rejected while overlays depend on the existing integration because replacement
-must not silently retarget those overlays.
+Type and catalog URI will be immutable through update. `CREATE OR REPLACE` will create a new
+resource identity. It will be rejected while overlays depend on the existing integration because
+replacement must not silently retarget those overlays.
+
+Integration type identifies the catalog access protocol; it does not define the format of every
+table in that catalog. As in the existing Connector path, the catalog-access provider will determine
+each table's `TableFormat`. Capture will persist that value on the table protobuf at
+`Table.upstream.format`. Table format therefore remains table-owned metadata and will not be stored
+or inferred as an Integration-wide property.
 
 ### Authentication and credentials
 
-Persisted resources contain only non-secret authentication configuration,
-`credentials_configured`, and a server-managed credential generation. Secret values are supplied
-on create or through the dedicated authentication-update RPC and are never returned.
+Persisted resources will contain only non-secret authentication configuration,
+`credentials_configured`, and a server-managed credential generation. Secret values will be
+supplied on create or through the dedicated authentication-update RPC and will never be returned.
 
-The service derives its internal secret key from integration ID and credential generation. No
-secret-manager reference is exposed in the public resource. `CatalogIntegrationCredentialStore`
-provides the typed service-side resolution primitive required by a later catalog-access adapter.
+The service will derive its internal secret key from integration ID and credential generation. No
+secret-manager reference will be exposed in the public resource.
+`CatalogIntegrationCredentialStore` will provide the typed service-side resolution primitive
+required by a later catalog-access adapter.
 
-Credential publication has these guarantees:
+Credential publication must provide these guarantees:
 
-- a new immutable generation is reserved with atomic `putIfAbsent` before the resource CAS;
-- the old generation is retired only after the new resource generation is published;
-- a definite publication failure removes the prepared secret;
-- an acknowledgement-uncertain publication retains the secret because the resource CAS may have
+- reserve a new immutable generation with atomic `putIfAbsent` before the resource CAS;
+- retire the old generation only after the new resource generation is published;
+- remove the prepared secret after a definite publication failure;
+- retain the secret after an acknowledgement-uncertain publication because the resource CAS may have
   succeeded; and
-- idempotent create may carry credentials, excludes secret bytes from its fingerprint, and returns
+- permit credentials on idempotent create, exclude secret bytes from its fingerprint, and return
   the first successfully published value for that key.
 
-Reclamation of retained, unreachable credential generations is not implemented in this stack. A
-later orphan-reclamation PR will add that mechanism; this document does not claim it exists today.
+Reclamation of retained, unreachable credential generations is deferred to a later
+orphan-reclamation phase.
+
+### Vended storage credentials
+
+Integration authentication and vended storage credentials serve different boundaries. Integration
+authentication authorizes Floecat to call the catalog API. The catalog then vends short-lived,
+storage-scoped credentials that authorize reads of the table metadata and data files referenced by
+that catalog.
+
+Credential vending is a required Catalog Integration contract, not an optional optimization. The
+catalog-access provider will request vended credentials through the provider protocol and use them
+for object-storage access. It must not fall back to Connector credentials, ambient service
+credentials, or the credentials used to authenticate to the catalog API. Vended credentials may be
+scoped to a table, path, or operation and must be reacquired or renewed according to their expiry.
+They are process-local runtime material: they will not be written to the Integration resource,
+`CatalogIntegrationCredentialStore`, table protobufs, logs, or persisted catalog-client
+configuration.
+
+Integration validation will test the two credential boundaries independently. It will verify that
+the catalog endpoint is reachable and accepts the configured Integration authentication, then use a
+provider-specific, non-mutating operation to obtain vended credentials and prove they can access
+the referenced object storage. A validation result must not report `OK` when vending was skipped or
+could not be verified. Authentication, vending, expiry, scope, and storage-access failures will be
+reported as separate `ERROR` rows through the SQL validation contract.
 
 ### Catalog overlay
 
-`CatalogOverlay` is the read-only top-level SQL catalog backed by one integration. It does not point
-to, create, mutate, empty, or delete a separate Floecat `Catalog` resource. Its display name is the
-SQL catalog name.
+`CatalogOverlay` will be the read-only top-level SQL catalog backed by one integration. It will not
+point to, create, mutate, empty, or delete a separate Floecat `Catalog` resource. Its display name
+will be the SQL catalog name.
 
-Catalog and CatalogOverlay create, rename, replacement, and delete operations use one shared
-account-level name reservation, so they cannot expose the same top-level SQL name. An overlay keeps
-an immutable integration binding through update. Replacement may choose a different binding
+Catalog and CatalogOverlay create, rename, replacement, and delete operations will use one shared
+account-level name reservation, so they cannot expose the same top-level SQL name. An overlay will
+keep an immutable integration binding through update. Replacement may choose a different binding
 because it creates a new overlay identity.
+
+The SQL mutation surface is deliberately narrower than the administrative API. SQL
+`ALTER CATALOG OVERLAY` will only rename an existing overlay; it will not change the Integration
+binding or the included and excluded namespace paths. SQL will change either the binding or
+namespace selection through `CREATE OR REPLACE CATALOG OVERLAY`, which atomically publishes a new
+overlay identity under the SQL catalog name. Replacement will retire the old overlay's bindings and
+capture demand and establish them from the replacement definition.
 
 ## Namespace selection
 
@@ -103,12 +141,15 @@ for a separate prefix-remapping contract.
   discovery is wired to overlays.
 - Several overlays may select the same upstream object without requiring duplicate capture.
 
-The current API and CLI implement storage and mutation of these selections. They do not yet make
-the selected namespaces query-visible.
+The API and CLI layers will store and may update these selections directly. That administrative
+update capability will not be mapped to SQL `ALTER CATALOG OVERLAY`; SQL clients must use
+`CREATE OR REPLACE` for filter changes. The initial delivery phases will not make the selected
+namespaces query-visible.
 
 ## Catalog access boundary
 
-PR #440 implements the Connector-independent boundary anticipated by this design:
+The catalog-access SPI phase will introduce the Connector-independent boundary defined by this
+design:
 
 ```text
 CatalogConnectionConfig
@@ -120,37 +161,47 @@ CatalogClientFactory
 CatalogCapabilities
 ```
 
-No SPI type imports Connector protobufs or carries a Connector resource ID. Provider lookup is by
-catalog protocol and fails explicitly for missing or duplicate providers.
+No SPI type will import Connector protobufs or carry a Connector resource ID. Provider lookup will
+be by catalog protocol and will fail explicitly for missing or duplicate providers.
 
-The Iceberg REST provider in #440 implements:
+The Iceberg REST provider will provide:
 
 - connection validation using a namespace-list request;
-- structured namespace and table enumeration;
-- provider-neutral table metadata and stable Iceberg table UUID identity when available;
+- structured namespace, table, and view enumeration;
+- provider-neutral table metadata, including the provider-determined `TableFormat`, and stable
+  upstream table identity when available;
+- provider-neutral view metadata, including output schema, SQL representations and dialects,
+  default namespace/search path, properties, and stable view identity when available;
 - anonymous, OAuth2, and AWS SigV4 client authentication;
-- separate catalog-signing and storage credential scopes; and
+- separate catalog-signing and storage credential scopes;
+- acquisition and renewal of short-lived, provider-vended storage credentials; and
 - renewable, process-local AWS credential registrations with serialized refresh and terminal
   failure handling.
 
-The SPI validates persistable configuration so secrets, credential-provider handles, user-info,
-and secret-bearing headers cannot cross the configuration boundary. Secret values are supplied
-separately through `ResolvedCatalogCredentials`.
+Views are first-class catalog objects in discovery and capture. The Integration path will reuse
+Floecat's existing view semantics and query-resolution behavior rather than introduce a parallel
+external-view abstraction. A provider that advertises view support must support both enumeration
+and loading of a view's metadata. Providers without that capability will return namespaces and
+tables normally and will not advertise view support.
 
-The remaining adapter must translate the Integration protobuf authentication variants and resolved
+The SPI will validate persistable configuration so secrets, credential-provider handles,
+user-info, and secret-bearing headers cannot cross the configuration boundary. Secret values will
+be supplied separately through `ResolvedCatalogCredentials`.
+
+The later adapter must translate the Integration protobuf authentication variants and resolved
 `CatalogIntegrationCredentials` onto the SPI's authentication schemes. Integration authentication
-is currently required, so the adapter need not select the SPI's `NONE` scheme. It must also perform
-provider-specific compatibility checks. #440 does not yet call
+will be required, so the adapter need not select the SPI's `NONE` scheme. It must also perform
+provider-specific compatibility checks. The catalog-access SPI phase will not call
 `CatalogIntegrationCredentialStore`, expose Integration validation/discovery RPCs, or schedule
 work.
 
-The catalog client owns external I/O only. Capture planning, Floecat persistence, overlay binding,
-scheduling, and query resolution remain outside it.
+The catalog client will own external I/O only. Capture planning, Floecat persistence, overlay
+binding, scheduling, and query resolution will remain outside it.
 
 ## Canonical captured metadata
 
-This section is target design, not current implementation. External metadata will be captured once
-per integration rather than copied per overlay. A canonical key is:
+External metadata will be captured once per integration rather than copied per overlay. A
+canonical key will be:
 
 ```text
 (account_id, integration_id, object_kind, upstream_object_id)
@@ -160,18 +211,62 @@ Provider-stable object IDs are preferred. When a provider has no stable ID, the 
 upstream path is an explicitly unstable identity and rename is observed as delete plus create.
 Display names and overlay selection are never part of canonical identity.
 
-Canonical tables will own schemas, snapshots, manifests, file groups, and statistics. A lightweight
-overlay binding will associate a canonical object with its SQL-visible path. This requires a new
-integration-owned external-object reference rather than adding an integration ID to the existing
-Connector-rooted `UpstreamRef`.
+Canonical tables will own their provider-determined format, schemas, snapshots, manifests, file
+groups, and statistics. The capture adapter will carry the format reported by the catalog-access
+provider into `Table.upstream.format`; downstream planning and query paths will continue to read it
+from the table protobuf. Canonical views will own their output schema, SQL definitions and dialects,
+creation search path, properties, and base-relation references. Views will not own table snapshots,
+manifests, file groups, or table statistics.
+
+A lightweight overlay binding will associate a canonical table or view with its SQL-visible path.
+An overlay-bound view will resolve its base relations within that overlay's projection of the same
+integration, using the captured upstream namespace/search-path context. The overlay display name
+will not become part of the canonical view definition or identity, allowing one captured view to be
+exposed through several overlays. This requires a new integration-owned external-object reference
+rather than adding an integration ID to the existing Connector-rooted `UpstreamRef`.
+
+## Table validation and visibility
+
+Creating or replacing an overlay will establish capture demand for the tables selected by its
+namespace rules. The integration-owned scheduler will trigger or join discovery, file scanning,
+table validation, and statistics collection for the effective union of active overlay selections.
+An existing capture may satisfy that demand when it is current for the Integration configuration
+and capture-plan generations; creating another overlay will not duplicate the scan.
+
+A table will not become query-visible through an overlay until its current capture has completed
+validation. Validation will compare each discovered Parquet file with the captured table format and
+metadata. A file that cannot be interpreted consistently with that metadata will produce one
+integration-owned validation-error record containing the Integration identity, canonical table
+identity and display path, `TableFormat`, file path, and error message. The SQL system view
+`sys.catalog_integration_table_error` will expose one row per current file error.
+
+Validation errors and table visibility will follow these rules:
+
+- no current file errors makes the table eligible for every matching active overlay binding;
+- one or more current file errors makes the table ineligible by default through every overlay that
+  references the canonical table;
+- error publication is atomic with the validation generation, so a partially published scan cannot
+  expose a table or mix errors from different generations;
+- a successful later validation atomically retires the previous error set and restores default
+  visibility without requiring overlay recreation; and
+- `DESCRIBE CATALOG INTEGRATION <integration> WITH VALIDATE` will request revalidation in addition
+  to connection, authentication, and credential-vending checks.
+
+The SQL `ALTER TABLE` override defined by the SQL specification will make a table query-visible
+despite current file errors. That override will be stored on the addressed overlay binding, not on
+the shared canonical table, so it will not weaken the default for other overlays. The error rows
+will remain visible while the override is active. Views have no file-validation state; resolving a
+view must still respect the visibility of its base tables and cannot use a view to bypass an
+invalid table's visibility gate.
 
 ## Refresh and reconciliation ownership
 
-This section is also deferred target design. Overlays will state user-facing freshness and
-retention demand; integrations will own upstream work. For active overlays on one integration, the
-scheduler will compute one effective plan:
+This behavior is deferred beyond the initial delivery. Overlays will state user-facing freshness
+and retention demand; integrations will own upstream work. For active overlays on one integration,
+the scheduler will compute one effective plan:
 
-- capture scope is the union of selected namespaces;
+- discovery and capture scope is the union of selected namespaces, including matching tables and
+  views, while file validation and statistics collection apply to the matching tables;
 - refresh interval is the shortest requested interval;
 - retained history satisfies the longest requested retention; and
 - pausing an overlay removes its visibility and demand, while pausing an integration stops all new
@@ -183,29 +278,35 @@ selection, pause, replacement, or deletion changes.
 
 ## Lifecycle and garbage collection
 
-| Operation | Current stack | Later behavior |
+| Operation | Initial delivery behavior | Later behavior |
 | --- | --- | --- |
 | Rename integration or overlay | Atomic rename with optimistic preconditions and shared SQL-name checks for overlays | No additional behavior required |
 | Replace integration | New identity; rejected while dependent overlays exist | Validation may run before publication |
 | Rotate credentials | Atomic new credential generation; old generation retired after publication | Reclaim acknowledgement-uncertain orphan generations |
+| Create or replace overlay | Stores namespace selection and integration dependency | Trigger or join validation and statistics capture; expose only validated tables |
 | Delete overlay | Removes resource pointers and integration dependency atomically | Fence jobs, remove bindings, retain shared captures still in use |
 | Delete integration | Rejected while overlays exist | Fence integration-owned jobs and captured publication |
 | Cascade integration delete | Durable deletion fence, dependent overlay deletion, resource deletion, and credential cleanup | Remove bindings and make unreferenced captures GC-eligible |
 | Delete account | Integration credentials are included in account cleanup | Include future bindings and captures |
 
-Captured metadata GC is not implemented. Future capture data becomes eligible only when no retained
+Captured metadata GC is deferred. Future capture data will become eligible only when no retained
 binding or query pin references it, no current-generation job can publish to it, and its retention
-grace period has elapsed.
+grace period has elapsed. Validation-error records will be retained with their canonical table and
+atomically replaced or removed when a later validation generation is published. They will also be
+removed when the canonical table becomes eligible for collection.
 
-## Remaining API evolution
+## Follow-on API evolution
 
-The lower PRs already provide the SQL-facing CRUD and credential primitives. Remaining changes are:
+After the initial delivery, follow-on changes will:
 
 1. Wire Integration resources and the typed credential resolver to the catalog-access SPI.
 2. Add validation, capability, namespace-listing, and object-listing service RPCs required by the
-   SQL functions.
-3. Add integration-scoped canonical object identity and lightweight overlay bindings.
-4. Add overlay policy/state and integration-owned scheduling with generation fencing.
+   SQL functions. Validation will exercise both catalog authentication and usable storage-credential
+   vending; object listing will distinguish namespaces, tables, and views.
+3. Add integration-scoped canonical object identity, validation-error persistence, and lightweight
+   overlay bindings.
+4. Add overlay policy/state, table visibility and override handling, and integration-owned
+   scheduling with generation fencing.
 5. Add query visibility, retained capture GC, credential orphan reclamation, migration, and
    Connector retirement in separately reviewed changes.
 
@@ -214,30 +315,31 @@ replaced when semantics differ rather than accumulating aliases or hidden fallba
 
 ## Legacy Connector disposition
 
-Connectors currently remain operational as a separate API while the Integration path is completed.
-This is temporary coexistence, not a compatibility layer:
+Connectors will remain operational as a separate API while the Integration path is completed. This
+will be temporary coexistence, not a compatibility layer:
 
-- Integration and Overlay services do not create or read Connector resources.
-- The catalog-access SPI does not import Connector protos or delegate to Connector services.
+- Integration and Overlay services will not create or read Connector resources.
+- The catalog-access SPI will not import Connector protos or delegate to Connector services.
 - Future Integration validation and reconciliation must not call Connector RPCs.
 - Migration and Connector removal require their own reviewed change.
 
 There is deliberately no runtime fallback from an Integration to a Connector. Unsupported provider
 or authentication combinations must fail explicitly.
 
-## Delivery plan and PR boundaries
+## Delivery phases and boundaries
 
-1. **Complete — #424:** CRUD, SQL identity, authentication/credential lifecycle, atomic storage,
-   idempotency, dependency, cascade, and cleanup primitives.
-2. **Complete — #425:** CLI coverage for those APIs, including typed authentication and write-only
+1. **Architecture and delivery plan:** define the architecture, design decisions, and delivery
+   boundaries.
+2. **Resource and API foundation:** add CRUD, SQL identity, authentication/credential lifecycle,
+   atomic storage, idempotency, dependency, cascade, and cleanup primitives.
+3. **CLI surface:** add CLI coverage for those APIs, including typed authentication and write-only
    credential input for create and rotation commands.
-3. **This change — #446:** keep the architecture and delivery record aligned with implemented code.
-4. **Implemented later in the stack — #440:** neutral catalog-access SPI and Iceberg REST vertical
-   slice.
-5. **Next:** Integration-to-SPI adapter and SQL-required validation/discovery RPCs.
-6. **Later:** canonical capture/bindings, scheduling, query visibility, garbage collection,
-   migration, and Connector removal.
+4. **Catalog-access SPI:** add the neutral catalog-access SPI and Iceberg REST vertical slice,
+   including table and view discovery and loading.
+5. **Follow-on:** add the Integration-to-SPI adapter and SQL-required validation/discovery RPCs.
+6. **Later:** add canonical capture/bindings, table validation and error visibility, scheduling,
+   query visibility, garbage collection, migration, and Connector removal.
 
-The CLI currently resolves Integration and Overlay display names by listing the corresponding
-resource type. The duplication is isolated and does not require expanding the API until another
-consumer needs a generic resolver.
+The CLI will initially resolve Integration and Overlay display names by listing the corresponding
+resource type. The duplication will remain isolated and will not require expanding the API until
+another consumer needs a generic resolver.

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -20,15 +20,13 @@ a separate legacy path during migration and will eventually be deprecated.
 
 ## Resource and ownership model
 
-The target model has three distinct layers:
+The target model has two resource layers plus shared captured metadata:
 
 ```text
 CatalogIntegration                 connection, authentication, canonical upstream identity
  ├── captured namespace/table      shared metadata, snapshots, file groups, and statistics
- ├── CatalogOverlay                mappings, visibility, and freshness demand
- │    └── existing Catalog         SQL-visible placement; not owned by the overlay
- └── CatalogOverlay
-      └── existing Catalog
+ ├── CatalogOverlay "sales"        top-level SQL catalog, mappings, visibility, and demand
+ └── CatalogOverlay "finance"      another top-level projection of the same integration
 ```
 
 ### Catalog integration
@@ -48,19 +46,14 @@ generation. Credential writes use a dedicated request that never returns secret 
 
 ### Catalog overlay
 
-`CatalogOverlay` is a non-owning, read-only projection of one integration into one existing
-Floecat `Catalog`. It owns namespace mappings, visibility state, and refresh/retention demand. It
-does not create, rename, empty, lock, or delete its target catalog.
+`CatalogOverlay` is a read-only top-level SQL catalog backed by one integration. Its display name is
+the catalog name. It owns namespace mappings, visibility state, and refresh/retention demand; it
+does not point to or mutate a separate `Catalog` resource.
 
-Initially, at most one overlay may target a catalog. This keeps name resolution and collision
-reporting deterministic while still allowing several catalogs to expose different projections of
-the same integration. Supporting overlay composition within one catalog requires a separate design
-decision.
-
-The target catalog remains a normal catalog. Users may create local namespaces and views in it,
-and views may reference overlay-bound tables. Captured namespaces and relations are read-only.
-Local and overlay objects never shadow one another: an exposed-name collision prevents that binding
-from becoming visible and puts the overlay into a degraded condition until the conflict is fixed.
+Several overlays may expose different projections of the same integration under different
+top-level catalog names. The account-level catalog namespace must reject collisions between overlay
+display names and other top-level catalogs. Captured namespaces and relations inside an overlay are
+read-only; writable local objects belong in a separate regular catalog.
 
 ## Namespace selection and mapping
 
@@ -75,12 +68,12 @@ message NamespaceMapping {
 }
 
 message CatalogOverlaySpec {
-  ResourceId integration_id = 3;
-  ResourceId catalog_id = 4;
-  repeated NamespaceMapping namespace_mappings = 5;
-  repeated NamespacePath exclude_namespaces = 6;
-  CatalogOverlayState state = 7;
-  CatalogOverlayPolicy policy = 8;
+  optional string display_name = 1;
+  ResourceId integration_id = 2;
+  repeated NamespaceMapping namespace_mappings = 3;
+  repeated NamespacePath exclude_namespaces = 4;
+  CatalogOverlayState state = 5;
+  CatalogOverlayPolicy policy = 6;
 }
 ```
 
@@ -93,7 +86,7 @@ are fixed:
 - A non-recursive mapping exposes only the exact source namespace.
 - Exclusions are expressed in upstream namespace space and take precedence over mappings.
 - Newly discovered namespaces that match an active mapping become visible automatically.
-- Empty source or target prefixes represent the corresponding catalog root.
+- Empty source or target prefixes represent the upstream or overlay catalog root, respectively.
 - Source mappings within one overlay may not overlap. Target prefixes may not overlap. Rejecting
   ambiguity is preferable to order-dependent precedence.
 - Two overlays may expose the same canonical table under different catalogs or names without
@@ -117,10 +110,11 @@ upstream path is the fallback identity and an upstream rename is observed as del
 Display names and overlay mappings are never part of canonical identity.
 
 Canonical tables own their schemas, snapshots, manifests, file groups, and statistics. An overlay
-binding is lightweight state that associates a canonical object with an exposed catalog/namespace
-path. Its identity includes the overlay ID, canonical object ID, and exposed path. Query resolution
-returns the canonical table identity plus the binding through which it was resolved, so several
-names can safely share one captured object and one set of statistics.
+binding is lightweight state that associates a canonical object with a path inside the overlay's
+top-level catalog. Its identity includes the overlay ID, canonical object ID, and exposed path.
+Query resolution returns the canonical table identity plus the binding through which it was
+resolved, so several overlay catalogs can safely share one captured object and one set of
+statistics.
 
 This requires an explicit replacement for the current connector-rooted `UpstreamRef`; adding an
 integration ID beside a connector ID would create two competing identities. The integration path
@@ -181,8 +175,7 @@ Lifecycle operations have the following effects:
 | Operation | Required behavior |
 | --- | --- |
 | Pause overlay | Hide its bindings and remove its policy demand; retain shared captures. |
-| Delete overlay | Fence its jobs, remove bindings and policy demand, and leave its catalog untouched. |
-| Drop target catalog | Reject while an overlay references it unless an explicit cascade removes the overlay first. |
+| Delete overlay | Fence its jobs, remove its top-level catalog bindings and policy demand, and retain shared captures still in use. |
 | Pause integration | Stop new work and fence publication from work planned before the pause. |
 | Rotate credentials | Atomically advance the credential/configuration generation; never expose the old or new secret. |
 | Delete integration | Reject while overlays exist unless explicit cascade was requested. |
@@ -217,8 +210,9 @@ temporary coexistence decision, not a compatibility layer:
 - Integration validation and reconciliation do not call Connector RPCs.
 - New integration contracts and neutral catalog-access types do not import Connector protos.
 - Existing Connector-backed tables and jobs continue to work unchanged until an explicit migration.
-- Migration maps connectivity and authentication to integrations and placement/filtering to
-  overlays, then retires Connector APIs and persisted state in a separately reviewed change.
+- Migration maps connectivity and authentication to integrations and top-level catalog
+  projection/filtering to overlays, then retires Connector APIs and persisted state in a separately
+  reviewed change.
 
 There is deliberately no runtime fallback from an Integration to a Connector. Silent fallback would
 make ownership, credentials, scheduling, and failure semantics impossible to reason about.

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -14,12 +14,14 @@ Catalog Integration and Catalog Overlay split today's `Connector` into its two i
 | --- | --- |
 | `uri`, `auth`, `kind` — how Floecat reaches and authenticates to an upstream catalog | `CatalogIntegration` |
 | `source` — which upstream namespaces are selected | `CatalogOverlay` |
-| `destination` — where the selection lands in Floecat | `CatalogOverlay`, through the catalog it owns |
-| `policy`, `state` — refresh cadence, retention, pause | `CatalogOverlay` |
+| `destination` — where the selection lands in Floecat | `CatalogOverlay`, through a reference to an existing `Catalog` |
+| `policy` — refresh cadence, retention, pause | Overlay demand or a referenced policy, deferred from the initial API |
+| scheduler state — leases, attempts, progress, last success | Integration-owned scheduler state, separate from the Overlay resource |
 
 Connectors will be deprecated and replaced by these two resources. One integration can serve many
-overlays, which is the reuse a single `Connector` cannot express: today every destination needs its
-own connector, and therefore its own copy of the endpoint and credentials.
+overlays, and overlays from one or more integrations can target the same Floecat catalog. This is the
+reuse a single `Connector` cannot express: today every destination needs its own connector, and
+therefore its own copy of the endpoint and credentials.
 
 This is a decomposition of the connector resource, not a new metadata architecture. Captured
 metadata continues to materialize into the existing `Catalog` / `Namespace` / `Table` / `View` /
@@ -37,18 +39,20 @@ hierarchy, a second table identity, or a second name-resolution path.
 | Durability primitives | Reserved resource identity, receipt-in-batch idempotency, companion pointer operations, mutation-store reads, and strongly consistent lifecycle reads | Integration and Overlay resources |
 | Account deletion fence | Durable account-deletion fencing and resumable descendant cleanup | Integration- and Overlay-specific CRUD |
 | Catalog Integration API | Integration CRUD, typed authentication, write-only credential storage and rotation, dependencies, cascade deletion, idempotency, and optimistic concurrency | Upstream connectivity, provider discovery, validation RPCs, capture, reconciliation, and query visibility |
-| Catalog Overlay API | Overlay CRUD, overlay-owned catalog lifecycle, namespace selection, dependencies, cascade deletion, idempotency, and optimistic concurrency | Capture, reconciliation, and query visibility |
-| Shell CLI | Integration and Overlay CRUD commands, typed authentication input, write-only credential input, authentication rotation, pagination, name resolution, namespace filters, cascade, and etag preconditions | Connectivity validation, discovery, capture, reconciliation, and query visibility |
+| Catalog Overlay API | Overlay CRUD, references to existing target catalogs, namespace selection, Integration and Catalog dependencies, contribution lifecycle, idempotency, and optimistic concurrency | Capture, reconciliation, and query visibility |
+| Shell CLI | Integration and Overlay CRUD commands, target-Catalog binding, typed authentication input, write-only credential input, authentication rotation, pagination, name resolution, namespace filters, cascade, and etag preconditions | Connectivity validation, discovery, capture, reconciliation, and query visibility |
 | Catalog-access SPI | Connector-independent catalog client SPI plus an Iceberg REST provider with validation, discovery, table and view loading, OAuth2, SigV4, and renewable AWS credential support | Wiring Catalog Integration resources to the SPI, Integration validation/listing RPCs, persistence, scheduling, and capture |
 | Integration validation and discovery | Wire persisted Integration credentials to the SPI; validate catalog authentication, credential vending, and storage access; lazily list upstream namespaces, tables, and views | Persistence of discovery results, Overlay reconciliation, scheduling, and capture |
-| Overlay metadata reconciliation | A synchronous Overlay RPC wires persisted Integration credentials to the SPI and materializes selected namespaces, table definitions, and views with generation fencing and explicit lifecycle cleanup | Durable scheduling, snapshot/file capture, validation, and statistics |
+| Overlay metadata reconciliation | A synchronous Overlay RPC wires persisted Integration credentials to the SPI and materializes selected namespaces, table definitions, and views into an existing Catalog with generation fencing, collision checks, and contribution-scoped cleanup | Durable scheduling, snapshot/file capture, validation, and statistics |
 
 ## Goals
 
 The catalog integration model provides a way to:
 
 - authenticate Floecat to an upstream catalog once, and reuse that connection across many overlays;
-- select upstream namespaces and expose them beneath a single top-level catalog name;
+- select upstream namespaces and expose them in an existing Floecat catalog;
+- combine non-conflicting contributions from multiple overlays and integrations in one catalog while
+  retaining independently managed catalog content;
 - discover and validate upstream namespaces, tables, and views without depending on Connector
   resources; and
 - materialize external namespace, table-definition, and view metadata into ordinary Floecat
@@ -61,20 +65,24 @@ later migration, not through runtime fallback.
 ## Resource and ownership model
 
 ```text
-CatalogIntegration "prod-glue"     connection and authentication
- ├── CatalogOverlay "crm_data"     upstream selection -> owns Catalog "crm_data"
- └── CatalogOverlay "finance"      a different selection -> owns Catalog "finance"
+CatalogIntegration "prod-glue"          connection and authentication
+ └── CatalogOverlay "crm-import"        selection -> Catalog "analytics"
 
-Catalog "crm_data"                 owned by the overlay, read-only to clients
- └── Namespace ["sales"]           materialized from the overlay's selection
-      └── Table / View             ordinary resources with snapshots and statistics
+CatalogIntegration "finance-unity"      a different connection and authentication
+ └── CatalogOverlay "finance-import"    selection -> Catalog "analytics"
+
+Catalog "analytics"                     independently managed target
+ ├── Namespace ["crm"]                  materialized contribution from "crm-import"
+ ├── Namespace ["finance"]              materialized contribution from "finance-import"
+ └── Namespace ["local"]                directly managed Floecat content
 ```
 
-An overlay is a mapping resource that owns exactly one Floecat `Catalog`. The overlay's display name
-is that catalog's display name, so an overlay contributes one top-level catalog name and its
-selected upstream namespaces appear beneath it as ordinary namespaces. Name resolution, listing,
-pinning, planning, and garbage collection all operate on those resources with no overlay-specific
-path.
+An overlay is a mapping resource that references exactly one Integration and one existing Floecat
+`Catalog`. It does not own the target Catalog. Multiple overlays may target the same Catalog, and
+the Catalog retains its independent identity, name, writability, and lifecycle. An overlay owns only
+the materialized contributions produced by its mapping. Name resolution, listing, pinning, planning,
+and garbage collection operate on ordinary Catalog, Namespace, Table, View, and Snapshot resources
+with no overlay-specific read path.
 
 ### Catalog integration
 
@@ -88,9 +96,12 @@ AWS access keys, and AWS SigV4. Unity initially accepts only OAuth client creden
 authentication. The base service validates structural compatibility; endpoint and provider support
 remain the responsibility of the catalog-access adapter and provider.
 
-Type and catalog URI are immutable through update. A replacing create produces a new resource
-identity, and is rejected while overlays depend on the existing integration because replacement must
-not silently retarget those overlays.
+Integration type is immutable through update. The catalog URI is mutable with an etag precondition;
+publishing a URI update advances the Integration generation so reconciliation and durable work that
+observed the previous endpoint cannot publish afterward. Existing overlays and materialized resource
+identities remain attached to the same Integration. A replacing create is required only to change
+the Integration type, produces a new resource identity, and is rejected while overlays depend on the
+existing Integration because replacement must not silently retarget those overlays.
 
 Integration type identifies the catalog access protocol; it does not define the format of every
 table in that catalog. As in the existing Connector path, the catalog-access provider determines
@@ -147,40 +158,50 @@ reported as separate error entries.
 
 ### Catalog overlay
 
-`CatalogOverlay` binds one integration to one selection of upstream namespaces, and owns the Floecat
-`Catalog` those namespaces are exposed beneath. It is the direct replacement for the connector's
-`source` plus `destination` pair; the overlay does not carry a separate destination because the
-catalog it owns is the destination.
+`CatalogOverlay` binds one Integration and one selection of upstream namespaces to an existing
+Floecat `Catalog`. It is the direct replacement for the connector's `source` plus `destination`
+pair. The target is explicit because Catalog lifecycle remains independent from Overlay lifecycle.
 
 ```text
 CatalogOverlay
-  display_name         also the display name of the catalog it owns
+  display_name         independently managed Overlay name
   integration_id       which upstream catalog and credentials to use (immutable through update)
+  catalog_id           existing Floecat destination (immutable through update)
   include_namespaces   upstream selection
   exclude_namespaces   upstream selection
 ```
 
-The overlay's resource state is the mapping; the catalog it owns is where captured metadata lands.
-Creating an overlay creates that catalog in the same atomic pointer transaction, so an overlay can
-never exist without its catalog and a partially created overlay cannot leave an orphan catalog
-behind. Renaming an overlay renames its catalog in the same transaction.
+Creating an overlay verifies that both referenced resources exist in the same account and publishes
+dependencies on the Integration and target Catalog atomically with the Overlay. A Catalog cannot be
+deleted while an Overlay references it. Renaming either resource does not rename the other because
+the binding uses immutable resource identity rather than display name. Overlay display names remain
+unique among Overlays in the account but do not reserve Catalog names.
 
-Because the owned catalog is an ordinary `Catalog`, top-level name uniqueness is the existing
-catalog by-name uniqueness. No separate top-level name reservation is required, and an overlay and a
-directly created catalog cannot share a name for the same reason two catalogs cannot.
+The target Catalog remains directly manageable. Clients may create local namespaces and relations in
+it, and other overlays may contribute non-conflicting resources. Materialized Tables and Views carry
+typed Integration and Overlay provenance and reject direct mutation while managed by the Overlay.
+Namespaces are shared structural containers rather than exclusively Overlay-owned resources.
+Namespace claim state records every Overlay using a path and whether the container was originally
+created by Overlay materialization. A claim prevents structural deletion or movement of the
+Namespace while the Overlay uses it, but does not make the Namespace or Catalog generally read-only.
+Releasing a claim deletes the Namespace only when no other Overlay claims it, it contains no
+relations, and it was created for Overlay materialization; a pre-existing or directly managed
+Namespace is never deleted merely because an Overlay stops using it.
 
-An overlay-owned catalog is read-only to clients: it is created, renamed, and deleted only through
-its overlay, and the catalog API rejects direct mutation of it and of the namespaces, tables, and
-views captured beneath it. This reuses the existing structural write guard rather than introducing a
-second writability mechanism.
+A destination relation path has one writer. Reconciliation fails with a conflict rather than
+overwriting a local relation or a relation managed by another Overlay. Selecting the same upstream
+object through two Overlays is valid when they materialize to different Catalogs; after namespace
+remapping is introduced, distinct destination paths will also be valid. Selecting it into the same
+destination path is a mapping conflict. Namespace containers may be shared as long as their child
+relation names do not collide.
 
-The integration binding is immutable through update, because changing it retargets everything the
-overlay has materialized. A replacing create produces a new overlay identity and may choose a
-different binding.
+The Integration and Catalog bindings are immutable through update because changing either retargets
+everything the Overlay has materialized. A replacing create produces a new Overlay identity and may
+choose different bindings after the previous Overlay's contributions are retired.
 
-Deleting an overlay deletes the catalog it owns and everything captured beneath it. That cascade is
-the overlay's own contract, not a side effect: an overlay's contents exist only because the overlay
-selected them.
+Deleting an Overlay installs a deletion fence, removes only Tables, Views, snapshot state, and
+namespace claims managed by that Overlay, then removes its dependencies and resource record. It
+never deletes the target Catalog or unrelated content.
 
 ## Namespace selection
 
@@ -192,8 +213,8 @@ space.
 - An included path selects that namespace and all descendants.
 - An excluded path removes that namespace and all descendants; exclusion wins when both match.
 - Paths are normalized and deduplicated without flattening segment boundaries.
-- A selected upstream namespace materializes as a Floecat `Namespace` at the same path beneath the
-  overlay's catalog, preserving segment boundaries.
+- A selected upstream namespace maps to the same path in the target Catalog, preserving segment
+  boundaries. Namespace remapping is deferred.
 - Newly discovered namespaces matching the stored selection materialize on the next synchronous
   reconciliation.
 
@@ -259,11 +280,11 @@ name resolution remain outside it.
 
 ## Materialized metadata and deferred capture
 
-Synchronous metadata reconciliation materializes ordinary Floecat resources beneath the overlay's
-catalog. A selected upstream namespace becomes a `Namespace`; a selected upstream table becomes a
-`Table` definition and initial `TableRoot`; and a selected upstream view becomes a `View`. These are
-the same logical resources the Connector path produces today and use the existing repositories and
-name-resolution paths.
+Synchronous metadata reconciliation materializes ordinary Floecat resources in the Overlay's target
+Catalog. A selected upstream namespace uses or creates a `Namespace`; a selected upstream table
+becomes a `Table` definition and initial `TableRoot`; and a selected upstream view becomes a `View`.
+These are the same logical resources the Connector path produces today and use the existing
+repositories and name-resolution paths.
 
 This phase deliberately does not create `Snapshot` resources, file groups, validation results, or
 statistics. Those require extending the durable reconciler from its current Connector-rooted job
@@ -277,19 +298,48 @@ materialized object. Provider-stable IDs preserve a Floecat resource identity ac
 rename or namespace move; when a provider has no stable ID, the normalized full upstream path is an
 explicitly unstable identity and rename is observed as delete plus create.
 
-Two overlays that select the same upstream table produce two Floecat tables, one beneath each
-overlay's catalog, exactly as two connectors would today. Deduplicating captures across overlays is
-not in scope: it would require a table identity separate from the `Catalog`/`Namespace` hierarchy,
-which is precisely the parallel architecture this design avoids. If that reuse is wanted later, it
-belongs in a separately reviewed change against the table model itself, not in the Integration path.
+Two Overlays that select the same upstream table and map it to different Catalogs produce two
+Floecat Tables. Once namespace remapping exists, distinct destination paths will behave the same way.
+Their Snapshots, statistics, validation records, and visibility state are persisted independently
+under each Floecat Table identity. No persisted Snapshot, statistics, or validation object is shared
+across those Tables. Mapping both selections to the same destination relation path is a conflict, not
+an implicit deduplication mechanism.
+
+## Reconciliation publication and failure semantics
+
+Reconciliation is generation-fenced but is not one atomic transaction over an unbounded Catalog.
+Its publication order provides a monotonic safety contract:
+
+1. Validate the Integration and complete discovery for the entire selected scope without mutating
+   Floecat state.
+2. Preflight the complete desired inventory against the target Catalog, including destination name
+   conflicts and Overlay provenance.
+3. Create or update desired namespace claims, Tables, and Views while the observed Integration and
+   Overlay generations remain current.
+4. Only after all desired resources are published, retire managed relations absent from that
+   complete inventory, release unused namespace claims, and prune eligible empty namespace
+   containers.
+
+A validation, discovery, or preflight failure publishes nothing. A failure while publishing desired
+resources may leave successful creates or updates visible, but it does not retire prior resources;
+a retry converges them to the desired inventory. A failure during retirement may leave some stale
+resources temporarily visible, but every retired resource was absent from a completed discovery and
+all desired resources were published first. A retry completes cleanup.
+
+"Stale" means absent from the complete inventory produced for the same Overlay selection and
+Integration generation. Results from a partial discovery, a different Overlay, or an older
+configuration generation can never classify a resource as stale. Stale work may finish external I/O
+but cannot publish after its fence is invalidated.
 
 ## Table validation and visibility
 
-The later durable-capture phase will make an active overlay establish capture demand for the tables
-its selection matches. The integration-owned scheduler will trigger or join discovery, file
-scanning, table validation, and statistics collection for the effective union of active overlay
-selections on that integration. The synchronous metadata RPC in the current phase does not enqueue
-that work.
+The later durable-capture phase will make an active Overlay establish capture demand for the Tables
+its selection matches. The Integration-owned scheduler computes the effective union of active
+Overlay selections. The initial sharing guarantee applies only to upstream discovery and other
+external I/O that can be safely coalesced; it does not share persisted Floecat objects. Any later
+optimization that scans an upstream object once must still publish independently fenced results for
+each destination Table. The synchronous metadata RPC in the current phase does not enqueue that
+work.
 
 A table does not become query-visible until its current capture has completed validation. Validation
 compares each discovered Parquet file with the captured table format and metadata. A file that
@@ -310,13 +360,16 @@ Validation errors and table visibility follow these rules:
 - describing an integration may request revalidation in addition to connection, authentication, and
   credential-vending checks.
 
-Views have no file-validation state; resolving a view must still respect the visibility of its base
-tables and cannot be used to bypass an invalid table's visibility gate.
+Views have no file-validation state. Catalog-access providers remain responsible for enumerating and
+loading upstream View metadata, but they do not resolve View SQL or determine whether its base Tables
+are query-visible. Dependency resolution and enforcement of base-Table visibility belong to the
+ordinary name-resolution and planner/runtime path, outside the Integration and Overlay contracts.
 
 ## Refresh and reconciliation ownership
 
-Scheduling, freshness, and retention remain deferred. Overlays will state freshness and retention
-demand; integrations will own upstream connection work. For active overlays on one integration,
+Scheduling, freshness, and retention remain deferred. Overlays will state freshness, retention, and
+pause demand directly or through a reusable policy; operational scheduler state is separate from the
+Overlay resource. Integrations own upstream connection work. For active Overlays on one Integration,
 the scheduler computes one effective plan:
 
 - discovery scope is the union of selected namespaces, including matching tables and views, while
@@ -325,35 +378,41 @@ the scheduler computes one effective plan:
 - retained history satisfies the longest requested retention; and
 - pausing an overlay removes its demand, while pausing an integration stops all new upstream work.
 
-Sharing applies to upstream I/O: two overlays selecting the same upstream namespace from one
-integration issue one discovery pass, then materialize into their own catalogs.
+Sharing applies to upstream I/O: two Overlays selecting the same upstream namespace from one
+Integration may issue one discovery pass, then materialize independently into their configured
+destination paths. Persisted Tables and their descendant state remain destination-owned.
 
-The synchronous metadata reconciler already fences every resource publication on the observed
-Integration and Overlay pointer generations and the absence of account, Integration, and Overlay
+The synchronous metadata reconciler fences every resource publication on the observed Integration
+and Overlay pointer generations and the absence of account, Integration, Overlay, and target Catalog
 deletion markers. A future capture-plan generation must extend equivalent fencing to every planned
-and leased durable job. Stale work may finish external I/O but must not publish results after
-configuration, selection, pause, replacement, or deletion changes.
+and leased durable job. URI, credentials, selection, pause, replacement, target deletion, or Overlay
+deletion changes invalidate older work.
 
 ## Lifecycle and garbage collection
 
 | Operation | Current behavior | Deferred behavior |
 | --- | --- | --- |
 | Rename integration | Atomic rename with optimistic preconditions | No additional behavior required |
-| Rename overlay | Atomic rename of the overlay and the catalog it owns in one transaction | No additional behavior required |
+| Update integration endpoint | Atomic URI update with optimistic preconditions; advances the generation that fences reconciliation while preserving dependent Overlay identities | Optional validation before publication |
+| Rename overlay | Atomic Overlay-only rename with optimistic preconditions; the target Catalog name is unchanged | No additional behavior required |
+| Rename target catalog | Ordinary Catalog rename; Overlay bindings remain valid by resource ID | No additional behavior required |
 | Replace integration | New identity; rejected while dependent overlays exist | Validation may run before publication |
 | Rotate credentials | Atomic new credential generation; old generation retired after publication | Reclaim acknowledgement-uncertain orphan generations |
-| Create or replace overlay | Creates the overlay and its catalog atomically; stores selection and integration dependency; replacement fences and retires prior materializations | Trigger or join durable snapshot/file capture into that catalog |
-| Reconcile overlay | Synchronously validates the connection, discovers the selected inventory, and creates, updates, or retires namespaces, table definitions, and views behind generation fences | Schedule reconciliation and capture snapshots, files, validation, and statistics |
-| Delete overlay | Installs an Overlay deletion fence, explicitly retires materialized descendants, then atomically removes the empty catalog, overlay, dependency, and fence | Cancel and drain durable jobs |
+| Create or replace overlay | Attaches to an existing Catalog; atomically stores the selection plus Integration and Catalog dependencies; replacement fences and retires only the prior Overlay's contributions | Trigger or join durable snapshot/file capture into the target Catalog |
+| Reconcile overlay | Completes discovery and collision preflight, publishes desired namespace claims, Table definitions, and Views, then retires stale managed contributions behind generation fences | Schedule reconciliation and capture Snapshots, files, validation, and statistics |
+| Delete overlay | Installs an Overlay deletion fence, explicitly retires its materialized relations and namespace claims, then removes the Overlay dependencies, resource, and fence; the target Catalog remains | Cancel and drain durable jobs |
 | Delete integration | Rejected while overlays exist | Fence integration-owned jobs |
-| Cascade integration delete | Durable Integration and Overlay deletion fences, explicit descendant retirement, dependent overlay/catalog deletion, resource deletion, and credential cleanup | Cancel and drain durable jobs |
+| Delete target catalog | Rejected while Overlays reference it, even when it is otherwise empty | Fence Catalog-targeted jobs |
+| Cascade integration delete | Durable Integration and Overlay deletion fences, explicit retirement of each dependent Overlay's contributions, Overlay and Integration resource deletion, and credential cleanup; target Catalogs remain | Cancel and drain durable jobs |
 | Delete account | Durable deletion fence, then cleanup of overlays, integrations, and integration credentials | No additional behavior required |
 
-Overlay lifecycle code explicitly deletes logical `Namespace`, `Table`, and `View` resources and
-purges table snapshot/root pointer state; existing pointer and CAS-blob garbage collection remains
-responsible for reclaiming unreachable immutable blobs. Garbage collection is not a substitute for
-retiring the logical resource pointers. Validation-error records will be retained with their table
-and atomically replaced or removed when a later validation generation is published.
+Overlay lifecycle code explicitly deletes its logical `Table` and `View` resources, releases its
+Namespace claims, prunes only eligible empty Overlay-created Namespaces, and purges Table
+snapshot/root pointer state. It never deletes the target Catalog, another Overlay's resources, or
+directly managed content. Existing pointer and CAS-blob garbage collection remains responsible for
+reclaiming unreachable immutable blobs. Garbage collection is not a substitute for retiring the
+logical resource pointers. Validation-error records will be retained with their Table and atomically
+replaced or removed when a later validation generation is published.
 
 ## Durability contract
 
@@ -377,9 +436,10 @@ Integration-owned resources instead guarantee:
   record, then publishes the immutable success receipt in the same atomic pointer transaction as
   the resource. A replay returns the recorded answer; it never re-derives one from state that a
   later mutation may have changed.
-- **Fenced dependencies and cascades.** Dependency counts, cascade deletion, and lifecycle markers
-  are asserted inside the same pointer transaction as the mutation they guard, so a concurrent
-  create cannot slip beneath a delete that has already checked for dependents.
+- **Fenced dependencies and cascades.** Integration and target Catalog dependency counts, cascade
+  deletion, and lifecycle markers are asserted inside the same pointer transaction as the mutation
+  they guard, so a concurrent Overlay create cannot slip beneath a delete that has already checked
+  for dependents.
 - **Strongly consistent reads where absence is load-bearing.** A cascade or dependency check that
   misses a row produces an orphan or a wrongly permitted delete, so those paths do not read
   secondary indexes through an eventually consistent path.
@@ -440,8 +500,9 @@ and returning the existing resource:
   one. Replacement is itself state-idempotent and cannot be combined with an idempotency key.
 - **return existing** — returns the current resource unchanged when the name is already taken.
 
-Replacement rather than update is how a caller changes an immutable binding: the integration binding
-on an overlay, and the type and URI on an integration.
+Replacement rather than update is how a caller changes an Overlay's immutable Integration or target
+Catalog binding, or an Integration's type. An Integration URI is ordinary mutable configuration and
+does not require replacement.
 
 ## Follow-on API evolution
 
@@ -450,12 +511,14 @@ After the initial delivery, follow-on changes will:
 1. Add validation, capability, namespace-listing, and object-listing RPCs. Validation exercises both
    catalog authentication and usable storage-credential vending; object listing distinguishes
    namespaces, tables, and views.
-2. Add synchronous, generation-fenced Overlay metadata reconciliation. This materializes namespaces,
-   table definitions, and views, but not snapshots or files.
+2. Add synchronous, generation-fenced Overlay metadata reconciliation into an existing target
+   Catalog. This materializes Namespace claims, Table definitions, and Views, but not Snapshots or
+   files.
 3. Extend the durable reconciler with Integration/Overlay-rooted jobs and capture `Snapshot`, file,
    validation, and statistics state beneath the already materialized tables.
-4. Add overlay policy and state, table validation-error persistence, visibility and override
-   handling, and integration-owned scheduling with durable job-generation fencing.
+4. Add Overlay freshness, retention, and pause demand, separate scheduler runtime state, Table
+   validation-error persistence, visibility and override handling, and Integration-owned scheduling
+   with durable job-generation fencing.
 5. Add migration from Connectors and Connector removal in separately reviewed changes.
 
 Because backwards compatibility is not a project requirement at this stage, contracts should be
@@ -477,8 +540,10 @@ or authentication combinations must fail explicitly.
 Migration is mechanical because the resources are a decomposition of the connector: each connector
 yields one integration from its `uri`, `auth`, and `kind`, and one overlay from its `source` and
 `destination`, with connectors sharing an endpoint and credentials collapsing onto one integration.
-A connector whose destination is an existing catalog migrates by making that catalog overlay-owned,
-so its existing namespaces, tables, and snapshots remain valid and are not re-materialized.
+The Overlay references the Connector's existing destination Catalog; no Catalog ownership transfer
+occurs. Existing Connector-managed Tables and their descendants may be adopted in place by replacing
+their Connector provenance with Integration and Overlay provenance during the separately reviewed
+migration, so they need not be re-materialized.
 
 ## Initial CLI name resolution
 

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -1,29 +1,57 @@
 # Catalog Integration Architecture and Delivery Plan
 
-Status: proposed architecture and delivery plan for Catalog Integration.
+Status: accepted architecture and delivery contract for the Catalog Integration stack and its
+metadata-reconciliation follow-on.
 
-This document defines the target architecture and planned boundary of each delivery phase. It is
-aligned with the Catalog Integration and Catalog Overlay SQL specification. It separates the
-initial delivery scope from work that remains deferred.
+This document defines the target architecture and the boundary of each change in the initial stack.
+It separates that accepted delivery scope from architecture and behavior that remain deferred.
 
-## Planned delivery boundaries
+## What this work is
 
-| Change | Planned boundary | Explicitly deferred |
+Catalog Integration and Catalog Overlay split today's `Connector` into its two independent halves:
+
+| Connector concern | Replacement |
+| --- | --- |
+| `uri`, `auth`, `kind` — how Floecat reaches and authenticates to an upstream catalog | `CatalogIntegration` |
+| `source` — which upstream namespaces are selected | `CatalogOverlay` |
+| `destination` — where the selection lands in Floecat | `CatalogOverlay`, through the catalog it owns |
+| `policy`, `state` — refresh cadence, retention, pause | `CatalogOverlay` |
+
+Connectors will be deprecated and replaced by these two resources. One integration can serve many
+overlays, which is the reuse a single `Connector` cannot express: today every destination needs its
+own connector, and therefore its own copy of the endpoint and credentials.
+
+This is a decomposition of the connector resource, not a new metadata architecture. Captured
+metadata continues to materialize into the existing `Catalog` / `Namespace` / `Table` / `View` /
+`Snapshot` resources, and every downstream consumer — name resolution, the metagraph, `TableRoot`
+and pins, statistics visibility, garbage collection, transactions, and the Iceberg REST gateway —
+continues to read those resources unchanged. Nothing in this work introduces a parallel object
+hierarchy, a second table identity, or a second name-resolution path.
+
+## Initial stack delivery boundaries
+
+| Change | Boundary | Explicitly deferred |
 | --- | --- | --- |
 | This document | Architecture decisions and delivery boundaries | Production behavior |
-| Catalog Integration and Overlay APIs | CRUD resources, typed authentication, write-only credential storage and rotation, shared SQL catalog-name reservation, idempotency, optimistic concurrency, dependencies, cascade deletion, and atomic persistence primitives | Upstream connectivity, provider discovery, validation RPCs, capture, reconciliation, and query visibility |
+| Catalog graph view rename | Rename the existing metadata graph `CatalogOverlay` contract to `CatalogGraphView`, freeing `CatalogOverlay` for the mapping resource | Resource or persistence behavior |
+| Durability primitives | Reserved resource identity, receipt-in-batch idempotency, companion pointer operations, mutation-store reads, and strongly consistent lifecycle reads | Integration and Overlay resources |
+| Account deletion fence | Durable account-deletion fencing and resumable descendant cleanup | Integration- and Overlay-specific CRUD |
+| Catalog Integration API | Integration CRUD, typed authentication, write-only credential storage and rotation, dependencies, cascade deletion, idempotency, and optimistic concurrency | Upstream connectivity, provider discovery, validation RPCs, capture, reconciliation, and query visibility |
+| Catalog Overlay API | Overlay CRUD, overlay-owned catalog lifecycle, namespace selection, dependencies, cascade deletion, idempotency, and optimistic concurrency | Capture, reconciliation, and query visibility |
 | Shell CLI | Integration and Overlay CRUD commands, typed authentication input, write-only credential input, authentication rotation, pagination, name resolution, namespace filters, cascade, and etag preconditions | Connectivity validation, discovery, capture, reconciliation, and query visibility |
 | Catalog-access SPI | Connector-independent catalog client SPI plus an Iceberg REST provider with validation, discovery, table and view loading, OAuth2, SigV4, and renewable AWS credential support | Wiring Catalog Integration resources to the SPI, Integration validation/listing RPCs, persistence, scheduling, and capture |
+| Overlay metadata reconciliation | A synchronous Overlay RPC wires persisted Integration credentials to the SPI and materializes selected namespaces, table definitions, and views with generation fencing and explicit lifecycle cleanup | Durable scheduling, snapshot/file capture, validation, and statistics |
 
 ## Goals
 
-The catalog integration model will provide a SQL-compatible way to:
+The catalog integration model provides a way to:
 
-- authenticate Floecat to an upstream catalog;
-- select upstream namespaces beneath a read-only SQL catalog name;
+- authenticate Floecat to an upstream catalog once, and reuse that connection across many overlays;
+- select upstream namespaces and expose them beneath a single top-level catalog name;
 - discover and validate upstream namespaces, tables, and views without depending on Connector
   resources; and
-- eventually capture external metadata once while exposing it through one or more overlays.
+- materialize external namespace, table-definition, and view metadata into ordinary Floecat
+  resources on demand, then add durable snapshot/file capture and scheduling separately.
 
 The Integration path will not use, wrap, synthesize, or fall back to Connector resources.
 Connectors will remain a separate operational path until they are retired through an explicit
@@ -32,46 +60,53 @@ later migration, not through runtime fallback.
 ## Resource and ownership model
 
 ```text
-CatalogIntegration                 connection and authentication
- ├── captured namespace/table/view future shared metadata and statistics
- ├── CatalogOverlay "sales"        top-level SQL catalog and namespace selection
- └── CatalogOverlay "finance"      another projection of the same integration
+CatalogIntegration "prod-glue"     connection and authentication
+ ├── CatalogOverlay "crm_data"     upstream selection -> owns Catalog "crm_data"
+ └── CatalogOverlay "finance"      a different selection -> owns Catalog "finance"
+
+Catalog "crm_data"                 owned by the overlay, read-only to clients
+ └── Namespace ["sales"]           materialized from the overlay's selection
+      └── Table / View             ordinary resources with snapshots and statistics
 ```
+
+An overlay is a mapping resource that owns exactly one Floecat `Catalog`. The overlay's display name
+is that catalog's display name, so an overlay contributes one top-level catalog name and its
+selected upstream namespaces appear beneath it as ordinary namespaces. Name resolution, listing,
+pinning, planning, and garbage collection all operate on those resources with no overlay-specific
+path.
 
 ### Catalog integration
 
-`CatalogIntegration` will own the upstream protocol, HTTP(S) endpoint, non-secret authentication
-configuration, credential lifecycle, and eventually the canonical identity of captured external
-objects. Its immutable resource ID is operational identity; its display name is mutable SQL-facing
-metadata.
+`CatalogIntegration` owns the upstream protocol, HTTP(S) endpoint, non-secret authentication
+configuration, and credential lifecycle. Its immutable resource ID is operational identity; its
+display name is mutable metadata and must be unique among integrations in the account.
 
-The API will initially support Iceberg REST and Unity integration types. Authentication will be
-required and represented by typed protobuf messages for OAuth client credentials, bearer tokens,
-AWS assume role, AWS access keys, and AWS SigV4. Unity will initially accept only OAuth client
-credentials or bearer authentication. The base service will validate structural compatibility;
-endpoint/provider support will remain the responsibility of the catalog-access adapter and
-provider.
+The API initially supports Iceberg REST and Unity integration types. Authentication is required and
+represented by typed protobuf messages for OAuth client credentials, bearer tokens, AWS assume role,
+AWS access keys, and AWS SigV4. Unity initially accepts only OAuth client credentials or bearer
+authentication. The base service validates structural compatibility; endpoint and provider support
+remain the responsibility of the catalog-access adapter and provider.
 
-Type and catalog URI will be immutable through update. `CREATE OR REPLACE` will create a new
-resource identity. It will be rejected while overlays depend on the existing integration because
-replacement must not silently retarget those overlays.
+Type and catalog URI are immutable through update. A replacing create produces a new resource
+identity, and is rejected while overlays depend on the existing integration because replacement must
+not silently retarget those overlays.
 
 Integration type identifies the catalog access protocol; it does not define the format of every
-table in that catalog. As in the existing Connector path, the catalog-access provider will determine
-each table's `TableFormat`. Capture will persist that value on the table protobuf at
-`Table.upstream.format`. Table format therefore remains table-owned metadata and will not be stored
-or inferred as an Integration-wide property.
+table in that catalog. As in the existing Connector path, the catalog-access provider determines
+each table's `TableFormat`, and capture persists that value on the existing table protobuf at
+`Table.upstream.format`. Table format therefore remains table-owned metadata and is not stored or
+inferred as an Integration-wide property.
 
 ### Authentication and credentials
 
-Persisted resources will contain only non-secret authentication configuration,
-`credentials_configured`, and a server-managed credential generation. Secret values will be
-supplied on create or through the dedicated authentication-update RPC and will never be returned.
+Persisted resources contain only non-secret authentication configuration,
+`credentials_configured`, and a server-managed credential generation. Secret values are supplied on
+create or through the dedicated authentication-update RPC and are never returned.
 
-The service will derive its internal secret key from integration ID and credential generation. No
-secret-manager reference will be exposed in the public resource.
-`CatalogIntegrationCredentialStore` will provide the typed service-side resolution primitive
-required by a later catalog-access adapter.
+The service derives its internal secret key from integration ID and credential generation. No
+secret-manager reference is exposed in the public resource.
+`CatalogIntegrationCredentialStore` provides the typed service-side resolution primitive used by
+the catalog-access adapter.
 
 Credential publication must provide these guarantees:
 
@@ -94,62 +129,84 @@ storage-scoped credentials that authorize reads of the table metadata and data f
 that catalog.
 
 Credential vending is a required Catalog Integration contract, not an optional optimization. The
-catalog-access provider will request vended credentials through the provider protocol and use them
-for object-storage access. It must not fall back to Connector credentials, ambient service
-credentials, or the credentials used to authenticate to the catalog API. Vended credentials may be
-scoped to a table, path, or operation and must be reacquired or renewed according to their expiry.
-They are process-local runtime material: they will not be written to the Integration resource,
+catalog-access provider requests vended credentials through the provider protocol and uses them for
+object-storage access. It must not fall back to Connector credentials, ambient service credentials,
+or the credentials used to authenticate to the catalog API. Vended credentials may be scoped to a
+table, path, or operation and must be reacquired or renewed according to their expiry. They are
+process-local runtime material: they are not written to the Integration resource,
 `CatalogIntegrationCredentialStore`, table protobufs, logs, or persisted catalog-client
 configuration.
 
-Integration validation will test the two credential boundaries independently. It will verify that
-the catalog endpoint is reachable and accepts the configured Integration authentication, then use a
-provider-specific, non-mutating operation to obtain vended credentials and prove they can access
-the referenced object storage. A validation result must not report `OK` when vending was skipped or
-could not be verified. Authentication, vending, expiry, scope, and storage-access failures will be
-reported as separate `ERROR` rows through the SQL validation contract.
+Integration validation tests the two credential boundaries independently. It verifies that the
+catalog endpoint is reachable and accepts the configured Integration authentication, then uses a
+provider-specific, non-mutating operation to obtain vended credentials and prove they can access the
+referenced object storage. A validation result must not report success when vending was skipped or
+could not be verified. Authentication, vending, expiry, scope, and storage-access failures are
+reported as separate error entries.
 
 ### Catalog overlay
 
-`CatalogOverlay` will be the read-only top-level SQL catalog backed by one integration. It will not
-point to, create, mutate, empty, or delete a separate Floecat `Catalog` resource. Its display name
-will be the SQL catalog name.
+`CatalogOverlay` binds one integration to one selection of upstream namespaces, and owns the Floecat
+`Catalog` those namespaces are exposed beneath. It is the direct replacement for the connector's
+`source` plus `destination` pair; the overlay does not carry a separate destination because the
+catalog it owns is the destination.
 
-Catalog and CatalogOverlay create, rename, replacement, and delete operations will use one shared
-account-level name reservation, so they cannot expose the same top-level SQL name. An overlay will
-keep an immutable integration binding through update. Replacement may choose a different binding
-because it creates a new overlay identity.
+```text
+CatalogOverlay
+  display_name         also the display name of the catalog it owns
+  integration_id       which upstream catalog and credentials to use (immutable through update)
+  include_namespaces   upstream selection
+  exclude_namespaces   upstream selection
+```
 
-The SQL mutation surface is deliberately narrower than the administrative API. SQL
-`ALTER CATALOG OVERLAY` will only rename an existing overlay; it will not change the Integration
-binding or the included and excluded namespace paths. SQL will change either the binding or
-namespace selection through `CREATE OR REPLACE CATALOG OVERLAY`, which atomically publishes a new
-overlay identity under the SQL catalog name. Replacement will retire the old overlay's bindings and
-capture demand and establish them from the replacement definition.
+The overlay's resource state is the mapping; the catalog it owns is where captured metadata lands.
+Creating an overlay creates that catalog in the same atomic pointer transaction, so an overlay can
+never exist without its catalog and a partially created overlay cannot leave an orphan catalog
+behind. Renaming an overlay renames its catalog in the same transaction.
+
+Because the owned catalog is an ordinary `Catalog`, top-level name uniqueness is the existing
+catalog by-name uniqueness. No separate top-level name reservation is required, and an overlay and a
+directly created catalog cannot share a name for the same reason two catalogs cannot.
+
+An overlay-owned catalog is read-only to clients: it is created, renamed, and deleted only through
+its overlay, and the catalog API rejects direct mutation of it and of the namespaces, tables, and
+views captured beneath it. This reuses the existing structural write guard rather than introducing a
+second writability mechanism.
+
+The integration binding is immutable through update, because changing it retargets everything the
+overlay has materialized. A replacing create produces a new overlay identity and may choose a
+different binding.
+
+Deleting an overlay deletes the catalog it owns and everything captured beneath it. That cascade is
+the overlay's own contract, not a side effect: an overlay's contents exist only because the overlay
+selected them.
 
 ## Namespace selection
 
-The SQL contract's include/exclude namespace paths are the target model; they are not placeholders
-for a separate prefix-remapping contract.
+Selection is expressed as include and exclude namespace paths in the upstream catalog's namespace
+space.
 
 - Paths are ordered from external catalog root to namespace leaf and matched case-sensitively.
 - An empty include list selects the whole external namespace tree.
 - An included path selects that namespace and all descendants.
-- An excluded path removes that namespace and all descendants; exclusion wins.
+- An excluded path removes that namespace and all descendants; exclusion wins when both match.
 - Paths are normalized and deduplicated without flattening segment boundaries.
-- Newly discovered namespaces matching the stored selection become eligible automatically once
-  discovery is wired to overlays.
-- Several overlays may select the same upstream object without requiring duplicate capture.
+- A selected upstream namespace materializes as a Floecat `Namespace` at the same path beneath the
+  overlay's catalog, preserving segment boundaries.
+- Newly discovered namespaces matching the stored selection materialize on the next synchronous
+  reconciliation.
 
-The API and CLI layers will store and may update these selections directly. That administrative
-update capability will not be mapped to SQL `ALTER CATALOG OVERLAY`; SQL clients must use
-`CREATE OR REPLACE` for filter changes. The initial delivery phases will not make the selected
-namespaces query-visible.
+Selection is updatable through the administrative API. A client that can only express selection at
+creation time changes it by replacing the overlay, which produces a new identity under the same
+name. Reconciliation makes the selected namespace, table-definition, and view metadata visible;
+snapshot-backed table visibility remains deferred to durable capture.
 
 ## Catalog access boundary
 
-The catalog-access SPI phase will introduce the Connector-independent boundary defined by this
-design:
+The implemented contracts and provider behavior are documented in
+[Catalog Access SPI](catalog-access-spi.md).
+
+The catalog-access SPI phase introduces the Connector-independent boundary defined by this design:
 
 ```text
 CatalogConnectionConfig
@@ -161,162 +218,252 @@ CatalogClientFactory
 CatalogCapabilities
 ```
 
-No SPI type will import Connector protobufs or carry a Connector resource ID. Provider lookup will
-be by catalog protocol and will fail explicitly for missing or duplicate providers.
+No SPI type imports Connector protobufs or carries a Connector resource ID. Provider lookup is by
+catalog protocol and fails explicitly for missing or duplicate providers.
 
-The Iceberg REST provider will provide:
+The Iceberg REST provider provides:
 
 - connection validation using a namespace-list request;
 - structured namespace, table, and view enumeration;
 - provider-neutral table metadata, including the provider-determined `TableFormat`, and stable
   upstream table identity when available;
-- provider-neutral view metadata, including output schema, SQL representations and dialects,
-  default namespace/search path, properties, and stable view identity when available;
+- provider-neutral view metadata, including output schema, view definitions and dialects, default
+  namespace/search path, properties, and stable view identity when available;
 - anonymous, OAuth2, and AWS SigV4 client authentication;
 - separate catalog-signing and storage credential scopes;
 - acquisition and renewal of short-lived, provider-vended storage credentials; and
 - renewable, process-local AWS credential registrations with serialized refresh and terminal
   failure handling.
 
-Views are first-class catalog objects in discovery and capture. The Integration path will reuse
-Floecat's existing view semantics and query-resolution behavior rather than introduce a parallel
+Views are first-class catalog objects in discovery and capture. The Integration path reuses
+Floecat's existing view semantics and resolution behavior rather than introducing a parallel
 external-view abstraction. A provider that advertises view support must support both enumeration
-and loading of a view's metadata. Providers without that capability will return namespaces and
-tables normally and will not advertise view support.
+and loading of a view's metadata. Providers without that capability return namespaces and tables
+normally and do not advertise view support.
 
-The SPI will validate persistable configuration so secrets, credential-provider handles,
-user-info, and secret-bearing headers cannot cross the configuration boundary. Secret values will
-be supplied separately through `ResolvedCatalogCredentials`.
+The SPI validates persistable configuration so secrets, credential-provider handles, user-info, and
+secret-bearing headers cannot cross the configuration boundary. Secret values are supplied
+separately through `ResolvedCatalogCredentials`.
 
-The later adapter must translate the Integration protobuf authentication variants and resolved
-`CatalogIntegrationCredentials` onto the SPI's authentication schemes. Integration authentication
-will be required, so the adapter need not select the SPI's `NONE` scheme. It must also perform
-provider-specific compatibility checks. The catalog-access SPI phase will not call
-`CatalogIntegrationCredentialStore`, expose Integration validation/discovery RPCs, or schedule
-work.
+The service adapter translates OAuth client credentials, bearer tokens, and explicit static AWS
+SigV4 credentials from the Integration protobuf and `CatalogIntegrationCredentialStore` onto the
+SPI's authentication schemes. Ambient and assume-role AWS resolution are not yet wired into this
+adapter and fail explicitly. Integration authentication is required, so the adapter never selects
+the SPI's `NONE` scheme. Dedicated Integration validation/listing RPCs and scheduling remain
+deferred; synchronous Overlay reconciliation performs validation and discovery internally.
 
-The catalog client will own external I/O only. Capture planning, Floecat persistence, overlay
-binding, scheduling, and query resolution will remain outside it.
+The catalog client owns external I/O only. Capture planning, Floecat persistence, scheduling, and
+name resolution remain outside it.
 
-## Canonical captured metadata
+## Materialized metadata and deferred capture
 
-External metadata will be captured once per integration rather than copied per overlay. A
-canonical key will be:
+Synchronous metadata reconciliation materializes ordinary Floecat resources beneath the overlay's
+catalog. A selected upstream namespace becomes a `Namespace`; a selected upstream table becomes a
+`Table` definition and initial `TableRoot`; and a selected upstream view becomes a `View`. These are
+the same logical resources the Connector path produces today and use the existing repositories and
+name-resolution paths.
 
-```text
-(account_id, integration_id, object_kind, upstream_object_id)
-```
+This phase deliberately does not create `Snapshot` resources, file groups, validation results, or
+statistics. Those require extending the durable reconciler from its current Connector-rooted job
+identity to an Integration/Overlay-rooted plan. That protocol and snapshot/file capture belong in a
+separate follow-on change.
 
-Provider-stable object IDs are preferred. When a provider has no stable ID, the normalized full
-upstream path is an explicitly unstable identity and rename is observed as delete plus create.
-Display names and overlay selection are never part of canonical identity.
+Upstream identity is recorded on the existing `UpstreamRef`. The Connector path stores
+`connector_id` there; the Integration path stores `catalog_integration_id` and
+`catalog_overlay_id`. The provider's external identity and stability flag are stored with the
+materialized object. Provider-stable IDs preserve a Floecat resource identity across an upstream
+rename or namespace move; when a provider has no stable ID, the normalized full upstream path is an
+explicitly unstable identity and rename is observed as delete plus create.
 
-Canonical tables will own their provider-determined format, schemas, snapshots, manifests, file
-groups, and statistics. The capture adapter will carry the format reported by the catalog-access
-provider into `Table.upstream.format`; downstream planning and query paths will continue to read it
-from the table protobuf. Canonical views will own their output schema, SQL definitions and dialects,
-creation search path, properties, and base-relation references. Views will not own table snapshots,
-manifests, file groups, or table statistics.
-
-A lightweight overlay binding will associate a canonical table or view with its SQL-visible path.
-An overlay-bound view will resolve its base relations within that overlay's projection of the same
-integration, using the captured upstream namespace/search-path context. The overlay display name
-will not become part of the canonical view definition or identity, allowing one captured view to be
-exposed through several overlays. This requires a new integration-owned external-object reference
-rather than adding an integration ID to the existing Connector-rooted `UpstreamRef`.
+Two overlays that select the same upstream table produce two Floecat tables, one beneath each
+overlay's catalog, exactly as two connectors would today. Deduplicating captures across overlays is
+not in scope: it would require a table identity separate from the `Catalog`/`Namespace` hierarchy,
+which is precisely the parallel architecture this design avoids. If that reuse is wanted later, it
+belongs in a separately reviewed change against the table model itself, not in the Integration path.
 
 ## Table validation and visibility
 
-Creating or replacing an overlay will establish capture demand for the tables selected by its
-namespace rules. The integration-owned scheduler will trigger or join discovery, file scanning,
-table validation, and statistics collection for the effective union of active overlay selections.
-An existing capture may satisfy that demand when it is current for the Integration configuration
-and capture-plan generations; creating another overlay will not duplicate the scan.
+The later durable-capture phase will make an active overlay establish capture demand for the tables
+its selection matches. The integration-owned scheduler will trigger or join discovery, file
+scanning, table validation, and statistics collection for the effective union of active overlay
+selections on that integration. The synchronous metadata RPC in the current phase does not enqueue
+that work.
 
-A table will not become query-visible through an overlay until its current capture has completed
-validation. Validation will compare each discovered Parquet file with the captured table format and
-metadata. A file that cannot be interpreted consistently with that metadata will produce one
-integration-owned validation-error record containing the Integration identity, canonical table
-identity and display path, `TableFormat`, file path, and error message. The SQL system view
-`sys.catalog_integration_table_error` will expose one row per current file error.
+A table does not become query-visible until its current capture has completed validation. Validation
+compares each discovered Parquet file with the captured table format and metadata. A file that
+cannot be interpreted consistently with that metadata produces one validation-error record against
+the table, containing the table identity and display path, `TableFormat`, file path, and error
+message. The API must expose those records for listing, one entry per current file error.
 
-Validation errors and table visibility will follow these rules:
+Validation errors and table visibility follow these rules:
 
-- no current file errors makes the table eligible for every matching active overlay binding;
-- one or more current file errors makes the table ineligible by default through every overlay that
-  references the canonical table;
+- no current file errors makes the table query-visible;
+- one or more current file errors makes the table invisible by default;
 - error publication is atomic with the validation generation, so a partially published scan cannot
   expose a table or mix errors from different generations;
 - a successful later validation atomically retires the previous error set and restores default
-  visibility without requiring overlay recreation; and
-- `DESCRIBE CATALOG INTEGRATION <integration> WITH VALIDATE` will request revalidation in addition
-  to connection, authentication, and credential-vending checks.
+  visibility;
+- an explicit per-table override makes a table query-visible despite current file errors, and the
+  error records remain listable while the override is active; and
+- describing an integration may request revalidation in addition to connection, authentication, and
+  credential-vending checks.
 
-The SQL `ALTER TABLE` override defined by the SQL specification will make a table query-visible
-despite current file errors. That override will be stored on the addressed overlay binding, not on
-the shared canonical table, so it will not weaken the default for other overlays. The error rows
-will remain visible while the override is active. Views have no file-validation state; resolving a
-view must still respect the visibility of its base tables and cannot use a view to bypass an
-invalid table's visibility gate.
+Views have no file-validation state; resolving a view must still respect the visibility of its base
+tables and cannot be used to bypass an invalid table's visibility gate.
 
 ## Refresh and reconciliation ownership
 
-This behavior is deferred beyond the initial delivery. Overlays will state user-facing freshness
-and retention demand; integrations will own upstream work. For active overlays on one integration,
-the scheduler will compute one effective plan:
+Scheduling, freshness, and retention remain deferred. Overlays will state freshness and retention
+demand; integrations will own upstream connection work. For active overlays on one integration,
+the scheduler computes one effective plan:
 
-- discovery and capture scope is the union of selected namespaces, including matching tables and
-  views, while file validation and statistics collection apply to the matching tables;
+- discovery scope is the union of selected namespaces, including matching tables and views, while
+  file validation and statistics collection apply to the matching tables;
 - refresh interval is the shortest requested interval;
 - retained history satisfies the longest requested retention; and
-- pausing an overlay removes its visibility and demand, while pausing an integration stops all new
-  upstream work.
+- pausing an overlay removes its demand, while pausing an integration stops all new upstream work.
 
-A future integration configuration generation and capture-plan generation will fence every planned
-and leased job. Stale work may finish external I/O but must not publish results after configuration,
-selection, pause, replacement, or deletion changes.
+Sharing applies to upstream I/O: two overlays selecting the same upstream namespace from one
+integration issue one discovery pass, then materialize into their own catalogs.
+
+The synchronous metadata reconciler already fences every resource publication on the observed
+Integration and Overlay pointer generations and the absence of account, Integration, and Overlay
+deletion markers. A future capture-plan generation must extend equivalent fencing to every planned
+and leased durable job. Stale work may finish external I/O but must not publish results after
+configuration, selection, pause, replacement, or deletion changes.
 
 ## Lifecycle and garbage collection
 
-| Operation | Initial delivery behavior | Later behavior |
+| Operation | Current behavior | Deferred behavior |
 | --- | --- | --- |
-| Rename integration or overlay | Atomic rename with optimistic preconditions and shared SQL-name checks for overlays | No additional behavior required |
+| Rename integration | Atomic rename with optimistic preconditions | No additional behavior required |
+| Rename overlay | Atomic rename of the overlay and the catalog it owns in one transaction | No additional behavior required |
 | Replace integration | New identity; rejected while dependent overlays exist | Validation may run before publication |
 | Rotate credentials | Atomic new credential generation; old generation retired after publication | Reclaim acknowledgement-uncertain orphan generations |
-| Create or replace overlay | Stores namespace selection and integration dependency | Trigger or join validation and statistics capture; expose only validated tables |
-| Delete overlay | Removes resource pointers and integration dependency atomically | Fence jobs, remove bindings, retain shared captures still in use |
-| Delete integration | Rejected while overlays exist | Fence integration-owned jobs and captured publication |
-| Cascade integration delete | Durable deletion fence, dependent overlay deletion, resource deletion, and credential cleanup | Remove bindings and make unreferenced captures GC-eligible |
-| Delete account | Integration credentials are included in account cleanup | Include future bindings and captures |
+| Create or replace overlay | Creates the overlay and its catalog atomically; stores selection and integration dependency; replacement fences and retires prior materializations | Trigger or join durable snapshot/file capture into that catalog |
+| Reconcile overlay | Synchronously validates the connection, discovers the selected inventory, and creates, updates, or retires namespaces, table definitions, and views behind generation fences | Schedule reconciliation and capture snapshots, files, validation, and statistics |
+| Delete overlay | Installs an Overlay deletion fence, explicitly retires materialized descendants, then atomically removes the empty catalog, overlay, dependency, and fence | Cancel and drain durable jobs |
+| Delete integration | Rejected while overlays exist | Fence integration-owned jobs |
+| Cascade integration delete | Durable Integration and Overlay deletion fences, explicit descendant retirement, dependent overlay/catalog deletion, resource deletion, and credential cleanup | Cancel and drain durable jobs |
+| Delete account | Durable deletion fence, then cleanup of overlays, integrations, and integration credentials | No additional behavior required |
 
-Captured metadata GC is deferred. Future capture data will become eligible only when no retained
-binding or query pin references it, no current-generation job can publish to it, and its retention
-grace period has elapsed. Validation-error records will be retained with their canonical table and
-atomically replaced or removed when a later validation generation is published. They will also be
-removed when the canonical table becomes eligible for collection.
+Overlay lifecycle code explicitly deletes logical `Namespace`, `Table`, and `View` resources and
+purges table snapshot/root pointer state; existing pointer and CAS-blob garbage collection remains
+responsible for reclaiming unreachable immutable blobs. Garbage collection is not a substitute for
+retiring the logical resource pointers. Validation-error records will be retained with their table
+and atomically replaced or removed when a later validation generation is published.
+
+## Durability contract
+
+Integration-owned resources are held to a stricter durability contract than the Connector path they
+replace. This is a deliberate decision, not a side effect of the decomposition, and it is intended
+to become the standard the rest of the catalog moves toward rather than a local exception.
+
+The Connector path is the baseline being improved on. It stores a connector's secret under a key
+that is just the connector id, with no generation, and recovers from a failed rotation by putting
+the previous value back on a best-effort basis — a restore that can itself fail or lose a race.
+It does not publish an idempotency receipt atomically with the resource it created, so a retry
+after an acknowledgement-uncertain create reconstructs its answer from mutable resource state.
+
+Integration-owned resources instead guarantee:
+
+- **Generation-reserved credentials.** Each credential version is an immutable generation reserved
+  with atomic `putIfAbsent` before the resource CAS, retired only after the new generation is
+  published, and deliberately retained when publication is acknowledgement-uncertain. Rotation
+  never depends on a compensating write succeeding.
+- **Receipt-in-batch idempotency.** A create reserves its resource identity in a durable pending
+  record, then publishes the immutable success receipt in the same atomic pointer transaction as
+  the resource. A replay returns the recorded answer; it never re-derives one from state that a
+  later mutation may have changed.
+- **Fenced dependencies and cascades.** Dependency counts, cascade deletion, and lifecycle markers
+  are asserted inside the same pointer transaction as the mutation they guard, so a concurrent
+  create cannot slip beneath a delete that has already checked for dependents.
+- **Strongly consistent reads where absence is load-bearing.** A cascade or dependency check that
+  misses a row produces an orphan or a wrongly permitted delete, so those paths do not read
+  secondary indexes through an eventually consistent path.
+- **Mutation reads on raw stores.** Prerequisite and post-commit reads inside a mutation protocol
+  go to the stores being mutated, never through caches or read adapters.
+
+The cost is real and concentrated in shared code rather than in the new resources: most of it lands
+in the generic resource repository, the idempotency guard, account deletion, and the storage read
+interfaces. Three consequences are large enough to describe separately.
+
+### Delivery sequencing
+
+The durability primitives land as their own reviewed change before the account-deletion fence and
+the Integration and Overlay resources that depend on them. Keeping this cross-cutting work separate
+makes its effect on every resource type independently reviewable and keeps the resource/API changes
+focused on their own contracts.
+
+Future work that raises a cross-cutting contract should land as its own change first, with the
+feature that motivated it stacked on top. Where this contract is extended — to capture, scheduling,
+or the remaining resource types — that extension is its own reviewed change and does not ride along
+with the phase that needs it.
+
+### Account deletion fence
+
+Adding integrations, overlays, and their credentials to account cleanup makes account deletion a
+multi-resource operation, so deleting the account record alone is no longer a sufficient contract.
+Account deletion therefore installs a durable deletion fence before it removes the account record,
+and clears that fence only if the account delete itself does not commit.
+
+The fence has two consequences that reach beyond the Integration path:
+
+- Every resource create asserts the account's fence is absent in the same atomic pointer
+  transaction. A create that races an account deletion cannot leave a resource behind that cleanup
+  has already walked past.
+- A delete whose account record is already gone replays cleanup instead of reporting success. A
+  prior delete that committed the account record and then failed part-way through descendant
+  cleanup is resumable rather than permanently half-applied.
+
+### Consistent reads for cascade operations
+
+Cascade deletion and dependency checks must not read secondary indexes through an eventually
+consistent path: a missed overlay would leave an orphan behind a deleted integration, and a missed
+dependent would let a delete that should be rejected succeed. The storage SPI therefore exposes
+strongly consistent variants of prefix listing and counting alongside the ordinary reads, and
+cascade and dependency paths use those variants. Ordinary listing RPCs keep the default reads.
+
+The variants are defaults on the SPI interfaces that delegate to the existing reads, so a backend
+without a separate consistent-read mode inherits correct behavior. `storage/aws` overrides them
+with DynamoDB consistent reads.
+
+## Create-conflict behavior
+
+Create requests carry an explicit conflict mode so a caller can choose between failing, replacing,
+and returning the existing resource:
+
+- **error if exists** — the default; a name collision is an error.
+- **replace** — publishes a new resource identity under the same name, atomically retiring the old
+  one. Replacement is itself state-idempotent and cannot be combined with an idempotency key.
+- **return existing** — returns the current resource unchanged when the name is already taken.
+
+Replacement rather than update is how a caller changes an immutable binding: the integration binding
+on an overlay, and the type and URI on an integration.
 
 ## Follow-on API evolution
 
 After the initial delivery, follow-on changes will:
 
-1. Wire Integration resources and the typed credential resolver to the catalog-access SPI.
-2. Add validation, capability, namespace-listing, and object-listing service RPCs required by the
-   SQL functions. Validation will exercise both catalog authentication and usable storage-credential
-   vending; object listing will distinguish namespaces, tables, and views.
-3. Add integration-scoped canonical object identity, validation-error persistence, and lightweight
-   overlay bindings.
-4. Add overlay policy/state, table visibility and override handling, and integration-owned
-   scheduling with generation fencing.
-5. Add query visibility, retained capture GC, credential orphan reclamation, migration, and
-   Connector retirement in separately reviewed changes.
+1. Wire Integration resources and the typed credential resolver to the catalog-access SPI and add
+   synchronous, generation-fenced Overlay metadata reconciliation. This is the first follow-on and
+   materializes namespaces, table definitions, and views, but not snapshots or files.
+2. Add validation, capability, namespace-listing, and object-listing RPCs. Validation exercises both
+   catalog authentication and usable storage-credential vending; object listing distinguishes
+   namespaces, tables, and views.
+3. Extend the durable reconciler with Integration/Overlay-rooted jobs and capture `Snapshot`, file,
+   validation, and statistics state beneath the already materialized tables.
+4. Add overlay policy and state, table validation-error persistence, visibility and override
+   handling, and integration-owned scheduling with durable job-generation fencing.
+5. Add migration from Connectors and Connector removal in separately reviewed changes.
 
 Because backwards compatibility is not a project requirement at this stage, contracts should be
 replaced when semantics differ rather than accumulating aliases or hidden fallback behavior.
 
 ## Legacy Connector disposition
 
-Connectors will remain operational as a separate API while the Integration path is completed. This
-will be temporary coexistence, not a compatibility layer:
+Connectors remain operational as a separate API while the Integration path is completed. This is
+temporary coexistence, not a compatibility layer:
 
 - Integration and Overlay services will not create or read Connector resources.
 - The catalog-access SPI will not import Connector protos or delegate to Connector services.
@@ -326,19 +473,13 @@ will be temporary coexistence, not a compatibility layer:
 There is deliberately no runtime fallback from an Integration to a Connector. Unsupported provider
 or authentication combinations must fail explicitly.
 
-## Delivery phases and boundaries
+Migration is mechanical because the resources are a decomposition of the connector: each connector
+yields one integration from its `uri`, `auth`, and `kind`, and one overlay from its `source` and
+`destination`, with connectors sharing an endpoint and credentials collapsing onto one integration.
+A connector whose destination is an existing catalog migrates by making that catalog overlay-owned,
+so its existing namespaces, tables, and snapshots remain valid and are not re-materialized.
 
-1. **Architecture and delivery plan:** define the architecture, design decisions, and delivery
-   boundaries.
-2. **Resource and API foundation:** add CRUD, SQL identity, authentication/credential lifecycle,
-   atomic storage, idempotency, dependency, cascade, and cleanup primitives.
-3. **CLI surface:** add CLI coverage for those APIs, including typed authentication and write-only
-   credential input for create and rotation commands.
-4. **Catalog-access SPI:** add the neutral catalog-access SPI and Iceberg REST vertical slice,
-   including table and view discovery and loading.
-5. **Follow-on:** add the Integration-to-SPI adapter and SQL-required validation/discovery RPCs.
-6. **Later:** add canonical capture/bindings, table validation and error visibility, scheduling,
-   query visibility, garbage collection, migration, and Connector removal.
+## Initial CLI name resolution
 
 The CLI will initially resolve Integration and Overlay display names by listing the corresponding
 resource type. The duplication will remain isolated and will not require expanding the API until

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -1,131 +1,114 @@
-# Catalog Integration Architecture Decisions
+# Catalog Integration Architecture and Delivery Plan
 
-Status: accepted for implementation after the inert Integration and Overlay CRUD foundation.
+Status: accepted; the resource, authentication, CLI, and first catalog-access layers are
+implemented in the current PR stack.
 
-This document defines the target architecture for catalog integrations. It is intentionally a
-design boundary: it fixes resource ownership, namespace mapping, capture identity, scheduling, and
-lifecycle semantics before those behaviors are added to the production APIs.
+This document records both the target architecture and the boundary of each stacked change. It is
+aligned with the Catalog Integration and Catalog Overlay SQL specification. It distinguishes code
+already present below this change, code in the following PR, and work that remains deferred.
+
+## Stack implementation map
+
+| Change | Implemented boundary | Explicitly not implemented |
+| --- | --- | --- |
+| #424, Catalog Integration and Overlay APIs | CRUD resources, typed authentication, write-only credential storage and rotation, shared SQL catalog-name reservation, idempotency, optimistic concurrency, dependencies, cascade deletion, and atomic persistence primitives | Upstream connectivity, provider discovery, validation RPCs, capture, reconciliation, and query visibility |
+| #425, Shell CLI | Integration and Overlay CRUD commands, typed authentication input, write-only credential input, authentication rotation, pagination, name resolution, namespace filters, cascade, and etag preconditions | Connectivity validation, discovery, capture, reconciliation, and query visibility |
+| #439, this document | Architecture decisions and delivery boundaries | Production behavior |
+| #440, catalog-access SPI | Connector-independent catalog client SPI plus an Iceberg REST provider with validation, discovery, table loading, OAuth2, SigV4, and renewable AWS credential support | Wiring Catalog Integration resources to the SPI, Integration validation/listing RPCs, persistence, scheduling, and capture |
 
 ## Goals
 
-The catalog integration model will provide a simpler way to:
+The catalog integration model provides a SQL-compatible way to:
 
 - authenticate Floecat to an upstream catalog;
-- map upstream catalog namespaces into SQL-visible Floecat catalogs and namespaces;
-- define freshness and retention requirements; and
-- capture external metadata once while exposing it through one or more overlays.
+- select upstream namespaces beneath a read-only SQL catalog name;
+- discover and validate upstream objects without depending on Connector resources; and
+- eventually capture external metadata once while exposing it through one or more overlays.
 
-The new path does not use, wrap, synthesize, or fall back to Connector resources. Connectors remain
-a separate legacy path during migration and will eventually be deprecated.
+The Integration path does not use, wrap, synthesize, or fall back to Connector resources.
+Connectors currently remain a separate operational path and are retired through an explicit later
+migration, not through runtime fallback.
 
 ## Resource and ownership model
 
-The target model has two resource layers plus shared captured metadata:
-
 ```text
-CatalogIntegration                 connection, authentication, canonical upstream identity
- ├── captured namespace/table      shared metadata, snapshots, file groups, and statistics
- ├── CatalogOverlay "sales"        top-level SQL catalog, mappings, visibility, and demand
- └── CatalogOverlay "finance"      another top-level projection of the same integration
+CatalogIntegration                 connection and authentication
+ ├── captured namespace/table      future shared metadata and statistics
+ ├── CatalogOverlay "sales"        top-level SQL catalog and namespace selection
+ └── CatalogOverlay "finance"      another projection of the same integration
 ```
 
 ### Catalog integration
 
-`CatalogIntegration` owns the upstream catalog protocol, endpoint, authentication configuration,
-credential lifecycle, and canonical identity of captured external objects. Its immutable resource
-ID is used by capture and reconciliation; display names are never operational identity.
+`CatalogIntegration` owns the upstream protocol, HTTP(S) endpoint, non-secret authentication
+configuration, credential lifecycle, and eventually the canonical identity of captured external
+objects. Its immutable resource ID is operational identity; its display name is mutable SQL-facing
+metadata.
 
-The integration type identifies a catalog protocol or provider, such as Iceberg REST, Unity
-Catalog, or AWS Glue. It does not identify the table format. A provider can expose more than one
-table format, and format-specific behavior belongs to the discovered table metadata and catalog
-client capabilities.
+The API currently supports Iceberg REST and Unity integration types. Authentication is required and
+is represented by typed protobuf messages for OAuth client credentials, bearer tokens, AWS assume
+role, AWS access keys, and AWS SigV4. Unity currently accepts only OAuth client credentials or
+bearer authentication. The base service validates structural compatibility; endpoint/provider
+support is intentionally left to the catalog-access adapter and provider.
 
-Secret values are stored outside the integration protobuf. Reads expose only the configured
-authentication scheme, non-secret options, whether credentials are configured, and a credential
-generation. Credential writes use a dedicated request that never returns secret material.
+Type and catalog URI are immutable through update. `CREATE OR REPLACE` creates a new resource
+identity. It is rejected while overlays depend on the existing integration because replacement
+must not silently retarget those overlays.
+
+### Authentication and credentials
+
+Persisted resources contain only non-secret authentication configuration,
+`credentials_configured`, and a server-managed credential generation. Secret values are supplied
+on create or through the dedicated authentication-update RPC and are never returned.
+
+The service derives its internal secret key from integration ID and credential generation. No
+secret-manager reference is exposed in the public resource. `CatalogIntegrationCredentialStore`
+provides the typed service-side resolution primitive required by a later catalog-access adapter.
+
+Credential publication has these guarantees:
+
+- a new immutable generation is reserved with atomic `putIfAbsent` before the resource CAS;
+- the old generation is retired only after the new resource generation is published;
+- a definite publication failure removes the prepared secret;
+- an acknowledgement-uncertain publication retains the secret because the resource CAS may have
+  succeeded; and
+- idempotent create may carry credentials, excludes secret bytes from its fingerprint, and returns
+  the first successfully published value for that key.
+
+Reclamation of retained, unreachable credential generations is not implemented in this stack. A
+later orphan-reclamation PR will add that mechanism; this document does not claim it exists today.
 
 ### Catalog overlay
 
-`CatalogOverlay` is a read-only top-level SQL catalog backed by one integration. Its display name is
-the catalog name. It owns namespace mappings, visibility state, and refresh/retention demand; it
-does not point to or mutate a separate `Catalog` resource.
+`CatalogOverlay` is the read-only top-level SQL catalog backed by one integration. It does not point
+to, create, mutate, empty, or delete a separate Floecat `Catalog` resource. Its display name is the
+SQL catalog name.
 
-Several overlays may expose different projections of the same integration under different
-top-level catalog names. The account-level catalog namespace must reject collisions between overlay
-display names and other top-level catalogs. Captured namespaces and relations inside an overlay are
-read-only; writable local objects belong in a separate regular catalog.
+Catalog and CatalogOverlay create, rename, replacement, and delete operations use one shared
+account-level name reservation, so they cannot expose the same top-level SQL name. An overlay keeps
+an immutable integration binding through update. Replacement may choose a different binding
+because it creates a new overlay identity.
 
-## Namespace selection and mapping
+## Namespace selection
 
-The current include/exclude paths are sufficient for inert CRUD but not for the target product.
-The behavioral contract replaces them with explicit source-to-target prefix mappings:
+The SQL contract's include/exclude namespace paths are the target model; they are not placeholders
+for a separate prefix-remapping contract.
 
-```proto
-message NamespaceMapping {
-  NamespacePath source_prefix = 1;
-  NamespacePath target_prefix = 2;
-  bool recursive = 3;
-}
+- Paths are ordered from external catalog root to namespace leaf and matched case-sensitively.
+- An empty include list selects the whole external namespace tree.
+- An included path selects that namespace and all descendants.
+- An excluded path removes that namespace and all descendants; exclusion wins.
+- Paths are normalized and deduplicated without flattening segment boundaries.
+- Newly discovered namespaces matching the stored selection become eligible automatically once
+  discovery is wired to overlays.
+- Several overlays may select the same upstream object without requiring duplicate capture.
 
-message CatalogOverlaySpec {
-  optional string display_name = 1;
-  ResourceId integration_id = 2;
-  repeated NamespaceMapping namespace_mappings = 3;
-  repeated NamespacePath exclude_namespaces = 4;
-  CatalogOverlayState state = 5;
-  CatalogOverlayPolicy policy = 6;
-}
-```
-
-The protobuf above is illustrative. The inert CRUD field numbers remain contiguous; numbering for
-new fields and request separation are finalized when the contract is implemented. The semantics
-are fixed:
-
-- Paths are ordered from catalog root to namespace leaf, trimmed, and matched case-sensitively.
-- A recursive mapping maps every descendant by appending its suffix to `target_prefix`.
-- A non-recursive mapping exposes only the exact source namespace.
-- Exclusions are expressed in upstream namespace space and take precedence over mappings.
-- Newly discovered namespaces that match an active mapping become visible automatically.
-- Empty source or target prefixes represent the upstream or overlay catalog root, respectively.
-- Source mappings within one overlay may not overlap. Target prefixes may not overlap. Rejecting
-  ambiguity is preferable to order-dependent precedence.
-- Two overlays may expose the same canonical table under different catalogs or names without
-  duplicating captured metadata.
-
-For example, mapping `production.sales` to `sales` recursively exposes
-`production.sales.orders` as `sales.orders`. An exclusion for
-`production.sales.private` suppresses that namespace and all descendants.
-
-## Shared captured metadata
-
-External metadata is captured once per integration and is not stored as catalog-owned table copies.
-A canonical captured object key consists of:
-
-```text
-(account_id, integration_id, object_kind, upstream_object_id)
-```
-
-Provider-stable object IDs are preferred. When a provider has no stable ID, the normalized full
-upstream path is the fallback identity and an upstream rename is observed as delete plus create.
-Display names and overlay mappings are never part of canonical identity.
-
-Canonical tables own their schemas, snapshots, manifests, file groups, and statistics. An overlay
-binding is lightweight state that associates a canonical object with a path inside the overlay's
-top-level catalog. Its identity includes the overlay ID, canonical object ID, and exposed path.
-Query resolution returns the canonical table identity plus the binding through which it was
-resolved, so several overlay catalogs can safely share one captured object and one set of
-statistics.
-
-This requires an explicit replacement for the current connector-rooted `UpstreamRef`; adding an
-integration ID beside a connector ID would create two competing identities. The integration path
-will use a new canonical external-object reference. Connector-backed tables retain their existing
-reference until the explicit migration phase.
+The current API and CLI implement storage and mutation of these selections. They do not yet make
+the selected namespaces query-visible.
 
 ## Catalog access boundary
 
-Catalog connectivity is extracted behind a neutral library before integration-driven capture is
-implemented. The boundary uses catalog concepts rather than Connector RPC concepts. Its expected
-shape is:
+PR #440 implements the Connector-independent boundary anticipated by this design:
 
 ```text
 CatalogConnectionConfig
@@ -137,104 +120,124 @@ CatalogClientFactory
 CatalogCapabilities
 ```
 
-No type in this boundary imports Connector protobufs or carries a Connector resource ID. The first
-vertical slice is Iceberg REST. The existing Iceberg Connector remains operational on its separate
-Connector SPI and does not delegate to this library. Integration code likewise never delegates to a
-Connector resource or service. Unity Catalog and Glue support follow as separate provider
-implementations.
+No SPI type imports Connector protobufs or carries a Connector resource ID. Provider lookup is by
+catalog protocol and fails explicitly for missing or duplicate providers.
 
-The client boundary covers connection validation, namespace and relation enumeration, stable
-identity lookup, and provider metadata access. Capture planning, scheduling, Floecat persistence,
-overlay binding, and query resolution remain outside the catalog client.
+The Iceberg REST provider in #440 implements:
+
+- connection validation using a namespace-list request;
+- structured namespace and table enumeration;
+- provider-neutral table metadata and stable Iceberg table UUID identity when available;
+- anonymous, OAuth2, and AWS SigV4 client authentication;
+- separate catalog-signing and storage credential scopes; and
+- renewable, process-local AWS credential registrations with serialized refresh and terminal
+  failure handling.
+
+The SPI validates persistable configuration so secrets, credential-provider handles, user-info,
+and secret-bearing headers cannot cross the configuration boundary. Secret values are supplied
+separately through `ResolvedCatalogCredentials`.
+
+The remaining adapter must translate the Integration protobuf authentication variants and resolved
+`CatalogIntegrationCredentials` onto the SPI's authentication schemes. Integration authentication
+is currently required, so the adapter need not select the SPI's `NONE` scheme. It must also perform
+provider-specific compatibility checks. #440 does not yet call
+`CatalogIntegrationCredentialStore`, expose Integration validation/discovery RPCs, or schedule
+work.
+
+The catalog client owns external I/O only. Capture planning, Floecat persistence, overlay binding,
+scheduling, and query resolution remain outside it.
+
+## Canonical captured metadata
+
+This section is target design, not current implementation. External metadata will be captured once
+per integration rather than copied per overlay. A canonical key is:
+
+```text
+(account_id, integration_id, object_kind, upstream_object_id)
+```
+
+Provider-stable object IDs are preferred. When a provider has no stable ID, the normalized full
+upstream path is an explicitly unstable identity and rename is observed as delete plus create.
+Display names and overlay selection are never part of canonical identity.
+
+Canonical tables will own schemas, snapshots, manifests, file groups, and statistics. A lightweight
+overlay binding will associate a canonical object with its SQL-visible path. This requires a new
+integration-owned external-object reference rather than adding an integration ID to the existing
+Connector-rooted `UpstreamRef`.
 
 ## Refresh and reconciliation ownership
 
-Overlays state user-facing freshness and retention requirements; integrations own upstream work.
-For all active overlays on an active integration, the scheduler computes one effective capture
-plan:
+This section is also deferred target design. Overlays will state user-facing freshness and
+retention demand; integrations will own upstream work. For active overlays on one integration, the
+scheduler will compute one effective plan:
 
-- capture scope is the union of namespaces selected by active overlays;
+- capture scope is the union of selected namespaces;
 - refresh interval is the shortest requested interval;
-- retained history is sufficient for the longest requested retention; and
-- pausing an overlay removes its visibility and policy demand, while pausing an integration stops
-  all new upstream work for it.
+- retained history satisfies the longest requested retention; and
+- pausing an overlay removes its visibility and demand, while pausing an integration stops all new
+  upstream work.
 
-Changing connection configuration or credentials advances an integration configuration generation.
-Changing mappings, policy, or overlay state advances the effective capture-plan generation. Every
-planned and leased job carries both generations. Publishing captured data or bindings is conditional
-on those generations still being current. A stale job may finish external I/O, but it cannot publish
-results or repopulate a changed or deleted overlay.
-
-Reconciliation jobs and deduplication keys use integration and canonical external-object identity.
-There is no Connector fallback if an integration provider is unavailable or unsupported; the
-integration reports an actionable validation or reconciliation error.
+A future integration configuration generation and capture-plan generation will fence every planned
+and leased job. Stale work may finish external I/O but must not publish results after configuration,
+selection, pause, replacement, or deletion changes.
 
 ## Lifecycle and garbage collection
 
-Lifecycle operations have the following effects:
+| Operation | Current stack | Later behavior |
+| --- | --- | --- |
+| Rename integration or overlay | Atomic rename with optimistic preconditions and shared SQL-name checks for overlays | No additional behavior required |
+| Replace integration | New identity; rejected while dependent overlays exist | Validation may run before publication |
+| Rotate credentials | Atomic new credential generation; old generation retired after publication | Reclaim acknowledgement-uncertain orphan generations |
+| Delete overlay | Removes resource pointers and integration dependency atomically | Fence jobs, remove bindings, retain shared captures still in use |
+| Delete integration | Rejected while overlays exist | Fence integration-owned jobs and captured publication |
+| Cascade integration delete | Durable deletion fence, dependent overlay deletion, resource deletion, and credential cleanup | Remove bindings and make unreferenced captures GC-eligible |
+| Delete account | Integration credentials are included in account cleanup | Include future bindings and captures |
 
-| Operation | Required behavior |
-| --- | --- |
-| Pause overlay | Hide its bindings and remove its policy demand; retain shared captures. |
-| Delete overlay | Fence its jobs, remove its top-level catalog bindings and policy demand, and retain shared captures still in use. |
-| Pause integration | Stop new work and fence publication from work planned before the pause. |
-| Rotate credentials | Atomically advance the credential/configuration generation; never expose the old or new secret. |
-| Delete integration | Reject while overlays exist unless explicit cascade was requested. |
-| Cascade integration delete | Delete overlays, cancel/fence jobs, delete credentials, then make unreferenced captures GC-eligible. |
+Captured metadata GC is not implemented. Future capture data becomes eligible only when no retained
+binding or query pin references it, no current-generation job can publish to it, and its retention
+grace period has elapsed.
 
-Captured metadata becomes eligible for garbage collection only when no active or retained overlay
-binding references it, no query pin protects it, no in-flight current-generation job can publish to
-it, and the configured retention grace period has elapsed. Deleting an overlay never immediately
-deletes shared snapshots or statistics used by another overlay.
+## Remaining API evolution
 
-## Proposed API evolution
+The lower PRs already provide the SQL-facing CRUD and credential primitives. Remaining changes are:
 
-The inert CRUD resources remain the foundation. Behavioral implementation evolves them with:
+1. Wire Integration resources and the typed credential resolver to the catalog-access SPI.
+2. Add validation, capability, namespace-listing, and object-listing service RPCs required by the
+   SQL functions.
+3. Add integration-scoped canonical object identity and lightweight overlay bindings.
+4. Add overlay policy/state and integration-owned scheduling with generation fencing.
+5. Add query visibility, retained capture GC, credential orphan reclamation, migration, and
+   Connector retirement in separately reviewed changes.
 
-1. A typed, integration-owned catalog connection and authentication contract, dedicated credential
-   mutation, validation/capabilities RPCs, and credential generations.
-2. Namespace mappings and overlay refresh/retention policy, replacing selection-only filters.
-3. Canonical captured-resource and overlay-binding contracts independent of Connector protos.
-4. Configuration and capture-plan generations used by every reconciliation job and publish step.
-5. Explicit cascade requests, dependency reporting, job fencing, credential cleanup, and retained
-   metadata garbage collection.
-
-Because backwards compatibility is not a project requirement at this stage, fields should be
-replaced where the semantics differ rather than preserving aliases or hidden fallback behavior.
+Because backwards compatibility is not a project requirement at this stage, contracts should be
+replaced when semantics differ rather than accumulating aliases or hidden fallback behavior.
 
 ## Legacy Connector disposition
 
-Connectors remain operational as a separate legacy API while the new path is built. This is a
-temporary coexistence decision, not a compatibility layer:
+Connectors currently remain operational as a separate API while the Integration path is completed.
+This is temporary coexistence, not a compatibility layer:
 
 - Integration and Overlay services do not create or read Connector resources.
-- Integration validation and reconciliation do not call Connector RPCs.
-- New integration contracts and neutral catalog-access types do not import Connector protos.
-- Existing Connector-backed tables and jobs continue to work unchanged until an explicit migration.
-- Migration maps connectivity and authentication to integrations and top-level catalog
-  projection/filtering to overlays, then retires Connector APIs and persisted state in a separately
-  reviewed change.
+- The catalog-access SPI does not import Connector protos or delegate to Connector services.
+- Future Integration validation and reconciliation must not call Connector RPCs.
+- Migration and Connector removal require their own reviewed change.
 
-There is deliberately no runtime fallback from an Integration to a Connector. Silent fallback would
-make ownership, credentials, scheduling, and failure semantics impossible to reason about.
+There is deliberately no runtime fallback from an Integration to a Connector. Unsupported provider
+or authentication combinations must fail explicitly.
 
-## Implementation sequence
+## Delivery plan and PR boundaries
 
-The next changes should retain clear review boundaries:
+1. **Complete — #424:** CRUD, SQL identity, authentication/credential lifecycle, atomic storage,
+   idempotency, dependency, cascade, and cleanup primitives.
+2. **Complete — #425:** CLI coverage for those APIs, including typed authentication and write-only
+   credential input for create and rotation commands.
+3. **This change — #439:** keep the architecture and delivery record aligned with implemented code.
+4. **Implemented in the following PR — #440:** neutral catalog-access SPI and Iceberg REST vertical
+   slice.
+5. **Next:** Integration-to-SPI adapter and SQL-required validation/discovery RPCs.
+6. **Later:** canonical capture/bindings, scheduling, query visibility, garbage collection,
+   migration, and Connector removal.
 
-1. Introduce the neutral catalog-access SPI and an Iceberg REST implementation while leaving the
-   operational legacy Iceberg Connector on its separate Connector SPI.
-2. Add integration authentication, secret persistence, credential rotation, capability discovery,
-   validation, and their CLI surface. Do not schedule reconciliation yet.
-3. Add integration-scoped canonical capture identity and lightweight overlay bindings, including
-   collision and name-resolution tests.
-4. Move scheduling and job identity to integrations with generation fencing. Do not add Connector
-   fallback.
-5. Complete query visibility, cascade lifecycle, garbage collection, migration, and finally
-   Connector deprecation/removal in separate changes.
-
-The Integration/Overlay CLI currently resolves display names by listing the corresponding resource
-type, so its integration and overlay helpers contain similar pagination and ambiguity handling.
-That duplication is small and isolated. It should remain in the inert CLI change rather than
-expanding the earlier API PR. A generic resource resolver is worthwhile only when the Directory API
-supports these resource kinds or another CLI resource needs the same behavior.
+The CLI currently resolves Integration and Overlay display names by listing the corresponding
+resource type. The duplication is isolated and does not require expanding the API until another
+consumer needs a generic resolver.

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -138,9 +138,10 @@ CatalogCapabilities
 ```
 
 No type in this boundary imports Connector protobufs or carries a Connector resource ID. The first
-vertical slice is Iceberg REST. The existing Iceberg Connector may delegate catalog access to this
-library during transition, but Integration code never delegates to a Connector resource or service.
-Unity Catalog and Glue support follow as separate provider implementations.
+vertical slice is Iceberg REST. The existing Iceberg Connector remains operational on its separate
+Connector SPI and does not delegate to this library. Integration code likewise never delegates to a
+Connector resource or service. Unity Catalog and Glue support follow as separate provider
+implementations.
 
 The client boundary covers connection validation, namespace and relation enumeration, stable
 identity lookup, and provider metadata access. Capture planning, scheduling, Floecat persistence,
@@ -221,8 +222,8 @@ make ownership, credentials, scheduling, and failure semantics impossible to rea
 
 The next changes should retain clear review boundaries:
 
-1. Introduce the neutral catalog-access SPI and an Iceberg REST implementation; adapt the legacy
-   Iceberg Connector to use it internally.
+1. Introduce the neutral catalog-access SPI and an Iceberg REST implementation while leaving the
+   operational legacy Iceberg Connector on its separate Connector SPI.
 2. Add integration authentication, secret persistence, credential rotation, capability discovery,
    validation, and their CLI surface. Do not schedule reconciliation yet.
 3. Add integration-scoped canonical capture identity and lightweight overlay bindings, including

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Iceberg REST Gateway: iceberg-rest-gateway.md
       - Arrow Flight: arrow-flight.md
   - Catalog and Metadata:
+      - Catalog Integration Architecture Decisions: catalog-integration-design.md
       - Metadata Graph: metadata-graph.md
       - System Objects: system-objects.md
       - System Scans: system-scans.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,7 @@ nav:
       - Iceberg REST Gateway: iceberg-rest-gateway.md
       - Arrow Flight: arrow-flight.md
   - Catalog and Metadata:
-      - Catalog Integration Architecture Decisions: catalog-integration-design.md
+      - Catalog Integration Architecture and Delivery Plan: catalog-integration-design.md
       - Metadata Graph: metadata-graph.md
       - System Objects: system-objects.md
       - System Scans: system-scans.md


### PR DESCRIPTION
## Summary

Finalizes `catalog-integration-design.md` as the design and delivery contract for the catalog integration stack. It incorporates the implementation decisions reflected by the completed stack, links the eventual Catalog Access SPI, and fixes the documentation-area link.

This is PR 1 of 10 and intentionally contains documentation only.

## Type of Change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [x] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

- `make test-site`

- [x] `make fmt`
- [ ] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Stack position: **1/10**. Review this PR as the design baseline for the seven implementation PRs above it.

