### PR TITLE
feat(integration): add catalog integration API (stack 5/10)

### DIFF
--- a/core/proto/src/main/proto/floecat/common/common.proto
+++ b/core/proto/src/main/proto/floecat/common/common.proto
@@ -42,6 +42,7 @@ enum ResourceKind {
   RK_AGGREGATE = 14;
   RK_TRANSACTION = 15;
   RK_STORAGE_AUTHORITY = 16;
+  RK_CATALOG_INTEGRATION = 17;
 }
 
 message ResourceId {
@@ -188,6 +189,14 @@ message Error {
 
 message IdempotencyKey {
   string key = 1;
+}
+
+// API create-conflict behavior. The default preserves ordinary create semantics; the non-default
+// modes replace the existing resource identity, or return the existing resource unchanged.
+enum CreateMode {
+  CM_ERROR_IF_EXISTS = 0;
+  CM_REPLACE = 1;
+  CM_RETURN_EXISTING = 2;
 }
 
 message Precondition {

--- a/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
+++ b/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
@@ -1,0 +1,192 @@
+// Copyright 2026 Yellowbrick Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package ai.floedb.floecat.integration;
+
+option java_multiple_files = true;
+option java_package = "ai.floedb.floecat.integration.rpc";
+
+import "floecat/common/common.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/timestamp.proto";
+
+enum CatalogIntegrationType {
+  CIT_UNSPECIFIED = 0;
+  CIT_ICEBERG_REST = 1;
+  CIT_UNITY = 2;
+}
+
+message OAuthClientCredentialsAuthentication {
+  string client_id = 1;
+  optional string token_uri = 2;
+  repeated string scopes = 3;
+}
+
+message BearerAuthentication {}
+
+message AwsAssumeRoleAuthentication {
+  string role_arn = 1;
+  optional string external_id = 2;
+  optional string role_session_name = 3;
+}
+
+message AwsAccessKeyAuthentication {
+  string access_key_id = 1;
+}
+
+message AwsDefaultAuthentication {}
+
+message AwsSigV4Authentication {
+  oneof credentials {
+    AwsDefaultAuthentication aws_default = 1;
+    AwsAssumeRoleAuthentication aws_assume_role = 2;
+    AwsAccessKeyAuthentication aws_access_key = 3;
+  }
+  string region = 4;
+  optional string signing_name = 5;
+}
+
+// Persistable, non-secret authentication configuration and credential state.
+message CatalogAuthentication {
+  oneof configuration {
+    OAuthClientCredentialsAuthentication oauth_client_credentials = 1;
+    BearerAuthentication bearer = 2;
+    AwsAssumeRoleAuthentication aws_assume_role = 3;
+    AwsAccessKeyAuthentication aws_access_key = 4;
+    AwsSigV4Authentication aws_sigv4 = 5;
+  }
+  // Server-managed response state for separately stored secret material. Requests must leave these
+  // fields unset. Authentication modes using ambient or assumed credentials report false/zero.
+  bool credentials_configured = 20;
+  uint64 credential_generation = 21;
+}
+
+message SecretValue {
+  string value = 1;
+}
+
+message AwsAccessKeySecret {
+  string secret_access_key = 1;
+  optional string session_token = 2;
+}
+
+// Write-only secret material. This message is never stored in a CatalogIntegration resource.
+message CatalogIntegrationCredentials {
+  oneof credential {
+    SecretValue oauth_client_secret = 1;
+    SecretValue bearer_token = 2;
+    AwsAccessKeySecret aws_access_key = 3;
+  }
+}
+
+message CatalogIntegration {
+  ai.floedb.floecat.common.ResourceId resource_id = 1;
+  string display_name = 2;
+  CatalogIntegrationType type = 3;
+  // HTTP(S) catalog endpoint URL. User-info, secret-bearing query parameters, and fragments are rejected.
+  string catalog_uri = 4;
+  google.protobuf.Timestamp created_at = 5;
+  google.protobuf.Timestamp updated_at = 6;
+  CatalogAuthentication authentication = 7;
+}
+
+message CatalogIntegrationSpec {
+  optional string display_name = 1;
+  CatalogIntegrationType type = 2;
+  // HTTP(S) catalog endpoint URL. User-info, secret-bearing query parameters, and fragments are rejected.
+  optional string catalog_uri = 3;
+  CatalogAuthentication authentication = 4;
+}
+
+message CatalogIntegrationEntry {
+  CatalogIntegration integration = 1;
+  ai.floedb.floecat.common.MutationMeta meta = 2;
+}
+
+message CreateCatalogIntegrationRequest {
+  CatalogIntegrationSpec spec = 1;
+  ai.floedb.floecat.common.IdempotencyKey idempotency = 2;
+  // Non-default modes replace the existing identity, or return the existing resource unchanged.
+  // Non-default modes cannot be combined with idempotency; replacement is itself state-idempotent.
+  ai.floedb.floecat.common.CreateMode create_mode = 3;
+  // Write-only credential material matching spec.authentication when that mode requires a secret.
+  // It may be combined with idempotency. Secret values are excluded from the request fingerprint;
+  // retries with the same key return the first successfully published credentials.
+  CatalogIntegrationCredentials credentials = 4;
+}
+message CreateCatalogIntegrationResponse {
+  CatalogIntegration integration = 1;
+  ai.floedb.floecat.common.MutationMeta meta = 2;
+}
+
+message GetCatalogIntegrationRequest {
+  oneof selector {
+    ai.floedb.floecat.common.ResourceId integration_id = 1;
+    string display_name = 2;
+  }
+}
+message GetCatalogIntegrationResponse {
+  CatalogIntegration integration = 1;
+  ai.floedb.floecat.common.MutationMeta meta = 2;
+}
+
+message ListCatalogIntegrationsRequest {
+  ai.floedb.floecat.common.PageRequest page = 1;
+}
+message ListCatalogIntegrationsResponse {
+  repeated CatalogIntegrationEntry entries = 1;
+  ai.floedb.floecat.common.PageResponse page = 2;
+}
+
+message UpdateCatalogIntegrationRequest {
+  ai.floedb.floecat.common.ResourceId integration_id = 1;
+  // Only display_name is mutable. Type and catalog_uri identify the connection and are immutable.
+  CatalogIntegrationSpec spec = 2;
+  ai.floedb.floecat.common.Precondition precondition = 3;
+  google.protobuf.FieldMask update_mask = 4;
+}
+message UpdateCatalogIntegrationResponse {
+  CatalogIntegration integration = 1;
+  ai.floedb.floecat.common.MutationMeta meta = 2;
+}
+
+message UpdateCatalogIntegrationAuthenticationRequest {
+  ai.floedb.floecat.common.ResourceId integration_id = 1;
+  CatalogAuthentication authentication = 2;
+  // Optional write-only credential material matching authentication.
+  CatalogIntegrationCredentials credentials = 3;
+  ai.floedb.floecat.common.Precondition precondition = 4;
+}
+message UpdateCatalogIntegrationAuthenticationResponse {
+  CatalogIntegration integration = 1;
+  ai.floedb.floecat.common.MutationMeta meta = 2;
+}
+
+message DeleteCatalogIntegrationRequest {
+  ai.floedb.floecat.common.ResourceId integration_id = 1;
+  ai.floedb.floecat.common.Precondition precondition = 2;
+}
+message DeleteCatalogIntegrationResponse {
+  ai.floedb.floecat.common.MutationMeta meta = 1;
+}
+
+service CatalogIntegrations {
+  rpc GetCatalogIntegration(GetCatalogIntegrationRequest) returns (GetCatalogIntegrationResponse);
+  rpc ListCatalogIntegrations(ListCatalogIntegrationsRequest) returns (ListCatalogIntegrationsResponse);
+  rpc CreateCatalogIntegration(CreateCatalogIntegrationRequest) returns (CreateCatalogIntegrationResponse);
+  rpc UpdateCatalogIntegration(UpdateCatalogIntegrationRequest) returns (UpdateCatalogIntegrationResponse);
+  rpc UpdateCatalogIntegrationAuthentication(UpdateCatalogIntegrationAuthenticationRequest) returns (UpdateCatalogIntegrationAuthenticationResponse);
+  rpc DeleteCatalogIntegration(DeleteCatalogIntegrationRequest) returns (DeleteCatalogIntegrationResponse);
+}

--- a/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
+++ b/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
@@ -100,6 +100,8 @@ message CatalogIntegration {
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;
   CatalogAuthentication authentication = 7;
+  // Non-secret provider connection properties.
+  map<string, string> properties = 99;
 }
 
 message CatalogIntegrationSpec {
@@ -108,6 +110,8 @@ message CatalogIntegrationSpec {
   // HTTP(S) catalog endpoint URL. User-info, secret-bearing query parameters, and fragments are rejected.
   optional string catalog_uri = 3;
   CatalogAuthentication authentication = 4;
+  // Non-secret provider connection properties.
+  map<string, string> properties = 99;
 }
 
 message CatalogIntegrationEntry {

--- a/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
+++ b/core/proto/src/main/proto/floecat/integration/catalog_integration.proto
@@ -152,7 +152,8 @@ message ListCatalogIntegrationsResponse {
 
 message UpdateCatalogIntegrationRequest {
   ai.floedb.floecat.common.ResourceId integration_id = 1;
-  // Only display_name is mutable. Type and catalog_uri identify the connection and are immutable.
+  // Display name and catalog URI are mutable. Updating the URI advances the resource generation
+  // while preserving the integration identity and its dependent overlay bindings.
   CatalogIntegrationSpec spec = 2;
   ai.floedb.floecat.common.Precondition precondition = 3;
   google.protobuf.FieldMask update_mask = 4;

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/secrets/SecretsManager.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/secrets/SecretsManager.java
@@ -22,11 +22,22 @@ import java.util.Optional;
 public interface SecretsManager {
   void put(String accountId, String secretType, String secretId, byte[] payload);
 
+  /** Atomically creates a secret without replacing an existing value. */
+  boolean putIfAbsent(String accountId, String secretType, String secretId, byte[] payload);
+
   Optional<byte[]> get(String accountId, String secretType, String secretId);
 
   void update(String accountId, String secretType, String secretId, byte[] payload);
 
   void delete(String accountId, String secretType, String secretId);
+
+  /**
+   * Permanently deletes secret material that is no longer referenced by a published resource.
+   * Implementations with recoverable deletion should bypass that recovery window here.
+   */
+  default void deleteImmediately(String accountId, String secretType, String secretId) {
+    delete(accountId, secretType, secretId);
+  }
 
   static String buildSecretKey(String accountId, String secretType, String secretId) {
     requireNonBlank(accountId, "accountId");

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,8 @@ Views, Snapshots, statistics, and query-lifecycle artifacts.
 
 ```
 Account
- └── Catalog (logical catalog-of-catalogs)
+ ├── CatalogIntegration (external catalog identity)
+ └── Catalog (locally managed catalog)
       └── Namespace (hierarchical path)
            ├── Table (Iceberg/Delta metadata, upstream reference)
            │    └── Snapshot (immutable upstream checkpoints)
@@ -45,9 +46,13 @@ manifest entry without its `stats_generation_ref` is not yet query-visible — a
 to the newest finalized snapshot at or before it instead, so logical metadata can move current
 without exposing an unfinalized scan.
 
-The gRPC service (Quarkus) enforces tenancy, authorization, and idempotency while orchestrating
-connectors that ingest upstream metadata, reconciling it into the canonical blob/pointer stores, and
-serving execution-ready scan bundles.
+The gRPC service (Quarkus) enforces tenancy, authorization, idempotency, and transactional CRUD for
+catalog integrations. Catalog integrations include typed, non-secret authentication
+configuration plus write-only credential create/rotation primitives; secret payloads are stored
+separately and never returned. A typed credential-store resolver derives the internal secret key
+from integration identity and credential generation for follow-on clients. The resources remain operationally inert: this API does not perform
+connectivity validation, adapter selection, or reconciliation. Legacy connectors remain unchanged
+and are not part of the new contract.
 
 ## Components
 

--- a/docs/catalog-integration-design.md
+++ b/docs/catalog-integration-design.md
@@ -12,7 +12,7 @@ Catalog Integration and Catalog Overlay split today's `Connector` into its two i
 
 | Connector concern | Replacement |
 | --- | --- |
-| `uri`, `auth`, `kind` — how Floecat reaches and authenticates to an upstream catalog | `CatalogIntegration` |
+| `uri`, connection properties, `auth`, `kind` — how Floecat reaches and authenticates to an upstream catalog | `CatalogIntegration` |
 | `source` — which upstream namespaces are selected | `CatalogOverlay` |
 | `destination` — where the selection lands in Floecat | `CatalogOverlay`, through a reference to an existing `Catalog` |
 | `policy` — refresh cadence, retention, pause | Overlay demand or a referenced policy, deferred from the initial API |
@@ -86,9 +86,11 @@ with no overlay-specific read path.
 
 ### Catalog integration
 
-`CatalogIntegration` owns the upstream protocol, HTTP(S) endpoint, non-secret authentication
-configuration, and credential lifecycle. Its immutable resource ID is operational identity; its
-display name is mutable metadata and must be unique among integrations in the account.
+`CatalogIntegration` owns the upstream protocol, HTTP(S) endpoint, non-secret provider connection
+properties, authentication configuration, and credential lifecycle. Connection properties carry
+protocol-specific values such as the Iceberg REST warehouse; secret-bearing properties are rejected.
+Its immutable resource ID is operational identity; its display name is mutable metadata and must be
+unique among integrations in the account.
 
 The API initially supports Iceberg REST and Unity integration types. Authentication is required and
 represented by typed protobuf messages for OAuth client credentials, bearer tokens, AWS assume role,
@@ -96,12 +98,13 @@ AWS access keys, and AWS SigV4. Unity initially accepts only OAuth client creden
 authentication. The base service validates structural compatibility; endpoint and provider support
 remain the responsibility of the catalog-access adapter and provider.
 
-Integration type is immutable through update. The catalog URI is mutable with an etag precondition;
-publishing a URI update advances the Integration generation so reconciliation and durable work that
-observed the previous endpoint cannot publish afterward. Existing overlays and materialized resource
-identities remain attached to the same Integration. A replacing create is required only to change
-the Integration type, produces a new resource identity, and is rejected while overlays depend on the
-existing Integration because replacement must not silently retarget those overlays.
+Integration type is immutable through update. The catalog URI and connection properties are mutable
+with an etag precondition; publishing either update advances the Integration generation so
+reconciliation and durable work that observed the previous connection configuration cannot publish
+afterward. Existing overlays and materialized resource identities remain attached to the same
+Integration. A replacing create is required only to change the Integration type, produces a new
+resource identity, and is rejected while overlays depend on the existing Integration because
+replacement must not silently retarget those overlays.
 
 Integration type identifies the catalog access protocol; it does not define the format of every
 table in that catalog. As in the existing Connector path, the catalog-access provider determines

--- a/docs/fixed-roles.md
+++ b/docs/fixed-roles.md
@@ -8,14 +8,14 @@ Source of truth: `service/src/main/java/ai/floedb/floecat/service/security/RoleP
 
 | Role name | Purpose | Granted permissions |
 |-----------|---------|---------------------|
-| `default` | Baseline read-only tenant access. Used when no roles are provided in normal (`oidc`) mode. | `account.read`, `catalog.read`, `namespace.read`, `table.read`, `view.read` |
-| `administrator` | Full tenant-scoped administration of metadata and connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `system-objects.read`, `account.delete` |
-| `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `system-objects.read`, `account.delete` |
+| `default` | Baseline read-only tenant access. Used when no roles are provided in normal (`oidc`) mode. | `account.read`, `catalog.read`, `namespace.read`, `table.read`, `view.read`, `catalog-integration.read` |
+| `administrator` | Full tenant-scoped administration of metadata, catalog integrations, and legacy connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `system-objects.read`, `account.delete` |
+| `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `system-objects.read`, `account.delete` |
 | `platform-admin` (or configured value of `floecat.auth.platform-admin.role`) | Platform-level account management role from IdP. | `account.read`, `account.write`, `account.delete` |
-| `init-account` | Bootstrap role used to initialize account + initial resources. | `account.write`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `connector.create` |
+| `init-account` | Bootstrap role used to initialize account + initial resources. | `account.read`, `account.write`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `connector.create`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use` |
 | `delete-account` | Narrow internal role used to trigger account teardown. Floecat performs the implied cleanup internally. | `account.delete` |
 | `system-objects` | Minimal role for SystemObjects/GetSystemObjects access. | `system-objects.read` |
-| `reconcile-worker` | Dedicated machine principal for reconciler background gRPC work. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `system-objects.read`, `storage-authority.resolve-internal`, `reconcile-executor-control.internal` |
+| `reconcile-worker` | Dedicated machine principal for reconciler background gRPC work. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.use`, `system-objects.read`, `storage-authority.resolve-internal`, `reconcile-executor-control.internal` |
 
 ## Behavior Notes
 
@@ -28,3 +28,6 @@ Source of truth: `service/src/main/java/ai/floedb/floecat/service/security/RoleP
 - `init-account` also bypasses strict account existence validation during inbound context building.
 - `account.delete` is the dedicated destructive permission for account teardown. It is intentionally
   separate from broad catalog/table/connector management permissions.
+- `catalog-integration.write` administers integration records. `catalog-integration.use` is a
+  separate capability reserved for binding an integration from dependent resources without
+  granting integration-management authority.

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -21,8 +21,8 @@ running until its job trees drain while the new deployment writes and executes i
 Snapshot plans require one immutable file execution plan for every declared file path, so planner,
 executor, and finalizer implementations within one cohort must implement the same contract.
 
-The contract files are organised by domain (`common/`, `catalog/`, `query/`, `execution/`,
-`connector/`, `account/`, `types/`, `statistics/`, `reconciler/`). Generated Java stubs live
+The contract files are organised by domain (`common/`, `catalog/`, `integration/`, `query/`,
+`execution/`, `connector/`, `account/`, `types/`, `statistics/`, `reconciler/`). Generated Java stubs live
 under the `ai.floedb.floecat.*.rpc` packages and are consumed by the Quarkus service, connectors,
 CLI, and reconciler.
 
@@ -36,6 +36,11 @@ CLI, and reconciler.
   schemas also cover per-file statistics and index artifact metadata.
 - **`connector/connector.proto`** – Connector management RPCs plus reconciliation job tracking and
   validation routines.
+- **`integration/catalog_integration.proto`** – External catalog identity CRUD,
+  typed catalog authentication configuration, write-only credential payloads, non-secret
+  configured/generation state, and credential rotation. This contract is
+  independent of Connector and deliberately contain no connectivity-validation or reconciliation
+  operations.
 - **`query/lifecycle.proto`** – Query lifecycle (`BeginQuery`, `RenewQuery`, `EndQuery`, `GetQuery`) and the
   snapshot pin metadata sent down to the SQL planner.
 - **`query/system_objects_registry.proto`** – `GetSystemObjects` plus message definitions for builtin functions,
@@ -66,6 +71,7 @@ CLI, and reconciler.
 | `DirectoryService` | `Resolve*` & `Lookup*` RPCs | Translates between names and `ResourceId`s with pagination for batched lookups. |
 | `AccountService` | Account CRUD. |
 | `Connectors` | Connector CRUD, `ValidateConnector`, `StartCapture`, `GetReconcileJob`. |
+| `CatalogIntegrations` | Integration CRUD. |
 | `QueryService` | `BeginQuery`, `RenewQuery`, `EndQuery`, `GetQuery`. |
 | `QuerySchemaService` | `DescribeInputs`. |
 | `QueryScanService` | `InitScan`, `StreamDeleteFiles`, `StreamDataFiles`, `CloseScan`. |
@@ -76,8 +82,9 @@ CLI, and reconciler.
 | &nbsp;&nbsp;&nbsp;— Consumption pattern | | Clients read `UserObjectsBundleChunk` in three phases: 1) header chunk (cheap metadata), 2) zero or more `resolutions` chunk batches where each `RelationResolution` carries `input_index` + FOUND/NOT_FOUND/ERROR, and 3) a single end chunk with summary counts. Use `input_index` to map back to planner `TableReferenceCandidate`s and bind as soon as a `FOUND` arrives. For each `RelationInfo`, inspect `columns[*].status`: `COLUMN_STATUS_OK` exposes `columns[*].column`, while `COLUMN_STATUS_FAILED` exposes `columns[*].failure` with typed `ColumnFailureCode` plus details. Extension-defined failures must use `COLUMN_FAILURE_CODE_ENGINE_EXTENSION` and set `extension_code_value`; clients branch on `extension_code_value` inside the engine domain (for FloeDB, see `FloeDecorationFailureCode` in `extensions/floedb/src/main/proto/engine_floe.proto`). |
 | `SystemObjectsService` | `GetSystemObjects` | Returns the builtin catalog filtered by the `x-engine-kind` / `x-engine-version` headers supplied with the request. |
 
-Each RPC requires a populated `account_id` within the `ResourceId`s; the Quarkus service checks this
-before hitting repository storage.
+Resource IDs supplied to integration RPCs must include an `account_id` matching the
+authenticated principal's account. The service rejects blank or cross-account IDs before hitting
+repository storage.
 
 ### Planner Lifecycle & Execution Scan Schemas
 `query/lifecycle.proto` captures everything the planner needs to hold a lease:

--- a/docs/secrets-manager.md
+++ b/docs/secrets-manager.md
@@ -14,10 +14,21 @@ Each secret is tagged with:
 
 These tags support ABAC-style policies.
 
-Connector AuthCredentials and storage-authority source credentials are written to Secrets Manager
-and removed from the corresponding persisted resource records. Connector responses mask sensitive
-auth fields, and storage-authority resolution only returns client-safe config plus any temporary
-credentials minted for a specific table/location match.
+Connector AuthCredentials, catalog-integration credentials, and storage-authority source
+credentials are written to Secrets Manager and removed from the corresponding persisted resource
+records. Catalog integrations persist only typed non-secret authentication configuration,
+configured state, and a credential generation. Their internal secret key is derived from the
+integration ID and generation and is not part of the protobuf resource. Connector responses mask sensitive auth fields, and storage-authority
+resolution only returns client-safe config plus any temporary credentials minted for a specific
+table/location match.
+
+Catalog-integration credential replacement uses publish-before-retire ordering: the new secret is
+written with the atomic `putIfAbsent` primitive before the resource CAS, and the old secret is
+removed only after that CAS commits. Competing rotations allocate distinct immutable generations. A
+definite publication failure removes the unpublished generation. An acknowledgement-uncertain
+publication may leave an unreferenced generation because the service deliberately does not risk
+deleting a secret that a committed resource may reference. Durable cleanup records are drained by
+pointer GC once the generation is provably superseded.
 
 Connector secrets are never used for Iceberg REST client credential vending. Storage-authority
 secrets are the only credential source used for client credential vending.

--- a/docs/service.md
+++ b/docs/service.md
@@ -27,7 +27,7 @@ query lifecycle / scan bundle logic.
 │  ├─ Interceptors (context, localization, metering)                         │
 │  ├─ Security (PrincipalProvider, Authorizer)                               │
 │  ├─ Services (Catalog, Namespace, Table, View, Snapshot, Account,           │
-│  │            Directory, Statistics, Connectors, QueryService)             │
+│  │       Directory, Statistics, Integrations, Connectors, QueryService)      │
 │  ├─ QueryService (QueryContextStore, QueryServiceImpl)                     │
 │  ├─ Repositories (CatalogRepository, NamespaceRepository, TableRepository, │
 │  │                ViewRepository, SnapshotRepository, StatsRepository,     │
@@ -47,7 +47,7 @@ query lifecycle / scan bundle logic.
   production identity providers.
 - `service/repo` – Resource repositories layering pointer/blob stores and parsing protobuf payloads;
   includes key generation utilities (`Keys`, `ResourceKey`) and value normalizers.
-- `service/catalog` / `directory` / `account` / `statistics` / `connector` – gRPC service
+- `service/catalog` / `directory` / `account` / `statistics` / `integration` / `connector` – gRPC service
   implementations.
 - `catalog/builtin` – Shared builtin catalog data model, validator, and loader helpers.
 - `service/query` – Query lifecycle management (`QueryContext`, `QueryContextStore`,
@@ -79,7 +79,39 @@ helpers like `randomResourceId` (UUIDv4). Highlights:
   client-streaming `PutTargetStats` to batch writes per stream.
 - **DirectoryServiceImpl** – Provides fast name↔ID lookup via `MetadataGraph` (Resolve*/Lookup*) and
   reuses the graph’s ResolveFQ helpers for list/prefix pagination.
-- **AccountServiceImpl** – Administers accounts and enforces conventional permissions.
+- **AccountServiceImpl** – Administers accounts and enforces conventional permissions. Account
+  deletion installs a durable write fence, then uses strongly consistent enumeration to remove
+  catalog integrations before legacy connectors and local catalog descendants. Retrying a
+  committed account delete resumes cleanup using the deletion record's original mutation metadata.
+- **CatalogIntegrationsImpl** – Provides CRUD for external catalog identity records. The contract is
+  intentionally independent of legacy Connectors. It persists typed non-secret authentication
+  configuration for OAuth client credentials, bearer tokens, AWS assume-role/access-key, and AWS
+  SigV4. Secret values are accepted only in write-only credential messages, stored through the
+  SecretsManager under a deterministic integration-ID/credential-generation key, and never included
+  in resource responses. A typed credential-store resolver is available to follow-on catalog clients. A dedicated
+  authentication update RPC replaces configuration and rotates credentials while advancing a
+  visible credential generation. Unity integrations accept OAuth or bearer authentication; Iceberg
+  REST integrations accept every structurally valid authentication form the API supports.
+  Vendor/endpoint-specific compatibility is intentionally deferred to adapter selection and
+  validation in a follow-on change; this service does not yet perform connectivity validation or
+  reconciliation. Catalog endpoint URIs must
+  be hierarchical HTTP(S) URLs and cannot contain user-info, secret-bearing query parameters, or
+  fragments. Type and endpoint are immutable through update. The API exposes `CM_REPLACE` and
+  `CM_RETURN_EXISTING` as create-conflict primitives.
+  Replacement publishes a new resource identity and atomically swaps the name pointer before the
+  old identity is removed. Idempotent creates publish the
+  immutable success receipt in the same pointer transaction as the resource, so a retry never
+  rebuilds its response from subsequently mutable state. Creates carrying credentials support
+  idempotency. Secret values are excluded from durable request fingerprints and receipts, so the
+  first successfully published credential value wins for retries of the same key. Credential writes
+  happen before resource publication; definite publication failures remove the unpublished
+  generation, and replaced credentials are deleted only after the resource CAS commits. If the
+  publication acknowledgement is uncertain, the new secret is retained so a visible integration can
+  never reference a deleted secret. Durable cleanup records are drained after the generation is
+  provably superseded.
+  Get accepts either resource ID or
+  exact display name. Reads require
+  `catalog-integration.read`; writes require `catalog-integration.write`.
 - **ConnectorsImpl** – Manages connector lifecycle, validates `ConnectorSpec` via SPI factories,
   wires reconciliation job submission, and exposes `ValidateConnector` + `StartCapture`.
   `CaptureNow` maps to reconciler capture modes:

--- a/docs/service.md
+++ b/docs/service.md
@@ -96,7 +96,8 @@ helpers like `randomResourceId` (UUIDv4). Highlights:
   validation in a follow-on change; this service does not yet perform connectivity validation or
   reconciliation. Catalog endpoint URIs must
   be hierarchical HTTP(S) URLs and cannot contain user-info, secret-bearing query parameters, or
-  fragments. Type and endpoint are immutable through update. The API exposes `CM_REPLACE` and
+  fragments. Type is immutable through update; endpoint updates preserve the Integration identity
+  while advancing its etag. The API exposes `CM_REPLACE` and
   `CM_RETURN_EXISTING` as create-conflict primitives.
   Replacement publishes a new resource identity and atomically swaps the name pointer before the
   old identity is removed. Idempotent creates publish the

--- a/docs/storage-layout.md
+++ b/docs/storage-layout.md
@@ -26,6 +26,7 @@ Resource and transaction blobs:
 /accounts/{account_id}/tables/{table_id}/table/{sha}.pb
 /accounts/{account_id}/views/{view_id}/view/{sha}.pb
 /accounts/{account_id}/connectors/{connector_id}/connector/{sha}.pb
+/accounts/{account_id}/catalog-integrations/{integration_id}/integration/{sha}.pb
 /accounts/{account_id}/transactions/{tx_id}/transaction/{sha}.pb
 /accounts/{account_id}/transactions/{tx_id}/intent/{sha}.pb
 /accounts/{account_id}/transactions/{tx_id}/objects/{sha}.bin
@@ -89,11 +90,29 @@ Catalog hierarchy, lookup indexes, and maintenance markers:
 /accounts/{account_id}/catalogs/{catalog_id}/namespaces/{namespace_id}/relations/by-name/{relation_name}
 /accounts/{account_id}/connectors/by-id/{connector_id}
 /accounts/{account_id}/connectors/by-name/{connector_name}
+/accounts/{account_id}/catalog-integrations/by-id/{integration_id}
+/accounts/{account_id}/catalog-integrations/by-name/{integration_name}
+/accounts/{account_id}/catalog-integrations/overlays-marker/{integration_id}
+/accounts/{account_id}/catalog-integrations/deleting/{integration_id}
+/accounts/{account_id}/deleting
+/catalog-integration-credential-cleanup/{account_id}/{integration_id}/{generation}
 /accounts/{account_id}/catalogs/{catalog_id}/markers/children
 /accounts/{account_id}/namespaces/{namespace_id}/markers/children
 /accounts/{account_id}/gc/cas/generation-cursor
 /accounts/{account_id}/root-resyncs/by-table/{table_id}
 ```
+
+Catalog integration secret payloads are stored outside the resource blob through SecretsManager:
+
+```
+accounts/{account_id}/catalog-integrations/{integration_id}:{credential_generation}
+```
+
+The key is derived internally from the persisted integration identity and credential generation; it
+is not present in the resource payload. A new secret is written before publishing the matching
+generation; an old secret is deleted only after the resource mutation commits. Definite failures
+delete an unpublished generation. Durable cleanup records retain other candidates until pointer GC
+can prove that their generation is no longer referenced.
 
 Transaction and idempotency pointers:
 

--- a/docs/storage-layout.md
+++ b/docs/storage-layout.md
@@ -105,7 +105,7 @@ Catalog hierarchy, lookup indexes, and maintenance markers:
 Catalog integration secret payloads are stored outside the resource blob through SecretsManager:
 
 ```
-accounts/{account_id}/catalog-integrations/{integration_id}:{credential_generation}
+accounts/{account_id}/catalog-integrations/{integration_id}.credentials.{credential_generation}
 ```
 
 The key is derived internally from the persisted integration identity and credential generation; it

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -43,10 +43,12 @@ import ai.floedb.floecat.service.common.LogHelper;
 import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.credentials.DefaultCredentialResolver;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import ai.floedb.floecat.service.integration.CatalogIntegrationCredentialCleanup;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.reconciler.jobs.DurableReconcileJobStore;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
@@ -74,6 +76,7 @@ import org.jboss.logging.Logger;
 @GrpcService
 public class AccountServiceImpl extends BaseServiceImpl implements AccountService {
   @Inject AccountRepository accountRepo;
+  @Inject CatalogIntegrationRepository catalogIntegrationRepo;
   @Inject TableRootRepository tableRootRepo;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
@@ -84,6 +87,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
   @Inject DefaultCredentialResolver credentialResolver;
   @Inject SecretsManager secretsManager;
   @Inject Instance<DurableReconcileJobStore> durableReconcileJobStore;
+  @Inject CatalogIntegrationCredentialCleanup catalogIntegrationCredentialCleanup;
 
   private static final Set<String> ACCOUNT_MUTABLE_PATHS =
       Set.of("display_name", "description", "tags");
@@ -534,6 +538,11 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
               Keys.storageAuthorityPointerByIdPrefix(accountKey),
               accountKey,
               ResourceKind.RK_STORAGE_AUTHORITY);
+      List<ResourceId> catalogIntegrations =
+          listCanonicalResourceIds(
+              Keys.catalogIntegrationPointerByIdPrefix(accountKey),
+              accountKey,
+              ResourceKind.RK_CATALOG_INTEGRATION);
       List<ResourceId> connectors =
           listCanonicalResourceIds(
               Keys.connectorPointerByIdPrefix(accountKey), accountKey, ResourceKind.RK_CONNECTOR);
@@ -550,8 +559,12 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
           listCanonicalResourceIds(
               Keys.viewPointerByIdPrefix(accountKey), accountKey, ResourceKind.RK_VIEW);
 
+      List<ai.floedb.floecat.integration.rpc.CatalogIntegration>
+          integrationsWithScheduledCredentialCleanup =
+              scheduleCatalogIntegrationCredentialCleanup(catalogIntegrations, summary);
       cleanupStorageAuthorityCredentials(accountKey, storageAuthorities, summary);
       cleanupConnectorCredentials(accountKey, connectors, summary);
+      summary.catalogIntegrationsDeleted = catalogIntegrations.size();
       summary.catalogsDeleted = catalogs.size();
       summary.namespacesDeleted = namespaces.size();
       summary.tablesDeleted = tables.size();
@@ -568,21 +581,25 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
       summary.accountPointersDeleted +=
           pointerStore.deleteByPrefixExcluding(accountPrefix, deletionFence);
       assertAccountPointerSweepComplete(accountPrefix, deletionFence);
+      integrationsWithScheduledCredentialCleanup.forEach(
+          catalogIntegrationCredentialCleanup::cleanIfSuperseded);
       // The durable root pointers are gone; purge their read-your-writes cache entries as well.
       for (ResourceId tableId : tables) {
         tableRootRepo.purgeRoot(tableId);
       }
       invalidateAll(storageAuthorities);
       invalidateAll(connectors);
+      invalidateAll(catalogIntegrations);
       invalidateAll(catalogs);
       invalidateAll(namespaces);
       invalidateAll(tables);
       invalidateAll(views);
       summary.residualAccountBlobsDeleted += blobStore.deletePrefix(accountPrefix);
       CLEANUP_LOG.infof(
-          "account_delete_cleanup_complete account_id=%s account_pointer_deletes=%d storage_authorities=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d reconcile_jobs=%d residual_account_blob_deletes=%d",
+          "account_delete_cleanup_complete account_id=%s account_pointer_deletes=%d catalog_integrations=%d storage_authorities=%d connectors=%d credential_deletes=%d catalogs=%d namespaces=%d tables=%d views=%d reconcile_jobs=%d residual_account_blob_deletes=%d",
           summary.accountId,
           summary.accountPointersDeleted,
+          summary.catalogIntegrationsDeleted,
           summary.storageAuthoritiesDeleted,
           summary.connectorsDeleted,
           summary.credentialsDeleted,
@@ -596,6 +613,31 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
       CLEANUP_LOG.errorf(e, "account_delete_cleanup_failed account_id=%s", accountKey);
       throw e;
     }
+  }
+
+  private List<ai.floedb.floecat.integration.rpc.CatalogIntegration>
+      scheduleCatalogIntegrationCredentialCleanup(
+          List<ResourceId> integrationIds, AccountCleanupSummary summary) {
+    var scheduled = new ArrayList<ai.floedb.floecat.integration.rpc.CatalogIntegration>();
+    for (ResourceId integrationId : integrationIds) {
+      try {
+        catalogIntegrationRepo
+            .getById(integrationId)
+            .filter(catalogIntegrationCredentialCleanup::schedule)
+            .ifPresent(
+                integration -> {
+                  scheduled.add(integration);
+                  summary.credentialsDeleted++;
+                });
+      } catch (BaseResourceRepository.CorruptionException corruption) {
+        CLEANUP_LOG.warnf(
+            corruption,
+            "account_delete_cleanup_skipping_corrupt_catalog_integration account_id=%s integration_id=%s",
+            integrationId.getAccountId(),
+            integrationId.getId());
+      }
+    }
+    return List.copyOf(scheduled);
   }
 
   private void cleanupStorageAuthorityCredentials(
@@ -699,6 +741,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
   private static final class AccountCleanupSummary {
     private final String accountId;
     private int accountPointersDeleted;
+    private int catalogIntegrationsDeleted;
     private int storageAuthoritiesDeleted;
     private int connectorsDeleted;
     private int credentialsDeleted;

--- a/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/CasBlobGc.java
@@ -733,6 +733,14 @@ public class CasBlobGc {
               storageEstimate);
       pointersScanned +=
           collectPointers(
+              Keys.catalogIntegrationPointerByIdPrefix(accountId),
+              referenced,
+              null,
+              pageSize,
+              null,
+              storageEstimate);
+      pointersScanned +=
+          collectPointers(
               Keys.storageAuthorityPointerByIdPrefix(accountId),
               referenced,
               null,
@@ -1071,6 +1079,21 @@ public class CasBlobGc {
       blobsScanned += connectors.scanned();
       blobsDeleted += connectors.deleted();
       blobsRescued += connectors.rescued();
+
+      var catalogIntegrations =
+          deleteUnreferenced(
+              Keys.catalogIntegrationRootPrefix(accountId),
+              referenced,
+              walkedPinRoots,
+              walkFailures,
+              key -> key.contains("/integration/"),
+              null,
+              pageSize,
+              nowMs,
+              minAgeMs);
+      blobsScanned += catalogIntegrations.scanned();
+      blobsDeleted += catalogIntegrations.deleted();
+      blobsRescued += catalogIntegrations.rescued();
 
       var storageAuthorities =
           deleteUnreferenced(

--- a/service/src/main/java/ai/floedb/floecat/service/gc/PointerGc.java
+++ b/service/src/main/java/ai/floedb/floecat/service/gc/PointerGc.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.gc;
 
 import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.service.integration.CatalogIntegrationCredentialCleanup;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.spi.BlobStore;
@@ -38,6 +39,7 @@ public class PointerGc {
 
   @Inject PointerStore pointerStore;
   @Inject BlobStore blobStore;
+  @Inject CatalogIntegrationCredentialCleanup credentialCleanup;
 
   public record Result(int scanned, int deleted, int missingBlobs, int staleSecondaries) {}
 
@@ -57,6 +59,11 @@ public class PointerGc {
     int deleted = 0;
     int missingBlobs = 0;
     int staleSecondaries = 0;
+
+    CatalogIntegrationCredentialCleanup.Result credentialResult =
+        credentialCleanup.drain(deadlineMs, pageSize);
+    scanned += credentialResult.scanned();
+    deleted += credentialResult.deleted();
 
     Result byId =
         scanPrefix(
@@ -195,6 +202,34 @@ public class PointerGc {
     deleted += connectorsByName.deleted;
     missingBlobs += connectorsByName.missingBlobs;
     staleSecondaries += connectorsByName.staleSecondaries;
+
+    Result integrationsById =
+        scanPrefix(
+            Keys.catalogIntegrationPointerByIdPrefix(accountId),
+            pageSize,
+            deadlineMs,
+            blobCache,
+            p -> true,
+            nowMs,
+            minAgeMs);
+    scanned += integrationsById.scanned;
+    deleted += integrationsById.deleted;
+    missingBlobs += integrationsById.missingBlobs;
+    staleSecondaries += integrationsById.staleSecondaries;
+
+    Result integrationsByName =
+        scanPrefix(
+            Keys.catalogIntegrationPointerByNamePrefix(accountId),
+            pageSize,
+            deadlineMs,
+            blobCache,
+            p -> true,
+            nowMs,
+            minAgeMs);
+    scanned += integrationsByName.scanned;
+    deleted += integrationsByName.deleted;
+    missingBlobs += integrationsByName.missingBlobs;
+    staleSecondaries += integrationsByName.staleSecondaries;
 
     Result catalogsByName =
         scanPrefix(
@@ -439,6 +474,12 @@ public class PointerGc {
 
     if ("connectors".equals(scope) && parts.length >= 5 && "connector".equals(parts[4])) {
       return Keys.connectorPointerById(accountId, decode(parts[3]));
+    }
+
+    if ("catalog-integrations".equals(scope)
+        && parts.length >= 5
+        && "integration".equals(parts[4])) {
+      return Keys.catalogIntegrationPointerById(accountId, decode(parts[3]));
     }
 
     return null;

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogCreatePolicy.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogCreatePolicy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.integration;
+
+import ai.floedb.floecat.common.rpc.CreateMode;
+import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import java.util.Map;
+
+final class CatalogCreatePolicy {
+  private CatalogCreatePolicy() {}
+
+  static Selection validate(CreateMode mode, String idempotencyKey, String correlationId) {
+    String key = idempotencyKey == null ? "" : idempotencyKey.trim();
+    if (mode == CreateMode.UNRECOGNIZED) {
+      throw GrpcErrors.invalidArgument(correlationId, null, Map.of("field", "create_mode"));
+    }
+    if (!key.isEmpty() && mode != CreateMode.CM_ERROR_IF_EXISTS) {
+      throw GrpcErrors.invalidArgument(correlationId, null, Map.of("field", "idempotency"));
+    }
+    return new Selection(mode, key);
+  }
+
+  record Selection(CreateMode mode, String idempotencyKey) {}
+}

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogCreatePolicy.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogCreatePolicy.java
@@ -6,6 +6,8 @@
  */
 package ai.floedb.floecat.service.integration;
 
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.FIELD;
+
 import ai.floedb.floecat.common.rpc.CreateMode;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import java.util.Map;
@@ -16,10 +18,10 @@ final class CatalogCreatePolicy {
   static Selection validate(CreateMode mode, String idempotencyKey, String correlationId) {
     String key = idempotencyKey == null ? "" : idempotencyKey.trim();
     if (mode == CreateMode.UNRECOGNIZED) {
-      throw GrpcErrors.invalidArgument(correlationId, null, Map.of("field", "create_mode"));
+      throw GrpcErrors.invalidArgument(correlationId, FIELD, Map.of("field", "create_mode"));
     }
     if (!key.isEmpty() && mode != CreateMode.CM_ERROR_IF_EXISTS) {
-      throw GrpcErrors.invalidArgument(correlationId, null, Map.of("field", "idempotency"));
+      throw GrpcErrors.invalidArgument(correlationId, FIELD, Map.of("field", "idempotency"));
     }
     return new Selection(mode, key);
   }

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialCleanup.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialCleanup.java
@@ -19,6 +19,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -52,6 +53,23 @@ public class CatalogIntegrationCredentialCleanup {
         == CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET) return;
     schedule(integrationId, generation);
     cleanIfSuperseded(integrationId, generation);
+  }
+
+  public boolean cancelIfResourceUnchanged(
+      CatalogIntegration integration, long expectedPointerVersion) {
+    if (!CatalogIntegrationCredentialStore.hasStoredCredentials(integration)
+        || expectedPointerVersion <= 0L) return false;
+    ResourceId integrationId = integration.getResourceId();
+    String markerKey =
+        key(integrationId, integration.getAuthentication().getCredentialGeneration());
+    Pointer marker = pointerStore.get(markerKey).orElse(null);
+    if (marker == null) return false;
+    String canonicalKey =
+        Keys.catalogIntegrationPointerById(integrationId.getAccountId(), integrationId.getId());
+    return pointerStore.compareAndSetBatch(
+        List.of(
+            new PointerStore.CasCheck(canonicalKey, expectedPointerVersion),
+            new PointerStore.CasDelete(markerKey, marker.getVersion())));
   }
 
   public Result drain(long deadlineMs, int pageSize) {
@@ -92,7 +110,7 @@ public class CatalogIntegrationCredentialCleanup {
     Pointer marker = pointerStore.get(key).orElse(null);
     if (marker == null) return false;
     try {
-      var current = integrations.getById(integrationId);
+      var current = integrations.getByIdForMutation(integrationId);
       if (current.isPresent()
           && CatalogIntegrationCredentialStore.hasStoredCredentials(current.get())
           && current.get().getAuthentication().getCredentialGeneration() == generation) {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialCleanup.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialCleanup.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.integration;
+
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class CatalogIntegrationCredentialCleanup {
+  private static final Logger LOG = Logger.getLogger(CatalogIntegrationCredentialCleanup.class);
+
+  @Inject PointerStore pointerStore;
+  @Inject CatalogIntegrationRepository integrations;
+  @Inject CatalogIntegrationCredentialStore credentials;
+
+  public record Result(int scanned, int deleted) {}
+
+  public boolean schedule(CatalogIntegration integration) {
+    if (!CatalogIntegrationCredentialStore.hasStoredCredentials(integration)) return false;
+    schedule(
+        integration.getResourceId(), integration.getAuthentication().getCredentialGeneration());
+    return true;
+  }
+
+  public void cleanIfSuperseded(CatalogIntegration integration) {
+    if (!CatalogIntegrationCredentialStore.hasStoredCredentials(integration)) return;
+    cleanIfSuperseded(
+        integration.getResourceId(), integration.getAuthentication().getCredentialGeneration());
+  }
+
+  public void cleanPrepared(
+      ResourceId integrationId,
+      long generation,
+      CatalogIntegrationCredentials preparedCredentials) {
+    if (preparedCredentials.getCredentialCase()
+        == CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET) return;
+    schedule(integrationId, generation);
+    cleanIfSuperseded(integrationId, generation);
+  }
+
+  public Result drain(long deadlineMs, int pageSize) {
+    int scanned = 0;
+    int deleted = 0;
+    String token = "";
+    while (System.currentTimeMillis() < deadlineMs) {
+      var next = new StringBuilder();
+      var markers =
+          pointerStore.listPointersByPrefix(
+              Keys.catalogIntegrationCredentialCleanupPrefix(), Math.max(1, pageSize), token, next);
+      for (Pointer marker : markers) {
+        if (System.currentTimeMillis() >= deadlineMs) break;
+        scanned++;
+        CleanupTarget target = parse(marker.getKey());
+        if (target == null) {
+          LOG.errorf(
+              "invalid catalog integration credential cleanup marker key=%s", marker.getKey());
+          if (pointerStore.compareAndDelete(marker.getKey(), marker.getVersion())) deleted++;
+          continue;
+        }
+        if (cleanIfSuperseded(target.integrationId(), target.generation())) deleted++;
+      }
+      token = next.toString();
+      if (token.isEmpty()) break;
+    }
+    return new Result(scanned, deleted);
+  }
+
+  private void schedule(ResourceId integrationId, long generation) {
+    String key = key(integrationId, generation);
+    if (pointerStore.get(key).isPresent()) return;
+    pointerStore.compareAndSet(key, 0L, PointerReferences.opaqueMarkerPointer(key, key, 1L));
+  }
+
+  private boolean cleanIfSuperseded(ResourceId integrationId, long generation) {
+    String key = key(integrationId, generation);
+    Pointer marker = pointerStore.get(key).orElse(null);
+    if (marker == null) return false;
+    try {
+      var current = integrations.getById(integrationId);
+      if (current.isPresent()
+          && CatalogIntegrationCredentialStore.hasStoredCredentials(current.get())
+          && current.get().getAuthentication().getCredentialGeneration() == generation) {
+        return false;
+      }
+      credentials.deleteImmediately(integrationId, generation);
+      return pointerStore.compareAndDelete(key, marker.getVersion());
+    } catch (RuntimeException failure) {
+      LOG.warnf(
+          failure,
+          "catalog integration credential cleanup deferred account=%s integration=%s generation=%s",
+          integrationId.getAccountId(),
+          integrationId.getId(),
+          Long.toUnsignedString(generation));
+      return false;
+    }
+  }
+
+  private static String key(ResourceId integrationId, long generation) {
+    return Keys.catalogIntegrationCredentialCleanupPointer(
+        integrationId.getAccountId(), integrationId.getId(), generation);
+  }
+
+  private static CleanupTarget parse(String key) {
+    String prefix = Keys.catalogIntegrationCredentialCleanupPrefix();
+    if (key == null || !key.startsWith(prefix)) return null;
+    String[] parts = key.substring(prefix.length()).split("/", -1);
+    if (parts.length != 3) return null;
+    try {
+      String accountId = URLDecoder.decode(parts[0], StandardCharsets.UTF_8);
+      String integrationId = URLDecoder.decode(parts[1], StandardCharsets.UTF_8);
+      long generation = Long.parseUnsignedLong(parts[2]);
+      if (accountId.isBlank() || integrationId.isBlank() || generation == 0L) return null;
+      return new CleanupTarget(
+          ResourceId.newBuilder()
+              .setAccountId(accountId)
+              .setId(integrationId)
+              .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+              .build(),
+          generation);
+    } catch (IllegalArgumentException failure) {
+      return null;
+    }
+  }
+
+  private record CleanupTarget(ResourceId integrationId, long generation) {}
+}

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
@@ -49,7 +49,7 @@ public class CatalogIntegrationCredentialStore {
     if (!stored
         && secretsManager.get(integrationId.getAccountId(), SECRET_TYPE, reference).isEmpty()) {
       throw new BaseResourceRepository.AbortRetryableException(
-          "Catalog integration credential generation is not yet available");
+          "catalog integration credential generation is not yet available");
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
@@ -10,6 +10,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
 import ai.floedb.floecat.integration.rpc.CatalogIntegration;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.storage.secrets.SecretsManager;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -34,12 +35,21 @@ public class CatalogIntegrationCredentialStore {
     if (secretsManager.get(integrationId.getAccountId(), SECRET_TYPE, reference).isPresent()) {
       return;
     }
+    boolean stored;
     try {
-      secretsManager.putIfAbsent(integrationId.getAccountId(), SECRET_TYPE, reference, payload);
+      stored =
+          secretsManager.putIfAbsent(
+              integrationId.getAccountId(), SECRET_TYPE, reference, payload);
     } catch (RuntimeException failure) {
       if (secretsManager.get(integrationId.getAccountId(), SECRET_TYPE, reference).isEmpty()) {
         throw failure;
       }
+      return;
+    }
+    if (!stored
+        && secretsManager.get(integrationId.getAccountId(), SECRET_TYPE, reference).isEmpty()) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "Catalog integration credential generation is not yet available");
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.integration;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.storage.secrets.SecretsManager;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Optional;
+
+@ApplicationScoped
+public class CatalogIntegrationCredentialStore {
+  static final String SECRET_TYPE = "catalog-integrations";
+
+  @Inject SecretsManager secretsManager;
+
+  public void store(
+      ResourceId integrationId,
+      long credentialGeneration,
+      CatalogIntegrationCredentials credentials) {
+    if (credentials.getCredentialCase()
+        == CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET) {
+      return;
+    }
+    byte[] payload = credentials.toByteArray();
+    String reference = reference(integrationId, credentialGeneration);
+    if (secretsManager.get(integrationId.getAccountId(), SECRET_TYPE, reference).isPresent()) {
+      return;
+    }
+    try {
+      secretsManager.putIfAbsent(integrationId.getAccountId(), SECRET_TYPE, reference, payload);
+    } catch (RuntimeException failure) {
+      if (secretsManager.get(integrationId.getAccountId(), SECRET_TYPE, reference).isEmpty()) {
+        throw failure;
+      }
+    }
+  }
+
+  public long storeRotation(
+      ResourceId integrationId, long minimumGeneration, CatalogIntegrationCredentials credentials) {
+    if (credentials.getCredentialCase()
+        == CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET) {
+      return 0L;
+    }
+    byte[] payload = credentials.toByteArray();
+    long generation = minimumGeneration;
+    while (generation > 0L) {
+      String reference = reference(integrationId, generation);
+      var existing = secretsManager.get(integrationId.getAccountId(), SECRET_TYPE, reference);
+      if (existing.isPresent()) {
+        generation++;
+        continue;
+      }
+      try {
+        if (secretsManager.putIfAbsent(
+            integrationId.getAccountId(), SECRET_TYPE, reference, payload)) {
+          return generation;
+        }
+        generation++;
+      } catch (RuntimeException failure) {
+        existing = secretsManager.get(integrationId.getAccountId(), SECRET_TYPE, reference);
+        if (existing.isEmpty()) throw failure;
+        generation++;
+      }
+    }
+    throw new IllegalStateException("Catalog integration credential generation exhausted");
+  }
+
+  public Optional<CatalogIntegrationCredentials> resolve(CatalogIntegration integration) {
+    if (!hasStoredCredentials(integration)) return Optional.empty();
+    String reference =
+        reference(
+            integration.getResourceId(), integration.getAuthentication().getCredentialGeneration());
+    return secretsManager
+        .get(integration.getResourceId().getAccountId(), SECRET_TYPE, reference)
+        .map(CatalogIntegrationCredentialStore::parse)
+        .map(credentials -> requireCompatible(integration.getAuthentication(), credentials));
+  }
+
+  public void deleteImmediately(ResourceId integrationId, long credentialGeneration) {
+    secretsManager.deleteImmediately(
+        integrationId.getAccountId(), SECRET_TYPE, reference(integrationId, credentialGeneration));
+  }
+
+  static String reference(ResourceId integrationId, long credentialGeneration) {
+    if (credentialGeneration <= 0L) {
+      throw new IllegalArgumentException("credential generation must be positive");
+    }
+    return integrationId.getId() + ":" + Long.toUnsignedString(credentialGeneration);
+  }
+
+  static boolean hasStoredCredentials(CatalogIntegration integration) {
+    return integration.hasAuthentication()
+        && integration.getAuthentication().getCredentialsConfigured()
+        && usesStoredCredentials(integration.getAuthentication());
+  }
+
+  private static boolean usesStoredCredentials(CatalogAuthentication authentication) {
+    return switch (authentication.getConfigurationCase()) {
+      case OAUTH_CLIENT_CREDENTIALS, BEARER, AWS_ACCESS_KEY -> true;
+      case AWS_SIGV4 ->
+          authentication.getAwsSigv4().getCredentialsCase()
+              == ai.floedb.floecat.integration.rpc.AwsSigV4Authentication.CredentialsCase
+                  .AWS_ACCESS_KEY;
+      case AWS_ASSUME_ROLE, CONFIGURATION_NOT_SET -> false;
+    };
+  }
+
+  private static CatalogIntegrationCredentials parse(byte[] payload) {
+    try {
+      return CatalogIntegrationCredentials.parseFrom(payload);
+    } catch (Exception failure) {
+      throw new IllegalStateException("Failed to parse catalog integration credentials", failure);
+    }
+  }
+
+  private static CatalogIntegrationCredentials requireCompatible(
+      CatalogAuthentication authentication, CatalogIntegrationCredentials credentials) {
+    CatalogIntegrationCredentials.CredentialCase expected =
+        switch (authentication.getConfigurationCase()) {
+          case OAUTH_CLIENT_CREDENTIALS ->
+              CatalogIntegrationCredentials.CredentialCase.OAUTH_CLIENT_SECRET;
+          case BEARER -> CatalogIntegrationCredentials.CredentialCase.BEARER_TOKEN;
+          case AWS_ACCESS_KEY -> CatalogIntegrationCredentials.CredentialCase.AWS_ACCESS_KEY;
+          case AWS_SIGV4 ->
+              authentication.getAwsSigv4().getCredentialsCase()
+                      == ai.floedb.floecat.integration.rpc.AwsSigV4Authentication.CredentialsCase
+                          .AWS_ACCESS_KEY
+                  ? CatalogIntegrationCredentials.CredentialCase.AWS_ACCESS_KEY
+                  : CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET;
+          case AWS_ASSUME_ROLE, CONFIGURATION_NOT_SET ->
+              CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET;
+        };
+    if (credentials.getCredentialCase() != expected) {
+      throw new IllegalStateException(
+          "Stored catalog integration credentials do not match authentication configuration");
+    }
+    return credentials;
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
@@ -38,8 +38,7 @@ public class CatalogIntegrationCredentialStore {
     boolean stored;
     try {
       stored =
-          secretsManager.putIfAbsent(
-              integrationId.getAccountId(), SECRET_TYPE, reference, payload);
+          secretsManager.putIfAbsent(integrationId.getAccountId(), SECRET_TYPE, reference, payload);
     } catch (RuntimeException failure) {
       if (secretsManager.get(integrationId.getAccountId(), SECRET_TYPE, reference).isEmpty()) {
         throw failure;

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStore.java
@@ -93,7 +93,7 @@ public class CatalogIntegrationCredentialStore {
     if (credentialGeneration <= 0L) {
       throw new IllegalArgumentException("credential generation must be positive");
     }
-    return integrationId.getId() + ":" + Long.toUnsignedString(credentialGeneration);
+    return integrationId.getId() + ".credentials." + Long.toUnsignedString(credentialGeneration);
   }
 
   static boolean hasStoredCredentials(CatalogIntegration integration) {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -6,6 +6,14 @@
  */
 package ai.floedb.floecat.service.integration;
 
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.CATALOG_INTEGRATION;
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.CATALOG_INTEGRATION_ALREADY_EXISTS;
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.CATALOG_INTEGRATION_CHANGED;
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.CATALOG_INTEGRATION_DELETION_IN_PROGRESS;
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.FIELD;
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.SELECTOR_REQUIRED;
+import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.UPDATE_MASK_REQUIRED;
+
 import ai.floedb.floecat.common.rpc.CreateMode;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
@@ -53,7 +61,7 @@ import java.util.Set;
 
 @GrpcService
 public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogIntegrations {
-  private static final Set<String> MUTABLE_PATHS = Set.of("display_name");
+  private static final Set<String> MUTABLE_PATHS = Set.of("display_name", "catalog_uri");
 
   @Inject CatalogIntegrationRepository integrations;
   @Inject MarkerStore markerStore;
@@ -101,7 +109,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
               authz.require(pc, RolePermissions.CATALOG_INTEGRATION_READ);
               if (!request.hasIntegrationId() && !request.hasDisplayName())
                 throw GrpcErrors.invalidArgument(
-                    pc.getCorrelationId(), null, Map.of("field", "selector"));
+                    pc.getCorrelationId(), SELECTOR_REQUIRED, Map.of("field", "selector"));
               var row =
                   (request.hasIntegrationId()
                           ? integrations.getByIdWithMeta(
@@ -115,7 +123,15 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                                       pc.getCorrelationId()))
                               : throwMissingIntegrationSelector())
                       .orElseThrow(
-                          () -> GrpcErrors.notFound(pc.getCorrelationId(), null, Map.of()));
+                          () ->
+                              GrpcErrors.notFound(
+                                  pc.getCorrelationId(),
+                                  CATALOG_INTEGRATION,
+                                  Map.of(
+                                      "id",
+                                      request.hasIntegrationId()
+                                          ? request.getIntegrationId().getId()
+                                          : request.getDisplayName())));
               return GetCatalogIntegrationResponse.newBuilder()
                   .setIntegration(row.value())
                   .setMeta(row.meta())
@@ -164,7 +180,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                   || spec.getAuthentication().getConfigurationCase()
                       == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
                 throw GrpcErrors.invalidArgument(
-                    corr, null, Map.of("field", "authentication.configuration"));
+                    corr, FIELD, Map.of("field", "authentication.configuration"));
               }
               PreparedAuthentication preparedAuthentication =
                   prepareAuthentication(
@@ -301,7 +317,8 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
         return new CreateOutcome(current, true);
       if (mode == CreateMode.CM_RETURN_EXISTING) return new CreateOutcome(current, false);
       if (mode != CreateMode.CM_REPLACE)
-        throw GrpcErrors.alreadyExists(corr, null, Map.of("display_name", name));
+        throw GrpcErrors.alreadyExists(
+            corr, CATALOG_INTEGRATION_ALREADY_EXISTS, Map.of("display_name", name));
       long markerVersion =
           markerStore.catalogIntegrationOverlaysMarkerVersion(current.value().getResourceId());
       var replacement =
@@ -316,15 +333,21 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                   authentication)
               .build();
       credentialCleanup.schedule(current.value());
-      var replaced =
-          integrations.replaceIdentityWithMeta(
-              current.value(), current.meta().getPointerVersion(), replacement, markerVersion);
-      if (replaced.isEmpty()) {
-        throw new BaseResourceRepository.AbortRetryableException(
-            "integration dependencies changed during replacement");
+      try {
+        var replaced =
+            integrations.replaceIdentityWithMeta(
+                current.value(), current.meta().getPointerVersion(), replacement, markerVersion);
+        if (replaced.isEmpty()) {
+          throw new BaseResourceRepository.AbortRetryableException(
+              "integration dependencies changed during replacement");
+        }
+        credentialCleanup.cleanIfSuperseded(current.value());
+        return new CreateOutcome(replaced.get(), true);
+      } catch (RuntimeException failure) {
+        credentialCleanup.cancelIfResourceUnchanged(
+            current.value(), current.meta().getPointerVersion());
+        throw failure;
       }
-      credentialCleanup.cleanIfSuperseded(current.value());
-      return new CreateOutcome(replaced.get(), true);
     }
     var desired =
         applyAuthentication(
@@ -365,7 +388,8 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       if (mode != CreateMode.CM_ERROR_IF_EXISTS)
         throw new BaseResourceRepository.AbortRetryableException(
             "integration name owner changed during create");
-      throw GrpcErrors.alreadyExists(corr, null, Map.of("display_name", name));
+      throw GrpcErrors.alreadyExists(
+          corr, CATALOG_INTEGRATION_ALREADY_EXISTS, Map.of("display_name", name));
     }
   }
 
@@ -379,32 +403,44 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
               authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
               String corr = pc.getCorrelationId();
               ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
-              FieldMask mask =
+              Set<String> paths =
                   requiredMask(request.hasUpdateMask() ? request.getUpdateMask() : null, corr);
               var current =
                   integrations
                       .getByIdWithMeta(id)
-                      .orElseThrow(() -> GrpcErrors.notFound(corr, null, Map.of("id", id.getId())));
+                      .orElseThrow(
+                          () ->
+                              GrpcErrors.notFound(
+                                  corr, CATALOG_INTEGRATION, Map.of("id", id.getId())));
               MutationOps.BaseServiceChecks.enforcePreconditions(
                   corr, current.meta(), request.getPrecondition());
-              CatalogIntegration desired =
-                  current.value().toBuilder()
-                      .setDisplayName(
-                          mustNonEmpty(request.getSpec().getDisplayName(), "display_name", corr))
-                      .setUpdatedAt(nowTs())
-                      .build();
+              var desiredBuilder = current.value().toBuilder();
+              if (paths.contains("display_name")) {
+                desiredBuilder.setDisplayName(
+                    mustNonEmpty(request.getSpec().getDisplayName(), "display_name", corr));
+              }
+              if (paths.contains("catalog_uri")) {
+                desiredBuilder.setCatalogUri(
+                    validateCatalogUri(request.getSpec().getCatalogUri(), corr));
+              }
+              CatalogIntegration desired = desiredBuilder.setUpdatedAt(nowTs()).build();
               try {
                 var meta =
                     integrations
                         .updateWithMetaUnlessDeleting(desired, current.meta().getPointerVersion())
-                        .orElseThrow(() -> GrpcErrors.preconditionFailed(corr, null, Map.of()));
+                        .orElseThrow(
+                            () ->
+                                GrpcErrors.preconditionFailed(
+                                    corr, CATALOG_INTEGRATION_CHANGED, Map.of()));
                 return UpdateCatalogIntegrationResponse.newBuilder()
                     .setIntegration(desired)
                     .setMeta(meta)
                     .build();
               } catch (BaseResourceRepository.NameConflictException e) {
                 throw GrpcErrors.alreadyExists(
-                    corr, null, Map.of("display_name", desired.getDisplayName()));
+                    corr,
+                    CATALOG_INTEGRATION_ALREADY_EXISTS,
+                    Map.of("display_name", desired.getDisplayName()));
               }
             }),
         correlationId());
@@ -424,12 +460,15 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                   || request.getAuthentication().getConfigurationCase()
                       == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
                 throw GrpcErrors.invalidArgument(
-                    corr, null, Map.of("field", "authentication.configuration"));
+                    corr, FIELD, Map.of("field", "authentication.configuration"));
               }
               var current =
                   integrations
                       .getByIdWithMeta(id)
-                      .orElseThrow(() -> GrpcErrors.notFound(corr, null, Map.of("id", id.getId())));
+                      .orElseThrow(
+                          () ->
+                              GrpcErrors.notFound(
+                                  corr, CATALOG_INTEGRATION, Map.of("id", id.getId())));
               MutationOps.BaseServiceChecks.enforcePreconditions(
                   corr, current.meta(), request.getPrecondition());
               long nextGeneration =
@@ -470,13 +509,18 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                 var meta =
                     integrations
                         .updateWithMetaUnlessDeleting(desired, current.meta().getPointerVersion())
-                        .orElseThrow(() -> GrpcErrors.preconditionFailed(corr, null, Map.of()));
+                        .orElseThrow(
+                            () ->
+                                GrpcErrors.preconditionFailed(
+                                    corr, CATALOG_INTEGRATION_CHANGED, Map.of()));
                 credentialCleanup.cleanIfSuperseded(current.value());
                 return UpdateCatalogIntegrationAuthenticationResponse.newBuilder()
                     .setIntegration(desired)
                     .setMeta(meta)
                     .build();
               } catch (RuntimeException definiteFailure) {
+                credentialCleanup.cancelIfResourceUnchanged(
+                    current.value(), current.meta().getPointerVersion());
                 cleanupPreparedAuthenticationUnlessPublished(id, prepared);
                 throw definiteFailure;
               }
@@ -497,7 +541,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
               var current = integrations.getByIdWithMeta(id);
               if (current.isEmpty()) {
                 if (hasMeaningfulPrecondition(request.getPrecondition()))
-                  throw GrpcErrors.notFound(corr, null, Map.of("id", id.getId()));
+                  throw GrpcErrors.notFound(corr, CATALOG_INTEGRATION, Map.of("id", id.getId()));
                 return DeleteCatalogIntegrationResponse.newBuilder()
                     .setMeta(integrations.metaForSafe(id))
                     .build();
@@ -507,13 +551,21 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                   corr, meta, request.getPrecondition());
               if (integrations.cascadeDeletionFenceVersion(id) > 0L)
                 throw GrpcErrors.conflict(
-                    corr, null, Map.of("reason", "cascade deletion in progress"));
+                    corr,
+                    CATALOG_INTEGRATION_DELETION_IN_PROGRESS,
+                    Map.of("reason", "cascade deletion in progress"));
               long markerVersion = markerStore.catalogIntegrationOverlaysMarkerVersion(id);
               credentialCleanup.schedule(current.get().value());
-              if (!integrations.deleteWithPreconditionAndOverlayMarker(
-                  id, meta.getPointerVersion(), markerVersion)) {
-                throw new BaseResourceRepository.AbortRetryableException(
-                    "integration dependencies changed during deletion");
+              try {
+                if (!integrations.deleteWithPreconditionAndOverlayMarker(
+                    id, meta.getPointerVersion(), markerVersion)) {
+                  throw new BaseResourceRepository.AbortRetryableException(
+                      "integration dependencies changed during deletion");
+                }
+              } catch (RuntimeException failure) {
+                credentialCleanup.cancelIfResourceUnchanged(
+                    current.get().value(), meta.getPointerVersion());
+                throw failure;
               }
               credentialCleanup.cleanIfSuperseded(current.get().value());
               return DeleteCatalogIntegrationResponse.newBuilder().setMeta(meta).build();
@@ -521,10 +573,15 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
         correlationId());
   }
 
-  private static FieldMask requiredMask(FieldMask mask, String corr) {
-    if (mask == null || mask.getPathsCount() != 1 || !MUTABLE_PATHS.contains(mask.getPaths(0)))
-      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "update_mask"));
-    return mask;
+  private static Set<String> requiredMask(FieldMask mask, String corr) {
+    if (mask == null || mask.getPathsCount() == 0) {
+      throw GrpcErrors.invalidArgument(corr, UPDATE_MASK_REQUIRED, Map.of("field", "update_mask"));
+    }
+    Set<String> paths = Set.copyOf(mask.getPathsList());
+    if (paths.size() != mask.getPathsCount() || !MUTABLE_PATHS.containsAll(paths)) {
+      throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "update_mask"));
+    }
+    return paths;
   }
 
   private void cleanupPreparedAuthenticationUnlessPublished(
@@ -533,7 +590,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
         == CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET) {
       return;
     }
-    var published = integrations.getById(integrationId);
+    var published = integrations.getByIdForMutation(integrationId);
     if (published.isPresent()
         && published.get().hasAuthentication()
         && published.get().getAuthentication().getCredentialsConfigured()
@@ -551,7 +608,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
 
   private static void validateType(CatalogIntegrationType type, String corr) {
     if (type != CatalogIntegrationType.CIT_ICEBERG_REST && type != CatalogIntegrationType.CIT_UNITY)
-      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "type"));
+      throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "type"));
   }
 
   private static void validateAuthenticationType(
@@ -561,14 +618,15 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
     if (integrationType == CatalogIntegrationType.CIT_UNITY
         && configuration != CatalogAuthentication.ConfigurationCase.OAUTH_CLIENT_CREDENTIALS
         && configuration != CatalogAuthentication.ConfigurationCase.BEARER) {
-      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "authentication.configuration"));
+      throw GrpcErrors.invalidArgument(
+          corr, FIELD, Map.of("field", "authentication.configuration"));
     }
   }
 
   private static String validateCatalogUri(String value, String corr) {
     String candidate = value;
     if (candidate == null || candidate.isBlank() || candidate.indexOf('\0') >= 0)
-      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "catalog_uri"));
+      throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "catalog_uri"));
     try {
       URI uri = URI.create(candidate);
       if (!("http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()))
@@ -595,7 +653,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       }
       return candidate;
     } catch (IllegalArgumentException e) {
-      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "catalog_uri"));
+      throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "catalog_uri"));
     }
   }
 
@@ -608,12 +666,13 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       long generation,
       String corr) {
     if (requested.getCredentialsConfigured() || requested.getCredentialGeneration() != 0L) {
-      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "authentication.state"));
+      throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "authentication.state"));
     }
     var configuration = requested.getConfigurationCase();
     var credential = credentials.getCredentialCase();
     if (configuration == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
-      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "authentication.configuration"));
+      throw GrpcErrors.invalidArgument(
+          corr, FIELD, Map.of("field", "authentication.configuration"));
     }
 
     switch (configuration) {
@@ -626,7 +685,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
           scopes.add(requireNonBlank(scope, "authentication.scopes", corr));
         }
         if (scopes.size() != config.getScopesCount()) {
-          throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "authentication.scopes"));
+          throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "authentication.scopes"));
         }
         requireCredentialCase(
             credential, CatalogIntegrationCredentials.CredentialCase.OAUTH_CLIENT_SECRET, corr);
