### PR TITLE
feat(account): fence and resume account deletion (stack 4/10)

### DIFF
--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -154,6 +154,15 @@ public interface KvStore {
   Uni<Page> queryByPartitionKeyPrefix(
       String partitionKey, String sortKeyPrefix, int limit, Optional<String> pageToken);
 
+  default Uni<Page> queryByPartitionKeyPrefix(
+      String partitionKey,
+      String sortKeyPrefix,
+      int limit,
+      Optional<String> pageToken,
+      boolean consistentRead) {
+    return queryByPartitionKeyPrefix(partitionKey, sortKeyPrefix, limit, pageToken);
+  }
+
   /**
    * Returns a page token that resumes a {@link #queryByPartitionKeyPrefix} scan immediately after
    * the given key, in this store's native token encoding. The default throws; stores that serve

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -179,6 +179,10 @@ public interface KvStore {
    */
   Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix);
 
+  /** Deletes a prefix while continuously preserving one exact sort key. */
+  Uni<Integer> deleteByPrefixExcluding(
+      String partitionKey, String sortKeyPrefix, String excludedSortKey);
+
   /**
    * Remove all records in store. <br>
    * NB: for testing purposes only.

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -154,14 +154,12 @@ public interface KvStore {
   Uni<Page> queryByPartitionKeyPrefix(
       String partitionKey, String sortKeyPrefix, int limit, Optional<String> pageToken);
 
-  default Uni<Page> queryByPartitionKeyPrefix(
+  Uni<Page> queryByPartitionKeyPrefix(
       String partitionKey,
       String sortKeyPrefix,
       int limit,
       Optional<String> pageToken,
-      boolean consistentRead) {
-    return queryByPartitionKeyPrefix(partitionKey, sortKeyPrefix, limit, pageToken);
-  }
+      boolean consistentRead);
 
   /**
    * Returns a page token that resumes a {@link #queryByPartitionKeyPrefix} scan immediately after

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
@@ -123,10 +123,8 @@ public interface PointerStore {
   List<Pointer> listPointersByPrefix(
       String prefix, int limit, String pageToken, StringBuilder nextTokenOut);
 
-  default List<Pointer> listPointersByPrefixConsistent(
-      String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
-    return listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
-  }
+  List<Pointer> listPointersByPrefixConsistent(
+      String prefix, int limit, String pageToken, StringBuilder nextTokenOut);
 
   /**
    * Returns a page token that resumes a {@link #listPointersByPrefix} scan immediately after the
@@ -145,9 +143,7 @@ public interface PointerStore {
 
   int countByPrefix(String prefix);
 
-  default int countByPrefixConsistent(String prefix) {
-    return countByPrefix(prefix);
-  }
+  int countByPrefixConsistent(String prefix);
 
   boolean isEmpty();
 

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
@@ -123,6 +123,11 @@ public interface PointerStore {
   List<Pointer> listPointersByPrefix(
       String prefix, int limit, String pageToken, StringBuilder nextTokenOut);
 
+  default List<Pointer> listPointersByPrefixConsistent(
+      String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+    return listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
+  }
+
   /**
    * Returns a page token that resumes a {@link #listPointersByPrefix} scan immediately after the
    * given pointer key, as if a previous page had ended exactly at that key. This lets callers that
@@ -139,6 +144,10 @@ public interface PointerStore {
   int deleteByPrefix(String prefix);
 
   int countByPrefix(String prefix);
+
+  default int countByPrefixConsistent(String prefix) {
+    return countByPrefix(prefix);
+  }
 
   boolean isEmpty();
 

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStore.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.storage.spi;
 
 import ai.floedb.floecat.common.rpc.Pointer;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -140,6 +141,33 @@ public interface PointerStore {
   }
 
   int deleteByPrefix(String prefix);
+
+  /**
+   * Deletes every pointer under {@code prefix} except the exact {@code excludedKey}.
+   *
+   * <p>The exclusion is continuous: implementations must never delete and recreate the excluded
+   * key. Account teardown uses this to sweep an account partition while preserving its durable
+   * deletion fence.
+   */
+  default int deleteByPrefixExcluding(String prefix, String excludedKey) {
+    int deleted = 0;
+    String token = "";
+    var seenTokens = new HashSet<String>();
+    do {
+      var next = new StringBuilder();
+      List<Pointer> page = listPointersByPrefixConsistent(prefix, 500, token, next);
+      for (Pointer pointer : page) {
+        if (!pointer.getKey().equals(excludedKey) && delete(pointer.getKey())) {
+          deleted++;
+        }
+      }
+      token = next.toString();
+      if (!token.isBlank() && !seenTokens.add(token)) {
+        throw new IllegalStateException("stagnant pointer scan token: " + token);
+      }
+    } while (!token.isBlank());
+    return deleted;
+  }
 
   int countByPrefix(String prefix);
 

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
@@ -608,6 +608,16 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
     }
 
     @Override
+    public Uni<Page> queryByPartitionKeyPrefix(
+        String partitionKey,
+        String sortKeyPrefix,
+        int limit,
+        Optional<String> pageToken,
+        boolean consistentRead) {
+      return queryByPartitionKeyPrefix(partitionKey, sortKeyPrefix, limit, pageToken);
+    }
+
+    @Override
     public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
       int before = records.size();
       records

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/kv/EntityContractTest.java
@@ -619,6 +619,12 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
 
     @Override
     public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
+      return deleteByPrefixExcluding(partitionKey, sortKeyPrefix, null);
+    }
+
+    @Override
+    public Uni<Integer> deleteByPrefixExcluding(
+        String partitionKey, String sortKeyPrefix, String excludedSortKey) {
       int before = records.size();
       records
           .entrySet()
@@ -627,7 +633,8 @@ public class EntityContractTest extends AbstractEntityTest<Pointer> {
                   Objects.equals(e.getKey().partitionKey(), partitionKey)
                       && (sortKeyPrefix == null
                           || sortKeyPrefix.isEmpty()
-                          || e.getKey().sortKey().startsWith(sortKeyPrefix)));
+                          || e.getKey().sortKey().startsWith(sortKeyPrefix))
+                      && !Objects.equals(e.getKey().sortKey(), excludedSortKey));
       return Uni.createFrom().item(before - records.size());
     }
 

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -486,9 +486,8 @@ dependent would let a delete that should be rejected succeed. The storage SPI th
 strongly consistent variants of prefix listing and counting alongside the ordinary reads, and
 cascade and dependency paths use those variants. Ordinary listing RPCs keep the default reads.
 
-The variants are defaults on the SPI interfaces that delegate to the existing reads, so a backend
-without a separate consistent-read mode inherits correct behavior. `storage/aws` overrides them
-with DynamoDB consistent reads.
+SPI implementations must define the variants explicitly. Backends whose ordinary reads are already
+strongly consistent may delegate explicitly; `storage/aws` requests DynamoDB consistent reads.
 
 ## Create-conflict behavior
 

--- a/docs/storage-layout.md
+++ b/docs/storage-layout.md
@@ -75,6 +75,7 @@ Catalog hierarchy, lookup indexes, and maintenance markers:
 /accounts/by-id/{account_id}
 /accounts/by-name/{account_name}
 /accounts/{account_id}
+/accounts/{account_id}/deleting
 /accounts/{account_id}/catalogs/by-id/{catalog_id}
 /accounts/{account_id}/catalogs/by-name/{catalog_name}
 /accounts/{account_id}/storage-authorities/by-id/{authority_id}

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -31,7 +31,6 @@ import ai.floedb.floecat.account.rpc.ListAccountsRequest;
 import ai.floedb.floecat.account.rpc.ListAccountsResponse;
 import ai.floedb.floecat.account.rpc.UpdateAccountRequest;
 import ai.floedb.floecat.account.rpc.UpdateAccountResponse;
-import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -45,19 +44,13 @@ import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.credentials.DefaultCredentialResolver;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
+import ai.floedb.floecat.service.reconciler.jobs.DurableReconcileJobStore;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
-import ai.floedb.floecat.service.repo.impl.CatalogRepository;
-import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
-import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
-import ai.floedb.floecat.service.repo.impl.StorageAuthorityRepository;
-import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
-import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
-import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.service.storage.impl.StorageAuthorityResolver;
@@ -67,37 +60,30 @@ import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.FieldMask;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 import org.jboss.logging.Logger;
 
 @GrpcService
 public class AccountServiceImpl extends BaseServiceImpl implements AccountService {
   @Inject AccountRepository accountRepo;
-  @Inject CatalogRepository catalogRepo;
-  @Inject NamespaceRepository namespaceRepo;
-  @Inject TableRepository tableRepo;
   @Inject TableRootRepository tableRootRepo;
-  @Inject ConnectorRepository connectorRepo;
-  @Inject StorageAuthorityRepository storageAuthorityRepo;
-  @Inject ViewRepository viewRepo;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
   @Inject IdempotencyRepository idempotencyStore;
   @Inject UserGraph metadataGraph;
-  @Inject MarkerStore markerStore;
   @Inject PointerStore pointerStore;
   @Inject BlobStore blobStore;
   @Inject DefaultCredentialResolver credentialResolver;
   @Inject SecretsManager secretsManager;
+  @Inject Instance<DurableReconcileJobStore> durableReconcileJobStore;
 
   private static final Set<String> ACCOUNT_MUTABLE_PATHS =
       Set.of("display_name", "description", "tags");
@@ -542,17 +528,60 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     var summary = new AccountCleanupSummary(accountKey);
     CLEANUP_LOG.infof("account_delete_cleanup_start account_id=%s", accountKey);
     try {
-      cleanupTransactions(accountKey, summary);
-      cleanupStorageAuthorities(accountKey, summary);
-      cleanupConnectors(accountKey, summary);
-      cleanupCatalogs(accountKey, summary);
-      summary.residualAccountBlobsDeleted +=
-          blobStore.deletePrefix(Keys.accountRootPrefix(accountKey));
+      List<ResourceId> storageAuthorities =
+          listCanonicalResourceIds(
+              Keys.storageAuthorityPointerByIdPrefix(accountKey),
+              accountKey,
+              ResourceKind.RK_STORAGE_AUTHORITY);
+      List<ResourceId> connectors =
+          listCanonicalResourceIds(
+              Keys.connectorPointerByIdPrefix(accountKey), accountKey, ResourceKind.RK_CONNECTOR);
+      List<ResourceId> catalogs =
+          listCanonicalResourceIds(
+              Keys.catalogPointerByIdPrefix(accountKey), accountKey, ResourceKind.RK_CATALOG);
+      List<ResourceId> namespaces =
+          listCanonicalResourceIds(
+              Keys.namespacePointerByIdPrefix(accountKey), accountKey, ResourceKind.RK_NAMESPACE);
+      List<ResourceId> tables =
+          listCanonicalResourceIds(
+              Keys.tablePointerByIdPrefix(accountKey), accountKey, ResourceKind.RK_TABLE);
+      List<ResourceId> views =
+          listCanonicalResourceIds(
+              Keys.viewPointerByIdPrefix(accountKey), accountKey, ResourceKind.RK_VIEW);
+
+      cleanupStorageAuthorityCredentials(accountKey, storageAuthorities, summary);
+      cleanupConnectorCredentials(accountKey, connectors, summary);
+      summary.catalogsDeleted = catalogs.size();
+      summary.namespacesDeleted = namespaces.size();
+      summary.tablesDeleted = tables.size();
+      summary.viewsDeleted = views.size();
+
+      if (durableReconcileJobStore.isResolvable()) {
+        summary.reconcileJobsDeleted = durableReconcileJobStore.get().cleanupAccount(accountKey);
+      } else {
+        CLEANUP_LOG.warnf("account_delete_reconcile_cleanup_unavailable account_id=%s", accountKey);
+      }
+
+      String accountPrefix = Keys.accountRootPrefix(accountKey);
+      String deletionFence = Keys.accountDeletionMarker(accountKey);
+      summary.accountPointersDeleted +=
+          pointerStore.deleteByPrefixExcluding(accountPrefix, deletionFence);
+      assertAccountPointerSweepComplete(accountPrefix, deletionFence);
+      // The durable root pointers are gone; purge their read-your-writes cache entries as well.
+      for (ResourceId tableId : tables) {
+        tableRootRepo.purgeRoot(tableId);
+      }
+      invalidateAll(storageAuthorities);
+      invalidateAll(connectors);
+      invalidateAll(catalogs);
+      invalidateAll(namespaces);
+      invalidateAll(tables);
+      invalidateAll(views);
+      summary.residualAccountBlobsDeleted += blobStore.deletePrefix(accountPrefix);
       CLEANUP_LOG.infof(
-          "account_delete_cleanup_complete account_id=%s transaction_pointer_deletes=%d transaction_blob_deletes=%d storage_authorities=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d snapshot_prefix_deletes=%d constraint_prefix_deletes=%d table_blob_deletes=%d residual_account_blob_deletes=%d",
+          "account_delete_cleanup_complete account_id=%s account_pointer_deletes=%d storage_authorities=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d reconcile_jobs=%d residual_account_blob_deletes=%d",
           summary.accountId,
-          summary.transactionPointersDeleted,
-          summary.transactionBlobsDeleted,
+          summary.accountPointersDeleted,
           summary.storageAuthoritiesDeleted,
           summary.connectorsDeleted,
           summary.credentialsDeleted,
@@ -560,9 +589,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
           summary.namespacesDeleted,
           summary.tablesDeleted,
           summary.viewsDeleted,
-          summary.snapshotPrefixesDeleted,
-          summary.constraintPrefixesDeleted,
-          summary.tableBlobsDeleted,
+          summary.reconcileJobsDeleted,
           summary.residualAccountBlobsDeleted);
     } catch (RuntimeException e) {
       CLEANUP_LOG.errorf(e, "account_delete_cleanup_failed account_id=%s", accountKey);
@@ -570,134 +597,62 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     }
   }
 
-  private void cleanupTransactions(String accountId, AccountCleanupSummary summary) {
-    String prefix = Keys.transactionPrefix(accountId);
-    summary.transactionPointersDeleted += pointerStore.deleteByPrefix(prefix);
-    summary.transactionBlobsDeleted += blobStore.deletePrefix(prefix);
-  }
-
-  private void cleanupStorageAuthorities(String accountId, AccountCleanupSummary summary) {
-    for (var authority :
-        listAllPages(
-            (token, next) -> storageAuthorityRepo.listConsistent(accountId, 200, token, next))) {
-      var authorityId = authority.getResourceId();
+  private void cleanupStorageAuthorityCredentials(
+      String accountId, List<ResourceId> authorities, AccountCleanupSummary summary) {
+    for (ResourceId authorityId : authorities) {
       CLEANUP_LOG.infof(
           "account_delete_cleanup_storage_authority account_id=%s authority_id=%s",
           accountId, authorityId.getId());
-      // Delete the secret first. If repository deletion then races, a replay can still discover the
-      // authority and safely retry both idempotent operations.
       secretsManager.delete(
           accountId, StorageAuthorityResolver.STORAGE_AUTHORITY_SECRET_TYPE, authorityId.getId());
-      storageAuthorityRepo.deleteOrConfirmAbsent(authorityId);
       summary.storageAuthoritiesDeleted++;
       summary.credentialsDeleted++;
     }
   }
 
-  private void cleanupConnectors(String accountId, AccountCleanupSummary summary) {
-    for (var connector :
-        listAllPages((token, next) -> connectorRepo.listConsistent(accountId, 200, token, next))) {
-      var connectorId = connector.getResourceId();
+  private void cleanupConnectorCredentials(
+      String accountId, List<ResourceId> connectors, AccountCleanupSummary summary) {
+    for (ResourceId connectorId : connectors) {
       CLEANUP_LOG.infof(
           "account_delete_cleanup_connector account_id=%s connector_id=%s",
           accountId, connectorId.getId());
       credentialResolver.delete(accountId, connectorId.getId());
-      connectorRepo.deleteOrConfirmAbsent(connectorId);
       summary.connectorsDeleted++;
       summary.credentialsDeleted++;
     }
   }
 
-  private void cleanupCatalogs(String accountId, AccountCleanupSummary summary) {
-    for (var catalog :
-        listAllPages((token, next) -> catalogRepo.listConsistent(accountId, 200, token, next))) {
-      cleanupCatalog(catalog, summary);
-    }
-  }
-
-  private void cleanupCatalog(Catalog catalog, AccountCleanupSummary summary) {
-    var catalogId = catalog.getResourceId();
-    CLEANUP_LOG.infof(
-        "account_delete_cleanup_catalog account_id=%s catalog_id=%s",
-        catalogId.getAccountId(), catalogId.getId());
-    var namespaces =
-        new ArrayList<>(
-            namespaceRepo.listIdsConsistent(catalogId.getAccountId(), catalogId.getId()));
-    namespaces.sort(Comparator.comparingInt(this::namespaceDepth).reversed());
-    for (var namespaceId : namespaces) {
-      cleanupNamespace(namespaceId, summary);
-    }
-    catalogRepo.deleteOrConfirmAbsent(catalogId);
-    metadataGraph.invalidate(catalogId);
-    summary.catalogsDeleted++;
-  }
-
-  private void cleanupNamespace(ResourceId namespaceId, AccountCleanupSummary summary) {
-    var namespace = namespaceRepo.getByIdForMutation(namespaceId).orElse(null);
-    if (namespace == null) {
-      metadataGraph.invalidate(namespaceId);
-      return;
-    }
-    CLEANUP_LOG.infof(
-        "account_delete_cleanup_namespace account_id=%s namespace_id=%s catalog_id=%s",
-        namespaceId.getAccountId(), namespaceId.getId(), namespace.getCatalogId().getId());
-    cleanupViews(namespace, summary);
-    cleanupTables(namespace, summary);
-    namespaceRepo.deleteOrConfirmAbsent(namespaceId);
-    metadataGraph.invalidate(namespaceId);
-    markerStore.bumpCatalogMarker(namespace.getCatalogId());
-    bumpParentNamespaceMarkers(namespace);
-    summary.namespacesDeleted++;
-  }
-
-  private void cleanupTables(
-      ai.floedb.floecat.catalog.rpc.Namespace namespace, AccountCleanupSummary summary) {
-    for (var table :
-        listAllPages(
-            (token, next) ->
-                tableRepo.listConsistent(
-                    namespace.getResourceId().getAccountId(),
-                    namespace.getCatalogId().getId(),
-                    namespace.getResourceId().getId(),
-                    200,
-                    token,
-                    next))) {
-      cleanupTable(table, summary);
-    }
-  }
-
-  private void cleanupViews(
-      ai.floedb.floecat.catalog.rpc.Namespace namespace, AccountCleanupSummary summary) {
-    for (var view :
-        listAllPages(
-            (token, next) ->
-                viewRepo.listConsistent(
-                    namespace.getResourceId().getAccountId(),
-                    namespace.getCatalogId().getId(),
-                    namespace.getResourceId().getId(),
-                    200,
-                    token,
-                    next))) {
-      var viewId = view.getResourceId();
-      CLEANUP_LOG.infof(
-          "account_delete_cleanup_view account_id=%s namespace_id=%s view_id=%s",
-          viewId.getAccountId(), namespace.getResourceId().getId(), viewId.getId());
-      viewRepo.deleteOrConfirmAbsent(viewId);
-      metadataGraph.invalidate(viewId);
-      summary.viewsDeleted++;
-    }
-  }
-
-  private <T> List<T> listAllPages(BiFunction<String, StringBuilder, List<T>> pageLoader) {
-    var items = new ArrayList<T>();
+  private List<ResourceId> listCanonicalResourceIds(
+      String prefix, String accountId, ResourceKind kind) {
+    var ids = new ArrayList<ResourceId>();
     var seenTokens = new HashSet<String>();
     String token = "";
     while (true) {
       var next = new StringBuilder();
-      items.addAll(pageLoader.apply(token, next));
+      for (Pointer pointer :
+          pointerStore.listPointersByPrefixConsistent(prefix, 200, token, next)) {
+        String id;
+        try {
+          id = Keys.extractLastSegment(pointer.getKey());
+        } catch (RuntimeException malformedKey) {
+          CLEANUP_LOG.warnf(
+              malformedKey,
+              "account_delete_cleanup_skipping_malformed_canonical_pointer account_id=%s pointer_key=%s",
+              accountId,
+              pointer.getKey());
+          continue;
+        }
+        if (id == null || id.isBlank()) {
+          CLEANUP_LOG.warnf(
+              "account_delete_cleanup_skipping_malformed_canonical_pointer account_id=%s pointer_key=%s",
+              accountId, pointer.getKey());
+          continue;
+        }
+        ids.add(ResourceId.newBuilder().setAccountId(accountId).setId(id).setKind(kind).build());
+      }
       token = next.toString();
       if (token.isBlank()) {
-        return items;
+        return List.copyOf(ids);
       }
       if (!seenTokens.add(token)) {
         throw new IllegalStateException("stagnant page token during account cleanup: " + token);
@@ -705,58 +660,22 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     }
   }
 
-  private void cleanupTable(
-      ai.floedb.floecat.catalog.rpc.Table table, AccountCleanupSummary summary) {
-    var tableId = table.getResourceId();
-    CLEANUP_LOG.infof(
-        "account_delete_cleanup_table account_id=%s namespace_id=%s table_id=%s",
-        tableId.getAccountId(), table.getNamespaceId().getId(), tableId.getId());
-    purgeSnapshotsAndStats(tableId, summary);
-    tableRepo.deleteOrConfirmAbsent(tableId);
-    metadataGraph.invalidate(tableId);
-    markerStore.bumpNamespaceMarker(table.getNamespaceId());
-    summary.tablesDeleted++;
+  private void invalidateAll(List<ResourceId> resourceIds) {
+    resourceIds.forEach(metadataGraph::invalidate);
   }
 
-  private void purgeSnapshotsAndStats(ResourceId tableId, AccountCleanupSummary summary) {
-    CLEANUP_LOG.infof(
-        "account_delete_cleanup_snapshot_prefix account_id=%s table_id=%s",
-        tableId.getAccountId(), tableId.getId());
-    pointerStore.deleteByPrefix(Keys.snapshotRootPrefix(tableId.getAccountId(), tableId.getId()));
-    pointerStore.deleteByPrefix(
-        Keys.snapshotConstraintsPointerPrefix(tableId.getAccountId(), tableId.getId()));
-    // Through the repository, not a bare pointer-store delete: the root-pointer cache must drop
-    // its entry with the pointer (same-process read-your-writes).
-    tableRootRepo.purgeRoot(tableId);
-    // The root-resync re-drive marker lives under /accounts/{a}/root-resyncs/by-table/, outside the
-    // per-table /tables/{t}/ subtree the prefixes above cover. Delete it here so a failed
-    // post-commit
-    // resync on a transaction-only table does not survive account deletion as a durable orphan (its
-    // only other reaper, TransactionGc.redrivePendingRootResyncs, never runs for a deleted
-    // account).
-    pointerStore.delete(Keys.rootResyncPendingPointer(tableId.getAccountId(), tableId.getId()));
-    summary.tableBlobsDeleted +=
-        blobStore.deletePrefix(Keys.tableBlobPrefix(tableId.getAccountId(), tableId.getId()));
-    summary.snapshotPrefixesDeleted++;
-    summary.constraintPrefixesDeleted++;
-  }
-
-  private void bumpParentNamespaceMarkers(ai.floedb.floecat.catalog.rpc.Namespace namespace) {
-    var catalogId = namespace.getCatalogId();
-    var parents = namespace.getParentsList();
-    for (int i = 0; i < parents.size(); i++) {
-      var parentPath = parents.subList(0, i + 1);
-      namespaceRepo
-          .getByPathForMutation(catalogId.getAccountId(), catalogId.getId(), parentPath)
-          .map(ai.floedb.floecat.catalog.rpc.Namespace::getResourceId)
-          .ifPresent(markerStore::bumpNamespaceMarker);
+  private void assertAccountPointerSweepComplete(String accountPrefix, String deletionFence) {
+    Pointer remainingFence = pointerStore.get(deletionFence).orElse(null);
+    int remaining = pointerStore.countByPrefixConsistent(accountPrefix);
+    if (remainingFence == null || remaining != 1) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "account pointer sweep left " + remaining + " rows under " + accountPrefix);
     }
   }
 
   private static final class AccountCleanupSummary {
     private final String accountId;
-    private int transactionPointersDeleted;
-    private int transactionBlobsDeleted;
+    private int accountPointersDeleted;
     private int storageAuthoritiesDeleted;
     private int connectorsDeleted;
     private int credentialsDeleted;
@@ -764,18 +683,12 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     private int namespacesDeleted;
     private int tablesDeleted;
     private int viewsDeleted;
-    private int snapshotPrefixesDeleted;
-    private int constraintPrefixesDeleted;
-    private int tableBlobsDeleted;
+    private int reconcileJobsDeleted;
     private int residualAccountBlobsDeleted;
 
     private AccountCleanupSummary(String accountId) {
       this.accountId = accountId;
     }
-  }
-
-  private int namespaceDepth(ResourceId namespaceId) {
-    return namespaceRepo.getById(namespaceId).map(ns -> ns.getParentsCount()).orElse(0);
   }
 
   private Account applyAccountSpecPatch(

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -87,6 +87,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
 
   private static final Set<String> ACCOUNT_MUTABLE_PATHS =
       Set.of("display_name", "description", "tags");
+  private static final int POINTER_SWEEP_DIAGNOSTIC_KEY_LIMIT = 10;
 
   private static final Logger LOG = Logger.getLogger(AccountService.class);
   private static final Logger CLEANUP_LOG = Logger.getLogger(AccountServiceImpl.class);
@@ -664,12 +665,34 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     resourceIds.forEach(metadataGraph::invalidate);
   }
 
-  private void assertAccountPointerSweepComplete(String accountPrefix, String deletionFence) {
+  void assertAccountPointerSweepComplete(String accountPrefix, String deletionFence) {
     Pointer remainingFence = pointerStore.get(deletionFence).orElse(null);
     int remaining = pointerStore.countByPrefixConsistent(accountPrefix);
     if (remainingFence == null || remaining != 1) {
+      int unexpectedCount = remaining - (remainingFence == null ? 0 : 1);
+      var next = new StringBuilder();
+      List<String> unexpectedKeys =
+          pointerStore
+              .listPointersByPrefixConsistent(
+                  accountPrefix, POINTER_SWEEP_DIAGNOSTIC_KEY_LIMIT + 1, "", next)
+              .stream()
+              .map(Pointer::getKey)
+              .filter(key -> !key.equals(deletionFence))
+              .limit(POINTER_SWEEP_DIAGNOSTIC_KEY_LIMIT)
+              .toList();
       throw new BaseResourceRepository.AbortRetryableException(
-          "account pointer sweep left " + remaining + " rows under " + accountPrefix);
+          "account pointer sweep left "
+              + remaining
+              + " rows under "
+              + accountPrefix
+              + "; deletion_fence_present="
+              + (remainingFence != null)
+              + " unexpected_pointer_count="
+              + unexpectedCount
+              + " unexpected_pointer_keys="
+              + unexpectedKeys
+              + " unexpected_pointer_keys_truncated="
+              + (unexpectedCount > unexpectedKeys.size()));
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -546,8 +546,10 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
       cleanupStorageAuthorities(accountKey, summary);
       cleanupConnectors(accountKey, summary);
       cleanupCatalogs(accountKey, summary);
+      summary.residualAccountBlobsDeleted +=
+          blobStore.deletePrefix(Keys.accountRootPrefix(accountKey));
       CLEANUP_LOG.infof(
-          "account_delete_cleanup_complete account_id=%s transaction_pointer_deletes=%d transaction_blob_deletes=%d storage_authorities=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d snapshot_prefix_deletes=%d constraint_prefix_deletes=%d",
+          "account_delete_cleanup_complete account_id=%s transaction_pointer_deletes=%d transaction_blob_deletes=%d storage_authorities=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d snapshot_prefix_deletes=%d constraint_prefix_deletes=%d table_blob_deletes=%d residual_account_blob_deletes=%d",
           summary.accountId,
           summary.transactionPointersDeleted,
           summary.transactionBlobsDeleted,
@@ -559,7 +561,9 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
           summary.tablesDeleted,
           summary.viewsDeleted,
           summary.snapshotPrefixesDeleted,
-          summary.constraintPrefixesDeleted);
+          summary.constraintPrefixesDeleted,
+          summary.tableBlobsDeleted,
+          summary.residualAccountBlobsDeleted);
     } catch (RuntimeException e) {
       CLEANUP_LOG.errorf(e, "account_delete_cleanup_failed account_id=%s", accountKey);
       throw e;
@@ -731,6 +735,8 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     // only other reaper, TransactionGc.redrivePendingRootResyncs, never runs for a deleted
     // account).
     pointerStore.delete(Keys.rootResyncPendingPointer(tableId.getAccountId(), tableId.getId()));
+    summary.tableBlobsDeleted +=
+        blobStore.deletePrefix(Keys.tableBlobPrefix(tableId.getAccountId(), tableId.getId()));
     summary.snapshotPrefixesDeleted++;
     summary.constraintPrefixesDeleted++;
   }
@@ -760,6 +766,8 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     private int viewsDeleted;
     private int snapshotPrefixesDeleted;
     private int constraintPrefixesDeleted;
+    private int tableBlobsDeleted;
+    private int residualAccountBlobsDeleted;
 
     private AccountCleanupSummary(String accountId) {
       this.accountId = accountId;

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -50,6 +50,7 @@ import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import ai.floedb.floecat.service.repo.impl.StorageAuthorityRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
@@ -59,6 +60,8 @@ import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.service.storage.impl.StorageAuthorityResolver;
+import ai.floedb.floecat.storage.secrets.SecretsManager;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.FieldMask;
 import io.quarkus.grpc.GrpcService;
@@ -83,6 +86,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
   @Inject TableRepository tableRepo;
   @Inject TableRootRepository tableRootRepo;
   @Inject ConnectorRepository connectorRepo;
+  @Inject StorageAuthorityRepository storageAuthorityRepo;
   @Inject ViewRepository viewRepo;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
@@ -91,6 +95,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
   @Inject MarkerStore markerStore;
   @Inject PointerStore pointerStore;
   @Inject DefaultCredentialResolver credentialResolver;
+  @Inject SecretsManager secretsManager;
 
   private static final Set<String> ACCOUNT_MUTABLE_PATHS =
       Set.of("display_name", "description", "tags");
@@ -535,21 +540,42 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     var summary = new AccountCleanupSummary(accountKey);
     CLEANUP_LOG.infof("account_delete_cleanup_start account_id=%s", accountKey);
     try {
+      cleanupStorageAuthorities(accountKey, summary);
       cleanupConnectors(accountKey, summary);
       cleanupCatalogs(accountKey, summary);
       CLEANUP_LOG.infof(
-          "account_delete_cleanup_complete account_id=%s connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d snapshot_prefix_deletes=%d",
+          "account_delete_cleanup_complete account_id=%s storage_authorities=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d snapshot_prefix_deletes=%d constraint_prefix_deletes=%d",
           summary.accountId,
+          summary.storageAuthoritiesDeleted,
           summary.connectorsDeleted,
           summary.credentialsDeleted,
           summary.catalogsDeleted,
           summary.namespacesDeleted,
           summary.tablesDeleted,
           summary.viewsDeleted,
-          summary.snapshotPrefixesDeleted);
+          summary.snapshotPrefixesDeleted,
+          summary.constraintPrefixesDeleted);
     } catch (RuntimeException e) {
       CLEANUP_LOG.errorf(e, "account_delete_cleanup_failed account_id=%s", accountKey);
       throw e;
+    }
+  }
+
+  private void cleanupStorageAuthorities(String accountId, AccountCleanupSummary summary) {
+    for (var authority :
+        listAllPages(
+            (token, next) -> storageAuthorityRepo.listConsistent(accountId, 200, token, next))) {
+      var authorityId = authority.getResourceId();
+      CLEANUP_LOG.infof(
+          "account_delete_cleanup_storage_authority account_id=%s authority_id=%s",
+          accountId, authorityId.getId());
+      // Delete the secret first. If repository deletion then races, a replay can still discover the
+      // authority and safely retry both idempotent operations.
+      secretsManager.delete(
+          accountId, StorageAuthorityResolver.STORAGE_AUTHORITY_SECRET_TYPE, authorityId.getId());
+      storageAuthorityRepo.deleteOrConfirmAbsent(authorityId);
+      summary.storageAuthoritiesDeleted++;
+      summary.credentialsDeleted++;
     }
   }
 
@@ -682,6 +708,8 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
         "account_delete_cleanup_snapshot_prefix account_id=%s table_id=%s",
         tableId.getAccountId(), tableId.getId());
     pointerStore.deleteByPrefix(Keys.snapshotRootPrefix(tableId.getAccountId(), tableId.getId()));
+    pointerStore.deleteByPrefix(
+        Keys.snapshotConstraintsPointerPrefix(tableId.getAccountId(), tableId.getId()));
     // Through the repository, not a bare pointer-store delete: the root-pointer cache must drop
     // its entry with the pointer (same-process read-your-writes).
     tableRootRepo.purgeRoot(tableId);
@@ -693,6 +721,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     // account).
     pointerStore.delete(Keys.rootResyncPendingPointer(tableId.getAccountId(), tableId.getId()));
     summary.snapshotPrefixesDeleted++;
+    summary.constraintPrefixesDeleted++;
   }
 
   private void bumpParentNamespaceMarkers(ai.floedb.floecat.catalog.rpc.Namespace namespace) {
@@ -709,6 +738,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
 
   private static final class AccountCleanupSummary {
     private final String accountId;
+    private int storageAuthoritiesDeleted;
     private int connectorsDeleted;
     private int credentialsDeleted;
     private int catalogsDeleted;
@@ -716,6 +746,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     private int tablesDeleted;
     private int viewsDeleted;
     private int snapshotPrefixesDeleted;
+    private int constraintPrefixesDeleted;
 
     private AccountCleanupSummary(String accountId) {
       this.accountId = accountId;

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -33,6 +33,7 @@ import ai.floedb.floecat.account.rpc.UpdateAccountRequest;
 import ai.floedb.floecat.account.rpc.UpdateAccountResponse;
 import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.common.AccountIds;
@@ -53,6 +54,7 @@ import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
@@ -64,6 +66,7 @@ import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -405,42 +408,86 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                   var accountId = request.getAccountId();
                   ensureKind(accountId, ResourceKind.RK_ACCOUNT, "account_id", corr);
 
+                  var deletionMeta = accountDeletionMeta(accountId.getId());
                   MutationMeta meta;
                   try {
                     meta = accountRepo.metaFor(accountId);
                   } catch (BaseResourceRepository.NotFoundException missing) {
-                    var safe = accountRepo.metaForSafe(accountId);
+                    var safe = deletionMeta.orElseGet(() -> accountRepo.metaForSafe(accountId));
                     boolean callerCares = hasMeaningfulPrecondition(request.getPrecondition());
-                    if (callerCares && safe.getPointerVersion() == 0L) {
+                    if (callerCares && deletionMeta.isEmpty()) {
                       throw GrpcErrors.notFound(corr, ACCOUNT, Map.of("id", accountId.getId()));
                     }
                     MutationOps.BaseServiceChecks.enforcePreconditions(
                         corr, safe, request.getPrecondition());
+                    if (deletionMeta.isEmpty()) {
+                      ensureAccountDeletionFence(accountId.getId(), safe);
+                    }
+                    // A prior delete may have committed before descendant cleanup failed.
+                    cleanupAccountResources(accountId);
                     return DeleteAccountResponse.newBuilder().setMeta(safe).build();
                   }
 
-                  var out =
-                      MutationOps.deleteWithPreconditions(
-                          () -> meta,
-                          request.getPrecondition(),
-                          expected -> accountRepo.deleteWithPrecondition(accountId, expected),
-                          () -> accountRepo.metaForSafe(accountId),
-                          corr,
-                          "account",
-                          Map.of("id", accountId.getId()));
-
-                  if (out.getPointerVersion() == meta.getPointerVersion()
-                      && out.getEtag().equals(meta.getEtag())) {
-                    cleanupAccountResources(accountId);
+                  MutationOps.BaseServiceChecks.enforcePreconditions(
+                      corr, meta, request.getPrecondition());
+                  MutationMeta fencedMeta = ensureAccountDeletionFence(accountId.getId(), meta);
+                  if (!accountRepo.deleteWithPrecondition(
+                      accountId, fencedMeta.getPointerVersion())) {
+                    var current = accountRepo.metaForSafe(accountId);
+                    if (current.getPointerVersion() == 0L) {
+                      throw new BaseResourceRepository.AbortRetryableException(
+                          "account deletion raced another delete");
+                    }
+                    clearAccountDeletionFence(accountId.getId());
+                    MutationOps.BaseServiceChecks.enforcePreconditions(
+                        corr, current, request.getPrecondition());
+                    throw new BaseResourceRepository.AbortRetryableException(
+                        "account changed while deletion fence was installed");
                   }
-
-                  return DeleteAccountResponse.newBuilder().setMeta(out).build();
+                  cleanupAccountResources(accountId);
+                  return DeleteAccountResponse.newBuilder().setMeta(fencedMeta).build();
                 }),
             correlationId())
         .onFailure()
         .invoke(L::fail)
         .onItem()
         .invoke(L::ok);
+  }
+
+  private java.util.Optional<MutationMeta> accountDeletionMeta(String accountId) {
+    return pointerStore.get(Keys.accountDeletionMarker(accountId)).map(this::decodeDeletionMeta);
+  }
+
+  private MutationMeta ensureAccountDeletionFence(String accountId, MutationMeta meta) {
+    String key = Keys.accountDeletionMarker(accountId);
+    var existing = pointerStore.get(key);
+    if (existing.isPresent()) return decodeDeletionMeta(existing.get());
+    String payload = Base64.getEncoder().encodeToString(meta.toByteArray());
+    Pointer marker = PointerReferences.opaqueMarkerPointer(key, payload, 1L);
+    if (pointerStore.compareAndSet(key, 0L, marker)) return meta;
+    return pointerStore
+        .get(key)
+        .map(this::decodeDeletionMeta)
+        .orElseThrow(
+            () ->
+                new BaseResourceRepository.AbortRetryableException(
+                    "account deletion fence not visible"));
+  }
+
+  private MutationMeta decodeDeletionMeta(Pointer marker) {
+    try {
+      return MutationMeta.parseFrom(Base64.getDecoder().decode(marker.getBlobUri()));
+    } catch (Exception e) {
+      throw new BaseResourceRepository.CorruptionException(
+          "invalid account deletion fence: " + marker.getKey(), e);
+    }
+  }
+
+  private void clearAccountDeletionFence(String accountId) {
+    String key = Keys.accountDeletionMarker(accountId);
+    pointerStore
+        .get(key)
+        .ifPresent(marker -> pointerStore.compareAndDelete(key, marker.getVersion()));
   }
 
   private void cleanupAccountResources(ResourceId accountId) {
@@ -468,13 +515,16 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
 
   private void cleanupConnectors(String accountId, AccountCleanupSummary summary) {
     for (var connector :
-        listAllPages((token, next) -> connectorRepo.list(accountId, 200, token, next))) {
+        listAllPages((token, next) -> connectorRepo.listConsistent(accountId, 200, token, next))) {
       var connectorId = connector.getResourceId();
       CLEANUP_LOG.infof(
           "account_delete_cleanup_connector account_id=%s connector_id=%s",
           accountId, connectorId.getId());
-      connectorRepo.delete(connectorId);
       credentialResolver.delete(accountId, connectorId.getId());
+      if (!connectorRepo.delete(connectorId) && connectorRepo.getById(connectorId).isPresent()) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "connector changed during account cleanup");
+      }
       summary.connectorsDeleted++;
       summary.credentialsDeleted++;
     }
@@ -482,7 +532,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
 
   private void cleanupCatalogs(String accountId, AccountCleanupSummary summary) {
     for (var catalog :
-        listAllPages((token, next) -> catalogRepo.list(accountId, 200, token, next))) {
+        listAllPages((token, next) -> catalogRepo.listConsistent(accountId, 200, token, next))) {
       cleanupCatalog(catalog, summary);
     }
   }
@@ -493,12 +543,16 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
         "account_delete_cleanup_catalog account_id=%s catalog_id=%s",
         catalogId.getAccountId(), catalogId.getId());
     var namespaces =
-        new ArrayList<>(namespaceRepo.listIds(catalogId.getAccountId(), catalogId.getId()));
+        new ArrayList<>(
+            namespaceRepo.listIdsConsistent(catalogId.getAccountId(), catalogId.getId()));
     namespaces.sort(Comparator.comparingInt(this::namespaceDepth).reversed());
     for (var namespaceId : namespaces) {
       cleanupNamespace(namespaceId, summary);
     }
-    catalogRepo.delete(catalogId);
+    if (!catalogRepo.delete(catalogId) && catalogRepo.getById(catalogId).isPresent()) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "catalog changed during account cleanup");
+    }
     metadataGraph.invalidate(catalogId);
     summary.catalogsDeleted++;
   }
@@ -514,7 +568,10 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
         namespaceId.getAccountId(), namespaceId.getId(), namespace.getCatalogId().getId());
     cleanupViews(namespace, summary);
     cleanupTables(namespace, summary);
