### PR TITLE
feat(repo): add catalog integration durability primitives (stack 3/10)

### DIFF
--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
@@ -24,7 +24,13 @@ import java.util.Optional;
 
 public interface PointerStore {
   sealed interface CasOp
-      permits CasUpsert, UnconditionalUpsert, CasDelete, CasCheck, CasCheckAbsent {}
+      permits CasUpsert, UnconditionalUpsert, CasDelete, CasCheck, CasCheckAbsent {
+    /**
+     * The pointer this operation acts on. Every variant already carries it; declaring it here lets
+     * a caller assembling a mixed batch check for duplicate keys without matching on the variant.
+     */
+    String key();
+  }
 
   record CasUpsert(String key, long expectedVersion, Pointer next) implements CasOp {
     public CasUpsert {

--- a/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
+import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
@@ -32,6 +33,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.jboss.logging.Logger;
@@ -39,9 +42,164 @@ import org.jboss.logging.Logger;
 public final class IdempotencyGuard {
   public record CreateResult<T>(T resource, ResourceId resourceId) {}
 
+  public record CommittedCreate<T>(T resource, ResourceId resourceId, MutationMeta meta) {}
+
+  @FunctionalInterface
+  public interface SuccessCommitter<T> {
+    PointerStore.CasUpsert prepare(CommittedCreate<T> committed);
+  }
+
   public record Result<T>(T resource, MutationMeta meta) {}
 
   private static final Logger LOG = Logger.getLogger(IdempotencyGuard.class);
+
+  /**
+   * Idempotent resource creation with a durable identity reservation. A pending record contains the
+   * resource id before the create transaction runs. The creator must publish the immutable success
+   * receipt in the same pointer transaction as the resource; retries never reconstruct a receipt
+   * from mutable resource state.
+   */
+  public static <T> Result<T> runOnceReserved(
+      String accountId,
+      String opName,
+      String idempotencyKey,
+      byte[] requestBytes,
+      Supplier<ResourceId> resourceIdAllocator,
+      BiFunction<ResourceId, SuccessCommitter<T>, CommittedCreate<T>> creator,
+      Function<T, byte[]> serializer,
+      Function<byte[], T> parser,
+      IdempotencyRepository store,
+      long ttlSeconds,
+      Timestamp now,
+      Supplier<String> corrId) {
+    if (idempotencyKey == null || idempotencyKey.isBlank()) {
+      var created =
+          creator.apply(
+              resourceIdAllocator.get(),
+              ignored -> {
+                throw new IllegalStateException(
+                    "idempotency completion requested without an idempotency key");
+              });
+      return new Result<>(created.resource(), created.meta());
+    }
+
+    String key = Keys.idempotencyKey(accountId, opName, idempotencyKey);
+    String requestHash = sha256B64(requestBytes);
+    ResourceId reservedId;
+    Timestamp reservationCreatedAt;
+    Timestamp reservationExpiresAt;
+    Optional<ai.floedb.floecat.storage.rpc.IdempotencyRecord> existing = store.get(key);
+    if (existing.isPresent()) {
+      var replay = existing.get();
+      requireMatchingRequest(replay.getRequestHash(), requestHash, opName, idempotencyKey, corrId);
+      if (replay.getStatus() == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.SUCCEEDED) {
+        if (!replay.hasMeta()) {
+          throw new BaseResourceRepository.CorruptionException(
+              "idempotency meta missing for succeeded record: key=" + key, null);
+        }
+        return new Result<>(parser.apply(replay.getPayload().toByteArray()), replay.getMeta());
+      }
+      if (replay.getStatus() != ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.PENDING
+          || !replay.hasResourceId()
+          || replay.getResourceId().getId().isEmpty()) {
+        throw new StorageAbortRetryableException("idempotency record pending: key=" + key);
+      }
+      reservedId = replay.getResourceId();
+      reservationCreatedAt = replay.getCreatedAt();
+      reservationExpiresAt = replay.getExpiresAt();
+    } else {
+      reservedId = resourceIdAllocator.get();
+      Timestamp expiresAt = expiresAt(now, ttlSeconds);
+      if (!store.createPending(accountId, key, opName, requestHash, reservedId, now, expiresAt)) {
+        var winner = store.get(key);
+        if (winner.isEmpty()) {
+          throw new StorageAbortRetryableException(
+              "idempotency record not yet visible: key=" + key);
+        }
+        var replay = winner.get();
+        requireMatchingRequest(
+            replay.getRequestHash(), requestHash, opName, idempotencyKey, corrId);
+        if (replay.getStatus()
+            == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.SUCCEEDED) {
+          if (!replay.hasMeta()) {
+            throw new BaseResourceRepository.CorruptionException(
+                "idempotency meta missing for succeeded record: key=" + key, null);
+          }
+          return new Result<>(parser.apply(replay.getPayload().toByteArray()), replay.getMeta());
+        }
+        if (!replay.hasResourceId() || replay.getResourceId().getId().isEmpty()) {
+          throw new StorageAbortRetryableException("idempotency record pending: key=" + key);
+        }
+        reservedId = replay.getResourceId();
+        reservationCreatedAt = replay.getCreatedAt();
+        reservationExpiresAt = replay.getExpiresAt();
+      } else {
+        reservationCreatedAt = now;
+        reservationExpiresAt = expiresAt;
+      }
+    }
+
+    boolean committed = false;
+    try {
+      Timestamp commitCreatedAt = reservationCreatedAt;
+      Timestamp commitExpiresAt = reservationExpiresAt;
+      SuccessCommitter<T> committer =
+          created ->
+              store.prepareSuccess(
+                  accountId,
+                  key,
+                  opName,
+                  requestHash,
+                  created.resourceId(),
+                  created.meta(),
+                  serializer.apply(created.resource()),
+                  commitCreatedAt,
+                  commitExpiresAt);
+      CommittedCreate<T> created = creator.apply(reservedId, committer);
+      committed = true;
+      var completed = store.get(key);
+      if (completed.isPresent()
+          && completed.get().getStatus()
+              == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.SUCCEEDED) {
+        var exact = completed.get();
+        requireMatchingRequest(exact.getRequestHash(), requestHash, opName, idempotencyKey, corrId);
+        return new Result<>(parser.apply(exact.getPayload().toByteArray()), exact.getMeta());
+      }
+      throw new StorageAbortRetryableException(
+          "resource create returned without an atomic idempotency receipt: key=" + key);
+    } catch (Throwable failure) {
+      boolean retryable =
+          failure instanceof BaseResourceRepository.AbortRetryableException
+              || failure instanceof StorageAbortRetryableException;
+      if (!committed && !retryable) {
+        deletePendingIfOwned(
+            store, key, opName, requestHash, reservationCreatedAt, reservationExpiresAt, corrId);
+      }
+      throw failure;
+    }
+  }
+
+  private static void requireMatchingRequest(
+      String storedHash,
+      String requestHash,
+      String opName,
+      String idempotencyKey,
+      Supplier<String> corrId) {
+    if (!requestHash.equals(storedHash)) {
+      throw GrpcErrors.conflict(
+          corrId.get(), IDEMPOTENCY_MISMATCH, Map.of("op", opName, "key", idempotencyKey));
+    }
+  }
+
+  private static Timestamp expiresAt(Timestamp now, long ttlSeconds) {
+    long ttlMillis = Math.max(1, ttlSeconds) * 1000L;
+    return Timestamps.add(
+        now,
+        Duration.newBuilder()
+            .setSeconds(ttlMillis / 1000)
+            .setNanos((int) ((ttlMillis % 1000) * 1_000_000))
+            .build());
+  }
 
   public static <T> Result<T> runOnce(
       String accountId,
@@ -56,7 +214,6 @@ public final class IdempotencyGuard {
       long ttlSeconds,
       Timestamp now,
       Supplier<String> corrId) {
-
     if (idempotencyKey == null || idempotencyKey.isBlank()) {
       var created = creator.get();
       var meta = metaExtractor.apply(created.resource());
@@ -298,13 +455,33 @@ public final class IdempotencyGuard {
           (t instanceof BaseResourceRepository.AbortRetryableException)
               || (t instanceof StorageAbortRetryableException);
       if (!retryable) {
-        try {
-          store.delete(key);
-        } catch (Throwable deleteError) {
-          LOG.warnf(deleteError, "idempotency.delete_failed key=%s corr=%s", key, corrId.get());
-        }
+        deletePendingIfOwned(store, key, opName, requestHash, now, expiresAt, corrId);
       }
       throw t;
+    }
+  }
+
+  private static void deletePendingIfOwned(
+      IdempotencyRepository store,
+      String key,
+      String opName,
+      String requestHash,
+      Timestamp createdAt,
+      Timestamp expiresAt,
+      Supplier<String> corrId) {
+    try {
+      var current = store.get(key);
+      if (current.isEmpty()) return;
+      var record = current.get();
+      if (record.getStatus() == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.PENDING
+          && record.getOpName().equals(opName)
+          && record.getRequestHash().equals(requestHash)
+          && record.getCreatedAt().equals(createdAt)
+          && record.getExpiresAt().equals(expiresAt)) {
+        store.delete(key);
+      }
+    } catch (Throwable deleteError) {
+      LOG.warnf(deleteError, "idempotency.delete_failed key=%s corr=%s", key, corrId.get());
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
@@ -88,6 +88,7 @@ public final class IdempotencyGuard {
     ResourceId reservedId;
     Timestamp reservationCreatedAt;
     Timestamp reservationExpiresAt;
+    boolean reservationCreatedByCaller = false;
     Optional<ai.floedb.floecat.storage.rpc.IdempotencyRecord> existing = store.get(key);
     if (existing.isPresent()) {
       var replay = existing.get();
@@ -134,6 +135,7 @@ public final class IdempotencyGuard {
         reservationCreatedAt = replay.getCreatedAt();
         reservationExpiresAt = replay.getExpiresAt();
       } else {
+        reservationCreatedByCaller = true;
         reservationCreatedAt = now;
         reservationExpiresAt = expiresAt;
       }
@@ -172,8 +174,23 @@ public final class IdempotencyGuard {
           failure instanceof BaseResourceRepository.AbortRetryableException
               || failure instanceof StorageAbortRetryableException;
       if (!committed && !retryable) {
-        deletePendingIfOwned(
-            store, key, opName, requestHash, reservationCreatedAt, reservationExpiresAt, corrId);
+        var completed = store.get(key);
+        if (completed.isPresent()
+            && completed.get().getStatus()
+                == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.SUCCEEDED) {
+          var exact = completed.get();
+          requireMatchingRequest(
+              exact.getRequestHash(), requestHash, opName, idempotencyKey, corrId);
+          if (!exact.hasMeta()) {
+            throw new BaseResourceRepository.CorruptionException(
+                "idempotency meta missing for succeeded record: key=" + key, null);
+          }
+          return new Result<>(parser.apply(exact.getPayload().toByteArray()), exact.getMeta());
+        }
+        if (reservationCreatedByCaller) {
+          deletePendingIfOwned(
+              store, key, opName, requestHash, reservationCreatedAt, reservationExpiresAt, corrId);
+        }
       }
       throw failure;
     }

--- a/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
@@ -487,16 +487,7 @@ public final class IdempotencyGuard {
       Timestamp expiresAt,
       Supplier<String> corrId) {
     try {
-      var current = store.get(key);
-      if (current.isEmpty()) return;
-      var record = current.get();
-      if (record.getStatus() == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.PENDING
-          && record.getOpName().equals(opName)
-          && record.getRequestHash().equals(requestHash)
-          && record.getCreatedAt().equals(createdAt)
-          && record.getExpiresAt().equals(expiresAt)) {
-        store.delete(key);
-      }
+      store.deletePendingIfOwned(key, opName, requestHash, createdAt, expiresAt);
     } catch (Throwable deleteError) {
       LOG.warnf(deleteError, "idempotency.delete_failed key=%s corr=%s", key, corrId.get());
     }

--- a/service/src/main/java/ai/floedb/floecat/service/common/MutationOps.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/MutationOps.java
@@ -27,6 +27,7 @@ import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -121,6 +122,46 @@ public final class MutationOps {
         now,
         ttlSeconds,
         correlationIdSupplier);
+  }
+
+  /** For creators that can find and return an already-committed resource after a retry. */
+  public static <T extends Message> OpResult<T> createProtoRecoverable(
+      String account,
+      String operationName,
+      String idempotencyKey,
+      Fingerprinter fingerprint,
+      Supplier<ai.floedb.floecat.common.rpc.ResourceId> resourceIdAllocator,
+      BiFunction<
+              ai.floedb.floecat.common.rpc.ResourceId,
+              IdempotencyGuard.SuccessCommitter<T>,
+              IdempotencyGuard.CommittedCreate<T>>
+          creator,
+      IdempotencyRepository idempotencyStore,
+      Timestamp now,
+      long ttlSeconds,
+      Supplier<String> correlationIdSupplier,
+      ThrowingParser<T> parser) {
+    var result =
+        IdempotencyGuard.runOnceReserved(
+            account,
+            operationName,
+            idempotencyKey,
+            fingerprint.fingerprint(),
+            resourceIdAllocator,
+            creator,
+            Message::toByteArray,
+            bytes -> {
+              try {
+                return parser.parse(bytes);
+              } catch (Exception e) {
+                throw new BaseResourceRepository.CorruptionException("idempotency_parse_failed", e);
+              }
+            },
+            idempotencyStore,
+            ttlSeconds,
+            now,
+            correlationIdSupplier);
+    return new OpResult<>(result.resource(), result.meta());
   }
 
   public static final class PageIn {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/IdempotencyRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/IdempotencyRepository.java
@@ -38,16 +38,14 @@ public interface IdempotencyRepository {
    * Reserves the stable identity of a resource before its create transaction is attempted. The
    * reserved identity lets the resource and its immutable success receipt commit atomically.
    */
-  default boolean createPending(
+  boolean createPending(
       String accountId,
       String key,
       String opName,
       String requestHash,
       ResourceId resourceId,
       Timestamp createdAt,
-      Timestamp expiresAt) {
-    return createPending(accountId, key, opName, requestHash, createdAt, expiresAt);
-  }
+      Timestamp expiresAt);
 
   void finalizeSuccess(
       String accountId,
@@ -74,4 +72,7 @@ public interface IdempotencyRepository {
   }
 
   boolean delete(String key);
+
+  boolean deletePendingIfOwned(
+      String key, String opName, String requestHash, Timestamp createdAt, Timestamp expiresAt);
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/IdempotencyRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/IdempotencyRepository.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.repo;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.storage.rpc.IdempotencyRecord;
+import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.Timestamp;
 import java.util.Optional;
 
@@ -33,6 +34,21 @@ public interface IdempotencyRepository {
       Timestamp createdAt,
       Timestamp expiresAt);
 
+  /**
+   * Reserves the stable identity of a resource before its create transaction is attempted. The
+   * reserved identity lets the resource and its immutable success receipt commit atomically.
+   */
+  default boolean createPending(
+      String accountId,
+      String key,
+      String opName,
+      String requestHash,
+      ResourceId resourceId,
+      Timestamp createdAt,
+      Timestamp expiresAt) {
+    return createPending(accountId, key, opName, requestHash, createdAt, expiresAt);
+  }
+
   void finalizeSuccess(
       String accountId,
       String key,
@@ -43,6 +59,19 @@ public interface IdempotencyRepository {
       byte[] payloadBytes,
       Timestamp createdAt,
       Timestamp expiresAt);
+
+  default PointerStore.CasUpsert prepareSuccess(
+      String accountId,
+      String key,
+      String opName,
+      String requestHash,
+      ResourceId resourceId,
+      MutationMeta meta,
+      byte[] payloadBytes,
+      Timestamp createdAt,
+      Timestamp expiresAt) {
+    throw new UnsupportedOperationException("atomic idempotency completion is not supported");
+  }
 
   boolean delete(String key);
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/IdempotencyRepositoryImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/IdempotencyRepositoryImpl.java
@@ -32,6 +32,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -81,11 +82,25 @@ public final class IdempotencyRepositoryImpl implements IdempotencyRepository {
       String requestHash,
       Timestamp createdAt,
       Timestamp expiresAt) {
+    return createPending(
+        accountId, key, opName, requestHash, ResourceId.getDefaultInstance(), createdAt, expiresAt);
+  }
+
+  @Override
+  public boolean createPending(
+      String accountId,
+      String key,
+      String opName,
+      String requestHash,
+      ResourceId resourceId,
+      Timestamp createdAt,
+      Timestamp expiresAt) {
     var rec =
         IdempotencyRecord.newBuilder()
             .setOpName(opName)
             .setRequestHash(requestHash)
             .setStatus(IdempotencyRecord.Status.PENDING)
+            .setResourceId(resourceId)
             .setCreatedAt(createdAt)
             .setExpiresAt(expiresAt)
             .build();
@@ -114,7 +129,7 @@ public final class IdempotencyRepositoryImpl implements IdempotencyRepository {
   }
 
   @Override
-  public void finalizeSuccess(
+  public PointerStore.CasUpsert prepareSuccess(
       String accountId,
       String key,
       String opName,
@@ -124,6 +139,14 @@ public final class IdempotencyRepositoryImpl implements IdempotencyRepository {
       byte[] payloadBytes,
       Timestamp createdAt,
       Timestamp expiresAt) {
+    Pointer current =
+        ptr.get(key)
+            .orElseThrow(
+                () ->
+                    new StorageAbortRetryableException(
+                        "idempotency pending pointer missing: key=" + key));
+    IdempotencyRecord pending = readRecord(current);
+    requireMatchingPending(pending, opName, requestHash, resourceId, createdAt, expiresAt, key);
     var rec =
         IdempotencyRecord.newBuilder()
             .setOpName(opName)
@@ -138,29 +161,117 @@ public final class IdempotencyRepositoryImpl implements IdempotencyRepository {
 
     String uri = Keys.idempotencyBlobUri(accountId, key, "success-" + UUID.randomUUID());
     blobs.put(uri, rec.toByteArray(), "application/x-protobuf");
+    var next =
+        PointerReferences.asBlobPointer(
+                Pointer.newBuilder()
+                    .setKey(key)
+                    .setExpiresAt(expiresAt)
+                    .setVersion(current.getVersion() + 1L),
+                uri)
+            .build();
+    return new PointerStore.CasUpsert(key, current.getVersion(), next);
+  }
 
-    Pointer previous = null;
-    boolean updated = false;
+  @Override
+  public void finalizeSuccess(
+      String accountId,
+      String key,
+      String opName,
+      String requestHash,
+      ResourceId resourceId,
+      MutationMeta meta,
+      byte[] payloadBytes,
+      Timestamp createdAt,
+      Timestamp expiresAt) {
+
     for (int i = 0; i < CAS_MAX; i++) {
       var current = ptr.get(key).orElse(null);
-      long expected = current != null ? current.getVersion() : 0L;
-      var next =
-          PointerReferences.asBlobPointer(
-                  Pointer.newBuilder().setKey(key).setExpiresAt(expiresAt).setVersion(expected + 1),
-                  uri)
-              .build();
-      if (ptr.compareAndSet(key, expected, next)) {
-        previous = current;
-        updated = true;
-        break;
+      if (current != null) {
+        IdempotencyRecord record = readRecord(current);
+        if (record.getStatus() == IdempotencyRecord.Status.SUCCEEDED) {
+          requireMatchingSuccess(record, opName, requestHash, resourceId, meta, payloadBytes, key);
+          return;
+        }
       }
+      PointerStore.CasUpsert prepared =
+          prepareSuccess(
+              accountId,
+              key,
+              opName,
+              requestHash,
+              resourceId,
+              meta,
+              payloadBytes,
+              createdAt,
+              expiresAt);
+      if (ptr.compareAndSetBatch(java.util.List.of(prepared))) {
+        if (current != null && !current.getBlobUri().equals(prepared.next().getBlobUri())) {
+          blobs.delete(current.getBlobUri());
+        }
+        return;
+      }
+      blobs.delete(prepared.next().getBlobUri());
     }
-    if (!updated) {
-      blobs.delete(uri);
-      throw new StorageAbortRetryableException("idempotency pointer not yet visible: key=" + key);
+    throw new StorageAbortRetryableException("idempotency pointer not yet stable: key=" + key);
+  }
+
+  private IdempotencyRecord readRecord(Pointer pointer) {
+    try {
+      byte[] bytes = blobs.get(pointer.getBlobUri());
+      if (bytes == null) {
+        throw new StorageAbortRetryableException(
+            "idempotency blob not yet visible: " + pointer.getBlobUri());
+      }
+      return IdempotencyRecord.parseFrom(bytes);
+    } catch (StorageNotFoundException missing) {
+      throw new StorageAbortRetryableException(
+          "idempotency blob not yet visible: " + pointer.getBlobUri());
+    } catch (StorageAbortRetryableException retryable) {
+      throw retryable;
+    } catch (Exception e) {
+      throw new CorruptionException(
+          "failed to parse idempotency record: " + pointer.getBlobUri(), e);
     }
-    if (previous != null && !previous.getBlobUri().equals(uri)) {
-      blobs.delete(previous.getBlobUri());
+  }
+
+  private static void requireMatchingPending(
+      IdempotencyRecord record,
+      String opName,
+      String requestHash,
+      ResourceId resourceId,
+      Timestamp createdAt,
+      Timestamp expiresAt,
+      String key) {
+    boolean reservedIdentityMatches =
+        !record.hasResourceId()
+            || record.getResourceId().equals(ResourceId.getDefaultInstance())
+            || record.getResourceId().equals(resourceId);
+    if (record.getStatus() != IdempotencyRecord.Status.PENDING
+        || !record.getOpName().equals(opName)
+        || !record.getRequestHash().equals(requestHash)
+        || !reservedIdentityMatches
+        || !record.getCreatedAt().equals(createdAt)
+        || !record.getExpiresAt().equals(expiresAt)) {
+      throw new StorageAbortRetryableException(
+          "idempotency pending record changed before completion: key=" + key);
+    }
+  }
+
+  private static void requireMatchingSuccess(
+      IdempotencyRecord record,
+      String opName,
+      String requestHash,
+      ResourceId resourceId,
+      MutationMeta meta,
+      byte[] payloadBytes,
+      String key) {
+    if (!record.getOpName().equals(opName)
+        || !record.getRequestHash().equals(requestHash)
+        || !record.getResourceId().equals(resourceId)
+        || !record.getMeta().equals(meta)
+        || !Objects.deepEquals(record.getPayload().toByteArray(), payloadBytes)) {
+      throw new CorruptionException(
+          "idempotency success record changed before completion: key=" + key, null);
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/IdempotencyRepositoryImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/IdempotencyRepositoryImpl.java
@@ -290,4 +290,26 @@ public final class IdempotencyRepositoryImpl implements IdempotencyRepository {
     blobs.delete(pointer.getBlobUri());
     return true;
   }
+
+  @Override
+  public boolean deletePendingIfOwned(
+      String key, String opName, String requestHash, Timestamp createdAt, Timestamp expiresAt) {
+    Pointer pointer = ptr.get(key).orElse(null);
+    if (pointer == null) {
+      return false;
+    }
+    IdempotencyRecord record = readRecord(pointer);
+    if (record.getStatus() != IdempotencyRecord.Status.PENDING
+        || !record.getOpName().equals(opName)
+        || !record.getRequestHash().equals(requestHash)
+        || !record.getCreatedAt().equals(createdAt)
+        || !record.getExpiresAt().equals(expiresAt)) {
+      return false;
+    }
+    if (!ptr.compareAndDelete(key, pointer.getVersion())) {
+      return false;
+    }
+    blobs.delete(pointer.getBlobUri());
+    return true;
+  }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/ResourceKey.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/ResourceKey.java
@@ -16,4 +16,6 @@
 
 package ai.floedb.floecat.service.repo.model;
 
-public interface ResourceKey {}
+public interface ResourceKey {
+  String accountId();
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -611,7 +611,27 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
    */
   protected MutationMeta readMetaOrDefault(
       Optional<Pointer> pointerOpt, String pointerKey, String blobUri, Timestamp nowTs) {
-    var header = blobReads.head(blobUri);
+    return meta(blobReads.head(blobUri), pointerOpt, pointerKey, blobUri, nowTs);
+  }
+
+  /**
+   * Meta assembly for a mutation that has just committed. It heads the raw mutation blob store
+   * rather than the read adapter: the etag describes bytes this call wrote moments ago, so it must
+   * not be resolved through a read path that may be cached, eventually consistent, or subject to
+   * read admission. Mutation protocols keep every prerequisite and post-commit read on the raw
+   * stores they mutate.
+   */
+  protected MutationMeta committedMeta(
+      Optional<Pointer> pointerOpt, String pointerKey, String blobUri, Timestamp nowTs) {
+    return meta(mutationBlobStore.head(blobUri), pointerOpt, pointerKey, blobUri, nowTs);
+  }
+
+  private static MutationMeta meta(
+      Optional<BlobHeader> header,
+      Optional<Pointer> pointerOpt,
+      String pointerKey,
+      String blobUri,
+      Timestamp nowTs) {
     long version = pointerOpt.map(Pointer::getVersion).orElse(0L);
     String etag = header.map(BlobHeader::getEtag).orElse("");
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -1073,12 +1073,16 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           Set<String> allSecondaries = new HashSet<>(currentSecondaryKeys);
           allSecondaries.addAll(replacementSecondaryKeys);
           for (String pointerKey : allSecondaries) {
+            boolean inCurrent = currentSecondaryKeys.contains(pointerKey);
+            boolean inReplacement = replacementSecondaryKeys.contains(pointerKey);
+            if ((pointerKey.equals(currentCanonical) && inCurrent && !inReplacement)
+                || (pointerKey.equals(replacementCanonical) && inReplacement && !inCurrent)) {
+              continue;
+            }
             if (!batchedKeys.add(pointerKey)) {
               throw new IllegalArgumentException(
                   "secondary collides with canonical pointer: " + pointerKey);
             }
-            boolean inCurrent = currentSecondaryKeys.contains(pointerKey);
-            boolean inReplacement = replacementSecondaryKeys.contains(pointerKey);
             Pointer existing = mutationPointerStore.get(pointerKey).orElse(null);
             if (inCurrent) {
               if (existing == null

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -1279,6 +1279,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
    * partially completed earlier attempt as work already done rather than as an error.
    */
   public List<PointerStore.CasOp> prepareDeleteOps(K key) {
+    guardSystemObject(key);
     String canonicalPointer = schema.canonicalPointerForKey.apply(key);
     Pointer canonical = mutationPointerStore.get(canonicalPointer).orElse(null);
     if (canonical == null) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -50,6 +50,23 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
   private final ResourceSchema<T, K> schema;
 
   /** Build a direct-loading repository over the supplied stores. */
+  public record ResourceWithMeta<T>(T value, MutationMeta meta) {}
+
+  public record PointerConditions(
+      Map<String, Long> requiredVersions,
+      Set<String> requiredAbsent,
+      Map<String, Long> markerVersions) {
+    public PointerConditions {
+      requiredVersions = Map.copyOf(requiredVersions);
+      requiredAbsent = Set.copyOf(requiredAbsent);
+      markerVersions = Map.copyOf(markerVersions);
+    }
+
+    public static PointerConditions none() {
+      return new PointerConditions(Map.of(), Set.of(), Map.of());
+    }
+  }
+
   public GenericResourceRepository(
       PointerStore mutationPointerStore,
       BlobStore mutationBlobStore,
@@ -99,6 +116,25 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     return observeRepository("get_by_key", () -> getByKeyUnobserved(key));
   }
 
+  /** Returns a body and metadata resolved from the same canonical pointer version. */
+  public Optional<ResourceWithMeta<T>> getByKeyWithMeta(K key) {
+    return observeRepository(
+        "get_by_key_with_meta",
+        () -> {
+          String pointerKey = schema.canonicalPointerForKey.apply(key);
+          Optional<Pointer> pointer = pointerReads.get(pointerKey);
+          if (pointer.isEmpty()) return Optional.empty();
+          String blobUri = requireBlobReference(pointer.get(), pointerKey);
+          T value =
+              getByBlobUri(blobUri)
+                  .orElseThrow(() -> new CorruptionException("blob missing: " + blobUri, null));
+          MutationMeta meta =
+              readMetaOrDefault(
+                  pointer, pointerKey, blobUri, Timestamps.fromMillis(clock.millis()));
+          return Optional.of(new ResourceWithMeta<>(value, meta));
+        });
+  }
+
   /**
    * Graph-hydration primitive: fetches and parses a resource directly by blob URI, skipping the
    * pointer read, for callers that already resolved a <em>fresh</em> pointer (see {@code
@@ -135,6 +171,46 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       return Optional.empty();
     }
     return loadAndParseBlob(blobUri);
+  }
+
+  /**
+   * Lists resources together with metadata from the exact pointers used to select their blobs. This
+   * avoids pairing a listed body with metadata from a later concurrent mutation.
+   */
+  public List<ResourceWithMeta<T>> listByPrefixWithMeta(
+      String prefix, int limit, String token, StringBuilder nextOut) {
+    return observeRepository(
+        "list_by_prefix_with_meta",
+        () -> {
+          List<Pointer> pointers = pointerReads.list(prefix, Math.max(1, limit), token, nextOut);
+          List<ResourceWithMeta<T>> values = new ArrayList<>(pointers.size());
+          Timestamp now = Timestamps.fromMillis(clock.millis());
+          for (Pointer selectedPointer : pointers) {
+            String selectedBlobUri =
+                requireBlobReference(selectedPointer, selectedPointer.getKey());
+            T selectedValue =
+                getByBlobUri(selectedBlobUri)
+                    .orElseThrow(
+                        () -> new CorruptionException("blob missing: " + selectedBlobUri, null));
+            String canonicalKey =
+                schema.canonicalPointerForKey.apply(schema.keyFromValue.apply(selectedValue));
+            Optional<Pointer> canonicalPointer = pointerReads.get(canonicalKey);
+            if (canonicalPointer.isEmpty()) {
+              // The resource was deleted after the secondary-index page was selected.
+              continue;
+            }
+            String canonicalBlobUri = requireBlobReference(canonicalPointer.get(), canonicalKey);
+            if (!canonicalBlobUri.equals(selectedBlobUri)) {
+              // The resource changed after the secondary-index page was selected. Returning the
+              // new canonical body would violate both page membership and body/meta coherence.
+              continue;
+            }
+            MutationMeta meta =
+                readMetaOrDefault(canonicalPointer, canonicalKey, canonicalBlobUri, now);
+            values.add(new ResourceWithMeta<>(selectedValue, meta));
+          }
+          return List.copyOf(values);
+        });
   }
 
   public boolean existsByKey(K key) {
@@ -206,47 +282,279 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
    * all is a transient transaction conflict and is signalled as retryable.
    */
   public void create(T value) {
-    observeRepository(
+    createWithMeta(value, PointerConditions.none(), null)
+        .orElseThrow(() -> new AbortRetryableException("create conditions changed"));
+  }
+
+  /** Creates a resource and returns metadata for the exact canonical pointer that committed. */
+  public ResourceWithMeta<T> createWithMeta(T value) {
+    return createWithMeta(value, PointerConditions.none(), null)
+        .orElseThrow(() -> new AbortRetryableException("create conditions changed"));
+  }
+
+  /**
+   * Creates a resource while publishing caller-supplied companion pointer operations in the same
+   * atomic pointer transaction. The factory receives the exact body/meta pair that will commit, so
+   * a companion record can embed the committed metadata. Used both for idempotency receipts and to
+   * co-create a resource of another kind that must never exist without this one.
+   */
+  public ResourceWithMeta<T> createWithMeta(
+      T value, Function<ResourceWithMeta<T>, List<PointerStore.CasOp>> completionFactory) {
+    return createWithMeta(
+            value, PointerConditions.none(), Objects.requireNonNull(completionFactory))
+        .orElseThrow(() -> new AbortRetryableException("create conditions changed"));
+  }
+
+  /**
+   * Creates a resource in one atomic pointer transaction that also asserts every supplied external
+   * pointer condition, advances every supplied lifecycle marker, and — when {@code
+   * completionFactory} is non-null — publishes the caller's companion operations alongside the
+   * resource. The factory receives the exact body/meta pair that will commit.
+   *
+   * <p>Returns empty when a required version, a required absence, or a marker version no longer
+   * holds; the caller decides whether that is a conflict or a lost race. A create that commits (or
+   * replays a byte-identical prior create) always returns a value.
+   */
+  public Optional<ResourceWithMeta<T>> createWithMeta(
+      T value,
+      PointerConditions conditions,
+      Function<ResourceWithMeta<T>, List<PointerStore.CasOp>> completionFactory) {
+    CreateCommit commit = createInternal(value, conditions, completionFactory);
+    if (!commit.conditionsMatched()) {
+      return Optional.empty();
+    }
+    K key = schema.keyFromValue.apply(value);
+    String canonicalKey = schema.canonicalPointerForKey.apply(key);
+    String blobUri = requireBlobReference(commit.canonicalPointer(), canonicalKey);
+    if (!blobUri.equals(schema.blobUriForKey.apply(key))) {
+      throw new NameConflictException("canonical pointer bound to different blob: " + canonicalKey);
+    }
+    return Optional.of(new ResourceWithMeta<>(value, commit.meta()));
+  }
+
+  /** Resolves a secondary pointer and returns the body with its exact canonical metadata. */
+  public Optional<ResourceWithMeta<T>> getWithMeta(String pointerKey) {
+    Optional<Pointer> secondary = pointerReads.get(pointerKey);
+    if (secondary.isEmpty()) return Optional.empty();
+    String selectedBlobUri = requireBlobReference(secondary.get(), pointerKey);
+    T selected =
+        getByBlobUri(selectedBlobUri)
+            .orElseThrow(() -> new CorruptionException("blob missing: " + selectedBlobUri, null));
+    String canonicalKey = schema.canonicalPointerForKey.apply(schema.keyFromValue.apply(selected));
+    Optional<Pointer> canonical = pointerReads.get(canonicalKey);
+    if (canonical.isEmpty()) return Optional.empty();
+    String canonicalBlobUri = requireBlobReference(canonical.get(), canonicalKey);
+    if (!canonicalBlobUri.equals(selectedBlobUri)) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new ResourceWithMeta<>(
+            selected,
+            readMetaOrDefault(
+                canonical, canonicalKey, canonicalBlobUri, Timestamps.fromMillis(clock.millis()))));
+  }
+
+  private CreateCommit createInternal(
+      T value,
+      PointerConditions conditions,
+      Function<ResourceWithMeta<T>, List<PointerStore.CasOp>> completionFactory) {
+    Map<String, Long> requiredPointerVersions = conditions.requiredVersions();
+    Map<String, Long> markerVersions = conditions.markerVersions();
+    return observeRepository(
         "create",
         () -> {
-          K key = schema.keyFromValue.apply(value);
-          guardSystemObject(key);
-          String canonicalPointer = schema.canonicalPointerForKey.apply(key);
-          String blobUri = schema.blobUriForKey.apply(key);
-
-          int blobBytes = writeBlobAndGetSize(blobUri, value);
-
-          Map<String, String> secondaries = schema.secondaryPointersFromValue.apply(value);
-          // Canonical first, then secondaries, de-duplicated: some schemas (e.g. snapshots) expose
-          // the
-          // canonical by-id pointer as a secondary too, and a transactional batch must not contain
-          // two
-          // operations on the same key (DynamoDB rejects duplicate items within a transaction). All
-          // ops
-          // for a given key target the same blob, so dropping the duplicate is loss-free.
-          LinkedHashSet<String> uniqueKeys = new LinkedHashSet<>(1 + secondaries.size());
-          uniqueKeys.add(canonicalPointer);
-          uniqueKeys.addAll(secondaries.values());
-          List<String> pointerKeys = new ArrayList<>(uniqueKeys);
-
-          List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size());
-          for (String pointerKey : pointerKeys) {
-            ops.add(
-                new PointerStore.CasUpsert(
-                    pointerKey, 0L, reserve(pointerKey, blobUri, value, blobBytes)));
+          PreparedCreate prepared = prepareCreate(value);
+          Set<String> effectiveRequiredAbsent = new HashSet<>(conditions.requiredAbsent());
+          List<PointerStore.CasOp> ops =
+              new ArrayList<>(
+                  prepared.ops.size()
+                      + requiredPointerVersions.size()
+                      + effectiveRequiredAbsent.size()
+                      + markerVersions.size());
+          ops.addAll(prepared.ops);
+          Set<String> batchedKeys = new HashSet<>(prepared.pointerKeys);
+          addPointerConditions(requiredPointerVersions, effectiveRequiredAbsent, batchedKeys, ops);
+          addMarkerAdvances(markerVersions, batchedKeys, ops, "create");
+          MutationMeta committedMeta =
+              committedMeta(
+                  Optional.of(prepared.committedCanonical),
+                  prepared.canonicalPointerKey,
+                  prepared.blobUri,
+                  Timestamps.fromMillis(clock.millis()));
+          List<PointerStore.CasOp> companionOps = List.of();
+          if (completionFactory != null) {
+            ResourceWithMeta<T> committed = new ResourceWithMeta<>(value, committedMeta);
+            companionOps = completionFactory.apply(committed);
+            for (PointerStore.CasOp companion : companionOps) {
+              if (!batchedKeys.add(companion.key())) {
+                throw new IllegalArgumentException(
+                    "duplicate companion pointer in atomic create: " + companion.key());
+              }
+              ops.add(companion);
+            }
           }
 
           if (mutationPointerStore.compareAndSetBatch(ops)) {
-            healCanonicalBlobIfMissing(blobUri, value);
-            return;
+            healCanonicalBlobIfMissing(prepared.blobUri, value);
+            return new CreateCommit(true, prepared.committedCanonical, committedMeta);
           }
+
+          if (!pointerConditionsStillMatch(requiredPointerVersions, effectiveRequiredAbsent)) {
+            return new CreateCommit(false, null, null);
+          }
+          if (!markerVersionsStillMatch(markerVersions)) {
+            return new CreateCommit(false, null, null);
+          }
+
+          // A companion create that lost its own name reservation is a name conflict, not a
+          // transient one: the caller asked to publish a resource whose name another resource
+          // already owns. Classify it before this resource's own pointers, because the companion
+          // is the reason the batch could never have committed.
+          classifyCompanionConflict(companionOps);
 
           // The batch committed nothing (atomic) because at least one pointer already existed. Read
           // back
           // and classify, walking canonical-then-secondary order so a conflict reports the same
           // key/message as before.
-          classifyCreateConflict(blobUri, pointerKeys);
+          classifyCreateConflict(prepared.blobUri, prepared.pointerKeys);
+          Pointer canonical =
+              mutationPointerStore
+                  .get(prepared.canonicalPointerKey)
+                  .orElseThrow(
+                      () ->
+                          new CorruptionException(
+                              "created canonical pointer missing: " + prepared.canonicalPointerKey,
+                              null));
+          MutationMeta replayMeta =
+              committedMeta(
+                  Optional.of(canonical),
+                  prepared.canonicalPointerKey,
+                  requireBlobReference(canonical, prepared.canonicalPointerKey),
+                  Timestamps.fromMillis(clock.millis()));
+          return new CreateCommit(true, canonical, replayMeta);
         });
+  }
+
+  private record CreateCommit(
+      boolean conditionsMatched, Pointer canonicalPointer, MutationMeta meta) {}
+
+  private static void addPointerConditions(
+      Map<String, Long> requiredPointerVersions,
+      Set<String> requiredAbsentPointers,
+      Set<String> batchedKeys,
+      List<PointerStore.CasOp> ops) {
+    for (var required : requiredPointerVersions.entrySet()) {
+      if (batchedKeys.add(required.getKey())) {
+        ops.add(new PointerStore.CasCheck(required.getKey(), required.getValue()));
+      }
+    }
+    for (String pointerKey : requiredAbsentPointers) {
+      if (batchedKeys.add(pointerKey)) {
+        ops.add(new PointerStore.CasCheckAbsent(pointerKey));
+      }
+    }
+  }
+
+  /**
+   * Advances each supplied lifecycle marker from its expected version in the same batch. A marker
+   * that collides with a pointer this mutation already writes is a caller bug: the batch is atomic
+   * and a store rejects two operations on one key, so it is rejected before anything is attempted.
+   */
+  private static void addMarkerAdvances(
+      Map<String, Long> markerVersions,
+      Set<String> batchedKeys,
+      List<PointerStore.CasOp> ops,
+      String operation) {
+    for (var marker : markerVersions.entrySet()) {
+      String markerKey = marker.getKey();
+      long expectedVersion = marker.getValue();
+      if (!batchedKeys.add(markerKey)) {
+        throw new IllegalArgumentException(
+            "duplicate pointer in atomic " + operation + ": " + markerKey);
+      }
+      ops.add(
+          new PointerStore.CasUpsert(
+              markerKey,
+              expectedVersion,
+              PointerReferences.opaqueMarkerPointer(markerKey, markerKey, expectedVersion + 1L)));
+    }
+  }
+
+  private boolean markerVersionsStillMatch(Map<String, Long> markerVersions) {
+    for (var marker : markerVersions.entrySet()) {
+      if (!pointerVersionMatches(marker.getKey(), marker.getValue())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean pointerConditionsStillMatch(
+      Map<String, Long> requiredPointerVersions, Set<String> requiredAbsentPointers) {
+    for (var required : requiredPointerVersions.entrySet()) {
+      if (!pointerVersionMatches(required.getKey(), required.getValue())) {
+        return false;
+      }
+    }
+    for (String pointerKey : requiredAbsentPointers) {
+      if (mutationPointerStore.get(pointerKey).isPresent()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean pointerVersionMatches(String pointerKey, long expectedVersion) {
+    Pointer current = mutationPointerStore.get(pointerKey).orElse(null);
+    return expectedVersion == 0L
+        ? current == null
+        : current != null && current.getVersion() == expectedVersion;
+  }
+
+  private PreparedCreate prepareCreate(T value) {
+    K key = schema.keyFromValue.apply(value);
+    guardSystemObject(key);
+    String canonicalPointer = schema.canonicalPointerForKey.apply(key);
+    String blobUri = schema.blobUriForKey.apply(key);
+    int blobBytes = writeBlobAndGetSize(blobUri, value);
+
+    Map<String, String> secondaries = schema.secondaryPointersFromValue.apply(value);
+    LinkedHashSet<String> uniqueKeys = new LinkedHashSet<>(1 + secondaries.size());
+    uniqueKeys.add(canonicalPointer);
+    uniqueKeys.addAll(secondaries.values());
+    List<String> pointerKeys = new ArrayList<>(uniqueKeys);
+    List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size());
+    Pointer committedCanonical = null;
+    for (String pointerKey : pointerKeys) {
+      Pointer reserved = reserve(pointerKey, blobUri, value, blobBytes);
+      ops.add(new PointerStore.CasUpsert(pointerKey, 0L, reserved));
+      if (pointerKey.equals(canonicalPointer)) {
+        committedCanonical = reserved.toBuilder().setVersion(1L).build();
+      }
+    }
+    return new PreparedCreate(blobUri, canonicalPointer, committedCanonical, pointerKeys, ops);
+  }
+
+  private record PreparedCreate(
+      String blobUri,
+      String canonicalPointerKey,
+      Pointer committedCanonical,
+      List<String> pointerKeys,
+      List<PointerStore.CasOp> ops) {}
+
+  /**
+   * Raises a name conflict when a companion operation that reserves a fresh pointer (expected
+   * version 0) finds that pointer already taken. Without this, a collision on a co-created
+   * resource's name would surface as a retryable abort and spin until the caller gave up.
+   */
+  private void classifyCompanionConflict(List<PointerStore.CasOp> companionOps) {
+    for (PointerStore.CasOp companion : companionOps) {
+      if (companion instanceof PointerStore.CasUpsert upsert
+          && upsert.expectedVersion() == 0L
+          && mutationPointerStore.get(upsert.key()).isPresent()) {
+        throw new NameConflictException("companion pointer already reserved: " + upsert.key());
+      }
+    }
   }
 
   private void classifyCreateConflict(String blobUri, List<String> pointerKeys) {
@@ -286,6 +594,21 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
             + absent
             + " absent) for: "
             + pointerKeys);
+  }
+
+  /**
+   * Writes this resource's blob and returns the pointer operations that would create it, without
+   * committing anything. The caller folds them into another repository's atomic create so the two
+   * resources become visible together or not at all — see {@link #createWithMeta(Object,
+   * PointerConditions, Function)}.
+   *
+   * <p>The blob is content-addressed, so preparing operations that are never committed wastes space
+   * but cannot corrupt state or make the resource reachable: reachability comes from the pointers,
+   * and those are the caller's to commit. Every returned operation expects version 0, so a
+   * concurrent creator of the same resource loses the batch rather than being overwritten.
+   */
+  public List<PointerStore.CasOp> prepareCreateOps(T value) {
+    return prepareCreate(value).ops;
   }
 
   /**
@@ -337,7 +660,6 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
                 new PointerStore.CasUpsert(
                     pointerKey, 0L, reserve(pointerKey, blobUri, value, blobBytes)));
           }
-
           if (mutationPointerStore.compareAndSetBatch(ops)) {
             healCanonicalBlobIfMissing(blobUri, value);
             return true;
@@ -458,112 +780,190 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
    * version shift) is signalled as retryable.
    */
   public boolean update(T updatedValue, long expectedCanonicalVersion) {
-    return observeRepository(
-        "update",
-        () -> {
-          K key = schema.keyFromValue.apply(updatedValue);
-          guardSystemObject(key);
-          String canonicalPointer = schema.canonicalPointerForKey.apply(key);
-          String blobUri = schema.blobUriForKey.apply(key);
+    return updateWithMeta(updatedValue, expectedCanonicalVersion).isPresent();
+  }
 
-          T currentValue =
-              getByKeyForMutation(key)
-                  .orElseThrow(
-                      () ->
-                          new NotFoundException(
-                              schema.resourceName
-                                  + " not found for canonical: "
-                                  + canonicalPointer));
-          String currentBlobUri =
-              schema.blobUriForKey.apply(schema.keyFromValue.apply(currentValue));
+  /**
+   * Atomically updates a resource and returns metadata for the exact committed pointer version. The
+   * returned metadata is assembled from the committed pointer rather than a post-commit pointer
+   * reread, so a concurrent later writer cannot change the response.
+   */
+  public Optional<MutationMeta> updateWithMeta(T updatedValue, long expectedCanonicalVersion) {
+    return updateWithMetaWhilePointersMatchAndBumpMarkers(
+        updatedValue, expectedCanonicalVersion, PointerConditions.none());
+  }
 
-          Set<String> currentSecondary =
-              new HashSet<>(schema.secondaryPointersFromValue.apply(currentValue).values());
-          Set<String> nextSecondary =
-              new HashSet<>(schema.secondaryPointersFromValue.apply(updatedValue).values());
+  private record PreparedUpdate(
+      String blobUri,
+      Pointer committedCanonical,
+      Set<String> addedSecondaries,
+      Set<String> batchedKeys,
+      List<PointerStore.CasOp> ops) {}
 
-          Set<String> toAdd = new HashSet<>(nextSecondary);
-          toAdd.removeAll(currentSecondary);
-          Set<String> toDelete = new HashSet<>(currentSecondary);
-          toDelete.removeAll(nextSecondary);
-          Set<String> kept = new HashSet<>(nextSecondary);
-          kept.removeAll(toAdd);
+  /**
+   * Pointer operations that would update this resource from {@code expectedCanonicalVersion},
+   * without committing anything, so a caller can fold them into another repository's atomic
+   * mutation. Renaming an overlay uses this to rename the catalog it owns in the same transaction.
+   */
+  public List<PointerStore.CasOp> prepareUpdateOps(T updatedValue, long expectedCanonicalVersion) {
+    return prepareUpdate(updatedValue, expectedCanonicalVersion).ops;
+  }
 
-          int blobBytes = writeBlobAndGetSize(blobUri, updatedValue);
+  private PreparedUpdate prepareUpdate(T updatedValue, long expectedCanonicalVersion) {
+    K key = schema.keyFromValue.apply(updatedValue);
+    guardSystemObject(key);
+    String canonicalPointer = schema.canonicalPointerForKey.apply(key);
+    String blobUri = schema.blobUriForKey.apply(key);
 
-          boolean blobChanged = schema.casBlobs && !Objects.equals(currentBlobUri, blobUri);
+    T currentValue =
+        getByKeyForMutation(key)
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        schema.resourceName + " not found for canonical: " + canonicalPointer));
+    String currentBlobUri = schema.blobUriForKey.apply(schema.keyFromValue.apply(currentValue));
 
-          // Build a single all-or-nothing batch covering every pointer mutation this update
-          // implies. Ops
-          // are de-duplicated by key (a schema may expose the canonical pointer as a secondary too)
-          // with
-          // the canonical advance taking precedence. Because the batch is atomic the update can
-          // never
-          // leave partial pointer state; a conflict commits nothing and is classified below.
-          Set<String> batchedKeys = new HashSet<>();
-          List<PointerStore.CasOp> ops = new ArrayList<>();
+    Set<String> currentSecondary =
+        new HashSet<>(schema.secondaryPointersFromValue.apply(currentValue).values());
+    Set<String> nextSecondary =
+        new HashSet<>(schema.secondaryPointersFromValue.apply(updatedValue).values());
 
-          batchedKeys.add(canonicalPointer);
+    Set<String> toAdd = new HashSet<>(nextSecondary);
+    toAdd.removeAll(currentSecondary);
+    Set<String> toDelete = new HashSet<>(currentSecondary);
+    toDelete.removeAll(nextSecondary);
+    Set<String> kept = new HashSet<>(nextSecondary);
+    kept.removeAll(toAdd);
+
+    int blobBytes = writeBlobAndGetSize(blobUri, updatedValue);
+
+    boolean blobChanged = schema.casBlobs && !Objects.equals(currentBlobUri, blobUri);
+
+    // Build a single all-or-nothing batch covering every pointer mutation this update
+    // implies. Ops
+    // are de-duplicated by key (a schema may expose the canonical pointer as a secondary too)
+    // with
+    // the canonical advance taking precedence. Because the batch is atomic the update can
+    // never
+    // leave partial pointer state; a conflict commits nothing and is classified below.
+    Set<String> batchedKeys = new HashSet<>();
+    List<PointerStore.CasOp> ops = new ArrayList<>();
+
+    batchedKeys.add(canonicalPointer);
+    Pointer committedCanonical =
+        reserve(canonicalPointer, blobUri, updatedValue, blobBytes).toBuilder()
+            .setVersion(expectedCanonicalVersion + 1L)
+            .build();
+    ops.add(
+        new PointerStore.CasUpsert(canonicalPointer, expectedCanonicalVersion, committedCanonical));
+
+    for (String p : toAdd) {
+      if (!batchedKeys.add(p)) {
+        continue;
+      }
+      Pointer existing = mutationPointerStore.get(p).orElse(null);
+      if (existing == null) {
+        ops.add(new PointerStore.CasUpsert(p, 0L, reserve(p, blobUri, updatedValue, blobBytes)));
+      } else if (!blobUri.equals(existing.getBlobUri())) {
+        // The new name already belongs to a different blob. Nothing has been committed, so
+        // failing
+        // fast here leaves no partial state.
+        throw new NameConflictException("pointer bound to different blob: " + p);
+      }
+      // else: already reserved to our blob — idempotent, no op needed.
+    }
+
+    if (blobChanged) {
+      // Kept secondaries still point at the old content-addressed blob; advance each onto the
+      // new
+      // one (or reserve it if a legacy gap left it absent).
+      for (String p : kept) {
+        if (!batchedKeys.add(p)) {
+          continue;
+        }
+        Pointer existing = mutationPointerStore.get(p).orElse(null);
+        if (existing == null) {
+          ops.add(new PointerStore.CasUpsert(p, 0L, reserve(p, blobUri, updatedValue, blobBytes)));
+        } else if (!blobUri.equals(existing.getBlobUri())) {
           ops.add(
               new PointerStore.CasUpsert(
-                  canonicalPointer,
-                  expectedCanonicalVersion,
-                  reserve(canonicalPointer, blobUri, updatedValue, blobBytes)));
+                  p, existing.getVersion(), reserve(p, blobUri, updatedValue, blobBytes)));
+        }
+        // else: already on the new blob — no op needed.
+      }
+    }
 
-          for (String p : toAdd) {
-            if (!batchedKeys.add(p)) {
-              continue;
-            }
-            Pointer existing = mutationPointerStore.get(p).orElse(null);
-            if (existing == null) {
-              ops.add(
-                  new PointerStore.CasUpsert(p, 0L, reserve(p, blobUri, updatedValue, blobBytes)));
-            } else if (!blobUri.equals(existing.getBlobUri())) {
-              // The new name already belongs to a different blob. Nothing has been committed, so
-              // failing
-              // fast here leaves no partial state.
-              throw new NameConflictException("pointer bound to different blob: " + p);
-            }
-            // else: already reserved to our blob — idempotent, no op needed.
-          }
+    for (String p : toDelete) {
+      if (!batchedKeys.add(p)) {
+        continue;
+      }
+      Pointer existing = mutationPointerStore.get(p).orElse(null);
+      if (existing != null) {
+        ops.add(new PointerStore.CasDelete(p, existing.getVersion()));
+      }
+    }
 
-          if (blobChanged) {
-            // Kept secondaries still point at the old content-addressed blob; advance each onto the
-            // new
-            // one (or reserve it if a legacy gap left it absent).
-            for (String p : kept) {
-              if (!batchedKeys.add(p)) {
-                continue;
-              }
-              Pointer existing = mutationPointerStore.get(p).orElse(null);
-              if (existing == null) {
-                ops.add(
-                    new PointerStore.CasUpsert(
-                        p, 0L, reserve(p, blobUri, updatedValue, blobBytes)));
-              } else if (!blobUri.equals(existing.getBlobUri())) {
-                ops.add(
-                    new PointerStore.CasUpsert(
-                        p, existing.getVersion(), reserve(p, blobUri, updatedValue, blobBytes)));
-              }
-              // else: already on the new blob — no op needed.
-            }
-          }
+    return new PreparedUpdate(
+        blobUri, committedCanonical, Set.copyOf(toAdd), Set.copyOf(batchedKeys), List.copyOf(ops));
+  }
 
-          for (String p : toDelete) {
-            if (!batchedKeys.add(p)) {
-              continue;
+  /**
+   * Atomically updates a resource while external pointers retain their versions and advances the
+   * supplied lifecycle markers in the same transaction.
+   */
+  public Optional<MutationMeta> updateWithMetaWhilePointersMatchAndBumpMarkers(
+      T updatedValue, long expectedCanonicalVersion, PointerConditions conditions) {
+    return updateWithMetaWhilePointersMatchAndBumpMarkers(
+        updatedValue, expectedCanonicalVersion, conditions, List.of());
+  }
+
+  /**
+   * Updates a resource and publishes the caller's companion operations in the same atomic pointer
+   * transaction, so a resource this one owns is renamed or retargeted with it rather than after it.
+   */
+  public Optional<MutationMeta> updateWithMetaWhilePointersMatchAndBumpMarkers(
+      T updatedValue,
+      long expectedCanonicalVersion,
+      PointerConditions conditions,
+      List<PointerStore.CasOp> companions) {
+    Map<String, Long> requiredPointerVersions = conditions.requiredVersions();
+    Set<String> requiredAbsentPointers = conditions.requiredAbsent();
+    Map<String, Long> markerVersions = conditions.markerVersions();
+    return observeRepository(
+        "update_with_meta",
+        () -> {
+          K key = schema.keyFromValue.apply(updatedValue);
+          String canonicalPointer = schema.canonicalPointerForKey.apply(key);
+          PreparedUpdate prepared = prepareUpdate(updatedValue, expectedCanonicalVersion);
+          String blobUri = prepared.blobUri;
+          Set<String> toAdd = prepared.addedSecondaries;
+          Set<String> batchedKeys = new HashSet<>(prepared.batchedKeys);
+          List<PointerStore.CasOp> ops = new ArrayList<>(prepared.ops);
+          Pointer committedCanonical = prepared.committedCanonical;
+          addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
+          addMarkerAdvances(markerVersions, batchedKeys, ops, "update");
+          for (PointerStore.CasOp companion : companions) {
+            if (!batchedKeys.add(companion.key())) {
+              throw new IllegalArgumentException(
+                  "duplicate companion pointer in atomic update: " + companion.key());
             }
-            Pointer existing = mutationPointerStore.get(p).orElse(null);
-            if (existing != null) {
-              ops.add(new PointerStore.CasDelete(p, existing.getVersion()));
-            }
+            ops.add(companion);
           }
 
           if (mutationPointerStore.compareAndSetBatch(ops)) {
             healCanonicalBlobIfMissing(blobUri, updatedValue);
-            return true;
+            return Optional.of(
+                committedMeta(
+                    Optional.of(committedCanonical),
+                    canonicalPointer,
+                    blobUri,
+                    Timestamps.fromMillis(clock.millis())));
           }
-          return classifyUpdateConflict(canonicalPointer, expectedCanonicalVersion, blobUri, toAdd);
+          if (!pointerConditionsStillMatch(requiredPointerVersions, requiredAbsentPointers))
+            return Optional.empty();
+          if (!markerVersionsStillMatch(markerVersions)) return Optional.empty();
+          classifyUpdateConflict(canonicalPointer, expectedCanonicalVersion, blobUri, toAdd);
+          return Optional.empty();
         });
   }
 
@@ -610,6 +1010,128 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     throw new AbortRetryableException("update conflict for: " + canonicalPointer);
   }
 
+  /**
+   * Atomically replaces one resource identity with another. The old canonical pointer is deleted,
+   * the new canonical pointer is created, shared secondary pointers are swapped to the new body,
+   * and non-shared secondaries are removed/created in the same pointer transaction.
+   */
+  public Optional<ResourceWithMeta<T>> replaceIdentityWithMeta(
+      T currentValue,
+      long expectedCanonicalVersion,
+      T replacementValue,
+      PointerConditions conditions,
+      Map<String, Long> pointerVersionsToDelete) {
+    Map<String, Long> requiredPointerVersions = conditions.requiredVersions();
+    Set<String> requiredAbsentPointers = conditions.requiredAbsent();
+    Map<String, Long> markerVersions = conditions.markerVersions();
+    return observeRepository(
+        "replace_identity",
+        () -> {
+          K currentKey = schema.keyFromValue.apply(currentValue);
+          K replacementKey = schema.keyFromValue.apply(replacementValue);
+          guardSystemObject(currentKey);
+          guardSystemObject(replacementKey);
+          if (!currentKey.accountId().equals(replacementKey.accountId())) {
+            throw new IllegalArgumentException("replacement cannot cross accounts");
+          }
+
+          String currentCanonical = schema.canonicalPointerForKey.apply(currentKey);
+          String replacementCanonical = schema.canonicalPointerForKey.apply(replacementKey);
+          if (currentCanonical.equals(replacementCanonical)) {
+            throw new IllegalArgumentException("replacement must use a new resource identity");
+          }
+          Pointer currentPointer = mutationPointerStore.get(currentCanonical).orElse(null);
+          String currentBlobUri = schema.blobUriForKey.apply(currentKey);
+          if (currentPointer == null
+              || currentPointer.getVersion() != expectedCanonicalVersion
+              || !currentBlobUri.equals(requireBlobReference(currentPointer, currentCanonical))) {
+            return Optional.empty();
+          }
+
+          String replacementBlobUri = schema.blobUriForKey.apply(replacementKey);
+          int replacementBlobBytes = writeBlobAndGetSize(replacementBlobUri, replacementValue);
+          Map<String, String> currentSecondaries =
+              schema.secondaryPointersFromValue.apply(currentValue);
+          Map<String, String> replacementSecondaries =
+              schema.secondaryPointersFromValue.apply(replacementValue);
+          Set<String> currentSecondaryKeys = new HashSet<>(currentSecondaries.values());
+          Set<String> replacementSecondaryKeys = new HashSet<>(replacementSecondaries.values());
+
+          List<PointerStore.CasOp> ops = new ArrayList<>();
+          Set<String> batchedKeys = new HashSet<>();
+          batchedKeys.add(currentCanonical);
+          ops.add(new PointerStore.CasDelete(currentCanonical, expectedCanonicalVersion));
+
+          if (!batchedKeys.add(replacementCanonical)) {
+            throw new IllegalArgumentException("duplicate replacement canonical pointer");
+          }
+          Pointer replacementReserved =
+              reserve(
+                  replacementCanonical, replacementBlobUri, replacementValue, replacementBlobBytes);
+          ops.add(new PointerStore.CasUpsert(replacementCanonical, 0L, replacementReserved));
+
+          Set<String> allSecondaries = new HashSet<>(currentSecondaryKeys);
+          allSecondaries.addAll(replacementSecondaryKeys);
+          for (String pointerKey : allSecondaries) {
+            if (!batchedKeys.add(pointerKey)) {
+              throw new IllegalArgumentException(
+                  "secondary collides with canonical pointer: " + pointerKey);
+            }
+            boolean inCurrent = currentSecondaryKeys.contains(pointerKey);
+            boolean inReplacement = replacementSecondaryKeys.contains(pointerKey);
+            Pointer existing = mutationPointerStore.get(pointerKey).orElse(null);
+            if (inCurrent) {
+              if (existing == null
+                  || !currentBlobUri.equals(requireBlobReference(existing, pointerKey))) {
+                throw new CorruptionException(
+                    "current secondary is missing or references another blob: " + pointerKey, null);
+              }
+              if (inReplacement) {
+                ops.add(
+                    new PointerStore.CasUpsert(
+                        pointerKey,
+                        existing.getVersion(),
+                        reserve(
+                            pointerKey,
+                            replacementBlobUri,
+                            replacementValue,
+                            replacementBlobBytes)));
+              } else {
+                ops.add(new PointerStore.CasDelete(pointerKey, existing.getVersion()));
+              }
+            } else {
+              if (existing != null) {
+                throw new NameConflictException("pointer already exists: " + pointerKey);
+              }
+              ops.add(
+                  new PointerStore.CasUpsert(
+                      pointerKey,
+                      0L,
+                      reserve(
+                          pointerKey, replacementBlobUri, replacementValue, replacementBlobBytes)));
+            }
+          }
+
+          addPointerDeletes(pointerVersionsToDelete, batchedKeys, ops);
+          addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
+          addMarkerAdvances(markerVersions, batchedKeys, ops, "replacement");
+
+          if (!mutationPointerStore.compareAndSetBatch(ops)) {
+            return Optional.empty();
+          }
+          healCanonicalBlobIfMissing(replacementBlobUri, replacementValue);
+          Pointer committedCanonical = replacementReserved.toBuilder().setVersion(1L).build();
+          return Optional.of(
+              new ResourceWithMeta<>(
+                  replacementValue,
+                  committedMeta(
+                      Optional.of(committedCanonical),
+                      replacementCanonical,
+                      replacementBlobUri,
+                      Timestamps.fromMillis(clock.millis()))));
+        });
+  }
+
   public boolean delete(K key) {
     return observeRepository(
         "delete",
@@ -653,6 +1175,41 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
   }
 
   public boolean deleteWithPrecondition(K key, long expectedCanonicalVersion) {
+    return deleteWithPreconditionWhilePointersMatchAndDeletePointers(
+        key, expectedCanonicalVersion, PointerConditions.none(), Map.of());
+  }
+
+  /**
+   * Deletes the resource and supplied external pointers atomically while all remaining external
+   * pointer conditions hold.
+   */
+  public boolean deleteWithPreconditionWhilePointersMatchAndDeletePointers(
+      K key,
+      long expectedCanonicalVersion,
+      PointerConditions conditions,
+      Map<String, Long> pointerVersionsToDelete) {
+    return deleteWithPrecondition(
+        key, expectedCanonicalVersion, conditions, pointerVersionsToDelete, List.of());
+  }
+
+  /**
+   * Deletes the resource and the caller's companion operations in one atomic pointer transaction.
+   * Used to cascade into a resource this one owns, so neither can outlive the other.
+   */
+  public boolean deleteWithPreconditionAndCompanions(
+      K key, long expectedCanonicalVersion, List<PointerStore.CasOp> companions) {
+    return deleteWithPrecondition(
+        key, expectedCanonicalVersion, PointerConditions.none(), Map.of(), companions);
+  }
+
+  private boolean deleteWithPrecondition(
+      K key,
+      long expectedCanonicalVersion,
+      PointerConditions conditions,
+      Map<String, Long> pointerVersionsToDelete,
+      List<PointerStore.CasOp> companions) {
+    Map<String, Long> requiredPointerVersions = conditions.requiredVersions();
+    Set<String> requiredAbsentPointers = conditions.requiredAbsent();
     return observeRepository(
         "delete_with_precondition",
         () -> {
@@ -663,7 +1220,12 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           try {
             current = getByKeyForMutation(key);
           } catch (CorruptionException e) {
-            if (!deleteCanonicalPointer(canonicalPointer, expectedCanonicalVersion)) {
+            if (!deleteCanonicalPointer(
+                canonicalPointer,
+                expectedCanonicalVersion,
+                requiredPointerVersions,
+                requiredAbsentPointers,
+                pointerVersionsToDelete)) {
               return false;
             }
             if (!schema.casBlobs && !blobUri.isBlank()) {
@@ -679,7 +1241,11 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           if (!deleteAtomically(
               canonicalPointer,
               expectedCanonicalVersion,
-              new HashSet<>(schema.secondaryPointersFromValue.apply(currentValue).values()))) {
+              new HashSet<>(schema.secondaryPointersFromValue.apply(currentValue).values()),
+              requiredPointerVersions,
+              requiredAbsentPointers,
+              pointerVersionsToDelete,
+              companions)) {
             return false;
           }
 
@@ -692,6 +1258,59 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
   private boolean deleteAtomically(
       String canonicalPointer, long expectedCanonicalVersion, Set<String> currentSecondary) {
+    return deleteAtomically(
+        canonicalPointer,
+        expectedCanonicalVersion,
+        currentSecondary,
+        Map.of(),
+        Set.of(),
+        Map.of(),
+        List.of());
+  }
+
+  /**
+   * Returns the pointer operations that would delete this resource at its current versions, without
+   * committing anything, so a caller can fold them into another repository's atomic mutation. The
+   * counterpart to {@link #prepareCreateOps}.
+   *
+   * <p>Returns empty when the resource is already absent, which lets a cascading caller treat a
+   * partially completed earlier attempt as work already done rather than as an error.
+   */
+  public List<PointerStore.CasOp> prepareDeleteOps(K key) {
+    String canonicalPointer = schema.canonicalPointerForKey.apply(key);
+    Pointer canonical = mutationPointerStore.get(canonicalPointer).orElse(null);
+    if (canonical == null) {
+      return List.of();
+    }
+    Optional<T> current = getByKeyForMutation(key);
+    if (current.isEmpty()) {
+      return List.of(new PointerStore.CasDelete(canonicalPointer, canonical.getVersion()));
+    }
+    Set<String> batchedKeys = new HashSet<>();
+    List<PointerStore.CasOp> ops = new ArrayList<>();
+    batchedKeys.add(canonicalPointer);
+    ops.add(new PointerStore.CasDelete(canonicalPointer, canonical.getVersion()));
+    for (String pointerKey : schema.secondaryPointersFromValue.apply(current.get()).values()) {
+      if (!batchedKeys.add(pointerKey)) {
+        continue;
+      }
+      Pointer secondary = mutationPointerStore.get(pointerKey).orElse(null);
+      ops.add(
+          secondary != null
+              ? new PointerStore.CasDelete(pointerKey, secondary.getVersion())
+              : new PointerStore.CasCheckAbsent(pointerKey));
+    }
+    return List.copyOf(ops);
+  }
+
+  private boolean deleteAtomically(
+      String canonicalPointer,
+      long expectedCanonicalVersion,
+      Set<String> currentSecondary,
+      Map<String, Long> requiredPointerVersions,
+      Set<String> requiredAbsentPointers,
+      Map<String, Long> pointerVersionsToDelete,
+      List<PointerStore.CasOp> companions) {
     Set<String> batchedKeys = new HashSet<>();
     List<PointerStore.CasOp> ops = new ArrayList<>();
 
@@ -710,12 +1329,49 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       }
     }
 
+    addPointerDeletes(pointerVersionsToDelete, batchedKeys, ops);
+    addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
+    for (PointerStore.CasOp companion : companions) {
+      if (!batchedKeys.add(companion.key())) {
+        throw new IllegalArgumentException(
+            "duplicate companion pointer in atomic delete: " + companion.key());
+      }
+      ops.add(companion);
+    }
+
     return mutationPointerStore.compareAndSetBatch(ops);
   }
 
   private boolean deleteCanonicalPointer(String canonicalPointer, long expectedCanonicalVersion) {
-    return mutationPointerStore.compareAndSetBatch(
-        List.of(new PointerStore.CasDelete(canonicalPointer, expectedCanonicalVersion)));
+    return deleteCanonicalPointer(
+        canonicalPointer, expectedCanonicalVersion, Map.of(), Set.of(), Map.of());
+  }
+
+  private boolean deleteCanonicalPointer(
+      String canonicalPointer,
+      long expectedCanonicalVersion,
+      Map<String, Long> requiredPointerVersions,
+      Set<String> requiredAbsentPointers,
+      Map<String, Long> pointerVersionsToDelete) {
+    List<PointerStore.CasOp> ops = new ArrayList<>();
+    Set<String> batchedKeys = new HashSet<>();
+    batchedKeys.add(canonicalPointer);
+    ops.add(new PointerStore.CasDelete(canonicalPointer, expectedCanonicalVersion));
+    addPointerDeletes(pointerVersionsToDelete, batchedKeys, ops);
+    addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
+    return mutationPointerStore.compareAndSetBatch(ops);
+  }
+
+  private static void addPointerDeletes(
+      Map<String, Long> pointerVersionsToDelete,
+      Set<String> batchedKeys,
+      List<PointerStore.CasOp> ops) {
+    for (var entry : pointerVersionsToDelete.entrySet()) {
+      if (!batchedKeys.add(entry.getKey())) {
+        throw new IllegalArgumentException("duplicate pointer in atomic delete: " + entry.getKey());
+      }
+      ops.add(new PointerStore.CasDelete(entry.getKey(), entry.getValue()));
+    }
   }
 
   public MutationMeta metaFor(K key) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -1220,12 +1220,14 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           try {
             current = getByKeyForMutation(key);
           } catch (CorruptionException e) {
-            if (!deleteCanonicalPointer(
+            if (!deleteAtomically(
                 canonicalPointer,
                 expectedCanonicalVersion,
+                Set.of(),
                 requiredPointerVersions,
                 requiredAbsentPointers,
-                pointerVersionsToDelete)) {
+                pointerVersionsToDelete,
+                companions)) {
               return false;
             }
             if (!schema.casBlobs && !blobUri.isBlank()) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -962,6 +962,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           if (!pointerConditionsStillMatch(requiredPointerVersions, requiredAbsentPointers))
             return Optional.empty();
           if (!markerVersionsStillMatch(markerVersions)) return Optional.empty();
+          classifyCompanionConflict(companions);
           classifyUpdateConflict(canonicalPointer, expectedCanonicalVersion, blobUri, toAdd);
           return Optional.empty();
         });

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.service.repo.model.AccountKey;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.model.Schemas;
+import ai.floedb.floecat.service.repo.model.SnapshotKey;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
@@ -38,6 +39,7 @@ import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
@@ -186,6 +188,39 @@ class GenericResourceRepositoryCreateTest {
 
     assertThatCode(() -> snapshotRepo.create(snapshot)).doesNotThrowAnyException();
     assertThat(snapshotRepo.getById(tableId, 42L)).isPresent();
+  }
+
+  @Test
+  void replaceIdentity_deduplicatesCanonicalSecondaryAliases() {
+    var rejecting = new DuplicateKeyRejectingPointerStore(ptr);
+    var repo =
+        new GenericResourceRepository<>(
+            rejecting,
+            blobs,
+            Schemas.SNAPSHOT,
+            Snapshot::parseFrom,
+            Snapshot::toByteArray,
+            "application/x-protobuf");
+    var tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct-1")
+            .setId("tbl-1")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    var current = Snapshot.newBuilder().setTableId(tableId).setSnapshotId(42L).build();
+    var replacement = Snapshot.newBuilder().setTableId(tableId).setSnapshotId(43L).build();
+    repo.create(current);
+
+    assertThat(
+            repo.replaceIdentityWithMeta(
+                current,
+                1L,
+                replacement,
+                GenericResourceRepository.PointerConditions.none(),
+                Map.of()))
+        .isPresent();
+    assertThat(repo.getByKey(new SnapshotKey("acct-1", "tbl-1", 42L, ""))).isEmpty();
+    assertThat(repo.getByKey(new SnapshotKey("acct-1", "tbl-1", 43L, ""))).contains(replacement);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
@@ -27,8 +27,12 @@ import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.ConflictingBatchPointerStore;
 import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.DuplicateKeyRejectingPointerStore;
 import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.FailingBatchPointerStore;
+import ai.floedb.floecat.service.repo.model.AccountKey;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
@@ -288,5 +292,40 @@ class GenericResourceRepositoryCreateTest {
 
     assertThat(ptr.get(Keys.accountPointerById("acct-1"))).isEmpty();
     assertThat(ptr.get(Keys.accountPointerByName("alpha"))).isPresent();
+  }
+
+  @Test
+  void deleteWithCompanions_whenResourceBlobIsCorrupt_deletesCompanionAtomically() {
+    var repo =
+        new GenericResourceRepository<>(
+            ptr,
+            blobs,
+            Schemas.ACCOUNT,
+            Account::parseFrom,
+            Account::toByteArray,
+            "application/x-protobuf");
+    var account = account("acct-1", "alpha", "");
+    repo.create(account);
+
+    String canonicalKey = Keys.accountPointerById("acct-1");
+    var canonical = ptr.get(canonicalKey).orElseThrow();
+    assertThat(blobs.delete(canonical.getBlobUri())).isTrue();
+
+    String companionKey = "/test/owned-resource";
+    assertThat(
+            ptr.compareAndSet(
+                companionKey, 0L, PointerReferences.opaqueMarkerPointer(companionKey, "owned", 1L)))
+        .isTrue();
+    long companionVersion = ptr.get(companionKey).orElseThrow().getVersion();
+
+    assertThat(
+            repo.deleteWithPreconditionAndCompanions(
+                new AccountKey("acct-1"),
+                canonical.getVersion(),
+                List.of(new PointerStore.CasDelete(companionKey, companionVersion))))
+        .isTrue();
+
+    assertThat(ptr.get(canonicalKey)).isEmpty();
+    assertThat(ptr.get(companionKey)).isEmpty();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositorySystemGuardTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositorySystemGuardTest.java
@@ -22,7 +22,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.model.CatalogKey;
+import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
@@ -76,6 +79,24 @@ class GenericResourceRepositorySystemGuardTest {
   @Test
   void deleteWithPrecondition_systemCatalog_rejected() {
     assertThatThrownBy(() -> repo.deleteWithPrecondition(systemCatalogId(), 1L))
+        .isInstanceOf(BaseResourceRepository.SystemObjectImmutableException.class);
+  }
+
+  @Test
+  void prepareDeleteOps_systemCatalog_rejected() {
+    ResourceId systemId = systemCatalogId();
+    var generic =
+        new GenericResourceRepository<>(
+            ptr,
+            blobs,
+            Schemas.CATALOG,
+            Catalog::parseFrom,
+            Catalog::toByteArray,
+            "application/x-protobuf");
+
+    assertThatThrownBy(
+            () ->
+                generic.prepareDeleteOps(new CatalogKey(systemId.getAccountId(), systemId.getId())))
         .isInstanceOf(BaseResourceRepository.SystemObjectImmutableException.class);
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryUpdateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryUpdateTest.java
@@ -20,13 +20,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ai.floedb.floecat.account.rpc.Account;
+import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.FailingBatchPointerStore;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -115,6 +120,32 @@ class GenericResourceRepositoryUpdateTest {
     assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
     assertThat(repo.getByName("alpha")).isPresent();
     assertThat(repo.getByName("beta").orElseThrow().getResourceId().getId()).isEqualTo("acct-2");
+  }
+
+  @Test
+  void update_companionCreateCollision_throwsNameConflict() {
+    var repo =
+        new GenericResourceRepository<>(
+            ptr,
+            blobs,
+            Schemas.ACCOUNT,
+            Account::parseFrom,
+            Account::toByteArray,
+            "application/x-protobuf");
+    repo.create(account("acct-1", "alpha", "v1"));
+    String companionKey = "companion/by-name/taken";
+    Pointer companion = Pointer.newBuilder().setKey(companionKey).setVersion(1L).build();
+    assertThat(ptr.compareAndSet(companionKey, 0L, companion)).isTrue();
+
+    assertThatThrownBy(
+            () ->
+                repo.updateWithMetaWhilePointersMatchAndBumpMarkers(
+                    account("acct-1", "alpha", "v2"),
+                    1L,
+                    GenericResourceRepository.PointerConditions.none(),
+                    List.of(new PointerStore.CasUpsert(companionKey, 0L, companion))))
+        .isInstanceOf(BaseResourceRepository.NameConflictException.class)
+        .hasMessageContaining(companionKey);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
@@ -525,6 +525,41 @@ public class IdempotencyGuardTest {
   }
 
   @Test
+  void deletePendingIfOwnedDoesNotDeleteSuccessFinalizedAfterOwnershipCheck() throws Exception {
+    InMemoryPointerStore rawPtr = new InMemoryPointerStore();
+    InMemoryBlobStore rawBlobs = new InMemoryBlobStore();
+    String key = Keys.idempotencyKey(ACCOUNT, OP, "pending-cleanup-race");
+    String requestHash = sha256B64("REQ".getBytes(StandardCharsets.UTF_8));
+    Timestamp expiresAt = expiresFrom(NOW, 300);
+    var racingPtr = new CompareDeleteRacePointerStore(rawPtr);
+    var racingRepo = new IdempotencyRepositoryImpl(racingPtr, rawBlobs);
+
+    assertThat(racingRepo.createPending(ACCOUNT, key, OP, requestHash, NOW, expiresAt)).isTrue();
+    racingPtr.beforeNextCompareAndDelete(
+        key,
+        () ->
+            racingRepo.finalizeSuccess(
+                ACCOUNT,
+                key,
+                OP,
+                requestHash,
+                resourceId("winner"),
+                meta(2),
+                "WINNER".getBytes(StandardCharsets.UTF_8),
+                NOW,
+                expiresAt));
+
+    assertThat(racingRepo.deletePendingIfOwned(key, OP, requestHash, NOW, expiresAt)).isFalse();
+    assertThat(racingRepo.get(key))
+        .get()
+        .satisfies(
+            winner -> {
+              assertThat(winner.getStatus()).isEqualTo(IdempotencyRecord.Status.SUCCEEDED);
+              assertThat(winner.getPayload().toStringUtf8()).isEqualTo("WINNER");
+            });
+  }
+
+  @Test
   void staleLegacyFinalizerCannotCompleteAReusedIdempotencyKey() throws Exception {
     String key = Keys.idempotencyKey(ACCOUNT, OP, "reused-key");
     Timestamp expiresAt = expiresFrom(NOW, 300);

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
@@ -47,6 +47,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -149,6 +150,83 @@ public class IdempotencyGuardTest {
         .isInstanceOf(StorageAbortRetryableException.class);
     assertThat(creates).hasValue(1);
     assertThat(createdId.get()).isEqualTo(resourceId("reserved"));
+  }
+
+  @Test
+  void reservedCreateCommitsTheSuccessReceiptWithTheResourcePointer() {
+    String idemKey = "atomic-receipt";
+    byte[] request = "request".getBytes(StandardCharsets.UTF_8);
+    String key = Keys.idempotencyKey(ACCOUNT, OP, idemKey);
+    String resourcePointerKey = "acct/" + ACCOUNT + "/thing/reserved";
+    ResourceId reservedId = resourceId("reserved");
+    MutationMeta createdMeta = meta(1);
+
+    var out =
+        IdempotencyGuard.runOnceReserved(
+            ACCOUNT,
+            OP,
+            idemKey,
+            request,
+            () -> reservedId,
+            (id, committer) -> {
+              var committed = new IdempotencyGuard.CommittedCreate<>("RESOURCE", id, createdMeta);
+              PointerStore.CasUpsert receipt = committer.prepare(committed);
+              String blobUri = "blob://thing/" + id.getId();
+              blobs.put(
+                  blobUri, "RESOURCE".getBytes(StandardCharsets.UTF_8), "application/x-protobuf");
+              var resourcePointer =
+                  PointerReferences.asBlobPointer(
+                          Pointer.newBuilder().setKey(resourcePointerKey).setVersion(1L), blobUri)
+                      .build();
+              assertThat(
+                      ptr.compareAndSetBatch(
+                          List.of(
+                              new PointerStore.CasUpsert(resourcePointerKey, 0L, resourcePointer),
+                              receipt)))
+                  .isTrue();
+              return committed;
+            },
+            strSer(),
+            strParser(),
+            repo,
+            60,
+            NOW,
+            () -> "corr");
+
+    assertThat(out.resource()).isEqualTo("RESOURCE");
+    assertThat(out.meta()).isEqualTo(createdMeta);
+    assertThat(ptr.get(resourcePointerKey)).isPresent();
+    assertThat(repo.get(key))
+        .get()
+        .satisfies(
+            receipt -> {
+              assertThat(receipt.getStatus()).isEqualTo(IdempotencyRecord.Status.SUCCEEDED);
+              assertThat(receipt.getResourceId()).isEqualTo(reservedId);
+              assertThat(receipt.getMeta()).isEqualTo(createdMeta);
+              assertThat(receipt.getPayload().toStringUtf8()).isEqualTo("RESOURCE");
+            });
+
+    var replay =
+        IdempotencyGuard.runOnceReserved(
+            ACCOUNT,
+            OP,
+            idemKey,
+            request,
+            () -> {
+              throw new AssertionError("committed receipt must be replayed");
+            },
+            (id, committer) -> {
+              throw new AssertionError("committed receipt must be replayed");
+            },
+            strSer(),
+            strParser(),
+            repo,
+            60,
+            NOW,
+            () -> "corr");
+
+    assertThat(replay.resource()).isEqualTo("RESOURCE");
+    assertThat(replay.meta()).isEqualTo(createdMeta);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
@@ -152,6 +152,88 @@ public class IdempotencyGuardTest {
   }
 
   @Test
+  void reservedCreateAdopterDoesNotDeleteTheExistingPendingReservationOnFailure() throws Exception {
+    String idemKey = "adopted-reservation";
+    byte[] request = "request".getBytes(StandardCharsets.UTF_8);
+    String key = Keys.idempotencyKey(ACCOUNT, OP, idemKey);
+    String requestHash = sha256B64(request);
+    Timestamp expiresAt = expiresFrom(NOW, 60);
+    ResourceId reservedId = resourceId("reserved");
+    assertThat(repo.createPending(ACCOUNT, key, OP, requestHash, reservedId, NOW, expiresAt))
+        .isTrue();
+
+    assertThatThrownBy(
+            () ->
+                IdempotencyGuard.runOnceReserved(
+                    ACCOUNT,
+                    OP,
+                    idemKey,
+                    request,
+                    () -> {
+                      throw new AssertionError("existing reservation must be adopted");
+                    },
+                    (id, committer) -> {
+                      throw new BaseResourceRepository.NameConflictException("lost create race");
+                    },
+                    strSer(),
+                    strParser(),
+                    repo,
+                    60,
+                    NOW,
+                    () -> "corr"))
+        .isInstanceOf(BaseResourceRepository.NameConflictException.class);
+
+    assertThat(repo.get(key))
+        .get()
+        .satisfies(
+            pending -> {
+              assertThat(pending.getStatus()).isEqualTo(IdempotencyRecord.Status.PENDING);
+              assertThat(pending.getResourceId()).isEqualTo(reservedId);
+            });
+  }
+
+  @Test
+  void reservedCreateReplaysWinnerThatCompletesBeforeLoserReportsConflict() throws Exception {
+    String idemKey = "concurrent-winner";
+    byte[] request = "request".getBytes(StandardCharsets.UTF_8);
+    String key = Keys.idempotencyKey(ACCOUNT, OP, idemKey);
+    String requestHash = sha256B64(request);
+    Timestamp expiresAt = expiresFrom(NOW, 60);
+    ResourceId reservedId = resourceId("reserved");
+    MutationMeta winnerMeta = meta(7);
+
+    var out =
+        IdempotencyGuard.runOnceReserved(
+            ACCOUNT,
+            OP,
+            idemKey,
+            request,
+            () -> reservedId,
+            (id, committer) -> {
+              repo.finalizeSuccess(
+                  ACCOUNT,
+                  key,
+                  OP,
+                  requestHash,
+                  id,
+                  winnerMeta,
+                  "WINNER".getBytes(StandardCharsets.UTF_8),
+                  NOW,
+                  expiresAt);
+              throw new BaseResourceRepository.NameConflictException("lost create race");
+            },
+            strSer(),
+            strParser(),
+            repo,
+            60,
+            NOW,
+            () -> "corr");
+
+    assertThat(out.resource()).isEqualTo("WINNER");
+    assertThat(out.meta()).isEqualTo(winnerMeta);
+  }
+
+  @Test
   void runOnceReplay() throws Exception {
     var creator =
         (Supplier<IdempotencyGuard.CreateResult<String>>)

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
@@ -30,6 +30,7 @@ import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.rpc.IdempotencyRecord;
@@ -47,6 +48,9 @@ import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,6 +91,64 @@ public class IdempotencyGuardTest {
             () -> "corr");
 
     assertThat(out.resource()).isEqualTo("R1");
+  }
+
+  @Test
+  void reservedCreateNeverReconstructsAReceiptFromMutableResourceState() {
+    var body = new AtomicReference<String>();
+    var createdId = new AtomicReference<ResourceId>();
+    var creates = new AtomicInteger();
+    var allocator = (Supplier<ResourceId>) () -> resourceId("reserved");
+    BiFunction<
+            ResourceId,
+            IdempotencyGuard.SuccessCommitter<String>,
+            IdempotencyGuard.CommittedCreate<String>>
+        creator =
+            (id, ignored) -> {
+              if (createdId.get() == null) {
+                createdId.set(id);
+                body.set("original-name");
+                creates.incrementAndGet();
+              }
+              return new IdempotencyGuard.CommittedCreate<>(body.get(), id, meta(1));
+            };
+
+    assertThatThrownBy(
+            () ->
+                IdempotencyGuard.runOnceReserved(
+                    ACCOUNT,
+                    OP,
+                    "reserved-key",
+                    "request".getBytes(StandardCharsets.UTF_8),
+                    allocator,
+                    creator,
+                    strSer(),
+                    strParser(),
+                    repo,
+                    60,
+                    NOW,
+                    () -> "corr"))
+        .isInstanceOf(StorageAbortRetryableException.class);
+
+    body.set("renamed-after-commit");
+    assertThatThrownBy(
+            () ->
+                IdempotencyGuard.runOnceReserved(
+                    ACCOUNT,
+                    OP,
+                    "reserved-key",
+                    "request".getBytes(StandardCharsets.UTF_8),
+                    allocator,
+                    creator,
+                    strSer(),
+                    strParser(),
+                    repo,
+                    60,
+                    NOW,
+                    () -> "corr"))
+        .isInstanceOf(StorageAbortRetryableException.class);
+    assertThat(creates).hasValue(1);
+    assertThat(createdId.get()).isEqualTo(resourceId("reserved"));
   }
 
   @Test
@@ -378,6 +440,39 @@ public class IdempotencyGuardTest {
     assertThat(rawBlobs.head(winnerUri)).isPresent();
     assertThat(racingRepo.get(key)).isPresent();
     assertThat(racingRepo.get(key).orElseThrow().getPayload().toStringUtf8()).isEqualTo("WINNER");
+  }
+
+  @Test
+  void staleLegacyFinalizerCannotCompleteAReusedIdempotencyKey() throws Exception {
+    String key = Keys.idempotencyKey(ACCOUNT, OP, "reused-key");
+    Timestamp expiresAt = expiresFrom(NOW, 300);
+    String requestHash = sha256B64("SAME".getBytes(StandardCharsets.UTF_8));
+    Timestamp newerCreatedAt = Timestamps.add(NOW, Duration.newBuilder().setSeconds(1).build());
+    Timestamp newerExpiresAt = expiresFrom(newerCreatedAt, 300);
+
+    assertThat(repo.createPending(ACCOUNT, key, OP, requestHash, NOW, expiresAt)).isTrue();
+    assertThat(repo.delete(key)).isTrue();
+    assertThat(repo.createPending(ACCOUNT, key, OP, requestHash, newerCreatedAt, newerExpiresAt))
+        .isTrue();
+
+    assertThatThrownBy(
+            () ->
+                repo.finalizeSuccess(
+                    ACCOUNT,
+                    key,
+                    OP,
+                    requestHash,
+                    resourceId("old-resource"),
+                    meta(1),
+                    "old-payload".getBytes(StandardCharsets.UTF_8),
+                    NOW,
+                    expiresAt))
+        .isInstanceOf(StorageAbortRetryableException.class);
+
+    var current = repo.get(key).orElseThrow();
+    assertThat(current.getStatus()).isEqualTo(IdempotencyRecord.Status.PENDING);
+    assertThat(current.getRequestHash()).isEqualTo(requestHash);
+    assertThat(current.getCreatedAt()).isEqualTo(newerCreatedAt);
   }
 
   private static Function<String, byte[]> strSer() {

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
@@ -112,6 +112,28 @@ final class RepoTestPointerStores {
     }
   }
 
+  /** Commits a successful batch, then loses its acknowledgement to the caller. */
+  static final class CommitThenFailBatchPointerStore extends DelegatingPointerStore {
+    CommitThenFailBatchPointerStore(PointerStore delegate) {
+      super(delegate);
+    }
+
+    static final class InjectedAcknowledgementFailure extends RuntimeException {
+      InjectedAcknowledgementFailure(String message) {
+        super(message);
+      }
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<CasOp> ops) {
+      boolean committed = delegate.compareAndSetBatch(ops);
+      if (committed) {
+        throw new InjectedAcknowledgementFailure("injected failure after batch commit");
+      }
+      return false;
+    }
+  }
+
   /**
    * Reports every batch CAS as a non-committing conflict, mimicking a DynamoDB {@code
    * TransactionConflict} / {@code ConditionalCheckFailed} cancellation: nothing is mutated and


### PR DESCRIPTION
## Summary

Adds the repository durability primitives needed by catalog integrations and overlays: atomic mutation helpers, repository-backed idempotency operations, and the generic resource-repository behavior used by later API slices.

This PR deliberately separates foundational repository work from the catalog-specific resources that consume it.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Focused `IdempotencyGuard` and repository tests passed.

- [x] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Stack position: **3/10**. Base: `mc-catalog-graph-view-rename`. Review this as storage/repository infrastructure; no catalog integration API is introduced here.