@@ -681,7 +740,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
           }
           case CREDENTIALS_NOT_SET ->
               throw GrpcErrors.invalidArgument(
-                  corr, null, Map.of("field", "authentication.aws_sigv4.credentials"));
+                  corr, FIELD, Map.of("field", "authentication.aws_sigv4.credentials"));
         }
       }
       case CONFIGURATION_NOT_SET -> throw new IllegalStateException("handled above");
@@ -722,12 +781,12 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       CatalogIntegrationCredentials.CredentialCase expected,
       String corr) {
     if (actual == expected) return;
-    throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "credentials"));
+    throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "credentials"));
   }
 
   private static String requireNonBlank(String value, String field, String corr) {
     if (value == null || value.isBlank()) {
-      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", field));
+      throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", field));
     }
     return value.trim();
   }
@@ -747,7 +806,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
     mustNonEmpty(id.getId(), "integration_id.id", correlationId());
     if (!accountId.equals(id.getAccountId()))
       throw GrpcErrors.invalidArgument(
-          correlationId(), null, Map.of("field", "integration_id.account_id"));
+          correlationId(), FIELD, Map.of("field", "integration_id.account_id"));
     return id.toBuilder().setAccountId(accountId).build();
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -17,6 +17,7 @@ import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.Messag
 import ai.floedb.floecat.common.rpc.CreateMode;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.AwsAssumeRoleAuthentication;
 import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
 import ai.floedb.floecat.integration.rpc.CatalogIntegration;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
