### PR TITLE
feat(cli): add catalog integration and overlay commands (stack 7/10)

### DIFF
--- a/client-cli/EMBEDDING.md
+++ b/client-cli/EMBEDDING.md
@@ -24,6 +24,8 @@ CliCommandExecutor executor = CliCommandExecutor.builder()
     .tables(TableServiceGrpc.newBlockingStub(channel))
     .viewService(ViewServiceGrpc.newBlockingStub(channel))
     .connectors(ConnectorsGrpc.newBlockingStub(channel))
+    .integrations(CatalogIntegrationsGrpc.newBlockingStub(channel))
+    .overlays(CatalogOverlaysGrpc.newBlockingStub(channel))
     .reconcileControl(ReconcileControlGrpc.newBlockingStub(channel))
     .snapshots(SnapshotServiceGrpc.newBlockingStub(channel))
     .statistics(TableStatisticsServiceGrpc.newBlockingStub(channel))
@@ -111,6 +113,8 @@ expected: `catalog create "my catalog"` becomes three tokens.
 | `table` / `tables` | `tables <ns>`, `table get <fq>`, `resolve <fq>`, `describe <fq>` |
 | `view` / `views` | `views <ns>`, `view get <fq>` |
 | `connector` / `connectors` | `connectors`, `connector create ...`, `connector trigger <id>` |
+| `integration` / `integrations` | `integrations`, `integration create <name> <type> <uri> --auth-type <type>` |
+| `overlay` / `overlays` | `overlays`, `overlay create <name> <integration>` |
 | `snapshot` / `snapshots` | `snapshots <table>`, `snapshot get <table> --snapshot <id>` |
 | `stats` / `analyze` | `stats table <fq>`, `stats columns <fq>`, `analyze <fq>` |
 | `constraints` | `constraints list <table>` |

--- a/client-cli/EMBEDDING.md
+++ b/client-cli/EMBEDDING.md
@@ -114,7 +114,7 @@ expected: `catalog create "my catalog"` becomes three tokens.
 | `view` / `views` | `views <ns>`, `view get <fq>` |
 | `connector` / `connectors` | `connectors`, `connector create ...`, `connector trigger <id>` |
 | `integration` / `integrations` | `integrations`, `integration create <name> <type> <uri> --auth-type <type>` |
-| `overlay` / `overlays` | `overlays`, `overlay create <name> <integration>` |
+| `overlay` / `overlays` | `overlays`, `overlay create <name> <integration> <catalog>` |
 | `snapshot` / `snapshots` | `snapshots <table>`, `snapshot get <table> --snapshot <id>` |
 | `stats` / `analyze` | `stats table <fq>`, `stats columns <fq>`, `analyze <fq>` |
 | `constraints` | `constraints list <table>` |

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/CliCommandExecutor.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/CliCommandExecutor.java
@@ -28,6 +28,8 @@ import ai.floedb.floecat.catalog.rpc.TableStatisticsServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.ViewServiceGrpc;
 import ai.floedb.floecat.client.cli.util.CliUtils;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