-    namespaceRepo.delete(namespaceId);
+    if (!namespaceRepo.delete(namespaceId) && namespaceRepo.getById(namespaceId).isPresent()) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "namespace changed during account cleanup");
+    }
     metadataGraph.invalidate(namespaceId);
     markerStore.bumpCatalogMarker(namespace.getCatalogId());
     bumpParentNamespaceMarkers(namespace);
@@ -526,7 +583,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     for (var table :
         listAllPages(
             (token, next) ->
-                tableRepo.list(
+                tableRepo.listConsistent(
                     namespace.getResourceId().getAccountId(),
                     namespace.getCatalogId().getId(),
                     namespace.getResourceId().getId(),
@@ -542,7 +599,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     for (var view :
         listAllPages(
             (token, next) ->
-                viewRepo.list(
+                viewRepo.listConsistent(
                     namespace.getResourceId().getAccountId(),
                     namespace.getCatalogId().getId(),
                     namespace.getResourceId().getId(),
@@ -553,7 +610,10 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
       CLEANUP_LOG.infof(
           "account_delete_cleanup_view account_id=%s namespace_id=%s view_id=%s",
           viewId.getAccountId(), namespace.getResourceId().getId(), viewId.getId());
-      viewRepo.delete(viewId);
+      if (!viewRepo.delete(viewId) && viewRepo.getById(viewId).isPresent()) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "view changed during account cleanup");
+      }
       metadataGraph.invalidate(viewId);
       summary.viewsDeleted++;
     }
@@ -582,10 +642,13 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     CLEANUP_LOG.infof(
         "account_delete_cleanup_table account_id=%s namespace_id=%s table_id=%s",
         tableId.getAccountId(), table.getNamespaceId().getId(), tableId.getId());
-    tableRepo.delete(tableId);
+    purgeSnapshotsAndStats(tableId, summary);
+    if (!tableRepo.delete(tableId) && tableRepo.getById(tableId).isPresent()) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "table changed during account cleanup");
+    }
     metadataGraph.invalidate(tableId);
     markerStore.bumpNamespaceMarker(table.getNamespaceId());
-    purgeSnapshotsAndStats(tableId, summary);
     summary.tablesDeleted++;
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -421,7 +421,10 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                     MutationOps.BaseServiceChecks.enforcePreconditions(
                         corr, safe, request.getPrecondition());
                     if (deletionMeta.isEmpty()) {
-                      ensureAccountDeletionFence(accountId.getId(), safe);
+                      // Idempotent delete of an id that never existed must not create a permanent
+                      // tombstone. Every delete committed by this protocol leaves a durable fence,
+                      // so an absent account without one has no cleanup to resume.
+                      return DeleteAccountResponse.newBuilder().setMeta(safe).build();
                     }
                     // A prior delete may have committed before descendant cleanup failed.
                     cleanupAccountResources(accountId);
@@ -438,9 +441,25 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                       throw new BaseResourceRepository.AbortRetryableException(
                           "account deletion raced another delete");
                     }
-                    clearAccountDeletionFence(accountId.getId());
-                    MutationOps.BaseServiceChecks.enforcePreconditions(
-                        corr, current, request.getPrecondition());
+                    if (current.getPointerVersion() == fencedMeta.getPointerVersion()) {
+                      // DynamoDB may report TransactionConflict before the competing deletion
+                      // commits. Keep the shared fence while this version can still be deleted by
+                      // an in-flight attempt; clearing it would reopen descendant creates.
+                      throw new BaseResourceRepository.AbortRetryableException(
+                          "account deletion transaction conflicted");
+                    }
+                    // The account moved before the fence became effective. Preserve continuous
+                    // exclusion while rebinding the fence to the new version; deleting and
+                    // recreating the marker would introduce an ABA window for concurrent deleters.
+                    try {
+                      MutationOps.BaseServiceChecks.enforcePreconditions(
+                          corr, current, request.getPrecondition());
+                    } catch (RuntimeException failedPrecondition) {
+                      // This invocation cannot continue. Release only the stale fence it observed.
+                      clearAccountDeletionFence(accountId.getId(), fencedMeta);
+                      throw failedPrecondition;
+                    }
+                    advanceAccountDeletionFence(accountId.getId(), fencedMeta, current);
                     throw new BaseResourceRepository.AbortRetryableException(
                         "account changed while deletion fence was installed");
                   }
@@ -483,10 +502,31 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     }
   }
 
-  private void clearAccountDeletionFence(String accountId) {
+  private void advanceAccountDeletionFence(
+      String accountId, MutationMeta expectedMeta, MutationMeta nextMeta) {
+    String key = Keys.accountDeletionMarker(accountId);
+    Pointer marker =
+        pointerStore
+            .get(key)
+            .orElseThrow(
+                () ->
+                    new BaseResourceRepository.AbortRetryableException(
+                        "account deletion fence disappeared"));
+    if (!decodeDeletionMeta(marker).equals(expectedMeta)) {
+      throw new BaseResourceRepository.AbortRetryableException("account deletion fence changed");
+    }
+    String payload = Base64.getEncoder().encodeToString(nextMeta.toByteArray());
+    Pointer next = PointerReferences.opaqueMarkerPointer(key, payload, marker.getVersion() + 1L);
+    if (!pointerStore.compareAndSet(key, marker.getVersion(), next)) {
+      throw new BaseResourceRepository.AbortRetryableException("account deletion fence changed");
+    }
+  }
+
+  private void clearAccountDeletionFence(String accountId, MutationMeta expectedMeta) {
     String key = Keys.accountDeletionMarker(accountId);
     pointerStore
         .get(key)
+        .filter(marker -> decodeDeletionMeta(marker).equals(expectedMeta))
         .ifPresent(marker -> pointerStore.compareAndDelete(key, marker.getVersion()));
   }
 
@@ -521,10 +561,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
           "account_delete_cleanup_connector account_id=%s connector_id=%s",
           accountId, connectorId.getId());
       credentialResolver.delete(accountId, connectorId.getId());
-      if (!connectorRepo.delete(connectorId) && connectorRepo.getById(connectorId).isPresent()) {
-        throw new BaseResourceRepository.AbortRetryableException(
-            "connector changed during account cleanup");
-      }
+      connectorRepo.deleteOrConfirmAbsent(connectorId);
       summary.connectorsDeleted++;
       summary.credentialsDeleted++;
     }
@@ -549,16 +586,13 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     for (var namespaceId : namespaces) {
       cleanupNamespace(namespaceId, summary);
     }
-    if (!catalogRepo.delete(catalogId) && catalogRepo.getById(catalogId).isPresent()) {
-      throw new BaseResourceRepository.AbortRetryableException(
-          "catalog changed during account cleanup");
-    }
+    catalogRepo.deleteOrConfirmAbsent(catalogId);
     metadataGraph.invalidate(catalogId);
     summary.catalogsDeleted++;
   }
 
   private void cleanupNamespace(ResourceId namespaceId, AccountCleanupSummary summary) {
-    var namespace = namespaceRepo.getById(namespaceId).orElse(null);
+    var namespace = namespaceRepo.getByIdForMutation(namespaceId).orElse(null);
     if (namespace == null) {
       metadataGraph.invalidate(namespaceId);
       return;
@@ -568,10 +602,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
         namespaceId.getAccountId(), namespaceId.getId(), namespace.getCatalogId().getId());
     cleanupViews(namespace, summary);
     cleanupTables(namespace, summary);
-    if (!namespaceRepo.delete(namespaceId) && namespaceRepo.getById(namespaceId).isPresent()) {
-      throw new BaseResourceRepository.AbortRetryableException(
-          "namespace changed during account cleanup");
-    }
+    namespaceRepo.deleteOrConfirmAbsent(namespaceId);
     metadataGraph.invalidate(namespaceId);
     markerStore.bumpCatalogMarker(namespace.getCatalogId());
     bumpParentNamespaceMarkers(namespace);
@@ -610,10 +641,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
       CLEANUP_LOG.infof(
           "account_delete_cleanup_view account_id=%s namespace_id=%s view_id=%s",
           viewId.getAccountId(), namespace.getResourceId().getId(), viewId.getId());
-      if (!viewRepo.delete(viewId) && viewRepo.getById(viewId).isPresent()) {
-        throw new BaseResourceRepository.AbortRetryableException(
-            "view changed during account cleanup");
-      }
+      viewRepo.deleteOrConfirmAbsent(viewId);
       metadataGraph.invalidate(viewId);
       summary.viewsDeleted++;
     }
@@ -643,10 +671,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
         "account_delete_cleanup_table account_id=%s namespace_id=%s table_id=%s",
         tableId.getAccountId(), table.getNamespaceId().getId(), tableId.getId());
     purgeSnapshotsAndStats(tableId, summary);
-    if (!tableRepo.delete(tableId) && tableRepo.getById(tableId).isPresent()) {
-      throw new BaseResourceRepository.AbortRetryableException(
-          "table changed during account cleanup");
-    }
+    tableRepo.deleteOrConfirmAbsent(tableId);
     metadataGraph.invalidate(tableId);
     markerStore.bumpNamespaceMarker(table.getNamespaceId());
     summary.tablesDeleted++;
@@ -676,7 +701,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     for (int i = 0; i < parents.size(); i++) {
       var parentPath = parents.subList(0, i + 1);
       namespaceRepo
-          .getByPath(catalogId.getAccountId(), catalogId.getId(), parentPath)
+          .getByPathForMutation(catalogId.getAccountId(), catalogId.getId(), parentPath)
           .map(ai.floedb.floecat.catalog.rpc.Namespace::getResourceId)
           .ifPresent(markerStore::bumpNamespaceMarker);
     }

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -62,6 +62,7 @@ import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.service.storage.impl.StorageAuthorityResolver;
 import ai.floedb.floecat.storage.secrets.SecretsManager;
+import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.FieldMask;
 import io.quarkus.grpc.GrpcService;
@@ -94,6 +95,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
   @Inject UserGraph metadataGraph;
   @Inject MarkerStore markerStore;
   @Inject PointerStore pointerStore;
+  @Inject BlobStore blobStore;
   @Inject DefaultCredentialResolver credentialResolver;
   @Inject SecretsManager secretsManager;
 