@@ -731,8 +732,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       }
       case AWS_ASSUME_ROLE -> {
         var config = requested.getAwsAssumeRole();
-        validateAssumeRole(
-            config.getRoleArn(), config.hasRoleSessionName(), config.getRoleSessionName(), corr);
+        validateAssumeRole(config, corr);
         requireCredentialCase(
             credential, CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET, corr);
       }
@@ -756,11 +756,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
           }
           case AWS_ASSUME_ROLE -> {
             var assume = config.getAwsAssumeRole();
-            validateAssumeRole(
-                assume.getRoleArn(),
-                assume.hasRoleSessionName(),
-                assume.getRoleSessionName(),
-                corr);
+            validateAssumeRole(assume, corr);
             requireCredentialCase(
                 credential, CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET, corr);
           }
@@ -788,11 +784,13 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
     return new PreparedAuthentication(persisted.build(), credentials);
   }
 
-  private static void validateAssumeRole(
-      String roleArn, boolean hasSessionName, String sessionName, String corr) {
-    requireNonBlank(roleArn, "authentication.role_arn", corr);
-    if (hasSessionName) {
-      requireNonBlank(sessionName, "authentication.role_session_name", corr);
+  private static void validateAssumeRole(AwsAssumeRoleAuthentication config, String corr) {
+    requireNonBlank(config.getRoleArn(), "authentication.role_arn", corr);
+    if (config.hasExternalId()) {
+      requireNonBlank(config.getExternalId(), "authentication.external_id", corr);
+    }
+    if (config.hasRoleSessionName()) {
+      requireNonBlank(config.getRoleSessionName(), "authentication.role_session_name", corr);
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -328,6 +328,12 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
             corr, CATALOG_INTEGRATION_ALREADY_EXISTS, Map.of("display_name", name));
       long markerVersion =
           markerStore.catalogIntegrationOverlaysMarkerVersion(current.value().getResourceId());
+      if (markerVersion > 0L) {
+        throw GrpcErrors.conflict(
+            corr,
+            CATALOG_INTEGRATION_DELETION_IN_PROGRESS,
+            Map.of("reason", "dependent overlays exist"));
+      }
       var replacement =
           applyAuthentication(
                   CatalogIntegration.newBuilder()
@@ -344,7 +350,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       try {
         var replaced =
             integrations.replaceIdentityWithMeta(
-                current.value(), current.meta().getPointerVersion(), replacement, markerVersion);
+                current.value(), current.meta().getPointerVersion(), replacement);
         if (replaced.isEmpty()) {
           throw new BaseResourceRepository.AbortRetryableException(
               "integration dependencies changed during replacement");
@@ -570,10 +576,15 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                     CATALOG_INTEGRATION_DELETION_IN_PROGRESS,
                     Map.of("reason", "cascade deletion in progress"));
               long markerVersion = markerStore.catalogIntegrationOverlaysMarkerVersion(id);
+              if (markerVersion > 0L)
+                throw GrpcErrors.conflict(
+                    corr,
+                    CATALOG_INTEGRATION_DELETION_IN_PROGRESS,
+                    Map.of("reason", "dependent overlays exist"));
               credentialCleanup.schedule(current.get().value());
               try {
-                if (!integrations.deleteWithPreconditionAndOverlayMarker(
-                    id, meta.getPointerVersion(), markerVersion)) {
+                if (!integrations.deleteWithPreconditionAndNoOverlayMarker(
+                    id, meta.getPointerVersion())) {
                   throw new BaseResourceRepository.AbortRetryableException(
                       "integration dependencies changed during deletion");
                 }

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -61,7 +61,8 @@ import java.util.Set;
 
 @GrpcService
 public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogIntegrations {
-  private static final Set<String> MUTABLE_PATHS = Set.of("display_name", "catalog_uri");
+  private static final Set<String> MUTABLE_PATHS =
+      Set.of("display_name", "catalog_uri", "properties");
 
   @Inject CatalogIntegrationRepository integrations;
   @Inject MarkerStore markerStore;
@@ -176,6 +177,8 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
               }
               validateType(spec.getType(), corr);
               String uri = validateCatalogUri(spec.getCatalogUri(), corr);
+              Map<String, String> properties =
+                  validateConnectionProperties(spec.getPropertiesMap(), corr);
               if (!spec.hasAuthentication()
                   || spec.getAuthentication().getConfigurationCase()
                       == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
@@ -199,6 +202,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                       .scalar("display_name", name)
                       .scalar("type", spec.getType())
                       .scalar("catalog_uri", uri)
+                      .map("properties", properties)
                       .scalar("authentication", preparedAuthentication.authentication())
                       .bytes();
               var now = nowTs();
@@ -217,6 +221,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                           name,
                           spec.getType(),
                           uri,
+                          properties,
                           preparedAuthentication.authentication(),
                           mode,
                           false,
@@ -265,6 +270,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                                           name,
                                           spec.getType(),
                                           uri,
+                                          properties,
                                           preparedAuthentication.authentication(),
                                           CreateMode.CM_ERROR_IF_EXISTS,
                                           true,
@@ -304,6 +310,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       String name,
       CatalogIntegrationType type,
       String uri,
+      Map<String, String> properties,
       CatalogAuthentication authentication,
       CreateMode mode,
       boolean reservedIdentity,
@@ -328,6 +335,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                       .setDisplayName(name)
                       .setType(type)
                       .setCatalogUri(uri)
+                      .putAllProperties(properties)
                       .setCreatedAt(now)
                       .setUpdatedAt(now),
                   authentication)
@@ -356,6 +364,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                     .setDisplayName(name)
                     .setType(type)
                     .setCatalogUri(uri)
+                    .putAllProperties(properties)
                     .setCreatedAt(now)
                     .setUpdatedAt(now),
                 authentication)
@@ -422,6 +431,12 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
               if (paths.contains("catalog_uri")) {
                 desiredBuilder.setCatalogUri(
                     validateCatalogUri(request.getSpec().getCatalogUri(), corr));
+              }
+              if (paths.contains("properties")) {
+                desiredBuilder
+                    .clearProperties()
+                    .putAllProperties(
+                        validateConnectionProperties(request.getSpec().getPropertiesMap(), corr));
               }
               CatalogIntegration desired = desiredBuilder.setUpdatedAt(nowTs()).build();
               try {
@@ -655,6 +670,13 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
     } catch (IllegalArgumentException e) {
       throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "catalog_uri"));
     }
+  }
+
+  private static Map<String, String> validateConnectionProperties(
+      Map<String, String> properties, String corr) {
+    ai.floedb.floecat.service.common.PersistedSecretPropertyValidator.validateNoSecretKeys(
+        properties, corr, "properties");
+    return Map.copyOf(properties);
   }
 
   private record PreparedAuthentication(

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -1,0 +1,753 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.integration;
+
+import ai.floedb.floecat.common.rpc.CreateMode;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationEntry;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationSpec;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrations;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsResponse;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationResponse;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationResponse;
+import ai.floedb.floecat.service.common.BaseServiceImpl;
+import ai.floedb.floecat.service.common.Canonicalizer;
+import ai.floedb.floecat.service.common.IdempotencyGuard;
+import ai.floedb.floecat.service.common.MutationOps;
+import ai.floedb.floecat.service.error.impl.GrpcErrors;
+import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.MarkerStore;
+import ai.floedb.floecat.service.security.RolePermissions;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import com.google.protobuf.FieldMask;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+@GrpcService
+public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogIntegrations {
+  private static final Set<String> MUTABLE_PATHS = Set.of("display_name");
+
+  @Inject CatalogIntegrationRepository integrations;
+  @Inject MarkerStore markerStore;
+  @Inject PrincipalProvider principal;
+  @Inject Authorizer authz;
+  @Inject IdempotencyRepository idempotencyStore;
+  @Inject CatalogIntegrationCredentialStore credentialStore;
+  @Inject CatalogIntegrationCredentialCleanup credentialCleanup;
+
+  @Override
+  public Uni<ListCatalogIntegrationsResponse> listCatalogIntegrations(
+      ListCatalogIntegrationsRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_READ);
+              var page = MutationOps.pageIn(request.hasPage() ? request.getPage() : null);
+              var next = new StringBuilder();
+              var rows =
+                  integrations.listWithMeta(
+                      pc.getAccountId(), Math.max(1, page.limit), page.token, next);
+              var response = ListCatalogIntegrationsResponse.newBuilder();
+              rows.forEach(
+                  row ->
+                      response.addEntries(
+                          CatalogIntegrationEntry.newBuilder()
+                              .setIntegration(row.value())
+                              .setMeta(row.meta())));
+              return response
+                  .setPage(
+                      MutationOps.pageOut(next.toString(), integrations.count(pc.getAccountId())))
+                  .build();
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<GetCatalogIntegrationResponse> getCatalogIntegration(
+      GetCatalogIntegrationRequest request) {
+    return mapFailures(
+        run(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_READ);
+              if (!request.hasIntegrationId() && !request.hasDisplayName())
+                throw GrpcErrors.invalidArgument(
+                    pc.getCorrelationId(), null, Map.of("field", "selector"));
+              var row =
+                  (request.hasIntegrationId()
+                          ? integrations.getByIdWithMeta(
+                              scopedId(pc.getAccountId(), request.getIntegrationId()))
+                          : request.hasDisplayName()
+                              ? integrations.getByNameWithMeta(
+                                  pc.getAccountId(),
+                                  mustNonEmpty(
+                                      request.getDisplayName(),
+                                      "display_name",
+                                      pc.getCorrelationId()))
+                              : throwMissingIntegrationSelector())
+                      .orElseThrow(
+                          () -> GrpcErrors.notFound(pc.getCorrelationId(), null, Map.of()));
+              return GetCatalogIntegrationResponse.newBuilder()
+                  .setIntegration(row.value())
+                  .setMeta(row.meta())
+                  .build();
+            }),
+        correlationId());
+  }
+
+  private static java.util.Optional<
+          ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta<
+              CatalogIntegration>>
+      throwMissingIntegrationSelector() {
+    throw new IllegalStateException("validated integration selector missing");
+  }
+
+  @Override
+  public Uni<CreateCatalogIntegrationResponse> createCatalogIntegration(
+      CreateCatalogIntegrationRequest request) {
+    return mapFailures(
+        runWithRetry(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
+              String corr = pc.getCorrelationId();
+              CatalogIntegrationSpec spec = request.getSpec();
+              String name = mustNonEmpty(spec.getDisplayName(), "display_name", corr);
+              var createPolicy =
+                  CatalogCreatePolicy.validate(
+                      request.getCreateMode(),
+                      request.hasIdempotency() ? request.getIdempotency().getKey() : "",
+                      corr);
+              String key = createPolicy.idempotencyKey();
+              CreateMode mode = createPolicy.mode();
+              if (mode == CreateMode.CM_RETURN_EXISTING) {
+                var existing = integrations.getByNameWithMeta(pc.getAccountId(), name);
+                if (existing.isPresent()) {
+                  return CreateCatalogIntegrationResponse.newBuilder()
+                      .setIntegration(existing.get().value())
+                      .setMeta(existing.get().meta())
+                      .build();
+                }
+              }
+              validateType(spec.getType(), corr);
+              String uri = validateCatalogUri(spec.getCatalogUri(), corr);
+              if (!spec.hasAuthentication()
+                  || spec.getAuthentication().getConfigurationCase()
+                      == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
+                throw GrpcErrors.invalidArgument(
+                    corr, null, Map.of("field", "authentication.configuration"));
+              }
+              PreparedAuthentication preparedAuthentication =
+                  prepareAuthentication(
+                      spec.hasAuthentication()
+                          ? spec.getAuthentication()
+                          : CatalogAuthentication.getDefaultInstance(),
+                      request.hasCredentials()
+                          ? request.getCredentials()
+                          : CatalogIntegrationCredentials.getDefaultInstance(),
+                      1L,
+                      corr);
+              validateAuthenticationType(
+                  spec.getType(), preparedAuthentication.authentication(), corr);
+              byte[] fingerprint =
+                  new Canonicalizer()
+                      .scalar("display_name", name)
+                      .scalar("type", spec.getType())
+                      .scalar("catalog_uri", uri)
+                      .scalar("authentication", preparedAuthentication.authentication())
+                      .bytes();
+              var now = nowTs();
+
+              if (key.isEmpty()) {
+                ResourceId integrationId =
+                    randomResourceId(pc.getAccountId(), ResourceKind.RK_CATALOG_INTEGRATION);
+                credentialStore.store(
+                    integrationId,
+                    preparedAuthentication.authentication().getCredentialGeneration(),
+                    preparedAuthentication.credentials());
+                try {
+                  var created =
+                      createOrReplace(
+                          integrationId,
+                          name,
+                          spec.getType(),
+                          uri,
+                          preparedAuthentication.authentication(),
+                          mode,
+                          false,
+                          null,
+                          now,
+                          corr);
+                  if (!created.newIdentityPublished()) {
+                    cleanupPrepared(integrationId, preparedAuthentication);
+                  }
+                  return CreateCatalogIntegrationResponse.newBuilder()
+                      .setIntegration(created.row().value())
+                      .setMeta(created.row().meta())
+                      .build();
+                } catch (RuntimeException retryableFailure) {
+                  cleanupPrepared(integrationId, preparedAuthentication);
+                  throw retryableFailure;
+                }
+              }
+              var result =
+                  runIdempotentCreate(
+                      () ->
+                          MutationOps.createProtoRecoverable(
+                              pc.getAccountId(),
+                              "CreateCatalogIntegration",
+                              key,
+                              () -> fingerprint,
+                              () ->
+                                  randomResourceId(
+                                      pc.getAccountId(), ResourceKind.RK_CATALOG_INTEGRATION),
+                              (reservedId, completion) -> {
+                                var recovered = integrations.getByIdWithMeta(reservedId);
+                                if (recovered.isPresent()) {
+                                  throw new BaseResourceRepository.AbortRetryableException(
+                                      "integration exists before its idempotency receipt committed");
+                                }
+                                credentialStore.store(
+                                    reservedId,
+                                    preparedAuthentication
+                                        .authentication()
+                                        .getCredentialGeneration(),
+                                    preparedAuthentication.credentials());
+                                try {
+                                  var created =
+                                      createOrReplace(
+                                          reservedId,
+                                          name,
+                                          spec.getType(),
+                                          uri,
+                                          preparedAuthentication.authentication(),
+                                          CreateMode.CM_ERROR_IF_EXISTS,
+                                          true,
+                                          completion,
+                                          now,
+                                          corr);
+                                  return new IdempotencyGuard.CommittedCreate<>(
+                                      created.row().value(),
+                                      created.row().value().getResourceId(),
+                                      created.row().meta());
+                                } catch (RuntimeException definiteFailure) {
+                                  cleanupPrepared(reservedId, preparedAuthentication);
+                                  throw definiteFailure;
+                                }
+                              },
+                              idempotencyStore,
+                              now,
+                              idempotencyTtlSeconds(),
+                              this::correlationId,
+                              CatalogIntegration::parseFrom));
+              return CreateCatalogIntegrationResponse.newBuilder()
+                  .setIntegration(result.body)
+                  .setMeta(result.meta)
+                  .build();
+            }),
+        correlationId());
+  }
+
+  private record CreateOutcome(
+      ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta<
+              CatalogIntegration>
+          row,
+      boolean newIdentityPublished) {}
+
+  private CreateOutcome createOrReplace(
+      ResourceId newId,
+      String name,
+      CatalogIntegrationType type,
+      String uri,
+      CatalogAuthentication authentication,
+      CreateMode mode,
+      boolean reservedIdentity,
+      IdempotencyGuard.SuccessCommitter<CatalogIntegration> completion,
+      com.google.protobuf.Timestamp now,
+      String corr) {
+    var existing = integrations.getByNameWithMeta(newId.getAccountId(), name);
+    if (existing.isPresent()) {
+      var current = existing.get();
+      if (reservedIdentity && current.value().getResourceId().equals(newId))
+        return new CreateOutcome(current, true);
+      if (mode == CreateMode.CM_RETURN_EXISTING) return new CreateOutcome(current, false);
+      if (mode != CreateMode.CM_REPLACE)
+        throw GrpcErrors.alreadyExists(corr, null, Map.of("display_name", name));
+      long markerVersion =
+          markerStore.catalogIntegrationOverlaysMarkerVersion(current.value().getResourceId());
+      var replacement =
+          applyAuthentication(
+                  CatalogIntegration.newBuilder()
+                      .setResourceId(newId)
+                      .setDisplayName(name)
+                      .setType(type)
+                      .setCatalogUri(uri)
+                      .setCreatedAt(now)
+                      .setUpdatedAt(now),
+                  authentication)
+              .build();
+      credentialCleanup.schedule(current.value());
+      var replaced =
+          integrations.replaceIdentityWithMeta(
+              current.value(), current.meta().getPointerVersion(), replacement, markerVersion);
+      if (replaced.isEmpty()) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "integration dependencies changed during replacement");
+      }
+      credentialCleanup.cleanIfSuperseded(current.value());
+      return new CreateOutcome(replaced.get(), true);
+    }
+    var desired =
+        applyAuthentication(
+                CatalogIntegration.newBuilder()
+                    .setResourceId(newId)
+                    .setDisplayName(name)
+                    .setType(type)
+                    .setCatalogUri(uri)
+                    .setCreatedAt(now)
+                    .setUpdatedAt(now),
+                authentication)
+            .build();
+    try {
+      var created =
+          completion == null
+              ? integrations.createWithMeta(desired)
+              : integrations.createWithMetaAndCompletion(
+                  desired,
+                  row ->
+                      completion.prepare(
+                          new IdempotencyGuard.CommittedCreate<>(
+                              row.value(), row.value().getResourceId(), row.meta())));
+      return new CreateOutcome(created, true);
+    } catch (BaseResourceRepository.NameConflictException conflict) {
+      if (reservedIdentity) {
+        var recovered = integrations.getByIdWithMeta(newId);
+        if (recovered.isPresent())
+          throw new BaseResourceRepository.AbortRetryableException(
+              "integration exists before its idempotency receipt committed");
+        var owner = integrations.getByNameWithMeta(newId.getAccountId(), name);
+        if (owner.isEmpty()) {
+          throw new BaseResourceRepository.AbortRetryableException(
+              "integration create conflict not yet visible");
+        }
+        if (owner.get().value().getResourceId().equals(newId))
+          return new CreateOutcome(owner.get(), true);
+      }
+      if (mode != CreateMode.CM_ERROR_IF_EXISTS)
+        throw new BaseResourceRepository.AbortRetryableException(
+            "integration name owner changed during create");
+      throw GrpcErrors.alreadyExists(corr, null, Map.of("display_name", name));
+    }
+  }
+
+  @Override
+  public Uni<UpdateCatalogIntegrationResponse> updateCatalogIntegration(
+      UpdateCatalogIntegrationRequest request) {
+    return mapFailures(
+        runWithRetry(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
+              String corr = pc.getCorrelationId();
+              ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
+              FieldMask mask =
+                  requiredMask(request.hasUpdateMask() ? request.getUpdateMask() : null, corr);
+              var current =
+                  integrations
+                      .getByIdWithMeta(id)
+                      .orElseThrow(() -> GrpcErrors.notFound(corr, null, Map.of("id", id.getId())));
+              MutationOps.BaseServiceChecks.enforcePreconditions(
+                  corr, current.meta(), request.getPrecondition());
+              CatalogIntegration desired =
+                  current.value().toBuilder()
+                      .setDisplayName(
+                          mustNonEmpty(request.getSpec().getDisplayName(), "display_name", corr))
+                      .setUpdatedAt(nowTs())
+                      .build();
+              try {
+                var meta =
+                    integrations
+                        .updateWithMetaUnlessDeleting(desired, current.meta().getPointerVersion())
+                        .orElseThrow(() -> GrpcErrors.preconditionFailed(corr, null, Map.of()));
+                return UpdateCatalogIntegrationResponse.newBuilder()
+                    .setIntegration(desired)
+                    .setMeta(meta)
+                    .build();
+              } catch (BaseResourceRepository.NameConflictException e) {
+                throw GrpcErrors.alreadyExists(
+                    corr, null, Map.of("display_name", desired.getDisplayName()));
+              }
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<UpdateCatalogIntegrationAuthenticationResponse> updateCatalogIntegrationAuthentication(
+      UpdateCatalogIntegrationAuthenticationRequest request) {
+    return mapFailures(
+        runWithRetry(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
+              String corr = pc.getCorrelationId();
+              ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
+              if (!request.hasAuthentication()
+                  || request.getAuthentication().getConfigurationCase()
+                      == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
+                throw GrpcErrors.invalidArgument(
+                    corr, null, Map.of("field", "authentication.configuration"));
+              }
+              var current =
+                  integrations
+                      .getByIdWithMeta(id)
+                      .orElseThrow(() -> GrpcErrors.notFound(corr, null, Map.of("id", id.getId())));
+              MutationOps.BaseServiceChecks.enforcePreconditions(
+                  corr, current.meta(), request.getPrecondition());
+              long nextGeneration =
+                  current.value().hasAuthentication()
+                      ? current.value().getAuthentication().getCredentialGeneration() + 1L
+                      : 1L;
+              PreparedAuthentication prepared =
+                  prepareAuthentication(
+                      request.hasAuthentication()
+                          ? request.getAuthentication()
+                          : CatalogAuthentication.getDefaultInstance(),
+                      request.hasCredentials()
+                          ? request.getCredentials()
+                          : CatalogIntegrationCredentials.getDefaultInstance(),
+                      nextGeneration,
+                      corr);
+              validateAuthenticationType(
+                  current.value().getType(), prepared.authentication(), corr);
+              long allocatedGeneration =
+                  credentialStore.storeRotation(
+                      id,
+                      prepared.authentication().getCredentialGeneration(),
+                      prepared.credentials());
+              if (allocatedGeneration != prepared.authentication().getCredentialGeneration()) {
+                prepared =
+                    new PreparedAuthentication(
+                        prepared.authentication().toBuilder()
+                            .setCredentialGeneration(allocatedGeneration)
+                            .build(),
+                        prepared.credentials());
+              }
+              CatalogIntegration desired =
+                  applyAuthentication(current.value().toBuilder(), prepared.authentication())
+                      .setUpdatedAt(nowTs())
+                      .build();
+              credentialCleanup.schedule(current.value());
+              try {
+                var meta =
+                    integrations
+                        .updateWithMetaUnlessDeleting(desired, current.meta().getPointerVersion())
+                        .orElseThrow(() -> GrpcErrors.preconditionFailed(corr, null, Map.of()));
+                credentialCleanup.cleanIfSuperseded(current.value());
+                return UpdateCatalogIntegrationAuthenticationResponse.newBuilder()
+                    .setIntegration(desired)
+                    .setMeta(meta)
+                    .build();
+              } catch (RuntimeException definiteFailure) {
+                cleanupPreparedAuthenticationUnlessPublished(id, prepared);
+                throw definiteFailure;
+              }
+            }),
+        correlationId());
+  }
+
+  @Override
+  public Uni<DeleteCatalogIntegrationResponse> deleteCatalogIntegration(
+      DeleteCatalogIntegrationRequest request) {
+    return mapFailures(
+        runWithRetry(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
+              String corr = pc.getCorrelationId();
+              ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
+              var current = integrations.getByIdWithMeta(id);
+              if (current.isEmpty()) {
+                if (hasMeaningfulPrecondition(request.getPrecondition()))
+                  throw GrpcErrors.notFound(corr, null, Map.of("id", id.getId()));
+                return DeleteCatalogIntegrationResponse.newBuilder()
+                    .setMeta(integrations.metaForSafe(id))
+                    .build();
+              }
+              var meta = current.get().meta();
+              MutationOps.BaseServiceChecks.enforcePreconditions(
+                  corr, meta, request.getPrecondition());
+              if (integrations.cascadeDeletionFenceVersion(id) > 0L)
+                throw GrpcErrors.conflict(
+                    corr, null, Map.of("reason", "cascade deletion in progress"));
+              long markerVersion = markerStore.catalogIntegrationOverlaysMarkerVersion(id);
+              credentialCleanup.schedule(current.get().value());
+              if (!integrations.deleteWithPreconditionAndOverlayMarker(
+                  id, meta.getPointerVersion(), markerVersion)) {
+                throw new BaseResourceRepository.AbortRetryableException(
+                    "integration dependencies changed during deletion");
+              }
+              credentialCleanup.cleanIfSuperseded(current.get().value());
+              return DeleteCatalogIntegrationResponse.newBuilder().setMeta(meta).build();
+            }),
+        correlationId());
+  }
+
+  private static FieldMask requiredMask(FieldMask mask, String corr) {
+    if (mask == null || mask.getPathsCount() != 1 || !MUTABLE_PATHS.contains(mask.getPaths(0)))
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "update_mask"));
+    return mask;
+  }
+
+  private void cleanupPreparedAuthenticationUnlessPublished(
+      ResourceId integrationId, PreparedAuthentication prepared) {
+    if (prepared.credentials().getCredentialCase()
+        == CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET) {
+      return;
+    }
+    var published = integrations.getById(integrationId);
+    if (published.isPresent()
+        && published.get().hasAuthentication()
+        && published.get().getAuthentication().getCredentialsConfigured()
+        && published.get().getAuthentication().getCredentialGeneration()
+            == prepared.authentication().getCredentialGeneration()) {
+      return;
+    }
+    cleanupPrepared(integrationId, prepared);
+  }
+
+  private void cleanupPrepared(ResourceId integrationId, PreparedAuthentication prepared) {
+    credentialCleanup.cleanPrepared(
+        integrationId, prepared.authentication().getCredentialGeneration(), prepared.credentials());
+  }
+
+  private static void validateType(CatalogIntegrationType type, String corr) {
+    if (type != CatalogIntegrationType.CIT_ICEBERG_REST && type != CatalogIntegrationType.CIT_UNITY)
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "type"));
+  }
+
+  private static void validateAuthenticationType(
+      CatalogIntegrationType integrationType, CatalogAuthentication authentication, String corr) {
+    var configuration = authentication.getConfigurationCase();
+    if (configuration == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) return;
+    if (integrationType == CatalogIntegrationType.CIT_UNITY
+        && configuration != CatalogAuthentication.ConfigurationCase.OAUTH_CLIENT_CREDENTIALS
+        && configuration != CatalogAuthentication.ConfigurationCase.BEARER) {
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "authentication.configuration"));
+    }
+  }
+
+  private static String validateCatalogUri(String value, String corr) {
+    String candidate = value;
+    if (candidate == null || candidate.isBlank() || candidate.indexOf('\0') >= 0)
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "catalog_uri"));
+    try {
+      URI uri = URI.create(candidate);
+      if (!("http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()))
+          || uri.isOpaque()
+          || uri.getHost() == null
+          || uri.getHost().isBlank()
+          || uri.getRawUserInfo() != null
+          || uri.getRawFragment() != null) throw new IllegalArgumentException();
+      String rawQuery = uri.getRawQuery();
+      if (rawQuery != null) {
+        for (String parameter : rawQuery.split("[&;]", -1)) {
+          int separator = parameter.indexOf('=');
+          String rawKey = separator < 0 ? parameter : parameter.substring(0, separator);
+          String key = URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
+          String canonical =
+              ai.floedb.floecat.service.common.PersistedSecretPropertyValidator.canonicalSecretKey(
+                  key);
+          if (ai.floedb.floecat.service.common.PersistedSecretPropertyValidator
+                  .isForbiddenPersistedSecretKey(key)
+              || canonical.equals("sig")
+              || canonical.equals("signature")
+              || canonical.endsWith("_signature")) throw new IllegalArgumentException();
+        }
+      }
+      return candidate;
+    } catch (IllegalArgumentException e) {
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "catalog_uri"));
+    }
+  }
+
+  private record PreparedAuthentication(
+      CatalogAuthentication authentication, CatalogIntegrationCredentials credentials) {}
+
+  private static PreparedAuthentication prepareAuthentication(
+      CatalogAuthentication requested,
+      CatalogIntegrationCredentials credentials,
+      long generation,
+      String corr) {
+    if (requested.getCredentialsConfigured() || requested.getCredentialGeneration() != 0L) {
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "authentication.state"));
+    }
+    var configuration = requested.getConfigurationCase();
+    var credential = credentials.getCredentialCase();
+    if (configuration == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "authentication.configuration"));
+    }
+
+    switch (configuration) {
+      case OAUTH_CLIENT_CREDENTIALS -> {
+        var config = requested.getOauthClientCredentials();
+        requireNonBlank(config.getClientId(), "authentication.client_id", corr);
+        if (config.hasTokenUri()) validateCatalogUri(config.getTokenUri(), corr);
+        var scopes = new LinkedHashSet<String>();
+        for (String scope : config.getScopesList()) {
+          scopes.add(requireNonBlank(scope, "authentication.scopes", corr));
+        }
+        if (scopes.size() != config.getScopesCount()) {
+          throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "authentication.scopes"));
+        }
+        requireCredentialCase(
+            credential, CatalogIntegrationCredentials.CredentialCase.OAUTH_CLIENT_SECRET, corr);
+        requireNonBlank(credentials.getOauthClientSecret().getValue(), "credentials", corr);
+      }
+      case BEARER -> {
+        requireCredentialCase(
+            credential, CatalogIntegrationCredentials.CredentialCase.BEARER_TOKEN, corr);
+        requireNonBlank(credentials.getBearerToken().getValue(), "credentials", corr);
+      }
+      case AWS_ASSUME_ROLE -> {
+        var config = requested.getAwsAssumeRole();
+        validateAssumeRole(
+            config.getRoleArn(), config.hasRoleSessionName(), config.getRoleSessionName(), corr);
+        requireCredentialCase(
+            credential, CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET, corr);
+      }
+      case AWS_ACCESS_KEY -> {
+        requireNonBlank(
+            requested.getAwsAccessKey().getAccessKeyId(), "authentication.access_key_id", corr);
+        requireCredentialCase(
+            credential, CatalogIntegrationCredentials.CredentialCase.AWS_ACCESS_KEY, corr);
+        validateAccessKeySecret(credentials, corr);
+      }
+      case AWS_SIGV4 -> {
+        var config = requested.getAwsSigv4();
+        requireNonBlank(config.getRegion(), "authentication.region", corr);
+        if (config.hasSigningName()) {
+          requireNonBlank(config.getSigningName(), "authentication.signing_name", corr);
+        }
+        switch (config.getCredentialsCase()) {
+          case AWS_DEFAULT -> {
+            requireCredentialCase(
+                credential, CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET, corr);
+          }
+          case AWS_ASSUME_ROLE -> {
+            var assume = config.getAwsAssumeRole();
+            validateAssumeRole(
+                assume.getRoleArn(),
+                assume.hasRoleSessionName(),
+                assume.getRoleSessionName(),
+                corr);
+            requireCredentialCase(
+                credential, CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET, corr);
+          }
+          case AWS_ACCESS_KEY -> {
+            requireNonBlank(
+                config.getAwsAccessKey().getAccessKeyId(), "authentication.access_key_id", corr);
+            requireCredentialCase(
+                credential, CatalogIntegrationCredentials.CredentialCase.AWS_ACCESS_KEY, corr);
+            validateAccessKeySecret(credentials, corr);
+          }
+          case CREDENTIALS_NOT_SET ->
+              throw GrpcErrors.invalidArgument(
+                  corr, null, Map.of("field", "authentication.aws_sigv4.credentials"));
+        }
+      }
+      case CONFIGURATION_NOT_SET -> throw new IllegalStateException("handled above");
+    }
+
+    boolean storesCredentials =
+        credential != CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET;
+    var persisted =
+        requested.toBuilder()
+            .setCredentialsConfigured(storesCredentials)
+            .setCredentialGeneration(storesCredentials ? generation : 0L);
+    return new PreparedAuthentication(persisted.build(), credentials);
+  }
+
+  private static void validateAssumeRole(
+      String roleArn, boolean hasSessionName, String sessionName, String corr) {
+    requireNonBlank(roleArn, "authentication.role_arn", corr);
+    if (hasSessionName) {
+      requireNonBlank(sessionName, "authentication.role_session_name", corr);
+    }
+  }
+
+  private static void validateAccessKeySecret(
+      CatalogIntegrationCredentials credentials, String corr) {
+    if (credentials.getCredentialCase()
+        != CatalogIntegrationCredentials.CredentialCase.AWS_ACCESS_KEY) {
+      return;
+    }
+    var secret = credentials.getAwsAccessKey();
+    requireNonBlank(secret.getSecretAccessKey(), "credentials.secret_access_key", corr);
+    if (secret.hasSessionToken()) {
+      requireNonBlank(secret.getSessionToken(), "credentials.session_token", corr);
+    }
+  }
+
+  private static void requireCredentialCase(
+      CatalogIntegrationCredentials.CredentialCase actual,
+      CatalogIntegrationCredentials.CredentialCase expected,
+      String corr) {
+    if (actual == expected) return;
+    throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "credentials"));
+  }
+
+  private static String requireNonBlank(String value, String field, String corr) {
+    if (value == null || value.isBlank()) {
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", field));
+    }
+    return value.trim();
+  }
+
+  private static CatalogIntegration.Builder applyAuthentication(
+      CatalogIntegration.Builder builder, CatalogAuthentication authentication) {
+    if (authentication.getConfigurationCase()
+        == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
+      return builder.clearAuthentication();
+    }
+    return builder.setAuthentication(authentication);
+  }
+
+  private ResourceId scopedId(String accountId, ResourceId id) {
+    ensureKind(id, ResourceKind.RK_CATALOG_INTEGRATION, "integration_id", correlationId());
+    mustNonEmpty(id.getAccountId(), "integration_id.account_id", correlationId());
+    mustNonEmpty(id.getId(), "integration_id.id", correlationId());
+    if (!accountId.equals(id.getAccountId()))
+      throw GrpcErrors.invalidArgument(
+          correlationId(), null, Map.of("field", "integration_id.account_id"));
+    return id.toBuilder().setAccountId(accountId).build();
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -40,6 +40,7 @@ import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationResponse;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.Canonicalizer;
 import ai.floedb.floecat.service.common.IdempotencyGuard;
+import ai.floedb.floecat.service.common.LogHelper;
 import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
@@ -59,9 +60,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import org.jboss.logging.Logger;
 
 @GrpcService
 public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogIntegrations {
+  private static final Logger LOG = Logger.getLogger(CatalogIntegrations.class);
   private static final Set<String> MUTABLE_PATHS =
       Set.of("display_name", "catalog_uri", "properties");
 
@@ -76,70 +79,83 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
   @Override
   public Uni<ListCatalogIntegrationsResponse> listCatalogIntegrations(
       ListCatalogIntegrationsRequest request) {
+    var L = LogHelper.start(LOG, "ListCatalogIntegrations");
+
     return mapFailures(
-        run(
-            () -> {
-              var pc = principal.get();
-              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_READ);
-              var page = MutationOps.pageIn(request.hasPage() ? request.getPage() : null);
-              var next = new StringBuilder();
-              var rows =
-                  integrations.listWithMeta(
-                      pc.getAccountId(), Math.max(1, page.limit), page.token, next);
-              var response = ListCatalogIntegrationsResponse.newBuilder();
-              rows.forEach(
-                  row ->
-                      response.addEntries(
-                          CatalogIntegrationEntry.newBuilder()
-                              .setIntegration(row.value())
-                              .setMeta(row.meta())));
-              return response
-                  .setPage(
-                      MutationOps.pageOut(next.toString(), integrations.count(pc.getAccountId())))
-                  .build();
-            }),
-        correlationId());
+            run(
+                () -> {
+                  var pc = principal.get();
+                  authz.require(pc, RolePermissions.CATALOG_INTEGRATION_READ);
+                  var page = MutationOps.pageIn(request.hasPage() ? request.getPage() : null);
+                  var next = new StringBuilder();
+                  var rows =
+                      integrations.listWithMeta(
+                          pc.getAccountId(), Math.max(1, page.limit), page.token, next);
+                  var response = ListCatalogIntegrationsResponse.newBuilder();
+                  rows.forEach(
+                      row ->
+                          response.addEntries(
+                              CatalogIntegrationEntry.newBuilder()
+                                  .setIntegration(row.value())
+                                  .setMeta(row.meta())));
+                  return response
+                      .setPage(
+                          MutationOps.pageOut(
+                              next.toString(), integrations.count(pc.getAccountId())))
+                      .build();
+                }),
+            correlationId())
+        .onFailure()
+        .invoke(L::fail)
+        .onItem()
+        .invoke(L::ok);
   }
 
   @Override
   public Uni<GetCatalogIntegrationResponse> getCatalogIntegration(
       GetCatalogIntegrationRequest request) {
+    var L = LogHelper.start(LOG, "GetCatalogIntegration");
+
     return mapFailures(
-        run(
-            () -> {
-              var pc = principal.get();
-              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_READ);
-              if (!request.hasIntegrationId() && !request.hasDisplayName())
-                throw GrpcErrors.invalidArgument(
-                    pc.getCorrelationId(), SELECTOR_REQUIRED, Map.of("field", "selector"));
-              var row =
-                  (request.hasIntegrationId()
-                          ? integrations.getByIdWithMeta(
-                              scopedId(pc.getAccountId(), request.getIntegrationId()))
-                          : request.hasDisplayName()
-                              ? integrations.getByNameWithMeta(
-                                  pc.getAccountId(),
-                                  mustNonEmpty(
-                                      request.getDisplayName(),
-                                      "display_name",
-                                      pc.getCorrelationId()))
-                              : throwMissingIntegrationSelector())
-                      .orElseThrow(
-                          () ->
-                              GrpcErrors.notFound(
-                                  pc.getCorrelationId(),
-                                  CATALOG_INTEGRATION,
-                                  Map.of(
-                                      "id",
-                                      request.hasIntegrationId()
-                                          ? request.getIntegrationId().getId()
-                                          : request.getDisplayName())));
-              return GetCatalogIntegrationResponse.newBuilder()
-                  .setIntegration(row.value())
-                  .setMeta(row.meta())
-                  .build();
-            }),
-        correlationId());
+            run(
+                () -> {
+                  var pc = principal.get();
+                  authz.require(pc, RolePermissions.CATALOG_INTEGRATION_READ);
+                  if (!request.hasIntegrationId() && !request.hasDisplayName())
+                    throw GrpcErrors.invalidArgument(
+                        pc.getCorrelationId(), SELECTOR_REQUIRED, Map.of("field", "selector"));
+                  var row =
+                      (request.hasIntegrationId()
+                              ? integrations.getByIdWithMeta(
+                                  scopedId(pc.getAccountId(), request.getIntegrationId()))
+                              : request.hasDisplayName()
+                                  ? integrations.getByNameWithMeta(
+                                      pc.getAccountId(),
+                                      mustNonEmpty(
+                                          request.getDisplayName(),
+                                          "display_name",
+                                          pc.getCorrelationId()))
+                                  : throwMissingIntegrationSelector())
+                          .orElseThrow(
+                              () ->
+                                  GrpcErrors.notFound(
+                                      pc.getCorrelationId(),
+                                      CATALOG_INTEGRATION,
+                                      Map.of(
+                                          "id",
+                                          request.hasIntegrationId()
+                                              ? request.getIntegrationId().getId()
+                                              : request.getDisplayName())));
+                  return GetCatalogIntegrationResponse.newBuilder()
+                      .setIntegration(row.value())
+                      .setMeta(row.meta())
+                      .build();
+                }),
+            correlationId())
+        .onFailure()
+        .invoke(L::fail)
+        .onItem()
+        .invoke(L::ok);
   }
 
   private static java.util.Optional<
