### PR TITLE
feat(catalog-integration): reconcile overlay metadata (stack 10/10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@
 #   make compose-up COMPOSE_ENV_FILE=./env.localstack-oidc COMPOSE_PROFILES=localstack-oidc
 #   make compose-down COMPOSE_ENV_FILE=./env.localstack-oidc COMPOSE_PROFILES=localstack-oidc
 #   make compose-smoke          # sequential docker smoke (default: localstack + localstack-oidc)
+#   COMPOSE_SMOKE_MODES=polaris-integration make compose-smoke
 #   COMPOSE_SMOKE_MODES=localstack-remote make compose-smoke
 #   COMPOSE_SMOKE_MODES=localstack-oidc-remote make compose-smoke
 #   make logs-rest               # tail -f REST gateway log

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
@@ -179,6 +179,8 @@ final class IcebergRestCatalogClient implements CatalogClient {
               name,
               externalIdentity(name, metadata),
               "ICEBERG",
+              SchemaParser.toJson(table.schema()),
+              table.spec().fields().stream().map(field -> field.name()).toList(),
               metadataLocation(metadata),
               Optional.ofNullable(table.location()).filter(location -> !location.isBlank()),
               table.properties());

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistry.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistry.java
@@ -288,7 +288,7 @@ public final class RefreshingAwsCredentialsRegistry {
                 throw terminalRefresh;
               }
               if (snapshot.credentials().expiresAt() != null
-                  && now.isBefore(snapshot.credentials().expiresAt())) {
+                  && clock.instant().isBefore(snapshot.credentials().expiresAt())) {
                 return toAwsCredentials(snapshot.credentials());
               }
               throw e;

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -100,6 +101,9 @@ class IcebergRestCatalogClientTest {
     CatalogObjectName name =
         new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
     Table table = mock(Table.class);
+    Schema schema = new Schema(Types.NestedField.optional(1, "id", Types.LongType.get()));
+    when(table.schema()).thenReturn(schema);
+    when(table.spec()).thenReturn(PartitionSpec.builderFor(schema).identity("id").build());
     when(table.location()).thenReturn("s3://warehouse/sales/orders");
     when(table.properties()).thenReturn(Map.of("owner", "sales-team"));
     when(catalog.loadTable(TableIdentifier.of(Namespace.of("production", "sales"), "orders")))
@@ -112,6 +116,8 @@ class IcebergRestCatalogClientTest {
     assertEquals(ExternalObjectIdentity.pathFallback(name), loaded.identity());
     assertFalse(loaded.identity().stable());
     assertEquals("ICEBERG", loaded.format());
+    assertTrue(loaded.schemaJson().contains("\"name\":\"id\""));
+    assertEquals(List.of("id"), loaded.partitionKeys());
     assertEquals("s3://warehouse/sales/orders", loaded.storageLocation().orElseThrow());
     assertEquals(Map.of("owner", "sales-team"), loaded.properties());
   }
@@ -335,6 +341,9 @@ class IcebergRestCatalogClientTest {
     when(operations.current()).thenReturn(metadata);
     when(metadata.uuid()).thenReturn("6d4fe3f7-4615-4bc5-b9ae-62c691d6ba7e");
     when(metadata.metadataFileLocation()).thenReturn("s3://warehouse/metadata/v2.json");
+    Schema schema = new Schema(Types.NestedField.optional(1, "id", Types.LongType.get()));
+    when(table.schema()).thenReturn(schema);
+    when(table.spec()).thenReturn(PartitionSpec.unpartitioned());
     when(table.location()).thenReturn("s3://warehouse/sales/orders");
     when(table.properties()).thenReturn(Map.of());
     when(catalog.loadTable(TableIdentifier.of(Namespace.of("production", "sales"), "orders")))

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistryTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/auth/RefreshingAwsCredentialsRegistryTest.java
@@ -192,6 +192,32 @@ class RefreshingAwsCredentialsRegistryTest {
     }
   }
 
+  @Test
+  void failedRefreshDoesNotReturnCredentialsThatExpiredDuringTheRefresh() {
+    Instant start = Instant.parse("2026-08-05T12:00:00Z");
+    MutableClock clock = new MutableClock(start);
+    IllegalStateException refreshFailure = new IllegalStateException("refresh failed");
+    try (var registration =
+        RefreshingAwsCredentialsRegistry.register(
+            "expiry-during-refresh-test",
+            credentials("old", start.plusSeconds(30)),
+            () -> {
+              clock.advance(Duration.ofSeconds(10));
+              throw refreshFailure;
+            },
+            Duration.ofMinutes(1),
+            clock)) {
+      clock.advance(Duration.ofSeconds(21));
+      assertSame(
+          refreshFailure,
+          assertThrows(
+              IllegalStateException.class,
+              () ->
+                  RefreshingAwsCredentialsRegistry.resolve(
+                      registration.providerId(), AwsCredentialScope.CATALOG)));
+    }
+  }
+
   private static Map<String, String> providerProperties(
       RefreshingAwsCredentialsRegistry.Registration registration, AwsCredentialScope scope) {
     String providerId =

--- a/client-cli/EMBEDDING.md
+++ b/client-cli/EMBEDDING.md
@@ -114,7 +114,7 @@ expected: `catalog create "my catalog"` becomes three tokens.
 | `view` / `views` | `views <ns>`, `view get <fq>` |
 | `connector` / `connectors` | `connectors`, `connector create ...`, `connector trigger <id>` |
 | `integration` / `integrations` | `integrations`, `integration create <name> <type> <uri> --auth-type <type>`, `integration validate <name>`, `integration namespaces <name>`, `integration objects <name> <namespace>` |
-| `overlay` / `overlays` | `overlays`, `overlay create <name> <integration> <catalog>` |
+| `overlay` / `overlays` | `overlays`, `overlay create <name> <integration> <catalog>`, `overlay reconcile <name>` |
 | `snapshot` / `snapshots` | `snapshots <table>`, `snapshot get <table> --snapshot <id>` |
 | `stats` / `analyze` | `stats table <fq>`, `stats columns <fq>`, `analyze <fq>` |
 | `constraints` | `constraints list <table>` |

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/IntegrationCliSupport.java
@@ -39,6 +39,8 @@ import ai.floedb.floecat.integration.rpc.ListUpstreamNamespacesRequest;
 import ai.floedb.floecat.integration.rpc.ListUpstreamObjectsRequest;
 import ai.floedb.floecat.integration.rpc.NamespacePath;
 import ai.floedb.floecat.integration.rpc.OAuthClientCredentialsAuthentication;
+import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayResponse;
 import ai.floedb.floecat.integration.rpc.SecretValue;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
@@ -259,7 +261,7 @@ final class IntegrationCliSupport {
       DirectoryServiceGrpc.DirectoryServiceBlockingStub directory,
       Supplier<String> accountId) {
     if (args.isEmpty()) {
-      out.println("usage: overlay <list|get|create|update|delete> ...");
+      out.println("usage: overlay <list|get|create|update|reconcile|delete> ...");
       return;
     }
     switch (args.getFirst()) {
@@ -313,6 +315,18 @@ final class IntegrationCliSupport {
         var precondition = CliArgs.preconditionFromEtag(args);
         if (precondition != null) request.setPrecondition(precondition);
         printOverlays(List.of(overlays.updateCatalogOverlay(request.build()).getOverlay()), out);
+      }
+      case "reconcile" -> {
+        if (args.size() < 2) {
+          out.println("usage: overlay reconcile <name|id> [--etag <etag>]");
+          return;
+        }
+        var request =
+            ReconcileCatalogOverlayRequest.newBuilder()
+                .setOverlayId(resolveOverlay(args.get(1), overlays, accountId));
+        var precondition = CliArgs.preconditionFromEtag(args);
+        if (precondition != null) request.setPrecondition(precondition);
+        printReconcile(overlays.reconcileCatalogOverlay(request.build()), out);
       }
       case "delete" -> {
         if (args.size() < 2) {
@@ -676,6 +690,17 @@ final class IntegrationCliSupport {
           check.getIssue().name().replaceFirst("^CIVI_", ""),
           check.getSummary());
     }
+  }
+
+  private static void printReconcile(ReconcileCatalogOverlayResponse response, PrintStream out) {
+    out.printf("namespaces_created: %d%n", response.getNamespacesCreated());
+    out.printf("namespaces_deleted: %d%n", response.getNamespacesDeleted());
+    out.printf("tables_created: %d%n", response.getTablesCreated());
+    out.printf("tables_updated: %d%n", response.getTablesUpdated());
+    out.printf("tables_deleted: %d%n", response.getTablesDeleted());
+    out.printf("views_created: %d%n", response.getViewsCreated());
+    out.printf("views_updated: %d%n", response.getViewsUpdated());
+    out.printf("views_deleted: %d%n", response.getViewsDeleted());
   }
 
   private static void printIntegrationHeader(PrintStream out) {

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -596,6 +596,7 @@ public class Shell implements Runnable {
              [--include ns[,ns...]] [--exclude ns[,ns...]]
          overlay update <name|id> [--display <name>]
              [--include ns[,ns...]] [--exclude ns[,ns...]] [--etag <etag>]
+         overlay reconcile <name|id> [--etag <etag>]
          overlay delete <name|id> [--etag <etag>]
          connectors
          connector list [--kind <KIND>]

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/TableCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/TableCliSupport.java
@@ -508,6 +508,12 @@ final class TableCliSupport {
     out.printf(
         "  connector_id: %s%n",
         upstream.hasConnectorId() ? upstream.getConnectorId().getId() : "-");
+    out.printf(
+        "  integration_id: %s%n",
+        upstream.hasCatalogIntegrationId() ? upstream.getCatalogIntegrationId().getId() : "-");
+    out.printf(
+        "  overlay_id:    %s%n",
+        upstream.hasCatalogOverlayId() ? upstream.getCatalogOverlayId().getId() : "-");
     if (!upstream.getPartitionKeysList().isEmpty()) {
       out.printf("  partitions:   %s%n", String.join(", ", upstream.getPartitionKeysList()));
     }

--- a/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
+++ b/client-cli/src/test/java/ai/floedb/floecat/client/cli/IntegrationCliSupportTest.java
@@ -45,6 +45,8 @@ import ai.floedb.floecat.integration.rpc.ListUpstreamNamespacesResponse;
 import ai.floedb.floecat.integration.rpc.ListUpstreamObjectsRequest;
 import ai.floedb.floecat.integration.rpc.ListUpstreamObjectsResponse;
 import ai.floedb.floecat.integration.rpc.NamespacePath;
+import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayResponse;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationRequest;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationAuthenticationResponse;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogIntegrationRequest;
@@ -329,6 +331,18 @@ class IntegrationCliSupportTest {
     }
   }
 
+  @Test
+  void reconcilesOverlayByName() throws Exception {
+    try (Harness h = new Harness()) {
+      String output = h.run("overlay", List.of("reconcile", "sales", "--etag", "etag-1"));
+
+      assertEquals(OVERLAY_ID, h.overlays.lastReconcile.getOverlayId().getId());
+      assertEquals("etag-1", h.overlays.lastReconcile.getPrecondition().getExpectedEtag());
+      assertTrue(output.contains("namespaces_created: 1"));
+      assertTrue(output.contains("tables_created: 1"));
+    }
+  }
+
   private static ResourceId id(String id, ResourceKind kind) {
     return ResourceId.newBuilder().setAccountId("account").setId(id).setKind(kind).build();
   }
@@ -526,6 +540,7 @@ class IntegrationCliSupportTest {
     UpdateCatalogOverlayRequest lastUpdate;
     DeleteCatalogOverlayRequest lastDelete;
     int listCalls;
+    ReconcileCatalogOverlayRequest lastReconcile;
 
     @Override
     public void listCatalogOverlays(
@@ -571,6 +586,19 @@ class IntegrationCliSupportTest {
         StreamObserver<DeleteCatalogOverlayResponse> observer) {
       lastDelete = request;
       respond(observer, DeleteCatalogOverlayResponse.getDefaultInstance());
+    }
+
+    @Override
+    public void reconcileCatalogOverlay(
+        ReconcileCatalogOverlayRequest request,
+        StreamObserver<ReconcileCatalogOverlayResponse> observer) {
+      lastReconcile = request;
+      respond(
+          observer,
+          ReconcileCatalogOverlayResponse.newBuilder()
+              .setNamespacesCreated(1)
+              .setTablesCreated(1)
+              .build());
     }
   }
 

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogTable.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogTable.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.catalog.access;
 
 import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -25,6 +26,8 @@ public record CatalogTable(
     CatalogObjectName name,
     ExternalObjectIdentity identity,
     String format,
+    String schemaJson,
+    List<String> partitionKeys,
     Optional<String> metadataLocation,
     Optional<String> storageLocation,
     Map<String, String> properties) {
@@ -35,6 +38,11 @@ public record CatalogTable(
     if (format.isEmpty()) {
       throw new IllegalArgumentException("format must not be blank");
     }
+    schemaJson = Objects.requireNonNull(schemaJson, "schemaJson").trim();
+    if (schemaJson.isEmpty()) {
+      throw new IllegalArgumentException("schemaJson must not be blank");
+    }
+    partitionKeys = List.copyOf(Objects.requireNonNull(partitionKeys, "partitionKeys"));
     metadataLocation = Objects.requireNonNull(metadataLocation, "metadataLocation");
     storageLocation = Objects.requireNonNull(storageLocation, "storageLocation");
     properties = Map.copyOf(Objects.requireNonNull(properties, "properties"));

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogTable.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogTable.java
@@ -16,8 +16,8 @@
 
 package ai.floedb.floecat.catalog.access;
 
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/core/proto/src/main/proto/floecat/catalog/table.proto
+++ b/core/proto/src/main/proto/floecat/catalog/table.proto
@@ -46,6 +46,11 @@ message UpstreamRef {
   TableFormat format = 5;
   repeated string partition_keys = 6;
   ColumnIdAlgorithm column_id_algorithm = 7;
+  // Set for tables materialized through Catalog Integration reconciliation. Connector and
+  // integration identities are mutually exclusive.
+  optional ai.floedb.floecat.common.ResourceId catalog_integration_id = 8;
+  // Identifies the overlay whose owned catalog contains this materialization.
+  optional ai.floedb.floecat.common.ResourceId catalog_overlay_id = 9;
 }
 
 message Table {

--- a/core/proto/src/main/proto/floecat/catalog/table.proto
+++ b/core/proto/src/main/proto/floecat/catalog/table.proto
@@ -49,7 +49,7 @@ message UpstreamRef {
   // Set for tables materialized through Catalog Integration reconciliation. Connector and
   // integration identities are mutually exclusive.
   optional ai.floedb.floecat.common.ResourceId catalog_integration_id = 8;
-  // Identifies the overlay whose owned catalog contains this materialization.
+  // Identifies the overlay that manages this materialization.
   optional ai.floedb.floecat.common.ResourceId catalog_overlay_id = 9;
 }
 

--- a/core/proto/src/main/proto/floecat/integration/catalog_overlay.proto
+++ b/core/proto/src/main/proto/floecat/integration/catalog_overlay.proto
@@ -118,10 +118,31 @@ message DeleteCatalogOverlayResponse {
   ai.floedb.floecat.common.MutationMeta meta = 1;
 }
 
+// Runs one synchronous metadata reconciliation for an overlay. This materializes the selected
+// upstream namespace, table, and view inventory into the catalog owned by the overlay. Snapshot
+// and file capture are handled by the durable reconciliation layer in a later stack change.
+message ReconcileCatalogOverlayRequest {
+  ai.floedb.floecat.common.ResourceId overlay_id = 1;
+  ai.floedb.floecat.common.Precondition precondition = 2;
+}
+
+message ReconcileCatalogOverlayResponse {
+  ai.floedb.floecat.common.MutationMeta meta = 1;
+  uint32 namespaces_created = 2;
+  uint32 namespaces_deleted = 3;
+  uint32 tables_created = 4;
+  uint32 tables_updated = 5;
+  uint32 tables_deleted = 6;
+  uint32 views_created = 7;
+  uint32 views_updated = 8;
+  uint32 views_deleted = 9;
+}
+
 service CatalogOverlays {
   rpc GetCatalogOverlay(GetCatalogOverlayRequest) returns (GetCatalogOverlayResponse);
   rpc ListCatalogOverlays(ListCatalogOverlaysRequest) returns (ListCatalogOverlaysResponse);
   rpc CreateCatalogOverlay(CreateCatalogOverlayRequest) returns (CreateCatalogOverlayResponse);
   rpc UpdateCatalogOverlay(UpdateCatalogOverlayRequest) returns (UpdateCatalogOverlayResponse);
   rpc DeleteCatalogOverlay(DeleteCatalogOverlayRequest) returns (DeleteCatalogOverlayResponse);
+  rpc ReconcileCatalogOverlay(ReconcileCatalogOverlayRequest) returns (ReconcileCatalogOverlayResponse);
 }

--- a/docs/catalog-access-spi.md
+++ b/docs/catalog-access-spi.md
@@ -122,8 +122,11 @@ result.
 
 Discovery results are not persisted and do not materialize Floecat resources. Pagination is applied
 to deterministic provider inventories and continuation tokens are bound to the Integration pointer
-and credential generation, namespace, and object filter. Scheduling, reconciliation, and captured
-resource writes remain separate changes.
+and credential generation, namespace, and object filter.
+
+The synchronous Catalog Overlay reconciliation RPC uses the same Integration adapter to materialize
+selected namespaces, table definitions, and views as ordinary Floecat resources. Durable scheduling
+and snapshot/file capture remain separate changes.
 
 The legacy Connector remains operational and unchanged until its explicit migration/removal change.
 The Integration adapter and discovery implementation do not import, call, or fall back to it.

--- a/docs/catalog-integrations.md
+++ b/docs/catalog-integrations.md
@@ -55,6 +55,7 @@ overlay create sales-overlay lakehouse local-catalog --include prod.sales,prod.r
 integration validate lakehouse
 integration namespaces lakehouse
 integration objects lakehouse prod.sales --kinds table,view
+overlay reconcile sales-overlay
 ```
 
 The overlay command accepts either a resource ID or display name for the integration.
@@ -80,8 +81,17 @@ overlay list [--integration <name|id>]
 overlay get <name|id>
 overlay create <name> <integration-name|id> <catalog-name|id> [options]
 overlay update <name|id> [options]
+overlay reconcile <name|id> [--etag <etag>]
 overlay delete <name|id>
 ```
+
+Run only the real-Polaris Integration validation and Overlay reconciliation smoke scenario with:
+
+```text
+COMPOSE_SMOKE_MODES=polaris-integration make compose-smoke
+```
+
+This mode does not create or trigger a legacy Connector resource.
 
 Authentication types and their properties are:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -101,6 +101,7 @@ overlay create <name> <integration-name|id> <catalog-name|id>
     [--include ns[,ns...]] [--exclude ns[,ns...]]
 overlay update <name|id> [--display <name>]
     [--include ns[,ns...]] [--exclude ns[,ns...]] [--etag <etag>]
+overlay reconcile <name|id> [--etag <etag>]
 overlay delete <name|id> [--etag <etag>]
 
 connectors

--- a/docs/client-cli.md
+++ b/docs/client-cli.md
@@ -93,9 +93,8 @@ User command → Picocli parser → Shell subcommand → gRPC stub call
 Commands run synchronously inside the REPL thread; long-running operations (for example connector
 reconciliation) show job IDs that can be polled via `connector job <id>`.
 
-Integration validation and discovery connect directly through the catalog-access SPI. Overlay
-records remain configuration-only at this stack stage; they do not reconcile metadata or affect
-query execution.
+Integration validation connects directly through the catalog-access SPI. Overlay reconciliation
+materializes selected upstream metadata without creating or invoking a legacy Connector resource.
 To exercise the resource model from the Shell, create an integration and overlay:
 
 ```text
@@ -105,9 +104,8 @@ overlay create sales-overlay lakehouse local-catalog --include prod.sales
 integration validate lakehouse
 integration namespaces lakehouse
 integration objects lakehouse prod.sales --kinds table,view
+overlay reconcile sales-overlay
 ```
-
-Legacy connector commands remain the operational path for external catalog connectivity.
 
 `connector jobs` shows a parent-job summary table by default. Use
 `connector jobs --child <parent-job-id>` to render the descendant job tree rooted at that job.

--- a/docs/fixed-roles.md
+++ b/docs/fixed-roles.md
@@ -9,13 +9,13 @@ Source of truth: `service/src/main/java/ai/floedb/floecat/service/security/RoleP
 | Role name | Purpose | Granted permissions |
 |-----------|---------|---------------------|
 | `default` | Baseline read-only tenant access. Used when no roles are provided in normal (`oidc`) mode. | `account.read`, `catalog.read`, `namespace.read`, `table.read`, `view.read`, `catalog-integration.read`, `catalog-overlay.read` |
-| `administrator` | Full tenant-scoped administration of metadata, catalog integrations, catalog overlays, and legacy connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write`, `system-objects.read`, `account.delete` |
-| `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write`, `system-objects.read`, `account.delete` |
+| `administrator` | Full tenant-scoped administration of metadata, catalog integrations, catalog overlays, and legacy connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write`, `catalog-overlay.reconcile`, `catalog-overlay.delete`, `system-objects.read`, `account.delete` |
+| `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write`, `catalog-overlay.reconcile`, `catalog-overlay.delete`, `system-objects.read`, `account.delete` |
 | `platform-admin` (or configured value of `floecat.auth.platform-admin.role`) | Platform-level account management role from IdP. | `account.read`, `account.write`, `account.delete` |
 | `init-account` | Bootstrap role used to initialize account + initial resources. | `account.read`, `account.write`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `connector.create`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write` |
 | `delete-account` | Narrow internal role used to trigger account teardown. Floecat performs the implied cleanup internally. | `account.delete` |
 | `system-objects` | Minimal role for SystemObjects/GetSystemObjects access. | `system-objects.read` |
-| `reconcile-worker` | Dedicated machine principal for reconciler background gRPC work. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.use`, `catalog-overlay.read`, `system-objects.read`, `storage-authority.resolve-internal`, `reconcile-executor-control.internal` |
+| `reconcile-worker` | Dedicated machine principal for reconciler background gRPC work. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.reconcile`, `system-objects.read`, `storage-authority.resolve-internal`, `reconcile-executor-control.internal` |
 
 ## Behavior Notes
 
@@ -30,8 +30,13 @@ Source of truth: `service/src/main/java/ai/floedb/floecat/service/security/RoleP
   separate from broad catalog/table/connector management permissions.
 - `catalog-integration.write` administers integration records, while `catalog-integration.use`
   permits an integration to be bound to an overlay without granting integration-management
-  authority. Cascading integration deletion additionally requires `catalog-overlay.write` because
+  authority. Cascading integration deletion additionally requires `catalog-overlay.delete` because
   it deletes the dependent overlay resources.
 - `catalog-overlay.write` administers overlay records. Creating an overlay additionally requires
   `catalog-integration.use` and `catalog.write`, because it binds an integration to an existing
-  writable target Catalog. Renaming or deleting an overlay does not rename or delete that Catalog.
+  writable target Catalog. Renaming an overlay does not rename that Catalog.
+- `catalog-overlay.reconcile` authorizes materializing upstream metadata into an overlay and also
+  requires `catalog-integration.use`. It is not implied by `catalog-overlay.write` or the
+  namespace/table/view write permissions.
+- `catalog-overlay.delete` authorizes deletion of an overlay and its managed contributions. It does
+  not delete the target Catalog and is not implied by `catalog-overlay.write`.

--- a/docs/service.md
+++ b/docs/service.md
@@ -116,7 +116,7 @@ helpers like `randomResourceId` (UUIDv4). Highlights:
   Get accepts either resource ID or
   exact display name. Reads require
   `catalog-integration.read`; writes require `catalog-integration.write`, and cascading deletion of
-  dependent overlays also requires `catalog-overlay.write`.
+  dependent overlays also requires `catalog-overlay.delete`.
 - **CatalogOverlaysImpl** – Binds an integration and optional upstream namespace filters to an
   existing Catalog. The Catalog remains independently named, writable, and managed, and multiple
   overlays may target it. Creating an overlay atomically publishes Integration and Catalog
@@ -129,9 +129,12 @@ helpers like `randomResourceId` (UUIDv4). Highlights:
   selects all namespaces; paths select subtrees, exclusions
   take precedence, and matching is case-sensitive. The Integration and Catalog bindings are immutable through
   update; updates only replace the selected include/exclude lists or rename the overlay. Reads require
-  `catalog-overlay.read`; writes require `catalog-overlay.write`, and creation also requires
-  `catalog-integration.use`. Connectivity and
-  reconciliation are deferred.
+  `catalog-overlay.read`; create and update require `catalog-overlay.write`, and creation also
+  requires `catalog-integration.use` and `catalog.write`.
+  Reconciliation requires `catalog-overlay.reconcile` plus `catalog-integration.use`; deletion
+  requires `catalog-overlay.delete`. These dedicated permissions are not
+  inferred from `catalog-overlay.write` or namespace/table/view permissions. Connectivity is
+  deferred.
 - **ConnectorsImpl** – Manages connector lifecycle, validates `ConnectorSpec` via SPI factories,
   wires reconciliation job submission, and exposes `ValidateConnector` + `StartCapture`.
   `CaptureNow` maps to reconciler capture modes:

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootMutations.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootMutations.java
@@ -136,6 +136,25 @@ public final class TableRootMutations {
             .build();
   }
 
+  /** Replaces a stale definition publication without disturbing any other root state. */
+  public static TableRootCommitter.RootMutator replaceDefinitionIfMatches(
+      BlobRef expectedDefinitionRef, BlobRef replacementDefinitionRef) {
+    return current -> {
+      if (current.isEmpty()
+          || !current.get().hasDefinitionRef()
+          || !current.get().getDefinitionRef().equals(expectedDefinitionRef)) {
+        return null;
+      }
+      TableRoot.Builder replacement = current.get().toBuilder();
+      if (replacementDefinitionRef == null || replacementDefinitionRef.getUri().isEmpty()) {
+        replacement.clearDefinitionRef();
+      } else {
+        replacement.setDefinitionRef(replacementDefinitionRef);
+      }
+      return replacement.build();
+    };
+  }
+
   /**
    * Sets the stats-generation ref on an existing snapshot's entry — the generation publish, which
    * is also the snapshot's VISIBILITY commit: a non-null ref finalizes the snapshot, so the same

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
@@ -20,6 +20,7 @@ import ai.floedb.floecat.catalog.rpc.BlobRef;
 import ai.floedb.floecat.catalog.rpc.CurrentSnapshotPointer;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotManifestEntry;
+import ai.floedb.floecat.catalog.rpc.TableRoot;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.service.repo.impl.ConstraintRepository;
@@ -152,11 +153,17 @@ public class TableRootWriter {
 
   /** Records the table's (possibly new) immutable definition blob on the root. */
   public void commitDefinition(ResourceId tableId, MutationMeta meta) {
+    commitDefinitionReturningRoot(tableId, meta);
+  }
+
+  /** Records the definition and returns the root observed or committed by this invocation. */
+  public java.util.Optional<TableRoot> commitDefinitionReturningRoot(
+      ResourceId tableId, MutationMeta meta) {
     BlobRef definitionRef = BlobRefs.refFrom(meta);
     if (definitionRef == null) {
-      return;
+      return java.util.Optional.empty();
     }
-    committer.commit(tableId, TableRootMutations.setDefinition(tableId, definitionRef));
+    return committer.commit(tableId, TableRootMutations.setDefinition(tableId, definitionRef));
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
@@ -20,7 +20,6 @@ import ai.floedb.floecat.catalog.rpc.BlobRef;
 import ai.floedb.floecat.catalog.rpc.CurrentSnapshotPointer;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotManifestEntry;
-import ai.floedb.floecat.catalog.rpc.TableRoot;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.service.repo.impl.ConstraintRepository;
@@ -153,17 +152,24 @@ public class TableRootWriter {
 
   /** Records the table's (possibly new) immutable definition blob on the root. */
   public void commitDefinition(ResourceId tableId, MutationMeta meta) {
-    commitDefinitionReturningRoot(tableId, meta);
-  }
-
-  /** Records the definition and returns the root observed or committed by this invocation. */
-  public java.util.Optional<TableRoot> commitDefinitionReturningRoot(
-      ResourceId tableId, MutationMeta meta) {
     BlobRef definitionRef = BlobRefs.refFrom(meta);
     if (definitionRef == null) {
-      return java.util.Optional.empty();
+      return;
     }
-    return committer.commit(tableId, TableRootMutations.setDefinition(tableId, definitionRef));
+    committer.commit(tableId, TableRootMutations.setDefinition(tableId, definitionRef));
+  }
+
+  /** Restores the current table definition only when the root still publishes a stale revision. */
+  public void replaceDefinitionIfMatches(
+      ResourceId tableId, MutationMeta staleDefinition, MutationMeta currentDefinition) {
+    BlobRef staleRef = BlobRefs.refFrom(staleDefinition);
+    if (staleRef == null) {
+      return;
+    }
+    committer.commit(
+        tableId,
+        TableRootMutations.replaceDefinitionIfMatches(
+            staleRef, BlobRefs.refFrom(currentDefinition)));
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
@@ -97,6 +97,8 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
           "namespace_id",
           "upstream",
           "upstream.connector_id",
+          "upstream.catalog_integration_id",
+          "upstream.catalog_overlay_id",
           "upstream.uri",
           "upstream.namespace_path",
           "upstream.table_display_name",
@@ -648,6 +650,32 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
         }
       }
 
+      if (maskTargets(mask, "upstream.catalog_integration_id")) {
+        if (inUp.hasCatalogIntegrationId()) {
+          ensureKind(
+              inUp.getCatalogIntegrationId(),
+              ResourceKind.RK_CATALOG_INTEGRATION,
+              "spec.upstream.catalog_integration_id",
+              corr);
+          ub.setCatalogIntegrationId(inUp.getCatalogIntegrationId());
+        } else {
+          ub.clearCatalogIntegrationId();
+        }
+      }
+
+      if (maskTargets(mask, "upstream.catalog_overlay_id")) {
+        if (inUp.hasCatalogOverlayId()) {
+          ensureKind(
+              inUp.getCatalogOverlayId(),
+              ResourceKind.RK_CATALOG_OVERLAY,
+              "spec.upstream.catalog_overlay_id",
+              corr);
+          ub.setCatalogOverlayId(inUp.getCatalogOverlayId());
+        } else {
+          ub.clearCatalogOverlayId();
+        }
+      }
+
       if (maskTargets(mask, "upstream.uri")) {
         ub.setUri(inUp.getUri());
       }
@@ -741,6 +769,27 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
       ensureKind(
           up.getConnectorId(), ResourceKind.RK_CONNECTOR, "spec.upstream.connector_id", corr);
     }
+    if (up.hasCatalogIntegrationId()) {
+      ensureKind(
+          up.getCatalogIntegrationId(),
+          ResourceKind.RK_CATALOG_INTEGRATION,
+          "spec.upstream.catalog_integration_id",
+          corr);
+    }
+    if (up.hasCatalogOverlayId()) {
+      ensureKind(
+          up.getCatalogOverlayId(),
+          ResourceKind.RK_CATALOG_OVERLAY,
+          "spec.upstream.catalog_overlay_id",
+          corr);
+      if (!up.hasCatalogIntegrationId()) {
+        throw GrpcErrors.invalidArgument(
+            corr, null, Map.of("field", "spec.upstream.catalog_integration_id"));
+      }
+    }
+    if (up.hasConnectorId() && up.hasCatalogIntegrationId()) {
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "spec.upstream"));
+    }
 
     if (up.getNamespacePathCount() > 0) {
       for (var seg : up.getNamespacePathList()) {
@@ -788,6 +837,8 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
           "upstream",
           g ->
               g.scalar("connector_id", nullSafeId(up.getConnectorId()))
+                  .scalar("catalog_integration_id", nullSafeId(up.getCatalogIntegrationId()))
+                  .scalar("catalog_overlay_id", nullSafeId(up.getCatalogOverlayId()))
                   .scalar("uri", up.getUri())
                   .list("namespace_path", up.getNamespacePathList())
                   .scalar("table_display_name", up.getTableDisplayName())

--- a/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
@@ -628,7 +628,7 @@ public abstract class BaseServiceImpl {
     return (rid == null) ? "" : rid.getId();
   }
 
-  protected static String normalizeName(String in) {
+  public static String normalizeName(String in) {
     if (in == null) {
       return "";
     }

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -95,6 +95,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
   @Inject CatalogIntegrationCredentialStore credentialStore;
   @Inject CatalogIntegrationCredentialCleanup credentialCleanup;
   @Inject CatalogIntegrationDiscovery discovery;
+  @Inject CatalogOverlayReconciler overlayReconciler;
 
   @Override
   public Uni<ListCatalogIntegrationsResponse> listCatalogIntegrations(
@@ -837,6 +838,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
           throw new BaseResourceRepository.AbortRetryableException(
               "overlay changed while integration cascade deletion was fenced");
         }
+        overlayReconciler.retireMaterializedResources(dependent.value());
         long overlayFenceVersion = overlays.deletionFenceVersion(overlayId);
         if (overlayFenceVersion == 0L
             || !overlays.deleteWithFence(

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -760,8 +760,9 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                 () -> {
                   var pc = principal.get();
                   authz.require(pc, RolePermissions.CATALOG_INTEGRATION_WRITE);
-                  if (request.getCascade())
-                    authz.require(pc, RolePermissions.CATALOG_OVERLAY_WRITE);
+                  if (request.getCascade()) {
+                    authz.require(pc, RolePermissions.CATALOG_OVERLAY_DELETE);
+                  }
                   String corr = pc.getCorrelationId();
                   ResourceId id = scopedId(pc.getAccountId(), request.getIntegrationId());
                   var current = integrations.getByIdWithMeta(id);
@@ -973,19 +974,25 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
       throw GrpcErrors.invalidArgument(
           corr, FIELD, Map.of("field", "authentication.configuration"));
     }
+    CatalogAuthentication normalizedRequested = requested;
 
     switch (configuration) {
       case OAUTH_CLIENT_CREDENTIALS -> {
         var config = requested.getOauthClientCredentials();
-        requireNonBlank(config.getClientId(), "authentication.client_id", corr);
+        String clientId = normalizeNonBlank(config.getClientId(), "authentication.client_id", corr);
         if (config.hasTokenUri()) validateCatalogUri(config.getTokenUri(), corr);
         var scopes = new LinkedHashSet<String>();
         for (String scope : config.getScopesList()) {
-          scopes.add(requireNonBlank(scope, "authentication.scopes", corr));
+          scopes.add(normalizeNonBlank(scope, "authentication.scopes", corr));
         }
         if (scopes.size() != config.getScopesCount()) {
           throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "authentication.scopes"));
         }
+        normalizedRequested =
+            requested.toBuilder()
+                .setOauthClientCredentials(
+                    config.toBuilder().setClientId(clientId).clearScopes().addAllScopes(scopes))
+                .build();
         requireCredentialCase(
             credential, CatalogIntegrationCredentials.CredentialCase.OAUTH_CLIENT_SECRET, corr);
         requireNonBlank(credentials.getOauthClientSecret().getValue(), "credentials", corr);
@@ -1043,7 +1050,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
     boolean storesCredentials =
         credential != CatalogIntegrationCredentials.CredentialCase.CREDENTIAL_NOT_SET;
     var persisted =
-        requested.toBuilder()
+        normalizedRequested.toBuilder()
             .setCredentialsConfigured(storesCredentials)
             .setCredentialGeneration(storesCredentials ? generation : 0L);
     return new PreparedAuthentication(persisted.build(), credentials);
@@ -1080,10 +1087,14 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
     throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", "credentials"));
   }
 
-  private static String requireNonBlank(String value, String field, String corr) {
+  private static void requireNonBlank(String value, String field, String corr) {
     if (value == null || value.isBlank()) {
       throw GrpcErrors.invalidArgument(corr, FIELD, Map.of("field", field));
     }
+  }
+
+  private static String normalizeNonBlank(String value, String field, String corr) {
+    requireNonBlank(value, field, corr);
     return value.trim();
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
@@ -1,0 +1,793 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.integration;
+
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.CatalogTable;
+import ai.floedb.floecat.catalog.access.CatalogView;
+import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
+import ai.floedb.floecat.catalog.rpc.Namespace;
+import ai.floedb.floecat.catalog.rpc.Table;
+import ai.floedb.floecat.catalog.rpc.TableFormat;
+import ai.floedb.floecat.catalog.rpc.TableRoot;
+import ai.floedb.floecat.catalog.rpc.UpstreamRef;
+import ai.floedb.floecat.catalog.rpc.View;
+import ai.floedb.floecat.catalog.rpc.ViewSqlDefinition;
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.common.resolver.IcebergSchemaMapper;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
+import ai.floedb.floecat.service.catalog.impl.TableRootWriter;
+import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
+import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.repo.impl.TableRootRepository;
+import ai.floedb.floecat.service.repo.impl.ViewRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.PointerConditions;
+import ai.floedb.floecat.service.repo.util.MarkerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import com.google.protobuf.util.Timestamps;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Clock;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/** Materializes one Catalog Overlay's selected upstream metadata into its target catalog. */
+@ApplicationScoped
+public class CatalogOverlayReconciler {
+  static final String OVERLAY_ID_PROPERTY = "floecat.catalog-overlay.id";
+  static final String INTEGRATION_ID_PROPERTY = "floecat.catalog-integration.id";
+  static final String EXTERNAL_ID_PROPERTY = "floecat.external-object.id";
+  static final String EXTERNAL_ID_STABLE_PROPERTY = "floecat.external-object.identity-stable";
+  static final String METADATA_LOCATION_PROPERTY = "metadata_location";
+  static final String STORAGE_LOCATION_PROPERTY = "storage_location";
+  private static final int MAX_NAMESPACES = 100_000;
+
+  @Inject CatalogIntegrationAccess access;
+  @Inject CatalogIntegrationRepository integrations;
+  @Inject CatalogOverlayRepository overlays;
+  @Inject NamespaceRepository namespaces;
+  @Inject TableRepository tables;
+  @Inject ViewRepository views;
+  @Inject PointerStore pointerStore;
+  @Inject TableRootRepository tableRoots;
+  @Inject TableRootWriter rootWriter;
+  @Inject MarkerStore markerStore;
+  @Inject UserGraph metadataGraph;
+  @Inject TopologyGraph topology;
+
+  Clock clock = Clock.systemUTC();
+
+  public Result reconcile(
+      CatalogOverlay overlay,
+      MutationMeta overlayMeta,
+      CatalogIntegration integration,
+      MutationMeta integrationMeta) {
+    requireBinding(overlay, integration);
+    PointerConditions fence = fence(overlay, overlayMeta, integration, integrationMeta);
+    Discovery discovery;
+    try (CatalogClient client = access.open(integration)) {
+      client.validate();
+      discovery = discover(client, overlay);
+    }
+
+    var result = new MutableResult();
+    Map<NamespacePath, Namespace> localNamespaces =
+        reconcileNamespaces(overlay, integration, fence, discovery.materializedNamespaces(), result);
+    reconcileTables(
+        overlay,
+        overlayMeta,
+        integration,
+        integrationMeta,
+        fence,
+        discovery.tables(),
+        localNamespaces,
+        result);
+    reconcileViews(overlay, integration, fence, discovery.views(), localNamespaces, result);
+    retireNamespaces(
+        overlay, fence, discovery.materializedNamespaces(), localNamespaces, result);
+    assertFence(overlay, overlayMeta, integration, integrationMeta);
+    return result.freeze();
+  }
+
+  /** Removes every materialized descendant after the overlay deletion fence is installed. */
+  public void retireMaterializedResources(CatalogOverlay overlay) {
+    ResourceId catalogId = overlay.getCatalogId();
+    List<Namespace> catalogNamespaces = new ArrayList<>();
+    for (ResourceId namespaceId :
+        namespaces.listIdsConsistent(catalogId.getAccountId(), catalogId.getId())) {
+      namespaces.getById(namespaceId).ifPresent(catalogNamespaces::add);
+    }
+    catalogNamespaces.sort(
+        Comparator.comparingInt((Namespace namespace) -> path(namespace).segments().size())
+            .reversed());
+    for (Namespace namespace : catalogNamespaces) {
+      for (Table table : listTables(namespace)) {
+        if (!ownedBy(table.getPropertiesMap(), overlay)) continue;
+        if (!tables.delete(table.getResourceId()) && tables.getById(table.getResourceId()).isPresent()) {
+          throw new BaseResourceRepository.AbortRetryableException(
+              "Table changed during Catalog Overlay retirement");
+        }
+        purgeTableState(table.getResourceId());
+        relationChanged(table.getResourceId(), namespace.getResourceId());
+      }
+      for (View view : listViews(namespace)) {
+        if (!ownedBy(view.getPropertiesMap(), overlay)) continue;
+        if (!views.delete(view.getResourceId()) && views.getById(view.getResourceId()).isPresent()) {
+          throw new BaseResourceRepository.AbortRetryableException(
+              "View changed during Catalog Overlay retirement");
+        }
+        relationChanged(view.getResourceId(), namespace.getResourceId());
+      }
+      if (!ownedBy(namespace.getPropertiesMap(), overlay)
+          || !listTables(namespace).isEmpty()
+          || !listViews(namespace).isEmpty()) continue;
+      if (!namespaces.delete(namespace.getResourceId())
+          && namespaces.getById(namespace.getResourceId()).isPresent()) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "Namespace changed during Catalog Overlay retirement");
+      }
+      markerStore.bumpCatalogMarker(catalogId);
+      metadataGraph.invalidate(namespace.getResourceId());
+      topology.evictNamespaceRefs(catalogId);
+    }
+  }
+
+  private Discovery discover(CatalogClient client, CatalogOverlay overlay) {
+    var capabilities = client.capabilities();
+    for (CatalogCapability required :
+        List.of(
+            CatalogCapability.LIST_NAMESPACES,
+            CatalogCapability.LIST_TABLES,
+            CatalogCapability.LOAD_TABLE)) {
+      if (!capabilities.supports(required)) {
+        throw new UnsupportedOperationException(
+            "Catalog provider does not support required capability=" + required);
+      }
+    }
+    boolean listViews = capabilities.supports(CatalogCapability.LIST_VIEWS);
+    boolean loadViews = capabilities.supports(CatalogCapability.LOAD_VIEW);
+    if (listViews != loadViews) {
+      throw new IllegalStateException(
+          "Catalog provider must advertise LIST_VIEWS and LOAD_VIEW together");
+    }
+    Set<NamespacePath> materialized = new LinkedHashSet<>();
+    Map<CatalogObjectName, CatalogTable> discoveredTables = new LinkedHashMap<>();
+    Map<CatalogObjectName, CatalogView> discoveredViews = new LinkedHashMap<>();
+    Set<NamespacePath> seen = new HashSet<>();
+    var pending = new ArrayDeque<NamespacePath>();
+    pending.add(NamespacePath.root());
+    while (!pending.isEmpty()) {
+      NamespacePath parent = pending.removeFirst();
+      for (NamespacePath path : client.listNamespaces(parent).stream().sorted().toList()) {
+        if (!seen.add(path)) continue;
+        if (seen.size() > MAX_NAMESPACES) {
+          throw new IllegalStateException("Catalog namespace inventory exceeds " + MAX_NAMESPACES);
+        }
+        if (excluded(overlay, path)) continue;
+        if (selected(overlay, path)) {
+          addAncestors(path, materialized);
+          for (CatalogObjectName name : client.listTables(path).stream().sorted().toList()) {
+            CatalogTable table = client.loadTable(name);
+            if (!name.equals(table.name())) {
+              throw new IllegalStateException(
+                  "Catalog provider returned table metadata for the wrong object: expected="
+                      + name
+                      + " actual="
+                      + table.name());
+            }
+            discoveredTables.put(name, table);
+          }
+          if (listViews) {
+            for (CatalogObjectName name : client.listViews(path).stream().sorted().toList()) {
+              if (discoveredTables.containsKey(name)) {
+                throw new IllegalStateException(
+                    "Upstream relation name is both table and view: " + name);
+              }
+              CatalogView view = client.loadView(name);
+              if (!name.equals(view.name())) {
+                throw new IllegalStateException(
+                    "Catalog provider returned view metadata for the wrong object: expected="
+                        + name
+                        + " actual="
+                        + view.name());
+              }
+              discoveredViews.put(name, view);
+            }
+          }
+        }
+        if (mayContainSelection(overlay, path)) pending.addLast(path);
+      }
+    }
+    requireUniqueStableIdentities(
+        discoveredTables.values().stream().map(CatalogTable::identity).toList(), "table");
+    requireUniqueStableIdentities(
+        discoveredViews.values().stream().map(CatalogView::identity).toList(), "view");
+    return new Discovery(
+        Set.copyOf(materialized), Map.copyOf(discoveredTables), Map.copyOf(discoveredViews));
+  }
+
+  private Map<NamespacePath, Namespace> reconcileNamespaces(
+      CatalogOverlay overlay,
+      CatalogIntegration integration,
+      PointerConditions fence,
+      Set<NamespacePath> targetPaths,
+      MutableResult result) {
+    ResourceId catalogId = overlay.getCatalogId();
+    Map<NamespacePath, Namespace> current = new HashMap<>();
+    for (ResourceId namespaceId :
+        namespaces.listIdsConsistent(catalogId.getAccountId(), catalogId.getId())) {
+      namespaces.getById(namespaceId).ifPresent(value -> current.put(path(value), value));
+    }
+    for (NamespacePath path : targetPaths.stream().sorted().toList()) {
+      if (current.containsKey(path)) continue;
+      List<String> segments = path.segments();
+      Namespace created =
+          Namespace.newBuilder()
+              .setResourceId(randomId(catalogId.getAccountId(), ResourceKind.RK_NAMESPACE))
+              .setDisplayName(segments.get(segments.size() - 1))
+              .addAllParents(segments.subList(0, segments.size() - 1))
+              .setCatalogId(catalogId)
+              .setCreatedAt(now())
+              .putAllProperties(ownershipProperties(overlay, integration))
+              .build();
+      if (!namespaces.createWhilePointersMatch(created, fence)) lostFence();
+      markerStore.bumpCatalogMarker(catalogId);
+      metadataGraph.invalidate(created.getResourceId());
+      topology.evictNamespaceRefs(catalogId);
+      current.put(path, created);
+      result.namespacesCreated++;
+    }
+    return current;
+  }
+
+  private void reconcileTables(
+      CatalogOverlay overlay,
+      MutationMeta overlayMeta,
+      CatalogIntegration integration,
+      MutationMeta integrationMeta,
+      PointerConditions fence,
+      Map<CatalogObjectName, CatalogTable> discovered,
+      Map<NamespacePath, Namespace> localNamespaces,
+      MutableResult result) {
+    Map<String, Table> existingByIdentity = new HashMap<>();
+    Map<CatalogObjectName, Table> existingByName = new HashMap<>();
+    for (Namespace namespace : localNamespaces.values()) {
+      for (Table table : listTables(namespace)) {
+        if (!ownedBy(table.getPropertiesMap(), overlay)) continue;
+        existingByName.put(new CatalogObjectName(path(namespace), table.getDisplayName()), table);
+        stableIdentity(table.getPropertiesMap()).ifPresent(id -> existingByIdentity.put(id, table));
+      }
+    }
+
+    Set<String> retainedIds = new HashSet<>();
+    for (var entry : discovered.entrySet()) {
+      CatalogObjectName name = entry.getKey();
+      CatalogTable source = entry.getValue();
+      Namespace namespace = requireNamespace(localNamespaces, name.namespace());
+      Table current =
+          source.identity().stable()
+              ? existingByIdentity.get(source.identity().value())
+              : existingByName.get(name);
+      Table desired = tableFor(overlay, integration, namespace, source, current);
+      boolean changed = false;
+      MutationMeta definitionMeta;
+      if (current == null) {
+        definitionMeta =
+            tables.createWhilePointersMatch(desired, fence).orElseThrow(CatalogOverlayReconciler::lostFence);
+        result.tablesCreated++;
+        changed = true;
+      } else if (!current.equals(desired)) {
+        MutationMeta meta = tables.metaFor(current.getResourceId());
+        definitionMeta =
+            tables
+                .updateWhilePointersMatch(desired, meta.getPointerVersion(), fence)
+                .orElseThrow(CatalogOverlayReconciler::lostFence);
+        result.tablesUpdated++;
+        changed = true;
+      } else {
+        definitionMeta = tables.metaFor(current.getResourceId());
+      }
+      commitDefinitionWhileFenced(
+          desired.getResourceId(), definitionMeta, overlay, overlayMeta, integration, integrationMeta);
+      retainedIds.add(desired.getResourceId().getId());
+      if (changed) {
+        relationChanged(desired.getResourceId(), desired.getNamespaceId());
+        if (current != null && !current.getNamespaceId().equals(desired.getNamespaceId())) {
+          relationChanged(desired.getResourceId(), current.getNamespaceId());
+        }
+      }
+    }
+
+    for (Table stale : existingByName.values()) {
+      if (retainedIds.contains(stale.getResourceId().getId())) continue;
+      MutationMeta meta = tables.metaFor(stale.getResourceId());
+      if (!tables.deleteWhilePointersMatch(stale.getResourceId(), meta.getPointerVersion(), fence)) {
+        lostFence();
+      }
+      purgeTableState(stale.getResourceId());
+      relationChanged(stale.getResourceId(), stale.getNamespaceId());
+      result.tablesDeleted++;
+    }
+  }
+
+  private void reconcileViews(
+      CatalogOverlay overlay,
+      CatalogIntegration integration,
+      PointerConditions fence,
+      Map<CatalogObjectName, CatalogView> discovered,
+      Map<NamespacePath, Namespace> localNamespaces,
+      MutableResult result) {
+    Map<String, View> existingByIdentity = new HashMap<>();
+    Map<CatalogObjectName, View> existingByName = new HashMap<>();
+    for (Namespace namespace : localNamespaces.values()) {
+      for (View view : listViews(namespace)) {
+        if (!ownedBy(view.getPropertiesMap(), overlay)) continue;
+        existingByName.put(new CatalogObjectName(path(namespace), view.getDisplayName()), view);
+        stableIdentity(view.getPropertiesMap()).ifPresent(id -> existingByIdentity.put(id, view));
+      }
+    }
+
+    Set<String> retainedIds = new HashSet<>();
+    for (var entry : discovered.entrySet()) {
+      CatalogObjectName name = entry.getKey();
+      CatalogView source = entry.getValue();
+      Namespace namespace = requireNamespace(localNamespaces, name.namespace());
+      View current =
+          source.identity().stable()
+              ? existingByIdentity.get(source.identity().value())
+              : existingByName.get(name);
+      View desired = viewFor(overlay, integration, namespace, source, current);
+      boolean changed = false;
+      if (current == null) {
+        if (!views.createWhilePointersMatch(desired, fence)) lostFence();
+        result.viewsCreated++;
+        changed = true;
+      } else if (!current.equals(desired)) {
+        MutationMeta meta = views.metaFor(current.getResourceId());
+        if (views
+            .updateWhilePointersMatch(desired, meta.getPointerVersion(), fence)
+            .isEmpty()) lostFence();
+        result.viewsUpdated++;
+        changed = true;
+      }
+      retainedIds.add(desired.getResourceId().getId());
+      if (changed) {
+        relationChanged(desired.getResourceId(), desired.getNamespaceId());
+        if (current != null && !current.getNamespaceId().equals(desired.getNamespaceId())) {
+          relationChanged(desired.getResourceId(), current.getNamespaceId());
+        }
+      }
+    }
+
+    for (View stale : existingByName.values()) {
+      if (retainedIds.contains(stale.getResourceId().getId())) continue;
+      MutationMeta meta = views.metaFor(stale.getResourceId());
+      if (!views.deleteWhilePointersMatch(stale.getResourceId(), meta.getPointerVersion(), fence)) {
+        lostFence();
+      }
+      relationChanged(stale.getResourceId(), stale.getNamespaceId());
+      result.viewsDeleted++;
+    }
+  }
+
+  private void retireNamespaces(
+      CatalogOverlay overlay,
+      PointerConditions fence,
+      Set<NamespacePath> targetPaths,
+      Map<NamespacePath, Namespace> localNamespaces,
+      MutableResult result) {
+    List<Map.Entry<NamespacePath, Namespace>> stale =
+        localNamespaces.entrySet().stream()
+            .filter(entry -> !targetPaths.contains(entry.getKey()))
+            .filter(entry -> ownedBy(entry.getValue().getPropertiesMap(), overlay))
+            .sorted(Map.Entry.<NamespacePath, Namespace>comparingByKey().reversed())
+            .toList();
+    for (var entry : stale) {
+      Namespace namespace = entry.getValue();
+      if (!listTables(namespace).isEmpty() || !listViews(namespace).isEmpty()) {
+        throw new IllegalStateException(
+            "Cannot retire non-empty overlay namespace=" + entry.getKey());
+      }
+      MutationMeta meta = namespaces.metaFor(namespace.getResourceId());
+      if (!namespaces.deleteWhilePointersMatch(
+          namespace.getResourceId(), meta.getPointerVersion(), fence)) lostFence();
+      markerStore.bumpCatalogMarker(namespace.getCatalogId());
+      metadataGraph.invalidate(namespace.getResourceId());
+      topology.evictNamespaceRefs(namespace.getCatalogId());
+      result.namespacesDeleted++;
+    }
+  }
+
+  private Table tableFor(
+      CatalogOverlay overlay,
+      CatalogIntegration integration,
+      Namespace namespace,
+      CatalogTable source,
+      Table current) {
+    ResourceId id =
+        current == null
+            ? randomId(overlay.getResourceId().getAccountId(), ResourceKind.RK_TABLE)
+            : current.getResourceId();
+    var properties = objectProperties(overlay, integration, source.identity());
+    source.metadataLocation().ifPresent(value -> properties.put(METADATA_LOCATION_PROPERTY, value));
+    source.storageLocation().ifPresent(value -> properties.put(STORAGE_LOCATION_PROPERTY, value));
+    var upstream =
+        UpstreamRef.newBuilder()
+            .setCatalogIntegrationId(integration.getResourceId())
+            .setCatalogOverlayId(overlay.getResourceId())
+            .setUri(source.metadataLocation().orElse(integration.getCatalogUri()))
+            .addAllNamespacePath(source.name().namespace().segments())
+            .setTableDisplayName(source.name().name())
+            .setFormat(tableFormat(source.format()))
+            .addAllPartitionKeys(source.partitionKeys())
+            .setColumnIdAlgorithm(columnIdAlgorithm(source.format()))
+            .build();
+    return Table.newBuilder()
+        .setResourceId(id)
+        .setDisplayName(source.name().name())
+        .setCatalogId(overlay.getCatalogId())
+        .setNamespaceId(namespace.getResourceId())
+        .setCreatedAt(current == null ? now() : current.getCreatedAt())
+        .setSchemaJson(source.schemaJson())
+        .setUpstream(upstream)
+        .putAllProperties(properties)
+        .build();
+  }
+
+  private View viewFor(
+      CatalogOverlay overlay,
+      CatalogIntegration integration,
+      Namespace namespace,
+      CatalogView source,
+      View current) {
+    ResourceId id =
+        current == null
+            ? randomId(overlay.getResourceId().getAccountId(), ResourceKind.RK_VIEW)
+            : current.getResourceId();
+    var schema =
+        IcebergSchemaMapper.map(
+            ColumnIdAlgorithm.CID_FIELD_ID, source.outputSchemaJson(), Set.of());
+    var builder =
+        View.newBuilder()
+            .setResourceId(id)
+            .setCatalogId(overlay.getCatalogId())
+            .setNamespaceId(namespace.getResourceId())
+            .setDisplayName(source.name().name())
+            .setCreatedAt(current == null ? now() : current.getCreatedAt())
+            .addAllCreationSearchPath(source.defaultNamespace().segments())
+            .addAllOutputColumns(schema.getColumnsList())
+            .putAllProperties(objectProperties(overlay, integration, source.identity()));
+    for (var definition : source.definitions()) {
+      builder.addSqlDefinitions(
+          ViewSqlDefinition.newBuilder()
+              .setSql(definition.sql())
+              .setDialect(definition.dialect())
+              .build());
+    }
+    return builder.build();
+  }
+
+  private PointerConditions fence(
+      CatalogOverlay overlay,
+      MutationMeta overlayMeta,
+      CatalogIntegration integration,
+      MutationMeta integrationMeta) {
+    String accountId = overlay.getResourceId().getAccountId();
+    return new PointerConditions(
+        Map.of(
+            Keys.catalogOverlayPointerById(accountId, overlay.getResourceId().getId()),
+            overlayMeta.getPointerVersion(),
+            Keys.catalogIntegrationPointerById(accountId, integration.getResourceId().getId()),
+            integrationMeta.getPointerVersion()),
+        Set.of(
+            Keys.accountDeletionMarker(accountId),
+            Keys.catalogOverlayDeletionMarker(accountId, overlay.getResourceId().getId()),
+            Keys.catalogIntegrationDeletionMarker(accountId, integration.getResourceId().getId())),
+        Map.of());
+  }
+
+  private void assertFence(
+      CatalogOverlay overlay,
+      MutationMeta overlayMeta,
+      CatalogIntegration integration,
+      MutationMeta integrationMeta) {
+    if (overlays.metaForSafe(overlay.getResourceId()).getPointerVersion()
+            != overlayMeta.getPointerVersion()
+        || integrations.metaForSafe(integration.getResourceId()).getPointerVersion()
+            != integrationMeta.getPointerVersion()
+        || overlays.deletionFenceVersion(overlay.getResourceId()) != 0L
+        || integrations.cascadeDeletionFenceVersion(integration.getResourceId()) != 0L) {
+      lostFence();
+    }
+  }
+
+  private void commitDefinitionWhileFenced(
+      ResourceId tableId,
+      MutationMeta definitionMeta,
+      CatalogOverlay overlay,
+      MutationMeta overlayMeta,
+      CatalogIntegration integration,
+      MutationMeta integrationMeta) {
+    Optional<TableRoot> publishedRoot =
+        rootWriter.commitDefinitionReturningRoot(tableId, definitionMeta);
+    try {
+      assertFence(overlay, overlayMeta, integration, integrationMeta);
+    } catch (BaseResourceRepository.AbortRetryableException lost) {
+      removeStaleRootPublication(tableId, definitionMeta, publishedRoot);
+      throw lost;
+    }
+  }
+
+  private void removeStaleRootPublication(
+      ResourceId tableId, MutationMeta publishedDefinition, Optional<TableRoot> publishedRoot) {
+    MutationMeta currentDefinition = tables.metaForSafe(tableId);
+    if (sameRevision(publishedDefinition, currentDefinition) || publishedRoot.isEmpty()) return;
+
+    MutationMeta rootMeta = tableRoots.metaForSafeLive(tableId);
+    if (rootMeta.getBlobUri().isBlank()) return;
+    Optional<TableRoot> currentRoot = tableRoots.getByBlobUriLive(rootMeta.getBlobUri());
+    if (currentRoot.equals(publishedRoot)) {
+      // The expected version makes this cleanup harmless if a winning reconciliation has already
+      // advanced the root after our live read.
+      tableRoots.deleteWithPrecondition(tableId, rootMeta.getPointerVersion());
+    }
+  }
+
+  private static boolean sameRevision(MutationMeta first, MutationMeta second) {
+    return first.getPointerVersion() == second.getPointerVersion()
+        && first.getBlobUri().equals(second.getBlobUri())
+        && first.getEtag().equals(second.getEtag());
+  }
+
+  private static void requireBinding(CatalogOverlay overlay, CatalogIntegration integration) {
+    if (!overlay.getIntegrationId().equals(integration.getResourceId())) {
+      throw new IllegalArgumentException("Overlay is not bound to the supplied Catalog Integration");
+    }
+    if (!overlay.hasCatalogId()) {
+      throw new IllegalStateException("Catalog Overlay is missing its target catalog");
+    }
+  }
+
+  private List<Table> listTables(Namespace namespace) {
+    return listAll(
+        (token, next) ->
+            tables.listConsistent(
+                namespace.getResourceId().getAccountId(),
+                namespace.getCatalogId().getId(),
+                namespace.getResourceId().getId(),
+                200,
+                token,
+                next));
+  }
+
+  private List<View> listViews(Namespace namespace) {
+    return listAll(
+        (token, next) ->
+            views.listConsistent(
+                namespace.getResourceId().getAccountId(),
+                namespace.getCatalogId().getId(),
+                namespace.getResourceId().getId(),
+                200,
+                token,
+                next));
+  }
+
+  private static <T> List<T> listAll(Page<T> page) {
+    List<T> out = new ArrayList<>();
+    Set<String> seen = new HashSet<>();
+    String token = "";
+    while (true) {
+      var next = new StringBuilder();
+      out.addAll(page.load(token, next));
+      token = next.toString();
+      if (token.isBlank()) return List.copyOf(out);
+      if (!seen.add(token)) throw new IllegalStateException("Stagnant repository page token");
+    }
+  }
+
+  private void relationChanged(ResourceId relationId, ResourceId namespaceId) {
+    markerStore.bumpNamespaceMarker(namespaceId);
+    metadataGraph.invalidate(relationId);
+    topology.evictRelationRefs(namespaceId);
+  }
+
+  private void purgeTableState(ResourceId tableId) {
+    pointerStore.deleteByPrefix(Keys.snapshotRootPrefix(tableId.getAccountId(), tableId.getId()));
+    tableRoots.purgeRoot(tableId);
+  }
+
+  private static Namespace requireNamespace(
+      Map<NamespacePath, Namespace> namespaces, NamespacePath path) {
+    return Optional.ofNullable(namespaces.get(path))
+        .orElseThrow(() -> new IllegalStateException("Missing materialized namespace=" + path));
+  }
+
+  private static Map<String, String> ownershipProperties(
+      CatalogOverlay overlay, CatalogIntegration integration) {
+    return Map.of(
+        OVERLAY_ID_PROPERTY,
+        overlay.getResourceId().getId(),
+        INTEGRATION_ID_PROPERTY,
+        integration.getResourceId().getId());
+  }
+
+  private static Map<String, String> objectProperties(
+      CatalogOverlay overlay,
+      CatalogIntegration integration,
+      ExternalObjectIdentity identity) {
+    Map<String, String> properties = new LinkedHashMap<>(ownershipProperties(overlay, integration));
+    properties.put(EXTERNAL_ID_PROPERTY, identity.value());
+    properties.put(EXTERNAL_ID_STABLE_PROPERTY, Boolean.toString(identity.stable()));
+    return properties;
+  }
+
+  private static Optional<String> stableIdentity(Map<String, String> properties) {
+    if (!Boolean.parseBoolean(properties.get(EXTERNAL_ID_STABLE_PROPERTY))) return Optional.empty();
+    return Optional.ofNullable(properties.get(EXTERNAL_ID_PROPERTY)).filter(value -> !value.isBlank());
+  }
+
+  private static boolean ownedBy(Map<String, String> properties, CatalogOverlay overlay) {
+    return overlay.getResourceId().getId().equals(properties.get(OVERLAY_ID_PROPERTY));
+  }
+
+  private static void requireUniqueStableIdentities(
+      List<ExternalObjectIdentity> identities, String objectKind) {
+    Set<String> seen = new HashSet<>();
+    for (ExternalObjectIdentity identity : identities) {
+      if (identity.stable() && !seen.add(identity.value())) {
+        throw new IllegalStateException(
+            "Catalog provider returned duplicate stable "
+                + objectKind
+                + " identity="
+                + identity.value());
+      }
+    }
+  }
+
+  private static TableFormat tableFormat(String format) {
+    return switch (format.trim().toUpperCase(Locale.ROOT)) {
+      case "ICEBERG" -> TableFormat.TF_ICEBERG;
+      case "DELTA" -> TableFormat.TF_DELTA;
+      default -> throw new IllegalArgumentException("Unsupported upstream table format=" + format);
+    };
+  }
+
+  private static ColumnIdAlgorithm columnIdAlgorithm(String format) {
+    return switch (tableFormat(format)) {
+      case TF_ICEBERG -> ColumnIdAlgorithm.CID_FIELD_ID;
+      case TF_DELTA -> ColumnIdAlgorithm.CID_PATH_ORDINAL;
+      default -> throw new IllegalArgumentException("Unsupported upstream table format=" + format);
+    };
+  }
+
+  private static NamespacePath path(Namespace namespace) {
+    List<String> path = new ArrayList<>(namespace.getParentsList());
+    path.add(namespace.getDisplayName());
+    return new NamespacePath(path);
+  }
+
+  private static void addAncestors(NamespacePath path, Set<NamespacePath> materialized) {
+    for (int length = 1; length <= path.segments().size(); length++) {
+      materialized.add(new NamespacePath(path.segments().subList(0, length)));
+    }
+  }
+
+  private static boolean selected(CatalogOverlay overlay, NamespacePath path) {
+    if (overlay.getIncludeNamespacesCount() == 0) return true;
+    return overlay.getIncludeNamespacesList().stream()
+        .anyMatch(include -> startsWith(path.segments(), include.getSegmentsList()));
+  }
+
+  private static boolean mayContainSelection(CatalogOverlay overlay, NamespacePath path) {
+    if (overlay.getIncludeNamespacesCount() == 0 || selected(overlay, path)) return true;
+    return overlay.getIncludeNamespacesList().stream()
+        .anyMatch(include -> startsWith(include.getSegmentsList(), path.segments()));
+  }
+
+  private static boolean excluded(CatalogOverlay overlay, NamespacePath path) {
+    return overlay.getExcludeNamespacesList().stream()
+        .anyMatch(exclude -> startsWith(path.segments(), exclude.getSegmentsList()));
+  }
+
+  private static boolean startsWith(List<String> path, List<String> prefix) {
+    return path.size() >= prefix.size() && path.subList(0, prefix.size()).equals(prefix);
+  }
+
+  private com.google.protobuf.Timestamp now() {
+    return Timestamps.fromMillis(clock.millis());
+  }
+
+  private static ResourceId randomId(String accountId, ResourceKind kind) {
+    return ResourceId.newBuilder()
+        .setAccountId(accountId)
+        .setId(UUID.randomUUID().toString())
+        .setKind(kind)
+        .build();
+  }
+
+  private static BaseResourceRepository.AbortRetryableException lostFence() {
+    throw new BaseResourceRepository.AbortRetryableException(
+        "Catalog Overlay changed or deletion began during reconciliation");
+  }
+
+  @FunctionalInterface
+  private interface Page<T> {
+    List<T> load(String token, StringBuilder next);
+  }
+
+  private record Discovery(
+      Set<NamespacePath> materializedNamespaces,
+      Map<CatalogObjectName, CatalogTable> tables,
+      Map<CatalogObjectName, CatalogView> views) {}
+
+  public record Result(
+      int namespacesCreated,
+      int namespacesDeleted,
+      int tablesCreated,
+      int tablesUpdated,
+      int tablesDeleted,
+      int viewsCreated,
+      int viewsUpdated,
+      int viewsDeleted) {}
+
+  private static final class MutableResult {
+    private int namespacesCreated;
+    private int namespacesDeleted;
+    private int tablesCreated;
+    private int tablesUpdated;
+    private int tablesDeleted;
+    private int viewsCreated;
+    private int viewsUpdated;
+    private int viewsDeleted;
+
+    private Result freeze() {
+      return new Result(
+          namespacesCreated,
+          namespacesDeleted,
+          tablesCreated,
+          tablesUpdated,
+          tablesDeleted,
+          viewsCreated,
+          viewsUpdated,
+          viewsDeleted);
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
@@ -16,8 +16,8 @@
 
 package ai.floedb.floecat.service.integration;
 
-import ai.floedb.floecat.catalog.access.CatalogClient;
 import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogClient;
 import ai.floedb.floecat.catalog.access.CatalogObjectName;
 import ai.floedb.floecat.catalog.access.CatalogTable;
 import ai.floedb.floecat.catalog.access.CatalogView;
@@ -110,7 +110,10 @@ public class CatalogOverlayReconciler {
 
     var result = new MutableResult();
     Map<NamespacePath, Namespace> localNamespaces =
-        reconcileNamespaces(overlay, integration, fence, discovery.materializedNamespaces(), result);
+        reconcileNamespaces(
+            overlay, integration, fence, discovery.materializedNamespaces(), result);
+    retireStaleRelations(
+        overlay, fence, discovery.tables(), discovery.views(), localNamespaces, result);
     reconcileTables(
         overlay,
         overlayMeta,
@@ -121,8 +124,7 @@ public class CatalogOverlayReconciler {
         localNamespaces,
         result);
     reconcileViews(overlay, integration, fence, discovery.views(), localNamespaces, result);
-    retireNamespaces(
-        overlay, fence, discovery.materializedNamespaces(), localNamespaces, result);
+    retireNamespaces(overlay, fence, discovery.materializedNamespaces(), localNamespaces, result);
     assertFence(overlay, overlayMeta, integration, integrationMeta);
     return result.freeze();
   }
@@ -141,7 +143,8 @@ public class CatalogOverlayReconciler {
     for (Namespace namespace : catalogNamespaces) {
       for (Table table : listTables(namespace)) {
         if (!ownedBy(table.getPropertiesMap(), overlay)) continue;
-        if (!tables.delete(table.getResourceId()) && tables.getById(table.getResourceId()).isPresent()) {
+        if (!tables.delete(table.getResourceId())
+            && tables.getById(table.getResourceId()).isPresent()) {
           throw new BaseResourceRepository.AbortRetryableException(
               "Table changed during Catalog Overlay retirement");
         }
@@ -150,7 +153,8 @@ public class CatalogOverlayReconciler {
       }
       for (View view : listViews(namespace)) {
         if (!ownedBy(view.getPropertiesMap(), overlay)) continue;
-        if (!views.delete(view.getResourceId()) && views.getById(view.getResourceId()).isPresent()) {
+        if (!views.delete(view.getResourceId())
+            && views.getById(view.getResourceId()).isPresent()) {
           throw new BaseResourceRepository.AbortRetryableException(
               "View changed during Catalog Overlay retirement");
         }
@@ -278,6 +282,72 @@ public class CatalogOverlayReconciler {
     return current;
   }
 
+  private void retireStaleRelations(
+      CatalogOverlay overlay,
+      PointerConditions fence,
+      Map<CatalogObjectName, CatalogTable> discoveredTables,
+      Map<CatalogObjectName, CatalogView> discoveredViews,
+      Map<NamespacePath, Namespace> localNamespaces,
+      MutableResult result) {
+    Map<String, Table> tablesByIdentity = new HashMap<>();
+    Map<CatalogObjectName, Table> tablesByName = new HashMap<>();
+    Map<String, View> viewsByIdentity = new HashMap<>();
+    Map<CatalogObjectName, View> viewsByName = new HashMap<>();
+    for (Namespace namespace : localNamespaces.values()) {
+      NamespacePath namespacePath = path(namespace);
+      for (Table table : listTables(namespace)) {
+        if (!ownedBy(table.getPropertiesMap(), overlay)) continue;
+        tablesByName.put(new CatalogObjectName(namespacePath, table.getDisplayName()), table);
+        stableIdentity(table.getPropertiesMap()).ifPresent(id -> tablesByIdentity.put(id, table));
+      }
+      for (View view : listViews(namespace)) {
+        if (!ownedBy(view.getPropertiesMap(), overlay)) continue;
+        viewsByName.put(new CatalogObjectName(namespacePath, view.getDisplayName()), view);
+        stableIdentity(view.getPropertiesMap()).ifPresent(id -> viewsByIdentity.put(id, view));
+      }
+    }
+
+    Set<String> retainedTableIds = new HashSet<>();
+    for (var entry : discoveredTables.entrySet()) {
+      CatalogTable source = entry.getValue();
+      Table current =
+          source.identity().stable()
+              ? tablesByIdentity.get(source.identity().value())
+              : tablesByName.get(entry.getKey());
+      if (current != null) retainedTableIds.add(current.getResourceId().getId());
+    }
+    Set<String> retainedViewIds = new HashSet<>();
+    for (var entry : discoveredViews.entrySet()) {
+      CatalogView source = entry.getValue();
+      View current =
+          source.identity().stable()
+              ? viewsByIdentity.get(source.identity().value())
+              : viewsByName.get(entry.getKey());
+      if (current != null) retainedViewIds.add(current.getResourceId().getId());
+    }
+
+    for (Table stale : tablesByName.values()) {
+      if (retainedTableIds.contains(stale.getResourceId().getId())) continue;
+      MutationMeta meta = tables.metaFor(stale.getResourceId());
+      if (!tables.deleteWhilePointersMatch(
+          stale.getResourceId(), meta.getPointerVersion(), fence)) {
+        lostFence();
+      }
+      purgeTableState(stale.getResourceId());
+      relationChanged(stale.getResourceId(), stale.getNamespaceId());
+      result.tablesDeleted++;
+    }
+    for (View stale : viewsByName.values()) {
+      if (retainedViewIds.contains(stale.getResourceId().getId())) continue;
+      MutationMeta meta = views.metaFor(stale.getResourceId());
+      if (!views.deleteWhilePointersMatch(stale.getResourceId(), meta.getPointerVersion(), fence)) {
+        lostFence();
+      }
+      relationChanged(stale.getResourceId(), stale.getNamespaceId());
+      result.viewsDeleted++;
+    }
+  }
+
   private void reconcileTables(
       CatalogOverlay overlay,
       MutationMeta overlayMeta,
@@ -297,7 +367,6 @@ public class CatalogOverlayReconciler {
       }
     }
 
-    Set<String> retainedIds = new HashSet<>();
     for (var entry : discovered.entrySet()) {
       CatalogObjectName name = entry.getKey();
       CatalogTable source = entry.getValue();
@@ -311,7 +380,9 @@ public class CatalogOverlayReconciler {
       MutationMeta definitionMeta;
       if (current == null) {
         definitionMeta =
-            tables.createWhilePointersMatch(desired, fence).orElseThrow(CatalogOverlayReconciler::lostFence);
+            tables
+                .createWhilePointersMatch(desired, fence)
+                .orElseThrow(CatalogOverlayReconciler::lostFence);
         result.tablesCreated++;
         changed = true;
       } else if (!current.equals(desired)) {
@@ -326,25 +397,18 @@ public class CatalogOverlayReconciler {
         definitionMeta = tables.metaFor(current.getResourceId());
       }
       commitDefinitionWhileFenced(
-          desired.getResourceId(), definitionMeta, overlay, overlayMeta, integration, integrationMeta);
-      retainedIds.add(desired.getResourceId().getId());
+          desired.getResourceId(),
+          definitionMeta,
+          overlay,
+          overlayMeta,
+          integration,
+          integrationMeta);
       if (changed) {
         relationChanged(desired.getResourceId(), desired.getNamespaceId());
         if (current != null && !current.getNamespaceId().equals(desired.getNamespaceId())) {
           relationChanged(desired.getResourceId(), current.getNamespaceId());
         }
       }
-    }
-
-    for (Table stale : existingByName.values()) {
-      if (retainedIds.contains(stale.getResourceId().getId())) continue;
-      MutationMeta meta = tables.metaFor(stale.getResourceId());
-      if (!tables.deleteWhilePointersMatch(stale.getResourceId(), meta.getPointerVersion(), fence)) {
-        lostFence();
-      }
-      purgeTableState(stale.getResourceId());
-      relationChanged(stale.getResourceId(), stale.getNamespaceId());
-      result.tablesDeleted++;
     }
   }
 
@@ -365,7 +429,6 @@ public class CatalogOverlayReconciler {
       }
     }
 
-    Set<String> retainedIds = new HashSet<>();
     for (var entry : discovered.entrySet()) {
       CatalogObjectName name = entry.getKey();
       CatalogView source = entry.getValue();
@@ -382,29 +445,17 @@ public class CatalogOverlayReconciler {
         changed = true;
       } else if (!current.equals(desired)) {
         MutationMeta meta = views.metaFor(current.getResourceId());
-        if (views
-            .updateWhilePointersMatch(desired, meta.getPointerVersion(), fence)
-            .isEmpty()) lostFence();
+        if (views.updateWhilePointersMatch(desired, meta.getPointerVersion(), fence).isEmpty())
+          lostFence();
         result.viewsUpdated++;
         changed = true;
       }
-      retainedIds.add(desired.getResourceId().getId());
       if (changed) {
         relationChanged(desired.getResourceId(), desired.getNamespaceId());
         if (current != null && !current.getNamespaceId().equals(desired.getNamespaceId())) {
           relationChanged(desired.getResourceId(), current.getNamespaceId());
         }
       }
-    }
-
-    for (View stale : existingByName.values()) {
-      if (retainedIds.contains(stale.getResourceId().getId())) continue;
-      MutationMeta meta = views.metaFor(stale.getResourceId());
-      if (!views.deleteWhilePointersMatch(stale.getResourceId(), meta.getPointerVersion(), fence)) {
-        lostFence();
-      }
-      relationChanged(stale.getResourceId(), stale.getNamespaceId());
-      result.viewsDeleted++;
     }
   }
 
@@ -579,7 +630,8 @@ public class CatalogOverlayReconciler {
 
   private static void requireBinding(CatalogOverlay overlay, CatalogIntegration integration) {
     if (!overlay.getIntegrationId().equals(integration.getResourceId())) {
-      throw new IllegalArgumentException("Overlay is not bound to the supplied Catalog Integration");
+      throw new IllegalArgumentException(
+          "Overlay is not bound to the supplied Catalog Integration");
     }
     if (!overlay.hasCatalogId()) {
       throw new IllegalStateException("Catalog Overlay is missing its target catalog");
@@ -650,9 +702,7 @@ public class CatalogOverlayReconciler {
   }
 
   private static Map<String, String> objectProperties(
-      CatalogOverlay overlay,
-      CatalogIntegration integration,
-      ExternalObjectIdentity identity) {
+      CatalogOverlay overlay, CatalogIntegration integration, ExternalObjectIdentity identity) {
     Map<String, String> properties = new LinkedHashMap<>(ownershipProperties(overlay, integration));
     properties.put(EXTERNAL_ID_PROPERTY, identity.value());
     properties.put(EXTERNAL_ID_STABLE_PROPERTY, Boolean.toString(identity.stable()));
@@ -661,7 +711,8 @@ public class CatalogOverlayReconciler {
 
   private static Optional<String> stableIdentity(Map<String, String> properties) {
     if (!Boolean.parseBoolean(properties.get(EXTERNAL_ID_STABLE_PROPERTY))) return Optional.empty();
-    return Optional.ofNullable(properties.get(EXTERNAL_ID_PROPERTY)).filter(value -> !value.isBlank());
+    return Optional.ofNullable(properties.get(EXTERNAL_ID_PROPERTY))
+        .filter(value -> !value.isBlank());
   }
 
   private static boolean ownedBy(Map<String, String> properties, CatalogOverlay overlay) {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
@@ -651,12 +651,7 @@ public class CatalogOverlayReconciler {
     return listAll(
         (token, next) ->
             namespaces.listConsistent(
-                catalogId.getAccountId(),
-                catalogId.getId(),
-                List.of(),
-                200,
-                token,
-                next));
+                catalogId.getAccountId(), catalogId.getId(), List.of(), 200, token, next));
   }
 
   private List<View> listViews(Namespace namespace) {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
@@ -134,11 +134,7 @@ public class CatalogOverlayReconciler {
   /** Removes every materialized descendant after the overlay deletion fence is installed. */
   public void retireMaterializedResources(CatalogOverlay overlay) {
     ResourceId catalogId = overlay.getCatalogId();
-    List<Namespace> catalogNamespaces = new ArrayList<>();
-    for (ResourceId namespaceId :
-        namespaces.listIdsConsistent(catalogId.getAccountId(), catalogId.getId())) {
-      namespaces.getById(namespaceId).ifPresent(catalogNamespaces::add);
-    }
+    List<Namespace> catalogNamespaces = new ArrayList<>(listNamespaces(catalogId));
     catalogNamespaces.sort(
         Comparator.comparingInt((Namespace namespace) -> path(namespace).segments().size())
             .reversed());
@@ -269,11 +265,8 @@ public class CatalogOverlayReconciler {
       MutableResult result) {
     ResourceId catalogId = overlay.getCatalogId();
     Map<NamespacePath, Namespace> current = new HashMap<>();
-    for (ResourceId namespaceId :
-        namespaces.listIdsConsistent(catalogId.getAccountId(), catalogId.getId())) {
-      namespaces
-          .getByIdForMutation(namespaceId)
-          .ifPresent(value -> current.put(path(value), value));
+    for (Namespace namespace : listNamespaces(catalogId)) {
+      current.put(path(namespace), namespace);
     }
     for (NamespacePath path : targetPaths.stream().sorted().toList()) {
       if (current.containsKey(path)) continue;
@@ -649,6 +642,18 @@ public class CatalogOverlayReconciler {
                 namespace.getResourceId().getAccountId(),
                 namespace.getCatalogId().getId(),
                 namespace.getResourceId().getId(),
+                200,
+                token,
+                next));
+  }
+
+  private List<Namespace> listNamespaces(ResourceId catalogId) {
+    return listAll(
+        (token, next) ->
+            namespaces.listConsistent(
+                catalogId.getAccountId(),
+                catalogId.getId(),
+                List.of(),
                 200,
                 token,
                 next));

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
@@ -16,6 +16,8 @@
 
 package ai.floedb.floecat.service.integration;
 
+import static ai.floedb.floecat.service.common.BaseServiceImpl.normalizeName;
+
 import ai.floedb.floecat.catalog.access.CatalogCapability;
 import ai.floedb.floecat.catalog.access.CatalogClient;
 import ai.floedb.floecat.catalog.access.CatalogObjectName;
@@ -27,7 +29,6 @@ import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
 import ai.floedb.floecat.catalog.rpc.Namespace;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.TableFormat;
-import ai.floedb.floecat.catalog.rpc.TableRoot;
 import ai.floedb.floecat.catalog.rpc.UpstreamRef;
 import ai.floedb.floecat.catalog.rpc.View;
 import ai.floedb.floecat.catalog.rpc.ViewSqlDefinition;
@@ -39,6 +40,7 @@ import ai.floedb.floecat.integration.rpc.CatalogIntegration;
 import ai.floedb.floecat.integration.rpc.CatalogOverlay;
 import ai.floedb.floecat.scanner.spi.TopologyGraph;
 import ai.floedb.floecat.service.catalog.impl.TableRootWriter;
+import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
@@ -205,9 +207,10 @@ public class CatalogOverlayReconciler {
         if (seen.size() > MAX_NAMESPACES) {
           throw new IllegalStateException("Catalog namespace inventory exceeds " + MAX_NAMESPACES);
         }
-        if (excluded(overlay, path)) continue;
-        if (selected(overlay, path)) {
-          addAncestors(path, materialized);
+        NamespacePath normalizedPath = normalizePath(path);
+        if (excluded(overlay, normalizedPath)) continue;
+        if (selected(overlay, normalizedPath)) {
+          addAncestors(normalizedPath, materialized);
           for (CatalogObjectName name : client.listTables(path).stream().sorted().toList()) {
             CatalogTable table = client.loadTable(name);
             if (!name.equals(table.name())) {
@@ -217,13 +220,20 @@ public class CatalogOverlayReconciler {
                       + " actual="
                       + table.name());
             }
-            discoveredTables.put(name, table);
+            CatalogObjectName localName =
+                new CatalogObjectName(normalizedPath, normalizeName(name.name()));
+            if (discoveredTables.putIfAbsent(localName, table) != null) {
+              throw new IllegalStateException(
+                  "Upstream table names collide after normalization: " + localName);
+            }
           }
           if (listViews) {
             for (CatalogObjectName name : client.listViews(path).stream().sorted().toList()) {
-              if (discoveredTables.containsKey(name)) {
+              CatalogObjectName localName =
+                  new CatalogObjectName(normalizedPath, normalizeName(name.name()));
+              if (discoveredTables.containsKey(localName)) {
                 throw new IllegalStateException(
-                    "Upstream relation name is both table and view: " + name);
+                    "Upstream relation name is both table and view: " + localName);
               }
               CatalogView view = client.loadView(name);
               if (!name.equals(view.name())) {
@@ -233,11 +243,14 @@ public class CatalogOverlayReconciler {
                         + " actual="
                         + view.name());
               }
-              discoveredViews.put(name, view);
+              if (discoveredViews.putIfAbsent(localName, view) != null) {
+                throw new IllegalStateException(
+                    "Upstream view names collide after normalization: " + localName);
+              }
             }
           }
         }
-        if (mayContainSelection(overlay, path)) pending.addLast(path);
+        if (mayContainSelection(overlay, normalizedPath)) pending.addLast(path);
       }
     }
     requireUniqueStableIdentities(
@@ -258,7 +271,9 @@ public class CatalogOverlayReconciler {
     Map<NamespacePath, Namespace> current = new HashMap<>();
     for (ResourceId namespaceId :
         namespaces.listIdsConsistent(catalogId.getAccountId(), catalogId.getId())) {
-      namespaces.getById(namespaceId).ifPresent(value -> current.put(path(value), value));
+      namespaces
+          .getByIdForMutation(namespaceId)
+          .ifPresent(value -> current.put(path(value), value));
     }
     for (NamespacePath path : targetPaths.stream().sorted().toList()) {
       if (current.containsKey(path)) continue;
@@ -474,8 +489,7 @@ public class CatalogOverlayReconciler {
     for (var entry : stale) {
       Namespace namespace = entry.getValue();
       if (!listTables(namespace).isEmpty() || !listViews(namespace).isEmpty()) {
-        throw new IllegalStateException(
-            "Cannot retire non-empty overlay namespace=" + entry.getKey());
+        continue;
       }
       MutationMeta meta = namespaces.metaFor(namespace.getResourceId());
       if (!namespaces.deleteWhilePointersMatch(
@@ -513,7 +527,7 @@ public class CatalogOverlayReconciler {
             .build();
     return Table.newBuilder()
         .setResourceId(id)
-        .setDisplayName(source.name().name())
+        .setDisplayName(normalizeName(source.name().name()))
         .setCatalogId(overlay.getCatalogId())
         .setNamespaceId(namespace.getResourceId())
         .setCreatedAt(current == null ? now() : current.getCreatedAt())
@@ -541,9 +555,9 @@ public class CatalogOverlayReconciler {
             .setResourceId(id)
             .setCatalogId(overlay.getCatalogId())
             .setNamespaceId(namespace.getResourceId())
-            .setDisplayName(source.name().name())
+            .setDisplayName(normalizeName(source.name().name()))
             .setCreatedAt(current == null ? now() : current.getCreatedAt())
-            .addAllCreationSearchPath(source.defaultNamespace().segments())
+            .addAllCreationSearchPath(normalizePath(source.defaultNamespace()).segments())
             .addAllOutputColumns(schema.getColumnsList())
             .putAllProperties(objectProperties(overlay, integration, source.identity()));
     for (var definition : source.definitions()) {
@@ -597,29 +611,19 @@ public class CatalogOverlayReconciler {
       MutationMeta overlayMeta,
       CatalogIntegration integration,
       MutationMeta integrationMeta) {
-    Optional<TableRoot> publishedRoot =
-        rootWriter.commitDefinitionReturningRoot(tableId, definitionMeta);
+    rootWriter.commitDefinition(tableId, definitionMeta);
     try {
       assertFence(overlay, overlayMeta, integration, integrationMeta);
     } catch (BaseResourceRepository.AbortRetryableException lost) {
-      removeStaleRootPublication(tableId, definitionMeta, publishedRoot);
+      removeStaleRootPublication(tableId, definitionMeta);
       throw lost;
     }
   }
 
-  private void removeStaleRootPublication(
-      ResourceId tableId, MutationMeta publishedDefinition, Optional<TableRoot> publishedRoot) {
+  private void removeStaleRootPublication(ResourceId tableId, MutationMeta publishedDefinition) {
     MutationMeta currentDefinition = tables.metaForSafe(tableId);
-    if (sameRevision(publishedDefinition, currentDefinition) || publishedRoot.isEmpty()) return;
-
-    MutationMeta rootMeta = tableRoots.metaForSafeLive(tableId);
-    if (rootMeta.getBlobUri().isBlank()) return;
-    Optional<TableRoot> currentRoot = tableRoots.getByBlobUriLive(rootMeta.getBlobUri());
-    if (currentRoot.equals(publishedRoot)) {
-      // The expected version makes this cleanup harmless if a winning reconciliation has already
-      // advanced the root after our live read.
-      tableRoots.deleteWithPrecondition(tableId, rootMeta.getPointerVersion());
-    }
+    if (sameRevision(publishedDefinition, currentDefinition)) return;
+    rootWriter.replaceDefinitionIfMatches(tableId, publishedDefinition, currentDefinition);
   }
 
   private static boolean sameRevision(MutationMeta first, MutationMeta second) {
@@ -780,6 +784,14 @@ public class CatalogOverlayReconciler {
 
   private static boolean startsWith(List<String> path, List<String> prefix) {
     return path.size() >= prefix.size() && path.subList(0, prefix.size()).equals(prefix);
+  }
+
+  private static NamespacePath normalizePath(NamespacePath path) {
+    return new NamespacePath(normalizeSegments(path.segments()));
+  }
+
+  private static List<String> normalizeSegments(List<String> segments) {
+    return segments.stream().map(BaseServiceImpl::normalizeName).toList();
   }
 
   private com.google.protobuf.Timestamp now() {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
@@ -578,10 +578,7 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
                                   null));
               var result =
                   reconciler.reconcile(
-                      current.value(),
-                      current.meta(),
-                      integration.value(),
-                      integration.meta());
+                      current.value(), current.meta(), integration.value(), integration.meta());
               return ReconcileCatalogOverlayResponse.newBuilder()
                   .setMeta(current.meta())
                   .setNamespacesCreated(result.namespacesCreated())

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
@@ -629,7 +629,8 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
                     throw new BaseResourceRepository.AbortRetryableException(
                         "overlay changed while deletion was fenced");
                   reconciler.retireMaterializedResources(current.get().value());
-                  // Managed descendants retire behind the fence first. The final transaction removes
+                  // Managed descendants retire behind the fence first. The final transaction
+                  // removes
                   // only the overlay, its dependencies, and the fence; the target catalog remains.
                   long fenceVersion = overlays.deletionFenceVersion(id);
                   if (fenceVersion == 0L

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
@@ -35,6 +35,8 @@ import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayRequest;
 import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayResponse;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayRequest;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayResponse;
+import ai.floedb.floecat.scanner.spi.CatalogGraphView;
+import ai.floedb.floecat.service.catalog.impl.surface.CatalogSurfaceWritePolicy;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.Canonicalizer;
 import ai.floedb.floecat.service.common.IdempotencyGuard;
@@ -77,6 +79,7 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
   @Inject Authorizer authz;
   @Inject IdempotencyRepository idempotencyStore;
   @Inject CatalogOverlayReconciler reconciler;
+  @Inject CatalogGraphView graphView;
 
   @Override
   public Uni<ListCatalogOverlaysResponse> listCatalogOverlays(ListCatalogOverlaysRequest request) {
@@ -218,6 +221,7 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
                   ResourceId integrationId =
                       scopedIntegrationId(pc.getAccountId(), spec.getIntegrationId());
                   ResourceId catalogId = scopedCatalogId(pc.getAccountId(), spec.getCatalogId());
+                  catalogSurfaceWritePolicy().requireWritableCatalog(catalogId, "catalog_id", corr);
                   List<NamespacePath> includes =
                       normalizePaths(spec.getIncludeNamespacesList(), "include_namespaces", corr);
                   List<NamespacePath> excludes =
@@ -353,13 +357,6 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
         throw GrpcErrors.alreadyExists(
             corr, CATALOG_OVERLAY_ALREADY_EXISTS, Map.of("display_name", name));
 
-      if (!overlays.beginDeletion(
-          current.value().getResourceId(), current.meta().getPointerVersion())) {
-        throw new BaseResourceRepository.AbortRetryableException(
-            "overlay changed while replacement fenced its old identity");
-      }
-      reconciler.retireMaterializedResources(current.value());
-
       Map<String, Long> parentVersions = new java.util.HashMap<>(requiredVersions);
       ResourceId oldIntegrationId = current.value().getIntegrationId();
       if (!oldIntegrationId.equals(integrationId)) {
@@ -409,14 +406,23 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
               .setCreatedAt(now)
               .setUpdatedAt(now)
               .build();
+      Map<String, Long> replacementParents = Map.copyOf(parentVersions);
+      Set<String> replacementRequiredAbsent = Set.copyOf(requiredAbsent);
+      Map<String, Long> replacementMarkers = Map.copyOf(markerVersions);
+      if (!overlays.beginDeletion(
+          current.value().getResourceId(), current.meta().getPointerVersion())) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "overlay changed while replacement fenced its old identity");
+      }
+      reconciler.retireMaterializedResources(current.value());
       return overlays
           .replaceIdentityAttachedWithMeta(
               current.value(),
               current.meta().getPointerVersion(),
               replacement,
-              Map.copyOf(parentVersions),
-              Set.copyOf(requiredAbsent),
-              Map.copyOf(markerVersions))
+              replacementParents,
+              replacementRequiredAbsent,
+              replacementMarkers)
           .orElseThrow(
               () ->
                   new BaseResourceRepository.AbortRetryableException(
@@ -567,6 +573,8 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
                           () -> GrpcErrors.notFound(corr, null, Map.of("id", overlayId.getId())));
               MutationOps.BaseServiceChecks.enforcePreconditions(
                   corr, current.meta(), request.getPrecondition());
+              catalogSurfaceWritePolicy()
+                  .requireWritableCatalog(current.value().getCatalogId(), "catalog_id", corr);
               var integration =
                   integrations
                       .getByIdWithMeta(current.value().getIntegrationId())
@@ -635,6 +643,10 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
         .invoke(L::fail)
         .onItem()
         .invoke(L::ok);
+  }
+
+  private CatalogSurfaceWritePolicy catalogSurfaceWritePolicy() {
+    return new CatalogSurfaceWritePolicy(graphView);
   }
 
   private List<NamespacePath> normalizePaths(List<NamespacePath> paths, String field, String corr) {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
@@ -556,12 +556,8 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
         runWithRetry(
             () -> {
               var pc = principal.get();
-              authz.require(pc, RolePermissions.CATALOG_OVERLAY_WRITE);
+              authz.require(pc, RolePermissions.CATALOG_OVERLAY_RECONCILE);
               authz.require(pc, RolePermissions.CATALOG_INTEGRATION_USE);
-              authz.require(pc, RolePermissions.CATALOG_WRITE);
-              authz.require(pc, "namespace.write");
-              authz.require(pc, "table.write");
-              authz.require(pc, "view.write");
               String corr = pc.getCorrelationId();
               ResourceId overlayId = scopedOverlayId(pc.getAccountId(), request.getOverlayId());
               var current =
@@ -610,7 +606,7 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
             runWithRetry(
                 () -> {
                   var pc = principal.get();
-                  authz.require(pc, RolePermissions.CATALOG_OVERLAY_WRITE);
+                  authz.require(pc, RolePermissions.CATALOG_OVERLAY_DELETE);
                   String corr = pc.getCorrelationId();
                   ResourceId id = scopedOverlayId(pc.getAccountId(), request.getOverlayId());
                   var current = overlays.getByIdWithMeta(id);

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
@@ -31,6 +31,8 @@ import ai.floedb.floecat.integration.rpc.GetCatalogOverlayResponse;
 import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysRequest;
 import ai.floedb.floecat.integration.rpc.ListCatalogOverlaysResponse;
 import ai.floedb.floecat.integration.rpc.NamespacePath;
+import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayRequest;
+import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayResponse;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayRequest;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayResponse;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
@@ -74,6 +76,7 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
   @Inject IdempotencyRepository idempotencyStore;
+  @Inject CatalogOverlayReconciler reconciler;
 
   @Override
   public Uni<ListCatalogOverlaysResponse> listCatalogOverlays(ListCatalogOverlaysRequest request) {
@@ -350,6 +353,13 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
         throw GrpcErrors.alreadyExists(
             corr, CATALOG_OVERLAY_ALREADY_EXISTS, Map.of("display_name", name));
 
+      if (!overlays.beginDeletion(
+          current.value().getResourceId(), current.meta().getPointerVersion())) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "overlay changed while replacement fenced its old identity");
+      }
+      reconciler.retireMaterializedResources(current.value());
+
       Map<String, Long> parentVersions = new java.util.HashMap<>(requiredVersions);
       ResourceId oldIntegrationId = current.value().getIntegrationId();
       if (!oldIntegrationId.equals(integrationId)) {
@@ -388,8 +398,6 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
             Keys.catalogOverlaysMarker(accountId, oldCatalogId.getId()),
             markerStore.catalogOverlaysMarkerVersion(oldCatalogId));
       }
-      requiredAbsent.add(
-          Keys.catalogOverlayDeletionMarker(accountId, current.value().getResourceId().getId()));
       var replacement =
           CatalogOverlay.newBuilder()
               .setResourceId(overlayId)
@@ -542,6 +550,58 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
   }
 
   @Override
+  public Uni<ReconcileCatalogOverlayResponse> reconcileCatalogOverlay(
+      ReconcileCatalogOverlayRequest request) {
+    return mapFailures(
+        runWithRetry(
+            () -> {
+              var pc = principal.get();
+              authz.require(pc, RolePermissions.CATALOG_OVERLAY_WRITE);
+              authz.require(pc, RolePermissions.CATALOG_INTEGRATION_USE);
+              authz.require(pc, RolePermissions.CATALOG_WRITE);
+              authz.require(pc, "namespace.write");
+              authz.require(pc, "table.write");
+              authz.require(pc, "view.write");
+              String corr = pc.getCorrelationId();
+              ResourceId overlayId = scopedOverlayId(pc.getAccountId(), request.getOverlayId());
+              var current =
+                  overlays
+                      .getByIdWithMeta(overlayId)
+                      .orElseThrow(
+                          () -> GrpcErrors.notFound(corr, null, Map.of("id", overlayId.getId())));
+              MutationOps.BaseServiceChecks.enforcePreconditions(
+                  corr, current.meta(), request.getPrecondition());
+              var integration =
+                  integrations
+                      .getByIdWithMeta(current.value().getIntegrationId())
+                      .orElseThrow(
+                          () ->
+                              new BaseResourceRepository.CorruptionException(
+                                  "overlay references a missing Catalog Integration: "
+                                      + current.value().getIntegrationId().getId(),
+                                  null));
+              var result =
+                  reconciler.reconcile(
+                      current.value(),
+                      current.meta(),
+                      integration.value(),
+                      integration.meta());
+              return ReconcileCatalogOverlayResponse.newBuilder()
+                  .setMeta(current.meta())
+                  .setNamespacesCreated(result.namespacesCreated())
+                  .setNamespacesDeleted(result.namespacesDeleted())
+                  .setTablesCreated(result.tablesCreated())
+                  .setTablesUpdated(result.tablesUpdated())
+                  .setTablesDeleted(result.tablesDeleted())
+                  .setViewsCreated(result.viewsCreated())
+                  .setViewsUpdated(result.viewsUpdated())
+                  .setViewsDeleted(result.viewsDeleted())
+                  .build();
+            }),
+        correlationId());
+  }
+
+  @Override
   public Uni<DeleteCatalogOverlayResponse> deleteCatalogOverlay(
       DeleteCatalogOverlayRequest request) {
     var L = LogHelper.start(LOG, "DeleteCatalogOverlay");
@@ -567,9 +627,9 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
                   if (!overlays.beginDeletion(id, meta.getPointerVersion()))
                     throw new BaseResourceRepository.AbortRetryableException(
                         "overlay changed while deletion was fenced");
-                  // Reconciliation has not landed in this API change, so there are no materialized
-                  // contributions to retire yet. The fence is nevertheless installed before the
-                  // dependency pointers and resource are removed.
+                  reconciler.retireMaterializedResources(current.get().value());
+                  // Managed descendants retire behind the fence first. The final transaction removes
+                  // only the overlay, its dependencies, and the fence; the target catalog remains.
                   long fenceVersion = overlays.deletionFenceVersion(id);
                   if (fenceVersion == 0L
                       || !overlays.deleteWithFence(id, meta.getPointerVersion(), fenceVersion))

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepository.java
@@ -162,9 +162,7 @@ public class CatalogOverlayRepository {
         replacement,
         new PointerConditions(
             requiredPointerVersions, requiredAbsentPointers, parentMarkerVersions),
-        deletionFenceVersion == 0L
-            ? Map.of()
-            : Map.of(deletionFence, deletionFenceVersion));
+        deletionFenceVersion == 0L ? Map.of() : Map.of(deletionFence, deletionFenceVersion));
   }
 
   public boolean deleteWithPrecondition(ResourceId overlayId, long expectedPointerVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepository.java
@@ -152,13 +152,19 @@ public class CatalogOverlayRepository {
       Map<String, Long> requiredPointerVersions,
       Set<String> requiredAbsentPointers,
       Map<String, Long> parentMarkerVersions) {
+    String deletionFence =
+        Keys.catalogOverlayDeletionMarker(
+            current.getResourceId().getAccountId(), current.getResourceId().getId());
+    long deletionFenceVersion = deletionFenceVersion(current.getResourceId());
     return repo.replaceIdentityWithMeta(
         current,
         expectedPointerVersion,
         replacement,
         new PointerConditions(
             requiredPointerVersions, requiredAbsentPointers, parentMarkerVersions),
-        Map.of());
+        deletionFenceVersion == 0L
+            ? Map.of()
+            : Map.of(deletionFence, deletionFenceVersion));
   }
 
   public boolean deleteWithPrecondition(ResourceId overlayId, long expectedPointerVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -104,9 +104,7 @@ public class NamespaceRepository {
   }
 
   public boolean deleteWhilePointersMatch(
-      ResourceId namespaceResourceId,
-      long expectedPointerVersion,
-      PointerConditions conditions) {
+      ResourceId namespaceResourceId, long expectedPointerVersion, PointerConditions conditions) {
     return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
         new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()),
         expectedPointerVersion,

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.NamespaceKey;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.PointerConditions;
 import ai.floedb.floecat.service.repo.util.MetadataRepositoryFactory;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
@@ -33,6 +34,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -75,8 +77,18 @@ public class NamespaceRepository {
     repo.create(namespace);
   }
 
+  public boolean createWhilePointersMatch(Namespace namespace, PointerConditions conditions) {
+    return repo.createWithMeta(namespace, conditions, null).isPresent();
+  }
+
   public boolean update(Namespace namespace, long expectedPointerVersion) {
     return repo.update(namespace, expectedPointerVersion);
+  }
+
+  public Optional<MutationMeta> updateWhilePointersMatch(
+      Namespace namespace, long expectedPointerVersion, PointerConditions conditions) {
+    return repo.updateWithMetaWhilePointersMatchAndBumpMarkers(
+        namespace, expectedPointerVersion, conditions);
   }
 
   public boolean delete(ResourceId namespaceResourceId) {
@@ -89,6 +101,17 @@ public class NamespaceRepository {
     return repo.deleteWithPrecondition(
         new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()),
         expectedPointerVersion);
+  }
+
+  public boolean deleteWhilePointersMatch(
+      ResourceId namespaceResourceId,
+      long expectedPointerVersion,
+      PointerConditions conditions) {
+    return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
+        new NamespaceKey(namespaceResourceId.getAccountId(), namespaceResourceId.getId()),
+        expectedPointerVersion,
+        conditions,
+        Map.of());
   }
 
   public Optional<Namespace> getById(ResourceId namespaceResourceId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
@@ -71,7 +71,8 @@ public class TableRepository {
 
   public Optional<MutationMeta> createWhilePointersMatch(
       Table table, PointerConditions conditions) {
-    return repo.createWithMeta(table, conditions, null).map(GenericResourceRepository.ResourceWithMeta::meta);
+    return repo.createWithMeta(table, conditions, null)
+        .map(GenericResourceRepository.ResourceWithMeta::meta);
   }
 
   public boolean update(Table table, long expectedPointerVersion) {
@@ -95,9 +96,7 @@ public class TableRepository {
   }
 
   public boolean deleteWhilePointersMatch(
-      ResourceId tableResourceId,
-      long expectedPointerVersion,
-      PointerConditions conditions) {
+      ResourceId tableResourceId, long expectedPointerVersion, PointerConditions conditions) {
     return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
         new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()),
         expectedPointerVersion,

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.model.TableKey;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.PointerConditions;
 import ai.floedb.floecat.service.repo.util.MetadataRepositoryFactory;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
@@ -33,6 +34,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -67,8 +69,19 @@ public class TableRepository {
     repo.create(table);
   }
 
+  public Optional<MutationMeta> createWhilePointersMatch(
+      Table table, PointerConditions conditions) {
+    return repo.createWithMeta(table, conditions, null).map(GenericResourceRepository.ResourceWithMeta::meta);
+  }
+
   public boolean update(Table table, long expectedPointerVersion) {
     return repo.update(table, expectedPointerVersion);
+  }
+
+  public Optional<MutationMeta> updateWhilePointersMatch(
+      Table table, long expectedPointerVersion, PointerConditions conditions) {
+    return repo.updateWithMetaWhilePointersMatchAndBumpMarkers(
+        table, expectedPointerVersion, conditions);
   }
 
   public boolean delete(ResourceId tableResourceId) {
@@ -79,6 +92,17 @@ public class TableRepository {
     return repo.deleteWithPrecondition(
         new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()),
         expectedPointerVersion);
+  }
+
+  public boolean deleteWhilePointersMatch(
+      ResourceId tableResourceId,
+      long expectedPointerVersion,
+      PointerConditions conditions) {
+    return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
+        new TableKey(tableResourceId.getAccountId(), tableResourceId.getId()),
+        expectedPointerVersion,
+        conditions,
+        Map.of());
   }
 
   public Optional<Table> getById(ResourceId tableResourceId) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
@@ -93,9 +93,7 @@ public class ViewRepository {
   }
 
   public boolean deleteWhilePointersMatch(
-      ResourceId viewResourceId,
-      long expectedPointerVersion,
-      PointerConditions conditions) {
+      ResourceId viewResourceId, long expectedPointerVersion, PointerConditions conditions) {
     return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
         new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()),
         expectedPointerVersion,

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.model.ViewKey;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.PointerConditions;
 import ai.floedb.floecat.service.repo.util.MetadataRepositoryFactory;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
@@ -33,6 +34,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -67,8 +69,18 @@ public class ViewRepository {
     repo.create(view);
   }
 
+  public boolean createWhilePointersMatch(View view, PointerConditions conditions) {
+    return repo.createWithMeta(view, conditions, null).isPresent();
+  }
+
   public boolean update(View view, long expectedPointerVersion) {
     return repo.update(view, expectedPointerVersion);
+  }
+
+  public Optional<MutationMeta> updateWhilePointersMatch(
+      View view, long expectedPointerVersion, PointerConditions conditions) {
+    return repo.updateWithMetaWhilePointersMatchAndBumpMarkers(
+        view, expectedPointerVersion, conditions);
   }
 
   public boolean delete(ResourceId viewResourceId) {
@@ -78,6 +90,17 @@ public class ViewRepository {
   public boolean deleteWithPrecondition(ResourceId viewResourceId, long expectedPointerVersion) {
     return repo.deleteWithPrecondition(
         new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()), expectedPointerVersion);
+  }
+
+  public boolean deleteWhilePointersMatch(
+      ResourceId viewResourceId,
+      long expectedPointerVersion,
+      PointerConditions conditions) {
+    return repo.deleteWithPreconditionWhilePointersMatchAndDeletePointers(
+        new ViewKey(viewResourceId.getAccountId(), viewResourceId.getId()),
+        expectedPointerVersion,
+        conditions,
+        Map.of());
   }
 
   public Optional<View> getById(ResourceId viewResourceId) {

--- a/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
@@ -39,6 +39,8 @@ public final class RolePermissions {
   public static final String CATALOG_INTEGRATION_USE = "catalog-integration.use";
   public static final String CATALOG_OVERLAY_READ = "catalog-overlay.read";
   public static final String CATALOG_OVERLAY_WRITE = "catalog-overlay.write";
+  public static final String CATALOG_OVERLAY_RECONCILE = "catalog-overlay.reconcile";
+  public static final String CATALOG_OVERLAY_DELETE = "catalog-overlay.delete";
   private static final List<String> READ_PERMS =
       List.of(
           "account.read",
@@ -65,6 +67,8 @@ public final class RolePermissions {
           CATALOG_INTEGRATION_USE,
           CATALOG_OVERLAY_READ,
           CATALOG_OVERLAY_WRITE,
+          CATALOG_OVERLAY_RECONCILE,
+          CATALOG_OVERLAY_DELETE,
           "system-objects.read",
           "account.delete");
   private static final List<String> PLATFORM_PERMS =
@@ -100,6 +104,7 @@ public final class RolePermissions {
           CATALOG_INTEGRATION_READ,
           CATALOG_INTEGRATION_USE,
           CATALOG_OVERLAY_READ,
+          CATALOG_OVERLAY_RECONCILE,
           "system-objects.read",
           STORAGE_AUTHORITY_RESOLVE_INTERNAL,
           RECONCILE_EXECUTOR_CONTROL_INTERNAL);

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootWriterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootWriterTest.java
@@ -118,6 +118,13 @@ class TableRootWriterTest {
     return MutationMeta.newBuilder().setBlobUri("s3://t/table.pb").setEtag("etag-t").build();
   }
 
+  private MutationMeta definitionMeta(String revision) {
+    return MutationMeta.newBuilder()
+        .setBlobUri("s3://t/table-" + revision + ".pb")
+        .setEtag("etag-" + revision)
+        .build();
+  }
+
   @Test
   void commitStatsGenerationRecordsTheActiveGenerationOnTheEntry() {
     when(statsStore.activeStatsGeneration(tableId, 7L))
@@ -168,6 +175,33 @@ class TableRootWriterTest {
     when(constraintRepo.metaForSafe(tableId, 7L)).thenReturn(MutationMeta.getDefaultInstance());
     writer.commitConstraints(tableId, 7L);
     assertFalse(entry(7).hasConstraintsRef());
+  }
+
+  @Test
+  void replacingAStaleDefinitionPreservesSnapshotStateAndDoesNotClobberAWinner() {
+    MutationMeta original = definitionMeta("original");
+    MutationMeta stale = definitionMeta("stale");
+    MutationMeta winner = definitionMeta("winner");
+    writer.commitDefinition(tableId, original);
+    var before = roots.get(tableId).orElseThrow();
+
+    writer.commitDefinition(tableId, stale);
+    writer.replaceDefinitionIfMatches(tableId, stale, original);
+
+    var restored = roots.get(tableId).orElseThrow();
+    assertEquals(original.getBlobUri(), restored.getDefinitionRef().getUri());
+    assertEquals(original.getEtag(), restored.getDefinitionRef().getVersion());
+    assertEquals(before.getSnapshotManifestRef(), restored.getSnapshotManifestRef());
+    assertEquals(7L, restored.getCurrentSnapshotId());
+
+    writer.commitDefinition(tableId, winner);
+    writer.replaceDefinitionIfMatches(tableId, stale, original);
+
+    var retainedWinner = roots.get(tableId).orElseThrow();
+    assertEquals(winner.getBlobUri(), retainedWinner.getDefinitionRef().getUri());
+    assertEquals(winner.getEtag(), retainedWinner.getDefinitionRef().getVersion());
+    assertEquals(before.getSnapshotManifestRef(), retainedWinner.getSnapshotManifestRef());
+    assertEquals(7L, retainedWinner.getCurrentSnapshotId());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -263,6 +263,37 @@ class CatalogIntegrationsImplTest {
   }
 
   @Test
+  void createPersistsNormalizedOauthClientIdAndScopes() {
+    var response =
+        service
+            .createCatalogIntegration(
+                CreateCatalogIntegrationRequest.newBuilder()
+                    .setSpec(
+                        CatalogIntegrationSpec.newBuilder()
+                            .setDisplayName("Warehouse")
+                            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+                            .setCatalogUri("https://catalog.example")
+                            .setAuthentication(
+                                CatalogAuthentication.newBuilder()
+                                    .setOauthClientCredentials(
+                                        OAuthClientCredentialsAuthentication.newBuilder()
+                                            .setClientId("  client-id  ")
+                                            .addScopes("  catalog.read")
+                                            .addScopes("catalog.write  "))))
+                    .setCredentials(oauthCredentials())
+                    .build())
+            .await()
+            .indefinitely();
+
+    var persisted = ArgumentCaptor.forClass(CatalogIntegration.class);
+    verify(service.integrations).createWithMeta(persisted.capture());
+    var oauth = persisted.getValue().getAuthentication().getOauthClientCredentials();
+    assertEquals("client-id", oauth.getClientId());
+    assertEquals(List.of("catalog.read", "catalog.write"), oauth.getScopesList());
+    assertEquals(oauth, response.getIntegration().getAuthentication().getOauthClientCredentials());
+  }
+
+  @Test
   void updateAuthenticationRotatesCredentialsAndAdvancesGeneration() {
     var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
     var current =
@@ -1116,9 +1147,11 @@ class CatalogIntegrationsImplTest {
   }
 
   @Test
-  void cascadeDeleteRequiresOverlayWriteBeforeReadingIntegration() {
+  void legacyOverlayWriteDoesNotAuthorizeCascadeDelete() {
     service.authz = new Authorizer();
-    when(service.principal.get()).thenReturn(principal("catalog-integration.write"));
+    when(service.principal.get())
+        .thenReturn(
+            principal("catalog-integration.write", "catalog-overlay.write", "catalog.write"));
     var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
 
     var error =
@@ -1142,7 +1175,8 @@ class CatalogIntegrationsImplTest {
   void cascadeFencesDeletesDependentsAndAtomicallyCompletes() {
     service.authz = new Authorizer();
     when(service.principal.get())
-        .thenReturn(principal("catalog-integration.write", "catalog-overlay.write"));
+        .thenReturn(
+            principal("catalog-integration.write", "catalog-overlay.delete"));
     var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
     var integration = CatalogIntegration.newBuilder().setResourceId(integrationId).build();
     var integrationMeta = MutationMeta.newBuilder().setPointerVersion(7L).build();

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -80,6 +80,7 @@ class CatalogIntegrationsImplTest {
     service = new CatalogIntegrationsImpl();
     service.integrations = mock(CatalogIntegrationRepository.class);
     service.overlays = mock(CatalogOverlayRepository.class);
+    service.overlayReconciler = mock(CatalogOverlayReconciler.class);
     service.markerStore = mock(MarkerStore.class);
     service.principal = mock(PrincipalProvider.class);
     service.authz = mock(Authorizer.class);
@@ -1180,6 +1181,7 @@ class CatalogIntegrationsImplTest {
 
     verify(service.integrations).beginCascadeDeletion(integrationId, 7L);
     verify(service.overlays).beginDeletion(overlayId, 3L);
+    verify(service.overlayReconciler).retireMaterializedResources(overlay);
     verify(service.overlays).deleteWithFence(overlayId, 3L, 1L);
     verify(service.integrations)
         .deleteWithPreconditionForCascadeDeletion(integrationId, 7L, 4L, 1L);

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImplTest.java
@@ -1175,8 +1175,7 @@ class CatalogIntegrationsImplTest {
   void cascadeFencesDeletesDependentsAndAtomicallyCompletes() {
     service.authz = new Authorizer();
     when(service.principal.get())
-        .thenReturn(
-            principal("catalog-integration.write", "catalog-overlay.delete"));
+        .thenReturn(principal("catalog-integration.write", "catalog-overlay.delete"));
     var integrationId = id("integration", ResourceKind.RK_CATALOG_INTEGRATION);
     var integration = CatalogIntegration.newBuilder().setResourceId(integrationId).build();
     var integrationMeta = MutationMeta.newBuilder().setPointerVersion(7L).build();

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.access.CatalogCapabilities;
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.CatalogTable;
+import ai.floedb.floecat.catalog.access.CatalogView;
+import ai.floedb.floecat.catalog.access.CatalogViewDefinition;
+import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.common.rpc.MutationMeta;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.catalog.rpc.TableRoot;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.integration.rpc.CatalogOverlay;
+import ai.floedb.floecat.scanner.spi.TopologyGraph;
+import ai.floedb.floecat.service.catalog.impl.TableRootWriter;
+import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
+import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
+import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
+import ai.floedb.floecat.service.repo.impl.TableRepository;
+import ai.floedb.floecat.service.repo.impl.TableRootRepository;
+import ai.floedb.floecat.service.repo.impl.ViewRepository;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.MarkerStore;
+import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CatalogOverlayReconcilerTest {
+  private static final String SCHEMA_JSON =
+      "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":false,\"type\":\"long\"}]}";
+
+  private CatalogOverlayReconciler reconciler;
+  private CatalogIntegrationRepository integrations;
+  private CatalogOverlayRepository overlays;
+  private NamespaceRepository namespaces;
+  private TableRepository tables;
+  private ViewRepository views;
+  private CatalogIntegration integration;
+  private CatalogOverlay overlay;
+  private FakeCatalogClient client;
+
+  @BeforeEach
+  void setUp() {
+    var pointers = new InMemoryPointerStore();
+    var blobs = new InMemoryBlobStore();
+    integrations = new CatalogIntegrationRepository(pointers, blobs);
+    overlays = new CatalogOverlayRepository(pointers, blobs);
+    namespaces = new NamespaceRepository(pointers, blobs);
+    tables = new TableRepository(pointers, blobs);
+    views = new ViewRepository(pointers, blobs);
+
+    integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(id("integration", ResourceKind.RK_CATALOG_INTEGRATION))
+            .setDisplayName("upstream")
+            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+            .setCatalogUri("https://catalog.example/v1")
+            .build();
+    overlay =
+        CatalogOverlay.newBuilder()
+            .setResourceId(id("overlay", ResourceKind.RK_CATALOG_OVERLAY))
+            .setCatalogId(id("catalog", ResourceKind.RK_CATALOG))
+            .setIntegrationId(integration.getResourceId())
+            .setDisplayName("sales")
+            .addIncludeNamespaces(
+                ai.floedb.floecat.integration.rpc.NamespacePath.newBuilder()
+                    .addSegments("sales"))
+            .build();
+    integrations.create(integration);
+    overlays.create(overlay);
+
+    client = new FakeCatalogClient();
+    var access = mock(CatalogIntegrationAccess.class);
+    when(access.open(integration)).thenReturn(client);
+    reconciler = new CatalogOverlayReconciler();
+    reconciler.access = access;
+    reconciler.integrations = integrations;
+    reconciler.overlays = overlays;
+    reconciler.namespaces = namespaces;
+    reconciler.tables = tables;
+    reconciler.views = views;
+    reconciler.pointerStore = pointers;
+    reconciler.tableRoots = mock(TableRootRepository.class);
+    reconciler.rootWriter = mock(TableRootWriter.class);
+    reconciler.markerStore = mock(MarkerStore.class);
+    reconciler.metadataGraph = mock(UserGraph.class);
+    reconciler.topology = mock(TopologyGraph.class);
+  }
+
+  @Test
+  void materializesSelectedInventoryAndRetiresWhatDisappears() {
+    NamespacePath sales = NamespacePath.of("sales");
+    NamespacePath europe = NamespacePath.of("sales", "eu");
+    NamespacePath internal = NamespacePath.of("internal");
+    client.children.put(NamespacePath.root(), List.of(sales, internal));
+    client.children.put(sales, List.of(europe));
+    client.children.put(europe, List.of());
+    client.tables.put(
+        new CatalogObjectName(sales, "orders"),
+        new CatalogTable(
+            new CatalogObjectName(sales, "orders"),
+            ExternalObjectIdentity.stable("table-uuid"),
+            "ICEBERG",
+            SCHEMA_JSON,
+            List.of(),
+            Optional.of("s3://warehouse/orders/metadata.json"),
+            Optional.of("s3://warehouse/orders"),
+            Map.of()));
+    client.views.put(
+        new CatalogObjectName(europe, "summary"),
+        new CatalogView(
+            new CatalogObjectName(europe, "summary"),
+            ExternalObjectIdentity.stable("view-uuid"),
+            SCHEMA_JSON,
+            List.of(new CatalogViewDefinition("select id from orders", "ansi")),
+            europe,
+            Map.of()));
+
+    var first = reconcile();
+
+    assertEquals(2, first.namespacesCreated());
+    assertEquals(1, first.tablesCreated());
+    assertEquals(1, first.viewsCreated());
+    var salesNamespace =
+        namespaces.getByPath("acct", "catalog", List.of("sales")).orElseThrow();
+    var europeNamespace =
+        namespaces.getByPath("acct", "catalog", List.of("sales", "eu")).orElseThrow();
+    var table =
+        tables
+            .getByName("acct", "catalog", salesNamespace.getResourceId().getId(), "orders")
+            .orElseThrow();
+    assertEquals(integration.getResourceId(), table.getUpstream().getCatalogIntegrationId());
+    assertEquals(overlay.getResourceId(), table.getUpstream().getCatalogOverlayId());
+    assertEquals(SCHEMA_JSON, table.getSchemaJson());
+    assertTrue(
+        views
+            .getByName("acct", "catalog", europeNamespace.getResourceId().getId(), "summary")
+            .isPresent());
+
+    clearInvocations(reconciler.markerStore, reconciler.metadataGraph, reconciler.topology);
+    var second = reconcile();
+    assertEquals(new CatalogOverlayReconciler.Result(0, 0, 0, 0, 0, 0, 0, 0), second);
+    verifyNoInteractions(reconciler.markerStore, reconciler.metadataGraph, reconciler.topology);
+
+    client.children.put(sales, List.of());
+    client.tables.clear();
+    client.views.clear();
+    var third = reconcile();
+    assertEquals(1, third.namespacesDeleted());
+    assertEquals(1, third.tablesDeleted());
+    assertEquals(1, third.viewsDeleted());
+    assertTrue(namespaces.getByPath("acct", "catalog", List.of("sales", "eu")).isEmpty());
+
+    reconciler.retireMaterializedResources(overlay);
+    assertTrue(namespaces.listIdsConsistent("acct", "catalog").isEmpty());
+  }
+
+  @Test
+  void staleOverlayGenerationCannotPublish() {
+    NamespacePath sales = NamespacePath.of("sales");
+    client.children.put(NamespacePath.root(), List.of(sales));
+    client.children.put(sales, List.of());
+    var observed = overlays.metaFor(overlay.getResourceId());
+    assertTrue(overlays.update(overlay.toBuilder().setDisplayName("changed").build(), observed.getPointerVersion()));
+
+    assertThrows(
+        BaseResourceRepository.AbortRetryableException.class,
+        () ->
+            reconciler.reconcile(
+                overlay,
+                observed,
+                integration,
+                integrations.metaFor(integration.getResourceId())));
+    assertTrue(namespaces.listIdsConsistent("acct", "catalog").isEmpty());
+  }
+
+  @Test
+  void duplicateStableUpstreamIdentityIsRejectedBeforePublication() {
+    NamespacePath sales = NamespacePath.of("sales");
+    client.children.put(NamespacePath.root(), List.of(sales));
+    client.children.put(sales, List.of());
+    for (String name : List.of("orders", "returns")) {
+      CatalogObjectName objectName = new CatalogObjectName(sales, name);
+      client.tables.put(
+          objectName,
+          new CatalogTable(
+              objectName,
+              ExternalObjectIdentity.stable("duplicate-uuid"),
+              "ICEBERG",
+              SCHEMA_JSON,
+              List.of(),
+              Optional.empty(),
+              Optional.empty(),
+              Map.of()));
+    }
+
+    assertThrows(IllegalStateException.class, this::reconcile);
+    assertTrue(namespaces.listIdsConsistent("acct", "catalog").isEmpty());
+  }
+
+  @Test
+  void lostGenerationCannotLeaveAStaleTableRootPublication() {
+    NamespacePath sales = NamespacePath.of("sales");
+    CatalogObjectName orders = new CatalogObjectName(sales, "orders");
+    client.children.put(NamespacePath.root(), List.of(sales));
+    client.children.put(sales, List.of());
+    client.tables.put(
+        orders,
+        new CatalogTable(
+            orders,
+            ExternalObjectIdentity.stable("table-uuid"),
+            "ICEBERG",
+            SCHEMA_JSON,
+            List.of(),
+            Optional.empty(),
+            Optional.empty(),
+            Map.of()));
+    AtomicReference<TableRoot> publishedRoot = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              ResourceId tableId = invocation.getArgument(0);
+              TableRoot root = TableRoot.newBuilder().setTableId(tableId).build();
+              publishedRoot.set(root);
+              tables.delete(tableId);
+              MutationMeta current = overlays.metaFor(overlay.getResourceId());
+              overlays.update(
+                  overlay.toBuilder().setDisplayName("changed").build(),
+                  current.getPointerVersion());
+              return Optional.of(root);
+            })
+        .when(reconciler.rootWriter)
+        .commitDefinitionReturningRoot(any(), any());
+    when(reconciler.tableRoots.metaForSafeLive(any()))
+        .thenReturn(
+            MutationMeta.newBuilder().setPointerVersion(1L).setBlobUri("root-blob").build());
+    when(reconciler.tableRoots.getByBlobUriLive("root-blob"))
+        .thenAnswer(invocation -> Optional.of(publishedRoot.get()));
+    when(reconciler.tableRoots.deleteWithPrecondition(any(), eq(1L))).thenReturn(true);
+
+    assertThrows(BaseResourceRepository.AbortRetryableException.class, this::reconcile);
+    verify(reconciler.tableRoots).deleteWithPrecondition(any(), eq(1L));
+  }
+
+  private CatalogOverlayReconciler.Result reconcile() {
+    return reconciler.reconcile(
+        overlay,
+        overlays.metaFor(overlay.getResourceId()),
+        integration,
+        integrations.metaFor(integration.getResourceId()));
+  }
+
+  private static ResourceId id(String value, ResourceKind kind) {
+    return ResourceId.newBuilder().setAccountId("acct").setId(value).setKind(kind).build();
+  }
+
+  private static final class FakeCatalogClient implements CatalogClient {
+    private final Map<NamespacePath, List<NamespacePath>> children = new HashMap<>();
+    private final Map<CatalogObjectName, CatalogTable> tables = new HashMap<>();
+    private final Map<CatalogObjectName, CatalogView> views = new HashMap<>();
+
+    @Override
+    public CatalogCapabilities capabilities() {
+      return CatalogCapabilities.of(
+          CatalogCapability.LIST_NAMESPACES,
+          CatalogCapability.LIST_TABLES,
+          CatalogCapability.LOAD_TABLE,
+          CatalogCapability.LIST_VIEWS,
+          CatalogCapability.LOAD_VIEW);
+    }
+
+    @Override
+    public void validate() {}
+
+    @Override
+    public List<NamespacePath> listNamespaces(NamespacePath parent) {
+      return children.getOrDefault(parent, List.of());
+    }
+
+    @Override
+    public List<CatalogObjectName> listTables(NamespacePath namespace) {
+      return tables.keySet().stream().filter(name -> name.namespace().equals(namespace)).toList();
+    }
+
+    @Override
+    public CatalogTable loadTable(CatalogObjectName table) {
+      return tables.get(table);
+    }
+
+    @Override
+    public List<CatalogObjectName> listViews(NamespacePath namespace) {
+      return views.keySet().stream().filter(name -> name.namespace().equals(namespace)).toList();
+    }
+
+    @Override
+    public CatalogView loadView(CatalogObjectName view) {
+      return views.get(view);
+    }
+
+    @Override
+    public Optional<VendedStorageCredentials> vendStorageCredentials(CatalogObjectName table) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -197,6 +198,100 @@ class CatalogOverlayReconcilerTest {
   }
 
   @Test
+  void retiresOldStableIdentityBeforeRecreatingTheSameTableName() {
+    NamespacePath sales = NamespacePath.of("sales");
+    CatalogObjectName orders = new CatalogObjectName(sales, "orders");
+    client.children.put(NamespacePath.root(), List.of(sales));
+    client.children.put(sales, List.of());
+    client.tables.put(orders, catalogTable(orders, "old-table-uuid"));
+
+    reconcile();
+    var namespace = namespaces.getByPath("acct", "catalog", List.of("sales")).orElseThrow();
+    ResourceId oldId =
+        tables
+            .getByName("acct", "catalog", namespace.getResourceId().getId(), "orders")
+            .orElseThrow()
+            .getResourceId();
+
+    client.tables.put(orders, catalogTable(orders, "new-table-uuid"));
+    var result = reconcile();
+
+    ResourceId newId =
+        tables
+            .getByName("acct", "catalog", namespace.getResourceId().getId(), "orders")
+            .orElseThrow()
+            .getResourceId();
+    assertEquals(1, result.tablesDeleted());
+    assertEquals(1, result.tablesCreated());
+    assertNotEquals(oldId, newId);
+  }
+
+  @Test
+  void retiresRenameDestinationBeforeMovingAStableTable() {
+    NamespacePath sales = NamespacePath.of("sales");
+    CatalogObjectName orders = new CatalogObjectName(sales, "orders");
+    CatalogObjectName archived = new CatalogObjectName(sales, "archived_orders");
+    client.children.put(NamespacePath.root(), List.of(sales));
+    client.children.put(sales, List.of());
+    client.tables.put(orders, catalogTable(orders, "orders-uuid"));
+    client.tables.put(archived, catalogTable(archived, "archived-uuid"));
+
+    reconcile();
+    var namespace = namespaces.getByPath("acct", "catalog", List.of("sales")).orElseThrow();
+    ResourceId ordersId =
+        tables
+            .getByName("acct", "catalog", namespace.getResourceId().getId(), "orders")
+            .orElseThrow()
+            .getResourceId();
+
+    client.tables.clear();
+    client.tables.put(archived, catalogTable(archived, "orders-uuid"));
+    var result = reconcile();
+
+    assertEquals(1, result.tablesDeleted());
+    assertEquals(1, result.tablesUpdated());
+    assertTrue(
+        tables.getByName("acct", "catalog", namespace.getResourceId().getId(), "orders").isEmpty());
+    assertEquals(
+        ordersId,
+        tables
+            .getByName("acct", "catalog", namespace.getResourceId().getId(), "archived_orders")
+            .orElseThrow()
+            .getResourceId());
+  }
+
+  @Test
+  void retiresAViewBeforeCreatingATableWithTheSameRelationName() {
+    NamespacePath sales = NamespacePath.of("sales");
+    CatalogObjectName summary = new CatalogObjectName(sales, "summary");
+    client.children.put(NamespacePath.root(), List.of(sales));
+    client.children.put(sales, List.of());
+    client.views.put(
+        summary,
+        new CatalogView(
+            summary,
+            ExternalObjectIdentity.stable("view-uuid"),
+            SCHEMA_JSON,
+            List.of(new CatalogViewDefinition("select 1", "ansi")),
+            sales,
+            Map.of()));
+
+    reconcile();
+    client.views.clear();
+    client.tables.put(summary, catalogTable(summary, "table-uuid"));
+
+    var result = reconcile();
+
+    var namespace = namespaces.getByPath("acct", "catalog", List.of("sales")).orElseThrow();
+    assertEquals(1, result.viewsDeleted());
+    assertEquals(1, result.tablesCreated());
+    assertTrue(
+        tables
+            .getByName("acct", "catalog", namespace.getResourceId().getId(), "summary")
+            .isPresent());
+  }
+
+  @Test
   void staleOverlayGenerationCannotPublish() {
     NamespacePath sales = NamespacePath.of("sales");
     client.children.put(NamespacePath.root(), List.of(sales));
@@ -288,6 +383,18 @@ class CatalogOverlayReconcilerTest {
         overlays.metaFor(overlay.getResourceId()),
         integration,
         integrations.metaFor(integration.getResourceId()));
+  }
+
+  private static CatalogTable catalogTable(CatalogObjectName name, String stableIdentity) {
+    return new CatalogTable(
+        name,
+        ExternalObjectIdentity.stable(stableIdentity),
+        "ICEBERG",
+        SCHEMA_JSON,
+        List.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Map.of());
   }
 
   private static ResourceId id(String value, ResourceKind kind) {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -43,6 +44,7 @@ import ai.floedb.floecat.catalog.access.CatalogViewDefinition;
 import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
 import ai.floedb.floecat.catalog.access.NamespacePath;
 import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.rpc.Namespace;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
@@ -195,7 +197,7 @@ class CatalogOverlayReconcilerTest {
     assertTrue(namespaces.getByPath("acct", "catalog", List.of("sales", "eu")).isEmpty());
 
     reconciler.retireMaterializedResources(overlay);
-    assertTrue(namespaces.listIdsConsistent("acct", "catalog").isEmpty());
+    assertTrue(listLocalNamespaces().isEmpty());
   }
 
   @Test
@@ -307,7 +309,7 @@ class CatalogOverlayReconcilerTest {
         () ->
             reconciler.reconcile(
                 overlay, observed, integration, integrations.metaFor(integration.getResourceId())));
-    assertTrue(namespaces.listIdsConsistent("acct", "catalog").isEmpty());
+    assertTrue(listLocalNamespaces().isEmpty());
   }
 
   @Test
@@ -331,7 +333,7 @@ class CatalogOverlayReconcilerTest {
     }
 
     assertThrows(IllegalStateException.class, this::reconcile);
-    assertTrue(namespaces.listIdsConsistent("acct", "catalog").isEmpty());
+    assertTrue(listLocalNamespaces().isEmpty());
   }
 
   @Test
@@ -419,18 +421,17 @@ class CatalogOverlayReconcilerTest {
   }
 
   @Test
-  void consistentNamespaceEnumerationUsesMutationReads() {
+  void namespaceEnumerationUsesConsistentListing() {
     NamespacePath sales = NamespacePath.of("sales");
     client.children.put(NamespacePath.root(), List.of(sales));
     client.children.put(sales, List.of());
     reconcile();
     clearInvocations(namespaces);
-    doReturn(Optional.empty()).when(namespaces).getById(any());
 
     assertEquals(new CatalogOverlayReconciler.Result(0, 0, 0, 0, 0, 0, 0, 0), reconcile());
 
-    verify(namespaces).getByIdForMutation(any());
-    verify(namespaces, never()).getById(any());
+    verify(namespaces)
+        .listConsistent(eq("acct"), eq("catalog"), eq(List.of()), eq(200), eq(""), any());
   }
 
   @Test
@@ -474,6 +475,11 @@ class CatalogOverlayReconcilerTest {
         overlays.metaFor(overlay.getResourceId()),
         integration,
         integrations.metaFor(integration.getResourceId()));
+  }
+
+  private List<Namespace> listLocalNamespaces() {
+    return namespaces.listConsistent(
+        "acct", "catalog", List.of(), 200, "", new StringBuilder());
   }
 
   private static CatalogTable catalogTable(CatalogObjectName name, String stableIdentity) {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
@@ -20,13 +20,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.catalog.access.CatalogCapabilities;
@@ -39,10 +39,10 @@ import ai.floedb.floecat.catalog.access.CatalogViewDefinition;
 import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
 import ai.floedb.floecat.catalog.access.NamespacePath;
 import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
+import ai.floedb.floecat.catalog.rpc.TableRoot;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
-import ai.floedb.floecat.catalog.rpc.TableRoot;
 import ai.floedb.floecat.integration.rpc.CatalogIntegration;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
 import ai.floedb.floecat.integration.rpc.CatalogOverlay;
@@ -105,8 +105,7 @@ class CatalogOverlayReconcilerTest {
             .setIntegrationId(integration.getResourceId())
             .setDisplayName("sales")
             .addIncludeNamespaces(
-                ai.floedb.floecat.integration.rpc.NamespacePath.newBuilder()
-                    .addSegments("sales"))
+                ai.floedb.floecat.integration.rpc.NamespacePath.newBuilder().addSegments("sales"))
             .build();
     integrations.create(integration);
     overlays.create(overlay);
@@ -163,8 +162,7 @@ class CatalogOverlayReconcilerTest {
     assertEquals(2, first.namespacesCreated());
     assertEquals(1, first.tablesCreated());
     assertEquals(1, first.viewsCreated());
-    var salesNamespace =
-        namespaces.getByPath("acct", "catalog", List.of("sales")).orElseThrow();
+    var salesNamespace = namespaces.getByPath("acct", "catalog", List.of("sales")).orElseThrow();
     var europeNamespace =
         namespaces.getByPath("acct", "catalog", List.of("sales", "eu")).orElseThrow();
     var table =
@@ -297,16 +295,15 @@ class CatalogOverlayReconcilerTest {
     client.children.put(NamespacePath.root(), List.of(sales));
     client.children.put(sales, List.of());
     var observed = overlays.metaFor(overlay.getResourceId());
-    assertTrue(overlays.update(overlay.toBuilder().setDisplayName("changed").build(), observed.getPointerVersion()));
+    assertTrue(
+        overlays.update(
+            overlay.toBuilder().setDisplayName("changed").build(), observed.getPointerVersion()));
 
     assertThrows(
         BaseResourceRepository.AbortRetryableException.class,
         () ->
             reconciler.reconcile(
-                overlay,
-                observed,
-                integration,
-                integrations.metaFor(integration.getResourceId())));
+                overlay, observed, integration, integrations.metaFor(integration.getResourceId())));
     assertTrue(namespaces.listIdsConsistent("acct", "catalog").isEmpty());
   }
 
@@ -448,6 +445,10 @@ class CatalogOverlayReconcilerTest {
     public Optional<VendedStorageCredentials> vendStorageCredentials(CatalogObjectName table) {
       return Optional.empty();
     }
+
+    @Override
+    public void validateStorageAccess(
+        CatalogObjectName table, VendedStorageCredentials credentials) {}
 
     @Override
     public void close() {}

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -171,6 +172,7 @@ class CatalogOverlayReconcilerTest {
             .orElseThrow();
     assertEquals(integration.getResourceId(), table.getUpstream().getCatalogIntegrationId());
     assertEquals(overlay.getResourceId(), table.getUpstream().getCatalogOverlayId());
+    assertFalse(table.getUpstream().hasConnectorId());
     assertEquals(SCHEMA_JSON, table.getSchemaJson());
     assertTrue(
         views

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
@@ -22,10 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -40,7 +43,6 @@ import ai.floedb.floecat.catalog.access.CatalogViewDefinition;
 import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
 import ai.floedb.floecat.catalog.access.NamespacePath;
 import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
-import ai.floedb.floecat.catalog.rpc.TableRoot;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
@@ -64,7 +66,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -88,7 +89,7 @@ class CatalogOverlayReconcilerTest {
     var blobs = new InMemoryBlobStore();
     integrations = new CatalogIntegrationRepository(pointers, blobs);
     overlays = new CatalogOverlayRepository(pointers, blobs);
-    namespaces = new NamespaceRepository(pointers, blobs);
+    namespaces = spy(new NamespaceRepository(pointers, blobs));
     tables = new TableRepository(pointers, blobs);
     views = new ViewRepository(pointers, blobs);
 
@@ -334,6 +335,105 @@ class CatalogOverlayReconcilerTest {
   }
 
   @Test
+  void staleNamespaceContainingANonOverlayRelationIsLeftInPlace() {
+    NamespacePath sales = NamespacePath.of("sales");
+    CatalogObjectName orders = new CatalogObjectName(sales, "orders");
+    client.children.put(NamespacePath.root(), List.of(sales));
+    client.children.put(sales, List.of());
+    client.tables.put(orders, catalogTable(orders, "table-uuid"));
+
+    reconcile();
+    var namespace = namespaces.getByPath("acct", "catalog", List.of("sales")).orElseThrow();
+    var table =
+        tables
+            .getByName("acct", "catalog", namespace.getResourceId().getId(), "orders")
+            .orElseThrow();
+    MutationMeta tableMeta = tables.metaFor(table.getResourceId());
+    assertTrue(
+        tables.update(table.toBuilder().clearProperties().build(), tableMeta.getPointerVersion()));
+
+    client.children.clear();
+    client.tables.clear();
+    var result = reconcile();
+
+    assertEquals(0, result.namespacesDeleted());
+    assertTrue(namespaces.getByPath("acct", "catalog", List.of("sales")).isPresent());
+    assertTrue(tables.getById(table.getResourceId()).isPresent());
+  }
+
+  @Test
+  void normalizesSelectionAndMaterializedNamesButPreservesUpstreamIdentity() {
+    String rawNamespace = "sales\u00a0\u00a0team";
+    String rawChild = "private\u00a0\u00a0data";
+    String rawTable = "daily\u00a0\u00a0orders";
+    String rawView = "weekly  summary";
+    NamespacePath sales = NamespacePath.of(rawNamespace);
+    NamespacePath excluded = NamespacePath.of(rawNamespace, rawChild);
+    CatalogObjectName tableName = new CatalogObjectName(sales, rawTable);
+    CatalogObjectName viewName = new CatalogObjectName(sales, rawView);
+    MutationMeta overlayMeta = overlays.metaFor(overlay.getResourceId());
+    overlay =
+        overlay.toBuilder()
+            .clearIncludeNamespaces()
+            .addIncludeNamespaces(
+                ai.floedb.floecat.integration.rpc.NamespacePath.newBuilder()
+                    .addSegments("sales team"))
+            .addExcludeNamespaces(
+                ai.floedb.floecat.integration.rpc.NamespacePath.newBuilder()
+                    .addSegments("sales team")
+                    .addSegments("private data"))
+            .build();
+    assertTrue(overlays.update(overlay, overlayMeta.getPointerVersion()));
+    client.children.put(NamespacePath.root(), List.of(sales));
+    client.children.put(sales, List.of(excluded));
+    client.children.put(excluded, List.of());
+    client.tables.put(tableName, catalogTable(tableName, "table-uuid"));
+    client.tables.put(
+        new CatalogObjectName(excluded, "hidden"),
+        catalogTable(new CatalogObjectName(excluded, "hidden"), "hidden-uuid"));
+    client.views.put(
+        viewName,
+        new CatalogView(
+            viewName,
+            ExternalObjectIdentity.stable("view-uuid"),
+            SCHEMA_JSON,
+            List.of(new CatalogViewDefinition("select 1", "ansi")),
+            sales,
+            Map.of()));
+
+    reconcile();
+
+    var namespace = namespaces.getByPath("acct", "catalog", List.of("sales team")).orElseThrow();
+    var table =
+        tables
+            .getByName("acct", "catalog", namespace.getResourceId().getId(), "daily orders")
+            .orElseThrow();
+    assertEquals(rawNamespace, table.getUpstream().getNamespacePath(0));
+    assertEquals(rawTable, table.getUpstream().getTableDisplayName());
+    assertTrue(
+        views
+            .getByName("acct", "catalog", namespace.getResourceId().getId(), "weekly summary")
+            .isPresent());
+    assertTrue(
+        namespaces.getByPath("acct", "catalog", List.of("sales team", "private data")).isEmpty());
+  }
+
+  @Test
+  void consistentNamespaceEnumerationUsesMutationReads() {
+    NamespacePath sales = NamespacePath.of("sales");
+    client.children.put(NamespacePath.root(), List.of(sales));
+    client.children.put(sales, List.of());
+    reconcile();
+    clearInvocations(namespaces);
+    doReturn(Optional.empty()).when(namespaces).getById(any());
+
+    assertEquals(new CatalogOverlayReconciler.Result(0, 0, 0, 0, 0, 0, 0, 0), reconcile());
+
+    verify(namespaces).getByIdForMutation(any());
+    verify(namespaces, never()).getById(any());
+  }
+
+  @Test
   void lostGenerationCannotLeaveAStaleTableRootPublication() {
     NamespacePath sales = NamespacePath.of("sales");
     CatalogObjectName orders = new CatalogObjectName(sales, "orders");
@@ -350,30 +450,22 @@ class CatalogOverlayReconcilerTest {
             Optional.empty(),
             Optional.empty(),
             Map.of()));
-    AtomicReference<TableRoot> publishedRoot = new AtomicReference<>();
     doAnswer(
             invocation -> {
               ResourceId tableId = invocation.getArgument(0);
-              TableRoot root = TableRoot.newBuilder().setTableId(tableId).build();
-              publishedRoot.set(root);
               tables.delete(tableId);
               MutationMeta current = overlays.metaFor(overlay.getResourceId());
               overlays.update(
                   overlay.toBuilder().setDisplayName("changed").build(),
                   current.getPointerVersion());
-              return Optional.of(root);
+              return null;
             })
         .when(reconciler.rootWriter)
-        .commitDefinitionReturningRoot(any(), any());
-    when(reconciler.tableRoots.metaForSafeLive(any()))
-        .thenReturn(
-            MutationMeta.newBuilder().setPointerVersion(1L).setBlobUri("root-blob").build());
-    when(reconciler.tableRoots.getByBlobUriLive("root-blob"))
-        .thenAnswer(invocation -> Optional.of(publishedRoot.get()));
-    when(reconciler.tableRoots.deleteWithPrecondition(any(), eq(1L))).thenReturn(true);
+        .commitDefinition(any(), any());
 
     assertThrows(BaseResourceRepository.AbortRetryableException.class, this::reconcile);
-    verify(reconciler.tableRoots).deleteWithPrecondition(any(), eq(1L));
+    verify(reconciler.rootWriter).replaceDefinitionIfMatches(any(), any(), any());
+    verify(reconciler.tableRoots, never()).deleteWithPrecondition(any(), anyLong());
   }
 
   private CatalogOverlayReconciler.Result reconcile() {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlayReconcilerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -478,8 +477,7 @@ class CatalogOverlayReconcilerTest {
   }
 
   private List<Namespace> listLocalNamespaces() {
-    return namespaces.listConsistent(
-        "acct", "catalog", List.of(), 200, "", new StringBuilder());
+    return namespaces.listConsistent("acct", "catalog", List.of(), 200, "", new StringBuilder());
   }
 
   private static CatalogTable catalogTable(CatalogObjectName name, String stableIdentity) {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
@@ -219,6 +219,7 @@ class CatalogOverlaysImplTest {
 
   @Test
   void reconcileReportsMaterializedMetadataChanges() {
+    service.authz = new Authorizer();
     var overlayId = id("overlay", ResourceKind.RK_CATALOG_OVERLAY);
     var current = overlay(overlayId, integrationId(), catalogId(), "sales");
     var overlayMeta = MutationMeta.newBuilder().setPointerVersion(7L).build();
@@ -231,12 +232,7 @@ class CatalogOverlaysImplTest {
                 .setCorrelationId("corr")
                 .addAllPermissions(
                     Set.of(
-                        "catalog-overlay.write",
-                        "catalog-integration.use",
-                        "catalog.write",
-                        "namespace.write",
-                        "table.write",
-                        "view.write"))
+                        "catalog-overlay.reconcile", "catalog-integration.use"))
                 .build());
     when(service.overlays.getByIdWithMeta(overlayId))
         .thenReturn(Optional.of(new ResourceWithMeta<>(current, overlayMeta)));
@@ -260,6 +256,32 @@ class CatalogOverlaysImplTest {
     assertEquals(6, response.getViewsCreated());
     assertEquals(7, response.getViewsUpdated());
     assertEquals(8, response.getViewsDeleted());
+  }
+
+  @Test
+  void overlayWriteDoesNotAuthorizeDelete() {
+    service.authz = new Authorizer();
+    var overlayId = id("overlay", ResourceKind.RK_CATALOG_OVERLAY);
+    when(service.principal.get())
+        .thenReturn(
+            PrincipalContext.newBuilder()
+                .setAccountId("acct")
+                .setCorrelationId("corr")
+                .addPermissions("catalog-overlay.write")
+                .build());
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .deleteCatalogOverlay(
+                        DeleteCatalogOverlayRequest.newBuilder().setOverlayId(overlayId).build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.PERMISSION_DENIED, error.getStatus().getCode());
+    verify(service.overlays, never()).getByIdWithMeta(any());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
@@ -32,6 +32,8 @@ import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayRequest;
 import ai.floedb.floecat.integration.rpc.NamespacePath;
 import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayRequest;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayRequest;
+import ai.floedb.floecat.metagraph.model.CatalogNode;
+import ai.floedb.floecat.scanner.spi.CatalogGraphView;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
@@ -42,6 +44,7 @@ import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.storage.spi.PointerStore;
+import ai.floedb.floecat.systemcatalog.graph.SystemNodeRegistry;
 import com.google.protobuf.FieldMask;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -70,10 +73,12 @@ class CatalogOverlaysImplTest {
     service.authz = mock(Authorizer.class);
     service.idempotencyStore = mock(IdempotencyRepository.class);
     service.reconciler = mock(CatalogOverlayReconciler.class);
+    service.graphView = mock(CatalogGraphView.class);
     installBasePrincipal(service, service.principal);
     when(service.principal.get()).thenReturn(principal());
     stubIntegration(integrationId(), 5L);
     stubCatalog(catalogId(), 7L);
+    when(service.graphView.resolve(catalogId())).thenReturn(Optional.of(catalogNode(catalogId())));
     when(service.markerStore.catalogIntegrationOverlaysMarkerVersion(integrationId()))
         .thenReturn(2L);
     when(service.markerStore.catalogOverlaysMarkerVersion(catalogId())).thenReturn(3L);
@@ -218,6 +223,56 @@ class CatalogOverlaysImplTest {
   }
 
   @Test
+  void replacementValidatesTheOldCatalogBeforeInstallingADeletionFence() {
+    var oldOverlayId = id("old-overlay", ResourceKind.RK_CATALOG_OVERLAY);
+    var missingOldCatalogId = id("missing-old-catalog", ResourceKind.RK_CATALOG);
+    var current = overlay(oldOverlayId, integrationId(), missingOldCatalogId, "sales");
+    when(service.overlays.getByNameWithMeta("acct", "sales"))
+        .thenReturn(Optional.of(row(current, 9L)));
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogOverlay(
+                        CreateCatalogOverlayRequest.newBuilder()
+                            .setCreateMode(CreateMode.CM_REPLACE)
+                            .setSpec(baseSpec())
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.INTERNAL, error.getStatus().getCode());
+    verify(service.overlays, never()).beginDeletion(any(), anyLong());
+    verify(service.reconciler, never()).retireMaterializedResources(any());
+  }
+
+  @Test
+  void createRejectsASystemCatalogBeforeMaterializationCanBeScheduled() {
+    ResourceId systemCatalogId =
+        SystemNodeRegistry.systemCatalogContainerId("floedb").toBuilder()
+            .setAccountId("acct")
+            .build();
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createCatalogOverlay(
+                        CreateCatalogOverlayRequest.newBuilder()
+                            .setSpec(baseSpec().toBuilder().setCatalogId(systemCatalogId))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.PERMISSION_DENIED, error.getStatus().getCode());
+    verify(service.overlays, never())
+        .createAttachedWithMetaAndCompanions(any(), any(), any(), any(), any());
+  }
+
+  @Test
   void reconcileReportsMaterializedMetadataChanges() {
     service.authz = new Authorizer();
     var overlayId = id("overlay", ResourceKind.RK_CATALOG_OVERLAY);
@@ -254,6 +309,38 @@ class CatalogOverlaysImplTest {
     assertEquals(6, response.getViewsCreated());
     assertEquals(7, response.getViewsUpdated());
     assertEquals(8, response.getViewsDeleted());
+  }
+
+  @Test
+  void reconcileRejectsAPreviouslyPersistedSystemCatalogOverlay() {
+    service.authz = new Authorizer();
+    ResourceId systemCatalogId =
+        SystemNodeRegistry.systemCatalogContainerId("floedb").toBuilder()
+            .setAccountId("acct")
+            .build();
+    var overlayId = id("overlay", ResourceKind.RK_CATALOG_OVERLAY);
+    var current = overlay(overlayId, integrationId(), systemCatalogId, "sales");
+    when(service.principal.get())
+        .thenReturn(
+            PrincipalContext.newBuilder()
+                .setAccountId("acct")
+                .setCorrelationId("corr")
+                .addAllPermissions(Set.of("catalog-overlay.reconcile", "catalog-integration.use"))
+                .build());
+    when(service.overlays.getByIdWithMeta(overlayId)).thenReturn(Optional.of(row(current, 7L)));
+
+    var error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .reconcileCatalogOverlay(
+                        ReconcileCatalogOverlayRequest.newBuilder().setOverlayId(overlayId).build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(Status.Code.PERMISSION_DENIED, error.getStatus().getCode());
+    verify(service.reconciler, never()).reconcile(any(), any(), any(), any());
   }
 
   @Test
@@ -388,6 +475,18 @@ class CatalogOverlaysImplTest {
                 "catalog-integration.use",
                 "catalog.write"))
         .build();
+  }
+
+  private static CatalogNode catalogNode(ResourceId id) {
+    return new CatalogNode(
+        id,
+        "blob://catalog",
+        "analytics",
+        Map.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Map.of());
   }
 
   private static NamespacePath path(String... segments) {

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
@@ -230,9 +230,7 @@ class CatalogOverlaysImplTest {
             PrincipalContext.newBuilder()
                 .setAccountId("acct")
                 .setCorrelationId("corr")
-                .addAllPermissions(
-                    Set.of(
-                        "catalog-overlay.reconcile", "catalog-integration.use"))
+                .addAllPermissions(Set.of("catalog-overlay.reconcile", "catalog-integration.use"))
                 .build());
     when(service.overlays.getByIdWithMeta(overlayId))
         .thenReturn(Optional.of(new ResourceWithMeta<>(current, overlayMeta)));

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogOverlaysImplTest.java
@@ -30,6 +30,7 @@ import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayRequest;
 import ai.floedb.floecat.integration.rpc.CreateCatalogOverlayResponse;
 import ai.floedb.floecat.integration.rpc.DeleteCatalogOverlayRequest;
 import ai.floedb.floecat.integration.rpc.NamespacePath;
+import ai.floedb.floecat.integration.rpc.ReconcileCatalogOverlayRequest;
 import ai.floedb.floecat.integration.rpc.UpdateCatalogOverlayRequest;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
@@ -68,6 +69,7 @@ class CatalogOverlaysImplTest {
     service.principal = mock(PrincipalProvider.class);
     service.authz = mock(Authorizer.class);
     service.idempotencyStore = mock(IdempotencyRepository.class);
+    service.reconciler = mock(CatalogOverlayReconciler.class);
     installBasePrincipal(service, service.principal);
     when(service.principal.get()).thenReturn(principal());
     stubIntegration(integrationId(), 5L);
@@ -189,6 +191,7 @@ class CatalogOverlaysImplTest {
     when(service.markerStore.catalogIntegrationOverlaysMarkerVersion(oldIntegrationId))
         .thenReturn(4L);
     when(service.markerStore.catalogOverlaysMarkerVersion(oldCatalogId)).thenReturn(6L);
+    when(service.overlays.beginDeletion(oldOverlayId, 9L)).thenReturn(true);
     when(service.overlays.replaceIdentityAttachedWithMeta(
             any(), eq(9L), any(), any(), any(), any()))
         .thenAnswer(invocation -> Optional.of(row(invocation.getArgument(2), 1L)));
@@ -210,7 +213,53 @@ class CatalogOverlaysImplTest {
     var markers = ArgumentCaptor.forClass(Map.class);
     verify(service.overlays)
         .replaceIdentityAttachedWithMeta(any(), eq(9L), any(), any(), any(), markers.capture());
+    verify(service.reconciler).retireMaterializedResources(current);
     assertEquals(4, markers.getValue().size());
+  }
+
+  @Test
+  void reconcileReportsMaterializedMetadataChanges() {
+    var overlayId = id("overlay", ResourceKind.RK_CATALOG_OVERLAY);
+    var current = overlay(overlayId, integrationId(), catalogId(), "sales");
+    var overlayMeta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    var integration = CatalogIntegration.newBuilder().setResourceId(integrationId()).build();
+    var integrationMeta = MutationMeta.newBuilder().setPointerVersion(5L).build();
+    when(service.principal.get())
+        .thenReturn(
+            PrincipalContext.newBuilder()
+                .setAccountId("acct")
+                .setCorrelationId("corr")
+                .addAllPermissions(
+                    Set.of(
+                        "catalog-overlay.write",
+                        "catalog-integration.use",
+                        "catalog.write",
+                        "namespace.write",
+                        "table.write",
+                        "view.write"))
+                .build());
+    when(service.overlays.getByIdWithMeta(overlayId))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(current, overlayMeta)));
+    when(service.integrations.getByIdWithMeta(integrationId()))
+        .thenReturn(Optional.of(new ResourceWithMeta<>(integration, integrationMeta)));
+    when(service.reconciler.reconcile(current, overlayMeta, integration, integrationMeta))
+        .thenReturn(new CatalogOverlayReconciler.Result(2, 1, 3, 4, 5, 6, 7, 8));
+
+    var response =
+        service
+            .reconcileCatalogOverlay(
+                ReconcileCatalogOverlayRequest.newBuilder().setOverlayId(overlayId).build())
+            .await()
+            .indefinitely();
+
+    assertEquals(2, response.getNamespacesCreated());
+    assertEquals(1, response.getNamespacesDeleted());
+    assertEquals(3, response.getTablesCreated());
+    assertEquals(4, response.getTablesUpdated());
+    assertEquals(5, response.getTablesDeleted());
+    assertEquals(6, response.getViewsCreated());
+    assertEquals(7, response.getViewsUpdated());
+    assertEquals(8, response.getViewsDeleted());
   }
 
   @Test
@@ -229,6 +278,7 @@ class CatalogOverlaysImplTest {
         .indefinitely();
 
     verify(service.overlays).beginDeletion(overlayId, 7L);
+    verify(service.reconciler).retireMaterializedResources(current);
     verify(service.overlays).deleteWithFence(overlayId, 7L, 1L);
     verify(service.catalogs, never()).delete(any());
   }

--- a/service/src/test/java/ai/floedb/floecat/service/it/StatsOrchestratorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/StatsOrchestratorIT.java
@@ -22,7 +22,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.rpc.*;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
-import ai.floedb.floecat.service.it.profiles.ReconcilerWorkerLocalProfile;
+import ai.floedb.floecat.service.it.profiles.StatsOrchestratorProfile;
 import ai.floedb.floecat.service.statistics.StatsOrchestrator;
 import ai.floedb.floecat.service.util.TestDataResetter;
 import ai.floedb.floecat.service.util.TestSupport;
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.Test;
  * FAILED, TIMEOUT — and that async follow-up jobs are enqueued when required.
  */
 @QuarkusTest
-@TestProfile(ReconcilerWorkerLocalProfile.class)
+@TestProfile(StatsOrchestratorProfile.class)
 class StatsOrchestratorIT {
 
   @GrpcClient("floecat")
@@ -299,6 +299,8 @@ class StatsOrchestratorIT {
 
     Connector conn = createDummyConnector(cat.getResourceId(), ns.getResourceId(), "cancel");
     attachConnectorToTable(tableId, conn);
+    String connectorId = conn.getResourceId().getId();
+    Set<String> existingRootJobIds = listRootJobIds(tableId.getAccountId());
 
     // 2s budget: long enough for us to find and cancel the sync job before it times out
     StatsCaptureRequest req =
@@ -311,20 +313,30 @@ class StatsOrchestratorIT {
     CompletableFuture<StatsResolutionResult> future =
         CompletableFuture.supplyAsync(() -> orchestrator.resolve(req));
 
-    // Poll until the sync capture job appears, then cancel it to force FAILED outcome
-    String jobId = null;
+    // Poll for the newly-created queued root for this connector. This test's profile disables
+    // workers so the root cannot advance and enqueue children before cancellation.
+    ReconcileJobStore.ReconcileJob syncJob = null;
     long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
-    while (jobId == null && System.nanoTime() < deadline) {
-      var page = jobStore.list(tableId.getAccountId(), 10, "", "", Set.of("JS_QUEUED"));
-      if (!page.jobs.isEmpty()) {
-        jobId = page.jobs.get(0).jobId;
-      } else {
+    while (syncJob == null && System.nanoTime() < deadline) {
+      var page = jobStore.list(tableId.getAccountId(), 100, "", "", Set.of("JS_QUEUED"));
+      syncJob =
+          page.jobs.stream()
+              .filter(job -> !existingRootJobIds.contains(job.jobId))
+              .filter(job -> job.parentJobId == null || job.parentJobId.isBlank())
+              .filter(job -> connectorId.equals(job.connectorId))
+              .findFirst()
+              .orElse(null);
+      if (syncJob == null) {
         Thread.sleep(20);
       }
     }
-    assertNotNull(jobId, "sync capture job must appear in job store within 3s");
+    assertNotNull(syncJob, "sync capture root job must appear in job store within 3s");
 
-    jobStore.cancel(tableId.getAccountId(), jobId, "test_cancel");
+    var cancelled = jobStore.cancel(tableId.getAccountId(), syncJob.jobId, "test_cancel");
+    assertTrue(cancelled.isPresent(), "sync capture root job must be cancellable");
+    assertTrue(
+        Set.of("JS_CANCELLED", "JS_CANCELLING").contains(cancelled.get().state),
+        "sync capture root job must enter a cancellation state");
     StatsResolutionResult result = future.get(5, TimeUnit.SECONDS);
 
     assertEquals(StatsSyncOutcome.FAILED, result.outcome());
@@ -386,6 +398,12 @@ class StatsOrchestratorIT {
 
   private Set<String> listJobIds(String accountId) {
     return jobStore.list(accountId, 100, "", "", ALL_JOB_STATES).jobs.stream()
+        .map(job -> job.jobId)
+        .collect(java.util.stream.Collectors.toSet());
+  }
+
+  private Set<String> listRootJobIds(String accountId) {
+    return jobStore.listRootJobs(accountId, 100, "", "", Set.of()).jobs.stream()
         .map(job -> job.jobId)
         .collect(java.util.stream.Collectors.toSet());
   }

--- a/service/src/test/java/ai/floedb/floecat/service/it/profiles/StatsOrchestratorProfile.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/profiles/StatsOrchestratorProfile.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.it.profiles;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+public class StatsOrchestratorProfile implements QuarkusTestProfile {
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return Map.of(
+        "floecat.reconciler.worker.mode", "local",
+        "floecat.stats.sync.enabled", "true",
+        "reconciler.max-parallelism", "0");
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepositoryTest.java
@@ -122,6 +122,7 @@ class CatalogOverlayRepositoryTest {
         Map.of(
             Keys.catalogIntegrationOverlaysMarker("account", "old-integration"), 0L,
             Keys.catalogOverlaysMarker("account", "old-catalog"), 0L));
+    assertTrue(overlays.beginDeletion(current.getResourceId(), 1L));
     var replacement = overlay("new-overlay", "new-integration", "new-catalog");
 
     assertTrue(
@@ -145,6 +146,7 @@ class CatalogOverlayRepositoryTest {
     assertEquals(1, overlays.countByIntegration("account", "new-integration"));
     assertEquals(0, overlays.countByCatalog("account", "old-catalog"));
     assertEquals(1, overlays.countByCatalog("account", "new-catalog"));
+    assertEquals(0L, overlays.deletionFenceVersion(current.getResourceId()));
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
@@ -63,6 +63,13 @@ class KeysTest {
   }
 
   @Test
+  void catalogOverlayDeletionMarkerUsesPathSafeEncoding() {
+    assertEquals(
+        "/accounts/acct%20id/catalog-overlays/deleting/overlay%2Fid",
+        Keys.catalogOverlayDeletionMarker("acct id", "overlay/id"));
+  }
+
+  @Test
   void namespaceByPathKeyRoundTripsFullPathSegments() {
     String key =
         Keys.namespacePointerByPath(

--- a/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
@@ -49,6 +49,8 @@ class RolePermissionsTest {
           RolePermissions.CATALOG_INTEGRATION_USE,
           RolePermissions.CATALOG_OVERLAY_READ,
           RolePermissions.CATALOG_OVERLAY_WRITE,
+          RolePermissions.CATALOG_OVERLAY_RECONCILE,
+          RolePermissions.CATALOG_OVERLAY_DELETE,
           "system-objects.read",
           "account.delete");
   private static final List<String> INIT_ACCOUNT_PERMS =
@@ -83,6 +85,7 @@ class RolePermissionsTest {
           RolePermissions.CATALOG_INTEGRATION_READ,
           RolePermissions.CATALOG_INTEGRATION_USE,
           RolePermissions.CATALOG_OVERLAY_READ,
+          RolePermissions.CATALOG_OVERLAY_RECONCILE,
           "system-objects.read",
           RolePermissions.STORAGE_AUTHORITY_RESOLVE_INTERNAL,
           RolePermissions.RECONCILE_EXECUTOR_CONTROL_INTERNAL);
@@ -140,6 +143,9 @@ class RolePermissionsTest {
         RolePermissions.permissionsForRoles(List.of(RolePermissions.INIT_ACCOUNT_ROLE), false);
 
     assertThat(permissions).containsExactlyInAnyOrderElementsOf(INIT_ACCOUNT_PERMS);
+    assertThat(permissions)
+        .doesNotContain(
+            RolePermissions.CATALOG_OVERLAY_RECONCILE, RolePermissions.CATALOG_OVERLAY_DELETE);
   }
 
   @Test
@@ -163,5 +169,6 @@ class RolePermissionsTest {
         RolePermissions.permissionsForRoles(List.of(RolePermissions.RECONCILE_WORKER_ROLE), false);
 
     assertThat(permissions).containsExactlyInAnyOrderElementsOf(RECONCILE_WORKER_PERMS);
+    assertThat(permissions).doesNotContain(RolePermissions.CATALOG_OVERLAY_DELETE);
   }
 }

--- a/tools/compose-smoke.sh
+++ b/tools/compose-smoke.sh
@@ -781,21 +781,23 @@ quit")
       local localstack_authority_setup_out
 
       storage_bucket="$bucket"
-      storage_authority_name="smoke-upstream-iceberg-storage-${storage_bucket//[^a-zA-Z0-9]/_}-${COMPOSE_SMOKE_RUN_ID}"
-      localstack_authority_setup_out=$(run_cli_script "$compose_cmd" "account t-0001
+      if [ "$smoke_scope" = "full" ]; then
+        storage_authority_name="smoke-upstream-iceberg-storage-${storage_bucket//[^a-zA-Z0-9]/_}-${COMPOSE_SMOKE_RUN_ID}"
+        localstack_authority_setup_out=$(run_cli_script "$compose_cmd" "account t-0001
 storage-authority create $storage_authority_name --location-prefix s3://$storage_bucket/ --type s3 --region us-east-1 --endpoint http://localstack:4566 --path-style-access true --assume-role-arn arn:aws:iam::000000000000:role/polaris --duration-seconds 900 --cred-type aws --cred access_key_id=test --cred secret_access_key=test
 quit")
-      echo "$localstack_authority_setup_out"
-      assert_contains "$label upstream iceberg storage authority setup (${storage_bucket})" "$localstack_authority_setup_out" "$storage_authority_name"
+        echo "$localstack_authority_setup_out"
+        assert_contains "$label upstream iceberg storage authority setup (${storage_bucket})" "$localstack_authority_setup_out" "$storage_authority_name"
 
-      if [ "$storage_bucket" = "floecat" ]; then
-        localstack_storage_authority_name="$storage_authority_name"
+        if [ "$storage_bucket" = "floecat" ]; then
+          localstack_storage_authority_name="$storage_authority_name"
+        fi
       fi
 
       localstack_storage_bucket_resource_list+="\\\"arn:aws:s3:::${storage_bucket}\\\",\\\"arn:aws:s3:::${storage_bucket}/*\\\","
     done
     localstack_storage_bucket_resource_list=${localstack_storage_bucket_resource_list%,}
-    if [ -z "$localstack_storage_authority_name" ]; then
+    if [ "$smoke_scope" = "full" ] && [ -z "$localstack_storage_authority_name" ]; then
       echo "[FAIL] $label upstream iceberg expected floecat storage authority name not resolved"
       return 1
     fi
@@ -971,10 +973,65 @@ quit")
         "${COMPOSE_SMOKE_STATS_SLEEP_SECONDS:-2}"
     }
 
-    run_upstream_iceberg_scenario "storage-authority" "" "" "false"
-    if [ "$label" = "localstack-remote" ] || [ "$label" = "localstack-oidc-remote" ]; then
-      run_upstream_iceberg_scenario "polaris-vended-creds" "_vended_creds" "vended-credentials" "true"
+    if [ "$smoke_scope" = "full" ]; then
+      run_upstream_iceberg_scenario "storage-authority" "" "" "false"
+      if [ "$label" = "localstack-remote" ] || [ "$label" = "localstack-oidc-remote" ]; then
+        run_upstream_iceberg_scenario "polaris-vended-creds" "_vended_creds" "vended-credentials" "true"
+      fi
     fi
+
+    echo "==> [SMOKE] upstream iceberg Catalog Integration overlay reconciliation"
+    local integration_name="smoke-polaris-integration"
+    local overlay_name="smoke-polaris-overlay"
+    local integration_catalog_name="${COMPOSE_SMOKE_UPSTREAM_ICEBERG_DEST_CATALOG}_integration"
+    local integration_expected_table="${integration_catalog_name}.${COMPOSE_SMOKE_UPSTREAM_ICEBERG_EXPECTED_TABLE#*.}"
+    local integration_setup_out
+    integration_setup_out=$(run_cli_script "$compose_cmd" "account t-0001
+catalog create $integration_catalog_name --desc compose-smoke-polaris-integration
+integration create $integration_name iceberg-rest $COMPOSE_SMOKE_UPSTREAM_ICEBERG_URI --auth-type oauth-client-credentials --auth client_id=root token_uri=${COMPOSE_SMOKE_POLARIS_BASE_URI}/api/catalog/v1/oauth/tokens scopes=PRINCIPAL_ROLE:ALL --cred client_secret=s3cr3t --props warehouse=$warehouse s3.endpoint=http://localstack:4566 s3.path-style-access=true s3.region=us-east-1
+overlay create $overlay_name $integration_name $integration_catalog_name --include $source_namespace
+quit")
+    echo "$integration_setup_out"
+    assert_contains "$label Polaris integration setup" "$integration_setup_out" "INTEGRATION_ID"
+    assert_contains "$label Polaris overlay setup" "$integration_setup_out" "OVERLAY_ID"
+
+    local integration_validation_out
+    integration_validation_out=$(run_cli_script "$compose_cmd" "account t-0001
+integration validate $integration_name
+quit")
+    echo "$integration_validation_out"
+    assert_contains "$label Polaris integration validation" "$integration_validation_out" "valid: true"
+    assert_contains "$label Polaris discovery validation" "$integration_validation_out" "DISCOVERY"
+    assert_contains "$label Polaris credential vending validation" "$integration_validation_out" "CREDENTIAL_VENDING"
+    assert_contains "$label Polaris storage access validation" "$integration_validation_out" "STORAGE_ACCESS"
+
+    local integration_discovery_out
+    integration_discovery_out=$(run_cli_script "$compose_cmd" "account t-0001
+integration namespaces $integration_name
+integration objects $integration_name $source_namespace
+quit")
+    echo "$integration_discovery_out"
+    assert_contains "$label Polaris namespace discovery" "$integration_discovery_out" "$source_namespace"
+    assert_contains "$label Polaris object discovery" "$integration_discovery_out" "$source_table"
+    assert_contains "$label Polaris table-kind discovery" "$integration_discovery_out" "TABLE"
+
+    local overlay_reconcile_out
+    overlay_reconcile_out=$(run_cli_script "$compose_cmd" "account t-0001
+overlay reconcile $overlay_name
+quit")
+    echo "$overlay_reconcile_out"
+    assert_contains "$label Polaris overlay reconciliation" "$overlay_reconcile_out" "tables_created: 1"
+
+    local integration_table_out
+    integration_table_out=$(run_cli_script "$compose_cmd" "account t-0001
+resolve table $integration_expected_table
+describe table $integration_expected_table
+quit")
+    echo "$integration_table_out"
+    assert_contains "$label Polaris overlay table materialized" "$integration_table_out" "table id:"
+    assert_contains "$label Polaris overlay avoids Connector identity" "$integration_table_out" "connector_id: -"
+    assert_contains "$label Polaris overlay carries Integration identity" "$integration_table_out" "floecat.catalog-integration.id ="
+    assert_contains "$label Polaris overlay carries Overlay identity" "$integration_table_out" "floecat.catalog-overlay.id ="
   elif [ "$profile" = "localstack" ]; then
     echo "==> [SMOKE] skipping upstream iceberg rest import (set COMPOSE_SMOKE_UPSTREAM_ICEBERG_IMPORT=false to disable)"
   fi
@@ -1680,6 +1737,19 @@ for raw_mode in "${mode_list[@]}"; do
         "" \
         "QUARKUS_PROFILE_SERVICE=prod FLOECAT_RECONCILER_WORKER_MODE=local FLOECAT_RECONCILER_MAX_PARALLELISM=1 FLOECAT_RECONCILER_WORKER_AUTH_REQUIRED=false FLOECAT_SECURITY_ALLOWED_TOKEN_ENDPOINT_DOMAINS=$SMOKE_TOKEN_ENDPOINT_ALLOWLIST FLOECAT_SECURITY_ALLOW_PRIVATE_TOKEN_ENDPOINTS_FOR_ALLOWED_HOSTS=$SMOKE_ALLOW_PRIVATE_TOKEN_ENDPOINTS" \
         "0"
+      ;;
+    polaris-integration)
+      run_mode \
+        ./env.localstack \
+        localstack \
+        polaris-integration \
+        "localstack" \
+        "" \
+        "" \
+        "" \
+        "QUARKUS_PROFILE_SERVICE=prod FLOECAT_RECONCILER_WORKER_MODE=local FLOECAT_RECONCILER_MAX_PARALLELISM=1 FLOECAT_RECONCILER_WORKER_AUTH_REQUIRED=false FLOECAT_SECURITY_ALLOWED_TOKEN_ENDPOINT_DOMAINS=$SMOKE_TOKEN_ENDPOINT_ALLOWLIST FLOECAT_SECURITY_ALLOW_PRIVATE_TOKEN_ENDPOINTS_FOR_ALLOWED_HOSTS=$SMOKE_ALLOW_PRIVATE_TOKEN_ENDPOINTS" \
+        "0" \
+        "polaris-integration"
       ;;
     localstack-remote)
       run_mode \


### PR DESCRIPTION
## Summary

- wire persisted Catalog Integration credentials to the catalog-access SPI
- add synchronous, generation-fenced Catalog Overlay metadata reconciliation
- materialize and retire ordinary namespaces, table definitions, and views
- fence overlay replacement/deletion and explicitly clean owned descendants
- revise the architecture document to distinguish metadata reconciliation from durable snapshot/file capture

## Boundary

This PR does not schedule durable jobs or capture snapshots, files, validation results, or statistics. That work should be a separate follow-up above this PR because the current durable protocol is Connector-rooted.

## Validation

- 79 focused unit tests across the access provider, credential adapter, RPCs, reconciliation, lifecycle fencing, account cleanup, and repository keys
- 78 focused tests including the existing TableRootWriter contract and stale-root race
- final CatalogOverlayReconcilerTest run: 4 tests
- make test-site