@@ -78,6 +80,8 @@ public final class CliCommandExecutor {
   private final TableServiceGrpc.TableServiceBlockingStub tables;
   private final ViewServiceGrpc.ViewServiceBlockingStub viewService;
   private final ConnectorsGrpc.ConnectorsBlockingStub connectors;
+  private final CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations;
+  private final CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays;
   private final ReconcileControlGrpc.ReconcileControlBlockingStub reconcileControl;
   private final SnapshotServiceGrpc.SnapshotServiceBlockingStub snapshots;
   private final TableStatisticsServiceGrpc.TableStatisticsServiceBlockingStub statistics;
@@ -101,6 +105,8 @@ public final class CliCommandExecutor {
     this.tables = builder.tables;
     this.viewService = builder.viewService;
     this.connectors = builder.connectors;
+    this.integrations = builder.integrations;
+    this.overlays = builder.overlays;
     this.reconcileControl = builder.reconcileControl;
     this.snapshots = builder.snapshots;
     this.statistics = builder.statistics;
@@ -145,6 +151,8 @@ public final class CliCommandExecutor {
         .tables(TableServiceGrpc.newBlockingStub(channel))
         .viewService(ViewServiceGrpc.newBlockingStub(channel))
         .connectors(ConnectorsGrpc.newBlockingStub(channel))
+        .integrations(CatalogIntegrationsGrpc.newBlockingStub(channel))
+        .overlays(CatalogOverlaysGrpc.newBlockingStub(channel))
         .reconcileControl(ReconcileControlGrpc.newBlockingStub(channel))
         .snapshots(SnapshotServiceGrpc.newBlockingStub(channel))
         .statistics(TableStatisticsServiceGrpc.newBlockingStub(channel))
@@ -174,6 +182,8 @@ public final class CliCommandExecutor {
     private TableServiceGrpc.TableServiceBlockingStub tables;
     private ViewServiceGrpc.ViewServiceBlockingStub viewService;
     private ConnectorsGrpc.ConnectorsBlockingStub connectors;
+    private CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations;
+    private CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays;
     private ReconcileControlGrpc.ReconcileControlBlockingStub reconcileControl;
     private SnapshotServiceGrpc.SnapshotServiceBlockingStub snapshots;
     private TableStatisticsServiceGrpc.TableStatisticsServiceBlockingStub statistics;
@@ -227,6 +237,17 @@ public final class CliCommandExecutor {
 
     public Builder connectors(ConnectorsGrpc.ConnectorsBlockingStub connectors) {
       this.connectors = connectors;
+      return this;
+    }
+
+    public Builder integrations(
+        CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations) {
+      this.integrations = integrations;
+      return this;
+    }
+
+    public Builder overlays(CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays) {
+      this.overlays = overlays;
       return this;
     }
 
@@ -319,6 +340,8 @@ public final class CliCommandExecutor {
       Objects.requireNonNull(tables, "tables");
       Objects.requireNonNull(viewService, "viewService");
       Objects.requireNonNull(connectors, "connectors");
+      Objects.requireNonNull(integrations, "integrations");
+      Objects.requireNonNull(overlays, "overlays");
       Objects.requireNonNull(reconcileControl, "reconcileControl");
       Objects.requireNonNull(snapshots, "snapshots");
       Objects.requireNonNull(statistics, "statistics");
@@ -394,6 +417,9 @@ public final class CliCommandExecutor {
               snapshots,
               directory,
               getAccountId);
+      case "integrations", "integration", "overlays", "overlay" ->
+          IntegrationCliSupport.handle(
+              command, CliArgs.tail(tokens), out, integrations, overlays, directory, getAccountId);
       case "snapshots", "snapshot" ->
           SnapshotCliSupport.handle(
               command,

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
@@ -103,16 +103,19 @@ final class IntegrationCliSupport {
         if (args.size() < 4) {
           out.println(
               "usage: integration create <name> <iceberg-rest|unity> <uri>"
-                  + " --auth-type <type> [--auth k=v ...] [--cred k=v ...]");
+                  + " --auth-type <type> [--auth k=v ...] [--cred k=v ...]"
+                  + " [--props k=v ...]");
           return;
         }
         ParsedAuthentication parsedAuthentication = parseAuthentication(args);
+        Map<String, String> properties = CliUtils.parseKeyValueList(args, "--props");
         CatalogIntegrationSpec spec =
             integrationSpec(
                 Quotes.unquote(args.get(1)),
                 parseIntegrationType(Quotes.unquote(args.get(2))),
                 Quotes.unquote(args.get(3)),
-                parsedAuthentication.authentication());
+                parsedAuthentication.authentication(),
+                properties);
         var row =
             integrations
                 .createCatalogIntegration(
@@ -125,7 +128,9 @@ final class IntegrationCliSupport {
       }
       case "update" -> {
         if (args.size() < 2) {
-          out.println("usage: integration update <name|id> --display <name> [--etag <etag>]");
+          out.println(
+              "usage: integration update <name|id> [--display <name>] [--props k=v ...]"
+                  + " [--etag <etag>]");
           return;
         }
         ResourceId id = resolveIntegration(args.get(1), integrations, accountId);
@@ -270,12 +275,17 @@ final class IntegrationCliSupport {
   }
 
   private static CatalogIntegrationSpec integrationSpec(
-      String name, CatalogIntegrationType type, String uri, CatalogAuthentication authentication) {
+      String name,
+      CatalogIntegrationType type,
+      String uri,
+      CatalogAuthentication authentication,
+      Map<String, String> properties) {
     return CatalogIntegrationSpec.newBuilder()
         .setDisplayName(name)
         .setType(type)
         .setCatalogUri(uri)
         .setAuthentication(authentication)
+        .putAllProperties(properties)
         .build();
   }
 
@@ -392,12 +402,14 @@ final class IntegrationCliSupport {
     var b = CatalogIntegrationSpec.newBuilder();
     if (args.contains("--display"))
       b.setDisplayName(Quotes.unquote(CliArgs.parseStringFlag(args, "--display", "")));
+    if (args.contains("--props")) b.putAllProperties(CliUtils.parseKeyValueList(args, "--props"));
     return b.build();
   }
 
   private static FieldMask integrationUpdateMask(List<String> args) {
     var paths = new ArrayList<String>();
     addIfPresent(paths, args, "--display", "display_name");
+    addIfPresent(paths, args, "--props", "properties");
     return FieldMask.newBuilder().addAllPaths(paths).build();
   }
 

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
@@ -92,10 +92,7 @@ final class IntegrationCliSupport {
         }
         var row =
             integrations
-                .getCatalogIntegration(
-                    GetCatalogIntegrationRequest.newBuilder()
-                        .setIntegrationId(resolveIntegration(args.get(1), integrations, accountId))
-                        .build())
+                .getCatalogIntegration(integrationSelector(args.get(1), accountId))
                 .getIntegration();
         printIntegrations(List.of(row), out);
       }
@@ -129,8 +126,8 @@ final class IntegrationCliSupport {
       case "update" -> {
         if (args.size() < 2) {
           out.println(
-              "usage: integration update <name|id> [--display <name>] [--props k=v ...]"
-                  + " [--etag <etag>]");
+              "usage: integration update <name|id> [--display <name>] [--uri <uri>]"
+                  + " [--props k=v ...] [--etag <etag>]");
           return;
         }
         ResourceId id = resolveIntegration(args.get(1), integrations, accountId);
@@ -206,13 +203,7 @@ final class IntegrationCliSupport {
           out.println("usage: overlay get <name|id>");
           return;
         }
-        var row =
-            overlays
-                .getCatalogOverlay(
-                    GetCatalogOverlayRequest.newBuilder()
-                        .setOverlayId(resolveOverlay(args.get(1), overlays, accountId))
-                        .build())
-                .getOverlay();
+        var row = overlays.getCatalogOverlay(overlaySelector(args.get(1), accountId)).getOverlay();
         printOverlays(List.of(row), out);
       }
       case "create" -> {
@@ -400,8 +391,8 @@ final class IntegrationCliSupport {
 
   private static CatalogIntegrationSpec integrationUpdateSpec(List<String> args) {
     var b = CatalogIntegrationSpec.newBuilder();
-    if (args.contains("--display"))
-      b.setDisplayName(Quotes.unquote(CliArgs.parseStringFlag(args, "--display", "")));
+    if (args.contains("--display")) b.setDisplayName(requiredFlagValue(args, "--display"));
+    if (args.contains("--uri")) b.setCatalogUri(requiredFlagValue(args, "--uri"));
     if (args.contains("--props")) b.putAllProperties(CliUtils.parseKeyValueList(args, "--props"));
     return b.build();
   }
@@ -409,6 +400,7 @@ final class IntegrationCliSupport {
   private static FieldMask integrationUpdateMask(List<String> args) {
     var paths = new ArrayList<String>();
     addIfPresent(paths, args, "--display", "display_name");
+    addIfPresent(paths, args, "--uri", "catalog_uri");
     addIfPresent(paths, args, "--props", "properties");
     return FieldMask.newBuilder().addAllPaths(paths).build();
   }
@@ -426,8 +418,7 @@ final class IntegrationCliSupport {
 
   private static CatalogOverlaySpec overlayUpdateSpec(List<String> args) {
     var b = CatalogOverlaySpec.newBuilder();
-    if (args.contains("--display"))
-      b.setDisplayName(Quotes.unquote(CliArgs.parseStringFlag(args, "--display", "")));
+    if (args.contains("--display")) b.setDisplayName(requiredFlagValue(args, "--display"));
     if (args.contains("--include")) b.addAllIncludeNamespaces(paths(args, "--include"));
     if (args.contains("--exclude")) b.addAllExcludeNamespaces(paths(args, "--exclude"));
     return b.build();
@@ -442,7 +433,7 @@ final class IntegrationCliSupport {
   }
 
   private static List<NamespacePath> paths(List<String> args, String flag) {
-    String value = Quotes.unquote(CliArgs.parseStringFlag(args, flag, ""));
+    String value = args.contains(flag) ? requiredFlagValue(args, flag) : "";
     if (value.isBlank()) return List.of();
     return CliUtils.csvList(value).stream()
         .map(
@@ -496,25 +487,14 @@ final class IntegrationCliSupport {
       CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
       Supplier<String> accountId) {
     String value = Quotes.unquote(token);
-    if (CliUtils.looksLikeUuid(value))
+    if (CliUtils.looksLikeUuid(value)) {
       return rid(value, ResourceKind.RK_CATALOG_INTEGRATION, accountId);
-    var matches = new ArrayList<CatalogIntegration>();
-    CliArgs.forEachPage(
-        DEFAULT_PAGE_SIZE,
-        page ->
-            integrations.listCatalogIntegrations(
-                ListCatalogIntegrationsRequest.newBuilder().setPage(page).build()),
-        response ->
-            response.getEntriesList().stream().map(entry -> entry.getIntegration()).toList(),
-        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
-        rows ->
-            rows.stream()
-                .filter(row -> row.getDisplayName().equalsIgnoreCase(value))
-                .forEach(matches::add));
-    return uniqueId(
-        value,
-        "Catalog integration",
-        matches.stream().map(CatalogIntegration::getResourceId).toList());
+    }
+    return integrations
+        .getCatalogIntegration(
+            GetCatalogIntegrationRequest.newBuilder().setDisplayName(value).build())
+        .getIntegration()
+        .getResourceId();
   }
 
   private static ResourceId resolveOverlay(
@@ -525,26 +505,34 @@ final class IntegrationCliSupport {
     if (CliUtils.looksLikeUuid(value)) {
       return rid(value, ResourceKind.RK_CATALOG_OVERLAY, accountId);
     }
-    var matches = new ArrayList<CatalogOverlay>();
-    CliArgs.forEachPage(
-        DEFAULT_PAGE_SIZE,
-        page ->
-            overlays.listCatalogOverlays(
-                ListCatalogOverlaysRequest.newBuilder().setPage(page).build()),
-        response -> response.getEntriesList().stream().map(entry -> entry.getOverlay()).toList(),
-        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
-        rows ->
-            rows.stream()
-                .filter(row -> row.getDisplayName().equalsIgnoreCase(value))
-                .forEach(matches::add));
-    return uniqueId(
-        value, "Catalog overlay", matches.stream().map(CatalogOverlay::getResourceId).toList());
+    return overlays
+        .getCatalogOverlay(GetCatalogOverlayRequest.newBuilder().setDisplayName(value).build())
+        .getOverlay()
+        .getResourceId();
   }
 
-  private static ResourceId uniqueId(String value, String label, List<ResourceId> ids) {
-    if (ids.size() == 1) return ids.getFirst();
-    if (ids.isEmpty()) throw new IllegalArgumentException(label + " not found: " + value);
-    throw new IllegalArgumentException(label + " name is ambiguous: " + value);
+  private static GetCatalogIntegrationRequest integrationSelector(
+      String token, Supplier<String> accountId) {
+    String value = Quotes.unquote(token);
+    var request = GetCatalogIntegrationRequest.newBuilder();
+    if (CliUtils.looksLikeUuid(value)) {
+      request.setIntegrationId(rid(value, ResourceKind.RK_CATALOG_INTEGRATION, accountId));
+    } else {
+      request.setDisplayName(value);
+    }
+    return request.build();
+  }
+
+  private static GetCatalogOverlayRequest overlaySelector(
+      String token, Supplier<String> accountId) {
+    String value = Quotes.unquote(token);
+    var request = GetCatalogOverlayRequest.newBuilder();
+    if (CliUtils.looksLikeUuid(value)) {
+      request.setOverlayId(rid(value, ResourceKind.RK_CATALOG_OVERLAY, accountId));
+    } else {
+      request.setDisplayName(value);
+    }
+    return request.build();
   }
 
   private static ResourceId rid(
@@ -570,6 +558,14 @@ final class IntegrationCliSupport {
   private static void addIfPresent(
       List<String> paths, List<String> args, String flag, String path) {
     if (args.contains(flag)) paths.add(path);
+  }
+
+  private static String requiredFlagValue(List<String> args, String flag) {
+    int index = args.indexOf(flag);
+    if (index + 1 >= args.size() || args.get(index + 1).startsWith("--")) {
+      throw new IllegalArgumentException("Missing value for " + flag);
+    }
+    return Quotes.unquote(args.get(index + 1));
   }
 
   private static void printIntegrations(List<CatalogIntegration> rows, PrintStream out) {
@@ -598,16 +594,32 @@ final class IntegrationCliSupport {
   }
 
   private static void printOverlayHeader(PrintStream out) {
-    out.printf("%-36s  %-24s  %-36s%n", "OVERLAY_ID", "NAME", "INTEGRATION_ID");
+    out.printf(
+        "%-36s  %-24s  %-36s  %-36s  %-24s  %s%n",
+        "OVERLAY_ID",
+        "NAME",
+        "INTEGRATION_ID",
+        "CATALOG_ID",
+        "INCLUDE_NAMESPACES",
+        "EXCLUDE_NAMESPACES");
   }
 
   private static void printOverlayRows(List<CatalogOverlay> rows, PrintStream out) {
     for (var row : rows) {
       out.printf(
-          "%-36s  %-24s  %-36s%n",
+          "%-36s  %-24s  %-36s  %-36s  %-24s  %s%n",
           CliUtils.rid(row.getResourceId()),
           row.getDisplayName(),
-          CliUtils.rid(row.getIntegrationId()));
+          CliUtils.rid(row.getIntegrationId()),
+          CliUtils.rid(row.getCatalogId()),
+          formatNamespacePaths(row.getIncludeNamespacesList()),
+          formatNamespacePaths(row.getExcludeNamespacesList()));
     }
+  }
+
+  private static String formatNamespacePaths(List<NamespacePath> paths) {
+    return paths.stream()
+        .map(path -> String.join(".", path.getSegmentsList()))
+        .collect(java.util.stream.Collectors.joining(",", "[", "]"));
   }
 }

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
@@ -1,0 +1,601 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package ai.floedb.floecat.client.cli;
+
+import ai.floedb.floecat.catalog.rpc.DirectoryServiceGrpc;
+import ai.floedb.floecat.client.cli.util.CliUtils;
+import ai.floedb.floecat.client.cli.util.FQNameParserUtil;
+import ai.floedb.floecat.client.cli.util.Quotes;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.AwsAccessKeyAuthentication;
+import ai.floedb.floecat.integration.rpc.AwsAccessKeySecret;
+import ai.floedb.floecat.integration.rpc.AwsAssumeRoleAuthentication;
+import ai.floedb.floecat.integration.rpc.AwsDefaultAuthentication;
+import ai.floedb.floecat.integration.rpc.AwsSigV4Authentication;
+import ai.floedb.floecat.integration.rpc.BearerAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogAuthentication;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationCredentials;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationSpec;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaySpec;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
+import ai.floedb.floecat.integration.rpc.NamespacePath;
+import ai.floedb.floecat.integration.rpc.OAuthClientCredentialsAuthentication;
+import ai.floedb.floecat.integration.rpc.SecretValue;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayRequest;
+import com.google.protobuf.FieldMask;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/** Small CRUD surface for catalog integrations and their catalog overlays. */
+final class IntegrationCliSupport {
+  private static final int DEFAULT_PAGE_SIZE = 100;
+
+  private IntegrationCliSupport() {}
+
+  static void handle(
+      String command,
+      List<String> args,
+      PrintStream out,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays,
+      DirectoryServiceGrpc.DirectoryServiceBlockingStub directory,
+      Supplier<String> getCurrentAccountId) {
+    switch (command) {
+      case "integrations" -> listIntegrations(out, integrations);
+      case "integration" -> integrationCrud(args, out, integrations, getCurrentAccountId);
+      case "overlays" -> listOverlays(args, out, integrations, overlays, getCurrentAccountId);
+      case "overlay" ->
+          overlayCrud(args, out, integrations, overlays, directory, getCurrentAccountId);
+      default -> throw new IllegalArgumentException("Unsupported integration command: " + command);
+    }
+  }
+
+  private static void integrationCrud(
+      List<String> args,
+      PrintStream out,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      Supplier<String> accountId) {
+    if (args.isEmpty()) {
+      out.println("usage: integration <list|get|create|update|update-auth|delete> ...");
+      return;
+    }
+    switch (args.getFirst()) {
+      case "list" -> listIntegrations(out, integrations);
+      case "get" -> {
+        if (args.size() < 2) {
+          out.println("usage: integration get <name|id>");
+          return;
+        }
+        var row =
+            integrations
+                .getCatalogIntegration(
+                    GetCatalogIntegrationRequest.newBuilder()
+                        .setIntegrationId(resolveIntegration(args.get(1), integrations, accountId))
+                        .build())
+                .getIntegration();
+        printIntegrations(List.of(row), out);
+      }
+      case "create" -> {
+        if (args.size() < 4) {
+          out.println(
+              "usage: integration create <name> <iceberg-rest|unity> <uri>"
+                  + " --auth-type <type> [--auth k=v ...] [--cred k=v ...]");
+          return;
+        }
+        ParsedAuthentication parsedAuthentication = parseAuthentication(args);
+        CatalogIntegrationSpec spec =
+            integrationSpec(
+                Quotes.unquote(args.get(1)),
+                parseIntegrationType(Quotes.unquote(args.get(2))),
+                Quotes.unquote(args.get(3)),
+                parsedAuthentication.authentication());
+        var row =
+            integrations
+                .createCatalogIntegration(
+                    CreateCatalogIntegrationRequest.newBuilder()
+                        .setSpec(spec)
+                        .setCredentials(parsedAuthentication.credentials())
+                        .build())
+                .getIntegration();
+        printIntegrations(List.of(row), out);
+      }
+      case "update" -> {
+        if (args.size() < 2) {
+          out.println("usage: integration update <name|id> --display <name> [--etag <etag>]");
+          return;
+        }
+        ResourceId id = resolveIntegration(args.get(1), integrations, accountId);
+        FieldMask updateMask = integrationUpdateMask(args);
+        if (updateMask.getPathsCount() == 0) {
+          throw new IllegalArgumentException("No integration changes specified");
+        }
+        var request =
+            UpdateCatalogIntegrationRequest.newBuilder()
+                .setIntegrationId(id)
+                .setSpec(integrationUpdateSpec(args))
+                .setUpdateMask(updateMask);
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        printIntegrations(
+            List.of(integrations.updateCatalogIntegration(request.build()).getIntegration()), out);
+      }
+      case "update-auth" -> {
+        if (args.size() < 2) {
+          out.println(
+              "usage: integration update-auth <name|id> --auth-type <type>"
+                  + " [--auth k=v ...] [--cred k=v ...] [--etag <etag>]");
+          return;
+        }
+        ParsedAuthentication parsedAuthentication = parseAuthentication(args);
+        var request =
+            UpdateCatalogIntegrationAuthenticationRequest.newBuilder()
+                .setIntegrationId(resolveIntegration(args.get(1), integrations, accountId))
+                .setAuthentication(parsedAuthentication.authentication())
+                .setCredentials(parsedAuthentication.credentials());
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        printIntegrations(
+            List.of(
+                integrations
+                    .updateCatalogIntegrationAuthentication(request.build())
+                    .getIntegration()),
+            out);
+      }
+      case "delete" -> {
+        if (args.size() < 2) {
+          out.println("usage: integration delete <name|id> [--cascade] [--etag <etag>]");
+          return;
+        }
+        var request =
+            DeleteCatalogIntegrationRequest.newBuilder()
+                .setIntegrationId(resolveIntegration(args.get(1), integrations, accountId));
+        request.setCascade(args.contains("--cascade"));
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        integrations.deleteCatalogIntegration(request.build());
+        out.println("ok");
+      }
+      default -> out.println("unknown subcommand");
+    }
+  }
+
+  private static void overlayCrud(
+      List<String> args,
+      PrintStream out,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays,
+      DirectoryServiceGrpc.DirectoryServiceBlockingStub directory,
+      Supplier<String> accountId) {
+    if (args.isEmpty()) {
+      out.println("usage: overlay <list|get|create|update|delete> ...");
+      return;
+    }
+    switch (args.getFirst()) {
+      case "list" -> listOverlays(args, out, integrations, overlays, accountId);
+      case "get" -> {
+        if (args.size() < 2) {
+          out.println("usage: overlay get <name|id>");
+          return;
+        }
+        var row =
+            overlays
+                .getCatalogOverlay(
+                    GetCatalogOverlayRequest.newBuilder()
+                        .setOverlayId(resolveOverlay(args.get(1), overlays, accountId))
+                        .build())
+                .getOverlay();
+        printOverlays(List.of(row), out);
+      }
+      case "create" -> {
+        if (args.size() < 4) {
+          out.println(
+              "usage: overlay create <name> <integration-name|id> <catalog-name|id>"
+                  + " [--include a.b,c.d] [--exclude x.y]");
+          return;
+        }
+        var spec =
+            overlaySpec(
+                Quotes.unquote(args.get(1)),
+                resolveIntegration(args.get(2), integrations, accountId),
+                CatalogCliSupport.resolveCatalogId(args.get(3), directory, accountId),
+                args);
+        var row =
+            overlays
+                .createCatalogOverlay(
+                    CreateCatalogOverlayRequest.newBuilder().setSpec(spec).build())
+                .getOverlay();
+        printOverlays(List.of(row), out);
+      }
+      case "update" -> {
+        if (args.size() < 2) {
+          out.println(
+              "usage: overlay update <name|id> [--display <name>] [--include a.b,c.d]"
+                  + " [--exclude x.y]"
+                  + " [--etag <etag>]");
+          return;
+        }
+        ResourceId id = resolveOverlay(args.get(1), overlays, accountId);
+        FieldMask updateMask = overlayUpdateMask(args);
+        if (updateMask.getPathsCount() == 0) {
+          throw new IllegalArgumentException("No overlay changes specified");
+        }
+        var request =
+            UpdateCatalogOverlayRequest.newBuilder()
+                .setOverlayId(id)
+                .setSpec(overlayUpdateSpec(args))
+                .setUpdateMask(updateMask);
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        printOverlays(List.of(overlays.updateCatalogOverlay(request.build()).getOverlay()), out);
+      }
+      case "delete" -> {
+        if (args.size() < 2) {
+          out.println("usage: overlay delete <name|id> [--etag <etag>]");
+          return;
+        }
+        var request =
+            DeleteCatalogOverlayRequest.newBuilder()
+                .setOverlayId(resolveOverlay(args.get(1), overlays, accountId));
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        overlays.deleteCatalogOverlay(request.build());
+        out.println("ok");
+      }
+      default -> out.println("unknown subcommand");
+    }
+  }
+
+  private static CatalogIntegrationSpec integrationSpec(
+      String name, CatalogIntegrationType type, String uri, CatalogAuthentication authentication) {
+    return CatalogIntegrationSpec.newBuilder()
+        .setDisplayName(name)
+        .setType(type)
+        .setCatalogUri(uri)
+        .setAuthentication(authentication)
+        .build();
+  }
+
+  private static ParsedAuthentication parseAuthentication(List<String> args) {
+    String authType = normalized(CliArgs.parseStringFlag(args, "--auth-type", ""));
+    if (authType.isBlank()) {
+      throw new IllegalArgumentException("Missing --auth-type");
+    }
+    Map<String, String> auth = new LinkedHashMap<>(CliUtils.parseKeyValueList(args, "--auth"));
+    Map<String, String> credentials =
+        new LinkedHashMap<>(CliUtils.parseKeyValueList(args, "--cred"));
+    var authentication = CatalogAuthentication.newBuilder();
+    var secret = CatalogIntegrationCredentials.newBuilder();
+
+    switch (authType) {
+      case "OAUTH_CLIENT_CREDENTIALS", "OAUTH-CLIENT-CREDENTIALS", "OAUTH2" -> {
+        var oauth =
+            OAuthClientCredentialsAuthentication.newBuilder()
+                .setClientId(require(auth, "client_id", "--auth"));
+        setOptional(auth, "token_uri", oauth::setTokenUri);
+        String scopes = take(auth, "scopes");
+        if (scopes != null) oauth.addAllScopes(CliUtils.csvList(scopes));
+        authentication.setOauthClientCredentials(oauth);
+        secret.setOauthClientSecret(
+            SecretValue.newBuilder().setValue(require(credentials, "client_secret", "--cred")));
+      }
+      case "BEARER" -> {
+        authentication.setBearer(BearerAuthentication.getDefaultInstance());
+        secret.setBearerToken(
+            SecretValue.newBuilder().setValue(require(credentials, "token", "--cred")));
+      }
+      case "AWS_ASSUME_ROLE", "AWS-ASSUME-ROLE" ->
+          authentication.setAwsAssumeRole(assumeRole(auth));
+      case "AWS_ACCESS_KEY", "AWS-ACCESS-KEY" -> {
+        authentication.setAwsAccessKey(
+            AwsAccessKeyAuthentication.newBuilder()
+                .setAccessKeyId(require(auth, "access_key_id", "--auth")));
+        secret.setAwsAccessKey(accessKeySecret(credentials));
+      }
+      case "AWS_SIGV4", "AWS-SIGV4" -> {
+        var sigv4 =
+            AwsSigV4Authentication.newBuilder().setRegion(require(auth, "region", "--auth"));
+        setOptional(auth, "signing_name", sigv4::setSigningName);
+        String source = normalized(require(auth, "credential_source", "--auth"));
+        switch (source) {
+          case "DEFAULT", "AWS_DEFAULT", "AWS-DEFAULT" ->
+              sigv4.setAwsDefault(AwsDefaultAuthentication.getDefaultInstance());
+          case "ASSUME_ROLE", "ASSUME-ROLE", "AWS_ASSUME_ROLE", "AWS-ASSUME-ROLE" ->
+              sigv4.setAwsAssumeRole(assumeRole(auth));
+          case "ACCESS_KEY", "ACCESS-KEY", "AWS_ACCESS_KEY", "AWS-ACCESS-KEY" -> {
+            sigv4.setAwsAccessKey(
+                AwsAccessKeyAuthentication.newBuilder()
+                    .setAccessKeyId(require(auth, "access_key_id", "--auth")));
+            secret.setAwsAccessKey(accessKeySecret(credentials));
+          }
+          default ->
+              throw new IllegalArgumentException("Unsupported --auth credential_source: " + source);
+        }
+        authentication.setAwsSigv4(sigv4);
+      }
+      default -> throw new IllegalArgumentException("Unsupported --auth-type: " + authType);
+    }
+
+    rejectUnknown(auth, "--auth");
+    rejectUnknown(credentials, "--cred");
+    return new ParsedAuthentication(authentication.build(), secret.build());
+  }
+
+  private static AwsAssumeRoleAuthentication.Builder assumeRole(Map<String, String> auth) {
+    var assumeRole =
+        AwsAssumeRoleAuthentication.newBuilder().setRoleArn(require(auth, "role_arn", "--auth"));
+    setOptional(auth, "external_id", assumeRole::setExternalId);
+    setOptional(auth, "role_session_name", assumeRole::setRoleSessionName);
+    return assumeRole;
+  }
+
+  private static AwsAccessKeySecret.Builder accessKeySecret(Map<String, String> credentials) {
+    var secret =
+        AwsAccessKeySecret.newBuilder()
+            .setSecretAccessKey(require(credentials, "secret_access_key", "--cred"));
+    setOptional(credentials, "session_token", secret::setSessionToken);
+    return secret;
+  }
+
+  private static String require(Map<String, String> values, String key, String flag) {
+    String value = take(values, key);
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("Missing " + flag + " " + key + "=...");
+    }
+    return value;
+  }
+
+  private static String take(Map<String, String> values, String key) {
+    String value = values.remove(key);
+    return value == null ? null : Quotes.unquote(value);
+  }
+
+  private static void setOptional(
+      Map<String, String> values, String key, java.util.function.Consumer<String> setter) {
+    String value = take(values, key);
+    if (value != null && !value.isBlank()) setter.accept(value);
+  }
+
+  private static void rejectUnknown(Map<String, String> values, String flag) {
+    if (!values.isEmpty()) {
+      throw new IllegalArgumentException("Unsupported " + flag + " keys: " + values.keySet());
+    }
+  }
+
+  private record ParsedAuthentication(
+      CatalogAuthentication authentication, CatalogIntegrationCredentials credentials) {}
+
+  private static CatalogIntegrationSpec integrationUpdateSpec(List<String> args) {
+    var b = CatalogIntegrationSpec.newBuilder();
+    if (args.contains("--display"))
+      b.setDisplayName(Quotes.unquote(CliArgs.parseStringFlag(args, "--display", "")));
+    return b.build();
+  }
+
+  private static FieldMask integrationUpdateMask(List<String> args) {
+    var paths = new ArrayList<String>();
+    addIfPresent(paths, args, "--display", "display_name");
+    return FieldMask.newBuilder().addAllPaths(paths).build();
+  }
+
+  private static CatalogOverlaySpec overlaySpec(
+      String name, ResourceId integrationId, ResourceId catalogId, List<String> args) {
+    return CatalogOverlaySpec.newBuilder()
+        .setDisplayName(name)
+        .setIntegrationId(integrationId)
+        .setCatalogId(catalogId)
+        .addAllIncludeNamespaces(paths(args, "--include"))
+        .addAllExcludeNamespaces(paths(args, "--exclude"))
+        .build();
+  }
+
+  private static CatalogOverlaySpec overlayUpdateSpec(List<String> args) {
+    var b = CatalogOverlaySpec.newBuilder();
+    if (args.contains("--display"))
+      b.setDisplayName(Quotes.unquote(CliArgs.parseStringFlag(args, "--display", "")));
+    if (args.contains("--include")) b.addAllIncludeNamespaces(paths(args, "--include"));
+    if (args.contains("--exclude")) b.addAllExcludeNamespaces(paths(args, "--exclude"));
+    return b.build();
+  }
+
+  private static FieldMask overlayUpdateMask(List<String> args) {
+    var paths = new ArrayList<String>();
+    addIfPresent(paths, args, "--display", "display_name");
+    addIfPresent(paths, args, "--include", "include_namespaces");
+    addIfPresent(paths, args, "--exclude", "exclude_namespaces");
+    return FieldMask.newBuilder().addAllPaths(paths).build();
+  }
+
+  private static List<NamespacePath> paths(List<String> args, String flag) {
+    String value = Quotes.unquote(CliArgs.parseStringFlag(args, flag, ""));
+    if (value.isBlank()) return List.of();
+    return CliUtils.csvList(value).stream()
+        .map(
+            path ->
+                NamespacePath.newBuilder().addAllSegments(FQNameParserUtil.segments(path)).build())
+        .toList();
+  }
+
+  private static void listIntegrations(
+      PrintStream out, CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations) {
+    printIntegrationHeader(out);
+    CliArgs.forEachPage(
+        DEFAULT_PAGE_SIZE,
+        page ->
+            integrations.listCatalogIntegrations(
+                ListCatalogIntegrationsRequest.newBuilder().setPage(page).build()),
+        response ->
+            response.getEntriesList().stream().map(entry -> entry.getIntegration()).toList(),
+        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
+        rows -> printIntegrationRows(rows, out));
+  }
+
+  private static void listOverlays(
+      List<String> args,
+      PrintStream out,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays,
+      Supplier<String> accountId) {
+    ResourceId filter = null;
+    if (args.contains("--integration")) {
+      filter =
+          resolveIntegration(
+              CliArgs.parseStringFlag(args, "--integration", ""), integrations, accountId);
+    }
+    ResourceId integrationFilter = filter;
+    printOverlayHeader(out);
+    CliArgs.forEachPage(
+        DEFAULT_PAGE_SIZE,
+        page -> {
+          var request = ListCatalogOverlaysRequest.newBuilder().setPage(page);
+          if (integrationFilter != null) request.setIntegrationId(integrationFilter);
+          return overlays.listCatalogOverlays(request.build());
+        },
+        response -> response.getEntriesList().stream().map(entry -> entry.getOverlay()).toList(),
+        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
+        rows -> printOverlayRows(rows, out));
+  }
+
+  private static ResourceId resolveIntegration(
+      String token,
+      CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations,
+      Supplier<String> accountId) {
+    String value = Quotes.unquote(token);
+    if (CliUtils.looksLikeUuid(value))
+      return rid(value, ResourceKind.RK_CATALOG_INTEGRATION, accountId);
+    var matches = new ArrayList<CatalogIntegration>();
+    CliArgs.forEachPage(
+        DEFAULT_PAGE_SIZE,
+        page ->
+            integrations.listCatalogIntegrations(
+                ListCatalogIntegrationsRequest.newBuilder().setPage(page).build()),
+        response ->
+            response.getEntriesList().stream().map(entry -> entry.getIntegration()).toList(),
+        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
+        rows ->
+            rows.stream()
+                .filter(row -> row.getDisplayName().equalsIgnoreCase(value))
+                .forEach(matches::add));
+    return uniqueId(
+        value,
+        "Catalog integration",
+        matches.stream().map(CatalogIntegration::getResourceId).toList());
+  }
+
+  private static ResourceId resolveOverlay(
+      String token,
+      CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays,
+      Supplier<String> accountId) {
+    String value = Quotes.unquote(token);
+    if (CliUtils.looksLikeUuid(value)) {
+      return rid(value, ResourceKind.RK_CATALOG_OVERLAY, accountId);
+    }
+    var matches = new ArrayList<CatalogOverlay>();
+    CliArgs.forEachPage(
+        DEFAULT_PAGE_SIZE,
+        page ->
+            overlays.listCatalogOverlays(
+                ListCatalogOverlaysRequest.newBuilder().setPage(page).build()),
+        response -> response.getEntriesList().stream().map(entry -> entry.getOverlay()).toList(),
+        response -> response.hasPage() ? response.getPage().getNextPageToken() : "",
+        rows ->
+            rows.stream()
+                .filter(row -> row.getDisplayName().equalsIgnoreCase(value))
+                .forEach(matches::add));
+    return uniqueId(
+        value, "Catalog overlay", matches.stream().map(CatalogOverlay::getResourceId).toList());
+  }
+
+  private static ResourceId uniqueId(String value, String label, List<ResourceId> ids) {
+    if (ids.size() == 1) return ids.getFirst();
+    if (ids.isEmpty()) throw new IllegalArgumentException(label + " not found: " + value);
+    throw new IllegalArgumentException(label + " name is ambiguous: " + value);
+  }
+
+  private static ResourceId rid(
+      String id, ResourceKind kind, Supplier<String> getCurrentAccountId) {
+    String accountId = getCurrentAccountId.get();
+    if (accountId == null || accountId.isBlank())
+      throw new IllegalStateException("No account set. Use: account <accountId>");
+    return ResourceId.newBuilder().setAccountId(accountId).setKind(kind).setId(id).build();
+  }
+
+  private static CatalogIntegrationType parseIntegrationType(String value) {
+    return switch (normalized(value)) {
+      case "ICEBERG_REST", "ICEBERG-REST", "ICEBERG" -> CatalogIntegrationType.CIT_ICEBERG_REST;
+      case "UNITY" -> CatalogIntegrationType.CIT_UNITY;
+      default -> throw new IllegalArgumentException("Unknown integration type: " + value);
+    };
+  }
+
+  private static String normalized(String value) {
+    return Quotes.unquote(value).trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static void addIfPresent(
+      List<String> paths, List<String> args, String flag, String path) {
+    if (args.contains(flag)) paths.add(path);
+  }
+
+  private static void printIntegrations(List<CatalogIntegration> rows, PrintStream out) {
+    printIntegrationHeader(out);
+    printIntegrationRows(rows, out);
+  }
+
+  private static void printIntegrationHeader(PrintStream out) {
+    out.printf("%-36s  %-24s  %-14s  %s%n", "INTEGRATION_ID", "NAME", "TYPE", "URI");
+  }
+
+  private static void printIntegrationRows(List<CatalogIntegration> rows, PrintStream out) {
+    for (var row : rows) {
+      out.printf(
+          "%-36s  %-24s  %-14s  %s%n",
+          CliUtils.rid(row.getResourceId()),
+          row.getDisplayName(),
+          row.getType().name().replaceFirst("^CIT_", ""),
+          row.getCatalogUri());
+    }
+  }
+
+  private static void printOverlays(List<CatalogOverlay> rows, PrintStream out) {
+    printOverlayHeader(out);
+    printOverlayRows(rows, out);
+  }
+
+  private static void printOverlayHeader(PrintStream out) {
+    out.printf("%-36s  %-24s  %-36s%n", "OVERLAY_ID", "NAME", "INTEGRATION_ID");
+  }
+
+  private static void printOverlayRows(List<CatalogOverlay> rows, PrintStream out) {
+    for (var row : rows) {
+      out.printf(
+          "%-36s  %-24s  %-36s%n",
+          CliUtils.rid(row.getResourceId()),
+          row.getDisplayName(),
+          CliUtils.rid(row.getIntegrationId()));
+    }
+  }
+}

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -31,6 +31,8 @@ import ai.floedb.floecat.catalog.rpc.ViewServiceGrpc;
 import ai.floedb.floecat.client.cli.util.AuthHeaderInterceptor;
 import ai.floedb.floecat.client.cli.util.OidcClientCredentialsTokenProvider;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
@@ -63,9 +65,12 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "floecat-shell",
     version = "floecat-shell 0.1",
-    description = "Interactive CLI to browse and manage catalogs/namespaces/tables/connectors")
+    description =
+        "Interactive CLI to manage catalogs, integrations, overlays, tables, and connectors")
 @jakarta.inject.Singleton
 public class Shell implements Runnable {
+
+  static final String SENSITIVE_HISTORY_PATTERN = "*--cred *:*--cred-head *";
 
   @CommandLine.Option(
       names = {"-h", "--help"},
@@ -185,6 +190,14 @@ public class Shell implements Runnable {
 
   @Inject
   @GrpcClient("floecat")
+  CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrations;
+
+  @Inject
+  @GrpcClient("floecat")
+  CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlays;
+
+  @Inject
+  @GrpcClient("floecat")
   ReconcileControlGrpc.ReconcileControlBlockingStub reconcileControl;
 
   @Inject
@@ -250,6 +263,8 @@ public class Shell implements Runnable {
               .tables(tables)
               .viewService(viewService)
               .connectors(connectors)
+              .integrations(integrations)
+              .overlays(overlays)
               .reconcileControl(reconcileControl)
               .snapshots(snapshots)
               .statistics(statistics)
@@ -282,6 +297,10 @@ public class Shell implements Runnable {
               "table",
               "connectors",
               "connector",
+              "integrations",
+              "integration",
+              "overlays",
+              "overlay",
               "resolve",
               "describe",
               "snapshots",
@@ -302,6 +321,7 @@ public class Shell implements Runnable {
               .parser(parser)
               .completer(completer)
               .variable(LineReader.HISTORY_FILE, historyPath)
+              .variable(LineReader.HISTORY_IGNORE, SENSITIVE_HISTORY_PATTERN)
               .option(LineReader.Option.HISTORY_TIMESTAMPED, true)
               .build();
       Runtime.getRuntime()
@@ -559,6 +579,21 @@ public class Shell implements Runnable {
          query end <query_id> [--commit|--abort]
          query get <query_id>
          query fetch-scan <query_id> <table_id>
+         integrations
+         integration get <name|id>
+         integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
+             [--auth k=v ...] [--cred k=v ...]
+         integration update <name|id> --display <name> [--etag <etag>]
+         integration update-auth <name|id> --auth-type <type>
+             [--auth k=v ...] [--cred k=v ...] [--etag <etag>]
+         integration delete <name|id> [--cascade] [--etag <etag>]
+         overlays [--integration <name|id>]
+         overlay get <name|id>
+         overlay create <name> <integration>
+             [--include ns[,ns...]] [--exclude ns[,ns...]]
+         overlay update <name|id> [--display <name>]
+             [--include ns[,ns...]] [--exclude ns[,ns...]] [--etag <etag>]
+         overlay delete <name|id> [--etag <etag>]
          connectors
          connector list [--kind <KIND>]
          connector get <display_name|id>
@@ -698,6 +733,8 @@ public class Shell implements Runnable {
     snapshots = SnapshotServiceGrpc.newBlockingStub(overrideChannel);
     viewService = ViewServiceGrpc.newBlockingStub(overrideChannel);
     connectors = ConnectorsGrpc.newBlockingStub(overrideChannel);
+    integrations = CatalogIntegrationsGrpc.newBlockingStub(overrideChannel);
+    overlays = CatalogOverlaysGrpc.newBlockingStub(overrideChannel);
     reconcileControl = ReconcileControlGrpc.newBlockingStub(overrideChannel);
     queries = QueryServiceGrpc.newBlockingStub(overrideChannel);
     queryScan = QueryScanServiceGrpc.newBlockingStub(overrideChannel);
@@ -881,6 +918,8 @@ public class Shell implements Runnable {
     snapshots = snapshots.withInterceptors(authInterceptor);
     viewService = viewService.withInterceptors(authInterceptor);
     connectors = connectors.withInterceptors(authInterceptor);
+    integrations = integrations.withInterceptors(authInterceptor);
+    overlays = overlays.withInterceptors(authInterceptor);
     reconcileControl = reconcileControl.withInterceptors(authInterceptor);
     queries = queries.withInterceptors(authInterceptor);
     queryScan = queryScan.withInterceptors(authInterceptor);

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -583,7 +583,7 @@ public class Shell implements Runnable {
          integration get <name|id>
          integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
              [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
-         integration update <name|id> [--display <name>] [--props k=v ...] [--etag <etag>]
+         integration update <name|id> [--display <name>] [--uri <uri>] [--props k=v ...] [--etag <etag>]
          integration update-auth <name|id> --auth-type <type>
              [--auth k=v ...] [--cred k=v ...] [--etag <etag>]
          integration delete <name|id> [--cascade] [--etag <etag>]

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -582,8 +582,8 @@ public class Shell implements Runnable {
          integrations
          integration get <name|id>
          integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
-             [--auth k=v ...] [--cred k=v ...]
-         integration update <name|id> --display <name> [--etag <etag>]
+             [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
+         integration update <name|id> [--display <name>] [--props k=v ...] [--etag <etag>]
          integration update-auth <name|id> --auth-type <type>
              [--auth k=v ...] [--cred k=v ...] [--etag <etag>]
          integration delete <name|id> [--cascade] [--etag <etag>]

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -589,7 +589,7 @@ public class Shell implements Runnable {
          integration delete <name|id> [--cascade] [--etag <etag>]
          overlays [--integration <name|id>]
          overlay get <name|id>
-         overlay create <name> <integration>
+         overlay create <name> <integration> <catalog>
              [--include ns[,ns...]] [--exclude ns[,ns...]]
          overlay update <name|id> [--display <name>]
              [--include ns[,ns...]] [--exclude ns[,ns...]] [--etag <etag>]

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/CliCommandExecutorTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/CliCommandExecutorTest.java
@@ -43,6 +43,12 @@ import ai.floedb.floecat.catalog.rpc.ViewServiceGrpc;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
 import ai.floedb.floecat.connector.rpc.ListConnectorsRequest;
 import ai.floedb.floecat.connector.rpc.ListConnectorsResponse;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysResponse;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
@@ -108,6 +114,22 @@ class CliCommandExecutorTest {
     try (Harness h = new Harness()) {
       assertTrue(h.executor.execute("connectors"));
       assertEquals(1, h.connectorService.listConnectorsCalls.get());
+    }
+  }
+
+  @Test
+  void integrationsRouted() throws Exception {
+    try (Harness h = new Harness()) {
+      assertTrue(h.executor.execute("integrations"));
+      assertEquals(1, h.integrationService.listIntegrationsCalls.get());
+    }
+  }
+
+  @Test
+  void overlaysRouted() throws Exception {
+    try (Harness h = new Harness()) {
+      assertTrue(h.executor.execute("overlays"));
+      assertEquals(1, h.overlayService.listOverlaysCalls.get());
     }
   }
 
@@ -231,6 +253,8 @@ class CliCommandExecutorTest {
     final MinimalTableService tableService = new MinimalTableService();
     final MinimalViewService viewService = new MinimalViewService();
     final MinimalConnectorService connectorService = new MinimalConnectorService();
+    final MinimalIntegrationService integrationService = new MinimalIntegrationService();
+    final MinimalOverlayService overlayService = new MinimalOverlayService();
     final MinimalAccountService accountService = new MinimalAccountService();
     final MinimalQueryService queryService = new MinimalQueryService();
     final MinimalStorageAuthorityService storageAuthorityService =
@@ -247,6 +271,8 @@ class CliCommandExecutorTest {
               .addService(tableService)
               .addService(viewService)
               .addService(connectorService)
+              .addService(integrationService)
+              .addService(overlayService)
               .addService(accountService)
               .addService(queryService)
               .addService(new NullSnapshotService())
@@ -277,6 +303,8 @@ class CliCommandExecutorTest {
           .tables(TableServiceGrpc.newBlockingStub(channel))
           .viewService(ViewServiceGrpc.newBlockingStub(channel))
           .connectors(ConnectorsGrpc.newBlockingStub(channel))
+          .integrations(CatalogIntegrationsGrpc.newBlockingStub(channel))
+          .overlays(CatalogOverlaysGrpc.newBlockingStub(channel))
           .reconcileControl(ReconcileControlGrpc.newBlockingStub(channel))
           .snapshots(SnapshotServiceGrpc.newBlockingStub(channel))
           .statistics(TableStatisticsServiceGrpc.newBlockingStub(channel))
@@ -354,6 +382,34 @@ class CliCommandExecutorTest {
         ListConnectorsRequest request, StreamObserver<ListConnectorsResponse> responseObserver) {
       listConnectorsCalls.incrementAndGet();
       responseObserver.onNext(ListConnectorsResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static final class MinimalIntegrationService
+      extends CatalogIntegrationsGrpc.CatalogIntegrationsImplBase {
+    final AtomicInteger listIntegrationsCalls = new AtomicInteger();
+
+    @Override
+    public void listCatalogIntegrations(
+        ListCatalogIntegrationsRequest request,
+        StreamObserver<ListCatalogIntegrationsResponse> responseObserver) {
+      listIntegrationsCalls.incrementAndGet();
+      responseObserver.onNext(ListCatalogIntegrationsResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static final class MinimalOverlayService
+      extends CatalogOverlaysGrpc.CatalogOverlaysImplBase {
+    final AtomicInteger listOverlaysCalls = new AtomicInteger();
+
+    @Override
+    public void listCatalogOverlays(
+        ListCatalogOverlaysRequest request,
+        StreamObserver<ListCatalogOverlaysResponse> responseObserver) {
+      listOverlaysCalls.incrementAndGet();
+      responseObserver.onNext(ListCatalogOverlaysResponse.getDefaultInstance());
       responseObserver.onCompleted();
     }
   }

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package ai.floedb.floecat.client.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.catalog.rpc.DirectoryServiceGrpc;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationEntry;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
+import ai.floedb.floecat.integration.rpc.CatalogOverlayEntry;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.CreateCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayResponse;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayResponse;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.GetCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.GetCatalogOverlayResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysResponse;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationResponse;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationResponse;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayResponse;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IntegrationCliSupportTest {
+  private static final String INTEGRATION_ID = "00000000-0000-0000-0000-000000000011";
+  private static final String OVERLAY_ID = "00000000-0000-0000-0000-000000000012";
+  private static final String CATALOG_ID = "00000000-0000-0000-0000-000000000013";
+
+  @Test
+  void createsIntegrationWithOAuthCredentials() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run(
+          "integration",
+          List.of(
+              "create",
+              "lakehouse",
+              "iceberg-rest",
+              "https://catalog.example/v1",
+              "--auth-type",
+              "oauth-client-credentials",
+              "--auth",
+              "client_id=floecat",
+              "token_uri=https://identity.example/token",
+              "scopes=catalog.read,catalog.write",
+              "--cred",
+              "client_secret=secret"));
+
+      var spec = h.integrations.lastCreate.getSpec();
+      assertEquals("lakehouse", spec.getDisplayName());
+      assertEquals(CatalogIntegrationType.CIT_ICEBERG_REST, spec.getType());
+      assertEquals("https://catalog.example/v1", spec.getCatalogUri());
+      assertEquals("floecat", spec.getAuthentication().getOauthClientCredentials().getClientId());
+      assertEquals(
+          List.of("catalog.read", "catalog.write"),
+          spec.getAuthentication().getOauthClientCredentials().getScopesList());
+      assertEquals(
+          "secret", h.integrations.lastCreate.getCredentials().getOauthClientSecret().getValue());
+    }
+  }
+
+  @Test
+  void createsIntegrationWithSigV4AccessKeyCredentials() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run(
+          "integration",
+          List.of(
+              "create",
+              "lakehouse",
+              "iceberg-rest",
+              "https://catalog.example/v1",
+              "--auth-type",
+              "aws-sigv4",
+              "--auth",
+              "region=us-east-1",
+              "credential_source=access-key",
+              "access_key_id=AKIAEXAMPLE",
+              "--cred",
+              "secret_access_key=secret",
+              "session_token=session"));
+
+      var auth = h.integrations.lastCreate.getSpec().getAuthentication().getAwsSigv4();
+      assertEquals("us-east-1", auth.getRegion());
+      assertEquals("AKIAEXAMPLE", auth.getAwsAccessKey().getAccessKeyId());
+      assertEquals(
+          "session",
+          h.integrations.lastCreate.getCredentials().getAwsAccessKey().getSessionToken());
+    }
+  }
+
+  @Test
+  void listsAndGetsIntegrationByName() throws Exception {
+    try (Harness h = new Harness()) {
+      assertTrue(h.run("integrations", List.of()).contains("lakehouse"));
+      assertTrue(h.run("integration", List.of("get", "lakehouse")).contains("lakehouse"));
+    }
+  }
+
+  @Test
+  void updatesAndDeletesIntegrationById() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run("integration", List.of("update", INTEGRATION_ID, "--display", "renamed"));
+      assertEquals(
+          List.of("display_name"), h.integrations.lastUpdate.getUpdateMask().getPathsList());
+      assertEquals("renamed", h.integrations.lastUpdate.getSpec().getDisplayName());
+
+      h.run("integration", List.of("delete", INTEGRATION_ID, "--cascade"));
+      assertEquals(INTEGRATION_ID, h.integrations.lastDelete.getIntegrationId().getId());
+      assertTrue(h.integrations.lastDelete.getCascade());
+    }
+  }
+
+  @Test
+  void rotatesIntegrationAuthentication() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run(
+          "integration",
+          List.of(
+              "update-auth",
+              INTEGRATION_ID,
+              "--auth-type",
+              "bearer",
+              "--cred",
+              "token=replacement",
+              "--etag",
+              "etag-1"));
+
+      assertEquals(INTEGRATION_ID, h.integrations.lastAuthUpdate.getIntegrationId().getId());
+      assertTrue(h.integrations.lastAuthUpdate.getAuthentication().hasBearer());
+      assertEquals(
+          "replacement",
+          h.integrations.lastAuthUpdate.getCredentials().getBearerToken().getValue());
+      assertEquals("etag-1", h.integrations.lastAuthUpdate.getPrecondition().getExpectedEtag());
+    }
+  }
+
+  @Test
+  void createsOverlayForIntegration() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run(
+          "overlay",
+          List.of(
+              "create",
+              "sales",
+              "lakehouse",
+              CATALOG_ID,
+              "--include",
+              "prod.sales,prod.reference"));
+
+      var spec = h.overlays.lastCreate.getSpec();
+      assertEquals(INTEGRATION_ID, spec.getIntegrationId().getId());
+      assertEquals(CATALOG_ID, spec.getCatalogId().getId());
+      assertEquals(2, spec.getIncludeNamespacesCount());
+      assertEquals(List.of("prod", "sales"), spec.getIncludeNamespaces(0).getSegmentsList());
+    }
+  }
+
+  @Test
+  void listsAndGetsOverlayByName() throws Exception {
+    try (Harness h = new Harness()) {
+      assertTrue(h.run("overlays", List.of()).contains("sales"));
+      assertTrue(h.run("overlay", List.of("get", "sales")).contains("sales"));
+    }
+  }
+
+  @Test
+  void updatesAndDeletesOverlayById() throws Exception {
+    try (Harness h = new Harness()) {
+      h.run("overlay", List.of("update", OVERLAY_ID, "--display", "renamed", "--exclude", "tmp"));
+      assertEquals(
+          List.of("display_name", "exclude_namespaces"),
+          h.overlays.lastUpdate.getUpdateMask().getPathsList());
+      assertEquals("renamed", h.overlays.lastUpdate.getSpec().getDisplayName());
+
+      h.run("overlay", List.of("delete", OVERLAY_ID));
+      assertEquals(OVERLAY_ID, h.overlays.lastDelete.getOverlayId().getId());
+    }
+  }
+
+  private static ResourceId id(String id, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("account").setId(id).setKind(kind).build();
+  }
+
+  private static final class Harness implements AutoCloseable {
+    final IntegrationService integrations = new IntegrationService();
+    final OverlayService overlays = new OverlayService();
+    final Server server;
+    final ManagedChannel channel;
+    final CatalogIntegrationsGrpc.CatalogIntegrationsBlockingStub integrationStub;
+    final CatalogOverlaysGrpc.CatalogOverlaysBlockingStub overlayStub;
+    final DirectoryServiceGrpc.DirectoryServiceBlockingStub directoryStub;
+
+    Harness() throws Exception {
+      String name = InProcessServerBuilder.generateName();
+      server =
+          InProcessServerBuilder.forName(name)
+              .directExecutor()
+              .addService(integrations)
+              .addService(overlays)
+              .build()
+              .start();
+      channel = InProcessChannelBuilder.forName(name).directExecutor().build();
+      integrationStub = CatalogIntegrationsGrpc.newBlockingStub(channel);
+      overlayStub = CatalogOverlaysGrpc.newBlockingStub(channel);
+      directoryStub = DirectoryServiceGrpc.newBlockingStub(channel);
+    }
+
+    String run(String command, List<String> args) {
+      var bytes = new ByteArrayOutputStream();
+      IntegrationCliSupport.handle(
+          command,
+          args,
+          new PrintStream(bytes),
+          integrationStub,
+          overlayStub,
+          directoryStub,
+          () -> "account");
+      return bytes.toString();
+    }
+
+    @Override
+    public void close() {
+      channel.shutdownNow();
+      server.shutdownNow();
+    }
+  }
+
+  private static final class IntegrationService
+      extends CatalogIntegrationsGrpc.CatalogIntegrationsImplBase {
+    final CatalogIntegration integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id(INTEGRATION_ID, ResourceKind.RK_CATALOG_INTEGRATION))
+            .setDisplayName("lakehouse")
+            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+            .setCatalogUri("https://catalog.example/v1")
+            .build();
+    CreateCatalogIntegrationRequest lastCreate;
+    UpdateCatalogIntegrationRequest lastUpdate;
+    UpdateCatalogIntegrationAuthenticationRequest lastAuthUpdate;
+    DeleteCatalogIntegrationRequest lastDelete;
+
+    @Override
+    public void listCatalogIntegrations(
+        ListCatalogIntegrationsRequest request,
+        StreamObserver<ListCatalogIntegrationsResponse> observer) {
+      respond(
+          observer,
+          ListCatalogIntegrationsResponse.newBuilder()
+              .addEntries(CatalogIntegrationEntry.newBuilder().setIntegration(integration))
+              .build());
+    }
+
+    @Override
+    public void getCatalogIntegration(
+        GetCatalogIntegrationRequest request,
+        StreamObserver<GetCatalogIntegrationResponse> observer) {
+      respond(
+          observer, GetCatalogIntegrationResponse.newBuilder().setIntegration(integration).build());
+    }
+
+    @Override
+    public void createCatalogIntegration(
+        CreateCatalogIntegrationRequest request,
+        StreamObserver<CreateCatalogIntegrationResponse> observer) {
+      lastCreate = request;
+      respond(
+          observer,
+          CreateCatalogIntegrationResponse.newBuilder()
+              .setIntegration(
+                  integration.toBuilder().setDisplayName(request.getSpec().getDisplayName()))
+              .build());
+    }
+
+    @Override
+    public void updateCatalogIntegration(
+        UpdateCatalogIntegrationRequest request,
+        StreamObserver<UpdateCatalogIntegrationResponse> observer) {
+      lastUpdate = request;
+      respond(
+          observer,
+          UpdateCatalogIntegrationResponse.newBuilder().setIntegration(integration).build());
+    }
+
+    @Override
+    public void updateCatalogIntegrationAuthentication(
+        UpdateCatalogIntegrationAuthenticationRequest request,
+        StreamObserver<UpdateCatalogIntegrationAuthenticationResponse> observer) {
+      lastAuthUpdate = request;
+      respond(
+          observer,
+          UpdateCatalogIntegrationAuthenticationResponse.newBuilder()
+              .setIntegration(integration)
+              .build());
+    }
+
+    @Override
+    public void deleteCatalogIntegration(
+        DeleteCatalogIntegrationRequest request,
+        StreamObserver<DeleteCatalogIntegrationResponse> observer) {
+      lastDelete = request;
+      respond(observer, DeleteCatalogIntegrationResponse.getDefaultInstance());
+    }
+  }
+
+  private static final class OverlayService extends CatalogOverlaysGrpc.CatalogOverlaysImplBase {
+    final CatalogOverlay overlay =
+        CatalogOverlay.newBuilder()
+            .setResourceId(id(OVERLAY_ID, ResourceKind.RK_CATALOG_OVERLAY))
+            .setDisplayName("sales")
+            .setIntegrationId(id(INTEGRATION_ID, ResourceKind.RK_CATALOG_INTEGRATION))
+            .setCatalogId(id(CATALOG_ID, ResourceKind.RK_CATALOG))
+            .build();
+    CreateCatalogOverlayRequest lastCreate;
+    UpdateCatalogOverlayRequest lastUpdate;
+    DeleteCatalogOverlayRequest lastDelete;
+
+    @Override
+    public void listCatalogOverlays(
+        ListCatalogOverlaysRequest request, StreamObserver<ListCatalogOverlaysResponse> observer) {
+      respond(
+          observer,
+          ListCatalogOverlaysResponse.newBuilder()
+              .addEntries(CatalogOverlayEntry.newBuilder().setOverlay(overlay))
+              .build());
+    }
+
+    @Override
+    public void getCatalogOverlay(
+        GetCatalogOverlayRequest request, StreamObserver<GetCatalogOverlayResponse> observer) {
+      respond(observer, GetCatalogOverlayResponse.newBuilder().setOverlay(overlay).build());
+    }
+
+    @Override
+    public void createCatalogOverlay(
+        CreateCatalogOverlayRequest request,
+        StreamObserver<CreateCatalogOverlayResponse> observer) {
+      lastCreate = request;
+      respond(
+          observer,
+          CreateCatalogOverlayResponse.newBuilder()
+              .setOverlay(overlay.toBuilder().setDisplayName(request.getSpec().getDisplayName()))
+              .build());
+    }
+
+    @Override
+    public void updateCatalogOverlay(
+        UpdateCatalogOverlayRequest request,
+        StreamObserver<UpdateCatalogOverlayResponse> observer) {
+      lastUpdate = request;
+      respond(observer, UpdateCatalogOverlayResponse.newBuilder().setOverlay(overlay).build());
+    }
+
+    @Override
+    public void deleteCatalogOverlay(
+        DeleteCatalogOverlayRequest request,
+        StreamObserver<DeleteCatalogOverlayResponse> observer) {
+      lastDelete = request;
+      respond(observer, DeleteCatalogOverlayResponse.getDefaultInstance());
+    }
+  }
+
+  private static <T> void respond(StreamObserver<T> observer, T value) {
+    observer.onNext(value);
+    observer.onCompleted();
+  }
+}

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
@@ -7,6 +7,7 @@
 package ai.floedb.floecat.client.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.catalog.rpc.DirectoryServiceGrpc;
@@ -35,6 +36,7 @@ import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
 import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsResponse;
 import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
 import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysResponse;
+import ai.floedb.floecat.integration.rpc.NamespacePath;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationResponse;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
@@ -125,8 +127,11 @@ class IntegrationCliSupportTest {
   @Test
   void listsAndGetsIntegrationByName() throws Exception {
     try (Harness h = new Harness()) {
-      assertTrue(h.run("integrations", List.of()).contains("lakehouse"));
       assertTrue(h.run("integration", List.of("get", "lakehouse")).contains("lakehouse"));
+      assertEquals("lakehouse", h.integrations.lastGet.getDisplayName());
+      assertEquals(0, h.integrations.listCalls);
+
+      assertTrue(h.run("integrations", List.of()).contains("lakehouse"));
     }
   }
 
@@ -136,11 +141,20 @@ class IntegrationCliSupportTest {
       h.run(
           "integration",
           List.of(
-              "update", INTEGRATION_ID, "--display", "renamed", "--props", "warehouse=reporting"));
+              "update",
+              INTEGRATION_ID,
+              "--display",
+              "renamed",
+              "--uri",
+              "https://replacement.example/v1",
+              "--props",
+              "warehouse=reporting"));
       assertEquals(
-          List.of("display_name", "properties"),
+          List.of("display_name", "catalog_uri", "properties"),
           h.integrations.lastUpdate.getUpdateMask().getPathsList());
       assertEquals("renamed", h.integrations.lastUpdate.getSpec().getDisplayName());
+      assertEquals(
+          "https://replacement.example/v1", h.integrations.lastUpdate.getSpec().getCatalogUri());
       assertEquals(
           "reporting", h.integrations.lastUpdate.getSpec().getPropertiesMap().get("warehouse"));
 
@@ -151,6 +165,32 @@ class IntegrationCliSupportTest {
       h.run("integration", List.of("delete", INTEGRATION_ID, "--cascade"));
       assertEquals(INTEGRATION_ID, h.integrations.lastDelete.getIntegrationId().getId());
       assertTrue(h.integrations.lastDelete.getCascade());
+    }
+  }
+
+  @Test
+  void rejectsDisplayFlagWithoutValue() throws Exception {
+    try (Harness h = new Harness()) {
+      var error =
+          assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  h.run(
+                      "integration",
+                      List.of("update", INTEGRATION_ID, "--display", "--props", "k=v")));
+      assertEquals("Missing value for --display", error.getMessage());
+    }
+  }
+
+  @Test
+  void rejectsNamespaceFlagWithoutValue() throws Exception {
+    try (Harness h = new Harness()) {
+      var error =
+          assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  h.run("overlay", List.of("update", OVERLAY_ID, "--include", "--exclude", "tmp")));
+      assertEquals("Missing value for --include", error.getMessage());
     }
   }
 
@@ -202,8 +242,16 @@ class IntegrationCliSupportTest {
   @Test
   void listsAndGetsOverlayByName() throws Exception {
     try (Harness h = new Harness()) {
+      String output = h.run("overlay", List.of("get", "sales"));
+      assertTrue(output.contains("sales"));
+      assertTrue(output.contains("CATALOG_ID"));
+      assertTrue(output.contains(CATALOG_ID));
+      assertTrue(output.contains("[prod.sales]"));
+      assertTrue(output.contains("[tmp]"));
+      assertEquals("sales", h.overlays.lastGet.getDisplayName());
+      assertEquals(0, h.overlays.listCalls);
+
       assertTrue(h.run("overlays", List.of()).contains("sales"));
-      assertTrue(h.run("overlay", List.of("get", "sales")).contains("sales"));
     }
   }
 
@@ -279,14 +327,17 @@ class IntegrationCliSupportTest {
             .setCatalogUri("https://catalog.example/v1")
             .build();
     CreateCatalogIntegrationRequest lastCreate;
+    GetCatalogIntegrationRequest lastGet;
     UpdateCatalogIntegrationRequest lastUpdate;
     UpdateCatalogIntegrationAuthenticationRequest lastAuthUpdate;
     DeleteCatalogIntegrationRequest lastDelete;
+    int listCalls;
 
     @Override
     public void listCatalogIntegrations(
         ListCatalogIntegrationsRequest request,
         StreamObserver<ListCatalogIntegrationsResponse> observer) {
+      listCalls++;
       respond(
           observer,
           ListCatalogIntegrationsResponse.newBuilder()
@@ -298,6 +349,7 @@ class IntegrationCliSupportTest {
     public void getCatalogIntegration(
         GetCatalogIntegrationRequest request,
         StreamObserver<GetCatalogIntegrationResponse> observer) {
+      lastGet = request;
       respond(
           observer, GetCatalogIntegrationResponse.newBuilder().setIntegration(integration).build());
     }
@@ -353,14 +405,20 @@ class IntegrationCliSupportTest {
             .setDisplayName("sales")
             .setIntegrationId(id(INTEGRATION_ID, ResourceKind.RK_CATALOG_INTEGRATION))
             .setCatalogId(id(CATALOG_ID, ResourceKind.RK_CATALOG))
+            .addIncludeNamespaces(
+                NamespacePath.newBuilder().addSegments("prod").addSegments("sales"))
+            .addExcludeNamespaces(NamespacePath.newBuilder().addSegments("tmp"))
             .build();
     CreateCatalogOverlayRequest lastCreate;
+    GetCatalogOverlayRequest lastGet;
     UpdateCatalogOverlayRequest lastUpdate;
     DeleteCatalogOverlayRequest lastDelete;
+    int listCalls;
 
     @Override
     public void listCatalogOverlays(
         ListCatalogOverlaysRequest request, StreamObserver<ListCatalogOverlaysResponse> observer) {
+      listCalls++;
       respond(
           observer,
           ListCatalogOverlaysResponse.newBuilder()
@@ -371,6 +429,7 @@ class IntegrationCliSupportTest {
     @Override
     public void getCatalogOverlay(
         GetCatalogOverlayRequest request, StreamObserver<GetCatalogOverlayResponse> observer) {
+      lastGet = request;
       respond(observer, GetCatalogOverlayResponse.newBuilder().setOverlay(overlay).build());
     }
 

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
@@ -73,7 +73,10 @@ class IntegrationCliSupportTest {
               "token_uri=https://identity.example/token",
               "scopes=catalog.read,catalog.write",
               "--cred",
-              "client_secret=secret"));
+              "client_secret=secret",
+              "--props",
+              "warehouse=analytics",
+              "s3.region=us-east-1"));
 
       var spec = h.integrations.lastCreate.getSpec();
       assertEquals("lakehouse", spec.getDisplayName());
@@ -85,6 +88,8 @@ class IntegrationCliSupportTest {
           spec.getAuthentication().getOauthClientCredentials().getScopesList());
       assertEquals(
           "secret", h.integrations.lastCreate.getCredentials().getOauthClientSecret().getValue());
+      assertEquals("analytics", spec.getPropertiesMap().get("warehouse"));
+      assertEquals("us-east-1", spec.getPropertiesMap().get("s3.region"));
     }
   }
 
@@ -128,10 +133,20 @@ class IntegrationCliSupportTest {
   @Test
   void updatesAndDeletesIntegrationById() throws Exception {
     try (Harness h = new Harness()) {
-      h.run("integration", List.of("update", INTEGRATION_ID, "--display", "renamed"));
+      h.run(
+          "integration",
+          List.of(
+              "update", INTEGRATION_ID, "--display", "renamed", "--props", "warehouse=reporting"));
       assertEquals(
-          List.of("display_name"), h.integrations.lastUpdate.getUpdateMask().getPathsList());
+          List.of("display_name", "properties"),
+          h.integrations.lastUpdate.getUpdateMask().getPathsList());
       assertEquals("renamed", h.integrations.lastUpdate.getSpec().getDisplayName());
+      assertEquals(
+          "reporting", h.integrations.lastUpdate.getSpec().getPropertiesMap().get("warehouse"));
+
+      h.run("integration", List.of("update", INTEGRATION_ID, "--props"));
+      assertEquals(List.of("properties"), h.integrations.lastUpdate.getUpdateMask().getPathsList());
+      assertTrue(h.integrations.lastUpdate.getSpec().getPropertiesMap().isEmpty());
 
       h.run("integration", List.of("delete", INTEGRATION_ID, "--cascade"));
       assertEquals(INTEGRATION_ID, h.integrations.lastDelete.getIntegrationId().getId());

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellAuthInterceptorTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellAuthInterceptorTest.java
@@ -29,6 +29,12 @@ import ai.floedb.floecat.catalog.rpc.TableServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.TableStatisticsServiceGrpc;
 import ai.floedb.floecat.catalog.rpc.ViewServiceGrpc;
 import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationsGrpc;
+import ai.floedb.floecat.integration.rpc.CatalogOverlaysGrpc;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogIntegrationsResponse;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
+import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysResponse;
 import ai.floedb.floecat.query.rpc.QueryScanServiceGrpc;
 import ai.floedb.floecat.query.rpc.QuerySchemaServiceGrpc;
 import ai.floedb.floecat.query.rpc.QueryServiceGrpc;
@@ -55,7 +61,7 @@ class ShellAuthInterceptorTest {
       Metadata.Key.of("x-floe-session", Metadata.ASCII_STRING_MARSHALLER);
 
   @Test
-  void applyAuthInterceptorsAlsoWrapsStorageAuthoritiesStub() throws Exception {
+  void applyAuthInterceptorsWrapsAdditionalServiceStubs() throws Exception {
     AtomicReference<String> observedSession = new AtomicReference<>();
     String serverName = InProcessServerBuilder.generateName();
     Server server =
@@ -63,6 +69,8 @@ class ShellAuthInterceptorTest {
             .directExecutor()
             .intercept(new CaptureSessionHeaderInterceptor(observedSession))
             .addService(new StorageAuthorityService())
+            .addService(new IntegrationService())
+            .addService(new OverlayService())
             .build()
             .start();
     ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
@@ -82,6 +90,8 @@ class ShellAuthInterceptorTest {
       shell.snapshots = SnapshotServiceGrpc.newBlockingStub(channel);
       shell.viewService = ViewServiceGrpc.newBlockingStub(channel);
       shell.connectors = ConnectorsGrpc.newBlockingStub(channel);
+      shell.integrations = CatalogIntegrationsGrpc.newBlockingStub(channel);
+      shell.overlays = CatalogOverlaysGrpc.newBlockingStub(channel);
       shell.reconcileControl = ReconcileControlGrpc.newBlockingStub(channel);
       shell.queries = QueryServiceGrpc.newBlockingStub(channel);
       shell.queryScan = QueryScanServiceGrpc.newBlockingStub(channel);
@@ -96,6 +106,15 @@ class ShellAuthInterceptorTest {
       shell.storageAuthorities.listStorageAuthorities(
           ListStorageAuthoritiesRequest.getDefaultInstance());
 
+      assertEquals("session-123", observedSession.get());
+
+      observedSession.set(null);
+      shell.integrations.listCatalogIntegrations(
+          ListCatalogIntegrationsRequest.getDefaultInstance());
+      assertEquals("session-123", observedSession.get());
+
+      observedSession.set(null);
+      shell.overlays.listCatalogOverlays(ListCatalogOverlaysRequest.getDefaultInstance());
       assertEquals("session-123", observedSession.get());
     } finally {
       channel.shutdownNow();
@@ -125,6 +144,27 @@ class ShellAuthInterceptorTest {
         ListStorageAuthoritiesRequest request,
         StreamObserver<ListStorageAuthoritiesResponse> responseObserver) {
       responseObserver.onNext(ListStorageAuthoritiesResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static final class IntegrationService
+      extends CatalogIntegrationsGrpc.CatalogIntegrationsImplBase {
+    @Override
+    public void listCatalogIntegrations(
+        ListCatalogIntegrationsRequest request,
+        StreamObserver<ListCatalogIntegrationsResponse> responseObserver) {
+      responseObserver.onNext(ListCatalogIntegrationsResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static final class OverlayService extends CatalogOverlaysGrpc.CatalogOverlaysImplBase {
+    @Override
+    public void listCatalogOverlays(
+        ListCatalogOverlaysRequest request,
+        StreamObserver<ListCatalogOverlaysResponse> responseObserver) {
+      responseObserver.onNext(ListCatalogOverlaysResponse.getDefaultInstance());
       responseObserver.onCompleted();
     }
   }

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellHistoryTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/ShellHistoryTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package ai.floedb.floecat.client.cli;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jline.reader.impl.history.DefaultHistory;
+import org.junit.jupiter.api.Test;
+
+class ShellHistoryTest {
+
+  @Test
+  void credentialArgumentsAreExcludedFromPersistentHistory() {
+    var history = new TestHistory();
+
+    assertTrue(
+        history.matches(
+            Shell.SENSITIVE_HISTORY_PATTERN,
+            "integration create lakehouse iceberg-rest https://example --cred token=secret"));
+    assertTrue(
+        history.matches(
+            Shell.SENSITIVE_HISTORY_PATTERN,
+            "integration update-auth lakehouse --cred secret_access_key=secret"));
+    assertFalse(history.matches(Shell.SENSITIVE_HISTORY_PATTERN, "integration get lakehouse"));
+  }
+
+  private static final class TestHistory extends DefaultHistory {
+    boolean matches(String patterns, String line) {
+      return matchPatterns(patterns, line);
+    }
+  }
+}

--- a/docs/_snippets/docs-by-area.md
+++ b/docs/_snippets/docs-by-area.md
@@ -1,4 +1,6 @@
 - **Core platform**: architecture, service, caching, metadata graph, reconciler
-- **Integrations**: [catalog integration design](catalog-integration-design.md), connectors (Iceberg, Delta), Arrow Flight, client CLI
+- **Integrations**: [catalog integration design](catalog-integration-design.md),
+  [catalog integrations and overlays](catalog-integrations.md), connectors (Iceberg, Delta), Arrow
+  Flight, client CLI
 - **Storage and security**: storage backends, secrets manager, external authentication
 - **Operations and observability**: operations, telemetry, troubleshooting

--- a/docs/catalog-integrations.md
+++ b/docs/catalog-integrations.md
@@ -6,8 +6,8 @@ foundation for external-catalog connectivity:
 - A **catalog integration** records an upstream catalog type, URI, display name, non-secret
   connection properties, and typed authentication configuration. Credential material is stored
   separately and is never returned by the API.
-- A **catalog overlay** defines a top-level Floecat catalog backed by an integration and filtered
-  to selected upstream namespaces.
+- A **catalog overlay** maps selected upstream namespaces from an integration into an existing
+  Floecat destination catalog.
 
 ```text
 CatalogIntegration (external catalog identity)
@@ -21,7 +21,8 @@ for external catalog connectivity.
 
 ## Shell workflow
 
-Create the integration record, then define a top-level overlay catalog:
+Create the integration record, then map its selected namespaces into an existing destination
+catalog:
 
 ```text
 integration create lakehouse iceberg-rest https://catalog.example/v1 \
@@ -43,7 +44,7 @@ integrations
 integration list
 integration get <name|id>
 integration create <name> <type> <uri> --auth-type <type> [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
-integration update <name|id> [--display <name>] [--props k=v ...] [--etag <etag>]
+integration update <name|id> [--display <name>] [--uri <uri>] [--props k=v ...] [--etag <etag>]
 integration update-auth <name|id> --auth-type <type> [--auth k=v ...] [--cred k=v ...]
 integration delete <name|id>
 
@@ -77,7 +78,8 @@ it.
 ## Lifecycle
 
 - Overlay creation requires an existing integration.
-- Overlay display names are unique within an account and identify the top-level catalog.
+- Overlay display names are unique within an account and identify the mapping into a destination
+  catalog.
 - An integration cannot be deleted while overlays refer to it.
 - Integration deletion supports `--cascade` to delete dependent overlays.
 - Integration and overlay mutations support optimistic `--etag` preconditions.

--- a/docs/catalog-integrations.md
+++ b/docs/catalog-integrations.md
@@ -1,0 +1,81 @@
+# Catalog Integrations and Overlays
+
+Catalog integrations and overlays establish the resource, authentication, and SQL naming
+foundation for external-catalog connectivity:
+
+- A **catalog integration** records an upstream catalog type, URI, display name, and typed,
+  non-secret authentication configuration. Credential material is stored separately and is never
+  returned by the API.
+- A **catalog overlay** defines a top-level Floecat catalog backed by an integration and filtered
+  to selected upstream namespaces.
+
+```text
+CatalogIntegration (external catalog identity)
+ ├── CatalogOverlay "sales"
+ └── CatalogOverlay "finance"
+```
+
+These resources do not yet validate connectivity, refresh metadata, reconcile or capture tables,
+or affect query paths. The legacy `Connector` API and Shell commands remain the operational path
+for external catalog connectivity.
+
+## Shell workflow
+
+Create the integration record, then define a top-level overlay catalog:
+
+```text
+integration create lakehouse iceberg-rest https://catalog.example/v1 \
+  --auth-type oauth-client-credentials \
+  --auth client_id=floecat token_uri=https://identity.example/token \
+  --cred client_secret=secret
+overlay create sales-overlay lakehouse --include prod.sales,prod.reference
+```
+
+The overlay command accepts either a resource ID or display name for the integration.
+Namespace filters are comma-separated paths supplied with `--include` and `--exclude`. Omitting both
+selects the whole upstream namespace tree.
+
+The available commands are:
+
+```text
+integrations
+integration list
+integration get <name|id>
+integration create <name> <type> <uri> --auth-type <type> [--auth k=v ...] [--cred k=v ...]
+integration update <name|id> [options]
+integration update-auth <name|id> --auth-type <type> [--auth k=v ...] [--cred k=v ...]
+integration delete <name|id>
+
+overlays [--integration <name|id>]
+overlay list [--integration <name|id>]
+overlay get <name|id>
+overlay create <name> <integration-name|id> [options]
+overlay update <name|id> [options]
+overlay delete <name|id>
+```
+
+Authentication types and their properties are:
+
+| `--auth-type` | `--auth` properties | `--cred` properties |
+| --- | --- | --- |
+| `oauth-client-credentials` | `client_id`; optional `token_uri`, `scopes` CSV | `client_secret` |
+| `bearer` | none | `token` |
+| `aws-assume-role` | `role_arn`; optional `external_id`, `role_session_name` | none |
+| `aws-access-key` | `access_key_id` | `secret_access_key`; optional `session_token` |
+| `aws-sigv4` | `region`, `credential_source`; optional `signing_name`, plus source fields | source-dependent |
+
+For SigV4, `credential_source` is `default`, `assume-role`, or `access-key`. Assume-role uses the
+role properties above. Access-key uses the access-key properties above. The CLI rejects unknown
+properties instead of silently dropping them.
+
+## Lifecycle
+
+- Overlay creation requires an existing integration.
+- Overlay display names are unique within an account and identify the top-level catalog.
+- An integration cannot be deleted while overlays refer to it.
+- Integration deletion supports `--cascade` to delete dependent overlays.
+- Integration and overlay mutations support optimistic `--etag` preconditions.
+- Authentication replacement uses the dedicated `integration update-auth` command so credential
+  values remain write-only.
+
+The protobuf contracts are in `core/proto/src/main/proto/floecat/integration/`.

--- a/docs/catalog-integrations.md
+++ b/docs/catalog-integrations.md
@@ -29,7 +29,7 @@ integration create lakehouse iceberg-rest https://catalog.example/v1 \
   --auth client_id=floecat token_uri=https://identity.example/token \
   --cred client_secret=secret \
   --props warehouse=analytics
-overlay create sales-overlay lakehouse --include prod.sales,prod.reference
+overlay create sales-overlay lakehouse local-catalog --include prod.sales,prod.reference
 ```
 
 The overlay command accepts either a resource ID or display name for the integration.
@@ -50,7 +50,7 @@ integration delete <name|id>
 overlays [--integration <name|id>]
 overlay list [--integration <name|id>]
 overlay get <name|id>
-overlay create <name> <integration-name|id> [options]
+overlay create <name> <integration-name|id> <catalog-name|id> [options]
 overlay update <name|id> [options]
 overlay delete <name|id>
 ```

--- a/docs/catalog-integrations.md
+++ b/docs/catalog-integrations.md
@@ -3,9 +3,9 @@
 Catalog integrations and overlays establish the resource, authentication, and SQL naming
 foundation for external-catalog connectivity:
 
-- A **catalog integration** records an upstream catalog type, URI, display name, and typed,
-  non-secret authentication configuration. Credential material is stored separately and is never
-  returned by the API.
+- A **catalog integration** records an upstream catalog type, URI, display name, non-secret
+  connection properties, and typed authentication configuration. Credential material is stored
+  separately and is never returned by the API.
 - A **catalog overlay** defines a top-level Floecat catalog backed by an integration and filtered
   to selected upstream namespaces.
 
@@ -27,7 +27,8 @@ Create the integration record, then define a top-level overlay catalog:
 integration create lakehouse iceberg-rest https://catalog.example/v1 \
   --auth-type oauth-client-credentials \
   --auth client_id=floecat token_uri=https://identity.example/token \
-  --cred client_secret=secret
+  --cred client_secret=secret \
+  --props warehouse=analytics
 overlay create sales-overlay lakehouse --include prod.sales,prod.reference
 ```
 
@@ -41,8 +42,8 @@ The available commands are:
 integrations
 integration list
 integration get <name|id>
-integration create <name> <type> <uri> --auth-type <type> [--auth k=v ...] [--cred k=v ...]
-integration update <name|id> [options]
+integration create <name> <type> <uri> --auth-type <type> [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
+integration update <name|id> [--display <name>] [--props k=v ...] [--etag <etag>]
 integration update-auth <name|id> --auth-type <type> [--auth k=v ...] [--cred k=v ...]
 integration delete <name|id>
 
@@ -67,6 +68,11 @@ Authentication types and their properties are:
 For SigV4, `credential_source` is `default`, `assume-role`, or `access-key`. Assume-role uses the
 role properties above. Access-key uses the access-key properties above. The CLI rejects unknown
 properties instead of silently dropping them.
+
+`--props` supplies non-secret provider connection properties. For Iceberg REST catalogs such as
+Polaris, `warehouse=<catalog-name>` selects the upstream catalog without putting a query parameter in
+the base URI. Updating properties replaces the complete map; passing `--props` with no values clears
+it.
 
 ## Lifecycle
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,6 +81,25 @@ query end <query_id> [--commit|--abort]
 query get <query_id>
 query fetch-scan <query_id> <table_id>
 
+integrations
+integration list
+integration get <name|id>
+integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
+  [--auth k=v ...] [--cred k=v ...]
+integration update <name|id> --display <name> [--etag <etag>]
+integration update-auth <name|id> --auth-type <type>
+  [--auth k=v ...] [--cred k=v ...] [--etag <etag>]
+integration delete <name|id> [--cascade] [--etag <etag>]
+
+overlays [--integration <name|id>]
+overlay list [--integration <name|id>]
+overlay get <name|id>
+overlay create <name> <integration-name|id>
+    [--include ns[,ns...]] [--exclude ns[,ns...]]
+overlay update <name|id> [--display <name>]
+    [--include ns[,ns...]] [--exclude ns[,ns...]] [--etag <etag>]
+overlay delete <name|id> [--etag <etag>]
+
 connectors
 connector list [--kind <KIND>]
 connector get <display_name|id>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -94,7 +94,7 @@ integration delete <name|id> [--cascade] [--etag <etag>]
 overlays [--integration <name|id>]
 overlay list [--integration <name|id>]
 overlay get <name|id>
-overlay create <name> <integration-name|id>
+overlay create <name> <integration-name|id> <catalog-name|id>
     [--include ns[,ns...]] [--exclude ns[,ns...]]
 overlay update <name|id> [--display <name>]
     [--include ns[,ns...]] [--exclude ns[,ns...]] [--etag <etag>]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -85,8 +85,8 @@ integrations
 integration list
 integration get <name|id>
 integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
-  [--auth k=v ...] [--cred k=v ...]
-integration update <name|id> --display <name> [--etag <etag>]
+  [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
+integration update <name|id> [--display <name>] [--props k=v ...] [--etag <etag>]
 integration update-auth <name|id> --auth-type <type>
   [--auth k=v ...] [--cred k=v ...] [--etag <etag>]
 integration delete <name|id> [--cascade] [--etag <etag>]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -86,7 +86,7 @@ integration list
 integration get <name|id>
 integration create <name> <iceberg-rest|unity> <uri> --auth-type <type>
   [--auth k=v ...] [--cred k=v ...] [--props k=v ...]
-integration update <name|id> [--display <name>] [--props k=v ...] [--etag <etag>]
+integration update <name|id> [--display <name>] [--uri <uri>] [--props k=v ...] [--etag <etag>]
 integration update-auth <name|id> --auth-type <type>
   [--auth k=v ...] [--cred k=v ...] [--etag <etag>]
 integration delete <name|id> [--cascade] [--etag <etag>]

--- a/docs/client-cli.md
+++ b/docs/client-cli.md
@@ -99,7 +99,7 @@ To exercise the resource model from the Shell, create an integration and overlay
 
 ```text
 integration create lakehouse iceberg-rest https://catalog.example/v1 \
-  --auth-type bearer --cred token=secret
+  --auth-type bearer --cred token=secret --props warehouse=analytics
 overlay create sales-overlay lakehouse --include prod.sales
 ```
 

--- a/docs/client-cli.md
+++ b/docs/client-cli.md
@@ -56,8 +56,8 @@ The CLI exposes commands documented at runtime via `help`. Highlights:
 - `connectors` / `connector <subcommand>` – Manage connector definitions and reconciliation jobs.
 - `integrations` / `integration <subcommand>` – Manage upstream catalog identity, authentication,
   and write-only credentials.
-- `overlays` / `overlay <subcommand>` – Define a top-level catalog backed by an integration,
-  optionally filtering namespaces.
+- `overlays` / `overlay <subcommand>` – Map namespaces from an integration into an existing
+  destination catalog.
 - `storage-authorities` / `storage-authority <subcommand>` – Manage storage credential authorities
   used by the Iceberg REST gateway to vend temporary object-store credentials.
 

--- a/docs/client-cli.md
+++ b/docs/client-cli.md
@@ -4,7 +4,8 @@
 
 `client-cli/` packages a Picocli-based interactive shell backed by the same gRPC stubs used by the
 service. It is the quickest way for developers and operators to explore catalogs, namespaces, tables,
-connectors, storage authorities, and query-lifecycle workflows without writing bespoke clients.
+catalog integrations, overlays, legacy connectors, storage authorities, and query-lifecycle
+workflows without writing bespoke clients.
 
 The CLI runs as a Quarkus application, depends on generated RPC stubs, and includes helpers for
 fully-qualified name parsing (`FQNameParserUtil`) and CSV-like argument parsing for column lists
@@ -53,6 +54,10 @@ The CLI exposes commands documented at runtime via `help`. Highlights:
   while `query fetch-scan <query_id> <table_id>` requests the connector-provided `ScanFile` lists for
   an individual table.
 - `connectors` / `connector <subcommand>` – Manage connector definitions and reconciliation jobs.
+- `integrations` / `integration <subcommand>` – Manage upstream catalog identity, authentication,
+  and write-only credentials.
+- `overlays` / `overlay <subcommand>` – Define a top-level catalog backed by an integration,
+  optionally filtering namespaces.
 - `storage-authorities` / `storage-authority <subcommand>` – Manage storage credential authorities
   used by the Iceberg REST gateway to vend temporary object-store credentials.
 
@@ -87,6 +92,18 @@ User command → Picocli parser → Shell subcommand → gRPC stub call
 
 Commands run synchronously inside the REPL thread; long-running operations (for example connector
 reconciliation) show job IDs that can be polled via `connector job <id>`.
+
+Integration and overlay records currently provide CRUD configuration and credential lifecycle
+only. They do not connect to the upstream catalog, reconcile metadata, or affect query execution.
+To exercise the resource model from the Shell, create an integration and overlay:
+
+```text
+integration create lakehouse iceberg-rest https://catalog.example/v1 \
+  --auth-type bearer --cred token=secret
+overlay create sales-overlay lakehouse --include prod.sales
+```
+
+Legacy connector commands remain the operational path for external catalog connectivity.
 
 `connector jobs` shows a parent-job summary table by default. Use
 `connector jobs --child <parent-job-id>` to render the descendant job tree rooted at that job.

--- a/docs/client-cli.md
+++ b/docs/client-cli.md
@@ -100,7 +100,7 @@ To exercise the resource model from the Shell, create an integration and overlay
 ```text
 integration create lakehouse iceberg-rest https://catalog.example/v1 \
   --auth-type bearer --cred token=secret --props warehouse=analytics
-overlay create sales-overlay lakehouse --include prod.sales
+overlay create sales-overlay lakehouse local-catalog --include prod.sales
 ```
 
 Legacy connector commands remain the operational path for external catalog connectivity.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - Arrow Flight: arrow-flight.md
   - Catalog and Metadata:
       - Catalog Integration Architecture and Delivery Plan: catalog-integration-design.md
+      - Catalog Integrations and Overlays: catalog-integrations.md
       - Metadata Graph: metadata-graph.md
       - System Objects: system-objects.md
       - System Scans: system-scans.md


### PR DESCRIPTION
## Summary

Adds catalog integration and overlay commands to the client CLI, along with command execution support, shell wiring, history/auth coverage, CLI reference material, and an operator-facing catalog integrations guide.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Focused CLI suite: 29 tests passed.

- [x] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Stack position: **7/10**. Base: `mc-catalog-overlays-api`. This PR is limited to client/CLI and user documentation over the APIs below it.