@@ -152,152 +168,158 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
   @Override
   public Uni<CreateCatalogIntegrationResponse> createCatalogIntegration(
       CreateCatalogIntegrationRequest request) {
-    return mapFailures(
-        runWithRetry(
-            () -> {
-              var pc = principal.get();
-              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
-              String corr = pc.getCorrelationId();
-              CatalogIntegrationSpec spec = request.getSpec();
-              String name = mustNonEmpty(spec.getDisplayName(), "display_name", corr);
-              var createPolicy =
-                  CatalogCreatePolicy.validate(
-                      request.getCreateMode(),
-                      request.hasIdempotency() ? request.getIdempotency().getKey() : "",
-                      corr);
-              String key = createPolicy.idempotencyKey();
-              CreateMode mode = createPolicy.mode();
-              if (mode == CreateMode.CM_RETURN_EXISTING) {
-                var existing = integrations.getByNameWithMeta(pc.getAccountId(), name);
-                if (existing.isPresent()) {
-                  return CreateCatalogIntegrationResponse.newBuilder()
-                      .setIntegration(existing.get().value())
-                      .setMeta(existing.get().meta())
-                      .build();
-                }
-              }
-              validateType(spec.getType(), corr);
-              String uri = validateCatalogUri(spec.getCatalogUri(), corr);
-              Map<String, String> properties =
-                  validateConnectionProperties(spec.getPropertiesMap(), corr);
-              if (!spec.hasAuthentication()
-                  || spec.getAuthentication().getConfigurationCase()
-                      == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
-                throw GrpcErrors.invalidArgument(
-                    corr, FIELD, Map.of("field", "authentication.configuration"));
-              }
-              PreparedAuthentication preparedAuthentication =
-                  prepareAuthentication(
-                      spec.hasAuthentication()
-                          ? spec.getAuthentication()
-                          : CatalogAuthentication.getDefaultInstance(),
-                      request.hasCredentials()
-                          ? request.getCredentials()
-                          : CatalogIntegrationCredentials.getDefaultInstance(),
-                      1L,
-                      corr);
-              validateAuthenticationType(
-                  spec.getType(), preparedAuthentication.authentication(), corr);
-              byte[] fingerprint =
-                  new Canonicalizer()
-                      .scalar("display_name", name)
-                      .scalar("type", spec.getType())
-                      .scalar("catalog_uri", uri)
-                      .map("properties", properties)
-                      .scalar("authentication", preparedAuthentication.authentication())
-                      .bytes();
-              var now = nowTs();
+    var L = LogHelper.start(LOG, "CreateCatalogIntegration");
 
-              if (key.isEmpty()) {
-                ResourceId integrationId =
-                    randomResourceId(pc.getAccountId(), ResourceKind.RK_CATALOG_INTEGRATION);
-                credentialStore.store(
-                    integrationId,
-                    preparedAuthentication.authentication().getCredentialGeneration(),
-                    preparedAuthentication.credentials());
-                try {
-                  var created =
-                      createOrReplace(
-                          integrationId,
-                          name,
-                          spec.getType(),
-                          uri,
-                          properties,
-                          preparedAuthentication.authentication(),
-                          mode,
-                          false,
-                          null,
-                          now,
+    return mapFailures(
+            runWithRetry(
+                () -> {
+                  var pc = principal.get();
+                  authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
+                  String corr = pc.getCorrelationId();
+                  CatalogIntegrationSpec spec = request.getSpec();
+                  String name = mustNonEmpty(spec.getDisplayName(), "display_name", corr);
+                  var createPolicy =
+                      CatalogCreatePolicy.validate(
+                          request.getCreateMode(),
+                          request.hasIdempotency() ? request.getIdempotency().getKey() : "",
                           corr);
-                  if (!created.newIdentityPublished()) {
-                    cleanupPrepared(integrationId, preparedAuthentication);
+                  String key = createPolicy.idempotencyKey();
+                  CreateMode mode = createPolicy.mode();
+                  if (mode == CreateMode.CM_RETURN_EXISTING) {
+                    var existing = integrations.getByNameWithMeta(pc.getAccountId(), name);
+                    if (existing.isPresent()) {
+                      return CreateCatalogIntegrationResponse.newBuilder()
+                          .setIntegration(existing.get().value())
+                          .setMeta(existing.get().meta())
+                          .build();
+                    }
                   }
-                  return CreateCatalogIntegrationResponse.newBuilder()
-                      .setIntegration(created.row().value())
-                      .setMeta(created.row().meta())
-                      .build();
-                } catch (RuntimeException retryableFailure) {
-                  cleanupPrepared(integrationId, preparedAuthentication);
-                  throw retryableFailure;
-                }
-              }
-              var result =
-                  runIdempotentCreate(
-                      () ->
-                          MutationOps.createProtoRecoverable(
-                              pc.getAccountId(),
-                              "CreateCatalogIntegration",
-                              key,
-                              () -> fingerprint,
-                              () ->
-                                  randomResourceId(
-                                      pc.getAccountId(), ResourceKind.RK_CATALOG_INTEGRATION),
-                              (reservedId, completion) -> {
-                                var recovered = integrations.getByIdWithMeta(reservedId);
-                                if (recovered.isPresent()) {
-                                  throw new BaseResourceRepository.AbortRetryableException(
-                                      "integration exists before its idempotency receipt committed");
-                                }
-                                credentialStore.store(
-                                    reservedId,
-                                    preparedAuthentication
-                                        .authentication()
-                                        .getCredentialGeneration(),
-                                    preparedAuthentication.credentials());
-                                try {
-                                  var created =
-                                      createOrReplace(
-                                          reservedId,
-                                          name,
-                                          spec.getType(),
-                                          uri,
-                                          properties,
-                                          preparedAuthentication.authentication(),
-                                          CreateMode.CM_ERROR_IF_EXISTS,
-                                          true,
-                                          completion,
-                                          now,
-                                          corr);
-                                  return new IdempotencyGuard.CommittedCreate<>(
-                                      created.row().value(),
-                                      created.row().value().getResourceId(),
-                                      created.row().meta());
-                                } catch (RuntimeException definiteFailure) {
-                                  cleanupPrepared(reservedId, preparedAuthentication);
-                                  throw definiteFailure;
-                                }
-                              },
-                              idempotencyStore,
+                  validateType(spec.getType(), corr);
+                  String uri = validateCatalogUri(spec.getCatalogUri(), corr);
+                  Map<String, String> properties =
+                      validateConnectionProperties(spec.getPropertiesMap(), corr);
+                  if (!spec.hasAuthentication()
+                      || spec.getAuthentication().getConfigurationCase()
+                          == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
+                    throw GrpcErrors.invalidArgument(
+                        corr, FIELD, Map.of("field", "authentication.configuration"));
+                  }
+                  PreparedAuthentication preparedAuthentication =
+                      prepareAuthentication(
+                          spec.hasAuthentication()
+                              ? spec.getAuthentication()
+                              : CatalogAuthentication.getDefaultInstance(),
+                          request.hasCredentials()
+                              ? request.getCredentials()
+                              : CatalogIntegrationCredentials.getDefaultInstance(),
+                          1L,
+                          corr);
+                  validateAuthenticationType(
+                      spec.getType(), preparedAuthentication.authentication(), corr);
+                  byte[] fingerprint =
+                      new Canonicalizer()
+                          .scalar("display_name", name)
+                          .scalar("type", spec.getType())
+                          .scalar("catalog_uri", uri)
+                          .map("properties", properties)
+                          .scalar("authentication", preparedAuthentication.authentication())
+                          .bytes();
+                  var now = nowTs();
+
+                  if (key.isEmpty()) {
+                    ResourceId integrationId =
+                        randomResourceId(pc.getAccountId(), ResourceKind.RK_CATALOG_INTEGRATION);
+                    credentialStore.store(
+                        integrationId,
+                        preparedAuthentication.authentication().getCredentialGeneration(),
+                        preparedAuthentication.credentials());
+                    try {
+                      var created =
+                          createOrReplace(
+                              integrationId,
+                              name,
+                              spec.getType(),
+                              uri,
+                              properties,
+                              preparedAuthentication.authentication(),
+                              mode,
+                              false,
+                              null,
                               now,
-                              idempotencyTtlSeconds(),
-                              this::correlationId,
-                              CatalogIntegration::parseFrom));
-              return CreateCatalogIntegrationResponse.newBuilder()
-                  .setIntegration(result.body)
-                  .setMeta(result.meta)
-                  .build();
-            }),
-        correlationId());
+                              corr);
+                      if (!created.newIdentityPublished()) {
+                        cleanupPrepared(integrationId, preparedAuthentication);
+                      }
+                      return CreateCatalogIntegrationResponse.newBuilder()
+                          .setIntegration(created.row().value())
+                          .setMeta(created.row().meta())
+                          .build();
+                    } catch (RuntimeException retryableFailure) {
+                      cleanupPrepared(integrationId, preparedAuthentication);
+                      throw retryableFailure;
+                    }
+                  }
+                  var result =
+                      runIdempotentCreate(
+                          () ->
+                              MutationOps.createProtoRecoverable(
+                                  pc.getAccountId(),
+                                  "CreateCatalogIntegration",
+                                  key,
+                                  () -> fingerprint,
+                                  () ->
+                                      randomResourceId(
+                                          pc.getAccountId(), ResourceKind.RK_CATALOG_INTEGRATION),
+                                  (reservedId, completion) -> {
+                                    var recovered = integrations.getByIdWithMeta(reservedId);
+                                    if (recovered.isPresent()) {
+                                      throw new BaseResourceRepository.AbortRetryableException(
+                                          "integration exists before its idempotency receipt committed");
+                                    }
+                                    credentialStore.store(
+                                        reservedId,
+                                        preparedAuthentication
+                                            .authentication()
+                                            .getCredentialGeneration(),
+                                        preparedAuthentication.credentials());
+                                    try {
+                                      var created =
+                                          createOrReplace(
+                                              reservedId,
+                                              name,
+                                              spec.getType(),
+                                              uri,
+                                              properties,
+                                              preparedAuthentication.authentication(),
+                                              CreateMode.CM_ERROR_IF_EXISTS,
+                                              true,
+                                              completion,
+                                              now,
+                                              corr);
+                                      return new IdempotencyGuard.CommittedCreate<>(
+                                          created.row().value(),
+                                          created.row().value().getResourceId(),
+                                          created.row().meta());
+                                    } catch (RuntimeException definiteFailure) {
+                                      cleanupPrepared(reservedId, preparedAuthentication);
+                                      throw definiteFailure;
+                                    }
+                                  },
+                                  idempotencyStore,
+                                  now,
+                                  idempotencyTtlSeconds(),
+                                  this::correlationId,
+                                  CatalogIntegration::parseFrom));
+                  return CreateCatalogIntegrationResponse.newBuilder()
+                      .setIntegration(result.body)
+                      .setMeta(result.meta)
+                      .build();
+                }),
+            correlationId())
+        .onFailure()
+        .invoke(L::fail)
+        .onItem()
+        .invoke(L::ok);
   }
 
   private record CreateOutcome(
@@ -412,192 +434,214 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
   @Override
   public Uni<UpdateCatalogIntegrationResponse> updateCatalogIntegration(
       UpdateCatalogIntegrationRequest request) {
+    var L = LogHelper.start(LOG, "UpdateCatalogIntegration");
+
     return mapFailures(
-        runWithRetry(
-            () -> {
-              var pc = principal.get();
-              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
-              String corr = pc.getCorrelationId();
-              ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
-              Set<String> paths =
-                  requiredMask(request.hasUpdateMask() ? request.getUpdateMask() : null, corr);
-              var current =
-                  integrations
-                      .getByIdWithMeta(id)
-                      .orElseThrow(
-                          () ->
-                              GrpcErrors.notFound(
-                                  corr, CATALOG_INTEGRATION, Map.of("id", id.getId())));
-              MutationOps.BaseServiceChecks.enforcePreconditions(
-                  corr, current.meta(), request.getPrecondition());
-              var desiredBuilder = current.value().toBuilder();
-              if (paths.contains("display_name")) {
-                desiredBuilder.setDisplayName(
-                    mustNonEmpty(request.getSpec().getDisplayName(), "display_name", corr));
-              }
-              if (paths.contains("catalog_uri")) {
-                desiredBuilder.setCatalogUri(
-                    validateCatalogUri(request.getSpec().getCatalogUri(), corr));
-              }
-              if (paths.contains("properties")) {
-                desiredBuilder
-                    .clearProperties()
-                    .putAllProperties(
-                        validateConnectionProperties(request.getSpec().getPropertiesMap(), corr));
-              }
-              CatalogIntegration desired = desiredBuilder.setUpdatedAt(nowTs()).build();
-              try {
-                var meta =
-                    integrations
-                        .updateWithMetaUnlessDeleting(desired, current.meta().getPointerVersion())
-                        .orElseThrow(
-                            () ->
-                                GrpcErrors.preconditionFailed(
-                                    corr, CATALOG_INTEGRATION_CHANGED, Map.of()));
-                return UpdateCatalogIntegrationResponse.newBuilder()
-                    .setIntegration(desired)
-                    .setMeta(meta)
-                    .build();
-              } catch (BaseResourceRepository.NameConflictException e) {
-                throw GrpcErrors.alreadyExists(
-                    corr,
-                    CATALOG_INTEGRATION_ALREADY_EXISTS,
-                    Map.of("display_name", desired.getDisplayName()));
-              }
-            }),
-        correlationId());
+            runWithRetry(
+                () -> {
+                  var pc = principal.get();
+                  authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
+                  String corr = pc.getCorrelationId();
+                  ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
+                  Set<String> paths =
+                      requiredMask(request.hasUpdateMask() ? request.getUpdateMask() : null, corr);
+                  var current =
+                      integrations
+                          .getByIdWithMeta(id)
+                          .orElseThrow(
+                              () ->
+                                  GrpcErrors.notFound(
+                                      corr, CATALOG_INTEGRATION, Map.of("id", id.getId())));
+                  MutationOps.BaseServiceChecks.enforcePreconditions(
+                      corr, current.meta(), request.getPrecondition());
+                  var desiredBuilder = current.value().toBuilder();
+                  if (paths.contains("display_name")) {
+                    desiredBuilder.setDisplayName(
+                        mustNonEmpty(request.getSpec().getDisplayName(), "display_name", corr));
+                  }
+                  if (paths.contains("catalog_uri")) {
+                    desiredBuilder.setCatalogUri(
+                        validateCatalogUri(request.getSpec().getCatalogUri(), corr));
+                  }
+                  if (paths.contains("properties")) {
+                    desiredBuilder
+                        .clearProperties()
+                        .putAllProperties(
+                            validateConnectionProperties(
+                                request.getSpec().getPropertiesMap(), corr));
+                  }
+                  CatalogIntegration desired = desiredBuilder.setUpdatedAt(nowTs()).build();
+                  try {
+                    var meta =
+                        integrations
+                            .updateWithMetaUnlessDeleting(
+                                desired, current.meta().getPointerVersion())
+                            .orElseThrow(
+                                () ->
+                                    GrpcErrors.preconditionFailed(
+                                        corr, CATALOG_INTEGRATION_CHANGED, Map.of()));
+                    return UpdateCatalogIntegrationResponse.newBuilder()
+                        .setIntegration(desired)
+                        .setMeta(meta)
+                        .build();
+                  } catch (BaseResourceRepository.NameConflictException e) {
+                    throw GrpcErrors.alreadyExists(
+                        corr,
+                        CATALOG_INTEGRATION_ALREADY_EXISTS,
+                        Map.of("display_name", desired.getDisplayName()));
+                  }
+                }),
+            correlationId())
+        .onFailure()
+        .invoke(L::fail)
+        .onItem()
+        .invoke(L::ok);
   }
 
   @Override
   public Uni<UpdateCatalogIntegrationAuthenticationResponse> updateCatalogIntegrationAuthentication(
       UpdateCatalogIntegrationAuthenticationRequest request) {
+    var L = LogHelper.start(LOG, "UpdateCatalogIntegrationAuthentication");
+
     return mapFailures(
-        runWithRetry(
-            () -> {
-              var pc = principal.get();
-              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
-              String corr = pc.getCorrelationId();
-              ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
-              if (!request.hasAuthentication()
-                  || request.getAuthentication().getConfigurationCase()
-                      == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
-                throw GrpcErrors.invalidArgument(
-                    corr, FIELD, Map.of("field", "authentication.configuration"));
-              }
-              var current =
-                  integrations
-                      .getByIdWithMeta(id)
-                      .orElseThrow(
-                          () ->
-                              GrpcErrors.notFound(
-                                  corr, CATALOG_INTEGRATION, Map.of("id", id.getId())));
-              MutationOps.BaseServiceChecks.enforcePreconditions(
-                  corr, current.meta(), request.getPrecondition());
-              long nextGeneration =
-                  current.value().hasAuthentication()
-                      ? current.value().getAuthentication().getCredentialGeneration() + 1L
-                      : 1L;
-              PreparedAuthentication prepared =
-                  prepareAuthentication(
-                      request.hasAuthentication()
-                          ? request.getAuthentication()
-                          : CatalogAuthentication.getDefaultInstance(),
-                      request.hasCredentials()
-                          ? request.getCredentials()
-                          : CatalogIntegrationCredentials.getDefaultInstance(),
-                      nextGeneration,
-                      corr);
-              validateAuthenticationType(
-                  current.value().getType(), prepared.authentication(), corr);
-              long allocatedGeneration =
-                  credentialStore.storeRotation(
-                      id,
-                      prepared.authentication().getCredentialGeneration(),
-                      prepared.credentials());
-              if (allocatedGeneration != prepared.authentication().getCredentialGeneration()) {
-                prepared =
-                    new PreparedAuthentication(
-                        prepared.authentication().toBuilder()
-                            .setCredentialGeneration(allocatedGeneration)
-                            .build(),
-                        prepared.credentials());
-              }
-              CatalogIntegration desired =
-                  applyAuthentication(current.value().toBuilder(), prepared.authentication())
-                      .setUpdatedAt(nowTs())
-                      .build();
-              credentialCleanup.schedule(current.value());
-              try {
-                var meta =
-                    integrations
-                        .updateWithMetaUnlessDeleting(desired, current.meta().getPointerVersion())
-                        .orElseThrow(
-                            () ->
-                                GrpcErrors.preconditionFailed(
-                                    corr, CATALOG_INTEGRATION_CHANGED, Map.of()));
-                credentialCleanup.cleanIfSuperseded(current.value());
-                return UpdateCatalogIntegrationAuthenticationResponse.newBuilder()
-                    .setIntegration(desired)
-                    .setMeta(meta)
-                    .build();
-              } catch (RuntimeException definiteFailure) {
-                credentialCleanup.cancelIfResourceUnchanged(
-                    current.value(), current.meta().getPointerVersion());
-                cleanupPreparedAuthenticationUnlessPublished(id, prepared);
-                throw definiteFailure;
-              }
-            }),
-        correlationId());
+            runWithRetry(
+                () -> {
+                  var pc = principal.get();
+                  authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
+                  String corr = pc.getCorrelationId();
+                  ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
+                  if (!request.hasAuthentication()
+                      || request.getAuthentication().getConfigurationCase()
+                          == CatalogAuthentication.ConfigurationCase.CONFIGURATION_NOT_SET) {
+                    throw GrpcErrors.invalidArgument(
+                        corr, FIELD, Map.of("field", "authentication.configuration"));
+                  }
+                  var current =
+                      integrations
+                          .getByIdWithMeta(id)
+                          .orElseThrow(
+                              () ->
+                                  GrpcErrors.notFound(
+                                      corr, CATALOG_INTEGRATION, Map.of("id", id.getId())));
+                  MutationOps.BaseServiceChecks.enforcePreconditions(
+                      corr, current.meta(), request.getPrecondition());
+                  long nextGeneration =
+                      current.value().hasAuthentication()
+                          ? current.value().getAuthentication().getCredentialGeneration() + 1L
+                          : 1L;
+                  PreparedAuthentication prepared =
+                      prepareAuthentication(
+                          request.hasAuthentication()
+                              ? request.getAuthentication()
+                              : CatalogAuthentication.getDefaultInstance(),
+                          request.hasCredentials()
+                              ? request.getCredentials()
+                              : CatalogIntegrationCredentials.getDefaultInstance(),
+                          nextGeneration,
+                          corr);
+                  validateAuthenticationType(
+                      current.value().getType(), prepared.authentication(), corr);
+                  long allocatedGeneration =
+                      credentialStore.storeRotation(
+                          id,
+                          prepared.authentication().getCredentialGeneration(),
+                          prepared.credentials());
+                  if (allocatedGeneration != prepared.authentication().getCredentialGeneration()) {
+                    prepared =
+                        new PreparedAuthentication(
+                            prepared.authentication().toBuilder()
+                                .setCredentialGeneration(allocatedGeneration)
+                                .build(),
+                            prepared.credentials());
+                  }
+                  CatalogIntegration desired =
+                      applyAuthentication(current.value().toBuilder(), prepared.authentication())
+                          .setUpdatedAt(nowTs())
+                          .build();
+                  credentialCleanup.schedule(current.value());
+                  try {
+                    var meta =
+                        integrations
+                            .updateWithMetaUnlessDeleting(
+                                desired, current.meta().getPointerVersion())
+                            .orElseThrow(
+                                () ->
+                                    GrpcErrors.preconditionFailed(
+                                        corr, CATALOG_INTEGRATION_CHANGED, Map.of()));
+                    credentialCleanup.cleanIfSuperseded(current.value());
+                    return UpdateCatalogIntegrationAuthenticationResponse.newBuilder()
+                        .setIntegration(desired)
+                        .setMeta(meta)
+                        .build();
+                  } catch (RuntimeException definiteFailure) {
+                    credentialCleanup.cancelIfResourceUnchanged(
+                        current.value(), current.meta().getPointerVersion());
+                    cleanupPreparedAuthenticationUnlessPublished(id, prepared);
+                    throw definiteFailure;
+                  }
+                }),
+            correlationId())
+        .onFailure()
+        .invoke(L::fail)
+        .onItem()
+        .invoke(L::ok);
   }
 
   @Override
   public Uni<DeleteCatalogIntegrationResponse> deleteCatalogIntegration(
       DeleteCatalogIntegrationRequest request) {
+    var L = LogHelper.start(LOG, "DeleteCatalogIntegration");
+
     return mapFailures(
-        runWithRetry(
-            () -> {
-              var pc = principal.get();
-              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
-              String corr = pc.getCorrelationId();
-              ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
-              var current = integrations.getByIdWithMeta(id);
-              if (current.isEmpty()) {
-                if (hasMeaningfulPrecondition(request.getPrecondition()))
-                  throw GrpcErrors.notFound(corr, CATALOG_INTEGRATION, Map.of("id", id.getId()));
-                return DeleteCatalogIntegrationResponse.newBuilder()
-                    .setMeta(integrations.metaForSafe(id))
-                    .build();
-              }
-              var meta = current.get().meta();
-              MutationOps.BaseServiceChecks.enforcePreconditions(
-                  corr, meta, request.getPrecondition());
-              if (integrations.cascadeDeletionFenceVersion(id) > 0L)
-                throw GrpcErrors.conflict(
-                    corr,
-                    CATALOG_INTEGRATION_DELETION_IN_PROGRESS,
-                    Map.of("reason", "cascade deletion in progress"));
-              long markerVersion = markerStore.catalogIntegrationOverlaysMarkerVersion(id);
-              if (markerVersion > 0L)
-                throw GrpcErrors.conflict(
-                    corr,
-                    CATALOG_INTEGRATION_DELETION_IN_PROGRESS,
-                    Map.of("reason", "dependent overlays exist"));
-              credentialCleanup.schedule(current.get().value());
-              try {
-                if (!integrations.deleteWithPreconditionAndNoOverlayMarker(
-                    id, meta.getPointerVersion())) {
-                  throw new BaseResourceRepository.AbortRetryableException(
-                      "integration dependencies changed during deletion");
-                }
-              } catch (RuntimeException failure) {
-                credentialCleanup.cancelIfResourceUnchanged(
-                    current.get().value(), meta.getPointerVersion());
-                throw failure;
-              }
-              credentialCleanup.cleanIfSuperseded(current.get().value());
-              return DeleteCatalogIntegrationResponse.newBuilder().setMeta(meta).build();
-            }),
-        correlationId());
+            runWithRetry(
+                () -> {
+                  var pc = principal.get();
+                  authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
+                  String corr = pc.getCorrelationId();
+                  ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
+                  var current = integrations.getByIdWithMeta(id);
+                  if (current.isEmpty()) {
+                    if (hasMeaningfulPrecondition(request.getPrecondition()))
+                      throw GrpcErrors.notFound(
+                          corr, CATALOG_INTEGRATION, Map.of("id", id.getId()));
+                    return DeleteCatalogIntegrationResponse.newBuilder()
+                        .setMeta(integrations.metaForSafe(id))
+                        .build();
+                  }
+                  var meta = current.get().meta();
+                  MutationOps.BaseServiceChecks.enforcePreconditions(
+                      corr, meta, request.getPrecondition());
+                  if (integrations.cascadeDeletionFenceVersion(id) > 0L)
+                    throw GrpcErrors.conflict(
+                        corr,
+                        CATALOG_INTEGRATION_DELETION_IN_PROGRESS,
+                        Map.of("reason", "cascade deletion in progress"));
+                  long markerVersion = markerStore.catalogIntegrationOverlaysMarkerVersion(id);
+                  if (markerVersion > 0L)
+                    throw GrpcErrors.conflict(
+                        corr,
+                        CATALOG_INTEGRATION_DELETION_IN_PROGRESS,
+                        Map.of("reason", "dependent overlays exist"));
+                  credentialCleanup.schedule(current.get().value());
+                  try {
+                    if (!integrations.deleteWithPreconditionAndNoOverlayMarker(
+                        id, meta.getPointerVersion())) {
+                      throw new BaseResourceRepository.AbortRetryableException(
+                          "integration dependencies changed during deletion");
+                    }
+                  } catch (RuntimeException failure) {
+                    credentialCleanup.cancelIfResourceUnchanged(
+                        current.get().value(), meta.getPointerVersion());
+                    throw failure;
+                  }
+                  credentialCleanup.cleanIfSuperseded(current.get().value());
+                  return DeleteCatalogIntegrationResponse.newBuilder().setMeta(meta).build();
+                }),
+            correlationId())
+        .onFailure()
+        .invoke(L::fail)
+        .onItem()
+        .invoke(L::ok);
   }
 
   private static Set<String> requiredMask(FieldMask mask, String corr) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