@@ -540,12 +542,15 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
     var summary = new AccountCleanupSummary(accountKey);
     CLEANUP_LOG.infof("account_delete_cleanup_start account_id=%s", accountKey);
     try {
+      cleanupTransactions(accountKey, summary);
       cleanupStorageAuthorities(accountKey, summary);
       cleanupConnectors(accountKey, summary);
       cleanupCatalogs(accountKey, summary);
       CLEANUP_LOG.infof(
-          "account_delete_cleanup_complete account_id=%s storage_authorities=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d snapshot_prefix_deletes=%d constraint_prefix_deletes=%d",
+          "account_delete_cleanup_complete account_id=%s transaction_pointer_deletes=%d transaction_blob_deletes=%d storage_authorities=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d snapshot_prefix_deletes=%d constraint_prefix_deletes=%d",
           summary.accountId,
+          summary.transactionPointersDeleted,
+          summary.transactionBlobsDeleted,
           summary.storageAuthoritiesDeleted,
           summary.connectorsDeleted,
           summary.credentialsDeleted,
@@ -559,6 +564,12 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
       CLEANUP_LOG.errorf(e, "account_delete_cleanup_failed account_id=%s", accountKey);
       throw e;
     }
+  }
+
+  private void cleanupTransactions(String accountId, AccountCleanupSummary summary) {
+    String prefix = Keys.transactionPrefix(accountId);
+    summary.transactionPointersDeleted += pointerStore.deleteByPrefix(prefix);
+    summary.transactionBlobsDeleted += blobStore.deletePrefix(prefix);
   }
 
   private void cleanupStorageAuthorities(String accountId, AccountCleanupSummary summary) {
@@ -738,6 +749,8 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
 
   private static final class AccountCleanupSummary {
     private final String accountId;
+    private int transactionPointersDeleted;
+    private int transactionBlobsDeleted;
     private int storageAuthoritiesDeleted;
     private int connectorsDeleted;
     private int credentialsDeleted;

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueue.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueue.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.List;
 import java.util.function.LongConsumer;
 
 /**
@@ -62,20 +63,36 @@ public class RootResyncQueue {
    */
   public void enqueue(ResourceId tableId) {
     String key = Keys.rootResyncPendingPointer(tableId.getAccountId(), tableId.getId());
+    String fenceKey = Keys.accountDeletionMarker(tableId.getAccountId());
     RuntimeException lastFailure = null;
     for (int attempt = 0; attempt < ENQUEUE_ATTEMPTS; attempt++) {
       try {
-        if (pointerStore.compareAndSet(key, 0L, PointerReferences.blobPointer(key, "", 1L))) {
+        if (pointerStore.get(fenceKey).isPresent()) {
+          return;
+        }
+        if (pointerStore.compareAndSetBatch(
+            List.of(
+                new PointerStore.CasCheckAbsent(fenceKey),
+                new PointerStore.CasUpsert(key, 0L, PointerReferences.blobPointer(key, "", 1L))))) {
+          return;
+        }
+        if (pointerStore.get(fenceKey).isPresent()) {
           return;
         }
         var existing = pointerStore.get(key).orElse(null);
         if (existing == null) {
           continue; // deleted between the failed create and the read: re-create
         }
-        if (pointerStore.compareAndSet(
-            key,
-            existing.getVersion(),
-            PointerReferences.blobPointer(key, "", existing.getVersion() + 1))) {
+        if (pointerStore.compareAndSetBatch(
+            List.of(
+                new PointerStore.CasCheckAbsent(fenceKey),
+                new PointerStore.CasUpsert(
+                    key,
+                    existing.getVersion(),
+                    PointerReferences.blobPointer(key, "", existing.getVersion() + 1))))) {
+          return;
+        }
+        if (pointerStore.get(fenceKey).isPresent()) {
           return;
         }
         // Lost the touch to another enqueue or a delete: retry from the top.

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootCommitter.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootCommitter.java
@@ -152,6 +152,8 @@ public class TableRootCommitter {
         lastGone = gone;
         won = false;
         desired = null;
+      } catch (BaseResourceRepository.AccountDeletionInProgressException deleting) {
+        throw deleting;
       } catch (BaseResourceRepository.RepoException terminal) {
         throw new CommitFailedException(
             "table root commit failed for table " + tableId.getId(), terminal);

--- a/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
@@ -266,6 +266,13 @@ public abstract class BaseServiceImpl {
       // surface it as the same PERMISSION_DENIED the policy would have produced.
       return GrpcErrors.permissionDenied(corrId, SYSTEM_OBJECT_IMMUTABLE, null, t);
     }
+    if (t instanceof BaseResourceRepository.AccountDeletionInProgressException deleting) {
+      return GrpcErrors.preconditionFailed(
+          corrId,
+          ACCOUNT_DELETION_IN_PROGRESS,
+          Map.of("account_id", deleting.accountId()),
+          deleting);
+    }
     if (t instanceof BaseResourceRepository.NameConflictException
         || t instanceof StorageConflictException) {
       return GrpcErrors.conflict(corrId, null, null, t);

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -394,7 +394,8 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                     ensureNoStoredCredentials(storedAuth);
                     var connector = builder.setAuth(storedAuth).build();
                     try {
-                      connectorRepo.create(connector);
+                      createConnectorWithCredentialCompensation(
+                          connector, storedCredentials, accountId, secretId);
                     } catch (BaseResourceRepository.NameConflictException nce) {
                       if (storedCredentials) {
                         credentialResolver.delete(accountId, secretId);
@@ -428,7 +429,8 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                                     ensureNoStoredCredentials(storedAuth);
                                     var connector = builder.setAuth(storedAuth).build();
                                     try {
-                                      connectorRepo.create(connector);
+                                      createConnectorWithCredentialCompensation(
+                                          connector, storedCredentials, accountId, secretId);
                                     } catch (BaseResourceRepository.NameConflictException nce) {
                                       if (storedCredentials) {
                                         credentialResolver.delete(accountId, secretId);
@@ -780,6 +782,18 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
       credentialResolver.store(accountId, secretId, priorCredentials.get());
     } else {
       credentialResolver.delete(accountId, secretId);
+    }
+  }
+
+  void createConnectorWithCredentialCompensation(
+      Connector connector, boolean storedCredentials, String accountId, String secretId) {
+    try {
+      connectorRepo.create(connector);
+    } catch (BaseResourceRepository.AccountDeletionInProgressException deleting) {
+      if (storedCredentials) {
+        credentialResolver.delete(accountId, secretId);
+      }
+      throw deleting;
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -79,6 +79,8 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQue
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.telemetry.ServiceMetrics;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.stats.spi.StatsStore.UnpublishedGenerationDeleteResult;
@@ -100,6 +102,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -377,6 +380,64 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         maxAttempts,
         this::backoffMs);
     return leaseStore;
+  }
+
+  /**
+   * Removes every durable reconcile job and attributable lease row owned by an account.
+   *
+   * <p>This enumerates canonical index entries without decoding job payloads, so corrupt inline job
+   * state cannot prevent account teardown. Each canonical cleanup uses its stored manifest to
+   * remove global lookup, state and ready-queue rows before the account subtree is swept.
+   */
+  public int cleanupAccount(String accountId) {
+    if (accountId == null || accountId.isBlank()) {
+      return 0;
+    }
+    int deleted = 0;
+    String pageToken = "";
+    var seenTokens = new HashSet<String>();
+    while (true) {
+      var page = jobIndexStore().listCanonicalPointers(accountId, 200, pageToken);
+      for (CanonicalPointerSnapshot snapshot : page.pointers()) {
+        String jobId = Keys.extractLastSegment(snapshot.canonicalPointerKey());
+        if (jobId == null || jobId.isBlank()) {
+          LOG.warnf(
+              "Skipping malformed canonical reconcile pointer during account cleanup accountId=%s key=%s",
+              accountId, snapshot.canonicalPointerKey());
+          continue;
+        }
+        if (!leaseManager().deleteAccountJobLease(accountId, jobId)) {
+          throw new BaseResourceRepository.AbortRetryableException(
+              "reconcile lease changed during account cleanup: " + jobId);
+        }
+        var deleteBatch = jobIndexStore().buildAccountCleanupJobDeleteBatch(snapshot);
+        if (deleteBatch.writes().isEmpty()) {
+          throw new BaseResourceRepository.AbortRetryableException(
+              "reconcile cleanup manifest unavailable: " + jobId);
+        }
+        var plan = new ReconcileJobIndexStore.JobWritePlan<>(jobId, deleteBatch, List.of());
+        List<ReconcileJobIndexStore.JobWriteChunk<String>> chunks =
+            jobIndexStore().writeItemCount(deleteBatch, List.of())
+                    > jobIndexStore().maxWriteItemsPerBatch()
+                ? jobIndexStore().chunkOversizedJobDeletePlan(plan)
+                : jobIndexStore().chunkJobWritePlans(List.of(plan));
+        for (var chunk : chunks) {
+          if (!jobIndexStore()
+              .compareAndSetBatchWithPointerOps(chunk.indexBatch(), chunk.extraPointerOps())) {
+            throw new BaseResourceRepository.AbortRetryableException(
+                "reconcile job changed during account cleanup: " + jobId);
+          }
+        }
+        deleted++;
+      }
+      pageToken = page.nextPageToken();
+      if (pageToken == null || pageToken.isBlank()) {
+        return deleted;
+      }
+      if (!seenTokens.add(pageToken)) {
+        throw new IllegalStateException("stagnant canonical reconcile cleanup token: " + pageToken);
+      }
+    }
   }
 
   private ReconcileReadyQueueStore readyQueue() {
@@ -743,7 +804,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         Pointer created =
             PointerReferences.inlineJsonPointer(
                 claimKey, snapshotCoverageClaimReference(followerJobId), 1L);
-        if (pointerStore.compareAndSet(claimKey, 0L, created)) {
+        if (AccountDeletionFence.compareAndSet(
+            pointerStore, spec.accountId, claimKey, 0L, created)) {
           return;
         }
         continue;
@@ -753,7 +815,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         Pointer replacement =
             PointerReferences.inlineJsonPointer(
                 claimKey, snapshotCoverageClaimReference(followerJobId), current.getVersion() + 1L);
-        if (pointerStore.compareAndSet(claimKey, current.getVersion(), replacement)) {
+        if (AccountDeletionFence.compareAndSet(
+            pointerStore, spec.accountId, claimKey, current.getVersion(), replacement)) {
           completeSnapshotCoverageClaimReplacement(
               spec.accountId, claimKey, followerJobId, ownerJobId);
           return;
@@ -772,7 +835,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         Pointer replacement =
             PointerReferences.inlineJsonPointer(
                 claimKey, snapshotCoverageClaimReference(followerJobId), current.getVersion() + 1L);
-        if (pointerStore.compareAndSet(claimKey, current.getVersion(), replacement)) {
+        if (AccountDeletionFence.compareAndSet(
+            pointerStore, spec.accountId, claimKey, current.getVersion(), replacement)) {
           // A missing or terminal owner has no pending coverage for its successor to inherit.
           completeSnapshotCoverageClaimReplacement(spec.accountId, claimKey, followerJobId, "");
           return;
@@ -785,7 +849,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         Pointer replacement =
             PointerReferences.inlineJsonPointer(
                 claimKey, snapshotCoverageClaimReference(followerJobId), current.getVersion() + 1L);
-        if (pointerStore.compareAndSet(claimKey, current.getVersion(), replacement)) {
+        if (AccountDeletionFence.compareAndSet(
+            pointerStore, spec.accountId, claimKey, current.getVersion(), replacement)) {
           completeSnapshotCoverageClaimReplacement(
               spec.accountId, claimKey, followerJobId, owner.record);
           return;
@@ -3276,7 +3341,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
             PointerReferences.asOpaqueMarkerPointer(
                     current.toBuilder().setVersion(current.getVersion() + 1L), payload)
                 .build();
-        if (pointerStore.compareAndSet(key, current.getVersion(), next)) {
+        if (AccountDeletionFence.compareAndSet(
+            pointerStore, effectiveAccountId, key, current.getVersion(), next)) {
           return true;
         }
         continue;
@@ -3288,7 +3354,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
               : PointerReferences.asOpaqueMarkerPointer(
                       current.toBuilder().setVersion(current.getVersion() + 1L), payload)
                   .build();
-      if (pointerStore.compareAndSet(key, expectedVersion, next)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, effectiveAccountId, key, expectedVersion, next)) {
         return true;
       }
     }
@@ -4205,7 +4272,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     for (int attempt = 0; attempt < CAS_MAX; attempt++) {
       PointerStore.UnconditionalUpsert upsert =
           projectionRefreshMarkerTouch(effectiveAccountId, effectiveParentJobId, dirtyAtMs);
-      if (upsert != null && pointerStore.compareAndSetBatch(List.of(upsert))) {
+      if (upsert != null
+          && AccountDeletionFence.compareAndSetBatch(
+              pointerStore, effectiveAccountId, List.of(upsert))) {
         projectionMaintenance().signalWork();
         return;
       }
@@ -4466,7 +4535,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       String blobUri = encodeInlineFinalizedSnapshotEvent(next);
       Pointer pointer =
           PointerReferences.inlineJsonPointer(identityKey, blobUri, expectedVersion + 1L);
-      if (pointerStore.compareAndSet(identityKey, expectedVersion, pointer)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, event.accountId, identityKey, expectedVersion, pointer)) {
         return;
       }
     }
@@ -4623,7 +4693,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     }
     String accountId = blankToEmpty(record.accountId);
     String parentJobId = blankToEmpty(record.parentJobId);
-    java.util.HashSet<String> visited = new java.util.HashSet<>();
+    HashSet<String> visited = new HashSet<>();
     while (!accountId.isBlank() && !parentJobId.isBlank() && visited.add(parentJobId)) {
       StoredEnvelope parent = loadByAnyAccount(parentJobId).orElse(null);
       if (parent == null || parent.record == null || !accountId.equals(parent.record.accountId)) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/projection/ReconcileJobProjectionStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/projection/ReconcileJobProjectionStore.java
@@ -22,6 +22,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.storage.ReconcilePayloa
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexStore;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
@@ -86,7 +87,8 @@ public class ReconcileJobProjectionStore {
         return;
       }
       Pointer next = PointerReferences.inlineJsonPointer(key, blobUri, expectedVersion + 1L);
-      if (pointerStore.compareAndSet(key, expectedVersion, next)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, projection.accountId(), key, expectedVersion, next)) {
         return;
       }
     }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/projection/ReconcileJobRootSummaryStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/projection/ReconcileJobRootSummaryStore.java
@@ -30,6 +30,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJo
 import ai.floedb.floecat.service.reconciler.jobs.durable.storage.ReconcilePayloadStore;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
@@ -138,7 +139,8 @@ public class ReconcileJobRootSummaryStore {
         return;
       }
       Pointer next = PointerReferences.inlineJsonPointer(key, blobUri, expectedVersion + 1L);
-      if (pointerStore.compareAndSet(key, expectedVersion, next)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, summary.accountId(), key, expectedVersion, next)) {
         return;
       }
     }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileCancellationMaintenanceService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileCancellationMaintenanceService.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.reconciler.jobs.durable.queue;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
@@ -258,7 +259,8 @@ public class ReconcileCancellationMaintenanceService {
                 pointer.toBuilder().setVersion(pointer.getVersion() + 1L),
                 cancellationCleanupPayload(nextRequest))
             .build();
-    pointerStore.compareAndSet(pointer.getKey(), pointer.getVersion(), next);
+    AccountDeletionFence.compareAndSet(
+        pointerStore, request.accountId(), pointer.getKey(), pointer.getVersion(), next);
   }
 
   private void logMaintenanceSummary(long startedAtMs, CancellationStats stats) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
@@ -22,6 +22,7 @@ import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_SORT_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_VERSION;
 
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.spi.PointerStore;
@@ -1482,6 +1483,13 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
   private boolean compareAndSetDynamo(
       ReconcileJobIndexStore.JobIndexWriteBatch batch, List<PointerStore.CasOp> extraPointerOps) {
     List<TransactWriteItem> tx = new ArrayList<>();
+    List<PointerStore.CasOp> fenceSources = new ArrayList<>();
+    fenceSources.addAll(JobIndexWriteBatchSupport.toCasOps(batch));
+    fenceSources.addAll(extraPointerOps);
+    for (PointerStore.CasCheckAbsent fence :
+        AccountDeletionFence.checksForAccountWrites(fenceSources)) {
+      tx.add(buildGenericPointerCheckAbsent(fence.key()));
+    }
     if (batch != null) {
       for (ReconcileJobIndexStore.JobIndexWriteOp op : batch.writes()) {
         if (op instanceof ReconcileJobIndexStore.JobIndexUpsert upsert) {
@@ -2315,11 +2323,20 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
   }
 
   private TransactWriteItem buildGenericPointerCheckAbsent(String pointerKey) {
+    return buildGenericPointerCheckAbsent(table, pointerKey);
+  }
+
+  static TransactWriteItem buildGenericPointerCheckAbsent(String table, String pointerKey) {
     GenericPointerKey key = genericPointerKey(pointerKey);
-    return buildCheckAbsent(key.partitionKey(), key.sortKey());
+    return buildCheckAbsent(table, key.partitionKey(), key.sortKey());
   }
 
   private TransactWriteItem buildCheckAbsent(String partitionKey, String sortKey) {
+    return buildCheckAbsent(table, partitionKey, sortKey);
+  }
+
+  private static TransactWriteItem buildCheckAbsent(
+      String table, String partitionKey, String sortKey) {
     return TransactWriteItem.builder()
         .conditionCheck(
             software.amazon.awssdk.services.dynamodb.model.ConditionCheck.builder()

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackend.java
@@ -21,6 +21,8 @@ import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_PARTITION_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_SORT_KEY;
 import static ai.floedb.floecat.storage.kv.KvAttributes.ATTR_VERSION;
 
+import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import io.quarkus.arc.properties.IfBuildProperty;
@@ -168,6 +170,10 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
       return true;
     }
     List<TransactWriteItem> tx = new ArrayList<>();
+    for (PointerStore.CasCheckAbsent fence :
+        accountFenceChecks(jobIndexBatch, leaseBatch, pointerTouches)) {
+      tx.add(DynamoReconcileJobIndexBackend.buildGenericPointerCheckAbsent(table, fence.key()));
+    }
     if (jobIndexBatch != null) {
       for (ReconcileJobIndexStore.JobIndexWriteOp write : jobIndexBatch.writes()) {
         if (write instanceof ReconcileJobIndexStore.JobIndexUpsert upsert) {
@@ -299,6 +305,49 @@ public class DynamoReconcileLeaseBackend implements ReconcileLeaseBackend {
           (System.nanoTime() - startedNanos) / 1_000_000.0);
       return false;
     }
+  }
+
+  private List<PointerStore.CasCheckAbsent> accountFenceChecks(
+      ReconcileJobIndexStore.JobIndexWriteBatch jobIndexBatch,
+      LeaseWriteBatch leaseBatch,
+      List<PointerStore.UnconditionalUpsert> pointerTouches) {
+    List<PointerStore.CasOp> sources = new ArrayList<>();
+    sources.addAll(JobIndexWriteBatchSupport.toCasOps(jobIndexBatch));
+    if (leaseBatch != null) {
+      for (LeaseWriteOp write : leaseBatch.writes()) {
+        if (write instanceof LeaseRecordUpsert upsert) {
+          String key = LeaseBackendSupport.leasePointerKey(upsert.accountId(), upsert.jobId());
+          sources.add(
+              new PointerStore.CasUpsert(
+                  key,
+                  upsert.expectedVersion(),
+                  PointerReferences.inlineJsonPointer(
+                      key, upsert.encodedLease(), upsert.expectedVersion() + 1L)));
+        } else if (write instanceof LeaseExpiryUpsert upsert) {
+          sources.add(
+              new PointerStore.CasUpsert(
+                  upsert.leaseExpiryKey(),
+                  upsert.expectedVersion(),
+                  PointerReferences.pointerKeyPointer(
+                      upsert.leaseExpiryKey(),
+                      upsert.canonicalPointerKey(),
+                      upsert.expectedVersion() + 1L)));
+        } else if (write instanceof LeaseOwnerUpsert upsert) {
+          sources.add(
+              new PointerStore.CasUpsert(
+                  upsert.ownerKey(),
+                  upsert.expectedVersion(),
+                  PointerReferences.pointerKeyPointer(
+                      upsert.ownerKey(),
+                      upsert.canonicalPointerKey(),
+                      upsert.expectedVersion() + 1L)));
+        }
+      }
+    }
+    if (pointerTouches != null) {
+      sources.addAll(pointerTouches);
+    }
+    return AccountDeletionFence.checksForAccountWrites(sources);
   }
 
   private String leaseRecordKey(String accountId, String jobId) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileJobIndexBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileJobIndexBackend.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.reconciler.jobs.durable.store;
 
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.inject.Inject;
@@ -154,10 +155,6 @@ public class MemoryReconcileJobIndexBackend implements ReconcileJobIndexBackend 
   @Override
   public synchronized boolean compareAndSetBatch(
       ReconcileJobIndexStore.JobIndexWriteBatch batch, List<PointerStore.CasOp> extraPointerOps) {
-    int transactionItems =
-        NativeReconcileJobIndexStore.physicalWriteItemCount(batch)
-            + (extraPointerOps == null ? 0 : extraPointerOps.size());
-    ReconcileJobWriteLimits.requireWithinTransactionLimit(transactionItems);
     if (batch != null) {
       for (ReconcileJobIndexStore.JobIndexWriteOp write : batch.writes()) {
         if (write instanceof ReconcileJobIndexStore.JobIndexUpsert upsert
@@ -212,7 +209,13 @@ public class MemoryReconcileJobIndexBackend implements ReconcileJobIndexBackend 
     if (extraPointerOps != null) {
       ops.addAll(extraPointerOps);
     }
-    boolean committed = pointerStore.compareAndSetBatch(ops);
+    List<PointerStore.CasOp> fencedOps = AccountDeletionFence.withChecksForAccountWrites(ops);
+    int transactionItems =
+        NativeReconcileJobIndexStore.physicalWriteItemCount(batch)
+            + (extraPointerOps == null ? 0 : extraPointerOps.size())
+            + AccountDeletionFence.checksForAccountWrites(ops).size();
+    ReconcileJobWriteLimits.requireWithinTransactionLimit(transactionItems);
+    boolean committed = pointerStore.compareAndSetBatch(fencedOps);
     if (!committed) {
       return false;
     }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileJobIndexStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileJobIndexStore.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJo
 import ai.floedb.floecat.service.reconciler.jobs.durable.storage.ReconcileJobIndexes;
 import ai.floedb.floecat.service.reconciler.jobs.durable.storage.ReconcilePayloadStore;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.nio.charset.StandardCharsets;
@@ -444,6 +445,25 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
   }
 
   @Override
+  public CanonicalPointerPage listCanonicalPointers(
+      String accountId, int pageSize, String pageToken) {
+    if (blank(accountId)) {
+      return new CanonicalPointerPage(List.of(), "");
+    }
+    var page =
+        jobIndexBackend.listCanonicalEntries(
+            accountId, Math.max(1, pageSize), blankToEmpty(pageToken));
+    List<CanonicalPointerSnapshot> pointers = new ArrayList<>();
+    for (JobIndexEntrySnapshot entry : page.entries()) {
+      if (isCanonicalJobPointerKey(accountId, entry.pointerKey())) {
+        pointers.add(
+            new CanonicalPointerSnapshot(entry.pointerKey(), entry.blobUri(), entry.version()));
+      }
+    }
+    return new CanonicalPointerPage(List.copyOf(pointers), page.nextPageToken());
+  }
+
+  @Override
   public StoredJobPage listStoredJobsInState(String state, int pageSize, String pageToken) {
     String effectiveState = blankToEmpty(state);
     if (effectiveState.isBlank()) {
@@ -599,6 +619,42 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
     return buildJobDeleteBatch(currentSnapshot, ReconcileJobIndexCleanupManifest.EMPTY);
   }
 
+  @Override
+  public JobIndexWriteBatch buildAccountCleanupJobDeleteBatch(
+      CanonicalPointerSnapshot currentSnapshot) {
+    if (currentSnapshot == null || blank(currentSnapshot.canonicalPointerKey())) {
+      return JobIndexWriteBatch.empty();
+    }
+    var canonicalKey =
+        JobIndexBackendSupport.parseCanonicalJobKey(currentSnapshot.canonicalPointerKey());
+    if (canonicalKey == null) {
+      return JobIndexWriteBatch.empty();
+    }
+    String lookupPointerKey =
+        Keys.reconcileJobLookupPointerByIdPrefix() + canonicalKey.jobSegment();
+    ReconcileJobIndexCleanupManifest boundedFallback =
+        new ReconcileJobIndexCleanupManifest(List.of(lookupPointerKey), List.of());
+    JobIndexWriteBatch manifested = buildJobDeleteBatch(currentSnapshot, boundedFallback);
+    if (!manifested.writes().isEmpty()) {
+      return manifested;
+    }
+
+    // The account fence prevents new writes. Delete the canonical row and its predictable global
+    // lookup even when corrupt manifest metadata cannot establish the normal cleanup lock. State,
+    // ready and lease-expiry indexes converge through their canonical-absence cleanup paths.
+    List<JobIndexWriteOp> deletes = new ArrayList<>();
+    deletes.add(
+        new JobIndexDelete(
+            currentSnapshot.canonicalPointerKey(),
+            currentSnapshot.version(),
+            "",
+            "",
+            false,
+            false));
+    appendOwnedDelete(deletes, lookupPointerKey, currentSnapshot.canonicalPointerKey(), true);
+    return new JobIndexWriteBatch(List.copyOf(deletes), ReadyQueueMutation.empty());
+  }
+
   private JobIndexWriteBatch buildJobDeleteBatch(
       CanonicalPointerSnapshot currentSnapshot, ReconcileJobIndexCleanupManifest fallbackManifest) {
     var session = jobIndexBackend.beginJobCleanup(currentSnapshot, fallbackManifest).orElse(null);
@@ -698,7 +754,14 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
 
   @Override
   public int writeItemCount(JobIndexWriteBatch batch, List<PointerStore.CasOp> extraPointerOps) {
-    return physicalWriteItemCount(batch) + (extraPointerOps == null ? 0 : extraPointerOps.size());
+    List<PointerStore.CasOp> fenceSources = new ArrayList<>();
+    fenceSources.addAll(JobIndexWriteBatchSupport.toCasOps(batch));
+    if (extraPointerOps != null) {
+      fenceSources.addAll(extraPointerOps);
+    }
+    return physicalWriteItemCount(batch)
+        + (extraPointerOps == null ? 0 : extraPointerOps.size())
+        + AccountDeletionFence.checksForAccountWrites(fenceSources).size();
   }
 
   @Override
@@ -771,8 +834,6 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
     List<JobIndexWriteOp> finalWrites = new ArrayList<>();
     finalWrites.add(canonicalDelete);
     List<String> readyDeletes = new ArrayList<>();
-    int referenceItems = 0;
-    int referenceCapacity = ReconcileJobWriteLimits.MAX_TRANSACTION_ITEMS - 1;
     for (JobIndexWriteOp write : plan.indexBatch().writes()) {
       if (write == canonicalDelete) {
         continue;
@@ -784,27 +845,44 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
         finalWrites.add(write);
         continue;
       }
-      int itemCount = physicalWriteItemCount(write);
-      if (referenceItems > 0 && referenceItems + itemCount > referenceCapacity) {
+      List<JobIndexWriteOp> candidateWrites = new ArrayList<>(referenceWrites);
+      candidateWrites.add(write);
+      if ((!referenceWrites.isEmpty() || !readyDeletes.isEmpty())
+          && cleanupReferenceWriteItemCount(canonicalDelete, candidateWrites, readyDeletes)
+              > ReconcileJobWriteLimits.MAX_TRANSACTION_ITEMS) {
         chunks.add(buildCleanupReferenceChunk(canonicalDelete, referenceWrites, readyDeletes));
         referenceWrites = new ArrayList<>();
         readyDeletes = new ArrayList<>();
-        referenceItems = 0;
       }
       referenceWrites.add(write);
-      referenceItems += itemCount;
+      if (cleanupReferenceWriteItemCount(canonicalDelete, referenceWrites, readyDeletes)
+          > ReconcileJobWriteLimits.MAX_TRANSACTION_ITEMS) {
+        throw new IllegalStateException(
+            "single cleanup reference exceeds "
+                + ReconcileJobWriteLimits.MAX_TRANSACTION_ITEMS
+                + " write items");
+      }
     }
     for (String readyDelete : plan.indexBatch().readyMutation().deletes()) {
-      if (referenceItems >= referenceCapacity) {
+      List<String> candidateReadyDeletes = new ArrayList<>(readyDeletes);
+      candidateReadyDeletes.add(readyDelete);
+      if ((!referenceWrites.isEmpty() || !readyDeletes.isEmpty())
+          && cleanupReferenceWriteItemCount(canonicalDelete, referenceWrites, candidateReadyDeletes)
+              > ReconcileJobWriteLimits.MAX_TRANSACTION_ITEMS) {
         chunks.add(buildCleanupReferenceChunk(canonicalDelete, referenceWrites, readyDeletes));
         referenceWrites = new ArrayList<>();
         readyDeletes = new ArrayList<>();
-        referenceItems = 0;
       }
       readyDeletes.add(readyDelete);
-      referenceItems++;
+      if (cleanupReferenceWriteItemCount(canonicalDelete, referenceWrites, readyDeletes)
+          > ReconcileJobWriteLimits.MAX_TRANSACTION_ITEMS) {
+        throw new IllegalStateException(
+            "single ready cleanup reference exceeds "
+                + ReconcileJobWriteLimits.MAX_TRANSACTION_ITEMS
+                + " write items");
+      }
     }
-    if (referenceItems > 0) {
+    if (!referenceWrites.isEmpty() || !readyDeletes.isEmpty()) {
       chunks.add(buildCleanupReferenceChunk(canonicalDelete, referenceWrites, readyDeletes));
     }
 
@@ -827,17 +905,30 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
       JobIndexDelete canonicalDelete,
       List<JobIndexWriteOp> referenceWrites,
       List<String> readyDeletes) {
+    JobWritePlan<T> chunkPlan =
+        new JobWritePlan<>(
+            null, cleanupReferenceBatch(canonicalDelete, referenceWrites, readyDeletes), List.of());
+    return buildJobWriteChunk(List.of(chunkPlan));
+  }
+
+  private int cleanupReferenceWriteItemCount(
+      JobIndexDelete canonicalDelete,
+      List<JobIndexWriteOp> referenceWrites,
+      List<String> readyDeletes) {
+    return writeItemCount(
+        cleanupReferenceBatch(canonicalDelete, referenceWrites, readyDeletes), List.of());
+  }
+
+  private JobIndexWriteBatch cleanupReferenceBatch(
+      JobIndexDelete canonicalDelete,
+      List<JobIndexWriteOp> referenceWrites,
+      List<String> readyDeletes) {
     List<JobIndexWriteOp> writes = new ArrayList<>(referenceWrites.size() + 1);
     writes.add(
         new JobIndexCheck(canonicalDelete.pointerKey(), canonicalDelete.expectedVersion(), true));
     writes.addAll(referenceWrites);
-    JobWritePlan<T> chunkPlan =
-        new JobWritePlan<>(
-            null,
-            new JobIndexWriteBatch(
-                List.copyOf(writes), new ReadyQueueMutation(List.of(), List.copyOf(readyDeletes))),
-            List.of());
-    return buildJobWriteChunk(List.of(chunkPlan));
+    return new JobIndexWriteBatch(
+        List.copyOf(writes), new ReadyQueueMutation(List.of(), List.copyOf(readyDeletes)));
   }
 
   private <T> JobWriteChunk<T> buildJobWriteChunk(List<JobWritePlan<T>> plans) {
@@ -1722,8 +1813,15 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
   }
 
   private boolean isCanonicalJobPointerKey(String accountId, String key) {
-    return key != null
-        && key.equals(Keys.reconcileJobPointerById(accountId, jobIdFromCanonicalKey(key)));
+    if (key == null) {
+      return false;
+    }
+    String prefix = Keys.reconcileJobPointerByIdPrefix(accountId);
+    if (!key.startsWith(prefix)) {
+      return false;
+    }
+    String encodedJobId = key.substring(prefix.length());
+    return !encodedJobId.isBlank() && encodedJobId.indexOf('/') < 0;
   }
 
   private long countPages(
@@ -1748,11 +1846,6 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
         return count;
       }
     }
-  }
-
-  private String jobIdFromCanonicalKey(String key) {
-    int slash = key == null ? -1 : key.lastIndexOf('/');
-    return slash < 0 ? "" : key.substring(slash + 1);
   }
 
   private static ListCursor decodeListCursor(String pageToken) {
@@ -1823,11 +1916,30 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
     JobIndexEntrySnapshot canonicalPointer =
         jobIndexBackend.loadIndexEntry(indexPointer.blobUri()).orElse(null);
     if (canonicalPointer == null) {
+      deleteOrphanedIndexPointer(indexPointer);
       return Optional.empty();
     }
     return readRecord(
         new CanonicalPointerSnapshot(
             canonicalPointer.pointerKey(), canonicalPointer.blobUri(), canonicalPointer.version()));
+  }
+
+  private void deleteOrphanedIndexPointer(JobIndexEntrySnapshot indexPointer) {
+    // Global time-ordered indexes cannot be swept by account prefix. Their read/maintenance path
+    // must therefore consume a row whose canonical account-scoped job no longer exists.
+    try {
+      jobIndexBackend.compareAndSetBatch(
+          new JobIndexWriteBatch(
+              List.of(
+                  new JobIndexDelete(
+                      indexPointer.pointerKey(), indexPointer.version(), indexPointer.blobUri())),
+              ReadyQueueMutation.empty()));
+    } catch (RuntimeException e) {
+      // Index convergence is best-effort on a read path. A transient cleanup failure must not turn
+      // an otherwise valid empty list result into a failed request.
+      LOG.debugf(
+          e, "Failed to delete orphaned reconcile index pointer key=%s", indexPointer.pointerKey());
+    }
   }
 
   private Optional<StoredReconcileJob> readCurrentRecordFromStateIndexPointer(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileLeaseStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileLeaseStore.java
@@ -829,6 +829,43 @@ public class NativeReconcileLeaseStore implements ReconcileLeaseStore {
     return false;
   }
 
+  @Override
+  public boolean deleteAccountJobLease(String accountId, String jobId) {
+    if (blank(accountId) || blank(jobId)) {
+      return true;
+    }
+    for (int attempt = 0; attempt < casMax; attempt++) {
+      var leaseSnapshot = leaseBackend.loadLease(accountId, jobId).orElse(null);
+      if (leaseSnapshot == null) {
+        return true;
+      }
+      List<ReconcileLeaseBackend.LeaseWriteOp> writes = new ArrayList<>();
+      writes.add(
+          new ReconcileLeaseBackend.LeaseRecordDelete(accountId, jobId, leaseSnapshot.version()));
+      leaseStateCodec
+          .decode(leaseSnapshot.encodedLease())
+          .map(lease -> leaseExpiryPointerKey(lease.expiresAtMs, accountId, jobId))
+          .filter(key -> !key.isBlank())
+          .map(leaseBackend::loadLeaseExpiry)
+          .flatMap(value -> value)
+          .filter(
+              expiry ->
+                  Keys.reconcileJobStateRowById(accountId, jobId)
+                      .equals(expiry.canonicalPointerKey()))
+          .ifPresent(
+              expiry ->
+                  writes.add(
+                      new ReconcileLeaseBackend.LeaseExpiryDelete(
+                          expiry.leaseExpiryKey(), expiry.version())));
+      if (leaseBackend.compareAndSetBatch(
+          ReconcileJobIndexStore.JobIndexWriteBatch.empty(),
+          new ReconcileLeaseBackend.LeaseWriteBatch(List.copyOf(writes)))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public boolean tryAcquireLaneLease(
       StoredReconcileJob record, String canonicalPointerKey, long now) {
     if (record == null
@@ -989,6 +1026,7 @@ public class NativeReconcileLeaseStore implements ReconcileLeaseStore {
     String canonicalKey = leaseExpiryEntry.canonicalPointerKey();
     var canonicalRecordOpt = jobIndexStore.readCanonicalRecordByKey(canonicalKey);
     if (canonicalRecordOpt.isEmpty()) {
+      deleteStaleLeaseExpiry(leaseExpiryEntry);
       return;
     }
     var canonicalRecord = canonicalRecordOpt.get();
@@ -1005,6 +1043,20 @@ public class NativeReconcileLeaseStore implements ReconcileLeaseStore {
       return;
     }
     reclaimRunningOrCancellingJob(canonicalKey, canonicalRecord, lease, nowMs);
+  }
+
+  private void deleteStaleLeaseExpiry(LeaseExpiryEntry entry) {
+    var current = leaseBackend.loadLeaseExpiry(entry.leaseExpiryPointerKey()).orElse(null);
+    if (current == null
+        || !Objects.equals(entry.canonicalPointerKey(), current.canonicalPointerKey())) {
+      return;
+    }
+    leaseBackend.compareAndSetBatch(
+        ReconcileJobIndexStore.JobIndexWriteBatch.empty(),
+        new ReconcileLeaseBackend.LeaseWriteBatch(
+            List.of(
+                new ReconcileLeaseBackend.LeaseExpiryDelete(
+                    current.leaseExpiryKey(), current.version()))));
   }
 
   private boolean hasActiveLaneLease(StoredReconcileJob record, long now) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileJobIndexStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileJobIndexStore.java
@@ -35,6 +35,8 @@ public interface ReconcileJobIndexStore {
 
   record StoredJobPage(List<StoredReconcileJob> records, String nextPageToken) {}
 
+  record CanonicalPointerPage(List<CanonicalPointerSnapshot> pointers, String nextPageToken) {}
+
   record IndexBackfillResult(boolean updated, boolean retryable) {
     public static IndexBackfillResult unchanged() {
       return new IndexBackfillResult(false, false);
@@ -220,6 +222,8 @@ public interface ReconcileJobIndexStore {
   StoredJobPage listStoredJobs(
       String accountId, int pageSize, String pageToken, String connectorId, Set<String> states);
 
+  CanonicalPointerPage listCanonicalPointers(String accountId, int pageSize, String pageToken);
+
   StoredJobPage listStoredJobsInState(String state, int pageSize, String pageToken);
 
   StoredJobPage listStoredJobsPendingStatsCleanup(int pageSize, String pageToken);
@@ -241,6 +245,16 @@ public interface ReconcileJobIndexStore {
       StoredReconcileJob current);
 
   JobIndexWriteBatch buildJobDeleteBatch(CanonicalPointerSnapshot currentSnapshot);
+
+  /**
+   * Builds a bounded delete for account teardown. Implementations may omit undiscoverable global
+   * references, which must converge through their orphan-removal paths after the canonical row is
+   * gone.
+   */
+  default JobIndexWriteBatch buildAccountCleanupJobDeleteBatch(
+      CanonicalPointerSnapshot currentSnapshot) {
+    return buildJobDeleteBatch(currentSnapshot);
+  }
 
   IndexBackfillResult backfillStoredJobIndexes(String canonicalPointerKey);
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileLeaseStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReconcileLeaseStore.java
@@ -121,6 +121,9 @@ public interface ReconcileLeaseStore {
 
   boolean clearLeaseIfEpochMatches(String accountId, String jobId, String leaseEpoch);
 
+  /** Deletes a job lease and its attributable expiry row during whole-account teardown. */
+  boolean deleteAccountJobLease(String accountId, String jobId);
+
   boolean tryAcquireLaneLease(StoredReconcileJob record, String canonicalPointerKey, long nowMs);
 
   void clearLaneLeaseIfOwned(StoredReconcileJob record, String expectedReference);

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
@@ -71,6 +71,11 @@ public class CatalogRepository {
     return repo.delete(new CatalogKey(catalogResourceId.getAccountId(), catalogResourceId.getId()));
   }
 
+  public void deleteOrConfirmAbsent(ResourceId catalogResourceId) {
+    repo.deleteOrConfirmAbsent(
+        new CatalogKey(catalogResourceId.getAccountId(), catalogResourceId.getId()));
+  }
+
   public boolean deleteWithPrecondition(ResourceId catalogResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
         new CatalogKey(catalogResourceId.getAccountId(), catalogResourceId.getId()),

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
@@ -90,6 +90,12 @@ public class CatalogRepository {
     return repo.listByPrefix(Keys.catalogPointerByNamePrefix(accountId), limit, pageToken, nextOut);
   }
 
+  public List<Catalog> listConsistent(
+      String accountId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefixConsistent(
+        Keys.catalogPointerByNamePrefix(accountId), limit, pageToken, nextOut);
+  }
+
   public int count(String accountId) {
     return repo.countByPrefix(Keys.catalogPointerByNamePrefix(accountId));
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
@@ -71,11 +71,6 @@ public class CatalogRepository {
     return repo.delete(new CatalogKey(catalogResourceId.getAccountId(), catalogResourceId.getId()));
   }
 
-  public void deleteOrConfirmAbsent(ResourceId catalogResourceId) {
-    repo.deleteOrConfirmAbsent(
-        new CatalogKey(catalogResourceId.getAccountId(), catalogResourceId.getId()));
-  }
-
   public boolean deleteWithPrecondition(ResourceId catalogResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
         new CatalogKey(catalogResourceId.getAccountId(), catalogResourceId.getId()),

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
@@ -61,11 +61,6 @@ public class ConnectorRepository {
         new ConnectorKey(connectorResourceId.getAccountId(), connectorResourceId.getId()));
   }
 
-  public void deleteOrConfirmAbsent(ResourceId connectorResourceId) {
-    repo.deleteOrConfirmAbsent(
-        new ConnectorKey(connectorResourceId.getAccountId(), connectorResourceId.getId()));
-  }
-
   public boolean deleteWithPrecondition(
       ResourceId connectorResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
@@ -88,6 +88,12 @@ public class ConnectorRepository {
         Keys.connectorPointerByNamePrefix(accountId), limit, pageToken, nextOut);
   }
 
+  public List<Connector> listConsistent(
+      String accountId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefixConsistent(
+        Keys.connectorPointerByNamePrefix(accountId), limit, pageToken, nextOut);
+  }
+
   public int count(String accountId) {
     return repo.countByPrefix(Keys.connectorPointerByNamePrefix(accountId));
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
@@ -61,6 +61,11 @@ public class ConnectorRepository {
         new ConnectorKey(connectorResourceId.getAccountId(), connectorResourceId.getId()));
   }
 
+  public void deleteOrConfirmAbsent(ResourceId connectorResourceId) {
+    repo.deleteOrConfirmAbsent(
+        new ConnectorKey(connectorResourceId.getAccountId(), connectorResourceId.getId()));
+  }
+
   public boolean deleteWithPrecondition(
       ResourceId connectorResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/GenerationArtifactMap.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/GenerationArtifactMap.java
@@ -15,6 +15,7 @@ import ai.floedb.floecat.reconciler.rpc.SnapshotCaptureManifest;
 import ai.floedb.floecat.service.repo.cache.ImmutableBlobCache;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.storage.errors.StorageNotFoundException;
 import ai.floedb.floecat.storage.spi.BlobStore;
@@ -76,7 +77,7 @@ final class GenerationArtifactMap {
       }
       throw new IllegalStateException("generation artifact map already differs: " + key);
     }
-    if (!pointerStore.compareAndSet(key, 0L, next)) {
+    if (!AccountDeletionFence.compareAndSet(pointerStore, tableId.getAccountId(), key, 0L, next)) {
       existing = pointerStore.get(key).orElse(null);
       if (existing == null
           || !existing.getBlobUri().equals(captureManifestUri)

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.reconciler.rpc.SnapshotCaptureManifest;
 import ai.floedb.floecat.service.repo.cache.ImmutableBlobCache;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.TableBlobReachabilityGuard;
 import ai.floedb.floecat.stats.spi.StatsStore;
@@ -58,7 +59,8 @@ import java.util.concurrent.Semaphore;
 
 @ApplicationScoped
 public class IndexArtifactRepository {
-  private static final int MAX_POINTER_BATCH_SIZE = 100;
+  // Leave one DynamoDB transaction slot for the account-deletion fence check.
+  private static final int MAX_POINTER_BATCH_SIZE = 99;
   private static final int MAX_PARALLEL_SIDECAR_CHECKS = 50;
   private static final String DIRECT_GENERATION = Keys.INDEX_ARTIFACT_DIRECT_GENERATION;
   private static final String LIST_TOKEN_PREFIX = "v1.";
@@ -142,13 +144,20 @@ public class IndexArtifactRepository {
               targetStorageId,
               blobSha256);
       blobStore.put(blobUri, bytes, "application/x-protobuf");
-      registerWrites(
-          List.of(
-              new PrewrittenIndexWrite(
-                  generationPointer(tableId, value.getSnapshotId(), generationId, targetStorageId),
-                  targetStorageId,
-                  blobUri,
-                  bytes.length)));
+      try {
+        registerWrites(
+            tableId,
+            List.of(
+                new PrewrittenIndexWrite(
+                    generationPointer(
+                        tableId, value.getSnapshotId(), generationId, targetStorageId),
+                    targetStorageId,
+                    blobUri,
+                    bytes.length)));
+      } catch (BaseResourceRepository.AccountDeletionInProgressException deleting) {
+        deleteBlobQuietly(blobUri);
+        throw deleting;
+      }
       Optional<String> after = activeGeneration(tableId, value.getSnapshotId());
       if (before.equals(after) && after.isPresent()) {
         return;
@@ -260,7 +269,7 @@ public class IndexArtifactRepository {
       }
     }
     refreshPrewrittenSharedSidecars(tableId, snapshotId, unique.values());
-    registerWrites(new ArrayList<>(unique.values()));
+    registerWrites(tableId, new ArrayList<>(unique.values()));
   }
 
   public ActivationFence activateGeneration(
@@ -293,7 +302,7 @@ public class IndexArtifactRepository {
                           new PointerStore.CasUpsert(
                               update.pointerKey(), update.expectedVersion(), update.next()))
               .toList();
-      if (!pointerStore.compareAndSetBatch(updates)) {
+      if (!AccountDeletionFence.compareAndSetBatch(pointerStore, tableId.getAccountId(), updates)) {
         throw new BaseResourceRepository.AbortRetryableException(
             "index artifact generation activation conflicted for snapshot " + snapshotId);
       }
@@ -528,8 +537,12 @@ public class IndexArtifactRepository {
     String pointerKey =
         Keys.snapshotIndexArtifactActiveGenerationPointer(
             tableId.getAccountId(), tableId.getId(), snapshotId);
-    return pointerStore.compareAndSet(
-        pointerKey, 0L, PointerReferences.opaqueMarkerPointer(pointerKey, DIRECT_GENERATION, 1L));
+    return AccountDeletionFence.compareAndSet(
+        pointerStore,
+        tableId.getAccountId(),
+        pointerKey,
+        0L,
+        PointerReferences.opaqueMarkerPointer(pointerKey, DIRECT_GENERATION, 1L));
   }
 
   private void deleteDirectGenerationPointers(ResourceId tableId, long snapshotId) {
@@ -683,9 +696,10 @@ public class IndexArtifactRepository {
         .build();
   }
 
-  private void registerWrites(List<PrewrittenIndexWrite> writes) {
+  private void registerWrites(ResourceId tableId, List<PrewrittenIndexWrite> writes) {
     for (int from = 0; from < writes.size(); from += MAX_POINTER_BATCH_SIZE) {
-      registerChunk(writes.subList(from, Math.min(from + MAX_POINTER_BATCH_SIZE, writes.size())));
+      registerChunk(
+          tableId, writes.subList(from, Math.min(from + MAX_POINTER_BATCH_SIZE, writes.size())));
     }
   }
 
@@ -839,7 +853,7 @@ public class IndexArtifactRepository {
     }
   }
 
-  private void registerChunk(List<PrewrittenIndexWrite> writes) {
+  private void registerChunk(ResourceId tableId, List<PrewrittenIndexWrite> writes) {
     List<PrewrittenIndexWrite> remaining = new ArrayList<>(writes);
     List<PointerStore.CasOp> initial = new ArrayList<>(remaining.size());
     for (PrewrittenIndexWrite write : remaining) {
@@ -850,7 +864,7 @@ public class IndexArtifactRepository {
               PointerReferences.blobPointer(
                   write.pointerKey(), write.blobUri(), 1L, write.blobBytes())));
     }
-    if (pointerStore.compareAndSetBatch(initial)) {
+    if (AccountDeletionFence.compareAndSetBatch(pointerStore, tableId.getAccountId(), initial)) {
       return;
     }
     for (int attempt = 1; attempt < 4; attempt++) {
@@ -870,7 +884,8 @@ public class IndexArtifactRepository {
                 PointerReferences.blobPointer(
                     write.pointerKey(), write.blobUri(), expectedVersion + 1L, write.blobBytes())));
       }
-      if (ops.isEmpty() || pointerStore.compareAndSetBatch(ops)) {
+      if (ops.isEmpty()
+          || AccountDeletionFence.compareAndSetBatch(pointerStore, tableId.getAccountId(), ops)) {
         return;
       }
       remaining = nextRemaining;
@@ -878,6 +893,14 @@ public class IndexArtifactRepository {
     throw new BaseResourceRepository.AbortRetryableException(
         "index artifact reference update conflicted repeatedly for "
             + remaining.getFirst().pointerKey());
+  }
+
+  private void deleteBlobQuietly(String blobUri) {
+    try {
+      blobStore.delete(blobUri);
+    } catch (RuntimeException ignored) {
+      // Best effort: the durable account fence still prevents publishing the blob.
+    }
   }
 
   private Optional<String> activeGeneration(ResourceId tableId, long snapshotId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -112,6 +112,17 @@ public class NamespaceRepository {
     return repo.listByPrefix(prefix, limit, pageToken, nextOut);
   }
 
+  public List<Namespace> listConsistent(
+      String accountId,
+      String catalogId,
+      List<String> parentSegmentsOrEmpty,
+      int limit,
+      String pageToken,
+      StringBuilder nextOut) {
+    String prefix = Keys.namespacePointerByPathPrefix(accountId, catalogId, parentSegmentsOrEmpty);
+    return repo.listByPrefixConsistent(prefix, limit, pageToken, nextOut);
+  }
+
   public int count(String accountId, String catalogId, List<String> parentSegmentsOrEmpty) {
     String prefix = Keys.namespacePointerByPathPrefix(accountId, catalogId, parentSegmentsOrEmpty);
     return repo.countByPrefix(prefix);
@@ -136,6 +147,19 @@ public class NamespaceRepository {
     for (Namespace ns : namespaces) {
       ids.add(ns.getResourceId());
     }
+    return ids;
+  }
+
+  public List<ResourceId> listIdsConsistent(String accountId, String catalogId) {
+    String prefix = Keys.namespacePointerByPathPrefix(accountId, catalogId, List.of());
+    List<ResourceId> ids = new java.util.ArrayList<>();
+    String token = "";
+    do {
+      var next = new StringBuilder();
+      List<Namespace> namespaces = repo.listByPrefixConsistent(prefix, 200, token, next);
+      for (Namespace ns : namespaces) ids.add(ns.getResourceId());
+      token = next.toString();
+    } while (!token.isBlank());
     return ids;
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -84,6 +84,11 @@ public class NamespaceRepository {
         new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
   }
 
+  public void deleteOrConfirmAbsent(ResourceId namespaceResourceId) {
+    repo.deleteOrConfirmAbsent(
+        new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
+  }
+
   public boolean deleteWithPrecondition(
       ResourceId namespaceResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
@@ -96,9 +101,19 @@ public class NamespaceRepository {
         new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
   }
 
+  public Optional<Namespace> getByIdForMutation(ResourceId namespaceResourceId) {
+    return repo.getByKeyForMutation(
+        new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
+  }
+
   public Optional<Namespace> getByPath(
       String accountId, String catalogId, List<String> pathSegments) {
     return repo.get(Keys.namespacePointerByPath(accountId, catalogId, pathSegments));
+  }
+
+  public Optional<Namespace> getByPathForMutation(
+      String accountId, String catalogId, List<String> pathSegments) {
+    return repo.getForMutation(Keys.namespacePointerByPath(accountId, catalogId, pathSegments));
   }
 
   public List<Namespace> list(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -84,11 +84,6 @@ public class NamespaceRepository {
         new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
   }
 
-  public void deleteOrConfirmAbsent(ResourceId namespaceResourceId) {
-    repo.deleteOrConfirmAbsent(
-        new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
-  }
-
   public boolean deleteWithPrecondition(
       ResourceId namespaceResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
@@ -101,19 +96,9 @@ public class NamespaceRepository {
         new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
   }
 
-  public Optional<Namespace> getByIdForMutation(ResourceId namespaceResourceId) {
-    return repo.getByKeyForMutation(
-        new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()));
-  }
-
   public Optional<Namespace> getByPath(
       String accountId, String catalogId, List<String> pathSegments) {
     return repo.get(Keys.namespacePointerByPath(accountId, catalogId, pathSegments));
-  }
-
-  public Optional<Namespace> getByPathForMutation(
-      String accountId, String catalogId, List<String> pathSegments) {
-    return repo.getForMutation(Keys.namespacePointerByPath(accountId, catalogId, pathSegments));
   }
 
   public List<Namespace> list(
@@ -162,19 +147,6 @@ public class NamespaceRepository {
     for (Namespace ns : namespaces) {
       ids.add(ns.getResourceId());
     }
-    return ids;
-  }
-
-  public List<ResourceId> listIdsConsistent(String accountId, String catalogId) {
-    String prefix = Keys.namespacePointerByPathPrefix(accountId, catalogId, List.of());
-    List<ResourceId> ids = new java.util.ArrayList<>();
-    String token = "";
-    do {
-      var next = new StringBuilder();
-      List<Namespace> namespaces = repo.listByPrefixConsistent(prefix, 200, token, next);
-      for (Namespace ns : namespaces) ids.add(ns.getResourceId());
-      token = next.toString();
-    } while (!token.isBlank());
     return ids;
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -28,6 +28,7 @@ import ai.floedb.floecat.reconciler.rpc.ReusableArtifactBundlePayload;
 import ai.floedb.floecat.service.repo.cache.ImmutableBlobCache;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.TableBlobReachabilityGuard;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
@@ -52,9 +53,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -67,7 +70,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 
 @ApplicationScoped
 public class StatsRepository implements StatsStore {
-  private static final int MAX_POINTER_BATCH_SIZE = 100;
+  // Leave one DynamoDB transaction slot for the account-deletion fence check.
+  private static final int MAX_POINTER_BATCH_SIZE = 99;
   private static final String GENERATION_WRITING = "WRITING";
   private static final String GENERATION_PUBLISHING = "PUBLISHING";
   private static final String GENERATION_PUBLISHED = "PUBLISHED";
@@ -335,8 +339,12 @@ public class StatsRepository implements StatsStore {
         throw new IllegalStateException(
             "prepared file-group marker conflicts with the accepted result: " + fileGroupJobId);
       }
-      if (pointerStore.compareAndSet(
-          pointerKey, 0L, PointerReferences.opaqueMarkerPointer(pointerKey, marker, 1L))) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore,
+          tableId.getAccountId(),
+          pointerKey,
+          0L,
+          PointerReferences.opaqueMarkerPointer(pointerKey, marker, 1L))) {
         return;
       }
     }
@@ -408,6 +416,7 @@ public class StatsRepository implements StatsStore {
       }
       PrewrittenStatsWrite write =
           new PrewrittenStatsWrite(
+              tableId.getAccountId(),
               targetPointerKey(tableId, snapshotId, generationId, value.targetStorageId()),
               value.blobUri(),
               value.blobBytes());
@@ -546,7 +555,8 @@ public class StatsRepository implements StatsStore {
       for (Pointer source : sourcePointers) {
         String destinationKey =
             destinationPrefix + source.getKey().substring(sourcePrefix.length());
-        rebaseInheritedStatsPointer(destinationKey, source, capturedBlobPrefix);
+        rebaseInheritedStatsPointer(
+            tableId.getAccountId(), destinationKey, source, capturedBlobPrefix);
       }
       pageToken = next.toString();
     } while (!pageToken.isBlank());
@@ -554,7 +564,7 @@ public class StatsRepository implements StatsStore {
   }
 
   private void rebaseInheritedStatsPointer(
-      String destinationKey, Pointer source, String capturedBlobPrefix) {
+      String accountId, String destinationKey, Pointer source, String capturedBlobPrefix) {
     for (int attempt = 0; attempt < 4; attempt++) {
       Pointer destination = pointerStore.get(destinationKey).orElse(null);
       if (destination != null && destination.getBlobUri().startsWith(capturedBlobPrefix)) {
@@ -574,7 +584,8 @@ public class StatsRepository implements StatsStore {
       Pointer inherited =
           PointerReferences.blobPointer(
               destinationKey, source.getBlobUri(), expectedVersion + 1L, referencedBytes);
-      if (pointerStore.compareAndSet(destinationKey, expectedVersion, inherited)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, accountId, destinationKey, expectedVersion, inherited)) {
         return;
       }
     }
@@ -618,6 +629,7 @@ public class StatsRepository implements StatsStore {
       }
       writes.add(
           new PrewrittenStatsWrite(
+              tableId.getAccountId(),
               pointerPrefix + Hashing.sha256Hex(object.blobUri()),
               object.blobUri(),
               object.blobBytes()));
@@ -1412,7 +1424,7 @@ public class StatsRepository implements StatsStore {
             tableId.getAccountId(), tableId.getId(), snapshotId, generationId);
     markGenerationPublishing(tableId, snapshotId, generationId);
     StringValue manifest = StringValue.of(generationId);
-    targetStatsStorage.putManifestBlob(manifestBlobUri, manifest);
+    targetStatsStorage.putManifestBlob(tableId.getAccountId(), manifestBlobUri, manifest);
     if (blobCache != null) {
       // Write-through the DECODED form readGenerationId caches: the first scan/planner read after
       // this publish pays neither a cold fetch nor a parse (URI is per-generation, immutable).
@@ -1425,9 +1437,15 @@ public class StatsRepository implements StatsStore {
     long expectedVersion = current.map(ActiveSnapshotStats::manifestVersion).orElse(0L);
     Pointer next =
         PointerReferences.blobPointer(manifestPointer, manifestBlobUri, expectedVersion + 1L);
-    if (!pointerStore.compareAndSet(manifestPointer, expectedVersion, next)) {
-      throw new BaseResourceRepository.AbortRetryableException(
-          "active target stats generation update conflicted for snapshot " + snapshotId);
+    try {
+      if (!AccountDeletionFence.compareAndSet(
+          pointerStore, tableId.getAccountId(), manifestPointer, expectedVersion, next)) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "active target stats generation update conflicted for snapshot " + snapshotId);
+      }
+    } catch (BaseResourceRepository.AccountDeletionInProgressException deleting) {
+      deleteQuietly(() -> blobStore.delete(manifestBlobUri));
+      throw deleting;
     }
   }
 
@@ -1462,7 +1480,8 @@ public class StatsRepository implements StatsStore {
     Pointer next =
         PointerReferences.blobPointer(manifestPointer, manifestBlobUri, expectedVersion + 1L);
     if (publicationFence == null) {
-      return pointerStore.compareAndSet(manifestPointer, expectedVersion, next);
+      return AccountDeletionFence.compareAndSet(
+          pointerStore, tableId.getAccountId(), manifestPointer, expectedVersion, next);
     }
     List<PointerStore.CasOp> publication =
         new ArrayList<>(publicationFence.pointerUpdates().size() + 1);
@@ -1474,7 +1493,8 @@ public class StatsRepository implements StatsStore {
                     new PointerStore.CasUpsert(
                         update.pointerKey(), update.expectedVersion(), update.next()))
         .forEach(publication::add);
-    return pointerStore.compareAndSetBatch(publication);
+    return AccountDeletionFence.compareAndSetBatch(
+        pointerStore, tableId.getAccountId(), publication);
   }
 
   private static StatsStore.StatsGenerationPredecessor predecessorOf(
@@ -1560,7 +1580,8 @@ public class StatsRepository implements StatsStore {
             "prewritten target stats publication intent is missing for generation " + generationId);
       }
       Pointer next = PointerReferences.opaqueMarkerPointer(pointerKey, intent, 1L);
-      if (pointerStore.compareAndSet(pointerKey, 0L, next)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, tableId.getAccountId(), pointerKey, 0L, next)) {
         return;
       }
     }
@@ -1605,7 +1626,8 @@ public class StatsRepository implements StatsStore {
       }
       Pointer next =
           PointerReferences.opaqueMarkerPointer(lifecyclePointer, GENERATION_WRITING, 1L);
-      if (pointerStore.compareAndSet(lifecyclePointer, 0L, next)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, tableId.getAccountId(), lifecyclePointer, 0L, next)) {
         if (pointerStore.get(deletedFencePointer).isPresent()) {
           pointerStore.compareAndDelete(lifecyclePointer, next.getVersion());
           throw new BaseResourceRepository.AbortRetryableException(
@@ -1637,7 +1659,8 @@ public class StatsRepository implements StatsStore {
       Pointer next =
           PointerReferences.opaqueMarkerPointer(
               lifecyclePointer, GENERATION_PUBLISHING, expectedVersion + 1L);
-      if (pointerStore.compareAndSet(lifecyclePointer, expectedVersion, next)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, tableId.getAccountId(), lifecyclePointer, expectedVersion, next)) {
         return;
       }
     }
@@ -1664,7 +1687,8 @@ public class StatsRepository implements StatsStore {
       Pointer next =
           PointerReferences.opaqueMarkerPointer(
               lifecyclePointer, GENERATION_PUBLISHED, expectedVersion + 1L);
-      if (pointerStore.compareAndSet(lifecyclePointer, expectedVersion, next)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, tableId.getAccountId(), lifecyclePointer, expectedVersion, next)) {
         return;
       }
     }
@@ -1694,7 +1718,8 @@ public class StatsRepository implements StatsStore {
       Pointer next =
           PointerReferences.opaqueMarkerPointer(
               lifecyclePointer, GENERATION_DELETING, expectedVersion + 1L);
-      if (pointerStore.compareAndSet(lifecyclePointer, expectedVersion, next)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, tableId.getAccountId(), lifecyclePointer, expectedVersion, next)) {
         return GenerationDeleteClaim.CLAIMED;
       }
     }
@@ -1770,22 +1795,30 @@ public class StatsRepository implements StatsStore {
     String manifestBlobUri =
         Keys.snapshotTargetStatsManifestBlobUri(
             tableId.getAccountId(), tableId.getId(), snapshotId, generationId);
-    targetStatsStorage.putManifestBlob(manifestBlobUri, StringValue.of(generationId));
+    targetStatsStorage.putManifestBlob(
+        tableId.getAccountId(), manifestBlobUri, StringValue.of(generationId));
     Pointer created = PointerReferences.blobPointer(manifestPointer, manifestBlobUri, 1L);
     String lifecyclePointer = generationLifecyclePointer(tableId, snapshotId, generationId);
     Pointer published =
         PointerReferences.opaqueMarkerPointer(lifecyclePointer, GENERATION_PUBLISHED, 1L);
-    if (pointerStore.compareAndSetBatch(
-        List.of(
-            new PointerStore.CasUpsert(manifestPointer, 0L, created),
-            new PointerStore.CasUpsert(lifecyclePointer, 0L, published)))) {
-      return new ActiveSnapshotStats(
+    try {
+      if (AccountDeletionFence.compareAndSetBatch(
+          pointerStore,
           tableId.getAccountId(),
-          tableId.getId(),
-          generationId,
-          manifestPointer,
-          1L,
-          manifestBlobUri);
+          List.of(
+              new PointerStore.CasUpsert(manifestPointer, 0L, created),
+              new PointerStore.CasUpsert(lifecyclePointer, 0L, published)))) {
+        return new ActiveSnapshotStats(
+            tableId.getAccountId(),
+            tableId.getId(),
+            generationId,
+            manifestPointer,
+            1L,
+            manifestBlobUri);
+      }
+    } catch (BaseResourceRepository.AccountDeletionInProgressException deleting) {
+      deleteQuietly(() -> blobStore.delete(manifestBlobUri));
+      throw deleting;
     }
     deleteQuietly(() -> blobStore.delete(manifestBlobUri));
     ActiveSnapshotStats resolved =
@@ -2439,7 +2472,8 @@ public class StatsRepository implements StatsStore {
       Pointer next =
           PointerReferences.opaqueMarkerPointer(
               lifecyclePointer, GENERATION_DELETING, current.getVersion() + 1L);
-      if (pointerStore.compareAndSet(lifecyclePointer, current.getVersion(), next)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, tableId.getAccountId(), lifecyclePointer, current.getVersion(), next)) {
         return true;
       }
     }
@@ -2462,7 +2496,8 @@ public class StatsRepository implements StatsStore {
       Pointer restored =
           PointerReferences.opaqueMarkerPointer(
               lifecyclePointer, GENERATION_PUBLISHED, current.getVersion() + 1L);
-      if (pointerStore.compareAndSet(lifecyclePointer, current.getVersion(), restored)) {
+      if (AccountDeletionFence.compareAndSet(
+          pointerStore, tableId.getAccountId(), lifecyclePointer, current.getVersion(), restored)) {
         return;
       }
     }
@@ -2496,7 +2531,8 @@ public class StatsRepository implements StatsStore {
               .build();
       Pointer existingFence = pointerStore.get(deletedFencePointer).orElse(null);
       if (existingFence == null
-          && !pointerStore.compareAndSet(deletedFencePointer, 0L, deletedFence)) {
+          && !AccountDeletionFence.compareAndSet(
+              pointerStore, tableId.getAccountId(), deletedFencePointer, 0L, deletedFence)) {
         continue;
       }
       if (pointerStore.compareAndDelete(lifecyclePointer, current.getVersion())
@@ -2677,7 +2713,8 @@ public class StatsRepository implements StatsStore {
 
   private record TargetStatsWrite(String pointerKey, String blobUri, TargetStatsRecord value) {}
 
-  private record PrewrittenStatsWrite(String pointerKey, String blobUri, long blobBytes) {
+  private record PrewrittenStatsWrite(
+      String accountId, String pointerKey, String blobUri, long blobBytes) {
     private boolean sameReference(PrewrittenStatsWrite other) {
       return other != null && blobBytes == other.blobBytes && blobUri.equals(other.blobUri);
     }
@@ -2765,8 +2802,14 @@ public class StatsRepository implements StatsStore {
     }
 
     private void create(String pointerKey, String blobUri, TargetStatsRecord value) {
+      String accountId = value.getTableId().getAccountId();
       putBlob(blobUri, value);
-      reserveAllOrRollback(value.getSerializedSize(), pointerKey, blobUri);
+      try {
+        reserveIndexOrIdempotentFenced(accountId, pointerKey, blobUri, value.getSerializedSize());
+      } catch (AccountDeletionInProgressException deleting) {
+        deleteBlobQuietly(blobUri);
+        throw deleting;
+      }
     }
 
     private void createBatch(List<TargetStatsWrite> writes) {
@@ -2781,10 +2824,21 @@ public class StatsRepository implements StatsStore {
         }
       }
       List<TargetStatsWrite> pending = new ArrayList<>(uniqueWrites.values());
-      for (TargetStatsWrite write : pending) {
-        putBlob(write.blobUri(), write.value());
+      String accountId = targetStatsAccountId(pending);
+      AccountDeletionFence.requireAbsent(mutationPointerStore, accountId);
+      Set<String> blobsCreatedByCall = new LinkedHashSet<>();
+      try {
+        for (TargetStatsWrite write : pending) {
+          if (blobStore.head(write.blobUri()).isEmpty()) {
+            blobsCreatedByCall.add(write.blobUri());
+          }
+          putBlob(write.blobUri(), write.value());
+        }
+        forEachPointerBatch(pending, this::reserveBatchOrClassify);
+      } catch (AccountDeletionInProgressException deleting) {
+        blobsCreatedByCall.forEach(this::deleteBlobQuietly);
+        throw deleting;
       }
-      forEachPointerBatch(pending, this::reserveBatchOrClassify);
     }
 
     private void overwriteBatch(List<TargetStatsWrite> writes) {
@@ -2795,7 +2849,9 @@ public class StatsRepository implements StatsStore {
       for (TargetStatsWrite write : writes) {
         uniqueWrites.put(write.pointerKey(), write);
       }
-      for (TargetStatsWrite write : uniqueWrites.values()) {
+      List<TargetStatsWrite> pending = new ArrayList<>(uniqueWrites.values());
+      AccountDeletionFence.requireAbsent(mutationPointerStore, targetStatsAccountId(pending));
+      for (TargetStatsWrite write : pending) {
         overwrite(write.pointerKey(), write.blobUri(), write.value());
       }
     }
@@ -2809,17 +2865,19 @@ public class StatsRepository implements StatsStore {
         uniqueWrites.put(write.pointerKey(), write);
       }
       List<PrewrittenStatsWrite> pending = new ArrayList<>(uniqueWrites.values());
-      forEachPointerBatch(pending, this::overwriteReferencesChunk);
+      String accountId = prewrittenStatsAccountId(pending);
+      forEachPointerBatch(pending, batch -> overwriteReferencesChunk(accountId, batch));
     }
 
     private void createExactReferencesBatch(List<PrewrittenStatsWrite> writes) {
       if (writes == null || writes.isEmpty()) {
         return;
       }
-      forEachPointerBatch(writes, this::createExactReferencesChunk);
+      String accountId = prewrittenStatsAccountId(writes);
+      forEachPointerBatch(writes, batch -> createExactReferencesChunk(accountId, batch));
     }
 
-    private void createExactReferencesChunk(List<PrewrittenStatsWrite> writes) {
+    private void createExactReferencesChunk(String accountId, List<PrewrittenStatsWrite> writes) {
       List<PrewrittenStatsWrite> remaining = new ArrayList<>(writes);
       for (int attempt = 0; attempt < CAS_MAX; attempt++) {
         List<PointerStore.CasOp> creates = new ArrayList<>();
@@ -2833,7 +2891,8 @@ public class StatsRepository implements StatsStore {
           missing.add(write);
           creates.add(prewrittenStatsUpsert(write, 0L));
         }
-        if (creates.isEmpty() || mutationPointerStore.compareAndSetBatch(creates)) {
+        if (creates.isEmpty()
+            || AccountDeletionFence.compareAndSetBatch(mutationPointerStore, accountId, creates)) {
           return;
         }
         remaining = missing;
@@ -2864,13 +2923,13 @@ public class StatsRepository implements StatsStore {
       }
     }
 
-    private void overwriteReferencesChunk(List<PrewrittenStatsWrite> writes) {
+    private void overwriteReferencesChunk(String accountId, List<PrewrittenStatsWrite> writes) {
       List<PrewrittenStatsWrite> remaining = new ArrayList<>(writes);
       List<PointerStore.CasOp> initial = new ArrayList<>(remaining.size());
       for (PrewrittenStatsWrite write : remaining) {
         initial.add(prewrittenStatsUpsert(write, 0L));
       }
-      if (mutationPointerStore.compareAndSetBatch(initial)) {
+      if (AccountDeletionFence.compareAndSetBatch(mutationPointerStore, accountId, initial)) {
         return;
       }
       for (int attempt = 1; attempt < CAS_MAX; attempt++) {
@@ -2885,7 +2944,8 @@ public class StatsRepository implements StatsStore {
           nextRemaining.add(write);
           ops.add(prewrittenStatsUpsert(write, expectedVersion));
         }
-        if (ops.isEmpty() || mutationPointerStore.compareAndSetBatch(ops)) {
+        if (ops.isEmpty()
+            || AccountDeletionFence.compareAndSetBatch(mutationPointerStore, accountId, ops)) {
           return;
         }
         remaining = nextRemaining;
@@ -2906,19 +2966,32 @@ public class StatsRepository implements StatsStore {
     }
 
     private void overwrite(String pointerKey, String blobUri, TargetStatsRecord value) {
+      String accountId = value.getTableId().getAccountId();
+      boolean blobExistedBefore = blobStore.head(blobUri).isPresent();
       putBlob(blobUri, value);
-      for (int attempt = 0; attempt < CAS_MAX; attempt++) {
-        Pointer existing = mutationPointerStore.get(pointerKey).orElse(null);
-        long expectedVersion = existing == null ? 0L : existing.getVersion();
-        if (existing != null && blobUri.equals(existing.getBlobUri())) {
-          return;
+      try {
+        for (int attempt = 0; attempt < CAS_MAX; attempt++) {
+          Pointer existing = mutationPointerStore.get(pointerKey).orElse(null);
+          long expectedVersion = existing == null ? 0L : existing.getVersion();
+          if (existing != null && blobUri.equals(existing.getBlobUri())) {
+            return;
+          }
+          Pointer next =
+              PointerReferences.blobPointer(
+                  pointerKey,
+                  blobUri,
+                  Math.max(1L, expectedVersion + 1L),
+                  value.getSerializedSize());
+          if (AccountDeletionFence.compareAndSet(
+              mutationPointerStore, accountId, pointerKey, expectedVersion, next)) {
+            return;
+          }
         }
-        Pointer next =
-            PointerReferences.blobPointer(
-                pointerKey, blobUri, Math.max(1L, expectedVersion + 1L), value.getSerializedSize());
-        if (mutationPointerStore.compareAndSet(pointerKey, expectedVersion, next)) {
-          return;
+      } catch (AccountDeletionInProgressException deleting) {
+        if (!blobExistedBefore) {
+          deleteBlobQuietly(blobUri);
         }
+        throw deleting;
       }
       throw new AbortRetryableException("overwrite conflict: " + pointerKey);
     }
@@ -2931,15 +3004,24 @@ public class StatsRepository implements StatsStore {
       if (mutationPointerStore.get(pointerKey).isPresent()) {
         return false;
       }
+      String accountId = value.getTableId().getAccountId();
       boolean blobExistedBefore = blobStore.head(blobUri).isPresent();
       putBlob(blobUri, value);
       Pointer reserve =
           PointerReferences.blobPointer(pointerKey, blobUri, 1L, value.getSerializedSize());
-      if (!mutationPointerStore.compareAndSet(pointerKey, 0L, reserve)) {
-        cleanupCreateIfAbsentBlobOnCasMiss(pointerKey, blobUri, blobExistedBefore);
-        return false;
+      try {
+        if (!AccountDeletionFence.compareAndSet(
+            mutationPointerStore, accountId, pointerKey, 0L, reserve)) {
+          cleanupCreateIfAbsentBlobOnCasMiss(pointerKey, blobUri, blobExistedBefore);
+          return false;
+        }
+        return true;
+      } catch (AccountDeletionInProgressException deleting) {
+        if (!blobExistedBefore) {
+          deleteBlobQuietly(blobUri);
+        }
+        throw deleting;
       }
-      return true;
     }
 
     private List<TargetStatsRecord> createBatchIfAbsent(List<TargetStatsWrite> writes) {
@@ -2954,51 +3036,62 @@ public class StatsRepository implements StatsStore {
         }
       }
       List<TargetStatsWrite> remaining = new ArrayList<>(uniqueWrites.values());
+      String accountId = targetStatsAccountId(remaining);
+      AccountDeletionFence.requireAbsent(mutationPointerStore, accountId);
       List<TargetStatsRecord> created = new ArrayList<>(remaining.size());
-      while (!remaining.isEmpty()) {
-        List<TargetStatsWrite> absent = new ArrayList<>(remaining.size());
-        for (TargetStatsWrite write : remaining) {
-          if (mutationPointerStore.get(write.pointerKey()).isEmpty()) {
-            absent.add(write);
+      Set<String> blobsCreatedByCall = new LinkedHashSet<>();
+      try {
+        while (!remaining.isEmpty()) {
+          List<TargetStatsWrite> absent = new ArrayList<>(remaining.size());
+          for (TargetStatsWrite write : remaining) {
+            if (mutationPointerStore.get(write.pointerKey()).isEmpty()) {
+              absent.add(write);
+            }
           }
-        }
-        if (absent.isEmpty()) {
-          break;
-        }
-        boolean[] blobExistedBefore = new boolean[absent.size()];
-        for (int i = 0; i < absent.size(); i++) {
-          TargetStatsWrite write = absent.get(i);
-          blobExistedBefore[i] = blobStore.head(write.blobUri()).isPresent();
-          putBlob(write.blobUri(), write.value());
-        }
-        List<TargetStatsWrite> nextRemaining = new ArrayList<>();
-        for (int from = 0; from < absent.size(); from += MAX_POINTER_BATCH_SIZE) {
-          List<TargetStatsWrite> batch =
-              absent.subList(from, Math.min(from + MAX_POINTER_BATCH_SIZE, absent.size()));
-          if (reserveIfAbsentBatch(batch)) {
-            batch.forEach(write -> created.add(write.value()));
-            continue;
+          if (absent.isEmpty()) {
+            break;
           }
-          for (int offset = 0; offset < batch.size(); offset++) {
-            TargetStatsWrite write = batch.get(offset);
-            Pointer pointer = mutationPointerStore.get(write.pointerKey()).orElse(null);
-            if (pointer == null) {
-              nextRemaining.add(write);
+          boolean[] blobExistedBefore = new boolean[absent.size()];
+          for (int i = 0; i < absent.size(); i++) {
+            TargetStatsWrite write = absent.get(i);
+            blobExistedBefore[i] = blobStore.head(write.blobUri()).isPresent();
+            putBlob(write.blobUri(), write.value());
+            if (!blobExistedBefore[i]) {
+              blobsCreatedByCall.add(write.blobUri());
+            }
+          }
+          List<TargetStatsWrite> nextRemaining = new ArrayList<>();
+          for (int from = 0; from < absent.size(); from += MAX_POINTER_BATCH_SIZE) {
+            List<TargetStatsWrite> batch =
+                absent.subList(from, Math.min(from + MAX_POINTER_BATCH_SIZE, absent.size()));
+            if (reserveIfAbsentBatch(batch)) {
+              batch.forEach(write -> created.add(write.value()));
               continue;
             }
-            int originalIndex = from + offset;
-            if (!blobExistedBefore[originalIndex]
-                && !write.blobUri().equals(pointer.getBlobUri())) {
-              cleanupCreateIfAbsentBlobOnCasMiss(
-                  write.pointerKey(), write.blobUri(), blobExistedBefore[originalIndex]);
+            for (int offset = 0; offset < batch.size(); offset++) {
+              TargetStatsWrite write = batch.get(offset);
+              Pointer pointer = mutationPointerStore.get(write.pointerKey()).orElse(null);
+              if (pointer == null) {
+                nextRemaining.add(write);
+                continue;
+              }
+              int originalIndex = from + offset;
+              if (!blobExistedBefore[originalIndex]
+                  && !write.blobUri().equals(pointer.getBlobUri())) {
+                cleanupCreateIfAbsentBlobOnCasMiss(
+                    write.pointerKey(), write.blobUri(), blobExistedBefore[originalIndex]);
+              }
             }
           }
+          if (nextRemaining.size() == absent.size()) {
+            throw new AbortRetryableException(
+                "create conflict, no pointer present: " + absent.get(0).pointerKey());
+          }
+          remaining = nextRemaining;
         }
-        if (nextRemaining.size() == absent.size()) {
-          throw new AbortRetryableException(
-              "create conflict, no pointer present: " + absent.get(0).pointerKey());
-        }
-        remaining = nextRemaining;
+      } catch (AccountDeletionInProgressException deleting) {
+        blobsCreatedByCall.forEach(this::deleteBlobQuietly);
+        throw deleting;
       }
       return List.copyOf(created);
     }
@@ -3009,8 +3102,12 @@ public class StatsRepository implements StatsStore {
       }
     }
 
-    private void putManifestBlob(String blobUri, StringValue manifest) {
+    private void putManifestBlob(String accountId, String blobUri, StringValue manifest) {
       putBlobStrictBytes(blobUri, manifest.toByteArray());
+      if (mutationPointerStore.get(Keys.accountDeletionMarker(accountId)).isPresent()) {
+        deleteBlobQuietly(blobUri);
+        throw new AccountDeletionInProgressException(accountId);
+      }
     }
 
     private MutationMeta metaForPointer(String pointerKey, String blobUri, Timestamp nowTs) {
@@ -3018,6 +3115,7 @@ public class StatsRepository implements StatsStore {
     }
 
     private void reserveBatchOrClassify(List<TargetStatsWrite> writes) {
+      String accountId = targetStatsAccountId(writes);
       List<TargetStatsWrite> remaining = new ArrayList<>(writes);
       while (!remaining.isEmpty()) {
         List<PointerStore.CasOp> ops = new ArrayList<>(remaining.size());
@@ -3029,7 +3127,7 @@ public class StatsRepository implements StatsStore {
                   PointerReferences.blobPointer(
                       write.pointerKey(), write.blobUri(), 1L, write.value().getSerializedSize())));
         }
-        if (mutationPointerStore.compareAndSetBatch(ops)) {
+        if (AccountDeletionFence.compareAndSetBatch(mutationPointerStore, accountId, ops)) {
           return;
         }
         List<TargetStatsWrite> nextRemaining = new ArrayList<>();
@@ -3053,6 +3151,7 @@ public class StatsRepository implements StatsStore {
     }
 
     private boolean reserveIfAbsentBatch(List<TargetStatsWrite> writes) {
+      String accountId = targetStatsAccountId(writes);
       List<PointerStore.CasOp> ops = new ArrayList<>(writes.size());
       for (TargetStatsWrite write : writes) {
         ops.add(
@@ -3062,7 +3161,32 @@ public class StatsRepository implements StatsStore {
                 PointerReferences.blobPointer(
                     write.pointerKey(), write.blobUri(), 1L, write.value().getSerializedSize())));
       }
-      return mutationPointerStore.compareAndSetBatch(ops);
+      return AccountDeletionFence.compareAndSetBatch(mutationPointerStore, accountId, ops);
+    }
+
+    private static String targetStatsAccountId(List<TargetStatsWrite> writes) {
+      String accountId = writes.getFirst().value().getTableId().getAccountId();
+      if (writes.stream()
+          .anyMatch(write -> !accountId.equals(write.value().getTableId().getAccountId()))) {
+        throw new IllegalArgumentException("target stats batch cannot cross accounts");
+      }
+      return accountId;
+    }
+
+    private static String prewrittenStatsAccountId(List<PrewrittenStatsWrite> writes) {
+      String accountId = writes.getFirst().accountId();
+      if (writes.stream().anyMatch(write -> !accountId.equals(write.accountId()))) {
+        throw new IllegalArgumentException("prewritten target stats batch cannot cross accounts");
+      }
+      return accountId;
+    }
+
+    private void deleteBlobQuietly(String blobUri) {
+      try {
+        blobStore.delete(blobUri);
+      } catch (RuntimeException ignored) {
+        // Best effort: the durable account fence still prevents publishing the blob.
+      }
     }
 
     private void cleanupCreateIfAbsentBlobOnCasMiss(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -2026,42 +2026,46 @@ public class StatsRepository implements StatsStore {
   public boolean discoverGenerationKeys(
       ResourceId tableId, long deadlineMs, GenerationGcContinuation continuation) {
     java.util.Objects.requireNonNull(continuation, "continuation");
-    String prefix = Keys.snapshotRootPrefix(tableId.getAccountId(), tableId.getId());
     while (!continuation.pointerScanComplete) {
-      if (System.currentTimeMillis() >= deadlineMs) {
+      if (!discoverGenerationKeysPage(tableId, deadlineMs, continuation)) {
         return false;
-      }
-      StringBuilder next = new StringBuilder();
-      List<Pointer> page =
-          pointerStore.listPointersByPrefix(prefix, 500, continuation.pointerToken, next);
-      boolean pageComplete = true;
-      for (Pointer pointer : page) {
-        if (System.currentTimeMillis() >= deadlineMs) {
-          pageComplete = false;
-          break;
-        }
-        Keys.GenerationKey generation = Keys.generationFromTargetPointerKey(pointer.getKey());
-        if (generation != null
-            && pointer
-                .getKey()
-                .equals(
-                    generationLifecyclePointer(
-                        tableId, generation.snapshotId(), generation.generationId()))) {
-          continuation.discover(generation);
-        }
-      }
-      if (!pageComplete) {
-        return false;
-      }
-      continuation.pointerToken = next.toString();
-      if (continuation.pointerToken.isBlank()) {
-        continuation.pointerScanComplete = true;
       }
     }
     if (!continuation.scanComplete) {
       continuation.scanComplete = true;
       continuation.candidates = List.copyOf(continuation.discovered);
       continuation.discovered = null;
+    }
+    return true;
+  }
+
+  /** Processes one pointer page so continuation behavior can be tested without wall-clock races. */
+  boolean discoverGenerationKeysPage(
+      ResourceId tableId, long deadlineMs, GenerationGcContinuation continuation) {
+    if (System.currentTimeMillis() >= deadlineMs) {
+      return false;
+    }
+    String prefix = Keys.snapshotRootPrefix(tableId.getAccountId(), tableId.getId());
+    StringBuilder next = new StringBuilder();
+    List<Pointer> page =
+        pointerStore.listPointersByPrefix(prefix, 500, continuation.pointerToken, next);
+    for (Pointer pointer : page) {
+      if (System.currentTimeMillis() >= deadlineMs) {
+        return false;
+      }
+      Keys.GenerationKey generation = Keys.generationFromTargetPointerKey(pointer.getKey());
+      if (generation != null
+          && pointer
+              .getKey()
+              .equals(
+                  generationLifecyclePointer(
+                      tableId, generation.snapshotId(), generation.generationId()))) {
+        continuation.discover(generation);
+      }
+    }
+    continuation.pointerToken = next.toString();
+    if (continuation.pointerToken.isBlank()) {
+      continuation.pointerScanComplete = true;
     }
     return true;
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StorageAuthorityRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StorageAuthorityRepository.java
@@ -60,11 +60,6 @@ public class StorageAuthorityRepository {
     return repo.delete(new StorageAuthorityKey(authorityId.getAccountId(), authorityId.getId()));
   }
 
-  public void deleteOrConfirmAbsent(ResourceId authorityId) {
-    repo.deleteOrConfirmAbsent(
-        new StorageAuthorityKey(authorityId.getAccountId(), authorityId.getId()));
-  }
-
   public boolean deleteWithPrecondition(ResourceId authorityId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
         new StorageAuthorityKey(authorityId.getAccountId(), authorityId.getId()),

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StorageAuthorityRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StorageAuthorityRepository.java
@@ -60,6 +60,11 @@ public class StorageAuthorityRepository {
     return repo.delete(new StorageAuthorityKey(authorityId.getAccountId(), authorityId.getId()));
   }
 
+  public void deleteOrConfirmAbsent(ResourceId authorityId) {
+    repo.deleteOrConfirmAbsent(
+        new StorageAuthorityKey(authorityId.getAccountId(), authorityId.getId()));
+  }
+
   public boolean deleteWithPrecondition(ResourceId authorityId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
         new StorageAuthorityKey(authorityId.getAccountId(), authorityId.getId()),
@@ -77,6 +82,12 @@ public class StorageAuthorityRepository {
   public List<StorageAuthority> list(
       String accountId, int limit, String pageToken, StringBuilder nextOut) {
     return repo.listByPrefix(
+        Keys.storageAuthorityPointerByNamePrefix(accountId), limit, pageToken, nextOut);
+  }
+
+  public List<StorageAuthority> listConsistent(
+      String accountId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefixConsistent(
         Keys.storageAuthorityPointerByNamePrefix(accountId), limit, pageToken, nextOut);
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
@@ -101,6 +101,17 @@ public class TableRepository {
     return repo.listByPrefix(prefix, limit, pageToken, nextOut);
   }
 
+  public List<Table> listConsistent(
+      String accountId,
+      String catalogId,
+      String namespaceId,
+      int limit,
+      String pageToken,
+      StringBuilder nextOut) {
+    String prefix = Keys.tablePointerByNamePrefix(accountId, catalogId, namespaceId);
+    return repo.listByPrefixConsistent(prefix, limit, pageToken, nextOut);
+  }
+
   public int count(String accountId, String catalogId, String namespaceId) {
     return repo.countByPrefix(Keys.tablePointerByNamePrefix(accountId, catalogId, namespaceId));
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
@@ -75,6 +75,11 @@ public class TableRepository {
     return repo.delete(new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()));
   }
 
+  public void deleteOrConfirmAbsent(ResourceId tableResourceId) {
+    repo.deleteOrConfirmAbsent(
+        new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()));
+  }
+
   public boolean deleteWithPrecondition(ResourceId tableResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
         new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()),

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
@@ -75,11 +75,6 @@ public class TableRepository {
     return repo.delete(new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()));
   }
 
-  public void deleteOrConfirmAbsent(ResourceId tableResourceId) {
-    repo.deleteOrConfirmAbsent(
-        new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()));
-  }
-
   public boolean deleteWithPrecondition(ResourceId tableResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
         new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()),

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
@@ -100,6 +100,17 @@ public class ViewRepository {
     return repo.listByPrefix(prefix, limit, pageToken, nextOut);
   }
 
+  public List<View> listConsistent(
+      String accountId,
+      String catalogId,
+      String namespaceId,
+      int limit,
+      String pageToken,
+      StringBuilder nextOut) {
+    String prefix = Keys.viewPointerByNamePrefix(accountId, catalogId, namespaceId);
+    return repo.listByPrefixConsistent(prefix, limit, pageToken, nextOut);
+  }
+
   public int count(String accountId, String catalogId, String namespaceId) {
     return repo.countByPrefix(Keys.viewPointerByNamePrefix(accountId, catalogId, namespaceId));
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
@@ -75,10 +75,6 @@ public class ViewRepository {
     return repo.delete(new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()));
   }
 
-  public void deleteOrConfirmAbsent(ResourceId viewResourceId) {
-    repo.deleteOrConfirmAbsent(new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()));
-  }
-
   public boolean deleteWithPrecondition(ResourceId viewResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
         new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()), expectedPointerVersion);

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
@@ -75,6 +75,10 @@ public class ViewRepository {
     return repo.delete(new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()));
   }
 
+  public void deleteOrConfirmAbsent(ResourceId viewResourceId) {
+    repo.deleteOrConfirmAbsent(new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()));
+  }
+
   public boolean deleteWithPrecondition(ResourceId viewResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
         new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()), expectedPointerVersion);

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -157,6 +157,11 @@ public final class Keys {
     return "/accounts/by-name/";
   }
 
+  /** Durable fence that prevents new account-scoped writes once deletion begins. */
+  public static String accountDeletionMarker(String accountId) {
+    return "/accounts/" + encode(req("account_id", accountId)) + "/deleting";
+  }
+
   public static String accountBlobUri(String accountId, String sha256) {
     String tid = req("account_id", accountId);
     String sha = req("sha256", sha256);

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -170,6 +170,11 @@ public final class Keys {
 
   // ===== Transactions =====
 
+  public static String transactionPrefix(String accountId) {
+    String tid = req("account_id", accountId);
+    return "/accounts/" + encode(tid) + "/transactions/";
+  }
+
   public static String transactionPointerById(String accountId, String txId) {
     String tid = req("account_id", accountId);
     String tx = req("tx_id", txId);

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -159,7 +159,16 @@ public final class Keys {
 
   /** Durable fence that prevents new account-scoped writes once deletion begins. */
   public static String accountDeletionMarker(String accountId) {
-    return "/accounts/" + encode(req("account_id", accountId)) + "/deleting";
+    return accountDeletionMarkerForEncodedSegment(encode(req("account_id", accountId)));
+  }
+
+  /** Builds the deletion fence when the account segment was extracted from an existing key. */
+  public static String accountDeletionMarkerForEncodedSegment(String encodedAccountSegment) {
+    String segment = req("encoded_account_segment", encodedAccountSegment);
+    if (segment.indexOf('/') >= 0) {
+      throw new IllegalArgumentException("encoded_account_segment must be one path segment");
+    }
+    return accountRootPrefix() + segment + "/deleting";
   }
 
   public static String accountBlobUri(String accountId, String sha256) {
@@ -1339,12 +1348,12 @@ public final class Keys {
   public static String reconcileJobLeasePointerById(String accountId, String jobId) {
     String tid = req("account_id", accountId);
     String jid = req("job_id", jobId);
-    return reconcileJobLeasePointerByIdPrefix(tid) + jid;
+    return reconcileJobLeasePointerByIdPrefix(tid) + encode(jid);
   }
 
   public static String reconcileJobLeasePointerByIdPrefix(String accountId) {
     String tid = req("account_id", accountId);
-    return accountRootPrefix() + tid + "/reconcile/job-leases/by-id/";
+    return accountRootPrefix(tid) + "reconcile/job-leases/by-id/";
   }
 
   public static String reconcileJobLeaseExpiryPointerPrefix() {
@@ -1362,7 +1371,7 @@ public final class Keys {
   public static String reconcileJobLeaseExpiryPointerSuffix(String accountId, String jobId) {
     String tid = req("account_id", accountId);
     String jid = req("job_id", jobId);
-    return "/accounts/" + tid + "/jobs/" + jid;
+    return "/accounts/" + encode(tid) + "/jobs/" + encode(jid);
   }
 
   public static String reconcileJobResultBlobUri(String accountId, String jobId, String suffix) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/AccountDeletionFence.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/AccountDeletionFence.java
@@ -8,9 +8,12 @@ package ai.floedb.floecat.service.repo.util;
 
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /** Account-deletion exclusion for repositories that publish raw pointer transactions. */
 public final class AccountDeletionFence {
@@ -39,5 +42,61 @@ public final class AccountDeletionFence {
       throw new BaseResourceRepository.AccountDeletionInProgressException(accountId);
     }
     return committed;
+  }
+
+  /** Returns exact fence checks for every account touched by a pointer upsert. */
+  public static List<PointerStore.CasCheckAbsent> checksForAccountWrites(
+      List<? extends PointerStore.CasOp> operations) {
+    Set<String> fenceKeys = new LinkedHashSet<>();
+    Set<String> existingChecks = new LinkedHashSet<>();
+    if (operations != null) {
+      for (PointerStore.CasOp operation : operations) {
+        if (operation instanceof PointerStore.CasUpsert upsert) {
+          collectFenceKey(upsert.key(), fenceKeys);
+          if (PointerReferences.isPointerKeyPointer(upsert.next())) {
+            collectFenceKey(upsert.next().getBlobUri(), fenceKeys);
+          }
+        } else if (operation instanceof PointerStore.UnconditionalUpsert upsert) {
+          collectFenceKey(upsert.key(), fenceKeys);
+          if (PointerReferences.isPointerKeyPointer(upsert.next())) {
+            collectFenceKey(upsert.next().getBlobUri(), fenceKeys);
+          }
+        } else if (operation instanceof PointerStore.CasCheckAbsent check) {
+          existingChecks.add(check.key());
+        }
+      }
+    }
+    fenceKeys.removeAll(existingChecks);
+    return fenceKeys.stream().map(PointerStore.CasCheckAbsent::new).toList();
+  }
+
+  public static List<PointerStore.CasOp> withChecksForAccountWrites(
+      List<? extends PointerStore.CasOp> operations) {
+    List<PointerStore.CasOp> fenced = new ArrayList<>();
+    fenced.addAll(checksForAccountWrites(operations));
+    if (operations != null) {
+      fenced.addAll(operations);
+    }
+    return List.copyOf(fenced);
+  }
+
+  private static void collectFenceKey(String pointerKey, Set<String> fenceKeys) {
+    if (pointerKey == null || pointerKey.isBlank()) {
+      return;
+    }
+    String normalized = pointerKey.startsWith("/") ? pointerKey : "/" + pointerKey;
+    String prefix = Keys.accountRootPrefix();
+    if (!normalized.startsWith(prefix)) {
+      return;
+    }
+    int segmentEnd = normalized.indexOf('/', prefix.length());
+    if (segmentEnd < 0) {
+      return;
+    }
+    String accountSegment = normalized.substring(prefix.length(), segmentEnd);
+    if (accountSegment.isBlank() || Keys.isReservedAccountDirectorySegment(accountSegment)) {
+      return;
+    }
+    fenceKeys.add(Keys.accountDeletionMarkerForEncodedSegment(accountSegment));
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/AccountDeletionFence.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/AccountDeletionFence.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.repo.util;
+
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Account-deletion exclusion for repositories that publish raw pointer transactions. */
+public final class AccountDeletionFence {
+  private AccountDeletionFence() {}
+
+  public static void requireAbsent(PointerStore pointerStore, String accountId) {
+    if (pointerStore.get(Keys.accountDeletionMarker(accountId)).isPresent()) {
+      throw new BaseResourceRepository.AccountDeletionInProgressException(accountId);
+    }
+  }
+
+  public static boolean compareAndSet(
+      PointerStore pointerStore, String accountId, String key, long expectedVersion, Pointer next) {
+    return compareAndSetBatch(
+        pointerStore, accountId, List.of(new PointerStore.CasUpsert(key, expectedVersion, next)));
+  }
+
+  public static boolean compareAndSetBatch(
+      PointerStore pointerStore, String accountId, List<? extends PointerStore.CasOp> operations) {
+    String fenceKey = Keys.accountDeletionMarker(accountId);
+    List<PointerStore.CasOp> fenced = new ArrayList<>(operations.size() + 1);
+    fenced.add(new PointerStore.CasCheckAbsent(fenceKey));
+    fenced.addAll(operations);
+    boolean committed = pointerStore.compareAndSetBatch(fenced);
+    if (!committed && pointerStore.get(fenceKey).isPresent()) {
+      throw new BaseResourceRepository.AccountDeletionInProgressException(accountId);
+    }
+    return committed;
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -107,7 +107,7 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
   }
 
   /** A resource mutation was rejected because its owning account is being deleted. */
-  public static class AccountDeletionInProgressException extends PreconditionFailedException {
+  public static class AccountDeletionInProgressException extends RepoException {
     private final String accountId;
 
     public AccountDeletionInProgressException(String accountId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -106,6 +106,20 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
     }
   }
 
+  /** A resource mutation was rejected because its owning account is being deleted. */
+  public static class AccountDeletionInProgressException extends PreconditionFailedException {
+    private final String accountId;
+
+    public AccountDeletionInProgressException(String accountId) {
+      super("account deletion in progress: " + accountId);
+      this.accountId = accountId;
+    }
+
+    public String accountId() {
+      return accountId;
+    }
+  }
+
   public static class AbortRetryableException extends RepoException {
     public AbortRetryableException(String msg) {
       super(msg);

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -502,12 +502,27 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
         .toList();
   }
 
+  public List<T> listByPrefixConsistent(
+      String prefix, int limit, String token, StringBuilder nextOut) {
+    return listByPrefixWithKeys(prefix, limit, token, nextOut, true).stream()
+        .map(KeyedValue::value)
+        .toList();
+  }
+
   protected List<KeyedValue<T>> listByPrefixWithKeys(
       String prefix, int limit, String token, StringBuilder nextOut) {
+    return listByPrefixWithKeys(prefix, limit, token, nextOut, false);
+  }
+
+  private List<KeyedValue<T>> listByPrefixWithKeys(
+      String prefix, int limit, String token, StringBuilder nextOut, boolean consistentRead) {
     return observeRepository(
-        "list_by_prefix",
+        consistentRead ? "list_by_prefix_consistent" : "list_by_prefix",
         () -> {
-          var rows = pointerReads.list(prefix, Math.max(1, limit), token, nextOut);
+          var rows =
+              consistentRead
+                  ? pointerReads.listConsistent(prefix, Math.max(1, limit), token, nextOut)
+                  : pointerReads.list(prefix, Math.max(1, limit), token, nextOut);
           var ordinaryUris = new ArrayList<String>(rows.size());
           var projectionKeys = new ArrayList<ImmutableBlobCache.ProjectionKey>(rows.size());
           for (var row : rows) {
@@ -586,6 +601,11 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
   @Override
   public int countByPrefix(String prefix) {
     return observeRepository("count_by_prefix", () -> pointerReads.count(prefix));
+  }
+
+  public int countByPrefixConsistent(String prefix) {
+    return observeRepository(
+        "count_by_prefix_consistent", () -> pointerReads.countConsistent(prefix));
   }
 
   protected static String sha256B64(byte[] data) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/BaseResourceRepository.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public abstract class BaseResourceRepository<T> implements ResourceRepository<T> {
@@ -328,12 +329,27 @@ public abstract class BaseResourceRepository<T> implements ResourceRepository<T>
   }
 
   private boolean reserveIndexOrIdempotent(String key, String blobUri, long referencedBytes) {
+    return reserveIndexOrIdempotent(
+        key, blobUri, referencedBytes, next -> mutationPointerStore.compareAndSet(key, 0L, next));
+  }
+
+  protected boolean reserveIndexOrIdempotentFenced(
+      String accountId, String key, String blobUri, long referencedBytes) {
+    return reserveIndexOrIdempotent(
+        key,
+        blobUri,
+        referencedBytes,
+        next -> AccountDeletionFence.compareAndSet(mutationPointerStore, accountId, key, 0L, next));
+  }
+
+  private boolean reserveIndexOrIdempotent(
+      String key, String blobUri, long referencedBytes, Predicate<Pointer> reserveAttempt) {
     var reserve =
         referencedBytes >= 0L
             ? PointerReferences.blobPointer(key, blobUri, 1L, referencedBytes)
             : PointerReferences.blobPointer(key, blobUri, 1L);
 
-    if (mutationPointerStore.compareAndSet(key, 0L, reserve)) {
+    if (reserveAttempt.test(reserve)) {
       return true;
     }
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -236,8 +236,14 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
   }
 
   /** Load the current value through the raw stores that participate in a mutation transaction. */
-  private Optional<T> getByKeyForMutation(K key) {
-    return readForMutation(schema.canonicalPointerForKey.apply(key));
+  public Optional<T> getByKeyForMutation(K key) {
+    return observeRepository(
+        "get_by_key_for_mutation", () -> readForMutation(schema.canonicalPointerForKey.apply(key)));
+  }
+
+  /** Resolve any pointer through the raw stores that participate in a mutation transaction. */
+  public Optional<T> getForMutation(String pointerKey) {
+    return observeRepository("get_for_mutation", () -> readForMutation(pointerKey));
   }
 
   private boolean existsByKeyUnobserved(K key) {
@@ -334,9 +340,12 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     return Optional.of(new ResourceWithMeta<>(value, commit.meta()));
   }
 
-  private NotFoundException accountDeletionInProgress(T value) {
-    return new NotFoundException(
-        "account deletion in progress: " + schema.keyFromValue.apply(value).accountId());
+  private AccountDeletionInProgressException accountDeletionInProgress(T value) {
+    return accountDeletionInProgress(schema.keyFromValue.apply(value));
+  }
+
+  private AccountDeletionInProgressException accountDeletionInProgress(K key) {
+    return new AccountDeletionInProgressException(key.accountId());
   }
 
   /** Resolves a secondary pointer and returns the body with its exact canonical metadata. */
@@ -370,10 +379,14 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     return observeRepository(
         "create",
         () -> {
-          PreparedCreate prepared = prepareCreate(value);
           K resourceKey = schema.keyFromValue.apply(value);
+          String accountDeletionMarker = Keys.accountDeletionMarker(resourceKey.accountId());
+          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
+            throw accountDeletionInProgress(resourceKey);
+          }
+          PreparedCreate prepared = prepareCreate(value);
           Set<String> effectiveRequiredAbsent = new HashSet<>(conditions.requiredAbsent());
-          effectiveRequiredAbsent.add(Keys.accountDeletionMarker(resourceKey.accountId()));
+          effectiveRequiredAbsent.add(accountDeletionMarker);
           List<PointerStore.CasOp> ops =
               new ArrayList<>(
                   prepared.ops.size()
@@ -406,6 +419,12 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           if (mutationPointerStore.compareAndSetBatch(ops)) {
             healCanonicalBlobIfMissing(prepared.blobUri, value);
             return new CreateCommit(true, prepared.committedCanonical, committedMeta);
+          }
+
+          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
+            cleanupCreateIfAbsentBlobOnCasMiss(
+                prepared.canonicalPointerKey, prepared.blobUri, prepared.blobExistedBefore);
+            throw accountDeletionInProgress(resourceKey);
           }
 
           if (!pointerConditionsStillMatch(requiredPointerVersions, effectiveRequiredAbsent)) {
@@ -525,6 +544,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     guardSystemObject(key);
     String canonicalPointer = schema.canonicalPointerForKey.apply(key);
     String blobUri = schema.blobUriForKey.apply(key);
+    boolean blobExistedBefore = mutationBlobStore.head(blobUri).isPresent();
     int blobBytes = writeBlobAndGetSize(blobUri, value);
 
     Map<String, String> secondaries = schema.secondaryPointersFromValue.apply(value);
@@ -541,7 +561,8 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
         committedCanonical = reserved.toBuilder().setVersion(1L).build();
       }
     }
-    return new PreparedCreate(blobUri, canonicalPointer, committedCanonical, pointerKeys, ops);
+    return new PreparedCreate(
+        blobUri, canonicalPointer, committedCanonical, pointerKeys, ops, blobExistedBefore);
   }
 
   private record PreparedCreate(
@@ -549,7 +570,8 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       String canonicalPointerKey,
       Pointer committedCanonical,
       List<String> pointerKeys,
-      List<PointerStore.CasOp> ops) {}
+      List<PointerStore.CasOp> ops,
+      boolean blobExistedBefore) {}
 
   /**
    * Raises a name conflict when a companion operation that reserves a fresh pointer (expected
@@ -666,7 +688,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           String accountDeletionMarker = Keys.accountDeletionMarker(key.accountId());
           if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
             cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
-            throw new NotFoundException("account deletion in progress: " + key.accountId());
+            throw accountDeletionInProgress(key);
           }
           List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size() + 1);
           for (String pointerKey : pointerKeys) {
@@ -682,7 +704,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
           if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
             cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
-            throw new NotFoundException("account deletion in progress: " + key.accountId());
+            throw accountDeletionInProgress(key);
           }
           return classifyCreateIfAbsentConflict(
               canonicalPointer, blobUri, pointerKeys, blobExistedBefore);
@@ -953,6 +975,10 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
         "update_with_meta",
         () -> {
           K key = schema.keyFromValue.apply(updatedValue);
+          String accountDeletionMarker = Keys.accountDeletionMarker(key.accountId());
+          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
+            throw accountDeletionInProgress(key);
+          }
           String canonicalPointer = schema.canonicalPointerForKey.apply(key);
           PreparedUpdate prepared = prepareUpdate(updatedValue, expectedCanonicalVersion);
           String blobUri = prepared.blobUri;
@@ -961,7 +987,6 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           List<PointerStore.CasOp> ops = new ArrayList<>(prepared.ops);
           Pointer committedCanonical = prepared.committedCanonical;
           addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
-          String accountDeletionMarker = Keys.accountDeletionMarker(key.accountId());
           if (batchedKeys.add(accountDeletionMarker)) {
             ops.add(new PointerStore.CasCheckAbsent(accountDeletionMarker));
           }
@@ -985,7 +1010,9 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
           if (!pointerConditionsStillMatch(requiredPointerVersions, requiredAbsentPointers))
             return Optional.empty();
-          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) return Optional.empty();
+          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
+            throw accountDeletionInProgress(key);
+          }
           if (!markerVersionsStillMatch(markerVersions)) return Optional.empty();
           classifyCompanionConflict(companions);
           classifyUpdateConflict(canonicalPointer, expectedCanonicalVersion, blobUri, toAdd);
@@ -1060,6 +1087,10 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           if (!currentKey.accountId().equals(replacementKey.accountId())) {
             throw new IllegalArgumentException("replacement cannot cross accounts");
           }
+          String accountDeletionMarker = Keys.accountDeletionMarker(currentKey.accountId());
+          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
+            throw accountDeletionInProgress(currentKey);
+          }
 
           String currentCanonical = schema.canonicalPointerForKey.apply(currentKey);
           String replacementCanonical = schema.canonicalPointerForKey.apply(replacementKey);
@@ -1075,6 +1106,8 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
 
           String replacementBlobUri = schema.blobUriForKey.apply(replacementKey);
+          boolean replacementBlobExistedBefore =
+              mutationBlobStore.head(replacementBlobUri).isPresent();
           int replacementBlobBytes = writeBlobAndGetSize(replacementBlobUri, replacementValue);
           Map<String, String> currentSecondaries =
               schema.secondaryPointersFromValue.apply(currentValue);
@@ -1144,13 +1177,17 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
           addPointerDeletes(pointerVersionsToDelete, batchedKeys, ops);
           addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
-          String accountDeletionMarker = Keys.accountDeletionMarker(currentKey.accountId());
           if (batchedKeys.add(accountDeletionMarker)) {
             ops.add(new PointerStore.CasCheckAbsent(accountDeletionMarker));
           }
           addMarkerAdvances(markerVersions, batchedKeys, ops, "replacement");
 
           if (!mutationPointerStore.compareAndSetBatch(ops)) {
+            if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
+              cleanupCreateIfAbsentBlobOnCasMiss(
+                  replacementCanonical, replacementBlobUri, replacementBlobExistedBefore);
+              throw accountDeletionInProgress(currentKey);
+            }
             return Optional.empty();
           }
           healCanonicalBlobIfMissing(replacementBlobUri, replacementValue);
@@ -1206,6 +1243,13 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
           return true;
         });
+  }
+
+  /** Deletes a resource or confirms through the raw mutation stores that it is already absent. */
+  public void deleteOrConfirmAbsent(K key) {
+    if (!delete(key) && getByKeyForMutation(key).isPresent()) {
+      throw new AbortRetryableException(schema.resourceName + " changed during deletion");
+    }
   }
 
   public boolean deleteWithPrecondition(K key, long expectedCanonicalVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.service.repo.cache.ImmutableBlobCache;
+import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.model.ResourceKey;
 import ai.floedb.floecat.service.repo.model.ResourceSchema;
@@ -283,13 +284,13 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
    */
   public void create(T value) {
     createWithMeta(value, PointerConditions.none(), null)
-        .orElseThrow(() -> new AbortRetryableException("create conditions changed"));
+        .orElseThrow(() -> accountDeletionInProgress(value));
   }
 
   /** Creates a resource and returns metadata for the exact canonical pointer that committed. */
   public ResourceWithMeta<T> createWithMeta(T value) {
     return createWithMeta(value, PointerConditions.none(), null)
-        .orElseThrow(() -> new AbortRetryableException("create conditions changed"));
+        .orElseThrow(() -> accountDeletionInProgress(value));
   }
 
   /**
@@ -302,7 +303,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       T value, Function<ResourceWithMeta<T>, List<PointerStore.CasOp>> completionFactory) {
     return createWithMeta(
             value, PointerConditions.none(), Objects.requireNonNull(completionFactory))
-        .orElseThrow(() -> new AbortRetryableException("create conditions changed"));
+        .orElseThrow(() -> accountDeletionInProgress(value));
   }
 
   /**
@@ -312,8 +313,9 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
    * resource. The factory receives the exact body/meta pair that will commit.
    *
    * <p>Returns empty when a required version, a required absence, or a marker version no longer
-   * holds; the caller decides whether that is a conflict or a lost race. A create that commits (or
-   * replays a byte-identical prior create) always returns a value.
+   * holds, including the implicit account-deletion fence that every create asserts; the caller
+   * decides whether that is a conflict or a lost race. A create that commits (or replays a
+   * byte-identical prior create) always returns a value.
    */
   public Optional<ResourceWithMeta<T>> createWithMeta(
       T value,
@@ -330,6 +332,11 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       throw new NameConflictException("canonical pointer bound to different blob: " + canonicalKey);
     }
     return Optional.of(new ResourceWithMeta<>(value, commit.meta()));
+  }
+
+  private NotFoundException accountDeletionInProgress(T value) {
+    return new NotFoundException(
+        "account deletion in progress: " + schema.keyFromValue.apply(value).accountId());
   }
 
   /** Resolves a secondary pointer and returns the body with its exact canonical metadata. */
@@ -364,7 +371,9 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
         "create",
         () -> {
           PreparedCreate prepared = prepareCreate(value);
+          K resourceKey = schema.keyFromValue.apply(value);
           Set<String> effectiveRequiredAbsent = new HashSet<>(conditions.requiredAbsent());
+          effectiveRequiredAbsent.add(Keys.accountDeletionMarker(resourceKey.accountId()));
           List<PointerStore.CasOp> ops =
               new ArrayList<>(
                   prepared.ops.size()
@@ -654,15 +663,26 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           uniqueKeys.addAll(secondaries.values());
           List<String> pointerKeys = new ArrayList<>(uniqueKeys);
 
-          List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size());
+          String accountDeletionMarker = Keys.accountDeletionMarker(key.accountId());
+          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
+            cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
+            throw new NotFoundException("account deletion in progress: " + key.accountId());
+          }
+          List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size() + 1);
           for (String pointerKey : pointerKeys) {
             ops.add(
                 new PointerStore.CasUpsert(
                     pointerKey, 0L, reserve(pointerKey, blobUri, value, blobBytes)));
           }
+          ops.add(new PointerStore.CasCheckAbsent(accountDeletionMarker));
+
           if (mutationPointerStore.compareAndSetBatch(ops)) {
             healCanonicalBlobIfMissing(blobUri, value);
             return true;
+          }
+          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
+            cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
+            throw new NotFoundException("account deletion in progress: " + key.accountId());
           }
           return classifyCreateIfAbsentConflict(
               canonicalPointer, blobUri, pointerKeys, blobExistedBefore);
@@ -941,6 +961,10 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           List<PointerStore.CasOp> ops = new ArrayList<>(prepared.ops);
           Pointer committedCanonical = prepared.committedCanonical;
           addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
+          String accountDeletionMarker = Keys.accountDeletionMarker(key.accountId());
+          if (batchedKeys.add(accountDeletionMarker)) {
+            ops.add(new PointerStore.CasCheckAbsent(accountDeletionMarker));
+          }
           addMarkerAdvances(markerVersions, batchedKeys, ops, "update");
           for (PointerStore.CasOp companion : companions) {
             if (!batchedKeys.add(companion.key())) {
@@ -961,6 +985,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
           if (!pointerConditionsStillMatch(requiredPointerVersions, requiredAbsentPointers))
             return Optional.empty();
+          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) return Optional.empty();
           if (!markerVersionsStillMatch(markerVersions)) return Optional.empty();
           classifyCompanionConflict(companions);
           classifyUpdateConflict(canonicalPointer, expectedCanonicalVersion, blobUri, toAdd);
@@ -1119,6 +1144,10 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
           addPointerDeletes(pointerVersionsToDelete, batchedKeys, ops);
           addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
+          String accountDeletionMarker = Keys.accountDeletionMarker(currentKey.accountId());
+          if (batchedKeys.add(accountDeletionMarker)) {
+            ops.add(new PointerStore.CasCheckAbsent(accountDeletionMarker));
+          }
           addMarkerAdvances(markerVersions, batchedKeys, ops, "replacement");
 
           if (!mutationPointerStore.compareAndSetBatch(ops)) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -1218,7 +1218,10 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           try {
             current = getByKeyForMutation(key);
           } catch (CorruptionException e) {
-            if (!deleteCanonicalPointer(canonicalPointer, canonicalPtr.getVersion())) {
+            Set<String> corruptSecondaries =
+                secondaryPointersReferencingBlob(key, canonicalPointer, blobUri);
+            if (!deleteAtomically(
+                canonicalPointer, canonicalPtr.getVersion(), corruptSecondaries)) {
               return false;
             }
             if (!schema.casBlobs && !blobUri.isBlank()) {
@@ -1243,13 +1246,6 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
           return true;
         });
-  }
-
-  /** Deletes a resource or confirms through the raw mutation stores that it is already absent. */
-  public void deleteOrConfirmAbsent(K key) {
-    if (!delete(key) && getByKeyForMutation(key).isPresent()) {
-      throw new AbortRetryableException(schema.resourceName + " changed during deletion");
-    }
   }
 
   public boolean deleteWithPrecondition(K key, long expectedCanonicalVersion) {
@@ -1301,7 +1297,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
             if (!deleteAtomically(
                 canonicalPointer,
                 expectedCanonicalVersion,
-                Set.of(),
+                secondaryPointersReferencingBlob(key, canonicalPointer, blobUri),
                 requiredPointerVersions,
                 requiredAbsentPointers,
                 pointerVersionsToDelete,
@@ -1363,7 +1359,22 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     if (canonical == null) {
       return List.of();
     }
-    Optional<T> current = getByKeyForMutation(key);
+    Optional<T> current;
+    try {
+      current = getByKeyForMutation(key);
+    } catch (CorruptionException corrupt) {
+      List<PointerStore.CasOp> ops = new ArrayList<>();
+      ops.add(new PointerStore.CasDelete(canonicalPointer, canonical.getVersion()));
+      for (String pointerKey :
+          secondaryPointersReferencingBlob(
+              key, canonicalPointer, resolveBlobUriForDelete(key, canonicalPointer))) {
+        Pointer secondary = mutationPointerStore.get(pointerKey).orElse(null);
+        if (secondary != null) {
+          ops.add(new PointerStore.CasDelete(pointerKey, secondary.getVersion()));
+        }
+      }
+      return List.copyOf(ops);
+    }
     if (current.isEmpty()) {
       return List.of(new PointerStore.CasDelete(canonicalPointer, canonical.getVersion()));
     }
@@ -1423,24 +1434,43 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     return mutationPointerStore.compareAndSetBatch(ops);
   }
 
-  private boolean deleteCanonicalPointer(String canonicalPointer, long expectedCanonicalVersion) {
-    return deleteCanonicalPointer(
-        canonicalPointer, expectedCanonicalVersion, Map.of(), Set.of(), Map.of());
+  private Set<String> secondaryPointersReferencingBlob(
+      K key, String canonicalPointer, String blobUri) {
+    if (blobUri == null || blobUri.isBlank()) {
+      return Set.of();
+    }
+    var matches = new java.util.LinkedHashSet<String>();
+    collectPointersReferencingBlob(
+        Keys.accountRootPrefix(key.accountId()), canonicalPointer, blobUri, matches);
+    if (canonicalPointer.equals(Keys.accountPointerById(key.accountId()))) {
+      collectPointersReferencingBlob(
+          Keys.accountPointerByNamePrefix(), canonicalPointer, blobUri, matches);
+    }
+    return Set.copyOf(matches);
   }
 
-  private boolean deleteCanonicalPointer(
-      String canonicalPointer,
-      long expectedCanonicalVersion,
-      Map<String, Long> requiredPointerVersions,
-      Set<String> requiredAbsentPointers,
-      Map<String, Long> pointerVersionsToDelete) {
-    List<PointerStore.CasOp> ops = new ArrayList<>();
-    Set<String> batchedKeys = new HashSet<>();
-    batchedKeys.add(canonicalPointer);
-    ops.add(new PointerStore.CasDelete(canonicalPointer, expectedCanonicalVersion));
-    addPointerDeletes(pointerVersionsToDelete, batchedKeys, ops);
-    addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
-    return mutationPointerStore.compareAndSetBatch(ops);
+  private void collectPointersReferencingBlob(
+      String prefix, String canonicalPointer, String blobUri, Set<String> matches) {
+    String token = "";
+    Set<String> seenTokens = new HashSet<>();
+    while (true) {
+      StringBuilder next = new StringBuilder();
+      for (Pointer pointer :
+          mutationPointerStore.listPointersByPrefixConsistent(prefix, 200, token, next)) {
+        if (!canonicalPointer.equals(pointer.getKey())
+            && PointerReferences.isBlobPointer(pointer)
+            && blobUri.equals(pointer.getBlobUri())) {
+          matches.add(pointer.getKey());
+        }
+      }
+      token = next.toString();
+      if (token.isBlank()) {
+        return;
+      }
+      if (!seenTokens.add(token)) {
+        throw new IllegalStateException("stagnant pointer scan token: " + token);
+      }
+    }
   }
 
   private static void addPointerDeletes(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/MarkerStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/MarkerStore.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.List;
 
 @ApplicationScoped
 public class MarkerStore {
@@ -42,36 +43,54 @@ public class MarkerStore {
 
   public void bumpCatalogMarker(ResourceId catalogId) {
     String key = Keys.catalogChildrenMarker(catalogId.getAccountId(), catalogId.getId());
-    bumpMarker(key);
+    bumpMarker(catalogId.getAccountId(), key);
   }
 
   public void bumpNamespaceMarker(ResourceId namespaceId) {
     String key = Keys.namespaceChildrenMarker(namespaceId.getAccountId(), namespaceId.getId());
-    bumpMarker(key);
+    bumpMarker(namespaceId.getAccountId(), key);
   }
 
   public boolean advanceCatalogMarker(ResourceId catalogId, long expectedVersion) {
     String key = Keys.catalogChildrenMarker(catalogId.getAccountId(), catalogId.getId());
-    return advanceMarker(key, expectedVersion);
+    return advanceMarker(catalogId.getAccountId(), key, expectedVersion);
   }
 
   public boolean advanceNamespaceMarker(ResourceId namespaceId, long expectedVersion) {
     String key = Keys.namespaceChildrenMarker(namespaceId.getAccountId(), namespaceId.getId());
-    return advanceMarker(key, expectedVersion);
+    return advanceMarker(namespaceId.getAccountId(), key, expectedVersion);
   }
 
-  private void bumpMarker(String key) {
+  private void bumpMarker(String accountId, String key) {
     for (int i = 0; i < CAS_MAX; i++) {
+      if (pointerStore.get(Keys.accountDeletionMarker(accountId)).isPresent()) {
+        return;
+      }
       var current = pointerStore.get(key).orElse(null);
       long expected = current == null ? 0L : current.getVersion();
-      if (advanceMarker(key, expected)) {
+      if (tryAdvanceMarker(accountId, key, expected)) {
         return;
       }
     }
   }
 
-  private boolean advanceMarker(String key, long expectedVersion) {
+  private boolean advanceMarker(String accountId, String key, long expectedVersion) {
+    String fenceKey = Keys.accountDeletionMarker(accountId);
+    if (pointerStore.get(fenceKey).isPresent()) {
+      throw new BaseResourceRepository.AccountDeletionInProgressException(accountId);
+    }
+    boolean advanced = tryAdvanceMarker(accountId, key, expectedVersion);
+    if (!advanced && pointerStore.get(fenceKey).isPresent()) {
+      throw new BaseResourceRepository.AccountDeletionInProgressException(accountId);
+    }
+    return advanced;
+  }
+
+  private boolean tryAdvanceMarker(String accountId, String key, long expectedVersion) {
     var next = PointerReferences.opaqueMarkerPointer(key, key, expectedVersion + 1);
-    return pointerStore.compareAndSet(key, expectedVersion, next);
+    return pointerStore.compareAndSetBatch(
+        List.of(
+            new PointerStore.CasCheckAbsent(Keys.accountDeletionMarker(accountId)),
+            new PointerStore.CasUpsert(key, expectedVersion, next)));
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/RepositoryReads.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/RepositoryReads.java
@@ -72,8 +72,22 @@ public record RepositoryReads(Pointers pointers, Blobs blobs) {
           }
 
           @Override
+          public List<Pointer> listConsistent(
+              String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+            return policy.read(
+                () ->
+                    pointers.listPointersByPrefixConsistent(
+                        prefix, limit, pageToken, nextTokenOut));
+          }
+
+          @Override
           public int count(String prefix) {
             return policy.read(() -> pointers.countByPrefix(prefix));
+          }
+
+          @Override
+          public int countConsistent(String prefix) {
+            return policy.read(() -> pointers.countByPrefixConsistent(prefix));
           }
         },
         new Blobs() {
@@ -108,8 +122,15 @@ public record RepositoryReads(Pointers pointers, Blobs blobs) {
     /** Read one ordered page and append the continuation token to {@code nextTokenOut}. */
     List<Pointer> list(String prefix, int limit, String pageToken, StringBuilder nextTokenOut);
 
+    /** Read one strongly consistent ordered page and append its continuation token. */
+    List<Pointer> listConsistent(
+        String prefix, int limit, String pageToken, StringBuilder nextTokenOut);
+
     /** Count pointers below one storage prefix. */
     int count(String prefix);
+
+    /** Count pointers below one storage prefix using strongly consistent reads. */
+    int countConsistent(String prefix);
   }
 
   /** Blob-store read operations exposed to resource repositories. */

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityResolver.java
@@ -56,7 +56,7 @@ import software.amazon.awssdk.services.sts.model.Credentials;
 
 @ApplicationScoped
 public class StorageAuthorityResolver {
-  static final String STORAGE_AUTHORITY_SECRET_TYPE = "storage-authorities";
+  public static final String STORAGE_AUTHORITY_SECRET_TYPE = "storage-authorities";
   private static final Logger LOG = Logger.getLogger(StorageAuthorityResolver.class.getName());
   private static final Duration ASSUME_ROLE_CACHE_REFRESH_SKEW = Duration.ofMinutes(5);
   private static final int ASSUME_ROLE_MAX_ATTEMPTS = 3;

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
@@ -249,6 +249,10 @@ public class TransactionIntentApplierSupport {
 
     var ops = new ArrayList<PointerStore.CasOp>();
     Set<String> touchedKeys = new HashSet<>();
+    ApplyOutcome fenceOutcome = appendAccountDeletionFenceChecks(intents, touchedKeys, ops);
+    if (fenceOutcome.status != ApplyStatus.APPLIED) {
+      return fenceOutcome;
+    }
     for (var intent : intents) {
       ApplyOutcome planOutcome = planIntentOps(intent, ops, touchedKeys);
       if (planOutcome.status != ApplyStatus.APPLIED) {
@@ -265,6 +269,10 @@ public class TransactionIntentApplierSupport {
     }
 
     if (!ops.isEmpty() && !pointerStore.compareAndSetBatch(ops)) {
+      ApplyOutcome fenceOutcomeAfterFailure = findAccountDeletionConflict(intents);
+      if (fenceOutcomeAfterFailure != null) {
+        return fenceOutcomeAfterFailure;
+      }
       ApplyOutcome conflictOutcome = findExpectedVersionConflict(intents);
       if (conflictOutcome != null) {
         return conflictOutcome;
@@ -293,6 +301,10 @@ public class TransactionIntentApplierSupport {
 
     var ops = new ArrayList<PointerStore.CasOp>();
     Set<String> touchedKeys = new HashSet<>();
+    ApplyOutcome fenceOutcome = appendAccountDeletionFenceChecks(intents, touchedKeys, ops);
+    if (fenceOutcome.status != ApplyStatus.APPLIED) {
+      return fenceOutcome;
+    }
     for (var intent : intents) {
       ApplyOutcome planOutcome = planIntentOps(intent, ops, touchedKeys);
       if (planOutcome.status != ApplyStatus.APPLIED) {
@@ -330,8 +342,50 @@ public class TransactionIntentApplierSupport {
     if (pointerStore.compareAndSetBatch(ops)) {
       return ApplyOutcome.applied();
     }
+    ApplyOutcome fenceOutcomeAfterFailure = findAccountDeletionConflict(intents);
+    if (fenceOutcomeAfterFailure != null) {
+      return fenceOutcomeAfterFailure;
+    }
     return classifyAtomicApplyFailure(
         appliedTransaction, expectedTransactionPointerVersion, intents, intentRepo);
+  }
+
+  private ApplyOutcome appendAccountDeletionFenceChecks(
+      List<TransactionIntent> intents, Set<String> touchedKeys, List<PointerStore.CasOp> ops) {
+    for (TransactionIntent intent : intents) {
+      if (intent == null || intent.getAccountId().isBlank()) {
+        return ApplyOutcome.conflict(
+            "TRANSACTION_INTENT_INVALID_ACCOUNT",
+            "transaction intent account_id is required",
+            null,
+            null,
+            null);
+      }
+      String markerKey = Keys.accountDeletionMarker(intent.getAccountId());
+      if (pointerStore.get(markerKey).isPresent()) {
+        return accountDeletionConflict(intent.getAccountId());
+      }
+      if (touchedKeys.add(markerKey)) {
+        ops.add(new PointerStore.CasCheckAbsent(markerKey));
+      }
+    }
+    return ApplyOutcome.applied();
+  }
+
+  private ApplyOutcome findAccountDeletionConflict(List<TransactionIntent> intents) {
+    for (TransactionIntent intent : intents) {
+      if (intent != null
+          && !intent.getAccountId().isBlank()
+          && pointerStore.get(Keys.accountDeletionMarker(intent.getAccountId())).isPresent()) {
+        return accountDeletionConflict(intent.getAccountId());
+      }
+    }
+    return null;
+  }
+
+  private ApplyOutcome accountDeletionConflict(String accountId) {
+    return ApplyOutcome.conflict(
+        "ACCOUNT_DELETION_IN_PROGRESS", "account deletion is in progress", null, null, accountId);
   }
 
   private ApplyOutcome planIntentOps(

--- a/service/src/main/resources/errors_en.properties
+++ b/service/src/main/resources/errors_en.properties
@@ -74,6 +74,7 @@ MC_NOT_FOUND.systemcatalog.not.found=Builtin catalog not found for engine versio
 MC_NOT_FOUND.scan.handle=Scan handle not found: {handle}.
 
 MC_PRECONDITION_FAILED.version.mismatch=Version mismatch (expected {expected}, got {actual}).
+MC_PRECONDITION_FAILED.account.deletion.in.progress=Account "{account_id}" is being deleted.
 MC_PRECONDITION_FAILED.catalog.children.changed=Catalog metadata changed while evaluating the request.
 MC_PRECONDITION_FAILED.namespace.children.changed=Namespace metadata changed while evaluating the request.
 MC_PRECONDITION_FAILED.query.not.active=The query is not in an active state.

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -11,13 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,45 +23,33 @@ import ai.floedb.floecat.account.rpc.AccountSpec;
 import ai.floedb.floecat.account.rpc.CreateAccountRequest;
 import ai.floedb.floecat.account.rpc.DeleteAccountRequest;
 import ai.floedb.floecat.account.rpc.UpdateAccountRequest;
-import ai.floedb.floecat.catalog.rpc.Catalog;
-import ai.floedb.floecat.catalog.rpc.Namespace;
-import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.ErrorCode;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.Precondition;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
-import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.credentials.DefaultCredentialResolver;
 import ai.floedb.floecat.service.error.impl.FloecatStatus;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
-import ai.floedb.floecat.service.repo.impl.CatalogRepository;
-import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
-import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
-import ai.floedb.floecat.service.repo.impl.StorageAuthorityRepository;
-import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
-import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
-import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.service.storage.impl.StorageAuthorityResolver;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
-import ai.floedb.floecat.storage.rpc.StorageAuthority;
 import ai.floedb.floecat.storage.secrets.SecretsManager;
 import com.google.protobuf.FieldMask;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import jakarta.enterprise.inject.Instance;
 import java.lang.reflect.Field;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,24 +64,19 @@ class AccountServiceImplTest {
   void setUp() {
     service = new AccountServiceImpl();
     service.accountRepo = mock(AccountRepository.class);
-    service.catalogRepo = mock(CatalogRepository.class);
-    service.namespaceRepo = mock(NamespaceRepository.class);
-    service.tableRepo = mock(TableRepository.class);
     service.tableRootRepo = mock(TableRootRepository.class);
-    service.connectorRepo = mock(ConnectorRepository.class);
-    service.storageAuthorityRepo = mock(StorageAuthorityRepository.class);
-    service.viewRepo = mock(ViewRepository.class);
     service.principal = mock(PrincipalProvider.class);
     service.authz = mock(Authorizer.class);
     service.idempotencyStore = mock(IdempotencyRepository.class);
     service.metadataGraph = mock(UserGraph.class);
-    service.markerStore = mock(MarkerStore.class);
     pointers = new TrackingPointerStore();
     service.pointerStore = pointers;
     blobs = new InMemoryBlobStore();
     service.blobStore = blobs;
     service.credentialResolver = mock(DefaultCredentialResolver.class);
     service.secretsManager = mock(SecretsManager.class);
+    service.durableReconcileJobStore = mock(Instance.class);
+    when(service.durableReconcileJobStore.isResolvable()).thenReturn(false);
     installBasePrincipal(service, service.principal);
     when(service.principal.get())
         .thenReturn(
@@ -123,23 +103,29 @@ class AccountServiceImplTest {
             .setId("authority")
             .setKind(ResourceKind.RK_STORAGE_AUTHORITY)
             .build();
-    StorageAuthority authority = StorageAuthority.newBuilder().setResourceId(authorityId).build();
+    String authorityPointer = Keys.storageAuthorityPointerById("acct", authorityId.getId());
+    putPointer(authorityPointer, "/accounts/acct/storage-authorities/authority/broken.pb");
     when(service.accountRepo.metaFor(accountId)).thenReturn(meta);
     when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
-    when(service.storageAuthorityRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
-        .thenReturn(List.of(authority));
+    doAnswer(
+            ignored -> {
+              assertTrue(pointers.get(authorityPointer).isPresent());
+              return null;
+            })
+        .when(service.secretsManager)
+        .delete(
+            "acct", StorageAuthorityResolver.STORAGE_AUTHORITY_SECRET_TYPE, authorityId.getId());
 
     service
         .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
         .await()
         .indefinitely();
 
-    var ordered = inOrder(service.secretsManager, service.storageAuthorityRepo);
-    ordered
-        .verify(service.secretsManager)
+    verify(service.secretsManager)
         .delete(
             "acct", StorageAuthorityResolver.STORAGE_AUTHORITY_SECRET_TYPE, authorityId.getId());
-    ordered.verify(service.storageAuthorityRepo).deleteOrConfirmAbsent(authorityId);
+    assertTrue(pointers.get(authorityPointer).isEmpty());
+    assertTrue(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
   }
 
   @Test
@@ -148,11 +134,13 @@ class AccountServiceImplTest {
     ResourceId catalogId = resourceId("catalog", ResourceKind.RK_CATALOG);
     ResourceId namespaceId = resourceId("namespace", ResourceKind.RK_NAMESPACE);
     ResourceId tableId = resourceId("table", ResourceKind.RK_TABLE);
-    Catalog catalog = Catalog.newBuilder().setResourceId(catalogId).build();
-    Namespace namespace =
-        Namespace.newBuilder().setResourceId(namespaceId).setCatalogId(catalogId).build();
-    Table table = Table.newBuilder().setResourceId(tableId).setNamespaceId(namespaceId).build();
+    putPointer(Keys.catalogPointerById("acct", "catalog"), "broken-catalog");
+    putPointer(Keys.namespacePointerById("acct", "namespace"), "broken-namespace");
+    putPointer(Keys.tablePointerById("acct", "table"), "broken-table");
+    putPointer(Keys.catalogPointerByIdPrefix("acct"), "malformed-canonical-key");
     String constraintKey = Keys.snapshotConstraintsPointer("acct", "table", 7L);
+    String catalogMarker = Keys.catalogChildrenMarker("acct", "catalog");
+    String namespaceMarker = Keys.namespaceChildrenMarker("acct", "namespace");
     String tableBlobPrefix = Keys.tableBlobPrefix("acct", "table");
     String statsBlob = tableBlobPrefix + "target-stats/orphan.pb";
     String indexSidecar = tableBlobPrefix + "index-sidecars/orphan.parquet";
@@ -161,20 +149,23 @@ class AccountServiceImplTest {
         Keys.tableBlobPrefix("other-acct", "other-table") + "target-stats/live.pb";
     pointers.compareAndSet(
         constraintKey, 0L, PointerReferences.opaqueMarkerPointer(constraintKey, "constraint", 1L));
+    pointers.compareAndSet(
+        catalogMarker, 0L, PointerReferences.opaqueMarkerPointer(catalogMarker, "marker", 1L));
+    pointers.compareAndSet(
+        namespaceMarker, 0L, PointerReferences.opaqueMarkerPointer(namespaceMarker, "marker", 1L));
     blobs.put(statsBlob, new byte[] {1}, "application/x-protobuf");
     blobs.put(indexSidecar, new byte[] {2}, "application/octet-stream");
     blobs.put(residualBlob, new byte[] {3}, "application/x-protobuf");
     blobs.put(otherAccountBlob, new byte[] {4}, "application/x-protobuf");
     when(service.accountRepo.metaFor(accountId)).thenReturn(meta);
     when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
-    when(service.catalogRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
-        .thenReturn(List.of(catalog));
-    when(service.namespaceRepo.listIdsConsistent("acct", "catalog"))
-        .thenReturn(List.of(namespaceId));
-    when(service.namespaceRepo.getByIdForMutation(namespaceId)).thenReturn(Optional.of(namespace));
-    when(service.tableRepo.listConsistent(
-            eq("acct"), eq("catalog"), eq("namespace"), eq(200), anyString(), any()))
-        .thenReturn(List.of(table));
+    doAnswer(
+            ignored -> {
+              assertEquals(1, pointers.countByPrefixConsistent(Keys.accountRootPrefix("acct")));
+              return null;
+            })
+        .when(service.metadataGraph)
+        .invalidate(any(ResourceId.class));
 
     service
         .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
@@ -182,6 +173,9 @@ class AccountServiceImplTest {
         .indefinitely();
 
     assertFalse(pointers.get(constraintKey).isPresent());
+    assertFalse(pointers.get(catalogMarker).isPresent());
+    assertFalse(pointers.get(namespaceMarker).isPresent());
+    assertEquals(1, pointers.countByPrefixConsistent(Keys.accountRootPrefix("acct")));
     assertTrue(blobs.list(tableBlobPrefix, 100, "").keys().isEmpty());
     assertTrue(blobs.get(residualBlob) == null);
     assertTrue(blobs.get(otherAccountBlob) != null);
@@ -226,17 +220,12 @@ class AccountServiceImplTest {
             .setId("connector")
             .setKind(ResourceKind.RK_CONNECTOR)
             .build();
-    Connector connector = Connector.newBuilder().setResourceId(connectorId).build();
+    putPointer(Keys.connectorPointerById("acct", "connector"), "broken-connector");
     when(service.accountRepo.metaFor(accountId))
         .thenReturn(meta)
         .thenThrow(new BaseResourceRepository.NotFoundException("deleted"));
     when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
-    when(service.connectorRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
-        .thenReturn(List.of(connector), List.of(connector));
-    doThrow(new BaseResourceRepository.AbortRetryableException("connector changed"))
-        .doNothing()
-        .when(service.connectorRepo)
-        .deleteOrConfirmAbsent(connectorId);
+    pointers.failNextExcludedSweep = true;
 
     var response =
         service
@@ -247,7 +236,8 @@ class AccountServiceImplTest {
     assertEquals(meta, response.getMeta());
     assertTrue(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
     verify(service.accountRepo).deleteWithPrecondition(accountId, 7L);
-    verify(service.connectorRepo, org.mockito.Mockito.times(2)).deleteOrConfirmAbsent(connectorId);
+    verify(service.credentialResolver, org.mockito.Mockito.times(2))
+        .delete("acct", connectorId.getId());
   }
 
   @Test
@@ -265,8 +255,7 @@ class AccountServiceImplTest {
 
     assertEquals(missing, response.getMeta());
     assertFalse(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
-    verify(service.connectorRepo, never())
-        .listConsistent(anyString(), anyInt(), anyString(), any());
+    assertEquals(0, pointers.excludedSweepCalls);
   }
 
   @Test
@@ -403,13 +392,29 @@ class AccountServiceImplTest {
     return ResourceId.newBuilder().setAccountId("acct").setId(id).setKind(kind).build();
   }
 
+  private void putPointer(String key, String blobUri) {
+    pointers.compareAndSet(key, 0L, PointerReferences.blobPointer(key, blobUri, 1L));
+  }
+
   private static final class TrackingPointerStore extends InMemoryPointerStore {
     private int compareAndDeleteCalls;
+    private int excludedSweepCalls;
+    private boolean failNextExcludedSweep;
 
     @Override
     public synchronized boolean compareAndDelete(String key, long expectedVersion) {
       compareAndDeleteCalls++;
       return super.compareAndDelete(key, expectedVersion);
+    }
+
+    @Override
+    public synchronized int deleteByPrefixExcluding(String prefix, String excludedKey) {
+      excludedSweepCalls++;
+      if (failNextExcludedSweep) {
+        failNextExcludedSweep = false;
+        throw new BaseResourceRepository.AbortRetryableException("injected sweep conflict");
+      }
+      return super.deleteByPrefixExcluding(prefix, excludedKey);
     }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.account.rpc.Account;
 import ai.floedb.floecat.account.rpc.AccountSpec;
 import ai.floedb.floecat.account.rpc.CreateAccountRequest;
 import ai.floedb.floecat.account.rpc.DeleteAccountRequest;
+import ai.floedb.floecat.account.rpc.UpdateAccountRequest;
 import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.catalog.rpc.Namespace;
 import ai.floedb.floecat.catalog.rpc.Table;
@@ -55,9 +56,11 @@ import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.service.storage.impl.StorageAuthorityResolver;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.rpc.StorageAuthority;
 import ai.floedb.floecat.storage.secrets.SecretsManager;
+import com.google.protobuf.FieldMask;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.lang.reflect.Field;
@@ -70,6 +73,7 @@ class AccountServiceImplTest {
   private AccountServiceImpl service;
   private ResourceId accountId;
   private TrackingPointerStore pointers;
+  private InMemoryBlobStore blobs;
 
   @BeforeEach
   void setUp() {
@@ -89,6 +93,8 @@ class AccountServiceImplTest {
     service.markerStore = mock(MarkerStore.class);
     pointers = new TrackingPointerStore();
     service.pointerStore = pointers;
+    blobs = new InMemoryBlobStore();
+    service.blobStore = blobs;
     service.credentialResolver = mock(DefaultCredentialResolver.class);
     service.secretsManager = mock(SecretsManager.class);
     installBasePrincipal(service, service.principal);
@@ -166,6 +172,36 @@ class AccountServiceImplTest {
         .indefinitely();
 
     assertFalse(pointers.get(constraintKey).isPresent());
+  }
+
+  @Test
+  void accountDeletionPurgesPreparedTransactionsAndIntents() {
+    MutationMeta meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    String transactionPointer = Keys.transactionPointerById("acct", "tx-1");
+    String intentPointer =
+        Keys.transactionIntentPointerByTarget("acct", "/accounts/acct/tables/by-id/table-1");
+    String transactionBlob = Keys.transactionBlobUri("acct", "tx-1", "transaction-sha");
+    String intentBlob = Keys.transactionIntentBlobUri("acct", "tx-1", "intent-sha");
+    pointers.compareAndSet(
+        transactionPointer,
+        0L,
+        PointerReferences.blobPointer(transactionPointer, transactionBlob, 1L));
+    pointers.compareAndSet(
+        intentPointer, 0L, PointerReferences.blobPointer(intentPointer, intentBlob, 1L));
+    blobs.put(transactionBlob, new byte[] {1}, "application/x-protobuf");
+    blobs.put(intentBlob, new byte[] {2}, "application/x-protobuf");
+    when(service.accountRepo.metaFor(accountId)).thenReturn(meta);
+    when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
+
+    service
+        .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
+        .await()
+        .indefinitely();
+
+    assertTrue(pointers.get(transactionPointer).isEmpty());
+    assertTrue(pointers.get(intentPointer).isEmpty());
+    assertTrue(blobs.get(transactionBlob) == null);
+    assertTrue(blobs.get(intentBlob) == null);
   }
 
   @Test
@@ -305,6 +341,36 @@ class AccountServiceImplTest {
     FloecatStatus decoded = FloecatStatus.fromThrowable(failure);
     assertEquals(Status.Code.FAILED_PRECONDITION, decoded.canonicalCode());
     assertEquals(ErrorCode.MC_PRECONDITION_FAILED, decoded.errorCode());
+    assertEquals("account.deletion.in.progress", decoded.messageKey());
+    assertEquals("acct", decoded.params().get("account_id"));
+  }
+
+  @Test
+  void fenceBlockedUpdateUsesStructuredFailedPrecondition() {
+    MutationMeta meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    Account current = Account.newBuilder().setResourceId(accountId).setDisplayName("alpha").build();
+    when(service.accountRepo.metaFor(accountId)).thenReturn(meta);
+    when(service.accountRepo.getById(accountId)).thenReturn(Optional.of(current));
+    doThrow(new BaseResourceRepository.AccountDeletionInProgressException("acct"))
+        .when(service.accountRepo)
+        .update(any(Account.class), eq(7L));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .updateAccount(
+                        UpdateAccountRequest.newBuilder()
+                            .setAccountId(accountId)
+                            .setSpec(AccountSpec.newBuilder().setDisplayName("beta"))
+                            .setUpdateMask(FieldMask.newBuilder().addPaths("display_name"))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    FloecatStatus decoded = FloecatStatus.fromThrowable(failure);
+    assertEquals(Status.Code.FAILED_PRECONDITION, decoded.canonicalCode());
     assertEquals("account.deletion.in.progress", decoded.messageKey());
     assertEquals("acct", decoded.params().get("account_id"));
   }

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -7,22 +7,33 @@
 package ai.floedb.floecat.service.account.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.account.rpc.Account;
+import ai.floedb.floecat.account.rpc.AccountSpec;
+import ai.floedb.floecat.account.rpc.CreateAccountRequest;
 import ai.floedb.floecat.account.rpc.DeleteAccountRequest;
+import ai.floedb.floecat.common.rpc.ErrorCode;
 import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.Precondition;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.credentials.DefaultCredentialResolver;
+import ai.floedb.floecat.service.error.impl.FloecatStatus;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
@@ -38,6 +49,8 @@ import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +60,7 @@ import org.junit.jupiter.api.Test;
 class AccountServiceImplTest {
   private AccountServiceImpl service;
   private ResourceId accountId;
-  private InMemoryPointerStore pointers;
+  private TrackingPointerStore pointers;
 
   @BeforeEach
   void setUp() {
@@ -64,7 +77,7 @@ class AccountServiceImplTest {
     service.idempotencyStore = mock(IdempotencyRepository.class);
     service.metadataGraph = mock(UserGraph.class);
     service.markerStore = mock(MarkerStore.class);
-    pointers = new InMemoryPointerStore();
+    pointers = new TrackingPointerStore();
     service.pointerStore = pointers;
     service.credentialResolver = mock(DefaultCredentialResolver.class);
     installBasePrincipal(service, service.principal);
@@ -74,6 +87,7 @@ class AccountServiceImplTest {
                 .setAccountId("acct")
                 .setCorrelationId("corr")
                 .addPermissions("account.delete")
+                .addPermissions("account.write")
                 .build());
     accountId =
         ResourceId.newBuilder()
@@ -99,8 +113,10 @@ class AccountServiceImplTest {
     when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
     when(service.connectorRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
         .thenReturn(List.of(connector), List.of(connector));
-    when(service.connectorRepo.delete(connectorId)).thenReturn(false, true);
-    when(service.connectorRepo.getById(connectorId)).thenReturn(Optional.of(connector));
+    doThrow(new BaseResourceRepository.AbortRetryableException("connector changed"))
+        .doNothing()
+        .when(service.connectorRepo)
+        .deleteOrConfirmAbsent(connectorId);
 
     var response =
         service
@@ -111,7 +127,115 @@ class AccountServiceImplTest {
     assertEquals(meta, response.getMeta());
     assertTrue(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
     verify(service.accountRepo).deleteWithPrecondition(accountId, 7L);
-    verify(service.connectorRepo, org.mockito.Mockito.times(2)).delete(connectorId);
+    verify(service.connectorRepo, org.mockito.Mockito.times(2)).deleteOrConfirmAbsent(connectorId);
+  }
+
+  @Test
+  void deletingUnknownAccountDoesNotInstallFenceOrRunCleanup() {
+    MutationMeta missing = MutationMeta.newBuilder().setPointerVersion(0L).build();
+    when(service.accountRepo.metaFor(accountId))
+        .thenThrow(new BaseResourceRepository.NotFoundException("missing"));
+    when(service.accountRepo.metaForSafe(accountId)).thenReturn(missing);
+
+    var response =
+        service
+            .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
+            .await()
+            .indefinitely();
+
+    assertEquals(missing, response.getMeta());
+    assertFalse(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
+    verify(service.connectorRepo, never())
+        .listConsistent(anyString(), anyInt(), anyString(), any());
+  }
+
+  @Test
+  void transactionConflictKeepsFenceWhileSameAccountVersionCanStillCommit() {
+    MutationMeta meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    when(service.accountRepo.metaFor(accountId)).thenReturn(meta, meta);
+    when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(false, true);
+    when(service.accountRepo.metaForSafe(accountId)).thenReturn(meta);
+
+    var response =
+        service
+            .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
+            .await()
+            .indefinitely();
+
+    assertEquals(meta, response.getMeta());
+    assertEquals(0, pointers.compareAndDeleteCalls);
+    assertTrue(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
+  }
+
+  @Test
+  void changedAccountVersionAdvancesFenceWithoutReopeningMutations() {
+    MutationMeta version7 = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    MutationMeta version8 = MutationMeta.newBuilder().setPointerVersion(8L).build();
+    when(service.accountRepo.metaFor(accountId)).thenReturn(version7, version8);
+    when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(false);
+    when(service.accountRepo.deleteWithPrecondition(accountId, 8L)).thenReturn(true);
+    when(service.accountRepo.metaForSafe(accountId)).thenReturn(version8);
+
+    var response =
+        service
+            .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
+            .await()
+            .indefinitely();
+
+    assertEquals(version8, response.getMeta());
+    assertEquals(0, pointers.compareAndDeleteCalls);
+    assertEquals(2L, pointers.get(Keys.accountDeletionMarker("acct")).orElseThrow().getVersion());
+  }
+
+  @Test
+  void changedAccountVersionReleasesStaleFenceWhenPreconditionCannotBeRetried() {
+    MutationMeta version7 = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    MutationMeta version8 = MutationMeta.newBuilder().setPointerVersion(8L).build();
+    when(service.accountRepo.metaFor(accountId)).thenReturn(version7);
+    when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(false);
+    when(service.accountRepo.metaForSafe(accountId)).thenReturn(version8);
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            service
+                .deleteAccount(
+                    DeleteAccountRequest.newBuilder()
+                        .setAccountId(accountId)
+                        .setPrecondition(Precondition.newBuilder().setExpectedVersion(7L))
+                        .build())
+                .await()
+                .indefinitely());
+
+    assertEquals(1, pointers.compareAndDeleteCalls);
+    assertFalse(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
+  }
+
+  @Test
+  void fenceBlockedCreateUsesStructuredFailedPrecondition() {
+    when(service.accountRepo.getByName("alpha")).thenReturn(Optional.empty());
+    doThrow(new BaseResourceRepository.AccountDeletionInProgressException("acct"))
+        .when(service.accountRepo)
+        .create(any(Account.class));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createAccount(
+                        CreateAccountRequest.newBuilder()
+                            .setAccountId(accountId)
+                            .setSpec(AccountSpec.newBuilder().setDisplayName("alpha"))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    FloecatStatus decoded = FloecatStatus.fromThrowable(failure);
+    assertEquals(Status.Code.FAILED_PRECONDITION, decoded.canonicalCode());
+    assertEquals(ErrorCode.MC_PRECONDITION_FAILED, decoded.errorCode());
+    assertEquals("account.deletion.in.progress", decoded.messageKey());
+    assertEquals("acct", decoded.params().get("account_id"));
   }
 
   private static void installBasePrincipal(
@@ -122,6 +246,16 @@ class AccountServiceImplTest {
       field.set(service, principalProvider);
     } catch (ReflectiveOperationException e) {
       throw new AssertionError("Failed to inject BaseServiceImpl principal provider", e);
+    }
+  }
+
+  private static final class TrackingPointerStore extends InMemoryPointerStore {
+    private int compareAndDeleteCalls;
+
+    @Override
+    public synchronized boolean compareAndDelete(String key, long expectedVersion) {
+      compareAndDeleteCalls++;
+      return super.compareAndDelete(key, expectedVersion);
     }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -241,6 +241,32 @@ class AccountServiceImplTest {
   }
 
   @Test
+  void incompletePointerSweepReportsBoundedUnexpectedKeys() {
+    String accountPrefix = Keys.accountRootPrefix("acct");
+    String deletionFence = Keys.accountDeletionMarker("acct");
+    putPointer(deletionFence, "deletion-fence");
+    for (char suffix = 'a'; suffix <= 'l'; suffix++) {
+      putPointer(accountPrefix + "residual-" + suffix, "residual-" + suffix);
+    }
+
+    BaseResourceRepository.AbortRetryableException failure =
+        assertThrows(
+            BaseResourceRepository.AbortRetryableException.class,
+            () -> service.assertAccountPointerSweepComplete(accountPrefix, deletionFence));
+
+    String message = failure.getMessage();
+    assertTrue(message.contains("account pointer sweep left 13 rows under " + accountPrefix));
+    assertTrue(message.contains("deletion_fence_present=true"));
+    assertTrue(message.contains("unexpected_pointer_count=12"));
+    for (char suffix = 'a'; suffix <= 'j'; suffix++) {
+      assertTrue(message.contains(accountPrefix + "residual-" + suffix));
+    }
+    assertFalse(message.contains(accountPrefix + "residual-k"));
+    assertFalse(message.contains(accountPrefix + "residual-l"));
+    assertTrue(message.contains("unexpected_pointer_keys_truncated=true"));
+  }
+
+  @Test
   void deletingUnknownAccountDoesNotInstallFenceOrRunCleanup() {
     MutationMeta missing = MutationMeta.newBuilder().setPointerVersion(0L).build();
     when(service.accountRepo.metaFor(accountId))

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.account.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.account.rpc.DeleteAccountRequest;
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.service.common.BaseServiceImpl;
+import ai.floedb.floecat.service.credentials.DefaultCredentialResolver;
+import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
+import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.AccountRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogRepository;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.repo.impl.TableRootRepository;
+import ai.floedb.floecat.service.repo.impl.ViewRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.MarkerStore;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AccountServiceImplTest {
+  private AccountServiceImpl service;
+  private ResourceId accountId;
+  private InMemoryPointerStore pointers;
+
+  @BeforeEach
+  void setUp() {
+    service = new AccountServiceImpl();
+    service.accountRepo = mock(AccountRepository.class);
+    service.catalogRepo = mock(CatalogRepository.class);
+    service.namespaceRepo = mock(NamespaceRepository.class);
+    service.tableRepo = mock(TableRepository.class);
+    service.tableRootRepo = mock(TableRootRepository.class);
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.viewRepo = mock(ViewRepository.class);
+    service.principal = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.idempotencyStore = mock(IdempotencyRepository.class);
+    service.metadataGraph = mock(UserGraph.class);
+    service.markerStore = mock(MarkerStore.class);
+    pointers = new InMemoryPointerStore();
+    service.pointerStore = pointers;
+    service.credentialResolver = mock(DefaultCredentialResolver.class);
+    installBasePrincipal(service, service.principal);
+    when(service.principal.get())
+        .thenReturn(
+            PrincipalContext.newBuilder()
+                .setAccountId("acct")
+                .setCorrelationId("corr")
+                .addPermissions("account.delete")
+                .build());
+    accountId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("acct")
+            .setKind(ResourceKind.RK_ACCOUNT)
+            .build();
+  }
+
+  @Test
+  void descendantCleanupFailureRetriesBehindDurableDeletionFence() {
+    MutationMeta meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    ResourceId connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("connector")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .build();
+    Connector connector = Connector.newBuilder().setResourceId(connectorId).build();
+    when(service.accountRepo.metaFor(accountId))
+        .thenReturn(meta)
+        .thenThrow(new BaseResourceRepository.NotFoundException("deleted"));
+    when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
+    when(service.connectorRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
+        .thenReturn(List.of(connector), List.of(connector));
+    when(service.connectorRepo.delete(connectorId)).thenReturn(false, true);
+    when(service.connectorRepo.getById(connectorId)).thenReturn(Optional.of(connector));
+
+    var response =
+        service
+            .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
+            .await()
+            .indefinitely();
+
+    assertEquals(meta, response.getMeta());
+    assertTrue(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
+    verify(service.accountRepo).deleteWithPrecondition(accountId, 7L);
+    verify(service.connectorRepo, org.mockito.Mockito.times(2)).delete(connectorId);
+  }
+
+  private static void installBasePrincipal(
+      AccountServiceImpl service, PrincipalProvider principalProvider) {
+    try {
+      Field field = BaseServiceImpl.class.getDeclaredField("principal");
+      field.setAccessible(true);
+      field.set(service, principalProvider);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to inject BaseServiceImpl principal provider", e);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -24,6 +25,9 @@ import ai.floedb.floecat.account.rpc.Account;
 import ai.floedb.floecat.account.rpc.AccountSpec;
 import ai.floedb.floecat.account.rpc.CreateAccountRequest;
 import ai.floedb.floecat.account.rpc.DeleteAccountRequest;
+import ai.floedb.floecat.catalog.rpc.Catalog;
+import ai.floedb.floecat.catalog.rpc.Namespace;
+import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.common.rpc.ErrorCode;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.Precondition;
@@ -40,15 +44,20 @@ import ai.floedb.floecat.service.repo.impl.AccountRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import ai.floedb.floecat.service.repo.impl.StorageAuthorityRepository;
 import ai.floedb.floecat.service.repo.impl.TableRepository;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.service.storage.impl.StorageAuthorityResolver;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.rpc.StorageAuthority;
+import ai.floedb.floecat.storage.secrets.SecretsManager;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.lang.reflect.Field;
@@ -71,6 +80,7 @@ class AccountServiceImplTest {
     service.tableRepo = mock(TableRepository.class);
     service.tableRootRepo = mock(TableRootRepository.class);
     service.connectorRepo = mock(ConnectorRepository.class);
+    service.storageAuthorityRepo = mock(StorageAuthorityRepository.class);
     service.viewRepo = mock(ViewRepository.class);
     service.principal = mock(PrincipalProvider.class);
     service.authz = mock(Authorizer.class);
@@ -80,6 +90,7 @@ class AccountServiceImplTest {
     pointers = new TrackingPointerStore();
     service.pointerStore = pointers;
     service.credentialResolver = mock(DefaultCredentialResolver.class);
+    service.secretsManager = mock(SecretsManager.class);
     installBasePrincipal(service, service.principal);
     when(service.principal.get())
         .thenReturn(
@@ -95,6 +106,66 @@ class AccountServiceImplTest {
             .setId("acct")
             .setKind(ResourceKind.RK_ACCOUNT)
             .build();
+  }
+
+  @Test
+  void accountDeletionRemovesStorageAuthoritySecretBeforeRepositoryState() {
+    MutationMeta meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    ResourceId authorityId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("authority")
+            .setKind(ResourceKind.RK_STORAGE_AUTHORITY)
+            .build();
+    StorageAuthority authority = StorageAuthority.newBuilder().setResourceId(authorityId).build();
+    when(service.accountRepo.metaFor(accountId)).thenReturn(meta);
+    when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
+    when(service.storageAuthorityRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
+        .thenReturn(List.of(authority));
+
+    service
+        .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
+        .await()
+        .indefinitely();
+
+    var ordered = inOrder(service.secretsManager, service.storageAuthorityRepo);
+    ordered
+        .verify(service.secretsManager)
+        .delete(
+            "acct", StorageAuthorityResolver.STORAGE_AUTHORITY_SECRET_TYPE, authorityId.getId());
+    ordered.verify(service.storageAuthorityRepo).deleteOrConfirmAbsent(authorityId);
+  }
+
+  @Test
+  void accountDeletionPurgesSnapshotConstraintPointers() {
+    MutationMeta meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    ResourceId catalogId = resourceId("catalog", ResourceKind.RK_CATALOG);
+    ResourceId namespaceId = resourceId("namespace", ResourceKind.RK_NAMESPACE);
+    ResourceId tableId = resourceId("table", ResourceKind.RK_TABLE);
+    Catalog catalog = Catalog.newBuilder().setResourceId(catalogId).build();
+    Namespace namespace =
+        Namespace.newBuilder().setResourceId(namespaceId).setCatalogId(catalogId).build();
+    Table table = Table.newBuilder().setResourceId(tableId).setNamespaceId(namespaceId).build();
+    String constraintKey = Keys.snapshotConstraintsPointer("acct", "table", 7L);
+    pointers.compareAndSet(
+        constraintKey, 0L, PointerReferences.opaqueMarkerPointer(constraintKey, "constraint", 1L));
+    when(service.accountRepo.metaFor(accountId)).thenReturn(meta);
+    when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
+    when(service.catalogRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
+        .thenReturn(List.of(catalog));
+    when(service.namespaceRepo.listIdsConsistent("acct", "catalog"))
+        .thenReturn(List.of(namespaceId));
+    when(service.namespaceRepo.getByIdForMutation(namespaceId)).thenReturn(Optional.of(namespace));
+    when(service.tableRepo.listConsistent(
+            eq("acct"), eq("catalog"), eq("namespace"), eq(200), anyString(), any()))
+        .thenReturn(List.of(table));
+
+    service
+        .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
+        .await()
+        .indefinitely();
+
+    assertFalse(pointers.get(constraintKey).isPresent());
   }
 
   @Test
@@ -247,6 +318,10 @@ class AccountServiceImplTest {
     } catch (ReflectiveOperationException e) {
       throw new AssertionError("Failed to inject BaseServiceImpl principal provider", e);
     }
+  }
+
+  private static ResourceId resourceId(String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("acct").setId(id).setKind(kind).build();
   }
 
   private static final class TrackingPointerStore extends InMemoryPointerStore {

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -153,8 +153,18 @@ class AccountServiceImplTest {
         Namespace.newBuilder().setResourceId(namespaceId).setCatalogId(catalogId).build();
     Table table = Table.newBuilder().setResourceId(tableId).setNamespaceId(namespaceId).build();
     String constraintKey = Keys.snapshotConstraintsPointer("acct", "table", 7L);
+    String tableBlobPrefix = Keys.tableBlobPrefix("acct", "table");
+    String statsBlob = tableBlobPrefix + "target-stats/orphan.pb";
+    String indexSidecar = tableBlobPrefix + "index-sidecars/orphan.parquet";
+    String residualBlob = Keys.accountRootPrefix("acct") + "worker-output/orphan.pb";
+    String otherAccountBlob =
+        Keys.tableBlobPrefix("other-acct", "other-table") + "target-stats/live.pb";
     pointers.compareAndSet(
         constraintKey, 0L, PointerReferences.opaqueMarkerPointer(constraintKey, "constraint", 1L));
+    blobs.put(statsBlob, new byte[] {1}, "application/x-protobuf");
+    blobs.put(indexSidecar, new byte[] {2}, "application/octet-stream");
+    blobs.put(residualBlob, new byte[] {3}, "application/x-protobuf");
+    blobs.put(otherAccountBlob, new byte[] {4}, "application/x-protobuf");
     when(service.accountRepo.metaFor(accountId)).thenReturn(meta);
     when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
     when(service.catalogRepo.listConsistent(eq("acct"), eq(200), anyString(), any()))
@@ -172,6 +182,9 @@ class AccountServiceImplTest {
         .indefinitely();
 
     assertFalse(pointers.get(constraintKey).isPresent());
+    assertTrue(blobs.list(tableBlobPrefix, 100, "").keys().isEmpty());
+    assertTrue(blobs.get(residualBlob) == null);
+    assertTrue(blobs.get(otherAccountBlob) != null);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/RootRepairRequestsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/RootRepairRequestsTest.java
@@ -20,11 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -88,11 +89,11 @@ class RootRepairRequestsTest {
     var pointers =
         new InMemoryPointerStore() {
           @Override
-          public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
+          public boolean compareAndSetBatch(List<PointerStore.CasOp> ops) {
             if (failures.getAndDecrement() > 0) {
               throw new IllegalStateException("pointer store down");
             }
-            return super.compareAndSet(key, expectedVersion, next);
+            return super.compareAndSetBatch(ops);
           }
         };
     var repairs = new RootRepairRequests(new RootResyncQueue(pointers, backoffMs -> {}), () -> 0L);

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueueTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueueTest.java
@@ -19,11 +19,12 @@ package ai.floedb.floecat.service.catalog.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,11 +38,11 @@ class RootResyncQueueTest {
     var pointers =
         new InMemoryPointerStore() {
           @Override
-          public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
+          public boolean compareAndSetBatch(List<PointerStore.CasOp> ops) {
             if (transientFailures.getAndDecrement() > 0) {
               throw new IllegalStateException("transient pointer-store failure");
             }
-            return super.compareAndSet(key, expectedVersion, next);
+            return super.compareAndSetBatch(ops);
           }
         };
     var backoffs = new ArrayList<Long>();
@@ -59,5 +60,23 @@ class RootResyncQueueTest {
     assertTrue(
         pointers.get(Keys.rootResyncPendingPointer("acct", "tbl-transient")).isPresent(),
         "the recovered enqueue still records the pending root resync marker");
+  }
+
+  @Test
+  void enqueueDoesNotRecreateMarkerForDeletingAccount() {
+    var pointers = new InMemoryPointerStore();
+    var queue = new RootResyncQueue(pointers);
+    var tableId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("tbl-deleting")
+            .setKind(ResourceKind.RK_TABLE)
+            .build();
+    String fence = Keys.accountDeletionMarker("acct");
+    pointers.compareAndSet(fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "acct", 1L));
+
+    queue.enqueue(tableId);
+
+    assertTrue(pointers.get(Keys.rootResyncPendingPointer("acct", "tbl-deleting")).isEmpty());
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootCommitterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootCommitterTest.java
@@ -58,10 +58,11 @@ class TableRootCommitterTest {
 
   private TableRootRepository roots;
   private TableRootCommitter committer;
+  private InMemoryPointerStore pointers;
 
   @BeforeEach
   void setUp() {
-    var pointers = new InMemoryPointerStore();
+    pointers = new InMemoryPointerStore();
     var blobs = new InMemoryBlobStore();
     roots = new TableRootRepository(pointers, blobs);
     committer = new TableRootCommitter(roots, new TableBlobReachabilityGuard());
@@ -89,6 +90,24 @@ class TableRootCommitterTest {
     assertTrue(committed.hasCommittedAt());
     assertEquals("s3://tbl/def-1.pb", committed.getDefinitionRef().getUri());
     assertEquals(committed, roots.get(TABLE).orElseThrow());
+  }
+
+  @Test
+  void accountDeletionFenceIsNotWrappedAsCommitFailure() {
+    String fence = ai.floedb.floecat.service.repo.model.Keys.accountDeletionMarker("acct");
+    pointers.compareAndSet(
+        fence,
+        0L,
+        ai.floedb.floecat.service.repo.model.PointerReferences.opaqueMarkerPointer(
+            fence, "acct", 1L));
+
+    assertThrows(
+        BaseResourceRepository.AccountDeletionInProgressException.class,
+        () ->
+            committer.commit(
+                TABLE,
+                current ->
+                    TableRoot.newBuilder().setDefinitionRef(ref("s3://tbl/def.pb")).build()));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplCreateConnectorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/connector/impl/ConnectorsImplCreateConnectorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.connector.impl;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.spi.CredentialResolver;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import org.junit.jupiter.api.Test;
+
+class ConnectorsImplCreateConnectorTest {
+
+  @Test
+  void accountDeletionFenceCompensatesStoredCredentials() {
+    var service = new ConnectorsImpl();
+    service.connectorRepo = mock(ConnectorRepository.class);
+    service.credentialResolver = mock(CredentialResolver.class);
+    var connector =
+        Connector.newBuilder()
+            .setResourceId(
+                ResourceId.newBuilder()
+                    .setAccountId("acct")
+                    .setId("connector-1")
+                    .setKind(ResourceKind.RK_CONNECTOR))
+            .build();
+    var deleting = new BaseResourceRepository.AccountDeletionInProgressException("acct");
+    doThrow(deleting).when(service.connectorRepo).create(connector);
+
+    var thrown =
+        assertThrows(
+            BaseResourceRepository.AccountDeletionInProgressException.class,
+            () ->
+                service.createConnectorWithCredentialCompensation(
+                    connector, true, "acct", "connector-1"));
+
+    assertSame(deleting, thrown);
+    verify(service.credentialResolver).delete("acct", "connector-1");
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
@@ -2205,6 +2205,14 @@ class CasBlobGcTest {
     }
 
     @Override
+    public List<Pointer> listPointersByPrefixConsistent(
+        String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+      List<Pointer> page =
+          delegate.listPointersByPrefixConsistent(prefix, limit, pageToken, nextTokenOut);
+      return page.stream().filter(ptr -> !hiddenFromScans.contains(ptr.getKey())).toList();
+    }
+
+    @Override
     public int deleteByPrefix(String prefix) {
       return delegate.deleteByPrefix(prefix);
     }
@@ -2212,6 +2220,11 @@ class CasBlobGcTest {
     @Override
     public int countByPrefix(String prefix) {
       return delegate.countByPrefix(prefix);
+    }
+
+    @Override
+    public int countByPrefixConsistent(String prefix) {
+      return delegate.countByPrefixConsistent(prefix);
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.common.rpc.PointerReferenceKind;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
@@ -238,6 +239,205 @@ class DurableReconcileJobStoreTest {
         store.enqueue(ACCOUNT_ID, CONNECTOR_ID, false, CaptureMode.METADATA_AND_CAPTURE, scope);
 
     assertEquals(first, second);
+  }
+
+  @Test
+  void cleanupAccountDeletesCanonicalGlobalIndexesAndLeaseExpiry() {
+    String jobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.empty());
+    assertEquals(jobId, store.leaseNext().orElseThrow().jobId);
+    String canonicalKey = Keys.reconcileJobPointerById(ACCOUNT_ID, jobId);
+    String lookupKey = Keys.reconcileJobLookupPointerById(jobId);
+    String leaseKey = Keys.reconcileJobLeasePointerById(ACCOUNT_ID, jobId);
+    ReconcileLeaseStore.LeaseExpiryEntry expiry =
+        store.leaseStore.scanExpiredLeasePointersPage(Long.MAX_VALUE, 100, "").entries().stream()
+            .filter(entry -> canonicalKey.equals(entry.canonicalPointerKey()))
+            .findFirst()
+            .orElseThrow();
+    String deletionFence = Keys.accountDeletionMarker(ACCOUNT_ID);
+    assertTrue(
+        store.pointerStore.compareAndSet(
+            deletionFence,
+            0L,
+            PointerReferences.opaqueMarkerPointer(deletionFence, "deleting", 1L)));
+
+    assertEquals(1, store.cleanupAccount(ACCOUNT_ID));
+
+    assertTrue(store.pointerStore.get(canonicalKey).isEmpty());
+    assertTrue(store.pointerStore.get(lookupKey).isEmpty());
+    assertTrue(store.pointerStore.get(leaseKey).isEmpty());
+    assertTrue(store.pointerStore.get(expiry.leaseExpiryPointerKey()).isEmpty());
+    assertTrue(store.pointerStore.get(deletionFence).isPresent());
+  }
+
+  @Test
+  void cleanupAccountConsumesFilteredPagesAndEncodedJobIds() {
+    for (int i = 0; i < 200; i++) {
+      String malformedKey = Keys.reconcileJobPointerByIdPrefix(ACCOUNT_ID) + "aa-invalid/" + i;
+      assertTrue(
+          store.pointerStore.compareAndSet(
+              malformedKey, 0L, PointerReferences.inlineJsonPointer(malformedKey, "{}", 1L)));
+    }
+    String jobId = "zz+encoded/job";
+    String canonicalKey = Keys.reconcileJobPointerById(ACCOUNT_ID, jobId);
+    String lookupKey = Keys.reconcileJobLookupPointerById(jobId);
+    ReconcileJobIndexCleanupManifest manifest =
+        new ReconcileJobIndexCleanupManifest(List.of(lookupKey), List.of());
+    assertTrue(
+        store.jobIndexBackend.compareAndSetBatch(
+            new ReconcileJobIndexStore.JobIndexWriteBatch(
+                List.of(
+                    new ReconcileJobIndexStore.JobIndexUpsert(
+                        canonicalKey,
+                        0L,
+                        "inline:reconcile-job:e30",
+                        PointerReferenceKind.PRK_INLINE_JSON,
+                        manifest),
+                    new ReconcileJobIndexStore.JobIndexUpsert(
+                        lookupKey, 0L, canonicalKey, PointerReferenceKind.PRK_POINTER_KEY)),
+                ReconcileJobIndexStore.ReadyQueueMutation.empty())));
+
+    assertEquals(1, store.cleanupAccount(ACCOUNT_ID));
+
+    assertTrue(store.pointerStore.get(canonicalKey).isEmpty());
+    assertTrue(store.pointerStore.get(lookupKey).isEmpty());
+  }
+
+  @Test
+  void cleanupAccountDeletesJobsWithoutUsableManifestsAndCancellationMarkerConverges() {
+    String emptyJobId = "empty-manifest";
+    String emptyCanonicalKey = Keys.reconcileJobPointerById(ACCOUNT_ID, emptyJobId);
+    String emptyLookupKey = Keys.reconcileJobLookupPointerById(emptyJobId);
+    String invalidJobId = "invalid-manifest";
+    String invalidCanonicalKey = Keys.reconcileJobPointerById(ACCOUNT_ID, invalidJobId);
+    String invalidLookupKey = Keys.reconcileJobLookupPointerById(invalidJobId);
+    ReconcileJobIndexCleanupManifest invalidManifest =
+        new ReconcileJobIndexCleanupManifest(List.of("/invalid/cleanup/reference"), List.of());
+    assertTrue(
+        store.jobIndexBackend.compareAndSetBatch(
+            new ReconcileJobIndexStore.JobIndexWriteBatch(
+                List.of(
+                    new ReconcileJobIndexStore.JobIndexUpsert(
+                        emptyCanonicalKey,
+                        0L,
+                        "inline:reconcile-job:e30",
+                        PointerReferenceKind.PRK_INLINE_JSON,
+                        ReconcileJobIndexCleanupManifest.EMPTY),
+                    new ReconcileJobIndexStore.JobIndexUpsert(
+                        emptyLookupKey,
+                        0L,
+                        emptyCanonicalKey,
+                        PointerReferenceKind.PRK_POINTER_KEY),
+                    new ReconcileJobIndexStore.JobIndexUpsert(
+                        invalidCanonicalKey,
+                        0L,
+                        "inline:reconcile-job:e30",
+                        PointerReferenceKind.PRK_INLINE_JSON,
+                        invalidManifest),
+                    new ReconcileJobIndexStore.JobIndexUpsert(
+                        invalidLookupKey,
+                        0L,
+                        invalidCanonicalKey,
+                        PointerReferenceKind.PRK_POINTER_KEY)),
+                ReconcileJobIndexStore.ReadyQueueMutation.empty())));
+
+    String cancellationMarkerKey = Keys.reconcileCancellationCleanupPointer(ACCOUNT_ID, emptyJobId);
+    String cancellationPayload =
+        ReconcileCancellationMaintenanceService.cancellationCleanupPayload(
+            new ReconcileCancellationMaintenanceService.CancellationCleanupRequest(
+                ACCOUNT_ID, emptyJobId, "", false, false, false));
+    assertTrue(
+        store.pointerStore.compareAndSet(
+            cancellationMarkerKey,
+            0L,
+            PointerReferences.opaqueMarkerPointer(cancellationMarkerKey, cancellationPayload, 1L)));
+    String deletionFence = Keys.accountDeletionMarker(ACCOUNT_ID);
+    assertTrue(
+        store.pointerStore.compareAndSet(
+            deletionFence,
+            0L,
+            PointerReferences.opaqueMarkerPointer(deletionFence, "deleting", 1L)));
+
+    assertEquals(2, store.cleanupAccount(ACCOUNT_ID));
+
+    assertTrue(store.pointerStore.get(emptyCanonicalKey).isEmpty());
+    assertTrue(store.pointerStore.get(emptyLookupKey).isEmpty());
+    assertTrue(store.pointerStore.get(invalidCanonicalKey).isEmpty());
+    assertTrue(store.pointerStore.get(invalidLookupKey).isEmpty());
+    assertTrue(store.pointerStore.get(cancellationMarkerKey).isPresent());
+
+    runCancellationMaintenance();
+
+    assertTrue(store.pointerStore.get(cancellationMarkerKey).isEmpty());
+  }
+
+  @Test
+  void deletionFenceRejectsNewReconcileJobsAndLeases() {
+    String jobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.empty());
+    String fence = Keys.accountDeletionMarker(ACCOUNT_ID);
+    assertTrue(
+        store.pointerStore.compareAndSet(
+            fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "deleting", 1L)));
+
+    assertTrue(store.leaseNext().isEmpty());
+    assertTrue(
+        store.pointerStore.get(Keys.reconcileJobLeasePointerById(ACCOUNT_ID, jobId)).isEmpty());
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            store.enqueue(
+                ACCOUNT_ID,
+                "another-connector",
+                false,
+                CaptureMode.METADATA_AND_CAPTURE,
+                ReconcileScope.empty()));
+  }
+
+  @Test
+  void expiredLeaseIndexConvergesWhenCanonicalJobIsGone() {
+    String jobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.empty());
+    assertEquals(jobId, store.leaseNext().orElseThrow().jobId);
+    String canonicalKey = Keys.reconcileJobPointerById(ACCOUNT_ID, jobId);
+    ReconcileLeaseStore.LeaseExpiryEntry expiry =
+        store.leaseStore.scanExpiredLeasePointersPage(Long.MAX_VALUE, 100, "").entries().stream()
+            .filter(entry -> canonicalKey.equals(entry.canonicalPointerKey()))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(store.pointerStore.delete(canonicalKey));
+
+    store.leaseStore.reclaimExpiredLease(expiry, Long.MAX_VALUE);
+
+    assertTrue(store.pointerStore.get(expiry.leaseExpiryPointerKey()).isEmpty());
+  }
+
+  @Test
+  void stateIndexConvergesWhenCanonicalJobIsGone() {
+    String missingCanonical = Keys.reconcileJobPointerById(ACCOUNT_ID, "missing-job");
+    String stateKey = Keys.reconcileJobByStatePointer("JS_QUEUED", 1L, ACCOUNT_ID, "missing-job");
+    assertTrue(
+        store.pointerStore.compareAndSet(
+            stateKey, 0L, PointerReferences.pointerKeyPointer(stateKey, missingCanonical, 1L)));
+
+    assertTrue(store.jobIndexStore.listStoredJobsInState("JS_QUEUED", 100, "").records().isEmpty());
+
+    assertTrue(store.pointerStore.get(stateKey).isEmpty());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -7804,6 +7804,12 @@ class DurableReconcileJobStoreTest {
     }
 
     @Override
+    public List<Pointer> listPointersByPrefixConsistent(
+        String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+      return delegate.listPointersByPrefixConsistent(prefix, limit, pageToken, nextTokenOut);
+    }
+
+    @Override
     public int deleteByPrefix(String prefix) {
       return delegate.deleteByPrefix(prefix);
     }
@@ -7811,6 +7817,11 @@ class DurableReconcileJobStoreTest {
     @Override
     public int countByPrefix(String prefix) {
       return delegate.countByPrefix(prefix);
+    }
+
+    @Override
+    public int countByPrefixConsistent(String prefix) {
+      return delegate.countByPrefixConsistent(prefix);
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -420,11 +420,18 @@ class DurableReconcileJobStoreTest {
             .filter(entry -> canonicalKey.equals(entry.canonicalPointerKey()))
             .findFirst()
             .orElseThrow();
-    assertTrue(store.pointerStore.delete(canonicalKey));
+    var canonical = store.jobIndexBackend.loadIndexEntry(canonicalKey).orElseThrow();
+    assertTrue(
+        store.jobIndexBackend.compareAndSetBatch(
+            new ReconcileJobIndexStore.JobIndexWriteBatch(
+                List.of(
+                    new ReconcileJobIndexStore.JobIndexDelete(
+                        canonical.pointerKey(), canonical.version())),
+                ReconcileJobIndexStore.ReadyQueueMutation.empty())));
 
     store.leaseStore.reclaimExpiredLease(expiry, Long.MAX_VALUE);
 
-    assertTrue(store.pointerStore.get(expiry.leaseExpiryPointerKey()).isEmpty());
+    assertTrue(store.leaseBackend.loadLeaseExpiry(expiry.leaseExpiryPointerKey()).isEmpty());
   }
 
   @Test
@@ -432,12 +439,16 @@ class DurableReconcileJobStoreTest {
     String missingCanonical = Keys.reconcileJobPointerById(ACCOUNT_ID, "missing-job");
     String stateKey = Keys.reconcileJobByStatePointer("JS_QUEUED", 1L, ACCOUNT_ID, "missing-job");
     assertTrue(
-        store.pointerStore.compareAndSet(
-            stateKey, 0L, PointerReferences.pointerKeyPointer(stateKey, missingCanonical, 1L)));
+        store.jobIndexBackend.compareAndSetBatch(
+            new ReconcileJobIndexStore.JobIndexWriteBatch(
+                List.of(
+                    new ReconcileJobIndexStore.JobIndexUpsert(
+                        stateKey, 0L, missingCanonical, PointerReferenceKind.PRK_POINTER_KEY)),
+                ReconcileJobIndexStore.ReadyQueueMutation.empty())));
 
     assertTrue(store.jobIndexStore.listStoredJobsInState("JS_QUEUED", 100, "").records().isEmpty());
 
-    assertTrue(store.pointerStore.get(stateKey).isEmpty());
+    assertTrue(store.jobIndexBackend.loadIndexEntry(stateKey).isEmpty());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
@@ -597,7 +597,46 @@ class ReconcileMaintenanceServicesTest {
 
     @Override
     public boolean compareAndSetBatch(List<CasOp> ops) {
-      throw new UnsupportedOperationException();
+      synchronized (pointers) {
+        var keys = new java.util.HashSet<String>();
+        for (CasOp op : ops) {
+          if (!keys.add(op.key())) {
+            throw new IllegalArgumentException("duplicate pointer key in batch: " + op.key());
+          }
+          Pointer current = pointers.get(op.key());
+          if (op instanceof CasUpsert upsert) {
+            long currentVersion = current == null ? 0L : current.getVersion();
+            if (currentVersion != upsert.expectedVersion()) {
+              return false;
+            }
+          } else if (op instanceof CasDelete delete) {
+            if (current == null || current.getVersion() != delete.expectedVersion()) {
+              return false;
+            }
+          } else if (op instanceof CasCheck check) {
+            if (current == null || current.getVersion() != check.expectedVersion()) {
+              return false;
+            }
+          } else if (op instanceof CasCheckAbsent && current != null) {
+            return false;
+          }
+        }
+        for (CasOp op : ops) {
+          if (op instanceof CasUpsert upsert) {
+            pointers.put(
+                upsert.key(),
+                upsert.next().toBuilder()
+                    .setKey(upsert.key())
+                    .setVersion(upsert.expectedVersion() + 1L)
+                    .build());
+          } else if (op instanceof UnconditionalUpsert upsert) {
+            pointers.put(upsert.key(), upsert.next().toBuilder().setKey(upsert.key()).build());
+          } else if (op instanceof CasDelete delete) {
+            pointers.remove(delete.key());
+          }
+        }
+        return true;
+      }
     }
 
     @Override
@@ -759,6 +798,11 @@ class ReconcileMaintenanceServicesTest {
     @Override
     public boolean clearLeaseIfEpochMatches(String accountId, String jobId, String leaseEpoch) {
       return false;
+    }
+
+    @Override
+    public boolean deleteAccountJobLease(String accountId, String jobId) {
+      return true;
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
@@ -629,6 +629,12 @@ class ReconcileMaintenanceServicesTest {
     }
 
     @Override
+    public List<Pointer> listPointersByPrefixConsistent(
+        String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+      return listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
+    }
+
+    @Override
     public String pageTokenAfterKey(String key) {
       return key;
     }
@@ -650,6 +656,11 @@ class ReconcileMaintenanceServicesTest {
         }
       }
       return count;
+    }
+
+    @Override
+    public int countByPrefixConsistent(String prefix) {
+      return countByPrefix(prefix);
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackendTest.java
@@ -103,15 +103,20 @@ class DynamoReconcileJobIndexBackendTest {
         ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
     verify(dynamoDb).transactWriteItems(captor.capture());
     var items = captor.getValue().transactItems();
-    assertEquals(2, items.size());
-    var item = items.getFirst().put().item();
+    assertEquals(3, items.size());
+    var item = items.stream().filter(tx -> tx.put() != null).findFirst().orElseThrow().put().item();
     assertEquals("reconcile-job-lookup", item.get(ATTR_PARTITION_KEY).s());
     assertEquals("job/" + JOB_ID, item.get(ATTR_SORT_KEY).s());
     assertEquals(JobIndexBackendSupport.KIND_LOOKUP, item.get(ATTR_KIND).s());
     assertEquals(LOOKUP_KEY, item.get(JobIndexBackendSupport.ATTR_POINTER_KEY).s());
     assertEquals(CANONICAL_KEY, item.get(JobIndexBackendSupport.ATTR_BLOB_URI).s());
-    assertEquals(
-        "reconcile-job/by-id", items.get(1).conditionCheck().key().get(ATTR_PARTITION_KEY).s());
+    assertTrue(
+        items.stream()
+            .filter(tx -> tx.conditionCheck() != null)
+            .anyMatch(
+                tx ->
+                    "reconcile-job/by-id"
+                        .equals(tx.conditionCheck().key().get(ATTR_PARTITION_KEY).s())));
   }
 
   @Test
@@ -858,7 +863,12 @@ class DynamoReconcileJobIndexBackendTest {
         ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
     verify(dynamoDb).transactWriteItems(captor.capture());
     assertEquals(1, captor.getValue().transactItems().size());
-    var put = captor.getValue().transactItems().getFirst().put();
+    var put =
+        captor.getValue().transactItems().stream()
+            .filter(tx -> tx.put() != null)
+            .findFirst()
+            .orElseThrow()
+            .put();
     assertNull(put.conditionExpression());
     assertEquals("37", put.item().get(ATTR_VERSION).n());
   }
@@ -955,7 +965,13 @@ class DynamoReconcileJobIndexBackendTest {
     ArgumentCaptor<TransactWriteItemsRequest> txCaptor =
         ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
     verify(dynamoDb).transactWriteItems(txCaptor.capture());
-    var item = txCaptor.getValue().transactItems().getFirst().put().item();
+    var item =
+        txCaptor.getValue().transactItems().stream()
+            .filter(tx -> tx.put() != null)
+            .findFirst()
+            .orElseThrow()
+            .put()
+            .item();
     assertEquals(
         LOOKUP_KEY,
         item.get(JobIndexBackendSupport.ATTR_CLEANUP_INDEX_POINTER_KEYS).l().getFirst().s());

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackendUnitTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileLeaseBackendUnitTest.java
@@ -66,12 +66,17 @@ class DynamoReconcileLeaseBackendUnitTest {
         ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
     verify(dynamoDb).transactWriteItems(captor.capture());
     var items = captor.getValue().transactItems();
-    assertEquals(2, items.size());
-    var item = items.getFirst().put().item();
+    assertEquals(3, items.size());
+    var item = items.stream().filter(tx -> tx.put() != null).findFirst().orElseThrow().put().item();
     assertEquals("reconcile-job-lookup", item.get(ATTR_PARTITION_KEY).s());
     assertEquals("job/" + JOB_ID, item.get(ATTR_SORT_KEY).s());
-    assertEquals(
-        "reconcile-job/by-id", items.get(1).conditionCheck().key().get(ATTR_PARTITION_KEY).s());
+    assertTrue(
+        items.stream()
+            .filter(tx -> tx.conditionCheck() != null)
+            .anyMatch(
+                tx ->
+                    "reconcile-job/by-id"
+                        .equals(tx.conditionCheck().key().get(ATTR_PARTITION_KEY).s())));
   }
 
   @Test
@@ -158,7 +163,12 @@ class DynamoReconcileLeaseBackendUnitTest {
     ArgumentCaptor<TransactWriteItemsRequest> captor =
         ArgumentCaptor.forClass(TransactWriteItemsRequest.class);
     verify(dynamoDb).transactWriteItems(captor.capture());
-    var update = captor.getValue().transactItems().getFirst().update();
+    var update =
+        captor.getValue().transactItems().stream()
+            .filter(tx -> tx.update() != null)
+            .findFirst()
+            .orElseThrow()
+            .update();
     assertEquals(LOOKUP_KEY, update.expressionAttributeValues().get(":idx").l().getFirst().s());
     assertEquals(projectionKey, update.expressionAttributeValues().get(":ptr").l().getFirst().s());
     assertTrue(update.expressionAttributeValues().get(":true").bool());

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileJobIndexBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileJobIndexBackendTest.java
@@ -32,6 +32,46 @@ import org.junit.jupiter.api.Test;
 class MemoryReconcileJobIndexBackendTest {
 
   @Test
+  void accountDeletionFenceRejectsUpsertsButAllowsCleanupDeletes() {
+    String accountId = "acct-1";
+    String canonicalKey = Keys.reconcileJobPointerById(accountId, "job-1");
+    InMemoryPointerStore pointers = new InMemoryPointerStore();
+    MemoryReconcileJobIndexBackend backend = new MemoryReconcileJobIndexBackend(pointers);
+    var create =
+        new ReconcileJobIndexStore.JobIndexWriteBatch(
+            List.of(
+                new ReconcileJobIndexStore.JobIndexUpsert(
+                    canonicalKey,
+                    0L,
+                    "inline:reconcile-job:e30",
+                    PointerReferenceKind.PRK_INLINE_JSON,
+                    new ReconcileJobIndexCleanupManifest(
+                        List.of(Keys.reconcileJobLookupPointerById("job-1")), List.of()))),
+            ReconcileJobIndexStore.ReadyQueueMutation.empty());
+    assertTrue(backend.compareAndSetBatch(create));
+    String fence = Keys.accountDeletionMarker(accountId);
+    assertTrue(
+        pointers.compareAndSet(
+            fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "deleting", 1L)));
+
+    assertFalse(
+        backend.compareAndSetBatch(
+            new ReconcileJobIndexStore.JobIndexWriteBatch(
+                List.of(
+                    new ReconcileJobIndexStore.JobIndexUpsert(
+                        Keys.reconcileJobPointerById(accountId, "job-2"),
+                        0L,
+                        "inline:reconcile-job:e30",
+                        PointerReferenceKind.PRK_INLINE_JSON)),
+                ReconcileJobIndexStore.ReadyQueueMutation.empty())));
+    assertTrue(
+        backend.compareAndSetBatch(
+            new ReconcileJobIndexStore.JobIndexWriteBatch(
+                List.of(new ReconcileJobIndexStore.JobIndexDelete(canonicalKey, 1L)),
+                ReconcileJobIndexStore.ReadyQueueMutation.empty())));
+  }
+
+  @Test
   void clearInMemoryStateDropsCleanupMetadataAndMigrationState() {
     String canonicalKey = Keys.reconcileJobPointerById("acct", "job");
     String lookupKey = Keys.reconcileJobLookupPointerById("job");

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileLeaseBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileLeaseBackendTest.java
@@ -34,13 +34,13 @@ class MemoryReconcileLeaseBackendTest {
   private static final String CANONICAL_KEY = Keys.reconcileJobPointerById(ACCOUNT_ID, JOB_ID);
 
   @Test
-  void leaseRecordKeyPreservesAndParsesLegacyRawSegments() {
+  void leaseRecordKeyEncodesOpaqueSegments() {
     String pointerKey = LeaseBackendSupport.leasePointerKey("acct+legacy", "job%legacy");
 
-    assertEquals("/accounts/acct+legacy/reconcile/job-leases/by-id/job%legacy", pointerKey);
+    assertEquals("/accounts/acct%2Blegacy/reconcile/job-leases/by-id/job%25legacy", pointerKey);
     var parsed = LeaseBackendSupport.parseLeasePointerKey(pointerKey);
-    assertEquals("acct+legacy", parsed.accountSegment());
-    assertEquals("job%legacy", parsed.jobSegment());
+    assertEquals("acct%2Blegacy", parsed.accountSegment());
+    assertEquals("job%25legacy", parsed.jobSegment());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileJobIndexStorePointerSetTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileJobIndexStorePointerSetTest.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJo
 import ai.floedb.floecat.service.reconciler.jobs.durable.storage.ReconcileJobIndexes;
 import ai.floedb.floecat.service.reconciler.jobs.durable.storage.ReconcilePayloadStore;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
@@ -175,6 +176,28 @@ class NativeReconcileJobIndexStorePointerSetTest {
     assertEquals(canonicalKey, delete.pointerKey());
     assertEquals(7L, delete.expectedVersion());
     assertTrue(delete.requireCleanupLock());
+  }
+
+  @Test
+  void stateIndexReadIgnoresBestEffortOrphanDeleteFailure() {
+    String missingCanonical = Keys.reconcileJobPointerById(ACCOUNT_ID, "missing-job");
+    String stateKey = Keys.reconcileJobByStatePointer("JS_QUEUED", 1L, ACCOUNT_ID, "missing-job");
+    assertTrue(
+        pointers.compareAndSet(
+            stateKey, 0L, PointerReferences.pointerKeyPointer(stateKey, missingCanonical, 1L)));
+    MemoryReconcileJobIndexBackend failingBackend =
+        new MemoryReconcileJobIndexBackend(pointers) {
+          @Override
+          public boolean compareAndSetBatch(ReconcileJobIndexStore.JobIndexWriteBatch batch) {
+            throw new RuntimeException("injected orphan cleanup failure");
+          }
+        };
+    NativeReconcileJobIndexStore failingStore = new NativeReconcileJobIndexStore();
+    failingStore.bind(
+        failingBackend, payloadStore(), indexes, 4, (previous, current) -> {}, (a, b, op) -> {});
+
+    assertTrue(failingStore.listStoredJobsInState("JS_QUEUED", 100, "").records().isEmpty());
+    assertTrue(pointers.get(stateKey).isPresent());
   }
 
   @Test
@@ -430,8 +453,8 @@ class NativeReconcileJobIndexStorePointerSetTest {
                         ai.floedb.floecat.common.rpc.PointerReferenceKind.PRK_INLINE_JSON,
                         new ReconcileJobIndexCleanupManifest(referenceKeys, List.of()))),
                 ReconcileJobIndexStore.ReadyQueueMutation.empty())));
-    for (int offset = 0; offset < seedWrites.size(); offset += 100) {
-      int end = Math.min(seedWrites.size(), offset + 100);
+    for (int offset = 0; offset < seedWrites.size(); offset += 99) {
+      int end = Math.min(seedWrites.size(), offset + 99);
       assertTrue(
           backend.compareAndSetBatch(
               new ReconcileJobIndexStore.JobIndexWriteBatch(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileLeaseStore.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileLeaseStore.java
@@ -478,6 +478,14 @@ public final class InMemoryReconcileLeaseStore implements ReconcileLeaseStore {
   }
 
   @Override
+  public boolean deleteAccountJobLease(String accountId, String jobId) {
+    synchronized (state) {
+      StoredJobLease current = state.leasesByJob.get(jobStateKey(accountId, jobId));
+      return current == null || clearLeaseIfEpochMatches(accountId, jobId, current.epoch);
+    }
+  }
+
+  @Override
   public boolean tryAcquireLaneLease(
       StoredReconcileJob record, String canonicalPointerKey, long nowMs) {
     if (record == null

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
@@ -333,6 +333,32 @@ class GenericResourceRepositoryCreateTest {
   }
 
   @Test
+  void prepareDeleteOps_handlesCanonicalPointerWithoutBlobReference() {
+    var repo =
+        new GenericResourceRepository<>(
+            ptr,
+            blobs,
+            Schemas.CATALOG,
+            Catalog::parseFrom,
+            Catalog::toByteArray,
+            "application/x-protobuf");
+    var value = catalog("catalog-1", "alpha");
+    var key = new CatalogKey("acct", "catalog-1");
+    repo.create(value);
+    String canonicalKey = Keys.catalogPointerById("acct", "catalog-1");
+    assertThat(
+            ptr.compareAndSet(
+                canonicalKey,
+                1L,
+                PointerReferences.opaqueMarkerPointer(canonicalKey, "corrupt", 2L)))
+        .isTrue();
+
+    List<PointerStore.CasOp> ops = repo.prepareDeleteOps(key);
+
+    assertThat(ops).containsExactly(new PointerStore.CasDelete(canonicalKey, 2L));
+  }
+
+  @Test
   void deleteWithPrecondition_whenBatchThrows_leavesCanonicalAndSecondaryUntouched() {
     var baseRepo = new AccountRepository(ptr, blobs);
     var account = account("acct-1", "alpha", "");
@@ -407,7 +433,7 @@ class GenericResourceRepositoryCreateTest {
   }
 
   @Test
-  void delete_whenResourceBlobIsCorrupt_removesCanonicalPointer() {
+  void delete_whenResourceBlobIsCorrupt_removesCanonicalAndSecondaryPointers() {
     var repo = new AccountRepository(ptr, blobs);
     var account = account("acct-1", "alpha", "");
     repo.create(account);
@@ -418,7 +444,7 @@ class GenericResourceRepositoryCreateTest {
     assertThat(repo.delete(account.getResourceId())).isTrue();
 
     assertThat(ptr.get(Keys.accountPointerById("acct-1"))).isEmpty();
-    assertThat(ptr.get(Keys.accountPointerByName("alpha"))).isPresent();
+    assertThat(ptr.get(Keys.accountPointerByName("alpha"))).isEmpty();
   }
 
   @Test
@@ -453,6 +479,7 @@ class GenericResourceRepositoryCreateTest {
         .isTrue();
 
     assertThat(ptr.get(canonicalKey)).isEmpty();
+    assertThat(ptr.get(Keys.accountPointerByName("alpha"))).isEmpty();
     assertThat(ptr.get(companionKey)).isEmpty();
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ai.floedb.floecat.account.rpc.Account;
+import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
@@ -28,6 +29,7 @@ import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.ConflictingBatc
 import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.DuplicateKeyRejectingPointerStore;
 import ai.floedb.floecat.service.repo.impl.RepoTestPointerStores.FailingBatchPointerStore;
 import ai.floedb.floecat.service.repo.model.AccountKey;
+import ai.floedb.floecat.service.repo.model.CatalogKey;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.model.Schemas;
@@ -71,6 +73,21 @@ class GenericResourceRepositoryCreateTest {
         .build();
   }
 
+  private static Catalog catalog(String id, String name) {
+    return Catalog.newBuilder()
+        .setResourceId(
+            ResourceId.newBuilder().setAccountId("acct").setId(id).setKind(ResourceKind.RK_CATALOG))
+        .setDisplayName(name)
+        .build();
+  }
+
+  private void installAccountDeletionFence(String accountId) {
+    String key = Keys.accountDeletionMarker(accountId);
+    assertThat(
+            ptr.compareAndSet(key, 0L, PointerReferences.opaqueMarkerPointer(key, "deleting", 1L)))
+        .isTrue();
+  }
+
   @Test
   void create_happyPath_resolvesByIdAndByName_atVersionOne() {
     var repo = new AccountRepository(ptr, blobs);
@@ -83,6 +100,81 @@ class GenericResourceRepositoryCreateTest {
     assertThat(ptr.get(Keys.accountPointerById("acct-1")).orElseThrow().getVersion()).isEqualTo(1L);
     assertThat(ptr.get(Keys.accountPointerByName("alpha")).orElseThrow().getVersion())
         .isEqualTo(1L);
+  }
+
+  @Test
+  void createDuringAccountDeletionUsesTypedFailureAndReclaimsReservedBlob() {
+    var racingFence =
+        new RepoTestPointerStores.DelegatingPointerStore(ptr) {
+          @Override
+          public boolean compareAndSetBatch(List<PointerStore.CasOp> ops) {
+            installAccountDeletionFence("acct-1");
+            return super.compareAndSetBatch(ops);
+          }
+        };
+    var repo = new AccountRepository(racingFence, blobs);
+    var value = account("acct-1", "alpha", "");
+    String blobUri = Schemas.ACCOUNT.blobUriForKey.apply(Schemas.ACCOUNT.keyFromValue.apply(value));
+
+    assertThatThrownBy(() -> repo.create(value))
+        .isInstanceOf(BaseResourceRepository.AccountDeletionInProgressException.class)
+        .extracting("accountId")
+        .isEqualTo("acct-1");
+
+    assertThat(ptr.get(Keys.accountPointerById("acct-1"))).isEmpty();
+    assertThat(ptr.get(Keys.accountPointerByName("alpha"))).isEmpty();
+    assertThat(blobs.head(blobUri)).isEmpty();
+  }
+
+  @Test
+  void updateDuringAccountDeletionUsesTypedFailureAndPreservesResource() {
+    var repo =
+        new GenericResourceRepository<>(
+            ptr,
+            blobs,
+            Schemas.CATALOG,
+            Catalog::parseFrom,
+            Catalog::toByteArray,
+            "application/x-protobuf");
+    var current = catalog("catalog-1", "alpha");
+    repo.create(current);
+    installAccountDeletionFence("acct");
+
+    assertThatThrownBy(() -> repo.update(current.toBuilder().setDisplayName("beta").build(), 1L))
+        .isInstanceOf(BaseResourceRepository.AccountDeletionInProgressException.class);
+
+    assertThat(repo.getByKey(new CatalogKey("acct", "catalog-1"))).contains(current);
+    assertThat(ptr.get(Keys.catalogPointerByName("acct", "alpha"))).isPresent();
+    assertThat(ptr.get(Keys.catalogPointerByName("acct", "beta"))).isEmpty();
+  }
+
+  @Test
+  void replacementDuringAccountDeletionUsesTypedFailureAndPreservesCurrentIdentity() {
+    var repo =
+        new GenericResourceRepository<>(
+            ptr,
+            blobs,
+            Schemas.CATALOG,
+            Catalog::parseFrom,
+            Catalog::toByteArray,
+            "application/x-protobuf");
+    var current = catalog("catalog-1", "alpha");
+    var replacement = catalog("catalog-2", "alpha");
+    repo.create(current);
+    installAccountDeletionFence("acct");
+
+    assertThatThrownBy(
+            () ->
+                repo.replaceIdentityWithMeta(
+                    current,
+                    1L,
+                    replacement,
+                    GenericResourceRepository.PointerConditions.none(),
+                    Map.of()))
+        .isInstanceOf(BaseResourceRepository.AccountDeletionInProgressException.class);
+
+    assertThat(repo.getByKey(new CatalogKey("acct", "catalog-1"))).contains(current);
+    assertThat(repo.getByKey(new CatalogKey("acct", "catalog-2"))).isEmpty();
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
@@ -58,6 +58,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -73,6 +74,43 @@ class IndexArtifactRepositoryTest {
   private static IndexArtifactRepository createRepository(
       PointerStore pointers, BlobStore blobs, ImmutableBlobCache cache) {
     return new IndexArtifactRepository(pointers, blobs, cache, new TableBlobReachabilityGuard());
+  }
+
+  @Test
+  void directArtifactWriteDeletesBlobWhenAccountFenceWinsPublicationRace() {
+    InMemoryPointerStore pointers = new InMemoryPointerStore();
+    AtomicBoolean installFence = new AtomicBoolean(true);
+    InMemoryBlobStore blobs =
+        new InMemoryBlobStore() {
+          @Override
+          public void put(String uri, byte[] bytes, String contentType) {
+            super.put(uri, bytes, contentType);
+            if (uri.startsWith(Keys.tableBlobPrefix(TABLE_ID.getAccountId(), TABLE_ID.getId()))
+                && installFence.compareAndSet(true, false)) {
+              String fence = Keys.accountDeletionMarker(TABLE_ID.getAccountId());
+              pointers.compareAndSet(
+                  fence,
+                  0L,
+                  ai.floedb.floecat.service.repo.model.PointerReferences.opaqueMarkerPointer(
+                      fence, "deleting", 1L));
+            }
+          }
+        };
+    IndexArtifactRepository repository = createRepository(pointers, blobs);
+
+    assertThatThrownBy(
+            () -> repository.putIndexArtifact(indexRecord(714L, "s3://bucket/file.parquet")))
+        .isInstanceOf(BaseResourceRepository.AccountDeletionInProgressException.class);
+
+    assertThat(
+            blobs
+                .list(Keys.tableBlobPrefix(TABLE_ID.getAccountId(), TABLE_ID.getId()), 100, "")
+                .keys())
+        .isEmpty();
+    assertThat(
+            pointers.countByPrefix(
+                Keys.snapshotRootPrefix(TABLE_ID.getAccountId(), TABLE_ID.getId())))
+        .isZero();
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/RepoTestPointerStores.java
@@ -74,6 +74,12 @@ final class RepoTestPointerStores {
     }
 
     @Override
+    public List<Pointer> listPointersByPrefixConsistent(
+        String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+      return delegate.listPointersByPrefixConsistent(prefix, limit, pageToken, nextTokenOut);
+    }
+
+    @Override
     public int deleteByPrefix(String prefix) {
       return delegate.deleteByPrefix(prefix);
     }
@@ -81,6 +87,11 @@ final class RepoTestPointerStores {
     @Override
     public int countByPrefix(String prefix) {
       return delegate.countByPrefix(prefix);
+    }
+
+    @Override
+    public int countByPrefixConsistent(String prefix) {
+      return delegate.countByPrefixConsistent(prefix);
     }
 
     @Override

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -2243,24 +2243,15 @@ class StatsRepositoryTargetStorageTest {
                   key, 0L, PointerReferences.blobPointer(key, "blob-" + i, 1L)))
           .isTrue();
     }
-    long deadline = System.currentTimeMillis() + 20L;
     var observedTokens = new ArrayList<String>();
     PointerStore pointers =
         new RepoTestPointerStores.DelegatingPointerStore(rawPointers) {
-          private boolean delayed;
-
           @Override
           public List<Pointer> listPointersByPrefix(
               String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
             List<Pointer> page = super.listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
             if (prefix.equals(Keys.snapshotRootPrefix(TABLE_ID.getAccountId(), TABLE_ID.getId()))) {
               observedTokens.add(pageToken);
-              if (!delayed && !pageToken.isBlank()) {
-                delayed = true;
-                while (System.currentTimeMillis() <= deadline) {
-                  Thread.onSpinWait();
-                }
-              }
             }
             return page;
           }
@@ -2268,27 +2259,16 @@ class StatsRepositoryTargetStorageTest {
     StatsRepository repository = new StatsRepository(pointers, new InMemoryBlobStore());
     var continuation = new StatsRepository.GenerationGcContinuation();
 
-    StatsRepository.GenerationGcResult first =
-        repository.deleteUnreferencedGenerations(
-            TABLE_ID, ignored -> false, System.currentTimeMillis(), 0L, 10, deadline, continuation);
+    assertThat(repository.discoverGenerationKeysPage(TABLE_ID, Long.MAX_VALUE, continuation))
+        .isTrue();
     String savedToken = continuation.pointerContinuationToken();
-    assertThat(first.pending()).isTrue();
     assertThat(savedToken).isNotBlank();
 
     observedTokens.clear();
-    StatsRepository.GenerationGcResult resumed =
-        repository.deleteUnreferencedGenerations(
-            TABLE_ID,
-            ignored -> false,
-            System.currentTimeMillis(),
-            0L,
-            10,
-            System.currentTimeMillis() + 5_000L,
-            continuation);
+    assertThat(repository.discoverGenerationKeys(TABLE_ID, Long.MAX_VALUE, continuation)).isTrue();
 
     assertThat(observedTokens).isNotEmpty();
     assertThat(observedTokens.getFirst()).isEqualTo(savedToken);
-    assertThat(resumed.pending()).isFalse();
     assertThat(continuation.generations())
         .containsExactly(new Keys.GenerationKey(snapshotId, generationId));
   }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -76,6 +76,48 @@ class StatsRepositoryTargetStorageTest {
       ResourceId.newBuilder().setAccountId("a").setId("t").setKind(ResourceKind.RK_TABLE).build();
 
   @Test
+  void targetStatsWriteDeletesBlobWhenAccountFenceWinsPublicationRace() {
+    InMemoryPointerStore pointers = new InMemoryPointerStore();
+    InMemoryBlobStore storedBlobs = new InMemoryBlobStore();
+    long snapshotId = 98L;
+    StatsRepository seed = new StatsRepository(pointers, storedBlobs);
+    seed.putTargetStats(
+        TargetStatsRecords.fileRecord(
+            TABLE_ID,
+            snapshotId,
+            FileTargetStats.newBuilder().setFilePath("s3://bucket/seed.parquet").build()));
+    AtomicBoolean installFence = new AtomicBoolean(true);
+    AtomicReference<String> racedBlob = new AtomicReference<>();
+    BlobStore racingBlobs =
+        new DelegatingBlobStore(storedBlobs) {
+          @Override
+          public void put(String uri, byte[] bytes, String contentType) {
+            super.put(uri, bytes, contentType);
+            if (uri.startsWith(Keys.tableBlobPrefix(TABLE_ID.getAccountId(), TABLE_ID.getId()))
+                && installFence.compareAndSet(true, false)) {
+              racedBlob.set(uri);
+              String fence = Keys.accountDeletionMarker(TABLE_ID.getAccountId());
+              pointers.compareAndSet(
+                  fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "deleting", 1L));
+            }
+          }
+        };
+    StatsRepository repository = new StatsRepository(pointers, racingBlobs);
+    TargetStatsRecord raced =
+        TargetStatsRecords.fileRecord(
+            TABLE_ID,
+            snapshotId,
+            FileTargetStats.newBuilder().setFilePath("s3://bucket/raced.parquet").build());
+
+    assertThatThrownBy(() -> repository.putTargetStats(raced))
+        .isInstanceOf(BaseResourceRepository.AccountDeletionInProgressException.class);
+
+    assertThat(racedBlob).doesNotHaveNullValue();
+    assertThat(storedBlobs.head(racedBlob.get())).isEmpty();
+    assertThat(repository.getTargetStats(TABLE_ID, snapshotId, raced.getTarget())).isEmpty();
+  }
+
+  @Test
   void bundledPrewrittenStatsResolveAllTargetsWithOneBlobRead() {
     InMemoryPointerStore pointers = new InMemoryPointerStore();
     AtomicInteger bundleGets = new AtomicInteger();
@@ -669,7 +711,7 @@ class StatsRepositoryTargetStorageTest {
             new StatsStore.PrewrittenStatsObject(
                 secondObjectUri, objectBytes.length, new byte[32])));
 
-    assertThat(batchCalls).hasValue(1);
+    assertThat(batchCalls).hasValue(2);
     String generationPointerPrefix =
         Keys.snapshotTargetStatsGenerationPointerPrefix(
             TABLE_ID.getAccountId(), TABLE_ID.getId(), snapshotId, generationId);
@@ -1318,6 +1360,59 @@ class StatsRepositoryTargetStorageTest {
         .contains(existing);
     assertThat(repository.getTargetStats(TABLE_ID, snapshotId, missing.getTarget()))
         .contains(missing);
+  }
+
+  @Test
+  void putTargetStatsBatchIfAbsentPreservesPreexistingBlobWhenAccountFenceWins() throws Exception {
+    InMemoryPointerStore pointers = new InMemoryPointerStore();
+    InMemoryBlobStore storedBlobs = new InMemoryBlobStore();
+    long snapshotId = 9195L;
+    StatsRepository seed = new StatsRepository(pointers, storedBlobs);
+    seed.putTargetStats(
+        TargetStatsRecords.fileRecord(
+            TABLE_ID,
+            snapshotId,
+            FileTargetStats.newBuilder().setFilePath("s3://bucket/seed.parquet").build()));
+    String activeManifestUri = seed.activeStatsGeneration(TABLE_ID, snapshotId).orElseThrow();
+    String generationId = StringValue.parseFrom(storedBlobs.get(activeManifestUri)).getValue();
+    TargetStatsRecord preexisting =
+        TargetStatsRecords.columnRecord(
+            TABLE_ID,
+            snapshotId,
+            8L,
+            ScalarStats.newBuilder().setDisplayName("c8").setRowCount(13L).build(),
+            null);
+    seed.putTargetStatsIfAbsent(preexisting);
+    String preexistingPointer =
+        Keys.snapshotTargetStatsGenerationPointer(
+            TABLE_ID.getAccountId(),
+            TABLE_ID.getId(),
+            snapshotId,
+            generationId,
+            StatsTargetIdentity.storageId(preexisting.getTarget()));
+    String preexistingBlob = pointers.get(preexistingPointer).orElseThrow().getBlobUri();
+    pointers.delete(preexistingPointer);
+    AtomicBoolean installFence = new AtomicBoolean(true);
+    BlobStore racingBlobs =
+        new DelegatingBlobStore(storedBlobs) {
+          @Override
+          public void put(String uri, byte[] bytes, String contentType) {
+            super.put(uri, bytes, contentType);
+            if (preexistingBlob.equals(uri) && installFence.compareAndSet(true, false)) {
+              String fence = Keys.accountDeletionMarker(TABLE_ID.getAccountId());
+              pointers.compareAndSet(
+                  fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "deleting", 1L));
+            }
+          }
+        };
+    StatsRepository repository = new StatsRepository(pointers, racingBlobs);
+
+    assertThatThrownBy(
+            () ->
+                repository.putTargetStatsBatchIfAbsent(TABLE_ID, snapshotId, List.of(preexisting)))
+        .isInstanceOf(BaseResourceRepository.AccountDeletionInProgressException.class);
+
+    assertThat(storedBlobs.head(preexistingBlob)).isPresent();
   }
 
   @Test
@@ -2600,7 +2695,7 @@ class StatsRepositoryTargetStorageTest {
     repository.registerPrewrittenStatsReferencesInGeneration(
         TABLE_ID, snapshotId, generationId, references);
 
-    assertThat(batchCalls).hasValue(3);
+    assertThat(batchCalls).hasValue(4);
     assertThat(batchReads).hasValue(0);
     // Lifecycle and deletion-fence checks are point reads; no secondary indexes are maintained.
     assertThat(individualReads).hasValue(3);
@@ -2773,11 +2868,17 @@ class StatsRepositoryTargetStorageTest {
     var pointerStore =
         new RepoTestPointerStores.DelegatingPointerStore(pointerDelegate) {
           @Override
-          public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
-            if (manifestPointer.equals(key) && failActivation.compareAndSet(true, false)) {
+          public boolean compareAndSetBatch(List<CasOp> ops) {
+            boolean activatesManifest =
+                ops.stream()
+                    .anyMatch(
+                        op ->
+                            op instanceof PointerStore.CasUpsert upsert
+                                && manifestPointer.equals(upsert.key()));
+            if (activatesManifest && failActivation.compareAndSet(true, false)) {
               throw new StorageAbortRetryableException("injected activation failure");
             }
-            return super.compareAndSet(key, expectedVersion, next);
+            return super.compareAndSetBatch(ops);
           }
         };
     StatsRepository repository = new StatsRepository(pointerStore, new InMemoryBlobStore());
@@ -2814,11 +2915,17 @@ class StatsRepositoryTargetStorageTest {
     var pointerStore =
         new RepoTestPointerStores.DelegatingPointerStore(pointerDelegate) {
           @Override
-          public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
-            if (manifestPointer.equals(key) && failActivation.compareAndSet(true, false)) {
+          public boolean compareAndSetBatch(List<CasOp> ops) {
+            boolean activatesManifest =
+                ops.stream()
+                    .anyMatch(
+                        op ->
+                            op instanceof PointerStore.CasUpsert upsert
+                                && manifestPointer.equals(upsert.key()));
+            if (activatesManifest && failActivation.compareAndSet(true, false)) {
               throw new StorageAbortRetryableException("injected activation failure");
             }
-            return super.compareAndSet(key, expectedVersion, next);
+            return super.compareAndSetBatch(ops);
           }
         };
     StatsRepository repository = new StatsRepository(pointerStore, new InMemoryBlobStore());

--- a/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
@@ -68,17 +68,17 @@ class KeysTest {
   }
 
   @Test
-  void reconcileLeaseExpiryKeyPreservesLegacyRawAccountAndJobIds() {
+  void reconcileLeaseExpiryKeyEncodesAccountAndJobIds() {
     assertEquals(
         "/accounts/by-id/reconcile/job-leases/by-expiry/0000000000000000007"
-            + "/accounts/acct+legacy/jobs/job%legacy",
+            + "/accounts/acct%2Blegacy/jobs/job%25legacy",
         Keys.reconcileJobLeaseExpiryPointer(7L, "acct+legacy", "job%legacy"));
   }
 
   @Test
-  void reconcileLeaseKeyPreservesLegacyRawAccountAndJobIds() {
+  void reconcileLeaseKeyEncodesAccountAndJobIds() {
     assertEquals(
-        "/accounts/acct+legacy/reconcile/job-leases/by-id/job%legacy",
+        "/accounts/acct%2Blegacy/reconcile/job-leases/by-id/job%25legacy",
         Keys.reconcileJobLeasePointerById("acct+legacy", "job%legacy"));
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/repo/util/AccountDeletionFenceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/util/AccountDeletionFenceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.repo.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AccountDeletionFenceTest {
+  @Test
+  void reservedAccountDirectoriesDoNotCreateFenceChecks() {
+    Pointer pointer = Pointer.getDefaultInstance();
+
+    assertTrue(
+        AccountDeletionFence.checksForAccountWrites(
+                List.of(
+                    new PointerStore.CasUpsert(Keys.accountPointerById("account"), 0L, pointer),
+                    new PointerStore.CasUpsert(
+                        Keys.accountPointerByName("display-name"), 0L, pointer)))
+            .isEmpty());
+  }
+
+  @Test
+  void accountScopedWriteCreatesItsExactFenceCheck() {
+    String accountId = "account/with+encoding";
+
+    assertEquals(
+        List.of(new PointerStore.CasCheckAbsent(Keys.accountDeletionMarker(accountId))),
+        AccountDeletionFence.checksForAccountWrites(
+            List.of(
+                new PointerStore.CasUpsert(
+                    Keys.reconcileJobPointerById(accountId, "job"),
+                    0L,
+                    Pointer.getDefaultInstance()))));
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/util/MarkerStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/util/MarkerStoreTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.repo.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MarkerStoreTest {
+
+  @Test
+  void accountFenceBlocksMarkerWrites() {
+    var pointers = new InMemoryPointerStore();
+    var markers = new MarkerStore();
+    markers.pointerStore = pointers;
+    var catalogId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("catalog")
+            .setKind(ResourceKind.RK_CATALOG)
+            .build();
+    String fence = Keys.accountDeletionMarker("acct");
+    pointers.compareAndSet(fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "acct", 1L));
+
+    markers.bumpCatalogMarker(catalogId);
+
+    assertTrue(pointers.get(Keys.catalogChildrenMarker("acct", "catalog")).isEmpty());
+    assertThrows(
+        BaseResourceRepository.AccountDeletionInProgressException.class,
+        () -> markers.advanceCatalogMarker(catalogId, 0L));
+  }
+
+  @Test
+  void markerContentionStillReturnsFalse() {
+    var pointers = new InMemoryPointerStore();
+    var markers = new MarkerStore();
+    markers.pointerStore = pointers;
+    var namespaceId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("namespace")
+            .setKind(ResourceKind.RK_NAMESPACE)
+            .build();
+
+    markers.bumpNamespaceMarker(namespaceId);
+
+    assertFalse(markers.advanceNamespaceMarker(namespaceId, 0L));
+  }
+
+  @Test
+  void fenceThatWinsTheMarkerBatchIsPropagated() {
+    String fence = Keys.accountDeletionMarker("acct");
+    var pointers =
+        new InMemoryPointerStore() {
+          @Override
+          public boolean compareAndSetBatch(List<PointerStore.CasOp> ops) {
+            super.compareAndSet(
+                fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "acct", 1L));
+            return false;
+          }
+        };
+    var markers = new MarkerStore();
+    markers.pointerStore = pointers;
+    var catalogId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("catalog")
+            .setKind(ResourceKind.RK_CATALOG)
+            .build();
+
+    assertThrows(
+        BaseResourceRepository.AccountDeletionInProgressException.class,
+        () -> markers.advanceCatalogMarker(catalogId, 0L));
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/util/RepositoryReadsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/util/RepositoryReadsTest.java
@@ -16,6 +16,7 @@
 package ai.floedb.floecat.service.repo.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -25,7 +26,9 @@ import ai.floedb.floecat.service.repo.model.CatalogKey;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
@@ -81,6 +84,23 @@ class RepositoryReadsTest {
     assertThat(admittedReads).hasValue(0);
   }
 
+  @Test
+  void deleteConfirmationUsesRawStoresAfterTransactionConflict() {
+    ConflictNextBatchPointerStore pointers = new ConflictNextBatchPointerStore();
+    InMemoryBlobStore blobs = new InMemoryBlobStore();
+    AtomicInteger admittedReads = new AtomicInteger();
+    GenericResourceRepository<Catalog, CatalogKey> repository =
+        repository(pointers, blobs, null, countedReads(pointers, blobs, admittedReads));
+    repository.create(catalog("sales"));
+    admittedReads.set(0);
+    pointers.conflictNextBatch = true;
+
+    assertThatThrownBy(() -> repository.deleteOrConfirmAbsent(KEY))
+        .isInstanceOf(BaseResourceRepository.AbortRetryableException.class);
+    assertThat(admittedReads).hasValue(0);
+    assertThat(repository.getByKey(KEY)).isPresent();
+  }
+
   /** Build a catalog repository with explicit read policy and optional immutable cache. */
   private static GenericResourceRepository<Catalog, CatalogKey> repository(
       InMemoryPointerStore pointers,
@@ -122,5 +142,18 @@ class RepositoryReadsTest {
             return operation.get();
           }
         });
+  }
+
+  private static final class ConflictNextBatchPointerStore extends InMemoryPointerStore {
+    private boolean conflictNextBatch;
+
+    @Override
+    public synchronized boolean compareAndSetBatch(List<PointerStore.CasOp> ops) {
+      if (conflictNextBatch) {
+        conflictNextBatch = false;
+        return false;
+      }
+      return super.compareAndSetBatch(ops);
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/util/RepositoryReadsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/util/RepositoryReadsTest.java
@@ -16,7 +16,6 @@
 package ai.floedb.floecat.service.repo.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -26,9 +25,7 @@ import ai.floedb.floecat.service.repo.model.CatalogKey;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
-import ai.floedb.floecat.storage.spi.PointerStore;
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
@@ -84,23 +81,6 @@ class RepositoryReadsTest {
     assertThat(admittedReads).hasValue(0);
   }
 
-  @Test
-  void deleteConfirmationUsesRawStoresAfterTransactionConflict() {
-    ConflictNextBatchPointerStore pointers = new ConflictNextBatchPointerStore();
-    InMemoryBlobStore blobs = new InMemoryBlobStore();
-    AtomicInteger admittedReads = new AtomicInteger();
-    GenericResourceRepository<Catalog, CatalogKey> repository =
-        repository(pointers, blobs, null, countedReads(pointers, blobs, admittedReads));
-    repository.create(catalog("sales"));
-    admittedReads.set(0);
-    pointers.conflictNextBatch = true;
-
-    assertThatThrownBy(() -> repository.deleteOrConfirmAbsent(KEY))
-        .isInstanceOf(BaseResourceRepository.AbortRetryableException.class);
-    assertThat(admittedReads).hasValue(0);
-    assertThat(repository.getByKey(KEY)).isPresent();
-  }
-
   /** Build a catalog repository with explicit read policy and optional immutable cache. */
   private static GenericResourceRepository<Catalog, CatalogKey> repository(
       InMemoryPointerStore pointers,
@@ -142,18 +122,5 @@ class RepositoryReadsTest {
             return operation.get();
           }
         });
-  }
-
-  private static final class ConflictNextBatchPointerStore extends InMemoryPointerStore {
-    private boolean conflictNextBatch;
-
-    @Override
-    public synchronized boolean compareAndSetBatch(List<PointerStore.CasOp> ops) {
-      if (conflictNextBatch) {
-        conflictNextBatch = false;
-        return false;
-      }
-      return super.compareAndSetBatch(ops);
-    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionGcTest.java
@@ -391,8 +391,8 @@ class TransactionGcTest {
     var failingStore =
         new InMemoryPointerStore() {
           @Override
-          public boolean compareAndSet(
-              String key, long expectedVersion, ai.floedb.floecat.common.rpc.Pointer pointer) {
+          public boolean compareAndSetBatch(
+              java.util.List<ai.floedb.floecat.storage.spi.PointerStore.CasOp> ops) {
             throw new IllegalStateException("store down");
           }
         };

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
@@ -129,6 +129,83 @@ class TransactionIntentApplierSupportTest {
   }
 
   @Test
+  void applyTransactionRejectsIntentWhenAccountDeletionIsAlreadyFenced() throws Exception {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var intentRepo = new TransactionIntentRepository(pointers, blobs);
+    var support = newSupport(pointers, blobs);
+    String targetKey = "/accounts/acct/custom/key-1";
+    String markerKey = Keys.accountDeletionMarker("acct");
+    pointers.compareAndSet(
+        markerKey, 0L, PointerReferences.opaqueMarkerPointer(markerKey, "deleting", 1L));
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId("acct")
+            .setTxId("tx-1")
+            .setTargetPointerKey(targetKey)
+            .setBlobUri("s3://bucket/blob-1")
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+
+    var outcome = support.applyTransactionBestEffort(List.of(intent), intentRepo);
+
+    assertEquals(TransactionIntentApplierSupport.ApplyStatus.CONFLICT, outcome.status());
+    assertEquals("ACCOUNT_DELETION_IN_PROGRESS", outcome.errorCode());
+    assertTrue(pointers.get(targetKey).isEmpty());
+  }
+
+  @Test
+  void applyTransactionAtomicallyChecksFenceInsidePointerBatch() throws Exception {
+    var pointers = new HookedPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var intentRepo = new TransactionIntentRepository(pointers, blobs);
+    var txRepo = new TransactionRepository(pointers, blobs);
+    var support = newSupport(pointers, blobs);
+    String accountId = "acct";
+    String txId = "tx-1";
+    String targetKey = "/accounts/acct/custom/key-1";
+    Transaction currentTxn =
+        Transaction.newBuilder()
+            .setAccountId(accountId)
+            .setTxId(txId)
+            .setState(TransactionState.TS_APPLYING)
+            .setUpdatedAt(Timestamps.fromMillis(1))
+            .build();
+    txRepo.create(currentTxn);
+    long txPointerVersion = txRepo.metaFor(accountId, txId).getPointerVersion();
+    TransactionIntent intent =
+        TransactionIntent.newBuilder()
+            .setAccountId(accountId)
+            .setTxId(txId)
+            .setTargetPointerKey(targetKey)
+            .setBlobUri("s3://bucket/blob-1")
+            .setCreatedAt(Timestamps.fromMillis(1))
+            .build();
+    intentRepo.create(intent);
+    String markerKey = Keys.accountDeletionMarker(accountId);
+    pointers.beforeBatch(
+        () ->
+            pointers.compareAndSet(
+                markerKey, 0L, PointerReferences.opaqueMarkerPointer(markerKey, "deleting", 1L)));
+    Transaction appliedTxn =
+        currentTxn.toBuilder()
+            .setState(TransactionState.TS_APPLIED)
+            .setUpdatedAt(Timestamps.fromMillis(2))
+            .build();
+
+    var outcome =
+        support.applyTransactionAtomically(
+            appliedTxn, txPointerVersion, List.of(intent), intentRepo);
+
+    assertEquals(TransactionIntentApplierSupport.ApplyStatus.CONFLICT, outcome.status());
+    assertEquals("ACCOUNT_DELETION_IN_PROGRESS", outcome.errorCode());
+    assertTrue(pointers.get(targetKey).isEmpty());
+    assertTrue(intentRepo.getByTarget(accountId, targetKey).isPresent());
+    assertEquals(
+        TransactionState.TS_APPLYING, txRepo.getById(accountId, txId).orElseThrow().getState());
+  }
+
+  @Test
   void applyTransactionRejectsTableIntentTargetMismatch() throws Exception {
     var pointers = new InMemoryPointerStore();
     var blobs = new InMemoryBlobStore();

--- a/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetterTest.java
@@ -260,6 +260,12 @@ public class TestDataResetterTest {
     }
 
     @Override
+    public List<Pointer> listPointersByPrefixConsistent(
+        String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+      return listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
+    }
+
+    @Override
     public int deleteByPrefix(String prefix) {
       final String pfx = prefix == null ? "" : prefix;
       int before = map.size();
@@ -277,6 +283,11 @@ public class TestDataResetterTest {
         }
       }
       return count;
+    }
+
+    @Override
+    public int countByPrefixConsistent(String prefix) {
+      return countByPrefix(prefix);
     }
 
     @Override

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
@@ -36,7 +36,9 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
+import software.amazon.awssdk.services.secretsmanager.model.DescribeSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.InvalidRequestException;
 import software.amazon.awssdk.services.secretsmanager.model.PutSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.ResourceExistsException;
 import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
@@ -224,6 +226,19 @@ public class ProdSecretsManager implements SecretsManager {
       client.deleteSecret(
           DeleteSecretRequest.builder().secretId(secretName).recoveryWindowInDays(7L).build());
     } catch (ResourceNotFoundException ignored) {
+    } catch (InvalidRequestException invalidState) {
+      try {
+        var description =
+            client.describeSecret(DescribeSecretRequest.builder().secretId(secretName).build());
+        if (description != null && description.deletedDate() != null) {
+          return;
+        }
+      } catch (ResourceNotFoundException ignored) {
+        return;
+      } catch (RuntimeException describeFailure) {
+        invalidState.addSuppressed(describeFailure);
+      }
+      throw invalidState;
     }
   }
 

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -464,11 +464,17 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   @Override
   public Uni<Page> queryByPartitionKeyPrefix(
       String pk, String skPrefix, int limit, Optional<String> pageToken) {
+    return queryByPartitionKeyPrefix(pk, skPrefix, limit, pageToken, false);
+  }
+
+  @Override
+  public Uni<Page> queryByPartitionKeyPrefix(
+      String pk, String skPrefix, int limit, Optional<String> pageToken, boolean consistentRead) {
     if (pk == null || pk.isBlank()) {
       throw new IllegalArgumentException("partition key must be provided for query");
     }
 
-    var qb = QueryRequest.builder().tableName(table).limit(limit);
+    var qb = QueryRequest.builder().tableName(table).limit(limit).consistentRead(consistentRead);
 
     if (skPrefix == null || skPrefix.isEmpty()) {
       qb.expressionAttributeNames(Map.of("#pk", ATTR_PARTITION_KEY))

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -502,6 +502,12 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
   @Override
   public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
+    return deleteByPrefixExcluding(partitionKey, sortKeyPrefix, null);
+  }
+
+  @Override
+  public Uni<Integer> deleteByPrefixExcluding(
+      String partitionKey, String sortKeyPrefix, String excludedSortKey) {
     Objects.requireNonNull(partitionKey, "Partition must be provided for delete by prefix");
     final var totalDeleted = new AtomicInteger(0);
     final var lekRef = new AtomicReference<Map<String, AttributeValue>>(null);
@@ -547,6 +553,9 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
               // build delete requests for this page
               var deletes = new ArrayList<WriteRequest>(resp.items().size());
               for (var item : resp.items()) {
+                if (item.get(ATTR_SORT_KEY).s().equals(excludedSortKey)) {
+                  continue;
+                }
                 var key =
                     Map.of(
                         ATTR_PARTITION_KEY, item.get(ATTR_PARTITION_KEY),

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
@@ -69,10 +69,28 @@ public abstract class KvPointerStore implements PointerStore {
   @Override
   public List<Pointer> listPointersByPrefix(
       String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+    return listPointersByPrefix(prefix, limit, pageToken, nextTokenOut, false);
+  }
+
+  @Override
+  public List<Pointer> listPointersByPrefixConsistent(
+      String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+    return listPointersByPrefix(prefix, limit, pageToken, nextTokenOut, true);
+  }
+
+  private List<Pointer> listPointersByPrefix(
+      String prefix,
+      int limit,
+      String pageToken,
+      StringBuilder nextTokenOut,
+      boolean consistentRead) {
     Optional<String> token =
         (pageToken == null || pageToken.isBlank()) ? Optional.empty() : Optional.of(pageToken);
 
-    var page = await(() -> pointers.listByPrefix(prefix, limit, token).await().indefinitely());
+    var page =
+        await(
+            () ->
+                pointers.listByPrefix(prefix, limit, token, consistentRead).await().indefinitely());
 
     if (nextTokenOut != null) {
       nextTokenOut.setLength(0);
@@ -94,13 +112,27 @@ public abstract class KvPointerStore implements PointerStore {
 
   @Override
   public int countByPrefix(String prefix) {
+    return countByPrefix(prefix, false);
+  }
+
+  @Override
+  public int countByPrefixConsistent(String prefix) {
+    return countByPrefix(prefix, true);
+  }
+
+  private int countByPrefix(String prefix, boolean consistentRead) {
     int count = 0;
 
     Optional<String> token = Optional.empty();
     do {
       Optional<String> pageToken = token;
       var page =
-          await(() -> pointers.listKeysByPrefix(prefix, 500, pageToken).await().indefinitely());
+          await(
+              () ->
+                  pointers
+                      .listKeysByPrefix(prefix, 500, pageToken, consistentRead)
+                      .await()
+                      .indefinitely());
 
       count += page.items().size();
       token = page.nextToken();

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStore.java
@@ -111,6 +111,12 @@ public abstract class KvPointerStore implements PointerStore {
   }
 
   @Override
+  public int deleteByPrefixExcluding(String prefix, String excludedKey) {
+    return await(
+        () -> pointers.deleteByPrefixExcluding(prefix, excludedKey).await().indefinitely());
+  }
+
+  @Override
   public int countByPrefix(String prefix) {
     return countByPrefix(prefix, false);
   }

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -343,9 +343,14 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
 
   public Uni<EntityPage<Pointer>> listByPrefix(
       String prefix, int limit, Optional<String> pageToken) {
+    return listByPrefix(prefix, limit, pageToken, false);
+  }
+
+  public Uni<EntityPage<Pointer>> listByPrefix(
+      String prefix, int limit, Optional<String> pageToken, boolean consistentRead) {
     var prefixKey = prefixKey(prefix);
     return kv.queryByPartitionKeyPrefix(
-            prefixKey.partitionKey(), prefixKey.sortKey(), limit, pageToken)
+            prefixKey.partitionKey(), prefixKey.sortKey(), limit, pageToken, consistentRead)
         .map(
             page ->
                 new EntityPage<>(
@@ -365,9 +370,14 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
    */
   public Uni<EntityPage<String>> listKeysByPrefix(
       String prefix, int limit, Optional<String> pageToken) {
+    return listKeysByPrefix(prefix, limit, pageToken, false);
+  }
+
+  public Uni<EntityPage<String>> listKeysByPrefix(
+      String prefix, int limit, Optional<String> pageToken, boolean consistentRead) {
     var prefixKey = prefixKey(prefix);
     return kv.queryByPartitionKeyPrefix(
-            prefixKey.partitionKey(), prefixKey.sortKey(), limit, pageToken)
+            prefixKey.partitionKey(), prefixKey.sortKey(), limit, pageToken, consistentRead)
         .map(
             page ->
                 new EntityPage<>(

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -395,6 +395,17 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
     return kv.deleteByPrefix(prefixKey.partitionKey(), prefixKey.sortKey());
   }
 
+  public Uni<Integer> deleteByPrefixExcluding(String prefix, String excludedKey) {
+    var prefixKey = prefixKey(prefix);
+    var excluded = pointerKey(excludedKey);
+    if (!prefixKey.partitionKey().equals(excluded.partitionKey())
+        || !excluded.sortKey().startsWith(prefixKey.sortKey())) {
+      throw new IllegalArgumentException("excluded pointer is outside prefix");
+    }
+    return kv.deleteByPrefixExcluding(
+        prefixKey.partitionKey(), prefixKey.sortKey(), excluded.sortKey());
+  }
+
   // ---- Helpers (testing)
 
   private String keyOf(Key key) {

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
@@ -27,6 +27,7 @@ import ai.floedb.floecat.storage.aws.AwsClients;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Base64;
 import java.util.Deque;
@@ -41,10 +42,39 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.DescribeSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.InvalidRequestException;
 import software.amazon.awssdk.services.sts.StsClient;
 
 class ProdSecretsManagerTest {
+
+  @Test
+  void deleteTreatsAlreadyScheduledSecretAsDeleted() {
+    InvalidRequestException scheduled =
+        InvalidRequestException.builder().message("secret is scheduled for deletion").build();
+    ClientHandle secretsClient = ClientHandle.secretsDeleteFailure(scheduled, true);
+    ClientHandle stsClient = ClientHandle.sts();
+    ProdSecretsManager manager =
+        new ProdSecretsManager(
+            new FakeAwsClients(), secretsClient.secretsClient, stsClient.stsClient);
+
+    manager.delete("acct", "connectors", "secret");
+  }
+
+  @Test
+  void deleteRethrowsInvalidRequestWhenSecretIsNotScheduled() {
+    InvalidRequestException invalid =
+        InvalidRequestException.builder().message("secret is managed by another service").build();
+    ClientHandle secretsClient = ClientHandle.secretsDeleteFailure(invalid, false);
+    ClientHandle stsClient = ClientHandle.sts();
+    ProdSecretsManager manager =
+        new ProdSecretsManager(
+            new FakeAwsClients(), secretsClient.secretsClient, stsClient.stsClient);
+
+    assertThrows(
+        InvalidRequestException.class, () -> manager.delete("acct", "connectors", "secret"));
+  }
 
   @Test
   void get_refreshes_direct_secrets_client_after_closed_pool() {
@@ -442,8 +472,10 @@ class ProdSecretsManagerTest {
 
   private static final class ClientHandle implements InvocationHandler {
     private final RuntimeException failure;
+    private final RuntimeException deleteFailure;
     private final Runnable beforeFailure;
     private final String secretString;
+    private final boolean scheduledForDeletion;
     private boolean closed;
     private int closeCount;
     private ClientHandle boundStsClient;
@@ -451,10 +483,17 @@ class ProdSecretsManagerTest {
     private final SecretsManagerClient secretsClient;
     private final StsClient stsClient;
 
-    private ClientHandle(RuntimeException failure, Runnable beforeFailure, String secretString) {
+    private ClientHandle(
+        RuntimeException failure,
+        RuntimeException deleteFailure,
+        Runnable beforeFailure,
+        String secretString,
+        boolean scheduledForDeletion) {
       this.failure = failure;
+      this.deleteFailure = deleteFailure;
       this.beforeFailure = beforeFailure;
       this.secretString = secretString;
+      this.scheduledForDeletion = scheduledForDeletion;
       this.secretsClient =
           (SecretsManagerClient)
               Proxy.newProxyInstance(
@@ -472,15 +511,20 @@ class ProdSecretsManagerTest {
     }
 
     static ClientHandle secretsFailure(RuntimeException failure, Runnable beforeFailure) {
-      return new ClientHandle(failure, beforeFailure, null);
+      return new ClientHandle(failure, null, beforeFailure, null, false);
     }
 
     static ClientHandle secretsValue(String secretString) {
-      return new ClientHandle(null, null, secretString);
+      return new ClientHandle(null, null, null, secretString, false);
+    }
+
+    static ClientHandle secretsDeleteFailure(
+        RuntimeException deleteFailure, boolean scheduledForDeletion) {
+      return new ClientHandle(null, deleteFailure, null, null, scheduledForDeletion);
     }
 
     static ClientHandle sts() {
-      return new ClientHandle(null, null, null);
+      return new ClientHandle(null, null, null, null, false);
     }
 
     @Override
@@ -494,6 +538,19 @@ class ProdSecretsManagerTest {
             throw failure;
           }
           yield GetSecretValueResponse.builder().secretString(secretString).build();
+        }
+        case "deleteSecret" -> {
+          if (deleteFailure != null) {
+            throw deleteFailure;
+          }
+          yield null;
+        }
+        case "describeSecret" -> {
+          DescribeSecretResponse.Builder response = DescribeSecretResponse.builder();
+          if (scheduledForDeletion) {
+            response.deletedDate(Instant.now());
+          }
+          yield response.build();
         }
         case "close" -> {
           closed = true;

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
@@ -438,7 +438,7 @@ public class DynamoDbKvStoreTest {
   }
 
   @Test
-  void queryByPartitionKeyPrefix_without_prefix_returns_all_in_pk() {
+  void queryByPartitionKeyPrefix_consistent_without_prefix_returns_all_in_pk() {
     FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
     DynamoDbKvStore store = newStore(handler);
 
@@ -447,8 +447,12 @@ public class DynamoDbKvStoreTest {
     put(store, "pk2", "c", 1L);
 
     var page =
-        store.queryByPartitionKeyPrefix("pk1", null, 10, Optional.empty()).await().indefinitely();
+        store
+            .queryByPartitionKeyPrefix("pk1", null, 10, Optional.empty(), true)
+            .await()
+            .indefinitely();
     assertEquals(2, page.items().size());
+    assertTrue(handler.lastQueryRequest.consistentRead());
   }
 
   @Test

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStoreTest.java
@@ -15,6 +15,7 @@
  */
 package ai.floedb.floecat.storage.kv.dynamodb.ps;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -28,6 +29,18 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class KvPointerStoreTest {
+
+  @Test
+  void deleteByPrefixExcludingPreservesEncodedAccountFence() {
+    FailingReadKvStore kv = new FailingReadKvStore(new RuntimeException("unused"));
+    KvPointerStore store = new KvPointerStore(new PointerStoreEntity(kv)) {};
+
+    assertEquals(
+        7, store.deleteByPrefixExcluding("/accounts/acct%2B1/", "/accounts/acct%2B1/deleting"));
+    assertEquals("accounts/acct%2B1", kv.deletedPartitionKey);
+    assertEquals("", kv.deletedSortKeyPrefix);
+    assertEquals("deleting", kv.excludedSortKey);
+  }
 
   @Test
   void getRethrowsNonClosedPoolRuntimeException() {
@@ -59,6 +72,9 @@ class KvPointerStoreTest {
 
   private static final class FailingReadKvStore implements KvStore {
     private final RuntimeException failure;
+    private String deletedPartitionKey;
+    private String deletedSortKeyPrefix;
+    private String excludedSortKey;
 
     private FailingReadKvStore(RuntimeException failure) {
       this.failure = failure;
@@ -104,6 +120,15 @@ class KvPointerStoreTest {
     @Override
     public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uni<Integer> deleteByPrefixExcluding(
+        String partitionKey, String sortKeyPrefix, String excludedSortKey) {
+      this.deletedPartitionKey = partitionKey;
+      this.deletedSortKeyPrefix = sortKeyPrefix;
+      this.excludedSortKey = excludedSortKey;
+      return Uni.createFrom().item(7);
     }
 
     @Override

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/KvPointerStoreTest.java
@@ -92,6 +92,16 @@ class KvPointerStoreTest {
     }
 
     @Override
+    public Uni<Page> queryByPartitionKeyPrefix(
+        String partitionKey,
+        String sortKeyPrefix,
+        int limit,
+        Optional<String> pageToken,
+        boolean consistentRead) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
       throw new UnsupportedOperationException();
     }

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
@@ -555,6 +555,17 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
     }
 
     @Override
+    public Uni<Page> queryByPartitionKeyPrefix(
+        String partitionKey,
+        String sortKeyPrefix,
+        int limit,
+        Optional<String> pageToken,
+        boolean consistentRead) {
+      return delegate.queryByPartitionKeyPrefix(
+          partitionKey, sortKeyPrefix, limit, pageToken, consistentRead);
+    }
+
+    @Override
     public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
       return delegate.deleteByPrefix(partitionKey, sortKeyPrefix);
     }

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
@@ -497,6 +497,26 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
     assertTrue(pointers.get(accountKey).await().indefinitely().isEmpty());
   }
 
+  @Test
+  void deleteByPrefixExcluding_preserves_account_deletion_fence() {
+    String prefix = "/accounts/account%2Fencoded/";
+    String fence = prefix + "deleting";
+    String catalog = prefix + "catalogs/by-id/catalog-1";
+    String reconcile = prefix + "reconcile/jobs/by-id/job-1";
+    String otherAccount = "/accounts/other/catalogs/by-id/catalog-2";
+    for (String key : List.of(fence, catalog, reconcile, otherAccount)) {
+      Pointer pointer = Pointer.newBuilder().setKey(key).setBlobUri("s3://b/value").build();
+      assertTrue(pointers.compareAndSet(key, 0L, pointer).await().indefinitely());
+    }
+
+    assertEquals(2, pointers.deleteByPrefixExcluding(prefix, fence).await().indefinitely());
+
+    assertTrue(pointers.get(fence).await().indefinitely().isPresent());
+    assertTrue(pointers.get(catalog).await().indefinitely().isEmpty());
+    assertTrue(pointers.get(reconcile).await().indefinitely().isEmpty());
+    assertTrue(pointers.get(otherAccount).await().indefinitely().isPresent());
+  }
+
   private static final class ConcurrentUpdateKvStore implements KvStore {
     private final KvStore delegate;
     private final KvStore.Key keyToUpdate;
@@ -568,6 +588,12 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
     @Override
     public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
       return delegate.deleteByPrefix(partitionKey, sortKeyPrefix);
+    }
+
+    @Override
+    public Uni<Integer> deleteByPrefixExcluding(
+        String partitionKey, String sortKeyPrefix, String excludedSortKey) {
+      return delegate.deleteByPrefixExcluding(partitionKey, sortKeyPrefix, excludedSortKey);
     }
 
     @Override

--- a/storage/common/src/test/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManagerIT.java
+++ b/storage/common/src/test/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManagerIT.java
@@ -187,6 +187,12 @@ class NotProdSecretsManagerIT {
     }
 
     @Override
+    public Uni<Integer> deleteByPrefixExcluding(
+        String partitionKey, String sortKeyPrefix, String excludedSortKey) {
+      throw new UnsupportedOperationException("deleteByPrefixExcluding not supported");
+    }
+
+    @Override
     public Uni<Void> reset() {
       records.clear();
       return Uni.createFrom().voidItem();

--- a/storage/common/src/test/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManagerIT.java
+++ b/storage/common/src/test/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManagerIT.java
@@ -172,6 +172,16 @@ class NotProdSecretsManagerIT {
     }
 
     @Override
+    public Uni<Page> queryByPartitionKeyPrefix(
+        String partitionKey,
+        String sortKeyPrefix,
+        int limit,
+        Optional<String> pageToken,
+        boolean consistentRead) {
+      throw new UnsupportedOperationException("queryByPartitionKeyPrefix not supported");
+    }
+
+    @Override
     public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
       throw new UnsupportedOperationException("deleteByPrefix not supported");
     }

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -196,6 +196,16 @@ public final class InMemoryKvStore implements KvStore {
   }
 
   @Override
+  public Uni<Page> queryByPartitionKeyPrefix(
+      String partitionKey,
+      String sortKeyPrefix,
+      int limit,
+      Optional<String> pageToken,
+      boolean consistentRead) {
+    return queryByPartitionKeyPrefix(partitionKey, sortKeyPrefix, limit, pageToken);
+  }
+
+  @Override
   public String pageTokenAfterKey(Key key) {
     // Same encoding as end-of-page tokens: base64 of the sort key to resume after.
     return encodeToken(key.sortKey());

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryKvStore.java
@@ -213,6 +213,12 @@ public final class InMemoryKvStore implements KvStore {
 
   @Override
   public Uni<Integer> deleteByPrefix(String partitionKey, String sortKeyPrefix) {
+    return deleteByPrefixExcluding(partitionKey, sortKeyPrefix, null);
+  }
+
+  @Override
+  public Uni<Integer> deleteByPrefixExcluding(
+      String partitionKey, String sortKeyPrefix, String excludedSortKey) {
     String pk = partitionKey == null ? "" : partitionKey;
     String skPrefix = sortKeyPrefix == null ? "" : sortKeyPrefix;
     int[] deleted = {0};
@@ -220,7 +226,10 @@ public final class InMemoryKvStore implements KvStore {
         .keySet()
         .removeIf(
             key -> {
-              boolean match = pk.equals(key.partitionKey()) && key.sortKey().startsWith(skPrefix);
+              boolean match =
+                  pk.equals(key.partitionKey())
+                      && key.sortKey().startsWith(skPrefix)
+                      && !key.sortKey().equals(excludedSortKey);
               if (match) {
                 deleted[0]++;
               }

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
@@ -169,6 +169,22 @@ public class InMemoryPointerStore implements PointerStore {
   }
 
   @Override
+  public synchronized int deleteByPrefixExcluding(String prefix, String excludedKey) {
+    final String pfx = (prefix == null) ? "" : prefix;
+    List<String> keys = new ArrayList<>();
+    for (String key : map.tailMap(pfx, true).keySet()) {
+      if (!key.startsWith(pfx)) {
+        break;
+      }
+      if (!key.equals(excludedKey)) {
+        keys.add(key);
+      }
+    }
+    keys.forEach(map::remove);
+    return keys.size();
+  }
+
+  @Override
   public synchronized boolean compareAndDelete(String key, long expectedVersion) {
     final boolean[] deleted = {false};
     map.compute(

--- a/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
+++ b/storage/memory/src/main/java/ai/floedb/floecat/storage/memory/InMemoryPointerStore.java
@@ -112,6 +112,12 @@ public class InMemoryPointerStore implements PointerStore {
   }
 
   @Override
+  public synchronized List<Pointer> listPointersByPrefixConsistent(
+      String prefix, int limit, String pageToken, StringBuilder nextTokenOut) {
+    return listPointersByPrefix(prefix, limit, pageToken, nextTokenOut);
+  }
+
+  @Override
   public String pageTokenAfterKey(String key) {
     // This store's page tokens are raw pointer keys ("resume after this key"), so the key itself
     // is the token. Resuming after a since-deleted key fails the same way an ordinary end-of-page
@@ -130,6 +136,11 @@ public class InMemoryPointerStore implements PointerStore {
       n++;
     }
     return n;
+  }
+
+  @Override
+  public synchronized int countByPrefixConsistent(String prefix) {
+    return countByPrefix(prefix);
   }
 
   @Override

--- a/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
+++ b/storage/memory/src/test/java/ai/floedb/floecat/storage/PointerStoreContractTest.java
@@ -65,6 +65,20 @@ public class PointerStoreContractTest {
   }
 
   @Test
+  void deleteByPrefixExcluding_preserves_only_the_exact_excluded_key() {
+    store.compareAndSet(key(1), 0L, pointer(key(1), 1L));
+    store.compareAndSet(key(2), 0L, pointer(key(2), 1L));
+    store.compareAndSet(otherKey(1), 0L, pointer(otherKey(1), 1L));
+
+    int deleted = store.deleteByPrefixExcluding(prefix(), key(1));
+
+    assertEquals(1, deleted);
+    assertTrue(store.get(key(1)).isPresent());
+    assertTrue(store.get(key(2)).isEmpty());
+    assertTrue(store.get(otherKey(1)).isPresent());
+  }
+
+  @Test
   void countByPrefix_matches_number_of_keys() {
     store.compareAndSet(key(1), 0L, pointer(key(1), 1L));
     store.compareAndSet(key(2), 0L, pointer(key(2), 1L));


### PR DESCRIPTION
## Summary

Makes account deletion fenced and resumable, and extends repository/storage deletion support so catalog-owned resources can be cleaned up safely. This establishes the lifecycle behavior required before catalog integration and overlay resources are added.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Focused account-deletion and repository/storage tests passed.

- [x] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Stack position: **4/10**. Base: `mc-catalog-durability-primitives`. The catalog-specific deletion hooks are added by the resource PRs above this one.