@@ -126,6 +126,7 @@ public class CatalogIntegrationRepository {
   }
 
   public boolean beginCascadeDeletion(ResourceId integrationId, long expectedPointerVersion) {
+    if (expectedPointerVersion <= 0L) return false;
     String canonical =
         Keys.catalogIntegrationPointerById(integrationId.getAccountId(), integrationId.getId());
     String fence =
@@ -180,6 +181,10 @@ public class CatalogIntegrationRepository {
 
   public Optional<CatalogIntegration> getById(ResourceId integrationId) {
     return repo.getByKey(key(integrationId));
+  }
+
+  public Optional<CatalogIntegration> getByIdForMutation(ResourceId integrationId) {
+    return repo.getByKeyForMutation(key(integrationId));
   }
 
   public Optional<ResourceWithMeta<CatalogIntegration>> getByIdWithMeta(ResourceId integrationId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
@@ -77,9 +77,7 @@ public class CatalogIntegrationRepository {
   }
 
   public Optional<ResourceWithMeta<CatalogIntegration>> replaceIdentityWithMeta(
-      CatalogIntegration current,
-      long expectedPointerVersion,
-      CatalogIntegration replacement) {
+      CatalogIntegration current, long expectedPointerVersion, CatalogIntegration replacement) {
     String accountId = current.getResourceId().getAccountId();
     String oldMarker =
         Keys.catalogIntegrationOverlaysMarker(accountId, current.getResourceId().getId());

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
@@ -79,8 +79,7 @@ public class CatalogIntegrationRepository {
   public Optional<ResourceWithMeta<CatalogIntegration>> replaceIdentityWithMeta(
       CatalogIntegration current,
       long expectedPointerVersion,
-      CatalogIntegration replacement,
-      long expectedOverlayMarkerVersion) {
+      CatalogIntegration replacement) {
     String accountId = current.getResourceId().getAccountId();
     String oldMarker =
         Keys.catalogIntegrationOverlaysMarker(accountId, current.getResourceId().getId());
@@ -92,36 +91,52 @@ public class CatalogIntegrationRepository {
         Keys.catalogIntegrationDeletionMarker(accountId, replacement.getResourceId().getId());
     Set<String> requiredAbsent = new java.util.HashSet<>();
     requiredAbsent.add(newMarker);
+    requiredAbsent.add(oldMarker);
     requiredAbsent.add(oldDeletionFence);
     requiredAbsent.add(newDeletionFence);
-    if (expectedOverlayMarkerVersion == 0L) requiredAbsent.add(oldMarker);
     return repo.replaceIdentityWithMeta(
         current,
         expectedPointerVersion,
         replacement,
         new PointerConditions(Map.of(), Set.copyOf(requiredAbsent), Map.of()),
-        expectedOverlayMarkerVersion == 0L
-            ? Map.of()
-            : Map.of(oldMarker, expectedOverlayMarkerVersion));
+        Map.of());
   }
 
   public boolean deleteWithPrecondition(ResourceId integrationId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(key(integrationId), expectedPointerVersion);
   }
 
-  public boolean deleteWithPreconditionAndOverlayMarker(
-      ResourceId integrationId, long expectedPointerVersion, long expectedMarkerVersion) {
+  public boolean deleteWithPreconditionAndNoOverlayMarker(
+      ResourceId integrationId, long expectedPointerVersion) {
     String marker =
         Keys.catalogIntegrationOverlaysMarker(integrationId.getAccountId(), integrationId.getId());
     String fence =
         Keys.catalogIntegrationDeletionMarker(integrationId.getAccountId(), integrationId.getId());
-    Set<String> requiredAbsent = new java.util.HashSet<>();
-    requiredAbsent.add(fence);
-    if (expectedMarkerVersion == 0L) requiredAbsent.add(marker);
     return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
         key(integrationId),
         expectedPointerVersion,
-        new PointerConditions(Map.of(), Set.copyOf(requiredAbsent), Map.of()),
+        new PointerConditions(Map.of(), Set.of(marker, fence), Map.of()),
+        Map.of());
+  }
+
+  public boolean deleteWithPreconditionForAccountDeletion(
+      ResourceId integrationId,
+      long expectedPointerVersion,
+      long expectedMarkerVersion,
+      long expectedAccountDeletionFenceVersion) {
+    if (expectedAccountDeletionFenceVersion <= 0L) return false;
+    String marker =
+        Keys.catalogIntegrationOverlaysMarker(integrationId.getAccountId(), integrationId.getId());
+    String fence =
+        Keys.catalogIntegrationDeletionMarker(integrationId.getAccountId(), integrationId.getId());
+    String accountFence = Keys.accountDeletionMarker(integrationId.getAccountId());
+    return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
+        key(integrationId),
+        expectedPointerVersion,
+        new PointerConditions(
+            Map.of(accountFence, expectedAccountDeletionFenceVersion),
+            expectedMarkerVersion == 0L ? Set.of(marker, fence) : Set.of(fence),
+            Map.of()),
         expectedMarkerVersion == 0L ? Map.of() : Map.of(marker, expectedMarkerVersion));
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
@@ -102,10 +102,6 @@ public class CatalogIntegrationRepository {
         Map.of());
   }
 
-  public boolean deleteWithPrecondition(ResourceId integrationId, long expectedPointerVersion) {
-    return repo.deleteWithPrecondition(key(integrationId), expectedPointerVersion);
-  }
-
   public boolean deleteWithPreconditionAndNoOverlayMarker(
       ResourceId integrationId, long expectedPointerVersion) {
     String marker =
@@ -170,7 +166,7 @@ public class CatalogIntegrationRepository {
         .orElse(0L);
   }
 
-  public boolean deleteWithPreconditionAndOverlayMarkerAndFence(
+  public boolean deleteWithPreconditionForCascadeDeletion(
       ResourceId integrationId,
       long expectedPointerVersion,
       long expectedMarkerVersion,
@@ -188,10 +184,6 @@ public class CatalogIntegrationRepository {
         new PointerConditions(
             Map.of(), expectedMarkerVersion == 0L ? Set.of(marker) : Set.of(), Map.of()),
         Map.copyOf(deletes));
-  }
-
-  public boolean delete(ResourceId integrationId) {
-    return repo.delete(key(integrationId));
   }
 
   public Optional<CatalogIntegration> getById(ResourceId integrationId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.service.repo.model.CatalogIntegrationKey;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.model.Schemas;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.PointerConditions;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta;
+import ai.floedb.floecat.storage.spi.BlobStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+@ApplicationScoped
+public class CatalogIntegrationRepository {
+
+  private final GenericResourceRepository<CatalogIntegration, CatalogIntegrationKey> repo;
+  private final PointerStore pointerStore;
+
+  @Inject
+  public CatalogIntegrationRepository(PointerStore pointerStore, BlobStore blobStore) {
+    this.pointerStore = pointerStore;
+    repo =
+        new GenericResourceRepository<>(
+            pointerStore,
+            blobStore,
+            Schemas.CATALOG_INTEGRATION,
+            CatalogIntegration::parseFrom,
+            CatalogIntegration::toByteArray,
+            "application/x-protobuf");
+  }
+
+  public void create(CatalogIntegration integration) {
+    repo.create(integration);
+  }
+
+  public ResourceWithMeta<CatalogIntegration> createWithMeta(CatalogIntegration integration) {
+    return repo.createWithMeta(integration);
+  }
+
+  public ResourceWithMeta<CatalogIntegration> createWithMetaAndCompletion(
+      CatalogIntegration integration,
+      Function<ResourceWithMeta<CatalogIntegration>, PointerStore.CasUpsert> completionFactory) {
+    return repo.createWithMeta(
+        integration, committed -> List.of(completionFactory.apply(committed)));
+  }
+
+  public boolean update(CatalogIntegration integration, long expectedPointerVersion) {
+    return repo.update(integration, expectedPointerVersion);
+  }
+
+  public Optional<MutationMeta> updateWithMetaUnlessDeleting(
+      CatalogIntegration integration, long expectedPointerVersion) {
+    String fence =
+        Keys.catalogIntegrationDeletionMarker(
+            integration.getResourceId().getAccountId(), integration.getResourceId().getId());
+    return repo.updateWithMetaWhilePointersMatchAndBumpMarkers(
+        integration,
+        expectedPointerVersion,
+        new PointerConditions(Map.of(), Set.of(fence), Map.of()));
+  }
+
+  public Optional<ResourceWithMeta<CatalogIntegration>> replaceIdentityWithMeta(
+      CatalogIntegration current,
+      long expectedPointerVersion,
+      CatalogIntegration replacement,
+      long expectedOverlayMarkerVersion) {
+    String accountId = current.getResourceId().getAccountId();
+    String oldMarker =
+        Keys.catalogIntegrationOverlaysMarker(accountId, current.getResourceId().getId());
+    String newMarker =
+        Keys.catalogIntegrationOverlaysMarker(accountId, replacement.getResourceId().getId());
+    String oldDeletionFence =
+        Keys.catalogIntegrationDeletionMarker(accountId, current.getResourceId().getId());
+    String newDeletionFence =
+        Keys.catalogIntegrationDeletionMarker(accountId, replacement.getResourceId().getId());
+    Set<String> requiredAbsent = new java.util.HashSet<>();
+    requiredAbsent.add(newMarker);
+    requiredAbsent.add(oldDeletionFence);
+    requiredAbsent.add(newDeletionFence);
+    if (expectedOverlayMarkerVersion == 0L) requiredAbsent.add(oldMarker);
+    return repo.replaceIdentityWithMeta(
+        current,
+        expectedPointerVersion,
+        replacement,
+        new PointerConditions(Map.of(), Set.copyOf(requiredAbsent), Map.of()),
+        expectedOverlayMarkerVersion == 0L
+            ? Map.of()
+            : Map.of(oldMarker, expectedOverlayMarkerVersion));
+  }
+
+  public boolean deleteWithPrecondition(ResourceId integrationId, long expectedPointerVersion) {
+    return repo.deleteWithPrecondition(key(integrationId), expectedPointerVersion);
+  }
+
+  public boolean deleteWithPreconditionAndOverlayMarker(
+      ResourceId integrationId, long expectedPointerVersion, long expectedMarkerVersion) {
+    String marker =
+        Keys.catalogIntegrationOverlaysMarker(integrationId.getAccountId(), integrationId.getId());
+    String fence =
+        Keys.catalogIntegrationDeletionMarker(integrationId.getAccountId(), integrationId.getId());
+    Set<String> requiredAbsent = new java.util.HashSet<>();
+    requiredAbsent.add(fence);
+    if (expectedMarkerVersion == 0L) requiredAbsent.add(marker);
+    return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
+        key(integrationId),
+        expectedPointerVersion,
+        new PointerConditions(Map.of(), Set.copyOf(requiredAbsent), Map.of()),
+        expectedMarkerVersion == 0L ? Map.of() : Map.of(marker, expectedMarkerVersion));
+  }
+
+  public boolean beginCascadeDeletion(ResourceId integrationId, long expectedPointerVersion) {
+    String canonical =
+        Keys.catalogIntegrationPointerById(integrationId.getAccountId(), integrationId.getId());
+    String fence =
+        Keys.catalogIntegrationDeletionMarker(integrationId.getAccountId(), integrationId.getId());
+    if (pointerStore.get(fence).isPresent()) {
+      return pointerStore
+          .get(canonical)
+          .map(pointer -> pointer.getVersion() == expectedPointerVersion)
+          .orElse(false);
+    }
+    return pointerStore.compareAndSetBatch(
+        List.of(
+            new PointerStore.CasCheck(canonical, expectedPointerVersion),
+            new PointerStore.CasCheckAbsent(
+                Keys.accountDeletionMarker(integrationId.getAccountId())),
+            new PointerStore.CasUpsert(
+                fence, 0L, PointerReferences.opaqueMarkerPointer(fence, fence, 1L))));
+  }
+
+  public long cascadeDeletionFenceVersion(ResourceId integrationId) {
+    return pointerStore
+        .get(
+            Keys.catalogIntegrationDeletionMarker(
+                integrationId.getAccountId(), integrationId.getId()))
+        .map(ai.floedb.floecat.common.rpc.Pointer::getVersion)
+        .orElse(0L);
+  }
+
+  public boolean deleteWithPreconditionAndOverlayMarkerAndFence(
+      ResourceId integrationId,
+      long expectedPointerVersion,
+      long expectedMarkerVersion,
+      long expectedFenceVersion) {
+    String marker =
+        Keys.catalogIntegrationOverlaysMarker(integrationId.getAccountId(), integrationId.getId());
+    String fence =
+        Keys.catalogIntegrationDeletionMarker(integrationId.getAccountId(), integrationId.getId());
+    Map<String, Long> deletes = new java.util.HashMap<>();
+    if (expectedMarkerVersion > 0L) deletes.put(marker, expectedMarkerVersion);
+    deletes.put(fence, expectedFenceVersion);
+    return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
+        key(integrationId),
+        expectedPointerVersion,
+        new PointerConditions(
+            Map.of(), expectedMarkerVersion == 0L ? Set.of(marker) : Set.of(), Map.of()),
+        Map.copyOf(deletes));
+  }
+
+  public boolean delete(ResourceId integrationId) {
+    return repo.delete(key(integrationId));
+  }
+
+  public Optional<CatalogIntegration> getById(ResourceId integrationId) {
+    return repo.getByKey(key(integrationId));
+  }
+
+  public Optional<ResourceWithMeta<CatalogIntegration>> getByIdWithMeta(ResourceId integrationId) {
+    return repo.getByKeyWithMeta(key(integrationId));
+  }
+
+  public boolean existsById(ResourceId integrationId) {
+    return repo.existsByKey(key(integrationId));
+  }
+
+  public Optional<CatalogIntegration> getByName(String accountId, String displayName) {
+    return repo.get(Keys.catalogIntegrationPointerByName(accountId, displayName));
+  }
+
+  public Optional<ResourceWithMeta<CatalogIntegration>> getByNameWithMeta(
+      String accountId, String displayName) {
+    return repo.getWithMeta(Keys.catalogIntegrationPointerByName(accountId, displayName));
+  }
+
+  public List<CatalogIntegration> list(
+      String accountId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefix(
+        Keys.catalogIntegrationPointerByNamePrefix(accountId), limit, pageToken, nextOut);
+  }
+
+  public List<CatalogIntegration> listConsistent(
+      String accountId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefixConsistent(
+        Keys.catalogIntegrationPointerByNamePrefix(accountId), limit, pageToken, nextOut);
+  }
+
+  public List<ResourceWithMeta<CatalogIntegration>> listWithMeta(
+      String accountId, int limit, String pageToken, StringBuilder nextOut) {
+    return repo.listByPrefixWithMeta(
+        Keys.catalogIntegrationPointerByNamePrefix(accountId), limit, pageToken, nextOut);
+  }
+
+  public int count(String accountId) {
+    return repo.countByPrefix(Keys.catalogIntegrationPointerByNamePrefix(accountId));
+  }
+
+  public MutationMeta metaFor(ResourceId integrationId) {
+    return repo.metaFor(key(integrationId));
+  }
+
+  public MutationMeta metaForSafe(ResourceId integrationId) {
+    return repo.metaForSafe(key(integrationId));
+  }
+
+  private static CatalogIntegrationKey key(ResourceId id) {
+    return new CatalogIntegrationKey(id.getAccountId(), id.getId());
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/CatalogIntegrationKey.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/CatalogIntegrationKey.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package ai.floedb.floecat.service.repo.model;
+
+public record CatalogIntegrationKey(String accountId, String integrationId, String sha256)
+    implements ResourceKey {
+  public CatalogIntegrationKey(String accountId, String integrationId) {
+    this(accountId, integrationId, "");
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -56,6 +56,8 @@ public final class Keys {
   public static final String SEG_IDEMPOTENCY = "/idempotency/";
   public static final String SEG_MARKERS = "/markers/";
   public static final String SEG_TRANSACTIONS = "/transactions/";
+  public static final String SEG_CATALOG_INTEGRATION_CREDENTIAL_CLEANUP =
+      "/catalog-integration-credential-cleanup/";
 
   private static String req(String name, String v) {
     if (v == null || v.isBlank()) {
@@ -99,6 +101,20 @@ public final class Keys {
 
   public static String encodeSegment(String s) {
     return encode(s);
+  }
+
+  public static String catalogIntegrationCredentialCleanupPrefix() {
+    return SEG_CATALOG_INTEGRATION_CREDENTIAL_CLEANUP;
+  }
+
+  public static String catalogIntegrationCredentialCleanupPointer(
+      String accountId, String integrationId, long generation) {
+    return SEG_CATALOG_INTEGRATION_CREDENTIAL_CLEANUP
+        + encode(req("account_id", accountId))
+        + "/"
+        + encode(req("integration_id", integrationId))
+        + "/"
+        + reqPositive("generation", generation);
   }
 
   private static String joinPathSegments(List<String> segments) {
@@ -1025,6 +1041,58 @@ public final class Keys {
         "/accounts/%s/connectors/%s/connector/%s.pb", encode(tid), encode(cid), encode(sha));
   }
 
+  // ===== Catalog Integration =====
+
+  public static String catalogIntegrationPointerById(String accountId, String integrationId) {
+    String tid = req("account_id", accountId);
+    String iid = req("integration_id", integrationId);
+    return "/accounts/" + encode(tid) + "/catalog-integrations/by-id/" + encode(iid);
+  }
+
+  public static String catalogIntegrationPointerByIdPrefix(String accountId) {
+    String tid = req("account_id", accountId);
+    return "/accounts/" + encode(tid) + "/catalog-integrations/by-id/";
+  }
+
+  public static String catalogIntegrationRootPrefix(String accountId) {
+    String tid = req("account_id", accountId);
+    return "/accounts/" + encode(tid) + "/catalog-integrations/";
+  }
+
+  public static String catalogIntegrationPointerByName(String accountId, String displayName) {
+    String tid = req("account_id", accountId);
+    String name = req("display_name", displayName);
+    return "/accounts/" + encode(tid) + "/catalog-integrations/by-name/" + encode(name);
+  }
+
+  public static String catalogIntegrationPointerByNamePrefix(String accountId) {
+    String tid = req("account_id", accountId);
+    return "/accounts/" + encode(tid) + "/catalog-integrations/by-name/";
+  }
+
+  /** Fixed-key generation marker advanced by every overlay creation for this integration. */
+  public static String catalogIntegrationOverlaysMarker(String accountId, String integrationId) {
+    String tid = req("account_id", accountId);
+    String iid = req("integration_id", integrationId);
+    return "/accounts/" + encode(tid) + "/catalog-integrations/overlays-marker/" + encode(iid);
+  }
+
+  public static String catalogIntegrationDeletionMarker(String accountId, String integrationId) {
+    String tid = req("account_id", accountId);
+    String iid = req("integration_id", integrationId);
+    return "/accounts/" + encode(tid) + "/catalog-integrations/deleting/" + encode(iid);
+  }
+
+  public static String catalogIntegrationBlobUri(
+      String accountId, String integrationId, String sha256) {
+    String tid = req("account_id", accountId);
+    String iid = req("integration_id", integrationId);
+    String sha = req("sha256", sha256);
+    return String.format(
+        "/accounts/%s/catalog-integrations/%s/integration/%s.pb",
+        encode(tid), encode(iid), encode(sha));
+  }
+
   // ===== Idempotency =====
 
   public static String idempotencyKey(String accountId, String operation, String key) {
@@ -1855,6 +1923,10 @@ public final class Keys {
       case "storage-authorities" ->
           seg.length == 6 && "storage-authority".equals(seg[4])
               ? storageAuthorityPointerById(account, percentDecode(seg[3]))
+              : null;
+      case "catalog-integrations" ->
+          seg.length == 6 && "integration".equals(seg[4])
+              ? catalogIntegrationPointerById(account, percentDecode(seg[3]))
               : null;
       case "tables" -> seg.length >= 6 ? tableBlobOwner(account, seg) : null;
       default -> null;

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Schemas.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Schemas.java
@@ -28,6 +28,7 @@ import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
 import ai.floedb.floecat.service.repo.util.ConstraintNormalizer;
 import ai.floedb.floecat.storage.rpc.StorageAuthority;
 import ai.floedb.floecat.transaction.rpc.Transaction;
@@ -267,6 +268,26 @@ public final class Schemas {
                     v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
               })
           .withCasBlobs();
+
+  public static final ResourceSchema<CatalogIntegration, CatalogIntegrationKey>
+      CATALOG_INTEGRATION =
+          ResourceSchema.<CatalogIntegration, CatalogIntegrationKey>of(
+                  "catalog-integration",
+                  key -> Keys.catalogIntegrationPointerById(key.accountId(), key.integrationId()),
+                  key ->
+                      Keys.catalogIntegrationBlobUri(
+                          key.accountId(), key.integrationId(), key.sha256()),
+                  v ->
+                      Map.of(
+                          "byName",
+                          Keys.catalogIntegrationPointerByName(
+                              v.getResourceId().getAccountId(), v.getDisplayName())),
+                  v -> {
+                    var sha = Hashing.sha256Hex(v.toByteArray());
+                    return new CatalogIntegrationKey(
+                        v.getResourceId().getAccountId(), v.getResourceId().getId(), sha);
+                  })
+              .withCasBlobs();
 
   public static final ResourceSchema<Transaction, TransactionKey> TRANSACTION =
       ResourceSchema.<Transaction, TransactionKey>of(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/MarkerStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/MarkerStore.java
@@ -36,6 +36,12 @@ public class MarkerStore {
     return pointerStore.get(key).map(Pointer::getVersion).orElse(0L);
   }
 
+  public long catalogIntegrationOverlaysMarkerVersion(ResourceId integrationId) {
+    String key =
+        Keys.catalogIntegrationOverlaysMarker(integrationId.getAccountId(), integrationId.getId());
+    return pointerStore.get(key).map(Pointer::getVersion).orElse(0L);
+  }
+
   public long namespaceMarkerVersion(ResourceId namespaceId) {
     String key = Keys.namespaceChildrenMarker(namespaceId.getAccountId(), namespaceId.getId());
     return pointerStore.get(key).map(Pointer::getVersion).orElse(0L);

--- a/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
@@ -33,8 +33,17 @@ public final class RolePermissions {
       "storage-authority.resolve-internal";
   public static final String RECONCILE_EXECUTOR_CONTROL_INTERNAL =
       "reconcile-executor-control.internal";
+  public static final String CATALOG_INTEGRATION_READ = "catalog-integration.read";
+  public static final String CATALOG_INTEGRATION_WRITE = "catalog-integration.write";
+  public static final String CATALOG_INTEGRATION_USE = "catalog-integration.use";
   private static final List<String> READ_PERMS =
-      List.of("account.read", "catalog.read", "namespace.read", "table.read", "view.read");
+      List.of(
+          "account.read",
+          "catalog.read",
+          "namespace.read",
+          "table.read",
+          "view.read",
+          CATALOG_INTEGRATION_READ);
   private static final List<String> FULL_PERMS =
       List.of(
           "account.read",
@@ -47,6 +56,9 @@ public final class RolePermissions {
           "view.read",
           "view.write",
           "connector.manage",
+          CATALOG_INTEGRATION_READ,
+          CATALOG_INTEGRATION_WRITE,
+          CATALOG_INTEGRATION_USE,
           "system-objects.read",
           "account.delete");
   private static final List<String> PLATFORM_PERMS =
@@ -60,7 +72,10 @@ public final class RolePermissions {
           "catalog.write",
           "namespace.read",
           "namespace.write",
-          "connector.create");
+          "connector.create",
+          CATALOG_INTEGRATION_READ,
+          CATALOG_INTEGRATION_WRITE,
+          CATALOG_INTEGRATION_USE);
   private static final List<String> DELETE_ACCOUNT_PERMS = List.of("account.delete");
   private static final List<String> RECONCILE_WORKER_PERMS =
       List.of(
@@ -74,6 +89,8 @@ public final class RolePermissions {
           "view.read",
           "view.write",
           "connector.manage",
+          CATALOG_INTEGRATION_READ,
+          CATALOG_INTEGRATION_USE,
           "system-objects.read",
           STORAGE_AUTHORITY_RESOLVE_INTERNAL,
           RECONCILE_EXECUTOR_CONTROL_INTERNAL);

--- a/service/src/main/resources/errors_en.properties
+++ b/service/src/main/resources/errors_en.properties
@@ -41,6 +41,7 @@ MC_NOT_FOUND.table.constraints=Table constraints not found for table "{table_id}
 MC_NOT_FOUND.view=View not found: {id}.
 MC_NOT_FOUND.snapshot=Snapshot not found: {id}.
 MC_NOT_FOUND.connector=Connector not found: {id}.
+MC_NOT_FOUND.catalog.integration=Catalog integration not found: {id}.
 MC_NOT_FOUND.job=Job not found: {id}.
 MC_NOT_FOUND.table.stats=Table statistics for snapshot "{snapshot_id}" not found for table "{table_id}".
 MC_NOT_FOUND.system.scan.scanner.not.found=System scanner "{scanner_id}" not found.
@@ -56,6 +57,8 @@ MC_CONFLICT.table.constraint.already.exists=Constraint "{constraint_name}" alrea
 MC_CONFLICT.view.already.exists=View "{display_name}" already exists in namespace.
 MC_CONFLICT.relation.name.already.claimed=Relation name "{display_name}" is already claimed by another relation in namespace.
 MC_CONFLICT.connector.already.exists=Connector "{display_name}" already exists.
+MC_CONFLICT.catalog.integration.already.exists=Catalog integration "{display_name}" already exists.
+MC_CONFLICT.catalog.integration.deletion.in.progress=Catalog integration operation blocked: {reason}.
 MC_CONFLICT.idempotency.mismatch=Idempotency key mismatch for {op}: key={key}.
 MC_CONFLICT.idempotency.already.succeeded.not.replayable=Idempotency succeeded; not replayable for {op}: key={key}.
 MC_CONFLICT.snapshot.mismatch=Snapshot metadata mismatch detected.
@@ -75,6 +78,7 @@ MC_NOT_FOUND.scan.handle=Scan handle not found: {handle}.
 
 MC_PRECONDITION_FAILED.version.mismatch=Version mismatch (expected {expected}, got {actual}).
 MC_PRECONDITION_FAILED.account.deletion.in.progress=Account "{account_id}" is being deleted.
+MC_PRECONDITION_FAILED.catalog.integration.changed=Catalog integration changed while applying the request.
 MC_PRECONDITION_FAILED.catalog.children.changed=Catalog metadata changed while evaluating the request.
 MC_PRECONDITION_FAILED.namespace.children.changed=Namespace metadata changed while evaluating the request.
 MC_PRECONDITION_FAILED.query.not.active=The query is not in an active state.

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -32,9 +32,11 @@ import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.credentials.DefaultCredentialResolver;
 import ai.floedb.floecat.service.error.impl.FloecatStatus;
+import ai.floedb.floecat.service.integration.CatalogIntegrationCredentialCleanup;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.AccountRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
@@ -64,6 +66,7 @@ class AccountServiceImplTest {
   void setUp() {
     service = new AccountServiceImpl();
     service.accountRepo = mock(AccountRepository.class);
+    service.catalogIntegrationRepo = mock(CatalogIntegrationRepository.class);
     service.tableRootRepo = mock(TableRootRepository.class);
     service.principal = mock(PrincipalProvider.class);
     service.authz = mock(Authorizer.class);
@@ -77,6 +80,7 @@ class AccountServiceImplTest {
     service.secretsManager = mock(SecretsManager.class);
     service.durableReconcileJobStore = mock(Instance.class);
     when(service.durableReconcileJobStore.isResolvable()).thenReturn(false);
+    service.catalogIntegrationCredentialCleanup = mock(CatalogIntegrationCredentialCleanup.class);
     installBasePrincipal(service, service.principal);
     when(service.principal.get())
         .thenReturn(

--- a/service/src/test/java/ai/floedb/floecat/service/credentials/DefaultCredentialResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/credentials/DefaultCredentialResolverTest.java
@@ -71,6 +71,13 @@ class DefaultCredentialResolverTest {
     }
 
     @Override
+    public boolean putIfAbsent(
+        String accountId, String secretType, String secretId, byte[] payload) {
+      put(accountId, secretType, secretId, payload);
+      return true;
+    }
+
+    @Override
     public Optional<byte[]> get(String accountId, String secretType, String secretId) {
       lastSecretType = secretType;
       lastSecretId = secretId;

--- a/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/CasBlobGcTest.java
@@ -112,6 +112,22 @@ class CasBlobGcTest {
   }
 
   @Test
+  void keepsCurrentIntegrationBlobAndDeletesSupersededBlob() {
+    String integrationCurrent =
+        Keys.catalogIntegrationBlobUri(ACCOUNT_ID, "integration-1", "sha-current");
+    String integrationOld = Keys.catalogIntegrationBlobUri(ACCOUNT_ID, "integration-1", "sha-old");
+    for (String blob : List.of(integrationCurrent, integrationOld)) {
+      blobs.put(blob, "data".getBytes(StandardCharsets.UTF_8), "application/x-protobuf");
+    }
+    putPointer(Keys.catalogIntegrationPointerById(ACCOUNT_ID, "integration-1"), integrationCurrent);
+
+    gc.runForAccount(ACCOUNT_ID);
+
+    assertTrue(blobs.head(integrationCurrent).isPresent());
+    assertFalse(blobs.head(integrationOld).isPresent());
+  }
+
+  @Test
   void estimatesKnownReferencedBytesFromPointersAlreadyScannedByTheMark() {
     String tableBlob = Keys.tableBlobUri(ACCOUNT_ID, TABLE_ID, "sha-table");
     String connectorBlob = Keys.connectorBlobUri(ACCOUNT_ID, "connector-1", "sha-connector");

--- a/service/src/test/java/ai/floedb/floecat/service/gc/PointerGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/gc/PointerGcTest.java
@@ -17,8 +17,13 @@
 package ai.floedb.floecat.service.gc;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.service.integration.CatalogIntegrationCredentialCleanup;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
@@ -47,6 +52,9 @@ class PointerGcTest {
     gc = new PointerGc();
     gc.pointerStore = pointers;
     gc.blobStore = blobs;
+    gc.credentialCleanup = mock(CatalogIntegrationCredentialCleanup.class);
+    when(gc.credentialCleanup.drain(anyLong(), anyInt()))
+        .thenReturn(new CatalogIntegrationCredentialCleanup.Result(0, 0));
   }
 
   @AfterEach

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialCleanupTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialCleanupTest.java
@@ -7,6 +7,7 @@
 package ai.floedb.floecat.service.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -22,6 +23,7 @@ import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
 import ai.floedb.floecat.integration.rpc.SecretValue;
 import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +51,7 @@ class CatalogIntegrationCredentialCleanupTest {
     ResourceId id = id("integration");
     CatalogIntegration integration = storedIntegration(id, 7L);
     String marker = Keys.catalogIntegrationCredentialCleanupPointer("acct", "integration", 7L);
-    when(integrations.getById(id))
+    when(integrations.getByIdForMutation(id))
         .thenReturn(Optional.of(integration), Optional.empty(), Optional.empty());
     doThrow(new IllegalStateException("secrets unavailable"))
         .doNothing()
@@ -73,7 +75,7 @@ class CatalogIntegrationCredentialCleanupTest {
   @Test
   void preparedCredentialCleanupIsDurable() {
     ResourceId id = id("prepared");
-    when(integrations.getById(id)).thenReturn(Optional.empty());
+    when(integrations.getByIdForMutation(id)).thenReturn(Optional.empty());
     CatalogIntegrationCredentials prepared =
         CatalogIntegrationCredentials.newBuilder()
             .setBearerToken(SecretValue.newBuilder().setValue("token"))
@@ -86,6 +88,28 @@ class CatalogIntegrationCredentialCleanupTest {
         pointers
             .get(Keys.catalogIntegrationCredentialCleanupPointer("acct", "prepared", 3L))
             .isEmpty());
+  }
+
+  @Test
+  void failedReplacementCancelsMarkerOnlyWhileResourceIsUnchanged() {
+    ResourceId id = id("integration");
+    CatalogIntegration integration = storedIntegration(id, 7L);
+    String canonical = Keys.catalogIntegrationPointerById("acct", "integration");
+    String marker = Keys.catalogIntegrationCredentialCleanupPointer("acct", "integration", 7L);
+    assertTrue(
+        pointers.compareAndSet(
+            canonical, 0L, PointerReferences.opaqueMarkerPointer(canonical, canonical, 1L)));
+
+    cleanup.schedule(integration);
+    assertTrue(cleanup.cancelIfResourceUnchanged(integration, 1L));
+    assertTrue(pointers.get(marker).isEmpty());
+
+    cleanup.schedule(integration);
+    assertTrue(
+        pointers.compareAndSet(
+            canonical, 1L, PointerReferences.opaqueMarkerPointer(canonical, canonical, 2L)));
+    assertFalse(cleanup.cancelIfResourceUnchanged(integration, 1L));
+    assertTrue(pointers.get(marker).isPresent());
   }
 
   private static ResourceId id(String value) {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialCleanupTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialCleanupTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.BearerAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.integration.rpc.SecretValue;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CatalogIntegrationCredentialCleanupTest {
+  private InMemoryPointerStore pointers;
+  private CatalogIntegrationRepository integrations;
+  private CatalogIntegrationCredentialStore credentials;
+  private CatalogIntegrationCredentialCleanup cleanup;
+
+  @BeforeEach
+  void setUp() {
+    pointers = new InMemoryPointerStore();
+    integrations = mock(CatalogIntegrationRepository.class);
+    credentials = mock(CatalogIntegrationCredentialStore.class);
+    cleanup = new CatalogIntegrationCredentialCleanup();
+    cleanup.pointerStore = pointers;
+    cleanup.integrations = integrations;
+    cleanup.credentials = credentials;
+  }
+
+  @Test
+  void retainsLiveGenerationAndRetriesFailedDeletionAfterResourceDisappears() {
+    ResourceId id = id("integration");
+    CatalogIntegration integration = storedIntegration(id, 7L);
+    String marker = Keys.catalogIntegrationCredentialCleanupPointer("acct", "integration", 7L);
+    when(integrations.getById(id))
+        .thenReturn(Optional.of(integration), Optional.empty(), Optional.empty());
+    doThrow(new IllegalStateException("secrets unavailable"))
+        .doNothing()
+        .when(credentials)
+        .deleteImmediately(id, 7L);
+
+    cleanup.schedule(integration);
+    cleanup.drain(System.currentTimeMillis() + 1_000L, 10);
+    assertTrue(pointers.get(marker).isPresent());
+
+    cleanup.drain(System.currentTimeMillis() + 1_000L, 10);
+    assertTrue(pointers.get(marker).isPresent());
+
+    CatalogIntegrationCredentialCleanup.Result result =
+        cleanup.drain(System.currentTimeMillis() + 1_000L, 10);
+    assertEquals(1, result.deleted());
+    assertTrue(pointers.get(marker).isEmpty());
+    verify(credentials, org.mockito.Mockito.times(2)).deleteImmediately(id, 7L);
+  }
+
+  @Test
+  void preparedCredentialCleanupIsDurable() {
+    ResourceId id = id("prepared");
+    when(integrations.getById(id)).thenReturn(Optional.empty());
+    CatalogIntegrationCredentials prepared =
+        CatalogIntegrationCredentials.newBuilder()
+            .setBearerToken(SecretValue.newBuilder().setValue("token"))
+            .build();
+
+    cleanup.cleanPrepared(id, 3L, prepared);
+
+    verify(credentials).deleteImmediately(id, 3L);
+    assertTrue(
+        pointers
+            .get(Keys.catalogIntegrationCredentialCleanupPointer("acct", "prepared", 3L))
+            .isEmpty());
+  }
+
+  private static ResourceId id(String value) {
+    return ResourceId.newBuilder()
+        .setAccountId("acct")
+        .setId(value)
+        .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+        .build();
+  }
+
+  private static CatalogIntegration storedIntegration(ResourceId id, long generation) {
+    return CatalogIntegration.newBuilder()
+        .setResourceId(id)
+        .setAuthentication(
+            CatalogAuthentication.newBuilder()
+                .setBearer(BearerAuthentication.getDefaultInstance())
+                .setCredentialsConfigured(true)
+                .setCredentialGeneration(generation))
+        .build();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.service.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.BearerAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.integration.rpc.SecretValue;
+import ai.floedb.floecat.storage.secrets.SecretsManager;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CatalogIntegrationCredentialStoreTest {
+  @Test
+  void existingGenerationIsImmutable() {
+    var secretsManager = mock(SecretsManager.class);
+    var store = new CatalogIntegrationCredentialStore();
+    store.secretsManager = secretsManager;
+    var integrationId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("integration")
+            .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+            .build();
+    var original =
+        CatalogIntegrationCredentials.newBuilder()
+            .setBearerToken(SecretValue.newBuilder().setValue("original"))
+            .build();
+    when(secretsManager.get(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 1L)))
+        .thenReturn(Optional.of(original.toByteArray()));
+
+    store.store(
+        integrationId,
+        1L,
+        CatalogIntegrationCredentials.newBuilder()
+            .setBearerToken(SecretValue.newBuilder().setValue("replacement"))
+            .build());
+
+    verify(secretsManager, never()).putIfAbsent(any(), any(), any(), any());
+    verify(secretsManager, never()).update(any(), any(), any(), any());
+  }
+
+  @Test
+  void rotationSkipsOccupiedGenerationEvenForSameCredentials() {
+    var secretsManager = mock(SecretsManager.class);
+    var store = new CatalogIntegrationCredentialStore();
+    store.secretsManager = secretsManager;
+    var integrationId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("integration")
+            .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+            .build();
+    var original =
+        CatalogIntegrationCredentials.newBuilder()
+            .setBearerToken(SecretValue.newBuilder().setValue("original"))
+            .build();
+    when(secretsManager.get(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 2L)))
+        .thenReturn(Optional.of(original.toByteArray()));
+    when(secretsManager.get(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 3L)))
+        .thenReturn(Optional.empty());
+    when(secretsManager.putIfAbsent(any(), any(), any(), any())).thenReturn(true);
+
+    assertEquals(3L, store.storeRotation(integrationId, 2L, original));
+    verify(secretsManager)
+        .putIfAbsent(
+            eq("acct"),
+            eq(CatalogIntegrationCredentialStore.SECRET_TYPE),
+            eq(CatalogIntegrationCredentialStore.reference(integrationId, 3L)),
+            eq(original.toByteArray()));
+  }
+
+  @Test
+  void resolvesTypedCredentialsFromResourceState() {
+    var secretsManager = mock(SecretsManager.class);
+    var store = new CatalogIntegrationCredentialStore();
+    store.secretsManager = secretsManager;
+    var integrationId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("integration")
+            .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+            .build();
+    var credentials =
+        CatalogIntegrationCredentials.newBuilder()
+            .setBearerToken(SecretValue.newBuilder().setValue("token"))
+            .build();
+    var integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setAuthentication(
+                CatalogAuthentication.newBuilder()
+                    .setBearer(BearerAuthentication.getDefaultInstance())
+                    .setCredentialsConfigured(true)
+                    .setCredentialGeneration(3L))
+            .build();
+    when(secretsManager.get(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 3L)))
+        .thenReturn(Optional.of(credentials.toByteArray()));
+
+    assertEquals(credentials, store.resolve(integration).orElseThrow());
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
@@ -95,6 +95,33 @@ class CatalogIntegrationCredentialStoreTest {
   }
 
   @Test
+  void rotationAdvancesWhenReservationReportsGenerationOccupied() {
+    var secretsManager = mock(SecretsManager.class);
+    var store = new CatalogIntegrationCredentialStore();
+    store.secretsManager = secretsManager;
+    var integrationId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("integration")
+            .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+            .build();
+    var credentials =
+        CatalogIntegrationCredentials.newBuilder()
+            .setBearerToken(SecretValue.newBuilder().setValue("replacement"))
+            .build();
+    when(secretsManager.get(any(), any(), any())).thenReturn(Optional.empty());
+    when(secretsManager.putIfAbsent(any(), any(), any(), any())).thenReturn(false, true);
+
+    assertEquals(3L, store.storeRotation(integrationId, 2L, credentials));
+    verify(secretsManager)
+        .putIfAbsent(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 3L),
+            credentials.toByteArray());
+  }
+
+  @Test
   void resolvesTypedCredentialsFromResourceState() {
     var secretsManager = mock(SecretsManager.class);
     var store = new CatalogIntegrationCredentialStore();

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +95,14 @@ class CatalogIntegrationCredentialStoreTest {
     when(secretsManager.putIfAbsent(any(), any(), any(), any())).thenReturn(false);
 
     store.store(integrationId, 1L, credentials);
+
+    verify(secretsManager, times(2))
+        .get(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 1L));
+    verify(secretsManager, never()).put(any(), any(), any(), any());
+    verify(secretsManager, never()).update(any(), any(), any(), any());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
@@ -7,6 +7,7 @@
 package ai.floedb.floecat.service.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -21,6 +22,7 @@ import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
 import ai.floedb.floecat.integration.rpc.CatalogIntegration;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
 import ai.floedb.floecat.integration.rpc.SecretValue;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.storage.secrets.SecretsManager;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -70,6 +72,51 @@ class CatalogIntegrationCredentialStoreTest {
 
     verify(secretsManager, never()).putIfAbsent(any(), any(), any(), any());
     verify(secretsManager, never()).update(any(), any(), any(), any());
+  }
+
+  @Test
+  void storeAcceptsGenerationThatBecomesVisibleAfterLosingReservation() {
+    var secretsManager = mock(SecretsManager.class);
+    var store = new CatalogIntegrationCredentialStore();
+    store.secretsManager = secretsManager;
+    var integrationId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("integration")
+            .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+            .build();
+    var credentials =
+        CatalogIntegrationCredentials.newBuilder()
+            .setBearerToken(SecretValue.newBuilder().setValue("token"))
+            .build();
+    when(secretsManager.get(any(), any(), any()))
+        .thenReturn(Optional.empty(), Optional.of(credentials.toByteArray()));
+    when(secretsManager.putIfAbsent(any(), any(), any(), any())).thenReturn(false);
+
+    store.store(integrationId, 1L, credentials);
+  }
+
+  @Test
+  void storeFailsRetryablyWhenLosingReservationRemainsUnavailable() {
+    var secretsManager = mock(SecretsManager.class);
+    var store = new CatalogIntegrationCredentialStore();
+    store.secretsManager = secretsManager;
+    var integrationId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("integration")
+            .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+            .build();
+    var credentials =
+        CatalogIntegrationCredentials.newBuilder()
+            .setBearerToken(SecretValue.newBuilder().setValue("token"))
+            .build();
+    when(secretsManager.get(any(), any(), any())).thenReturn(Optional.empty());
+    when(secretsManager.putIfAbsent(any(), any(), any(), any())).thenReturn(false);
+
+    assertThrows(
+        BaseResourceRepository.AbortRetryableException.class,
+        () -> store.store(integrationId, 1L, credentials));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationCredentialStoreTest.java
@@ -27,6 +27,20 @@ import org.junit.jupiter.api.Test;
 
 class CatalogIntegrationCredentialStoreTest {
   @Test
+  void referenceUsesAwsSecretsManagerSafeCharacters() {
+    var integrationId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setId("integration")
+            .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+            .build();
+
+    assertEquals(
+        "integration.credentials.7",
+        CatalogIntegrationCredentialStore.reference(integrationId, 7L));
+  }
+
+  @Test
   void existingGenerationIsImmutable() {
     var secretsManager = mock(SecretsManager.class);
     var store = new CatalogIntegrationCredentialStore();

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -624,7 +624,7 @@ class CatalogIntegrationsImplTest {
             Optional.of(
                 new ResourceWithMeta<>(
                     existing, MutationMeta.newBuilder().setPointerVersion(7L).build())));
-    when(service.integrations.replaceIdentityWithMeta(any(), eq(7L), any(), anyLong()))
+    when(service.integrations.replaceIdentityWithMeta(any(), eq(7L), any()))
         .thenAnswer(
             invocation ->
                 Optional.of(
@@ -651,6 +651,46 @@ class CatalogIntegrationsImplTest {
     assertNotEquals(existingId, response.getIntegration().getResourceId());
     assertEquals(1L, response.getMeta().getPointerVersion());
     assertEquals("https://new.example", response.getIntegration().getCatalogUri());
+  }
+
+  @Test
+  void createOrReplaceRejectsDependentOverlays() {
+    ResourceId existingId = id("existing", ResourceKind.RK_CATALOG_INTEGRATION);
+    var existing =
+        CatalogIntegration.newBuilder()
+            .setResourceId(existingId)
+            .setDisplayName("Warehouse")
+            .setType(CatalogIntegrationType.CIT_UNITY)
+            .setCatalogUri("https://old.example")
+            .build();
+    when(service.integrations.getByNameWithMeta("acct", "Warehouse"))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    existing, MutationMeta.newBuilder().setPointerVersion(7L).build())));
+    when(service.markerStore.catalogIntegrationOverlaysMarkerVersion(existingId)).thenReturn(4L);
+
+    StatusRuntimeException error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogIntegration(
+                        CreateCatalogIntegrationRequest.newBuilder()
+                            .setCreateMode(CreateMode.CM_REPLACE)
+                            .setSpec(
+                                CatalogIntegrationSpec.newBuilder()
+                                    .setDisplayName("Warehouse")
+                                    .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                                    .setCatalogUri("https://new.example")
+                                    .setAuthentication(oauthAuthentication()))
+                            .setCredentials(oauthCredentials())
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.ABORTED, error.getStatus().getCode());
+    verify(service.integrations, never()).replaceIdentityWithMeta(any(), anyLong(), any());
   }
 
   @Test
@@ -948,7 +988,7 @@ class CatalogIntegrationsImplTest {
   }
 
   @Test
-  void deleteChecksDependencyMarkerInSameTransaction() {
+  void deleteRequiresDependencyMarkerAbsentInSameTransaction() {
     var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
     var current =
         CatalogIntegration.newBuilder()
@@ -965,8 +1005,7 @@ class CatalogIntegrationsImplTest {
             Optional.of(
                 new ai.floedb.floecat.service.repo.util.GenericResourceRepository
                     .ResourceWithMeta<>(current, meta)));
-    when(service.markerStore.catalogIntegrationOverlaysMarkerVersion(integrationId)).thenReturn(4L);
-    when(service.integrations.deleteWithPreconditionAndOverlayMarker(integrationId, 7L, 4L))
+    when(service.integrations.deleteWithPreconditionAndNoOverlayMarker(integrationId, 7L))
         .thenReturn(true);
 
     service
@@ -976,12 +1015,38 @@ class CatalogIntegrationsImplTest {
         .indefinitely();
 
     verify(service.markerStore).catalogIntegrationOverlaysMarkerVersion(integrationId);
-    verify(service.integrations).deleteWithPreconditionAndOverlayMarker(integrationId, 7L, 4L);
+    verify(service.integrations).deleteWithPreconditionAndNoOverlayMarker(integrationId, 7L);
     verify(secretsManager)
         .deleteImmediately(
             "acct",
             CatalogIntegrationCredentialStore.SECRET_TYPE,
             CatalogIntegrationCredentialStore.reference(integrationId, 1L));
+  }
+
+  @Test
+  void deleteRejectsDependentOverlaysBeforeSchedulingCredentialCleanup() {
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var current = CatalogIntegration.newBuilder().setResourceId(integrationId).build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(7).build();
+    when(service.integrations.getByIdWithMeta(integrationId))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(current, meta)));
+    when(service.markerStore.catalogIntegrationOverlaysMarkerVersion(integrationId)).thenReturn(4L);
+
+    StatusRuntimeException error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .deleteCatalogIntegration(
+                        DeleteCatalogIntegrationRequest.newBuilder()
+                            .setIntegrationId(integrationId)
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.ABORTED, error.getStatus().getCode());
+    verify(service.integrations, never())
+        .deleteWithPreconditionAndNoOverlayMarker(any(), anyLong());
   }
 
   private static PrincipalContext principal() {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -1,0 +1,966 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package ai.floedb.floecat.service.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.common.rpc.CreateMode;
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.common.rpc.PrincipalContext;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.BearerAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationSpec;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.OAuthClientCredentialsAuthentication;
+import ai.floedb.floecat.integration.rpc.SecretValue;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
+import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta;
+import ai.floedb.floecat.service.repo.util.MarkerStore;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.rpc.IdempotencyRecord;
+import ai.floedb.floecat.storage.secrets.SecretsManager;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import com.google.protobuf.FieldMask;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class CatalogIntegrationsImplTest {
+  private CatalogIntegrationsImpl service;
+  private SecretsManager secretsManager;
+
+  @BeforeEach
+  void setUp() {
+    service = new CatalogIntegrationsImpl();
+    service.integrations = mock(CatalogIntegrationRepository.class);
+    service.markerStore = mock(MarkerStore.class);
+    service.principal = mock(PrincipalProvider.class);
+    service.authz = mock(Authorizer.class);
+    service.idempotencyStore = mock(IdempotencyRepository.class);
+    secretsManager = mock(SecretsManager.class);
+    service.credentialStore = new CatalogIntegrationCredentialStore();
+    service.credentialStore.secretsManager = secretsManager;
+    service.credentialCleanup = new CatalogIntegrationCredentialCleanup();
+    service.credentialCleanup.pointerStore = new InMemoryPointerStore();
+    service.credentialCleanup.integrations = service.integrations;
+    service.credentialCleanup.credentials = service.credentialStore;
+    when(secretsManager.putIfAbsent(any(), any(), any(), any())).thenReturn(true);
+    installBasePrincipal(service, service.principal);
+    when(service.principal.get()).thenReturn(principal());
+    when(service.integrations.createWithMeta(any()))
+        .thenAnswer(
+            invocation ->
+                new ResourceWithMeta<>(
+                    invocation.getArgument(0),
+                    MutationMeta.newBuilder().setPointerVersion(1L).build()));
+  }
+
+  @Test
+  void createPreservesSqlNameAndPersistsStrictHttpEndpoint() {
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Warehouse")
+                            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                            .setCatalogUri("https://catalog.example/v1")
+                            .setAuthentication(oauthAuthentication()))
+                    .setCredentials(oauthCredentials())
+                    .build())
+            .await()
+            .indefinitely();
+
+    var persisted = ArgumentCaptor.forClass(CatalogIntegration.class);
+    verify(service.integrations).createWithMeta(persisted.capture());
+    assertEquals("Warehouse", persisted.getValue().getDisplayName());
+    assertEquals("https://catalog.example/v1", response.getIntegration().getCatalogUri());
+  }
+
+  @Test
+  void createRejectsMalformedAndSecretBearingCatalogUris() {
+    for (String uri :
+        List.of(
+            "catalog.example",
+            "https://catalog.example/%ZZ",
+            "https://user:password@catalog.example",
+            "https://catalog.example?access_token=redacted",
+            "https://catalog.example?client%5Fsecret=redacted",
+            "https://catalog.example?X-Amz-Signature=redacted",
+            "https://catalog.example?sig=redacted",
+            "https://catalog.example#access_token=redacted",
+            "https://catalog.example#client_secret=redacted",
+            "https://catalog.example#")) {
+      var error =
+          assertThrows(
+              StatusRuntimeException.class,
+              () ->
+                  service
+                      .createCatalogIntegration(
+                          CreateCatalogIntegrationRequest.newBuilder()
+                              .setSpec(
+                                  CatalogIntegrationSpec.newBuilder()
+                                      .setDisplayName("Warehouse")
+                                      .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                                      .setCatalogUri(uri))
+                              .build())
+                      .await()
+                      .indefinitely(),
+              uri);
+
+      assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode(), uri);
+    }
+    verify(service.integrations, never()).createWithMeta(any());
+  }
+
+  @Test
+  void createAllowsBenignQueryParameters() {
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Warehouse")
+                            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                            .setCatalogUri("https://catalog.example/v1?warehouse=analytics")
+                            .setAuthentication(oauthAuthentication()))
+                    .setCredentials(oauthCredentials())
+                    .build())
+            .await()
+            .indefinitely();
+    assertEquals(
+        "https://catalog.example/v1?warehouse=analytics",
+        response.getIntegration().getCatalogUri());
+  }
+
+  @Test
+  void createStoresCredentialsSeparatelyUsingDeterministicReference() throws Exception {
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Warehouse")
+                            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                            .setCatalogUri("https://catalog.example")
+                            .setAuthentication(
+                                CatalogAuthentication.newBuilder()
+                                    .setOauthClientCredentials(
+                                        OAuthClientCredentialsAuthentication.newBuilder()
+                                            .setClientId("client-id")
+                                            .addScopes("catalog"))))
+                    .setCredentials(
+                        CatalogIntegrationCredentials.newBuilder()
+                            .setOauthClientSecret(
+                                SecretValue.newBuilder().setValue("client-secret")))
+                    .build())
+            .await()
+            .indefinitely();
+
+    var persisted = ArgumentCaptor.forClass(CatalogIntegration.class);
+    verify(service.integrations).createWithMeta(persisted.capture());
+    var storedAuthentication = persisted.getValue().getAuthentication();
+    assertTrue(storedAuthentication.getCredentialsConfigured());
+    assertEquals(1L, storedAuthentication.getCredentialGeneration());
+    assertEquals(storedAuthentication, response.getIntegration().getAuthentication());
+
+    var payload = ArgumentCaptor.forClass(byte[].class);
+    verify(secretsManager)
+        .putIfAbsent(
+            eq("acct"),
+            eq(CatalogIntegrationCredentialStore.SECRET_TYPE),
+            eq(
+                CatalogIntegrationCredentialStore.reference(
+                    persisted.getValue().getResourceId(), 1L)),
+            payload.capture());
+    assertEquals(
+        "client-secret",
+        CatalogIntegrationCredentials.parseFrom(payload.getValue())
+            .getOauthClientSecret()
+            .getValue());
+  }
+
+  @Test
+  void updateAuthenticationRotatesCredentialsAndAdvancesGeneration() {
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var current =
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setDisplayName("Warehouse")
+            .setType(CatalogIntegrationType.CIT_UNITY)
+            .setCatalogUri("https://catalog.example")
+            .setAuthentication(
+                CatalogAuthentication.newBuilder()
+                    .setOauthClientCredentials(
+                        OAuthClientCredentialsAuthentication.newBuilder().setClientId("client-id"))
+                    .setCredentialsConfigured(true)
+                    .setCredentialGeneration(1L))
+            .build();
+    when(service.integrations.getByIdWithMeta(integrationId))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    current, MutationMeta.newBuilder().setPointerVersion(7L).build())));
+    when(service.integrations.updateWithMetaUnlessDeleting(any(), eq(7L)))
+        .thenReturn(Optional.of(MutationMeta.newBuilder().setPointerVersion(8L).build()));
+
+    var response =
+        service
+            .updateCatalogIntegrationAuthentication(
+                UpdateCatalogIntegrationAuthenticationRequest.newBuilder()
+                    .setIntegrationId(integrationId)
+                    .setAuthentication(
+                        CatalogAuthentication.newBuilder()
+                            .setBearer(BearerAuthentication.getDefaultInstance()))
+                    .setCredentials(
+                        CatalogIntegrationCredentials.newBuilder()
+                            .setBearerToken(SecretValue.newBuilder().setValue("token")))
+                    .build())
+            .await()
+            .indefinitely();
+
+    var desired = ArgumentCaptor.forClass(CatalogIntegration.class);
+    verify(service.integrations).updateWithMetaUnlessDeleting(desired.capture(), eq(7L));
+    assertEquals(2L, response.getIntegration().getAuthentication().getCredentialGeneration());
+    assertEquals(desired.getValue(), response.getIntegration());
+    verify(secretsManager)
+        .putIfAbsent(
+            eq("acct"),
+            eq(CatalogIntegrationCredentialStore.SECRET_TYPE),
+            eq(CatalogIntegrationCredentialStore.reference(integrationId, 2L)),
+            any(byte[].class));
+    verify(secretsManager)
+        .deleteImmediately(
+            eq("acct"),
+            eq(CatalogIntegrationCredentialStore.SECRET_TYPE),
+            eq(CatalogIntegrationCredentialStore.reference(integrationId, 1L)));
+  }
+
+  @Test
+  void failedAuthenticationCasDeletesOnlyPreparedCredentialGeneration() {
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var current =
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setType(CatalogIntegrationType.CIT_UNITY)
+            .setAuthentication(
+                CatalogAuthentication.newBuilder()
+                    .setBearer(BearerAuthentication.getDefaultInstance())
+                    .setCredentialsConfigured(true)
+                    .setCredentialGeneration(1L))
+            .build();
+    when(service.integrations.getByIdWithMeta(integrationId))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    current, MutationMeta.newBuilder().setPointerVersion(7L).build())));
+    when(service.integrations.updateWithMetaUnlessDeleting(any(), eq(7L)))
+        .thenReturn(Optional.empty());
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .updateCatalogIntegrationAuthentication(
+                        UpdateCatalogIntegrationAuthenticationRequest.newBuilder()
+                            .setIntegrationId(integrationId)
+                            .setAuthentication(
+                                CatalogAuthentication.newBuilder()
+                                    .setBearer(BearerAuthentication.getDefaultInstance()))
+                            .setCredentials(
+                                CatalogIntegrationCredentials.newBuilder()
+                                    .setBearerToken(SecretValue.newBuilder().setValue("new-token")))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.FAILED_PRECONDITION, error.getStatus().getCode());
+    verify(secretsManager)
+        .deleteImmediately(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 2L));
+    verify(secretsManager, never())
+        .deleteImmediately(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 1L));
+  }
+
+  @Test
+  void losingAuthenticationCasRetainsGenerationPublishedByConcurrentWinner() {
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var current =
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setType(CatalogIntegrationType.CIT_UNITY)
+            .setAuthentication(
+                CatalogAuthentication.newBuilder()
+                    .setBearer(BearerAuthentication.getDefaultInstance())
+                    .setCredentialsConfigured(true)
+                    .setCredentialGeneration(1L))
+            .build();
+    var winner =
+        current.toBuilder()
+            .setAuthentication(
+                CatalogAuthentication.newBuilder()
+                    .setBearer(BearerAuthentication.getDefaultInstance())
+                    .setCredentialsConfigured(true)
+                    .setCredentialGeneration(2L))
+            .build();
+    when(service.integrations.getByIdWithMeta(integrationId))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    current, MutationMeta.newBuilder().setPointerVersion(7L).build())));
+    when(service.integrations.updateWithMetaUnlessDeleting(any(), eq(7L)))
+        .thenReturn(Optional.empty());
+    when(service.integrations.getById(integrationId)).thenReturn(Optional.of(winner));
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            service
+                .updateCatalogIntegrationAuthentication(
+                    UpdateCatalogIntegrationAuthenticationRequest.newBuilder()
+                        .setIntegrationId(integrationId)
+                        .setAuthentication(
+                            CatalogAuthentication.newBuilder()
+                                .setBearer(BearerAuthentication.getDefaultInstance()))
+                        .setCredentials(
+                            CatalogIntegrationCredentials.newBuilder()
+                                .setBearerToken(SecretValue.newBuilder().setValue("new-token")))
+                        .build())
+                .await()
+                .indefinitely());
+
+    verify(secretsManager, never())
+        .deleteImmediately(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 2L));
+  }
+
+  @Test
+  void unityRejectsAwsAuthentication() {
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogIntegration(
+                        CreateCatalogIntegrationRequest.newBuilder()
+                            .setSpec(
+                                CatalogIntegrationSpec.newBuilder()
+                                    .setDisplayName("Warehouse")
+                                    .setType(CatalogIntegrationType.CIT_UNITY)
+                                    .setCatalogUri("https://catalog.example")
+                                    .setAuthentication(
+                                        CatalogAuthentication.newBuilder()
+                                            .setAwsAssumeRole(
+                                                ai.floedb.floecat.integration.rpc
+                                                    .AwsAssumeRoleAuthentication.newBuilder()
+                                                    .setRoleArn(
+                                                        "arn:aws:iam::123456789012:role/test"))))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    verify(service.integrations, never()).createWithMeta(any());
+  }
+
+  @Test
+  void createRejectsMissingRequiredCredentials() {
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogIntegration(
+                        CreateCatalogIntegrationRequest.newBuilder()
+                            .setSpec(
+                                CatalogIntegrationSpec.newBuilder()
+                                    .setDisplayName("Warehouse")
+                                    .setType(CatalogIntegrationType.CIT_UNITY)
+                                    .setCatalogUri("https://catalog.example")
+                                    .setAuthentication(
+                                        CatalogAuthentication.newBuilder()
+                                            .setBearer(BearerAuthentication.getDefaultInstance())))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    verify(secretsManager, never()).putIfAbsent(any(), any(), any(), any());
+  }
+
+  @Test
+  void definiteCreateConflictDeletesPreparedCredentials() {
+    var existing =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("existing", ResourceKind.RK_CATALOG_INTEGRATION))
+            .setDisplayName("Warehouse")
+            .build();
+    when(service.integrations.getByNameWithMeta("acct", "Warehouse"))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    existing, MutationMeta.newBuilder().setPointerVersion(1L).build())));
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> service.createCatalogIntegration(validCreateRequest()).await().indefinitely());
+
+    assertEquals(Status.Code.ALREADY_EXISTS, error.getStatus().getCode());
+    var reference = ArgumentCaptor.forClass(String.class);
+    verify(secretsManager)
+        .putIfAbsent(
+            eq("acct"),
+            eq(CatalogIntegrationCredentialStore.SECRET_TYPE),
+            reference.capture(),
+            any(byte[].class));
+    verify(secretsManager)
+        .deleteImmediately(
+            "acct", CatalogIntegrationCredentialStore.SECRET_TYPE, reference.getValue());
+  }
+
+  @Test
+  void accountDeletionFenceFailureDeletesPreparedCredentials() {
+    when(service.integrations.createWithMeta(any()))
+        .thenThrow(new BaseResourceRepository.NotFoundException("account deletion is fenced"));
+
+    var failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () -> service.createCatalogIntegration(validCreateRequest()).await().indefinitely());
+    assertEquals(Status.Code.NOT_FOUND, failure.getStatus().getCode());
+
+    var reference = ArgumentCaptor.forClass(String.class);
+    verify(secretsManager)
+        .putIfAbsent(
+            eq("acct"),
+            eq(CatalogIntegrationCredentialStore.SECRET_TYPE),
+            reference.capture(),
+            any(byte[].class));
+    verify(secretsManager)
+        .deleteImmediately(
+            "acct", CatalogIntegrationCredentialStore.SECRET_TYPE, reference.getValue());
+  }
+
+  @Test
+  void createRejectsUnknownConflictMode() {
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogIntegration(
+                        CreateCatalogIntegrationRequest.newBuilder()
+                            .setCreateModeValue(99)
+                            .setSpec(
+                                CatalogIntegrationSpec.newBuilder()
+                                    .setDisplayName("Warehouse")
+                                    .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                                    .setCatalogUri("https://catalog.example"))
+                            .build())
+                    .await()
+                    .indefinitely());
+    assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+  }
+
+  @Test
+  void ifNotExistsReturnsExistingBeforeValidatingUnusedConnectionFields() {
+    var existing =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("existing", ResourceKind.RK_CATALOG_INTEGRATION))
+            .setDisplayName("Warehouse")
+            .setType(CatalogIntegrationType.CIT_UNITY)
+            .setCatalogUri("https://existing.example")
+            .build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(9L).build();
+    when(service.integrations.getByNameWithMeta("acct", "Warehouse"))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(existing, meta)));
+
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setCreateMode(CreateMode.CM_RETURN_EXISTING)
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Warehouse")
+                            .setType(CatalogIntegrationType.CIT_UNSPECIFIED)
+                            .setCatalogUri("not a URI"))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(existing, response.getIntegration());
+    assertEquals(meta, response.getMeta());
+    verify(service.integrations, never()).createWithMeta(any());
+  }
+
+  @Test
+  void ifNotExistsRaceDeletesCredentialsPreparedForUnpublishedIdentity() {
+    var existing =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("existing", ResourceKind.RK_CATALOG_INTEGRATION))
+            .setDisplayName("Warehouse")
+            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+            .setCatalogUri("https://existing.example")
+            .build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(9L).build();
+    when(service.integrations.getByNameWithMeta("acct", "Warehouse"))
+        .thenReturn(Optional.empty(), Optional.of(new ResourceWithMeta<>(existing, meta)));
+
+    var response =
+        service
+            .createCatalogIntegration(
+                validCreateRequest().toBuilder()
+                    .setCreateMode(CreateMode.CM_RETURN_EXISTING)
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(existing, response.getIntegration());
+    var reference = ArgumentCaptor.forClass(String.class);
+    verify(secretsManager)
+        .putIfAbsent(
+            eq("acct"),
+            eq(CatalogIntegrationCredentialStore.SECRET_TYPE),
+            reference.capture(),
+            any(byte[].class));
+    verify(secretsManager)
+        .deleteImmediately(
+            "acct", CatalogIntegrationCredentialStore.SECRET_TYPE, reference.getValue());
+    verify(service.integrations, never()).createWithMeta(any());
+  }
+
+  @Test
+  void createOrReplaceAtomicallySwapsToNewIdentity() {
+    ResourceId existingId = id("existing", ResourceKind.RK_CATALOG_INTEGRATION);
+    var existing =
+        CatalogIntegration.newBuilder()
+            .setResourceId(existingId)
+            .setDisplayName("Warehouse")
+            .setType(CatalogIntegrationType.CIT_UNITY)
+            .setCatalogUri("https://old.example")
+            .build();
+    when(service.integrations.getByNameWithMeta("acct", "Warehouse"))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    existing, MutationMeta.newBuilder().setPointerVersion(7L).build())));
+    when(service.integrations.replaceIdentityWithMeta(any(), eq(7L), any(), anyLong()))
+        .thenAnswer(
+            invocation ->
+                Optional.of(
+                    new ResourceWithMeta<>(
+                        invocation.getArgument(2),
+                        MutationMeta.newBuilder().setPointerVersion(1L).build())));
+
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setCreateMode(CreateMode.CM_REPLACE)
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Warehouse")
+                            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                            .setCatalogUri("https://new.example")
+                            .setAuthentication(oauthAuthentication()))
+                    .setCredentials(oauthCredentials())
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertNotEquals(existingId, response.getIntegration().getResourceId());
+    assertEquals(1L, response.getMeta().getPointerVersion());
+    assertEquals("https://new.example", response.getIntegration().getCatalogUri());
+  }
+
+  @Test
+  void idempotentCreateRequiresAtomicReceiptWithResourcePublication() {
+    var receipt = new AtomicReference<IdempotencyRecord>();
+    when(service.idempotencyStore.get(any()))
+        .thenAnswer(invocation -> Optional.ofNullable(receipt.get()));
+    when(service.idempotencyStore.createPending(
+            any(), any(), any(), any(), any(ResourceId.class), any(), any()))
+        .thenReturn(true);
+    when(service.idempotencyStore.prepareSuccess(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              String opName = invocation.getArgument(2, String.class);
+              String requestHash = invocation.getArgument(3, String.class);
+              ResourceId resourceId = invocation.getArgument(4, ResourceId.class);
+              MutationMeta meta = invocation.getArgument(5, MutationMeta.class);
+              byte[] payload = invocation.getArgument(6, byte[].class);
+              com.google.protobuf.Timestamp createdAt =
+                  invocation.getArgument(7, com.google.protobuf.Timestamp.class);
+              com.google.protobuf.Timestamp expiresAt =
+                  invocation.getArgument(8, com.google.protobuf.Timestamp.class);
+              receipt.set(
+                  IdempotencyRecord.newBuilder()
+                      .setOpName(opName)
+                      .setRequestHash(requestHash)
+                      .setStatus(IdempotencyRecord.Status.SUCCEEDED)
+                      .setResourceId(resourceId)
+                      .setMeta(meta)
+                      .setPayload(com.google.protobuf.ByteString.copyFrom(payload))
+                      .setCreatedAt(createdAt)
+                      .setExpiresAt(expiresAt)
+                      .build());
+              return new PointerStore.CasUpsert(
+                  "receipt", 1L, Pointer.newBuilder().setKey("receipt").build());
+            });
+    when(service.integrations.createWithMetaAndCompletion(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              CatalogIntegration value = invocation.getArgument(0);
+              var row =
+                  new ResourceWithMeta<>(
+                      value, MutationMeta.newBuilder().setPointerVersion(1L).build());
+              Function<ResourceWithMeta<CatalogIntegration>, PointerStore.CasUpsert> completion =
+                  invocation.getArgument(1);
+              completion.apply(row);
+              return row;
+            });
+
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setIdempotency(
+                        ai.floedb.floecat.common.rpc.IdempotencyKey.newBuilder().setKey("key"))
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Warehouse")
+                            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                            .setCatalogUri("https://catalog.example")
+                            .setAuthentication(oauthAuthentication()))
+                    .setCredentials(oauthCredentials())
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(receipt.get().getResourceId(), response.getIntegration().getResourceId());
+    verify(service.idempotencyStore)
+        .prepareSuccess(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    verify(service.idempotencyStore, never())
+        .finalizeSuccess(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    verify(service.idempotencyStore, never()).delete(any());
+    verify(secretsManager)
+        .putIfAbsent(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(
+                response.getIntegration().getResourceId(), 1L),
+            oauthCredentials().toByteArray());
+  }
+
+  @Test
+  void idempotentCreateAdoptsReservedIdentityPublishedByConcurrentRetry() {
+    var reservedId = new AtomicReference<ResourceId>();
+    var requestHash = new AtomicReference<String>();
+    var createdAt = new AtomicReference<com.google.protobuf.Timestamp>();
+    var expiresAt = new AtomicReference<com.google.protobuf.Timestamp>();
+    var meta = MutationMeta.newBuilder().setPointerVersion(9L).build();
+    when(service.idempotencyStore.get(any()))
+        .thenAnswer(
+            invocation -> {
+              if (reservedId.get() == null) return Optional.empty();
+              var integration =
+                  CatalogIntegration.newBuilder()
+                      .setResourceId(reservedId.get())
+                      .setDisplayName("Warehouse")
+                      .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                      .setCatalogUri("https://catalog.example")
+                      .build();
+              return Optional.of(
+                  IdempotencyRecord.newBuilder()
+                      .setOpName("CreateCatalogIntegration")
+                      .setRequestHash(requestHash.get())
+                      .setStatus(IdempotencyRecord.Status.SUCCEEDED)
+                      .setResourceId(reservedId.get())
+                      .setMeta(meta)
+                      .setPayload(integration.toByteString())
+                      .setCreatedAt(createdAt.get())
+                      .setExpiresAt(expiresAt.get())
+                      .build());
+            });
+    when(service.idempotencyStore.createPending(
+            any(), any(), any(), any(), any(ResourceId.class), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              requestHash.set(invocation.getArgument(3));
+              reservedId.set(invocation.getArgument(4));
+              createdAt.set(invocation.getArgument(5));
+              expiresAt.set(invocation.getArgument(6));
+              return true;
+            });
+    when(service.integrations.getByNameWithMeta("acct", "Warehouse"))
+        .thenAnswer(
+            invocation ->
+                Optional.of(
+                    new ResourceWithMeta<>(
+                        CatalogIntegration.newBuilder()
+                            .setResourceId(reservedId.get())
+                            .setDisplayName("Warehouse")
+                            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                            .setCatalogUri("https://catalog.example")
+                            .build(),
+                        meta)));
+
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setIdempotency(
+                        ai.floedb.floecat.common.rpc.IdempotencyKey.newBuilder().setKey("key"))
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Warehouse")
+                            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                            .setCatalogUri("https://catalog.example")
+                            .setAuthentication(oauthAuthentication()))
+                    .setCredentials(oauthCredentials())
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(reservedId.get(), response.getIntegration().getResourceId());
+    assertEquals(meta, response.getMeta());
+    verify(service.integrations, never()).createWithMetaAndCompletion(any(), any());
+    verify(service.idempotencyStore, never())
+        .prepareSuccess(any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void getResolvesSqlName() {
+    var integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("existing", ResourceKind.RK_CATALOG_INTEGRATION))
+            .setDisplayName("Warehouse")
+            .setAuthentication(
+                CatalogAuthentication.newBuilder()
+                    .setBearer(BearerAuthentication.getDefaultInstance())
+                    .setCredentialsConfigured(true)
+                    .setCredentialGeneration(3L))
+            .build();
+    when(service.integrations.getByNameWithMeta("acct", "Warehouse"))
+        .thenReturn(
+            Optional.of(
+                new ResourceWithMeta<>(
+                    integration, MutationMeta.newBuilder().setPointerVersion(3L).build())));
+    var response =
+        service
+            .getCatalogIntegration(
+                GetCatalogIntegrationRequest.newBuilder().setDisplayName("Warehouse").build())
+            .await()
+            .indefinitely();
+    assertEquals("Warehouse", response.getIntegration().getDisplayName());
+    assertTrue(response.getIntegration().getAuthentication().getCredentialsConfigured());
+    assertEquals(3L, response.getIntegration().getAuthentication().getCredentialGeneration());
+    assertEquals(3L, response.getMeta().getPointerVersion());
+  }
+
+  @Test
+  void updateRejectsImmutableCatalogUri() {
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var current =
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setCatalogUri("https://catalog.example")
+            .build();
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .updateCatalogIntegration(
+                        UpdateCatalogIntegrationRequest.newBuilder()
+                            .setIntegrationId(integrationId)
+                            .setSpec(
+                                CatalogIntegrationSpec.newBuilder()
+                                    .setCatalogUri("https://other.example"))
+                            .setUpdateMask(FieldMask.newBuilder().addPaths("catalog_uri"))
+                            .build())
+                    .await()
+                    .indefinitely());
+    assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    verify(service.integrations, never()).update(any(), anyLong());
+  }
+
+  @Test
+  void legacyConnectorPermissionDoesNotAuthorizeIntegrationCreate() {
+    service.authz = new Authorizer();
+    when(service.principal.get()).thenReturn(principal("connector.manage"));
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogIntegration(CreateCatalogIntegrationRequest.newBuilder().build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.PERMISSION_DENIED, error.getStatus().getCode());
+    verify(service.integrations, never()).create(any());
+  }
+
+  @Test
+  void updateRejectsConnectivityFields() {
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .updateCatalogIntegration(
+                        UpdateCatalogIntegrationRequest.newBuilder()
+                            .setIntegrationId(integrationId)
+                            .setUpdateMask(FieldMask.newBuilder().addPaths("auth"))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    verify(service.integrations, never()).update(any(), anyLong());
+  }
+
+  @Test
+  void deleteChecksDependencyMarkerInSameTransaction() {
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var current =
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setAuthentication(
+                CatalogAuthentication.newBuilder()
+                    .setBearer(BearerAuthentication.getDefaultInstance())
+                    .setCredentialsConfigured(true)
+                    .setCredentialGeneration(1L))
+            .build();
+    var meta = MutationMeta.newBuilder().setPointerVersion(7).build();
+    when(service.integrations.getByIdWithMeta(integrationId))
+        .thenReturn(
+            Optional.of(
+                new ai.floedb.floecat.service.repo.util.GenericResourceRepository
+                    .ResourceWithMeta<>(current, meta)));
+    when(service.markerStore.catalogIntegrationOverlaysMarkerVersion(integrationId)).thenReturn(4L);
+    when(service.integrations.deleteWithPreconditionAndOverlayMarker(integrationId, 7L, 4L))
+        .thenReturn(true);
+
+    service
+        .deleteCatalogIntegration(
+            DeleteCatalogIntegrationRequest.newBuilder().setIntegrationId(integrationId).build())
+        .await()
+        .indefinitely();
+
+    verify(service.markerStore).catalogIntegrationOverlaysMarkerVersion(integrationId);
+    verify(service.integrations).deleteWithPreconditionAndOverlayMarker(integrationId, 7L, 4L);
+    verify(secretsManager)
+        .deleteImmediately(
+            "acct",
+            CatalogIntegrationCredentialStore.SECRET_TYPE,
+            CatalogIntegrationCredentialStore.reference(integrationId, 1L));
+  }
+
+  private static PrincipalContext principal() {
+    return principal(
+        "catalog-integration.read", "catalog-integration.write", "catalog-integration.use");
+  }
+
+  private static CatalogAuthentication oauthAuthentication() {
+    return CatalogAuthentication.newBuilder()
+        .setOauthClientCredentials(
+            OAuthClientCredentialsAuthentication.newBuilder().setClientId("client-id"))
+        .build();
+  }
+
+  private static CatalogIntegrationCredentials oauthCredentials() {
+    return CatalogIntegrationCredentials.newBuilder()
+        .setOauthClientSecret(SecretValue.newBuilder().setValue("client-secret"))
+        .build();
+  }
+
+  private static CreateCatalogIntegrationRequest validCreateRequest() {
+    return CreateCatalogIntegrationRequest.newBuilder()
+        .setSpec(
+            CatalogIntegrationSpec.newBuilder()
+                .setDisplayName("Warehouse")
+                .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                .setCatalogUri("https://catalog.example")
+                .setAuthentication(oauthAuthentication()))
+        .setCredentials(oauthCredentials())
+        .build();
+  }
+
+  private static PrincipalContext principal(String... permissions) {
+    return PrincipalContext.newBuilder()
+        .setAccountId("acct")
+        .setCorrelationId("corr")
+        .addAllPermissions(List.of(permissions))
+        .build();
+  }
+
+  private static ResourceId id(String value, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("acct").setId(value).setKind(kind).build();
+  }
+
+  private static void installBasePrincipal(
+      CatalogIntegrationsImpl service, PrincipalProvider principalProvider) {
+    try {
+      Field field =
+          ai.floedb.floecat.service.common.BaseServiceImpl.class.getDeclaredField("principal");
+      field.setAccessible(true);
+      field.set(service, principalProvider);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to inject BaseServiceImpl principal provider", e);
+    }
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -355,7 +355,7 @@ class CatalogIntegrationsImplTest {
                     current, MutationMeta.newBuilder().setPointerVersion(7L).build())));
     when(service.integrations.updateWithMetaUnlessDeleting(any(), eq(7L)))
         .thenReturn(Optional.empty());
-    when(service.integrations.getById(integrationId)).thenReturn(Optional.of(winner));
+    when(service.integrations.getByIdForMutation(integrationId)).thenReturn(Optional.of(winner));
 
     assertThrows(
         StatusRuntimeException.class,
@@ -809,30 +809,37 @@ class CatalogIntegrationsImplTest {
   }
 
   @Test
-  void updateRejectsImmutableCatalogUri() {
+  void updateCatalogUriPreservesIdentityAndAdvancesGeneration() {
     var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
     var current =
         CatalogIntegration.newBuilder()
             .setResourceId(integrationId)
+            .setDisplayName("Warehouse")
             .setCatalogUri("https://catalog.example")
             .build();
-    var error =
-        assertThrows(
-            StatusRuntimeException.class,
-            () ->
-                service
-                    .updateCatalogIntegration(
-                        UpdateCatalogIntegrationRequest.newBuilder()
-                            .setIntegrationId(integrationId)
-                            .setSpec(
-                                CatalogIntegrationSpec.newBuilder()
-                                    .setCatalogUri("https://other.example"))
-                            .setUpdateMask(FieldMask.newBuilder().addPaths("catalog_uri"))
-                            .build())
-                    .await()
-                    .indefinitely());
-    assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
-    verify(service.integrations, never()).update(any(), anyLong());
+    var currentMeta = MutationMeta.newBuilder().setPointerVersion(4L).build();
+    var updatedMeta = MutationMeta.newBuilder().setPointerVersion(5L).build();
+    when(service.integrations.getByIdWithMeta(integrationId))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(current, currentMeta)));
+    when(service.integrations.updateWithMetaUnlessDeleting(any(), eq(4L)))
+        .thenReturn(Optional.of(updatedMeta));
+
+    var response =
+        service
+            .updateCatalogIntegration(
+                UpdateCatalogIntegrationRequest.newBuilder()
+                    .setIntegrationId(integrationId)
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder().setCatalogUri("https://other.example"))
+                    .setUpdateMask(FieldMask.newBuilder().addPaths("catalog_uri"))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(integrationId, response.getIntegration().getResourceId());
+    assertEquals("Warehouse", response.getIntegration().getDisplayName());
+    assertEquals("https://other.example", response.getIntegration().getCatalogUri());
+    assertEquals(5L, response.getMeta().getPointerVersion());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -480,8 +480,7 @@ class CatalogIntegrationsImplTest {
                                         .setRegion("us-east-1")
                                         .setAwsAssumeRole(
                                             AwsAssumeRoleAuthentication.newBuilder()
-                                                .setRoleArn(
-                                                    "arn:aws:iam::123456789012:role/test")
+                                                .setRoleArn("arn:aws:iam::123456789012:role/test")
                                                 .setExternalId(" ")))
                                 .build()))
                     .await()

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -54,6 +54,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -102,6 +103,8 @@ class CatalogIntegrationsImplTest {
                             .setDisplayName("Warehouse")
                             .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
                             .setCatalogUri("https://catalog.example/v1")
+                            .putProperties("warehouse", "analytics")
+                            .putProperties("s3.region", "us-east-1")
                             .setAuthentication(oauthAuthentication()))
                     .setCredentials(oauthCredentials())
                     .build())
@@ -112,6 +115,34 @@ class CatalogIntegrationsImplTest {
     verify(service.integrations).createWithMeta(persisted.capture());
     assertEquals("Warehouse", persisted.getValue().getDisplayName());
     assertEquals("https://catalog.example/v1", response.getIntegration().getCatalogUri());
+    assertEquals("analytics", response.getIntegration().getPropertiesMap().get("warehouse"));
+    assertEquals("us-east-1", response.getIntegration().getPropertiesMap().get("s3.region"));
+  }
+
+  @Test
+  void createRejectsSecretBearingConnectionProperties() {
+    for (String key : List.of("token", "s3.secret-access-key", "header.Authorization")) {
+      var error =
+          assertThrows(
+              StatusRuntimeException.class,
+              () ->
+                  service
+                      .createCatalogIntegration(
+                          CreateCatalogIntegrationRequest.newBuilder()
+                              .setSpec(
+                                  CatalogIntegrationSpec.newBuilder()
+                                      .setDisplayName("Warehouse")
+                                      .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                                      .setCatalogUri("https://catalog.example/v1")
+                                      .putProperties(key, "redacted"))
+                              .build())
+                      .await()
+                      .indefinitely(),
+              key);
+
+      assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode(), key);
+    }
+    verify(service.integrations, never()).createWithMeta(any());
   }
 
   @Test
@@ -839,6 +870,42 @@ class CatalogIntegrationsImplTest {
     assertEquals(integrationId, response.getIntegration().getResourceId());
     assertEquals("Warehouse", response.getIntegration().getDisplayName());
     assertEquals("https://other.example", response.getIntegration().getCatalogUri());
+    assertEquals(5L, response.getMeta().getPointerVersion());
+  }
+
+  @Test
+  void updateConnectionPropertiesReplacesThePersistedMap() {
+    var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
+    var current =
+        CatalogIntegration.newBuilder()
+            .setResourceId(integrationId)
+            .setDisplayName("Warehouse")
+            .setCatalogUri("https://catalog.example")
+            .putProperties("warehouse", "old-catalog")
+            .putProperties("removed", "value")
+            .build();
+    var currentMeta = MutationMeta.newBuilder().setPointerVersion(4L).build();
+    var updatedMeta = MutationMeta.newBuilder().setPointerVersion(5L).build();
+    when(service.integrations.getByIdWithMeta(integrationId))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(current, currentMeta)));
+    when(service.integrations.updateWithMetaUnlessDeleting(any(), eq(4L)))
+        .thenReturn(Optional.of(updatedMeta));
+
+    var response =
+        service
+            .updateCatalogIntegration(
+                UpdateCatalogIntegrationRequest.newBuilder()
+                    .setIntegrationId(integrationId)
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .putProperties("warehouse", "new-catalog"))
+                    .setUpdateMask(FieldMask.newBuilder().addPaths("properties"))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(Map.of("warehouse", "new-catalog"), response.getIntegration().getPropertiesMap());
+    assertEquals("https://catalog.example", response.getIntegration().getCatalogUri());
     assertEquals(5L, response.getMeta().getPointerVersion());
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -25,6 +25,8 @@ import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.AwsAssumeRoleAuthentication;
+import ai.floedb.floecat.integration.rpc.AwsSigV4Authentication;
 import ai.floedb.floecat.integration.rpc.BearerAuthentication;
 import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
 import ai.floedb.floecat.integration.rpc.CatalogIntegration;
@@ -434,6 +436,54 @@ class CatalogIntegrationsImplTest {
                                                     .setRoleArn(
                                                         "arn:aws:iam::123456789012:role/test"))))
                             .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    verify(service.integrations, never()).createWithMeta(any());
+  }
+
+  @Test
+  void createRejectsBlankTopLevelAssumeRoleExternalId() {
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogIntegration(
+                        createRequestWithAuthentication(
+                            CatalogAuthentication.newBuilder()
+                                .setAwsAssumeRole(
+                                    AwsAssumeRoleAuthentication.newBuilder()
+                                        .setRoleArn("arn:aws:iam::123456789012:role/test")
+                                        .setExternalId(" "))
+                                .build()))
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    verify(service.integrations, never()).createWithMeta(any());
+  }
+
+  @Test
+  void createRejectsBlankSigV4AssumeRoleExternalId() {
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogIntegration(
+                        createRequestWithAuthentication(
+                            CatalogAuthentication.newBuilder()
+                                .setAwsSigv4(
+                                    AwsSigV4Authentication.newBuilder()
+                                        .setRegion("us-east-1")
+                                        .setAwsAssumeRole(
+                                            AwsAssumeRoleAuthentication.newBuilder()
+                                                .setRoleArn(
+                                                    "arn:aws:iam::123456789012:role/test")
+                                                .setExternalId(" ")))
+                                .build()))
                     .await()
                     .indefinitely());
 
@@ -1076,6 +1126,18 @@ class CatalogIntegrationsImplTest {
                 .setCatalogUri("https://catalog.example")
                 .setAuthentication(oauthAuthentication()))
         .setCredentials(oauthCredentials())
+        .build();
+  }
+
+  private static CreateCatalogIntegrationRequest createRequestWithAuthentication(
+      CatalogAuthentication authentication) {
+    return CreateCatalogIntegrationRequest.newBuilder()
+        .setSpec(
+            CatalogIntegrationSpec.newBuilder()
+                .setDisplayName("Warehouse")
+                .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                .setCatalogUri("https://catalog.example")
+                .setAuthentication(authentication))
         .build();
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/it/CatalogIntegrationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/CatalogIntegrationIT.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.common.rpc.ErrorCode;
+import ai.floedb.floecat.common.rpc.IdempotencyKey;
+import ai.floedb.floecat.common.rpc.Precondition;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.BearerAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationSpec;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.OAuthClientCredentialsAuthentication;
+import ai.floedb.floecat.integration.rpc.SecretValue;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
+import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
+import ai.floedb.floecat.service.integration.CatalogIntegrationCredentialStore;
+import ai.floedb.floecat.service.util.TestDataResetter;
+import ai.floedb.floecat.service.util.TestSupport;
+import com.google.protobuf.FieldMask;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class CatalogIntegrationIT {
+  @GrpcClient("floecat")
+  CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations;
+
+  @Inject TestDataResetter resetter;
+  @Inject SeedRunner seeder;
+  @Inject CatalogIntegrationCredentialStore credentialStore;
+
+  @BeforeEach
+  void resetStores() {
+    resetter.wipeAll();
+    seeder.seedData();
+  }
+
+  @Test
+  void catalogIntegrationLifecycle() throws Exception {
+    var created =
+        integrations.createCatalogIntegration(
+            CreateCatalogIntegrationRequest.newBuilder()
+                .setSpec(
+                    CatalogIntegrationSpec.newBuilder()
+                        .setDisplayName("warehouse")
+                        .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                        .setCatalogUri("https://catalog.example/v1")
+                        .putProperties("warehouse", "analytics")
+                        .setAuthentication(oauthAuthentication("catalog-client")))
+                .setCredentials(oauthCredentials("initial-secret"))
+                .build());
+
+    CatalogIntegration integration = created.getIntegration();
+    var integrationId = integration.getResourceId();
+    assertEquals(ResourceKind.RK_CATALOG_INTEGRATION, integrationId.getKind());
+    assertTrue(integration.getAuthentication().getCredentialsConfigured());
+    assertEquals(1L, integration.getAuthentication().getCredentialGeneration());
+    assertEquals(
+        "initial-secret",
+        credentialStore.resolve(integration).orElseThrow().getOauthClientSecret().getValue());
+
+    var fetchedById =
+        integrations
+            .getCatalogIntegration(
+                GetCatalogIntegrationRequest.newBuilder().setIntegrationId(integrationId).build())
+            .getIntegration();
+    var fetchedByName =
+        integrations
+            .getCatalogIntegration(
+                GetCatalogIntegrationRequest.newBuilder().setDisplayName("warehouse").build())
+            .getIntegration();
+    assertEquals(integration, fetchedById);
+    assertEquals(integrationId, fetchedByName.getResourceId());
+
+    var listed =
+        integrations.listCatalogIntegrations(ListCatalogIntegrationsRequest.newBuilder().build());
+    assertEquals(1, listed.getEntriesCount());
+    assertEquals(integrationId, listed.getEntries(0).getIntegration().getResourceId());
+
+    var updated =
+        integrations.updateCatalogIntegration(
+            UpdateCatalogIntegrationRequest.newBuilder()
+                .setIntegrationId(integrationId)
+                .setSpec(
+                    CatalogIntegrationSpec.newBuilder()
+                        .setDisplayName("warehouse-renamed")
+                        .setCatalogUri("https://catalog.example/v2")
+                        .putProperties("warehouse", "finance"))
+                .setUpdateMask(
+                    FieldMask.newBuilder()
+                        .addPaths("display_name")
+                        .addPaths("catalog_uri")
+                        .addPaths("properties"))
+                .setPrecondition(precondition(created.getMeta()))
+                .build());
+    assertEquals("warehouse-renamed", updated.getIntegration().getDisplayName());
+    assertEquals("https://catalog.example/v2", updated.getIntegration().getCatalogUri());
+    assertEquals("finance", updated.getIntegration().getPropertiesMap().get("warehouse"));
+    assertEquals(integrationId, updated.getIntegration().getResourceId());
+
+    var rotated =
+        integrations.updateCatalogIntegrationAuthentication(
+            UpdateCatalogIntegrationAuthenticationRequest.newBuilder()
+                .setIntegrationId(integrationId)
+                .setAuthentication(oauthAuthentication("catalog-client-v2"))
+                .setCredentials(oauthCredentials("rotated-secret"))
+                .setPrecondition(precondition(updated.getMeta()))
+                .build());
+    assertEquals(2L, rotated.getIntegration().getAuthentication().getCredentialGeneration());
+    assertEquals(
+        "rotated-secret",
+        credentialStore
+            .resolve(rotated.getIntegration())
+            .orElseThrow()
+            .getOauthClientSecret()
+            .getValue());
+
+    integrations.deleteCatalogIntegration(
+        DeleteCatalogIntegrationRequest.newBuilder()
+            .setIntegrationId(integrationId)
+            .setPrecondition(precondition(rotated.getMeta()))
+            .build());
+
+    var missing =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                integrations.getCatalogIntegration(
+                    GetCatalogIntegrationRequest.newBuilder()
+                        .setIntegrationId(integrationId)
+                        .build()));
+    TestSupport.assertGrpcAndMc(
+        missing, Status.Code.NOT_FOUND, ErrorCode.MC_NOT_FOUND, "Catalog integration not found");
+    assertFalse(credentialStore.resolve(rotated.getIntegration()).isPresent());
+    assertEquals(
+        0,
+        integrations
+            .listCatalogIntegrations(ListCatalogIntegrationsRequest.newBuilder().build())
+            .getEntriesCount());
+  }
+
+  @Test
+  void createIsIdempotentThroughGrpc() {
+    var request =
+        CreateCatalogIntegrationRequest.newBuilder()
+            .setSpec(
+                CatalogIntegrationSpec.newBuilder()
+                    .setDisplayName("idempotent-warehouse")
+                    .setType(CatalogIntegrationType.CIT_UNITY)
+                    .setCatalogUri("https://unity.example/api/2.1/unity-catalog")
+                    .setAuthentication(
+                        CatalogAuthentication.newBuilder()
+                            .setBearer(BearerAuthentication.getDefaultInstance())))
+            .setCredentials(
+                CatalogIntegrationCredentials.newBuilder()
+                    .setBearerToken(SecretValue.newBuilder().setValue("token")))
+            .setIdempotency(IdempotencyKey.newBuilder().setKey("catalog-integration-it"))
+            .build();
+
+    var first = integrations.createCatalogIntegration(request);
+    var retry = integrations.createCatalogIntegration(request);
+
+    assertEquals(first.getIntegration(), retry.getIntegration());
+    assertEquals(first.getMeta(), retry.getMeta());
+    assertEquals(
+        1,
+        integrations
+            .listCatalogIntegrations(ListCatalogIntegrationsRequest.newBuilder().build())
+            .getEntriesCount());
+  }
+
+  private static CatalogAuthentication oauthAuthentication(String clientId) {
+    return CatalogAuthentication.newBuilder()
+        .setOauthClientCredentials(
+            OAuthClientCredentialsAuthentication.newBuilder().setClientId(clientId))
+        .build();
+  }
+
+  private static CatalogIntegrationCredentials oauthCredentials(String secret) {
+    return CatalogIntegrationCredentials.newBuilder()
+        .setOauthClientSecret(SecretValue.newBuilder().setValue(secret))
+        .build();
+  }
+
+  private static Precondition precondition(ai.floedb.floecat.common.rpc.MutationMeta meta) {
+    return Precondition.newBuilder()
+        .setExpectedVersion(meta.getPointerVersion())
+        .setExpectedEtag(meta.getEtag())
+        .build();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
@@ -135,9 +135,7 @@ class CatalogIntegrationRepositoryTest {
     assertFalse(repo.deleteWithPreconditionForAccountDeletion(id, version, 1L, 1L));
     assertTrue(
         pointers.compareAndSet(
-            accountFence,
-            0L,
-            PointerReferences.opaqueMarkerPointer(accountFence, "deleting", 1L)));
+            accountFence, 0L, PointerReferences.opaqueMarkerPointer(accountFence, "deleting", 1L)));
 
     assertTrue(repo.deleteWithPreconditionForAccountDeletion(id, version, 1L, 1L));
 

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package ai.floedb.floecat.service.repo.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.rpc.IdempotencyRecord;
+import com.google.protobuf.Timestamp;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class CatalogIntegrationRepositoryTest {
+
+  @Test
+  void roundTripsAndRefreshesNameIndex() {
+    var repo =
+        new CatalogIntegrationRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+    var id =
+        ResourceId.newBuilder()
+            .setAccountId("account")
+            .setId("integration")
+            .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+            .build();
+    var integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id)
+            .setDisplayName("warehouse")
+            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+            .setCatalogUri("https://catalog.example")
+            .build();
+
+    repo.create(integration);
+    assertEquals(integration, repo.getById(id).orElseThrow());
+    assertEquals(id, repo.getByName("account", "warehouse").orElseThrow().getResourceId());
+    assertEquals(1, repo.count("account"));
+
+    var meta = repo.metaFor(id);
+    assertTrue(
+        repo.update(
+            integration.toBuilder().setDisplayName("renamed-warehouse").build(),
+            meta.getPointerVersion()));
+    assertTrue(repo.getByName("account", "warehouse").isEmpty());
+    var renamed = repo.getByName("account", "renamed-warehouse").orElseThrow();
+    assertEquals(CatalogIntegrationType.CIT_ICEBERG_REST, renamed.getType());
+    assertEquals("https://catalog.example", renamed.getCatalogUri());
+  }
+
+  @Test
+  void deleteWithoutOverlayMarkerRequiresItToRemainAbsent() {
+    var pointers = new InMemoryPointerStore();
+    var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
+    var id =
+        ResourceId.newBuilder()
+            .setAccountId("account")
+            .setId("integration")
+            .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+            .build();
+    repo.create(
+        CatalogIntegration.newBuilder().setResourceId(id).setDisplayName("warehouse").build());
+    long version = repo.metaFor(id).getPointerVersion();
+
+    assertTrue(repo.deleteWithPreconditionAndOverlayMarker(id, version, 0L));
+    assertFalse(repo.getById(id).isPresent());
+    assertFalse(
+        pointers.get(Keys.catalogIntegrationOverlaysMarker("account", "integration")).isPresent());
+  }
+
+  @Test
+  void nonCascadeDeleteRequiresCascadeFenceToRemainAbsent() {
+    var pointers = new InMemoryPointerStore();
+    var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
+    var id = id("integration");
+    repo.create(
+        CatalogIntegration.newBuilder().setResourceId(id).setDisplayName("warehouse").build());
+    long version = repo.metaFor(id).getPointerVersion();
+
+    assertTrue(repo.beginCascadeDeletion(id, version));
+    assertFalse(repo.deleteWithPreconditionAndOverlayMarker(id, version, 0L));
+    assertTrue(repo.getById(id).isPresent());
+    assertTrue(
+        pointers.get(Keys.catalogIntegrationDeletionMarker("account", "integration")).isPresent());
+  }
+
+  @Test
+  void accountDeletionFenceRejectsNewResources() {
+    var pointers = new InMemoryPointerStore();
+    var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
+    String marker = Keys.accountDeletionMarker("account");
+    assertTrue(
+        pointers.compareAndSet(
+            marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "deleting", 1L)));
+    var integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(
+                ResourceId.newBuilder()
+                    .setAccountId("account")
+                    .setId("integration")
+                    .setKind(ResourceKind.RK_CATALOG_INTEGRATION))
+            .setDisplayName("warehouse")
+            .build();
+
+    assertThrows(BaseResourceRepository.NotFoundException.class, () -> repo.create(integration));
+    assertTrue(repo.getById(integration.getResourceId()).isEmpty());
+  }
+
+  @Test
+  void nameReadDoesNotReturnResourceRenamedAfterSecondarySelection() {
+    var repoRef = new AtomicReference<CatalogIntegrationRepository>();
+    var renamed = new AtomicBoolean();
+    var pointers =
+        new InMemoryPointerStore() {
+          @Override
+          public Optional<Pointer> get(String key) {
+            Optional<Pointer> selected = super.get(key);
+            if (key.equals(Keys.catalogIntegrationPointerByName("account", "warehouse"))
+                && renamed.compareAndSet(false, true)) {
+              var current = repoRef.get().getByIdWithMeta(id("integration")).orElseThrow();
+              assertTrue(
+                  repoRef
+                      .get()
+                      .update(
+                          current.value().toBuilder().setDisplayName("renamed").build(),
+                          current.meta().getPointerVersion()));
+            }
+            return selected;
+          }
+        };
+    var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
+    repoRef.set(repo);
+    var integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("integration"))
+            .setDisplayName("warehouse")
+            .build();
+    repo.create(integration);
+
+    assertTrue(repo.getByNameWithMeta("account", "warehouse").isEmpty());
+    assertEquals("renamed", repo.getByName("account", "renamed").orElseThrow().getDisplayName());
+  }
+
+  @Test
+  void replacementAtomicallySwapsToNewIdentity() {
+    var pointers = new InMemoryPointerStore();
+    var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
+    var original =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("old"))
+            .setDisplayName("warehouse")
+            .setCatalogUri("https://old.example")
+            .build();
+    repo.create(original);
+    var current = repo.getByIdWithMeta(original.getResourceId()).orElseThrow();
+    var replacement =
+        original.toBuilder().setResourceId(id("new")).setCatalogUri("https://new.example").build();
+
+    var replaced =
+        repo.replaceIdentityWithMeta(
+                current.value(), current.meta().getPointerVersion(), replacement, 0L)
+            .orElseThrow();
+
+    assertTrue(repo.getById(original.getResourceId()).isEmpty());
+    assertEquals(replacement, replaced.value());
+    assertEquals(
+        replacement.getResourceId(),
+        repo.getByName("account", "warehouse").orElseThrow().getResourceId());
+  }
+
+  @Test
+  void idempotencyReceiptAndIntegrationPointersBothCommitWhenAcknowledgementIsLost()
+      throws Exception {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var commitThenFail = new RepoTestPointerStores.CommitThenFailBatchPointerStore(pointers);
+    var repo = new CatalogIntegrationRepository(commitThenFail, blobs);
+    var idempotency = new IdempotencyRepositoryImpl(commitThenFail, blobs);
+    var integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("integration"))
+            .setDisplayName("warehouse")
+            .build();
+    String operation = "CreateCatalogIntegration";
+    String key = Keys.idempotencyKey("account", operation, "request-1");
+    Timestamp createdAt = timestamp(1L);
+    Timestamp expiresAt = timestamp(2L);
+    var committedMeta = new AtomicReference<ai.floedb.floecat.common.rpc.MutationMeta>();
+    assertTrue(
+        idempotency.createPending(
+            "account",
+            key,
+            operation,
+            "request-hash",
+            integration.getResourceId(),
+            createdAt,
+            expiresAt));
+
+    assertThrows(
+        RepoTestPointerStores.CommitThenFailBatchPointerStore.InjectedAcknowledgementFailure.class,
+        () ->
+            repo.createWithMetaAndCompletion(
+                integration,
+                row -> {
+                  committedMeta.set(row.meta());
+                  return idempotency.prepareSuccess(
+                      "account",
+                      key,
+                      operation,
+                      "request-hash",
+                      row.value().getResourceId(),
+                      row.meta(),
+                      row.value().toByteArray(),
+                      createdAt,
+                      expiresAt);
+                }));
+
+    var receipt = idempotency.get(key).orElseThrow();
+    assertEquals(IdempotencyRecord.Status.SUCCEEDED, receipt.getStatus());
+    assertEquals(committedMeta.get(), receipt.getMeta());
+    assertEquals(integration, CatalogIntegration.parseFrom(receipt.getPayload()));
+    assertEquals(integration, repo.getById(integration.getResourceId()).orElseThrow());
+    assertEquals(integration, repo.getByName("account", "warehouse").orElseThrow());
+  }
+
+  @Test
+  void idempotencyReceiptAndIntegrationPointersBothRemainUncommittedWhenBatchFails() {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    var failing = new RepoTestPointerStores.FailingBatchPointerStore(pointers);
+    var repo = new CatalogIntegrationRepository(failing, blobs);
+    var idempotency = new IdempotencyRepositoryImpl(failing, blobs);
+    var integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("integration"))
+            .setDisplayName("warehouse")
+            .build();
+    String operation = "CreateCatalogIntegration";
+    String key = Keys.idempotencyKey("account", operation, "request-1");
+    Timestamp createdAt = timestamp(1L);
+    Timestamp expiresAt = timestamp(2L);
+    assertTrue(
+        idempotency.createPending(
+            "account",
+            key,
+            operation,
+            "request-hash",
+            integration.getResourceId(),
+            createdAt,
+            expiresAt));
+
+    assertThrows(
+        RepoTestPointerStores.FailingBatchPointerStore.InjectedBatchFailure.class,
+        () ->
+            repo.createWithMetaAndCompletion(
+                integration,
+                row ->
+                    idempotency.prepareSuccess(
+                        "account",
+                        key,
+                        operation,
+                        "request-hash",
+                        row.value().getResourceId(),
+                        row.meta(),
+                        row.value().toByteArray(),
+                        createdAt,
+                        expiresAt)));
+
+    assertTrue(repo.getById(integration.getResourceId()).isEmpty());
+    assertTrue(repo.getByName("account", "warehouse").isEmpty());
+    assertEquals(IdempotencyRecord.Status.PENDING, idempotency.get(key).orElseThrow().getStatus());
+  }
+
+  private static Timestamp timestamp(long seconds) {
+    return Timestamp.newBuilder().setSeconds(seconds).build();
+  }
+
+  private static ResourceId id(String value) {
+    return ResourceId.newBuilder()
+        .setAccountId("account")
+        .setId(value)
+        .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+        .build();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
@@ -78,7 +78,7 @@ class CatalogIntegrationRepositoryTest {
         CatalogIntegration.newBuilder().setResourceId(id).setDisplayName("warehouse").build());
     long version = repo.metaFor(id).getPointerVersion();
 
-    assertTrue(repo.deleteWithPreconditionAndOverlayMarker(id, version, 0L));
+    assertTrue(repo.deleteWithPreconditionAndNoOverlayMarker(id, version));
     assertFalse(repo.getById(id).isPresent());
     assertFalse(
         pointers.get(Keys.catalogIntegrationOverlaysMarker("account", "integration")).isPresent());
@@ -94,10 +94,56 @@ class CatalogIntegrationRepositoryTest {
     long version = repo.metaFor(id).getPointerVersion();
 
     assertTrue(repo.beginCascadeDeletion(id, version));
-    assertFalse(repo.deleteWithPreconditionAndOverlayMarker(id, version, 0L));
+    assertFalse(repo.deleteWithPreconditionAndNoOverlayMarker(id, version));
     assertTrue(repo.getById(id).isPresent());
     assertTrue(
         pointers.get(Keys.catalogIntegrationDeletionMarker("account", "integration")).isPresent());
+  }
+
+  @Test
+  void nonCascadeDeleteRejectsExistingOverlayMarker() {
+    var pointers = new InMemoryPointerStore();
+    var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
+    var id = id("integration");
+    repo.create(
+        CatalogIntegration.newBuilder().setResourceId(id).setDisplayName("warehouse").build());
+    long version = repo.metaFor(id).getPointerVersion();
+    String marker = Keys.catalogIntegrationOverlaysMarker("account", "integration");
+    assertTrue(
+        pointers.compareAndSet(
+            marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "dependent", 1L)));
+
+    assertFalse(repo.deleteWithPreconditionAndNoOverlayMarker(id, version));
+
+    assertTrue(repo.getById(id).isPresent());
+    assertTrue(pointers.get(marker).isPresent());
+  }
+
+  @Test
+  void accountDeletionMayRemoveOverlayMarkerOnlyWhileAccountFenceExists() {
+    var pointers = new InMemoryPointerStore();
+    var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
+    var id = id("integration");
+    repo.create(
+        CatalogIntegration.newBuilder().setResourceId(id).setDisplayName("warehouse").build());
+    long version = repo.metaFor(id).getPointerVersion();
+    String marker = Keys.catalogIntegrationOverlaysMarker("account", "integration");
+    String accountFence = Keys.accountDeletionMarker("account");
+    assertTrue(
+        pointers.compareAndSet(
+            marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "dependent", 1L)));
+    assertFalse(repo.deleteWithPreconditionForAccountDeletion(id, version, 1L, 1L));
+    assertTrue(
+        pointers.compareAndSet(
+            accountFence,
+            0L,
+            PointerReferences.opaqueMarkerPointer(accountFence, "deleting", 1L)));
+
+    assertTrue(repo.deleteWithPreconditionForAccountDeletion(id, version, 1L, 1L));
+
+    assertTrue(repo.getById(id).isEmpty());
+    assertTrue(pointers.get(marker).isEmpty());
+    assertTrue(pointers.get(accountFence).isPresent());
   }
 
   @Test
@@ -184,7 +230,7 @@ class CatalogIntegrationRepositoryTest {
 
     var replaced =
         repo.replaceIdentityWithMeta(
-                current.value(), current.meta().getPointerVersion(), replacement, 0L)
+                current.value(), current.meta().getPointerVersion(), replacement)
             .orElseThrow();
 
     assertTrue(repo.getById(original.getResourceId()).isEmpty());
@@ -192,6 +238,33 @@ class CatalogIntegrationRepositoryTest {
     assertEquals(
         replacement.getResourceId(),
         repo.getByName("account", "warehouse").orElseThrow().getResourceId());
+  }
+
+  @Test
+  void replacementRejectsExistingOverlayMarker() {
+    var pointers = new InMemoryPointerStore();
+    var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
+    var original =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("old"))
+            .setDisplayName("warehouse")
+            .build();
+    repo.create(original);
+    var current = repo.getByIdWithMeta(original.getResourceId()).orElseThrow();
+    var replacement = original.toBuilder().setResourceId(id("new")).build();
+    String marker = Keys.catalogIntegrationOverlaysMarker("account", "old");
+    assertTrue(
+        pointers.compareAndSet(
+            marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "dependent", 1L)));
+
+    assertTrue(
+        repo.replaceIdentityWithMeta(
+                current.value(), current.meta().getPointerVersion(), replacement)
+            .isEmpty());
+
+    assertEquals(original, repo.getById(original.getResourceId()).orElseThrow());
+    assertTrue(repo.getById(replacement.getResourceId()).isEmpty());
+    assertTrue(pointers.get(marker).isPresent());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
@@ -101,6 +101,14 @@ class CatalogIntegrationRepositoryTest {
   }
 
   @Test
+  void cascadeDeletionRejectsNonPositiveExpectedVersion() {
+    var repo =
+        new CatalogIntegrationRepository(new InMemoryPointerStore(), new InMemoryBlobStore());
+
+    assertFalse(repo.beginCascadeDeletion(id("integration"), 0L));
+  }
+
+  @Test
   void accountDeletionFenceRejectsNewResources() {
     var pointers = new InMemoryPointerStore();
     var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
@@ -118,7 +126,9 @@ class CatalogIntegrationRepositoryTest {
             .setDisplayName("warehouse")
             .build();
 
-    assertThrows(BaseResourceRepository.NotFoundException.class, () -> repo.create(integration));
+    assertThrows(
+        BaseResourceRepository.AccountDeletionInProgressException.class,
+        () -> repo.create(integration));
     assertTrue(repo.getById(integration.getResourceId()).isEmpty());
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
@@ -180,6 +180,9 @@ class KeysTest {
         Keys.connectorPointerById("a c", "con 1"),
         Keys.ownerPointerKeyForBlob(Keys.connectorBlobUri("a c", "con 1", "sha")));
     assertEquals(
+        Keys.catalogIntegrationPointerById("a c", "int 1"),
+        Keys.ownerPointerKeyForBlob(Keys.catalogIntegrationBlobUri("a c", "int 1", "sha")));
+    assertEquals(
         Keys.tableRootByTable("a c", "tbl 1"),
         Keys.ownerPointerKeyForBlob(Keys.tableRootBlobUri("a c", "tbl 1", "sha")));
     assertEquals(

--- a/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
@@ -24,7 +24,13 @@ import org.junit.jupiter.api.Test;
 class RolePermissionsTest {
 
   private static final List<String> READ_PERMS =
-      List.of("account.read", "catalog.read", "namespace.read", "table.read", "view.read");
+      List.of(
+          "account.read",
+          "catalog.read",
+          "namespace.read",
+          "table.read",
+          "view.read",
+          RolePermissions.CATALOG_INTEGRATION_READ);
   private static final List<String> FULL_PERMS =
       List.of(
           "account.read",
@@ -37,6 +43,9 @@ class RolePermissionsTest {
           "view.read",
           "view.write",
           "connector.manage",
+          RolePermissions.CATALOG_INTEGRATION_READ,
+          RolePermissions.CATALOG_INTEGRATION_WRITE,
+          RolePermissions.CATALOG_INTEGRATION_USE,
           "system-objects.read",
           "account.delete");
   private static final List<String> INIT_ACCOUNT_PERMS =
@@ -47,7 +56,10 @@ class RolePermissionsTest {
           "catalog.write",
           "namespace.read",
           "namespace.write",
-          "connector.create");
+          "connector.create",
+          RolePermissions.CATALOG_INTEGRATION_READ,
+          RolePermissions.CATALOG_INTEGRATION_WRITE,
+          RolePermissions.CATALOG_INTEGRATION_USE);
   private static final List<String> DELETE_ACCOUNT_PERMS = List.of("account.delete");
   private static final List<String> PLATFORM_PERMS =
       List.of("account.read", "account.write", "account.delete");
@@ -63,6 +75,8 @@ class RolePermissionsTest {
           "view.read",
           "view.write",
           "connector.manage",
+          RolePermissions.CATALOG_INTEGRATION_READ,
+          RolePermissions.CATALOG_INTEGRATION_USE,
           "system-objects.read",
           RolePermissions.STORAGE_AUTHORITY_RESOLVE_INTERNAL,
           RolePermissions.RECONCILE_EXECUTOR_CONTROL_INTERNAL);

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolverTest.java
@@ -279,6 +279,12 @@ class ServerSideFileIoPropertiesResolverTest {
     public void put(String accountId, String secretType, String secretId, byte[] payload) {}
 
     @Override
+    public boolean putIfAbsent(
+        String accountId, String secretType, String secretId, byte[] payload) {
+      return true;
+    }
+
+    @Override
     public Optional<byte[]> get(String accountId, String secretType, String secretId) {
       return Optional.of(
           AuthCredentials.newBuilder()

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityResolverTest.java
@@ -80,6 +80,12 @@ class StorageAuthorityResolverTest {
           public void put(String accountId, String secretType, String secretId, byte[] payload) {}
 
           @Override
+          public boolean putIfAbsent(
+              String accountId, String secretType, String secretId, byte[] payload) {
+            return true;
+          }
+
+          @Override
           public Optional<byte[]> get(String accountId, String secretType, String secretId) {
             return Optional.of(
                 AuthCredentials.newBuilder()
@@ -697,6 +703,12 @@ class StorageAuthorityResolverTest {
     public void put(String accountId, String secretType, String secretId, byte[] payload) {}
 
     @Override
+    public boolean putIfAbsent(
+        String accountId, String secretType, String secretId, byte[] payload) {
+      return true;
+    }
+
+    @Override
     public Optional<byte[]> get(String accountId, String secretType, String secretId) {
       return Optional.of(
           AuthCredentials.newBuilder()
@@ -718,6 +730,12 @@ class StorageAuthorityResolverTest {
   private static class EmptySecretsManager implements SecretsManager {
     @Override
     public void put(String accountId, String secretType, String secretId, byte[] payload) {}
+
+    @Override
+    public boolean putIfAbsent(
+        String accountId, String secretType, String secretId, byte[] payload) {
+      return true;
+    }
 
     @Override
     public Optional<byte[]> get(String accountId, String secretType, String secretId) {

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
@@ -1857,6 +1857,13 @@ class StorageAuthorityServiceImplTest {
     }
 
     @Override
+    public boolean putIfAbsent(
+        String accountId, String secretType, String secretId, byte[] payload) {
+      put(accountId, secretType, secretId, payload);
+      return true;
+    }
+
+    @Override
     public Optional<byte[]> get(String accountId, String secretType, String secretId) {
       lastSecretId = secretId;
       return Optional.of(

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
@@ -212,6 +212,11 @@ public class ProdSecretsManager implements SecretsManager {
       return true;
     } catch (ResourceExistsException exists) {
       return false;
+    } catch (InvalidRequestException unavailable) {
+      // AWS retains a force-deleted secret name briefly while background deletion completes.
+      // Treat that immutable generation as occupied so callers can reserve the next generation.
+      if (isPendingDeletion(unavailable)) return false;
+      throw unavailable;
     }
   }
 

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManager.java
@@ -136,6 +136,12 @@ public class ProdSecretsManager implements SecretsManager {
   }
 
   @Override
+  public boolean putIfAbsent(String accountId, String secretType, String secretId, byte[] payload) {
+    return withClient(
+        accountId, client -> putIfAbsentOnce(client, accountId, secretType, secretId, payload));
+  }
+
+  @Override
   public Optional<byte[]> get(String accountId, String secretType, String secretId) {
     return withClient(accountId, client -> getOnce(client, accountId, secretType, secretId));
   }
@@ -160,6 +166,16 @@ public class ProdSecretsManager implements SecretsManager {
         });
   }
 
+  @Override
+  public void deleteImmediately(String accountId, String secretType, String secretId) {
+    withClient(
+        accountId,
+        client -> {
+          deleteImmediatelyOnce(client, accountId, secretType, secretId);
+          return null;
+        });
+  }
+
   private void putOnce(
       SecretsManagerClient client,
       String accountId,
@@ -180,6 +196,25 @@ public class ProdSecretsManager implements SecretsManager {
     }
   }
 
+  private boolean putIfAbsentOnce(
+      SecretsManagerClient client,
+      String accountId,
+      String secretType,
+      String secretId,
+      byte[] payload) {
+    ensureAwsCredentialsAvailable();
+    String secretName = SecretsManager.buildSecretKey(accountId, secretType, secretId);
+    String encoded = encodePayload(payload);
+    List<Tag> tags = buildTags(accountId, secretName);
+    try {
+      client.createSecret(
+          CreateSecretRequest.builder().name(secretName).secretString(encoded).tags(tags).build());
+      return true;
+    } catch (ResourceExistsException exists) {
+      return false;
+    }
+  }
+
   private Optional<byte[]> getOnce(
       SecretsManagerClient client, String accountId, String secretType, String secretId) {
     ensureAwsCredentialsAvailable();
@@ -195,6 +230,9 @@ public class ProdSecretsManager implements SecretsManager {
       return Optional.of(decodePayload(response.secretString()));
     } catch (ResourceNotFoundException missing) {
       return Optional.empty();
+    } catch (InvalidRequestException unavailable) {
+      if (isPendingDeletion(unavailable)) return Optional.empty();
+      throw unavailable;
     }
   }
 
@@ -240,6 +278,28 @@ public class ProdSecretsManager implements SecretsManager {
       }
       throw invalidState;
     }
+  }
+
+  private void deleteImmediatelyOnce(
+      SecretsManagerClient client, String accountId, String secretType, String secretId) {
+    ensureAwsCredentialsAvailable();
+    String secretName = SecretsManager.buildSecretKey(accountId, secretType, secretId);
+    try {
+      client.deleteSecret(
+          DeleteSecretRequest.builder()
+              .secretId(secretName)
+              .forceDeleteWithoutRecovery(true)
+              .build());
+    } catch (ResourceNotFoundException ignored) {
+    }
+  }
+
+  private static boolean isPendingDeletion(InvalidRequestException failure) {
+    String message = failure.getMessage();
+    if (message == null) return false;
+    String normalized = message.toLowerCase(java.util.Locale.ROOT);
+    return normalized.contains("marked for deletion")
+        || normalized.contains("scheduled for deletion");
   }
 
   private static List<Tag> buildTags(String accountId, String secretName) {

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -61,6 +61,8 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
 
   static final String KIND_POINTER = "Pointer";
   static final String GLOBAL_PK = "_ACCOUNT_DIR";
+  static final String CREDENTIAL_CLEANUP_PK = "_CATALOG_INTEGRATION_CREDENTIAL_CLEANUP";
+  static final String CREDENTIAL_CLEANUP_PREFIX = "catalog-integration-credential-cleanup/";
   static final String ATTR_BLOB_URI = "blob_uri";
   static final String ATTR_REFERENCE_KIND = "reference_kind";
   static final String ATTR_RESOURCE_ID = "rid";
@@ -83,6 +85,9 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
     String k = pointerKey.startsWith("/") ? pointerKey.substring(1) : pointerKey;
     if (k.startsWith("accounts/by-id/") || k.startsWith("accounts/by-name/")) {
       return new KvStore.Key(GLOBAL_PK, k);
+    }
+    if (k.startsWith(CREDENTIAL_CLEANUP_PREFIX)) {
+      return new KvStore.Key(CREDENTIAL_CLEANUP_PK, k);
     }
 
     if (!k.startsWith("accounts/")) {
@@ -114,6 +119,10 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
 
     if (p.startsWith("accounts/by-id/") || p.startsWith("accounts/by-name/")) {
       return new KvStore.Key(GLOBAL_PK, p);
+    }
+    if (p.equals("catalog-integration-credential-cleanup")
+        || p.startsWith(CREDENTIAL_CLEANUP_PREFIX)) {
+      return new KvStore.Key(CREDENTIAL_CLEANUP_PK, p);
     }
 
     if (!p.startsWith("accounts/")) {
@@ -409,7 +418,7 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
   // ---- Helpers (testing)
 
   private String keyOf(Key key) {
-    if (key.partitionKey().equals(GLOBAL_PK)) {
+    if (key.partitionKey().equals(GLOBAL_PK) || key.partitionKey().equals(CREDENTIAL_CLEANUP_PK)) {
       return "/" + key.sortKey();
     } else {
       return key.toString();

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
@@ -95,6 +95,21 @@ class ProdSecretsManagerTest {
   }
 
   @Test
+  void pendingDeletionIsAnOccupiedImmutableGeneration() {
+    ClientHandle pending =
+        ClientHandle.secretsFailure(
+            InvalidRequestException.builder()
+                .message("The secret was scheduled for deletion")
+                .build());
+    ProdSecretsManager manager =
+        new ProdSecretsManager(pending.secretsClient, ClientHandle.sts().stsClient);
+
+    assertFalse(
+        manager.putIfAbsent("acct", "catalog-integrations", "id:2", "replacement".getBytes()));
+    manager.shutdown();
+  }
+
+  @Test
   void immediateDeleteBypassesRecoveryWindow() {
     ClientHandle available = ClientHandle.secretsValue("unused");
     ProdSecretsManager manager =

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/aws/secrets/ProdSecretsManagerTest.java
@@ -42,9 +42,13 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
+import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
+import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.DescribeSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import software.amazon.awssdk.services.secretsmanager.model.InvalidRequestException;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceExistsException;
 import software.amazon.awssdk.services.sts.StsClient;
 
 class ProdSecretsManagerTest {
@@ -74,6 +78,53 @@ class ProdSecretsManagerTest {
 
     assertThrows(
         InvalidRequestException.class, () -> manager.delete("acct", "connectors", "secret"));
+  }
+
+  @Test
+  void pendingDeletionReadsAsUnavailableSoCredentialGenerationCanAdvance() {
+    ClientHandle pending =
+        ClientHandle.secretsFailure(
+            InvalidRequestException.builder()
+                .message("The secret was marked for deletion")
+                .build());
+    ProdSecretsManager manager =
+        new ProdSecretsManager(pending.secretsClient, ClientHandle.sts().stsClient);
+
+    assertTrue(manager.get("acct", "catalog-integrations", "id:2").isEmpty());
+    manager.shutdown();
+  }
+
+  @Test
+  void immediateDeleteBypassesRecoveryWindow() {
+    ClientHandle available = ClientHandle.secretsValue("unused");
+    ProdSecretsManager manager =
+        new ProdSecretsManager(available.secretsClient, ClientHandle.sts().stsClient);
+
+    manager.deleteImmediately("acct", "catalog-integrations", "id:2");
+
+    assertTrue(Boolean.TRUE.equals(available.deleteRequest.forceDeleteWithoutRecovery()));
+    assertEquals(null, available.deleteRequest.recoveryWindowInDays());
+    manager.shutdown();
+  }
+
+  @Test
+  void putIfAbsentDoesNotOverwriteExistingSecret() {
+    ClientHandle available = ClientHandle.secretsValue("unused");
+    ClientHandle existing =
+        ClientHandle.secretsFailure(
+            ResourceExistsException.builder().message("already exists").build());
+    ClientHandle stsClient = ClientHandle.sts();
+    FakeAwsClients awsClients = new FakeAwsClients();
+
+    ProdSecretsManager first =
+        new ProdSecretsManager(awsClients, available.secretsClient, stsClient.stsClient);
+    ProdSecretsManager second =
+        new ProdSecretsManager(awsClients, existing.secretsClient, ClientHandle.sts().stsClient);
+
+    assertTrue(first.putIfAbsent("acct", "catalog-integrations", "id:1", "a".getBytes()));
+    assertFalse(second.putIfAbsent("acct", "catalog-integrations", "id:1", "b".getBytes()));
+    first.shutdown();
+    second.shutdown();
   }
 
   @Test
@@ -480,6 +531,7 @@ class ProdSecretsManagerTest {
     private int closeCount;
     private ClientHandle boundStsClient;
     private final ProviderHandle provider = new ProviderHandle();
+    private DeleteSecretRequest deleteRequest;
     private final SecretsManagerClient secretsClient;
     private final StsClient stsClient;
 
@@ -539,11 +591,15 @@ class ProdSecretsManagerTest {
           }
           yield GetSecretValueResponse.builder().secretString(secretString).build();
         }
+        case "createSecret" -> {
+          if (failure != null) throw failure;
+          yield CreateSecretResponse.builder().build();
+        }
         case "deleteSecret" -> {
-          if (deleteFailure != null) {
-            throw deleteFailure;
-          }
-          yield null;
+          deleteRequest = (DeleteSecretRequest) args[0];
+          if (deleteFailure != null) throw deleteFailure;
+          if (failure != null) throw failure;
+          yield DeleteSecretResponse.builder().build();
         }
         case "describeSecret" -> {
           DescribeSecretResponse.Builder response = DescribeSecretResponse.builder();

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityKeyTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityKeyTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.storage.kv.dynamodb.ps;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PointerStoreEntityKeyTest {
+
+  @Test
+  void credentialCleanupPointerUsesDedicatedPartition() {
+    var key =
+        PointerStoreEntity._testKey(
+            "/catalog-integration-credential-cleanup/account/integration/3");
+
+    assertEquals(PointerStoreEntity.CREDENTIAL_CLEANUP_PK, key.partitionKey());
+    assertEquals("catalog-integration-credential-cleanup/account/integration/3", key.sortKey());
+  }
+
+  @Test
+  void credentialCleanupPrefixUsesDedicatedPartition() {
+    var key = PointerStoreEntity.prefixKey("/catalog-integration-credential-cleanup/");
+
+    assertEquals(PointerStoreEntity.CREDENTIAL_CLEANUP_PK, key.partitionKey());
+    assertEquals("catalog-integration-credential-cleanup/", key.sortKey());
+  }
+}

--- a/storage/common/src/main/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManager.java
+++ b/storage/common/src/main/java/ai/floedb/floecat/storage/common/secrets/NotProdSecretsManager.java
@@ -37,12 +37,17 @@ public class NotProdSecretsManager implements SecretsManager {
 
   @Override
   public void put(String accountId, String secretType, String secretId, byte[] payload) {
+    if (!putIfAbsent(accountId, secretType, secretId, payload)) {
+      throw new IllegalStateException(
+          "Secret already exists: " + keyFor(accountId, secretType, secretId).sortKey());
+    }
+  }
+
+  @Override
+  public boolean putIfAbsent(String accountId, String secretType, String secretId, byte[] payload) {
     KvStore.Key key = keyFor(accountId, secretType, secretId);
     KvStore.Record record = new KvStore.Record(key, KIND, copy(payload), Map.of(), 1L);
-    boolean ok = kv.putCas(record, 0L).await().indefinitely();
-    if (!ok) {
-      throw new IllegalStateException("Secret already exists: " + key.sortKey());
-    }
+    return kv.putCas(record, 0L).await().indefinitely();
   }
 
   @Override


### PR DESCRIPTION
## Summary

Adds the catalog integration resource and gRPC API, including persistence, idempotent CRUD behavior, authorization, credential storage and cleanup, garbage-collection hooks, account-deletion participation, and service/storage documentation.

Catalog overlays and CLI commands are intentionally excluded into subsequent PRs.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Focused catalog integration API/service suite: 117 tests passed.

- [x] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Stack position: **5/10**. Base: `mc-account-deletion-fence`. Review the integration resource independently of overlays, CLI, and connector-independent access.

