### PR TITLE
reconciler: scope reconcile jobs to a deployment cohort so incompatible versions can share one durable queue

### DIFF
--- a/core/proto/src/main/proto/floecat/reconciler/reconciler.proto
+++ b/core/proto/src/main/proto/floecat/reconciler/reconciler.proto
@@ -665,6 +665,9 @@ message LeasedReconcileJob {
   ReconcileSnapshotTask snapshot_task = 14;
   // Present for EXEC_FILE_GROUP jobs; empty otherwise.
   ReconcileFileGroupTask file_group_task = 15;
+  // Job-tree contract version stamped on this job. A versioned worker must reject the lease unless
+  // this exactly matches the affinity it declared in LeaseReconcileJobRequest.
+  string worker_affinity = 16;
 }
 
 // Request from an executor asking the scheduler for work it is willing to run.
@@ -679,6 +682,9 @@ message LeaseReconcileJobRequest {
   repeated ReconcileJobKind job_kinds = 4;
   // Local executor ids available to satisfy pinned-executor routing.
   repeated string executor_ids = 5;
+  // Job-tree contract version implemented by this worker. Floecat requires this to match its
+  // deployment affinity. Empty is accepted only by the temporary legacy-worker fallback.
+  string worker_affinity = 6;
 }
 
 message LeaseReconcileJobResponse {

--- a/core/proto/src/main/proto/floecat/reconciler/reconciler.proto
+++ b/core/proto/src/main/proto/floecat/reconciler/reconciler.proto
@@ -683,7 +683,7 @@ message LeaseReconcileJobRequest {
   // Local executor ids available to satisfy pinned-executor routing.
   repeated string executor_ids = 5;
   // Job-tree contract version implemented by this worker. Floecat requires this to match its
-  // deployment affinity. Empty is accepted only by the temporary legacy-worker fallback.
+  // deployment affinity exactly; an empty or mismatched affinity is rejected.
   string worker_affinity = 6;
 }
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -110,6 +110,10 @@ Notes:
   connects to `service:9100`, leases work independently, and heartbeats/completes jobs through
   the control-plane RPCs. No executor leader election is required.
 - Both services must share the same blob/kv backend configuration.
+- The control plane and its executor replicas must set the same
+  `FLOECAT_RECONCILER_WORKER_AFFINITY` (default `reconciler-v1`). Blank or mismatched executors are
+  rejected. During a versioned rollout, route old and new executor fleets only to their matching
+  control planes and keep the old deployment running until its job trees drain.
 - The durable reconcile store is split into native job-index, ready-queue, lease, and projection
   domains. Control-plane job-state transitions own job-index and ready mutations. Executor replicas
   only participate in lease coordination; they do not repair or rebuild queue indexes on reads.
@@ -188,7 +192,8 @@ Common configuration knobs:
   non-default endpoints. Temporary vended credentials come from storage authorities.
 - **Seed/fixtures**: `FLOECAT_SEED_ENABLED`, `FLOECAT_SEED_MODE`, `FLOECAT_FIXTURES_USE_AWS_S3`.
 - **Reconciler split deployment**:
-  `FLOECAT_RECONCILER_WORKER_MODE`, `FLOECAT_RECONCILER_MAX_PARALLELISM`,
+  `FLOECAT_RECONCILER_WORKER_MODE`, `FLOECAT_RECONCILER_WORKER_AFFINITY`,
+  `FLOECAT_RECONCILER_MAX_PARALLELISM`,
   `FLOECAT_RECONCILER_REMOTE_DEFAULT_EXECUTOR_ENABLED`,
   `FLOECAT_RECONCILER_REMOTE_PLANNER_EXECUTOR_ENABLED`,
   `FLOECAT_RECONCILER_REMOTE_SNAPSHOT_PLANNER_EXECUTOR_ENABLED`,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -105,6 +105,7 @@ Key reconciler mode flags live in `service/src/main/resources/application.proper
 
 ```properties
 floecat.reconciler.worker.mode
+floecat.reconciler.worker-affinity
 reconciler.max-parallelism
 floecat.reconciler.executor.remote-planner.enabled
 floecat.reconciler.executor.remote-default.enabled
@@ -132,6 +133,20 @@ Recommended split deployment:
 - Shared settings: same blob/kv backend, same reconciler OIDC worker principal configuration, executor nodes pointed at the control-plane gRPC host/port
 - Control-plane-specific setting: `reconciler.max-parallelism=0`
 - Executor-plane-specific setting: `floecat.reconciler.worker.mode=remote`
+
+#### Reconciler versioned rollout
+
+Set `floecat.reconciler.worker-affinity` to the job-tree contract version, currently
+`reconciler-v1`, on both the control plane and every executor routed to it. Lease requests require
+an exact match; blank or mismatched workers are rejected. Different affinities can share the same
+durable blob/kv backend because filtered ready indexes, including pinned-executor indexes, are
+partitioned by affinity, but their worker-control endpoints must remain separately routed.
+
+For an upgrade from an unversioned deployment, keep the old control plane and workers running to
+drain their unversioned job trees. Start the new control plane and workers with the new matching
+affinity, route each worker fleet only to its matching control plane, and retire the old deployment
+after its active trees have drained. A new deployment does not adopt, migrate, or lease the old
+cohort's jobs.
 
 Worker gRPC auth boundary:
 

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -186,8 +186,8 @@ engine release.
   `executor_id`, and repeated `executor_ids` selectors so a worker fleet can advertise both its
   concrete worker identity and the executor implementations it is willing to run. Versioned
   workers also declare `worker_affinity`; the server rejects a mismatch and echoes the job's
-  affinity in `LeasedReconcileJob` for worker-side validation. Empty affinity requests remain a
-  temporary legacy fallback controlled by `floecat.reconciler.allow-unversioned-workers`.
+  affinity in `LeasedReconcileJob` for worker-side validation. Empty affinity requests are rejected
+  by a versioned control plane, keeping unversioned workers isolated to an unversioned deployment.
 - **Stats vs constraints snapshot policy** – `PutTargetStats` currently accepts unknown snapshots
   (lenient ordering), while `PutTableConstraints` is strict and requires a materialized snapshot
   row before write. Rationale: stats keeps existing capture ordering compatibility, while

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -184,7 +184,10 @@ engine release.
   ceiling and validates commits against the immutable planned group.
 - **Executor leasing filters** – `LeaseReconcileJobRequest` accepts execution class, lane, job kind,
   `executor_id`, and repeated `executor_ids` selectors so a worker fleet can advertise both its
-  concrete worker identity and the executor implementations it is willing to run.
+  concrete worker identity and the executor implementations it is willing to run. Versioned
+  workers also declare `worker_affinity`; the server rejects a mismatch and echoes the job's
+  affinity in `LeasedReconcileJob` for worker-side validation. Empty affinity requests remain a
+  temporary legacy fallback controlled by `floecat.reconciler.allow-unversioned-workers`.
 - **Stats vs constraints snapshot policy** – `PutTargetStats` currently accepts unknown snapshots
   (lenient ordering), while `PutTableConstraints` is strict and requires a materialized snapshot
   row before write. Rationale: stats keeps existing capture ordering compatibility, while

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -8,10 +8,18 @@ compatibility.
 
 ### Remote executor versioning
 
-Snapshot plans now require one immutable file execution plan for every declared file path. Remote
-planner/finalizer executors and the control plane must therefore be cut over together after existing
-leases are drained. Rolling or split deployments containing both plan revisions are unsupported;
-there is intentionally no empty-plan compatibility fallback.
+`LeaseReconcileJobRequest.worker_affinity` identifies the job-tree contract implemented by a
+worker. It must exactly match the control plane's configured
+`floecat.reconciler.worker-affinity`; blank and mismatched values are rejected. The control plane
+echoes the owning affinity in `LeasedReconcileJob.worker_affinity`, and workers must reject a lease
+whose value differs from their own.
+
+Different affinities may share the same durable backend because ready-index slices, including
+pinned-executor slices, are affinity-qualified. They must not share worker routing: executors must
+connect only to a control plane with the same affinity. During an upgrade, keep the old deployment
+running until its job trees drain while the new deployment writes and executes its own cohort.
+Snapshot plans require one immutable file execution plan for every declared file path, so planner,
+executor, and finalizer implementations within one cohort must implement the same contract.
 
 The contract files are organised by domain (`common/`, `catalog/`, `query/`, `execution/`,
 `connector/`, `account/`, `types/`, `statistics/`, `reconciler/`). Generated Java stubs live

--- a/docs/reconciler.md
+++ b/docs/reconciler.md
@@ -327,6 +327,26 @@ Internally, the worker poller exposes `pollEvery` via `@Scheduled` (default ever
   - in `floecat.kv=memory`, the same domain model is preserved, but the physical implementation is
     in-memory rather than a literal Dynamo simulator
 
+### Job-tree versioning and deployment cohorts
+
+`floecat.reconciler.worker-affinity` is the job-tree contract version for one deployment, not its
+build version. The job store stamps it on every job at enqueue and constrains every lease to an
+exact match. Remote workers send the same value in `LeaseReconcileJobRequest.worker_affinity`, the
+control plane rejects blank or mismatched requests, and the leased job echoes the value for
+worker-side validation. Lease-bound RPCs also reject jobs owned by another cohort.
+
+The ready queue affinity-qualifies execution-class, execution-lane, job-kind, and pinned-executor
+index slices. The semantic execution policy and `pinnedExecutorId` remain unchanged; only the
+derived index filter is qualified. This prevents an older control plane that does not understand
+affinity from discovering versioned work through the corresponding raw filtered slices.
+
+Upgrades use separate draining cohorts. The old unversioned deployment continues serving its old
+workers and drains unversioned trees. The new deployment and workers use the same non-empty
+affinity (currently `reconciler-v1`) and process only that cohort. Route workers exclusively to the
+matching control plane, and do not retire the old deployment until its active trees have drained.
+Changing affinity does not migrate or reclaim queued jobs; it starts a separate cohort that may
+independently plan equivalent work.
+
 ### gRPC auth
 - Reconcile workers use the gRPC control plane for leasing, progress, and standalone worker
   payload/result exchange.
@@ -402,6 +422,9 @@ perform a post-completion final lease confirmation after that RPC has durably co
   - `remote` keeps the same gRPC lease protocol but is intended for executor-only nodes. Set
     `reconciler.max-parallelism=0` on control-plane-only nodes.
 - Worker capacity via `reconciler.max-parallelism`.
+- Job-tree contract affinity via `floecat.reconciler.worker-affinity` (default
+  `reconciler-v1`). Control planes and all of their local or remote executors must use exactly the
+  same value.
 - Job store selection:
   - `floecat.reconciler.job-store=durable` (service default) uses persisted queue records plus
     retry/lease tuning via:

--- a/docs/rust-remote-capture-executor.md
+++ b/docs/rust-remote-capture-executor.md
@@ -78,6 +78,7 @@ Relevant shared settings:
 
 ```properties
 floecat.reconciler.job-store=durable
+floecat.reconciler.worker-affinity=reconciler-v1
 floecat.reconciler.authorization.header=authorization
 floecat.reconciler.oidc.issuer=https://<issuer>/realms/<realm>
 floecat.reconciler.oidc.client-id=<reconcile-worker-client-id>
@@ -95,6 +96,20 @@ The worker participates only in the lease-coordination domain. Canonical reconci
 owned by control-plane job-state transitions, and remote workers should not assume reads or
 maintenance will repair queue drift for them.
 
+## Job-Tree Versioning
+
+The Rust worker must be configured with the same job-tree contract affinity as its control plane.
+Set `LeaseReconcileJobRequest.worker_affinity` on every lease request and require the returned
+`LeasedReconcileJob.worker_affinity` to match before starting work. The control plane rejects blank
+or mismatched affinities with `FAILED_PRECONDITION` and checks the owning job affinity again on
+lease-bound RPCs.
+
+Affinity versions the job-tree contract, not an individual build. Workers and control planes that
+can safely process the same job trees should use the same value. A breaking tree or payload change
+requires a new value and a separately routed control-plane/worker deployment. During an upgrade,
+leave the old deployment running until its cohort drains; do not route an unversioned worker to a
+`reconciler-v1` control plane.
+
 ## Worker Identity and Leasing
 The lease request supports:
 
@@ -103,12 +118,14 @@ The lease request supports:
 - job kinds
 - `executor_id`
 - repeated `executor_ids`
+- `worker_affinity`
 
 For a Rust file-group worker, use:
 
 - `job_kinds = [RJK_EXEC_FILE_GROUP]`
 - `executor_id = <stable worker instance id>`
 - `executor_ids` containing the executor implementations this process can satisfy
+- `worker_affinity` set to the worker's configured job-tree contract version
 
 The current Java poller advertises local executor ids so pinned jobs can route to compatible
 workers. A Rust fleet should do the same if you intend to use pinned executor routing.

--- a/docs/service.md
+++ b/docs/service.md
@@ -219,6 +219,7 @@ Notable `application.properties` keys:
 | `floecat.gc.cas.*` | Cadence, page size, min-age, tick slice settings for CAS blob GC. |
 | `floecat.gc.pointer.*` | Cadence, page size, min-age, tick slice settings for pointer GC. |
 | `floecat.gc.reconcile-jobs.*` | Cadence, retention, and slice settings for durable reconcile-job GC. Finished terminal jobs default to 24 h retention. |
+| `floecat.reconciler.worker-affinity` | Exact job-tree contract cohort shared by a control plane and its executor fleet (default `reconciler-v1`). |
 | `floecat.reconciler.job-store.*` | Durable reconcile queue selection and retry/lease tuning. |
 | `quarkus.log.*` | JSON logging, file rotation, audit handlers per RPC package. |
 | `quarkus.otel.*` / `quarkus.micrometer.*` | Observability exporters (see [`docs/operations.md`](operations.md)). |

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClient.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcRemoteReconcileExecutorClient.java
@@ -82,6 +82,7 @@ import com.google.protobuf.util.Timestamps;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.MetadataUtils;
@@ -135,6 +136,10 @@ class GrpcRemoteReconcileExecutorClient
   private final long workerControlKeepAliveTimeoutMs;
   private final boolean workerControlKeepAliveWithoutCalls;
   private final int planTableChildJobChunkMaxCount;
+
+  @ConfigProperty(name = "floecat.reconciler.worker-affinity", defaultValue = "reconciler-v1")
+  String workerAffinity = "reconciler-v1";
+
   private final Object workerControlLock = new Object();
   private volatile ManagedChannel workerControlChannel;
   private volatile ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub
@@ -356,11 +361,27 @@ class GrpcRemoteReconcileExecutorClient
                                 .map(GrpcRemoteReconcileExecutorClient::toProtoJobKind)
                                 .toList())
                         .addAllExecutorIds(effective.executorIds)
+                        .setWorkerAffinity(workerAffinity == null ? "" : workerAffinity.trim())
                         .build()));
     if (!response.getFound()) {
       return Optional.empty();
     }
+    String expectedAffinity = workerAffinity == null ? "" : workerAffinity.trim();
+    if (!expectedAffinity.isEmpty()
+        && !expectedAffinity.equals(response.getJob().getWorkerAffinity().trim())) {
+      throw Status.FAILED_PRECONDITION
+          .withDescription(
+              "leased reconcile job affinity does not match worker: job="
+                  + displayWorkerAffinity(response.getJob().getWorkerAffinity())
+                  + " worker="
+                  + displayWorkerAffinity(expectedAffinity))
+          .asRuntimeException();
+    }
     return Optional.of(new RemoteLeasedJob(fromProtoLease(response.getJob())));
+  }
+
+  private static String displayWorkerAffinity(String affinity) {
+    return affinity == null || affinity.isBlank() ? "<unversioned>" : affinity.trim();
   }
 
   @Override

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
@@ -48,18 +48,24 @@ public class ReconcileExecutorRegistry {
                 .toList();
   }
 
+  /**
+   * Whether a leased job carries an executor pin that names some executor other than {@code
+   * executor}. Pin eligibility has one implementation so the registry and the lease poller cannot
+   * disagree about which executor may run a job.
+   */
+  public boolean pinExcludes(ReconcileJobStore.LeasedJob lease, ReconcileExecutor executor) {
+    if (lease == null || lease.pinnedExecutorId == null || lease.pinnedExecutorId.isBlank()) {
+      return false;
+    }
+    return executor == null || !lease.pinnedExecutorId.equals(executor.id());
+  }
+
   public Optional<ReconcileExecutor> executorFor(ReconcileJobStore.LeasedJob lease) {
-    if (lease != null && lease.pinnedExecutorId != null && !lease.pinnedExecutorId.isBlank()) {
-      return executors.stream()
-          .filter(executor -> lease.pinnedExecutorId.equals(executor.id()))
-          .filter(executor -> executor.supportsJobKind(lease.jobKind))
-          .filter(
-              executor -> executor.supportsExecutionClass(lease.executionPolicy.executionClass()))
-          .filter(executor -> executor.supportsLane(lease.laneKey))
-          .filter(executor -> executor.supports(lease))
-          .findFirst();
+    if (lease == null) {
+      return Optional.empty();
     }
     return executors.stream()
+        .filter(executor -> !pinExcludes(lease, executor))
         .filter(executor -> executor.supportsJobKind(lease.jobKind))
         .filter(executor -> executor.supportsExecutionClass(lease.executionPolicy.executionClass()))
         .filter(executor -> executor.supportsLane(lease.laneKey))

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteReconcileExecutorPoller.java
@@ -282,8 +282,7 @@ public class RemoteReconcileExecutorPoller {
     if (executor == null || lease == null) {
       return false;
     }
-    String pinnedExecutorId = lease.pinnedExecutorId == null ? "" : lease.pinnedExecutorId.trim();
-    if (!pinnedExecutorId.isBlank() && !pinnedExecutorId.equals(executor.id())) {
+    if (executorRegistry.pinExcludes(lease, executor)) {
       return false;
     }
     return executor.supportsJobKind(lease.jobKind)

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutor.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutor.java
@@ -515,12 +515,7 @@ public class RemoteSnapshotPlanningReconcileExecutor implements ReconcileExecuto
         appendOnlyDelta.orElseGet(
             () ->
                 enrichFileGroupTasks(
-                    lease,
-                    payload,
-                    task,
-                    buildFileGroupTasks(lease, task),
-                    loadExplicitParentHistoricalArtifactsForReuse(
-                        lease, task, appendOnlyHistorical)));
+                    lease, payload, task, buildFileGroupTasks(lease, task), appendOnlyHistorical));
     List<ReconcileFileGroupTask> fileGroupTasks = enriched.groups();
     return PlannedSnapshotCapture.fileGroups(
         ReconcileSnapshotTask.of(
@@ -751,36 +746,6 @@ public class RemoteSnapshotPlanningReconcileExecutor implements ReconcileExecuto
     return loadLatestReconciledReuseManifest(
             reconcileContext(lease), tableId, task.snapshotId(), lease.connectorId)
         .orElse(null);
-  }
-
-  private HistoricalArtifacts loadExplicitParentHistoricalArtifactsForReuse(
-      ReconcileJobStore.LeasedJob lease,
-      ReconcileSnapshotTask task,
-      HistoricalArtifacts alreadyLoaded) {
-    if (lease.fullRescan || blobStore == null) {
-      return null;
-    }
-    ResourceId tableId =
-        ResourceId.newBuilder()
-            .setAccountId(lease.accountId)
-            .setId(task.tableId())
-            .setKind(ResourceKind.RK_TABLE)
-            .build();
-    ReconcileContext context = reconcileContext(lease);
-    Snapshot target = backend.fetchSnapshot(context, tableId, task.snapshotId()).orElse(null);
-    if (target == null || !target.hasParentSnapshotId()) {
-      return null;
-    }
-    if (alreadyLoaded != null
-        && alreadyLoaded.snapshot().getSnapshotId() == target.getParentSnapshotId()) {
-      return alreadyLoaded;
-    }
-    Snapshot parent =
-        backend.fetchSnapshot(context, tableId, target.getParentSnapshotId()).orElse(null);
-    if (parent == null) {
-      return null;
-    }
-    return loadReuseManifest(tableId, parent, lease.connectorId).orElse(null);
   }
 
   private EnrichedFileGroups enrichFileGroupTasks(

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
@@ -2078,11 +2078,28 @@ public interface ReconcileJobStore {
     public final Set<String> executorIds;
     public final Set<ReconcileJobKind> jobKinds;
 
+    /**
+     * Deployment cohort this worker belongs to, or empty when affinity is disabled. The job store
+     * forces this from its own configuration on every lease, so callers never set it.
+     */
+    public final ReconcileWorkerAffinity workerAffinity;
+
     public LeaseRequest(
         Set<ReconcileExecutionClass> executionClasses,
         Set<String> lanes,
         Set<String> executorIds,
         Set<ReconcileJobKind> jobKinds) {
+      this(executionClasses, lanes, executorIds, jobKinds, ReconcileWorkerAffinity.DISABLED);
+    }
+
+    public LeaseRequest(
+        Set<ReconcileExecutionClass> executionClasses,
+        Set<String> lanes,
+        Set<String> executorIds,
+        Set<ReconcileJobKind> jobKinds,
+        ReconcileWorkerAffinity workerAffinity) {
+      this.workerAffinity =
+          workerAffinity == null ? ReconcileWorkerAffinity.DISABLED : workerAffinity;
       this.executionClasses =
           executionClasses == null
               ? Set.of()
@@ -2132,8 +2149,18 @@ public interface ReconcileJobStore {
       return new LeaseRequest(executionClasses, lanes, executorIds, jobKinds);
     }
 
+    /**
+     * The single rule deciding whether a queued job may be leased by this request: cohort, executor
+     * pin, execution class, lane and job kind. Every job store delegates here so no two lease paths
+     * can disagree about eligibility.
+     *
+     * @param laneKey the job's lane key, which a request may name instead of the policy lane
+     */
     public boolean matches(
-        ReconcileExecutionPolicy policy, String pinnedExecutorId, ReconcileJobKind jobKind) {
+        ReconcileExecutionPolicy policy,
+        String pinnedExecutorId,
+        ReconcileJobKind jobKind,
+        String laneKey) {
       ReconcileExecutionPolicy effective =
           policy == null ? ReconcileExecutionPolicy.defaults() : policy;
       ReconcileJobKind effectiveJobKind =
@@ -2141,12 +2168,32 @@ public interface ReconcileJobStore {
       boolean classMatches =
           executionClasses.isEmpty() || executionClasses.contains(effective.executionClass());
       boolean laneMatches =
-          lanes.isEmpty() || lanes.contains(ANY_LANE) || lanes.contains(effective.lane());
+          lanes.isEmpty()
+              || lanes.contains(ANY_LANE)
+              || lanes.contains(effective.lane())
+              || lanes.contains(laneKey == null ? "" : laneKey.trim());
       boolean kindMatches = jobKinds.isEmpty() || jobKinds.contains(effectiveJobKind);
       String effectivePinnedExecutorId = pinnedExecutorId == null ? "" : pinnedExecutorId.trim();
       boolean executorMatches =
           effectivePinnedExecutorId.isEmpty() || executorIds.contains(effectivePinnedExecutorId);
-      return classMatches && laneMatches && kindMatches && executorMatches;
+      return classMatches && laneMatches && kindMatches && executorMatches && cohortMatches(policy);
+    }
+
+    /**
+     * A job may only be leased by its own deployment cohort. Exact equality also keeps a legacy job
+     * with no cohort away from an affinity-aware worker, and vice versa.
+     */
+    public boolean cohortMatches(ReconcileExecutionPolicy policy) {
+      return workerAffinity.matches(policy);
+    }
+
+    /** Returns this request constrained to the deployment's cohort. */
+    public LeaseRequest withWorkerAffinity(ReconcileWorkerAffinity workerAffinity) {
+      ReconcileWorkerAffinity effective =
+          workerAffinity == null ? ReconcileWorkerAffinity.DISABLED : workerAffinity;
+      return effective.equals(this.workerAffinity)
+          ? this
+          : new LeaseRequest(executionClasses, lanes, executorIds, jobKinds, effective);
     }
 
     public static String anyLaneToken() {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileWorkerAffinity.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileWorkerAffinity.java
@@ -90,7 +90,8 @@ public record ReconcileWorkerAffinity(String value) {
 
   /**
    * Qualifies a ready-index filter value with the owning cohort so each cohort scans its own slice
-   * of the execution-class, execution-lane and job-kind indexes instead of one shared slice.
+   * of the execution-class, execution-lane, pinned-executor and job-kind indexes instead of one
+   * shared slice.
    */
   public String indexFilterValue(String filterValue) {
     // Strip the separator from both halves so an operator-configured lane or cohort cannot compose

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileWorkerAffinity.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileWorkerAffinity.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.jobs;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Deployment-cohort affinity carried by a reconcile job's execution policy.
+ *
+ * <p>A cohort is a property of the deployment, not of any individual producer or executor. Both
+ * sides of the durable queue are therefore stamped at the job-store boundary: the enqueue path
+ * applies {@link #applyTo} so every job records its owning cohort, and the lease path forces that
+ * cohort onto every {@link ReconcileJobStore.LeaseRequest}. Two deployments configured with
+ * different cohorts can then share one durable queue without leasing each other's job trees.
+ *
+ * <p>Set a cohort to the job-tree contract version rather than the build version: versions that can
+ * safely process each other's trees should share a cohort, and only a breaking change to the tree
+ * should fork it. Coexisting deployments may share accounts and tables, so two cohorts will
+ * independently capture the same table -- duplicated work is the deliberate price of neither
+ * version touching the other's trees.
+ *
+ * <p>A cohort that goes away leaves its queued jobs claimable by nobody. The surviving cohort's
+ * planner re-enqueues the equivalent work, so nothing is lost, but the abandoned rows are not
+ * reclaimed by lease expiry or job GC (both of which only act on jobs that reached a terminal
+ * state). Draining in-flight trees before retiring a cohort avoids the leak.
+ */
+public record ReconcileWorkerAffinity(String value) {
+  public static final String ATTRIBUTE = "floecat.worker-affinity";
+  public static final ReconcileWorkerAffinity DISABLED = new ReconcileWorkerAffinity("");
+
+  /**
+   * Separates the cohort from the underlying value in a ready-index filter. A control character
+   * cannot collide with an operator-configured execution lane, and ready-index filter values are
+   * percent-encoded into a single key segment, so it round-trips unchanged.
+   */
+  private static final char INDEX_FILTER_SEPARATOR = '\u001f';
+
+  public ReconcileWorkerAffinity {
+    value = normalize(value);
+  }
+
+  public static ReconcileWorkerAffinity of(String value) {
+    String normalized = normalize(value);
+    return normalized.isEmpty() ? DISABLED : new ReconcileWorkerAffinity(normalized);
+  }
+
+  /** Applies the server-owned affinity, removing any caller-supplied value when it is disabled. */
+  public ReconcileExecutionPolicy applyTo(ReconcileExecutionPolicy policy) {
+    ReconcileExecutionPolicy effective =
+        policy == null ? ReconcileExecutionPolicy.defaults() : policy;
+    Map<String, String> attributes = new TreeMap<>(effective.attributes());
+    if (!enabled()) {
+      attributes.remove(ATTRIBUTE);
+    } else {
+      attributes.put(ATTRIBUTE, value);
+    }
+    return ReconcileExecutionPolicy.of(effective.executionClass(), effective.lane(), attributes);
+  }
+
+  /** The cohort that owns a job, or empty when the job predates or disables affinity. */
+  public static ReconcileWorkerAffinity fromPolicy(ReconcileExecutionPolicy policy) {
+    if (policy == null) {
+      return DISABLED;
+    }
+    return of(policy.attributes().get(ATTRIBUTE));
+  }
+
+  public boolean enabled() {
+    return !value.isEmpty();
+  }
+
+  public boolean matches(ReconcileExecutionPolicy policy) {
+    return equals(fromPolicy(policy));
+  }
+
+  /**
+   * Qualifies a ready-index filter value with the owning cohort so each cohort scans its own slice
+   * of the execution-class, execution-lane and job-kind indexes instead of one shared slice.
+   */
+  public String indexFilterValue(String filterValue) {
+    // Strip the separator from both halves so an operator-configured lane or cohort cannot compose
+    // a value that collides with another cohort's slice.
+    String normalizedCohort = stripSeparator(value);
+    String normalizedFilterValue = stripSeparator(filterValue == null ? "" : filterValue);
+    return normalizedCohort.isEmpty()
+        ? normalizedFilterValue
+        : normalizedCohort + INDEX_FILTER_SEPARATOR + normalizedFilterValue;
+  }
+
+  private static String stripSeparator(String value) {
+    return value.indexOf(INDEX_FILTER_SEPARATOR) < 0
+        ? value
+        : value.replace(String.valueOf(INDEX_FILTER_SEPARATOR), "");
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
@@ -29,6 +29,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotSelection;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.annotation.PostConstruct;
@@ -86,6 +87,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
   private volatile long leaseMs = DEFAULT_LEASE_MS;
   private volatile long reclaimIntervalMs = DEFAULT_RECLAIM_INTERVAL_MS;
   private volatile long lastReclaimAtMs;
+  private volatile ReconcileWorkerAffinity workerAffinity = ReconcileWorkerAffinity.DISABLED;
 
   public InMemoryReconcileJobStore() {
     reloadConfig();
@@ -113,6 +115,23 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
             1_000L,
             readLong(
                 "floecat.reconciler.job-store.reclaim-interval-ms", DEFAULT_RECLAIM_INTERVAL_MS));
+    workerAffinity = readWorkerAffinity("floecat.reconciler.worker-affinity");
+  }
+
+  private ReconcileWorkerAffinity readWorkerAffinity(String key) {
+    try {
+      var container = Arc.container();
+      if (container != null) {
+        var config = container.instance(org.eclipse.microprofile.config.Config.class);
+        if (config.isAvailable()) {
+          return ReconcileWorkerAffinity.of(
+              config.get().getOptionalValue(key, String.class).orElse(""));
+        }
+      }
+    } catch (RuntimeException ignored) {
+      // Fall back to system properties for plain unit construction.
+    }
+    return ReconcileWorkerAffinity.of(System.getProperty(key));
   }
 
   private int readInt(String key, int defaultValue) {
@@ -173,7 +192,8 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
             effectiveTableTask,
             effectiveViewTask);
     ReconcileExecutionPolicy effectivePolicy =
-        executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy;
+        workerAffinity.applyTo(
+            executionPolicy == null ? ReconcileExecutionPolicy.defaults() : executionPolicy);
     ReconcileScope identityScope =
         ReconcileScopeCanonicalizer.resolvedWorkScope(
             effectiveScope,
@@ -939,7 +959,8 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
   public Optional<LeasedJob> leaseNext(LeaseRequest request) {
     long now = System.currentTimeMillis();
     reclaimExpiredLeasesIfDue(now);
-    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
+    LeaseRequest effective =
+        (request == null ? LeaseRequest.all() : request).withWorkerAffinity(workerAffinity);
     int attempts = Math.max(1, ready.size());
     for (int i = 0; i < attempts; i++) {
       String jobId = ready.poll();
@@ -2311,27 +2332,15 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
 
   private static boolean matchesLeaseRequest(
       LeaseRequest request, ReconcileJob job, String pinnedExecutorId, String laneKey) {
-    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
     if (job == null) {
       return false;
     }
-    String effectivePinnedExecutorId = blankToEmpty(pinnedExecutorId);
-    if (!effectivePinnedExecutorId.isBlank()
-        && !effective.executorIds.contains(effectivePinnedExecutorId)) {
-      return false;
-    }
-    ReconcileExecutionPolicy policy =
-        job.executionPolicy == null ? ReconcileExecutionPolicy.defaults() : job.executionPolicy;
-    boolean classMatches =
-        effective.executionClasses.isEmpty()
-            || effective.executionClasses.contains(policy.executionClass());
-    boolean laneMatches =
-        effective.lanes.isEmpty()
-            || effective.lanes.contains(LeaseRequest.anyLaneToken())
-            || effective.lanes.contains(policy.lane())
-            || effective.lanes.contains(blankToEmpty(laneKey));
-    boolean kindMatches = effective.jobKinds.isEmpty() || effective.jobKinds.contains(job.jobKind);
-    return classMatches && laneMatches && kindMatches;
+    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
+    return effective.matches(
+        job.executionPolicy == null ? ReconcileExecutionPolicy.defaults() : job.executionPolicy,
+        blankToEmpty(pinnedExecutorId),
+        job.jobKind,
+        blankToEmpty(laneKey));
   }
 
   private static String hashValue(String value) {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -89,6 +90,40 @@ class ReconcileExecutorRegistryTest {
         new ReconcileExecutorRegistry(List.of(new TestExecutor("other", 1, true)));
 
     assertThat(registry.executorFor(lease)).isEmpty();
+  }
+
+  @Test
+  void cohortAffinityDoesNotLeakIntoExecutorPinning() {
+    // A cohort is enforced by the job store, so it must never masquerade as an executor pin here.
+    ReconcileExecutionPolicy policy =
+        ReconcileWorkerAffinity.of("ci-branch").applyTo(ReconcileExecutionPolicy.defaults());
+    ReconcileJobStore.LeasedJob lease = defaultLease(policy, "");
+    ReconcileExecutor fallback = new TestExecutor("fallback", 100, true);
+    ReconcileExecutor preferred = new TestExecutor("preferred", 10, true);
+
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(List.of(fallback, preferred));
+
+    assertThat(registry.executorFor(lease).orElseThrow().id()).isEqualTo("preferred");
+    assertThat(registry.leaseRequest().executorIds)
+        .containsExactlyInAnyOrder("fallback", "preferred");
+    assertThat(registry.leaseRequestFor(preferred).executorIds).containsExactly("preferred");
+  }
+
+  @Test
+  void pinEligibilityIsSharedWithTheLeasePoller() {
+    ReconcileExecutor preferred = new TestExecutor("preferred", 10, true);
+    ReconcileExecutor other = new TestExecutor("other", 20, true);
+    ReconcileExecutorRegistry registry = new ReconcileExecutorRegistry(List.of(preferred, other));
+
+    ReconcileJobStore.LeasedJob unpinned = defaultLease(ReconcileExecutionPolicy.defaults(), "");
+    ReconcileJobStore.LeasedJob pinned =
+        defaultLease(ReconcileExecutionPolicy.defaults(), "preferred");
+
+    // An unpinned job is runnable by whichever executor the poller offered.
+    assertThat(registry.pinExcludes(unpinned, other)).isFalse();
+    assertThat(registry.pinExcludes(pinned, preferred)).isFalse();
+    assertThat(registry.pinExcludes(pinned, other)).isTrue();
   }
 
   @Test
@@ -174,7 +209,8 @@ class ReconcileExecutorRegistryTest {
                 ReconcileExecutionPolicy.of(
                     ReconcileExecutionClass.HEAVY, "planner-lane", Map.of()),
                 "",
-                ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_CONNECTOR))
+                ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_CONNECTOR,
+                "planner-lane"))
         .isTrue();
   }
 
@@ -211,19 +247,31 @@ class ReconcileExecutorRegistryTest {
 
     assertThat(
             emptyExecutors.matches(
-                policy, "remote-a", ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_TABLE))
+                policy,
+                "remote-a",
+                ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_TABLE,
+                "remote"))
         .isFalse();
     assertThat(
             wrongExecutor.matches(
-                policy, "remote-a", ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_TABLE))
+                policy,
+                "remote-a",
+                ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_TABLE,
+                "remote"))
         .isFalse();
     assertThat(
             matchingExecutor.matches(
-                policy, "remote-a", ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_TABLE))
+                policy,
+                "remote-a",
+                ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_TABLE,
+                "remote"))
         .isTrue();
     assertThat(
             emptyExecutors.matches(
-                policy, "", ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_TABLE))
+                policy,
+                "",
+                ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_TABLE,
+                "remote"))
         .isTrue();
   }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutorTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteSnapshotPlanningReconcileExecutorTest.java
@@ -155,84 +155,6 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
   }
 
   @Test
-  void ordinaryPlanningLoadsReuseManifestOnlyFromExplicitParent() throws Exception {
-    var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
-    var workerClient = mock(RemotePlannerWorkerClient.class);
-    BlobStore blobStore = mock(BlobStore.class);
-    var executor =
-        new RemoteSnapshotPlanningReconcileExecutor(
-            backend, workerClient, ignored -> Optional.empty(), 2, true);
-    executor.blobStore = blobStore;
-    ReconcileJobStore.LeasedJob lease = lease(statsOnlyScope());
-    when(workerClient.getPlanSnapshotInput(any()))
-        .thenReturn(
-            new StandalonePlanSnapshotPayload(
-                lease.jobId,
-                lease.leaseEpoch,
-                "",
-                connectorId(),
-                ReconcilerService.CaptureMode.CAPTURE_ONLY,
-                false,
-                statsOnlyScope(),
-                snapshotTask()));
-    when(backend.captureSnapshotTargetStatsDirect(any(), any(), eq(55L), any(), any(), any()))
-        .thenReturn(Optional.empty());
-    when(backend.fetchSnapshotFilePlan(any(), any(), eq(55L)))
-        .thenReturn(
-            Optional.of(
-                new FloecatConnector.SnapshotFilePlan(
-                    List.of(snapshotFile("file-1", 10L)), List.of())));
-    long reuseBasisSnapshotId = 7L;
-    byte[] manifestBytes =
-        SnapshotCaptureManifest.newBuilder()
-            .setFormatVersion(1)
-            .setAccountId("acct")
-            .setConnectorId("connector-1")
-            .setTableId("table-1")
-            .setSnapshotId(reuseBasisSnapshotId)
-            .setReusableArtifactBundlesComplete(true)
-            .setReusableArtifactIndex(ReusableArtifactIndexStore.emptyReference())
-            .build()
-            .toByteArray();
-    String uri = "/reuse/7.pb";
-    byte[] manifestSha256 =
-        java.security.MessageDigest.getInstance("SHA-256").digest(manifestBytes);
-    when(backend.fetchSnapshot(any(), any(), eq(55L)))
-        .thenReturn(
-            Optional.of(
-                Snapshot.newBuilder()
-                    .setTableId(tableId())
-                    .setSnapshotId(55L)
-                    .setParentSnapshotId(reuseBasisSnapshotId)
-                    .build()));
-    when(backend.fetchSnapshot(any(), any(), eq(reuseBasisSnapshotId)))
-        .thenReturn(
-            Optional.of(
-                Snapshot.newBuilder()
-                    .setTableId(tableId())
-                    .setSnapshotId(reuseBasisSnapshotId)
-                    .setReuseManifestRef(
-                        SnapshotReuseManifestRef.newBuilder()
-                            .setFormatVersion(1)
-                            .setUri(uri)
-                            .setPayloadBytes(manifestBytes.length)
-                            .setPayloadSha256(ByteString.copyFrom(manifestSha256))
-                            .setStatsGenerationManifestUri("/stats/generation.pb"))
-                    .build()));
-    when(blobStore.get(uri)).thenReturn(manifestBytes);
-    when(workerClient.submitPlanSnapshotSuccess(any(), any(), any(), any())).thenReturn(true);
-
-    assertTrue(
-        executor
-            .execute(
-                new ReconcileExecutor.ExecutionContext(
-                    lease, () -> false, (a, b, c, d, e, f, g, h) -> {}))
-            .success());
-    verify(blobStore).get(uri);
-    verify(backend, never()).existingSnapshotIds(any(), any());
-  }
-
-  @Test
   void planningFallsBackWhenLatestReuseManifestIntegrityIsInvalid() {
     var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
     var workerClient = mock(RemotePlannerWorkerClient.class);
@@ -633,13 +555,13 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
   }
 
   @Test
-  void compactionOrDeleteChangeLoadsReusableBundlesFromLatestCompleteManifest() throws Exception {
+  void checkpointReusesLatestFinalizedBasisWithoutLoadingImmediateParent() throws Exception {
     var backend = mock(ai.floedb.floecat.reconciler.spi.ReconcilerBackend.class);
     var workerClient = mock(RemotePlannerWorkerClient.class);
     BlobStore blobStore = mock(BlobStore.class);
     var executor =
         new RemoteSnapshotPlanningReconcileExecutor(
-            backend, workerClient, ignored -> Optional.empty(), 2, true);
+            backend, workerClient, ignored -> Optional.empty(), 2, 0, true);
     executor.blobStore = blobStore;
     ReconcileJobStore.LeasedJob lease = lease(statsOnlyScope());
     when(workerClient.getPlanSnapshotInput(any()))
@@ -751,36 +673,6 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
                             .setPayloadSha256(ByteString.copyFrom(currentDigest))
                             .setStatsGenerationManifestUri("/stats/generation-8.pb"))
                     .build()));
-    when(backend.fetchSnapshot(any(), any(), eq(55L)))
-        .thenReturn(
-            Optional.of(
-                Snapshot.newBuilder()
-                    .setTableId(tableId())
-                    .setSnapshotId(55L)
-                    .setParentSnapshotId(8L)
-                    .build()));
-    when(backend.fetchSnapshot(any(), any(), eq(8L)))
-        .thenReturn(
-            Optional.of(
-                Snapshot.newBuilder()
-                    .setTableId(tableId())
-                    .setSnapshotId(8L)
-                    .setReuseManifestRef(
-                        SnapshotReuseManifestRef.newBuilder()
-                            .setFormatVersion(1)
-                            .setUri(currentUri)
-                            .setPayloadBytes(currentManifest.length)
-                            .setPayloadSha256(ByteString.copyFrom(currentDigest))
-                            .setStatsGenerationManifestUri("/stats/generation-8.pb"))
-                    .build()));
-    when(backend.fetchSnapshotFileDelta(any(), any(), eq(8L), eq(55L)))
-        .thenReturn(
-            Optional.of(
-                new FloecatConnector.SnapshotFileDelta(
-                    List.of(snapshotFile("file-3", 10L)),
-                    List.of("s3://bucket/file-2.parquet"),
-                    true,
-                    "schema")));
     when(blobStore.get(currentUri)).thenReturn(currentManifest);
     when(workerClient.submitPlanSnapshotSuccess(any(), any(), any(), any())).thenReturn(true);
 
@@ -811,6 +703,8 @@ class RemoteSnapshotPlanningReconcileExecutorTest {
             any());
     verify(blobStore).get(currentUri);
     verify(blobStore, never()).get(baseUri);
+    verify(backend, never()).fetchSnapshot(any(), any(), anyLong());
+    verify(backend, never()).fetchSnapshotFileDelta(any(), any(), anyLong(), anyLong());
   }
 
   @Test

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/ReconcileWorkerAffinityTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/ReconcileWorkerAffinityTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.reconciler.jobs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReconcileWorkerAffinityTest {
+
+  @Test
+  void serverAffinityOverridesCallerAttribute() {
+    ReconcileExecutionPolicy callerPolicy =
+        ReconcileExecutionPolicy.of(
+            ReconcileExecutionClass.HEAVY,
+            "remote",
+            Map.of(ReconcileWorkerAffinity.ATTRIBUTE, "caller", "other", "value"));
+
+    ReconcileExecutionPolicy policy =
+        ReconcileWorkerAffinity.of(" ci-branch ").applyTo(callerPolicy);
+
+    assertThat(policy.executionClass()).isEqualTo(ReconcileExecutionClass.HEAVY);
+    assertThat(policy.lane()).isEqualTo("remote");
+    assertThat(policy.attributes())
+        .containsEntry(ReconcileWorkerAffinity.ATTRIBUTE, "ci-branch")
+        .containsEntry("other", "value");
+  }
+
+  @Test
+  void disabledServerAffinityRemovesCallerAttribute() {
+    ReconcileExecutionPolicy callerPolicy =
+        ReconcileExecutionPolicy.of(
+            ReconcileExecutionClass.DEFAULT,
+            "",
+            Map.of(ReconcileWorkerAffinity.ATTRIBUTE, "caller", "other", "value"));
+
+    ReconcileExecutionPolicy policy = ReconcileWorkerAffinity.of(" ").applyTo(callerPolicy);
+
+    assertThat(policy.attributes())
+        .doesNotContainKey(ReconcileWorkerAffinity.ATTRIBUTE)
+        .containsEntry("other", "value");
+  }
+
+  @Test
+  void readsCohortBackFromPolicy() {
+    ReconcileExecutionPolicy policy =
+        ReconcileWorkerAffinity.of("ci-branch").applyTo(ReconcileExecutionPolicy.defaults());
+
+    assertThat(ReconcileWorkerAffinity.fromPolicy(policy))
+        .isEqualTo(ReconcileWorkerAffinity.of("ci-branch"));
+    assertThat(ReconcileWorkerAffinity.fromPolicy(ReconcileExecutionPolicy.defaults()))
+        .isEqualTo(ReconcileWorkerAffinity.DISABLED);
+  }
+
+  @Test
+  void indexFilterValuePartitionsSlicesPerCohort() {
+    String legacy = ReconcileWorkerAffinity.DISABLED.indexFilterValue("PLAN_SNAPSHOT");
+    String branch = ReconcileWorkerAffinity.of("ci-branch").indexFilterValue("PLAN_SNAPSHOT");
+    String steady = ReconcileWorkerAffinity.of("steady-state").indexFilterValue("PLAN_SNAPSHOT");
+
+    // A disabled cohort must keep the pre-affinity filter value so existing slices still resolve.
+    assertThat(legacy).isEqualTo("PLAN_SNAPSHOT");
+    assertThat(branch).isNotEqualTo(legacy).isNotEqualTo(steady).contains("PLAN_SNAPSHOT");
+  }
+
+  @Test
+  void cohortSeparatorCannotBeForgedFromAnExecutionLane() {
+    // Lanes are operator-supplied, so a lane must not be able to spoof another cohort's slice.
+    String spoofed =
+        ReconcileWorkerAffinity.DISABLED.indexFilterValue("ci-branch\u001fPLAN_SNAPSHOT");
+    String genuine = ReconcileWorkerAffinity.of("ci-branch").indexFilterValue("PLAN_SNAPSHOT");
+
+    assertThat(spoofed).isNotEqualTo(genuine);
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
@@ -33,6 +33,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -155,6 +156,116 @@ class InMemoryReconcileJobStoreTest {
             "");
 
     assertNotEquals(first, second);
+  }
+
+  @Test
+  void storeStampsItsOwnCohortOnEnqueueAndLease() {
+    // The store owns both stamps, so a caller cannot enqueue work its own deployment cannot lease.
+    System.setProperty("floecat.reconciler.worker-affinity", "ci-branch");
+    try {
+      var store = new InMemoryReconcileJobStore();
+      String jobId =
+          store.enqueuePlan(
+              "acct",
+              "conn",
+              false,
+              CaptureMode.METADATA_AND_CAPTURE,
+              ReconcileScope.empty(),
+              ReconcileExecutionPolicy.defaults(),
+              "");
+
+      var lease = store.leaseNext().orElseThrow();
+
+      assertEquals(jobId, lease.jobId);
+      assertEquals(
+          ReconcileWorkerAffinity.of("ci-branch"),
+          ReconcileWorkerAffinity.fromPolicy(lease.executionPolicy));
+      // The cohort is not an executor pin.
+      assertEquals("", lease.pinnedExecutorId);
+    } finally {
+      System.clearProperty("floecat.reconciler.worker-affinity");
+    }
+  }
+
+  @Test
+  void presentButEmptyAffinityPropertyLeavesAffinityDisabled() {
+    // The property ships as ${FLOECAT_RECONCILER_WORKER_AFFINITY:}, so the default deployment
+    // always presents it as an empty value. That must read as "disabled", not fail or stamp "".
+    System.setProperty("floecat.reconciler.worker-affinity", "   ");
+    try {
+      var store = new InMemoryReconcileJobStore();
+      String jobId =
+          store.enqueuePlan(
+              "acct",
+              "conn",
+              false,
+              CaptureMode.METADATA_AND_CAPTURE,
+              ReconcileScope.empty(),
+              ReconcileExecutionPolicy.defaults(),
+              "");
+
+      var lease = store.leaseNext().orElseThrow();
+
+      assertEquals(jobId, lease.jobId);
+      assertEquals(
+          ReconcileWorkerAffinity.DISABLED,
+          ReconcileWorkerAffinity.fromPolicy(lease.executionPolicy));
+      assertFalse(
+          lease.executionPolicy.attributes().containsKey(ReconcileWorkerAffinity.ATTRIBUTE));
+    } finally {
+      System.clearProperty("floecat.reconciler.worker-affinity");
+    }
+  }
+
+  @Test
+  void storeOverridesCallerSuppliedAffinity() {
+    // A caller must not be able to place work into, or steal work from, another cohort by passing
+    // the attribute itself. The store's own configuration always wins.
+    System.setProperty("floecat.reconciler.worker-affinity", "ci-branch");
+    try {
+      var store = new InMemoryReconcileJobStore();
+      String jobId =
+          store.enqueuePlan(
+              "acct",
+              "conn",
+              false,
+              CaptureMode.METADATA_AND_CAPTURE,
+              ReconcileScope.empty(),
+              ReconcileWorkerAffinity.of("steady-state")
+                  .applyTo(ReconcileExecutionPolicy.defaults()),
+              "");
+
+      var lease = store.leaseNext().orElseThrow();
+
+      assertEquals(jobId, lease.jobId);
+      assertEquals(
+          ReconcileWorkerAffinity.of("ci-branch"),
+          ReconcileWorkerAffinity.fromPolicy(lease.executionPolicy));
+    } finally {
+      System.clearProperty("floecat.reconciler.worker-affinity");
+    }
+  }
+
+  @Test
+  void leaseRequestCohortMustMatchTheJobExactly() {
+    ReconcileExecutionPolicy branch =
+        ReconcileWorkerAffinity.of("ci-branch").applyTo(ReconcileExecutionPolicy.defaults());
+    ReconcileExecutionPolicy legacy = ReconcileExecutionPolicy.defaults();
+    ReconcileJobStore.LeaseRequest request =
+        new ReconcileJobStore.LeaseRequest(
+            null, null, Set.of(), EnumSet.of(ReconcileJobKind.PLAN_CONNECTOR));
+
+    assertTrue(
+        request.withWorkerAffinity(ReconcileWorkerAffinity.of("ci-branch")).cohortMatches(branch));
+    assertFalse(
+        request
+            .withWorkerAffinity(ReconcileWorkerAffinity.of("steady-state"))
+            .cohortMatches(branch));
+    // Neither direction of the legacy boundary may cross.
+    assertFalse(request.cohortMatches(branch));
+    assertFalse(
+        request.withWorkerAffinity(ReconcileWorkerAffinity.of("ci-branch")).cohortMatches(legacy));
+    assertTrue(request.cohortMatches(legacy));
   }
 
   @Test

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImpl.java
@@ -36,6 +36,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotSelection;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.reconciler.jobs.ReusableArtifactBundleSelection;
 import ai.floedb.floecat.reconciler.rpc.CommitLeasedFileGroupResultRequest;
 import ai.floedb.floecat.reconciler.rpc.CommitLeasedFileGroupResultResponse;
@@ -118,6 +119,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
   @Inject LeasedSnapshotFinalizeInputService leasedSnapshotFinalizeInputService;
   @Inject LeasedSnapshotFinalizeExecutionService leasedSnapshotFinalizeExecutionService;
   @Inject LeasedPlannerWorkerService leasedPlannerWorkerService;
+  @Inject ReconcileWorkerAffinityGuard affinityGuard;
 
   @Override
   public Uni<LeaseReconcileJobResponse> leaseReconcileJob(LeaseReconcileJobRequest request) {
@@ -127,6 +129,8 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               var principalContext = principalProvider.get();
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
+              affinityGuard.requireLeaseRequestAffinity(
+                  request == null ? "" : request.getWorkerAffinity());
               Set<String> executorIds;
               if (request == null) {
                 executorIds = Set.of();
@@ -222,6 +226,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
                 requireExecutorControl(principalContext);
                 correlationId = principalContext.getCorrelationId();
                 jobId = mustNonEmpty(request.getJobId(), "job_id", correlationId);
+                affinityGuard.requireJobAffinity(jobId);
                 String leaseEpoch =
                     mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", correlationId);
                 setupNanos = System.nanoTime() - phaseStartNanos;
@@ -275,6 +280,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               String executorId = mustNonEmpty(request.getExecutorId(), "executor_id", corr);
               jobs.markRunning(jobId, leaseEpoch, System.currentTimeMillis(), executorId);
@@ -293,6 +299,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               var update =
                   jobs.reportProgress(
@@ -324,6 +331,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               if (request.getState() == ReconcileCompletionState.RCS_UNSPECIFIED
                   || request.getState() == ReconcileCompletionState.UNRECOGNIZED) {
@@ -512,6 +520,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               return GetReconcileCancellationResponse.newBuilder()
                   .setCancellationRequested(jobs.isCancellationRequested(jobId))
                   .build();
@@ -529,6 +538,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               var payload =
                   leasedPlannerWorkerService.resolvePlanConnector(
@@ -560,6 +570,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               if (request.hasSuccess()) {
                 boolean accepted =
@@ -614,6 +625,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               var payload =
                   leasedPlannerWorkerService.resolvePlanTable(principalContext, jobId, leaseEpoch);
@@ -644,6 +656,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               if (request.hasChunk()) {
                 boolean accepted =
@@ -708,6 +721,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               var payload =
                   leasedPlannerWorkerService.resolvePlanView(principalContext, jobId, leaseEpoch);
@@ -736,6 +750,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               if (request.hasSuccess()) {
                 var result =
@@ -787,6 +802,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               var payload =
                   leasedPlannerWorkerService.resolvePlanSnapshot(
@@ -818,6 +834,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               if (request.hasChunk()) {
                 boolean accepted =
@@ -879,6 +896,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               var payload =
                   leasedFileGroupExecutionService.resolve(principalContext, jobId, leaseEpoch);
@@ -970,6 +988,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               var payload =
                   leasedSnapshotFinalizeInputService.resolve(principalContext, jobId, leaseEpoch);
@@ -1035,6 +1054,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               var page =
                   leasedSnapshotFinalizeInputService.descriptorPage(
@@ -1112,6 +1132,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               if (request.hasSuccess()) {
                 if (!request.getSuccess().hasResultDescriptor()) {
@@ -1198,6 +1219,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
               requireExecutorControl(principalContext);
               String corr = principalContext.getCorrelationId();
               String jobId = mustNonEmpty(request.getJobId(), "job_id", corr);
+              affinityGuard.requireJobAffinity(jobId);
               String leaseEpoch = mustNonEmpty(request.getLeaseEpoch(), "lease_epoch", corr);
               if (request.hasSuccess()) {
                 boolean accepted =
@@ -1299,6 +1321,7 @@ public class ReconcileExecutorControlImpl extends BaseServiceImpl
         .setViewTask(toProtoViewTask(lease.viewTask))
         .setSnapshotTask(toProtoSnapshotTask(compactSnapshotTask(lease.snapshotTask)))
         .setFileGroupTask(toProtoFileGroupTask(compactFileGroupTask(lease.fileGroupTask)))
+        .setWorkerAffinity(ReconcileWorkerAffinity.fromPolicy(lease.executionPolicy).value())
         .build();
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileWorkerAffinityGuard.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileWorkerAffinityGuard.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.impl;
+
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
+import io.grpc.Status;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/** Enforces the remote worker, serving deployment, and leased job affinity contract. */
+@ApplicationScoped
+public class ReconcileWorkerAffinityGuard {
+  private static final Logger LOG = Logger.getLogger(ReconcileWorkerAffinityGuard.class);
+
+  @Inject ReconcileJobStore jobs;
+
+  @ConfigProperty(name = "floecat.reconciler.worker-affinity", defaultValue = "reconciler-v1")
+  String configuredAffinity = "reconciler-v1";
+
+  @ConfigProperty(name = "floecat.reconciler.allow-unversioned-workers", defaultValue = "true")
+  boolean allowUnversionedWorkers = true;
+
+  private final AtomicBoolean legacyWorkerWarningLogged = new AtomicBoolean();
+
+  public void requireLeaseRequestAffinity(String requestedAffinity) {
+    ReconcileWorkerAffinity requested = ReconcileWorkerAffinity.of(requestedAffinity);
+    ReconcileWorkerAffinity configured = configuredAffinity();
+    if (!requested.enabled()) {
+      if (!allowUnversionedWorkers) {
+        throw mismatch("unversioned reconcile workers are disabled", requested, configured);
+      }
+      if (legacyWorkerWarningLogged.compareAndSet(false, true)) {
+        LOG.warnf(
+            "Accepted an unversioned reconcile worker through the legacy fallback;"
+                + " treating it as affinity=%s",
+            configured.value());
+      }
+      return;
+    }
+    if (!requested.equals(configured)) {
+      throw mismatch(
+          "reconcile worker affinity does not match this deployment", requested, configured);
+    }
+  }
+
+  /** Rejects a lease-bound call routed through a deployment that does not own the job's cohort. */
+  public void requireJobAffinity(String jobId) {
+    if (jobId == null || jobId.isBlank()) {
+      return;
+    }
+    jobs.getCompactLeaseView(jobId)
+        .ifPresent(
+            job -> {
+              ReconcileWorkerAffinity jobAffinity =
+                  ReconcileWorkerAffinity.fromPolicy(job.executionPolicy);
+              ReconcileWorkerAffinity configured = configuredAffinity();
+              if (!jobAffinity.equals(configured)) {
+                throw mismatch(
+                    "reconcile job affinity does not match this deployment",
+                    jobAffinity,
+                    configured);
+              }
+            });
+  }
+
+  ReconcileWorkerAffinity configuredAffinity() {
+    return ReconcileWorkerAffinity.of(configuredAffinity);
+  }
+
+  private static io.grpc.StatusRuntimeException mismatch(
+      String message, ReconcileWorkerAffinity actual, ReconcileWorkerAffinity expected) {
+    return Status.FAILED_PRECONDITION
+        .withDescription(
+            message + ": worker_or_job=" + display(actual) + " deployment=" + display(expected))
+        .asRuntimeException();
+  }
+
+  private static String display(ReconcileWorkerAffinity affinity) {
+    return affinity == null || !affinity.enabled() ? "<unversioned>" : affinity.value();
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileWorkerAffinityGuard.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileWorkerAffinityGuard.java
@@ -21,40 +21,19 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import io.grpc.Status;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 /** Enforces the remote worker, serving deployment, and leased job affinity contract. */
 @ApplicationScoped
 public class ReconcileWorkerAffinityGuard {
-  private static final Logger LOG = Logger.getLogger(ReconcileWorkerAffinityGuard.class);
-
   @Inject ReconcileJobStore jobs;
 
   @ConfigProperty(name = "floecat.reconciler.worker-affinity", defaultValue = "reconciler-v1")
   String configuredAffinity = "reconciler-v1";
 
-  @ConfigProperty(name = "floecat.reconciler.allow-unversioned-workers", defaultValue = "true")
-  boolean allowUnversionedWorkers = true;
-
-  private final AtomicBoolean legacyWorkerWarningLogged = new AtomicBoolean();
-
   public void requireLeaseRequestAffinity(String requestedAffinity) {
     ReconcileWorkerAffinity requested = ReconcileWorkerAffinity.of(requestedAffinity);
     ReconcileWorkerAffinity configured = configuredAffinity();
-    if (!requested.enabled()) {
-      if (!allowUnversionedWorkers) {
-        throw mismatch("unversioned reconcile workers are disabled", requested, configured);
-      }
-      if (legacyWorkerWarningLogged.compareAndSet(false, true)) {
-        LOG.warnf(
-            "Accepted an unversioned reconcile worker through the legacy fallback;"
-                + " treating it as affinity=%s",
-            configured.value());
-      }
-      return;
-    }
     if (!requested.equals(configured)) {
       throw mismatch(
           "reconcile worker affinity does not match this deployment", requested, configured);

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -34,6 +34,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotContentState;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.reconciler.jobs.SnapshotPlanManifestIds;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredJobDefinition;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredJobLease;
@@ -210,6 +211,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   private int leaseMaxConcurrency = DEFAULT_LEASE_MAX_CONCURRENCY;
   long leaseAcquireTimeoutMs = DEFAULT_LEASE_ACQUIRE_TIMEOUT_MS;
   private long leaseScanBudgetMs = DEFAULT_LEASE_SCAN_BUDGET_MS;
+  private ReconcileWorkerAffinity workerAffinity = ReconcileWorkerAffinity.DISABLED;
   long snapshotCoverageClaimRetentionMs = DEFAULT_SNAPSHOT_COVERAGE_CLAIM_RETENTION_MS;
   private final Map<String, String> snapshotCoverageClaimGcTokens = new ConcurrentHashMap<>();
   volatile Semaphore leaseScanPermits = new Semaphore(DEFAULT_LEASE_MAX_CONCURRENCY, true);
@@ -439,7 +441,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
         this::materializeSnapshotPlan,
         readyQueue()::readyPointerKeys,
         this::statePointerKeys,
-        readyQueue()::readyPointerKeyForDue);
+        readyQueue()::readyPointerKeyForDue,
+        workerAffinity);
     return enqueuer;
   }
 
@@ -569,6 +572,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
             config
                 .getOptionalValue("floecat.reconciler.job-store.lease-scan-budget-ms", Long.class)
                 .orElse(DEFAULT_LEASE_SCAN_BUDGET_MS));
+    workerAffinity =
+        ReconcileWorkerAffinity.of(
+            config.getOptionalValue("floecat.reconciler.worker-affinity", String.class).orElse(""));
     snapshotCoverageClaimRetentionMs =
         Math.max(
             1_000L,
@@ -1523,7 +1529,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
       throw new LeaseScanCapacityExceededException(
           "reconcile lease scan capacity exhausted cap=" + leaseMaxConcurrency);
     }
-    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
+    LeaseRequest effective =
+        (request == null ? LeaseRequest.all() : request).withWorkerAffinity(workerAffinity);
     LeaseScanStats scanStats = new LeaseScanStats();
     configureLeaseScanStats(scanStats, startedAtMs);
     try {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileJobEnqueuer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileJobEnqueuer.java
@@ -31,6 +31,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotSelection;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.service.common.Canonicalizer;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredJobDefinition;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
@@ -65,6 +66,7 @@ public class ReconcileJobEnqueuer {
   private Function<StoredReconcileJob, List<String>> readyPointerKeys;
   private Function<StoredReconcileJob, List<String>> statePointerKeys;
   private ReadyPointerKeyForDue readyPointerKeyForDue;
+  private ReconcileWorkerAffinity workerAffinity = ReconcileWorkerAffinity.DISABLED;
 
   @FunctionalInterface
   public interface ReadyPointerKeyForDue {
@@ -80,7 +82,8 @@ public class ReconcileJobEnqueuer {
       Function<ReconcileSnapshotTask, SnapshotPlanBlob> materializeSnapshotPlan,
       Function<StoredReconcileJob, List<String>> readyPointerKeys,
       Function<StoredReconcileJob, List<String>> statePointerKeys,
-      ReadyPointerKeyForDue readyPointerKeyForDue) {
+      ReadyPointerKeyForDue readyPointerKeyForDue,
+      ReconcileWorkerAffinity workerAffinity) {
     this.blobStore = blobStore;
     this.payloadStore = payloadStore;
     this.projector = projector;
@@ -90,6 +93,8 @@ public class ReconcileJobEnqueuer {
     this.readyPointerKeys = readyPointerKeys;
     this.statePointerKeys = statePointerKeys;
     this.readyPointerKeyForDue = readyPointerKeyForDue;
+    this.workerAffinity =
+        workerAffinity == null ? ReconcileWorkerAffinity.DISABLED : workerAffinity;
   }
 
   public BulkEnqueueResult bulkEnqueue(List<BulkEnqueueSpec> specs) {
@@ -321,7 +326,10 @@ public class ReconcileJobEnqueuer {
             effectiveSnapshotTask,
             spec.captureMode == CaptureMode.CAPTURE_ONLY);
     ReconcileExecutionPolicy policy =
-        spec.executionPolicy == null ? ReconcileExecutionPolicy.defaults() : spec.executionPolicy;
+        workerAffinity.applyTo(
+            spec.executionPolicy == null
+                ? ReconcileExecutionPolicy.defaults()
+                : spec.executionPolicy);
     String laneKey =
         laneKey(
             spec.connectorId,

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.reconciler.jobs.durable.store;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeaseRequest;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeasedJob;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
@@ -92,26 +93,15 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
   }
 
   public boolean matchesLeaseRequest(StoredReconcileJob record, LeaseRequest request) {
-    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
-    String pinnedExecutorId = record == null ? "" : record.pinnedExecutorId();
-    if (!blank(pinnedExecutorId) && !effective.executorIds.contains(pinnedExecutorId)) {
-      return false;
-    }
     if (record == null) {
       return false;
     }
-    ReconcileExecutionPolicy policy = record.executionPolicy();
-    boolean classMatches =
-        effective.executionClasses.isEmpty()
-            || effective.executionClasses.contains(policy.executionClass());
-    boolean laneMatches =
-        effective.lanes.isEmpty()
-            || effective.lanes.contains(LeaseRequest.anyLaneToken())
-            || effective.lanes.contains(policy.lane())
-            || effective.lanes.contains(blankToEmpty(record.laneKey));
-    boolean kindMatches =
-        effective.jobKinds.isEmpty() || effective.jobKinds.contains(record.jobKind());
-    return classMatches && laneMatches && kindMatches;
+    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
+    return effective.matches(
+        record.executionPolicy(),
+        record.pinnedExecutorId(),
+        record.jobKind(),
+        blankToEmpty(record.laneKey));
   }
 
   public long readyPointerDueAt(StoredReconcileJob record) {
@@ -359,21 +349,33 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
         request.lanes.stream()
             .map(NativeReconcileReadyQueueStore::blankToEmpty)
             .filter(lane -> !lane.isBlank() && !LeaseRequest.anyLaneToken().equals(lane))
+            .map(request.workerAffinity::indexFilterValue)
             .sorted()
             .toList();
     if (!lanes.isEmpty()) {
       return selections(ReadyIndexType.EXECUTION_LANE, rotate(lanes, unpinnedSelectionCursor));
     }
-    List<String> jobKinds = request.jobKinds.stream().sorted().map(Enum::name).toList();
+    List<String> jobKinds =
+        request.jobKinds.stream()
+            .map(Enum::name)
+            .map(request.workerAffinity::indexFilterValue)
+            .sorted()
+            .toList();
     if (!jobKinds.isEmpty()) {
       return selections(ReadyIndexType.JOB_KIND, rotate(jobKinds, unpinnedSelectionCursor));
     }
     List<String> executionClasses =
-        request.executionClasses.stream().sorted().map(Enum::name).toList();
+        request.executionClasses.stream()
+            .map(Enum::name)
+            .map(request.workerAffinity::indexFilterValue)
+            .sorted()
+            .toList();
     if (!executionClasses.isEmpty()) {
       return selections(
           ReadyIndexType.EXECUTION_CLASS, rotate(executionClasses, unpinnedSelectionCursor));
     }
+    // The global index is not cohort-partitioned; only a fully unconstrained request reaches it,
+    // and matchesLeaseRequest still enforces the cohort on every candidate it yields.
     return List.of(
         new ReadyIndexSelection(
             new ReconcileReadyQueueBackend.ReadyQueueSlice(ReadyIndexType.GLOBAL, "")));
@@ -484,12 +486,20 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
       return false;
     }
     ReconcileExecutionPolicy policy = record.executionPolicy();
+    ReconcileWorkerAffinity workerAffinity = ReconcileWorkerAffinity.fromPolicy(policy);
     return switch (candidate.indexType()) {
       case GLOBAL -> true;
-      case EXECUTION_CLASS -> candidate.filterValue().equals(policy.executionClass().name());
-      case EXECUTION_LANE -> candidate.filterValue().equals(blankToEmpty(record.laneKey));
+      case EXECUTION_CLASS ->
+          candidate
+              .filterValue()
+              .equals(workerAffinity.indexFilterValue(policy.executionClass().name()));
+      case EXECUTION_LANE ->
+          candidate
+              .filterValue()
+              .equals(workerAffinity.indexFilterValue(blankToEmpty(record.laneKey)));
       case PINNED_EXECUTOR -> candidate.filterValue().equals(record.pinnedExecutorId());
-      case JOB_KIND -> candidate.filterValue().equals(record.jobKind().name());
+      case JOB_KIND ->
+          candidate.filterValue().equals(workerAffinity.indexFilterValue(record.jobKind().name()));
     };
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
@@ -330,6 +330,7 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
         request.executorIds.stream()
             .map(NativeReconcileReadyQueueStore::blankToEmpty)
             .filter(executorId -> !executorId.isBlank())
+            .map(request.workerAffinity::indexFilterValue)
             .sorted()
             .toList();
     if (executorIds.isEmpty()) {
@@ -497,7 +498,10 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
           candidate
               .filterValue()
               .equals(workerAffinity.indexFilterValue(blankToEmpty(record.laneKey)));
-      case PINNED_EXECUTOR -> candidate.filterValue().equals(record.pinnedExecutorId());
+      case PINNED_EXECUTOR ->
+          candidate
+              .filterValue()
+              .equals(workerAffinity.indexFilterValue(record.pinnedExecutorId()));
       case JOB_KIND ->
           candidate.filterValue().equals(workerAffinity.indexFilterValue(record.jobKind().name()));
     };

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueKeys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueKeys.java
@@ -89,6 +89,8 @@ public final class ReadyQueueKeys {
       return List.of();
     }
     List<String> keys = new ArrayList<>();
+    ReconcileWorkerAffinity workerAffinity =
+        ReconcileWorkerAffinity.fromPolicy(record.executionPolicy());
     String pinnedExecutorId = record.pinnedExecutorId();
     if (!blank(pinnedExecutorId)) {
       String pinnedExecutorKey =
@@ -96,13 +98,11 @@ public final class ReadyQueueKeys {
               record,
               ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR,
               dueAtMs,
-              pinnedExecutorId);
+              workerAffinity.indexFilterValue(pinnedExecutorId));
       return pinnedExecutorKey.isBlank() ? List.of() : List.of(pinnedExecutorKey);
     }
     // A cohort keeps its own slice of each filtered index, so a shared queue does not force
     // every deployment's workers through one undifferentiated scan.
-    ReconcileWorkerAffinity workerAffinity =
-        ReconcileWorkerAffinity.fromPolicy(record.executionPolicy());
     keys.add(readyPointerKeyFor(record, dueAtMs));
     String executionClassKey =
         readyPointerKeyFor(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueKeys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueKeys.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.reconciler.jobs.durable.store;
 
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
 import ai.floedb.floecat.service.repo.model.Keys;
 import java.util.ArrayList;
@@ -98,22 +99,28 @@ public final class ReadyQueueKeys {
               pinnedExecutorId);
       return pinnedExecutorKey.isBlank() ? List.of() : List.of(pinnedExecutorKey);
     }
+    // A cohort keeps its own slice of each filtered index, so a shared queue does not force
+    // every deployment's workers through one undifferentiated scan.
+    ReconcileWorkerAffinity workerAffinity =
+        ReconcileWorkerAffinity.fromPolicy(record.executionPolicy());
     keys.add(readyPointerKeyFor(record, dueAtMs));
     String executionClassKey =
         readyPointerKeyFor(
             record,
             ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_CLASS,
             dueAtMs,
-            record.executionPolicy().executionClass().name());
+            workerAffinity.indexFilterValue(record.executionPolicy().executionClass().name()));
     if (!executionClassKey.isBlank()) {
       keys.add(executionClassKey);
     }
     String executionLaneKey =
-        readyPointerKeyFor(
-            record,
-            ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE,
-            dueAtMs,
-            record.laneKey);
+        blank(record.laneKey)
+            ? ""
+            : readyPointerKeyFor(
+                record,
+                ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE,
+                dueAtMs,
+                workerAffinity.indexFilterValue(record.laneKey));
     if (!executionLaneKey.isBlank()) {
       keys.add(executionLaneKey);
     }
@@ -122,7 +129,7 @@ public final class ReadyQueueKeys {
             record,
             ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND,
             dueAtMs,
-            record.jobKind().name());
+            workerAffinity.indexFilterValue(record.jobKind().name()));
     if (!jobKindKey.isBlank()) {
       keys.add(jobKindKey);
     }

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -178,6 +178,9 @@ floecat.reconciler.worker.mode=${FLOECAT_RECONCILER_WORKER_MODE:local}
 # Every job a cohort enqueues is leasable only by that cohort, so a cohort that goes away leaves its
 # queued jobs unclaimed until they are cancelled or re-planned.
 floecat.reconciler.worker-affinity=${FLOECAT_RECONCILER_WORKER_AFFINITY:reconciler-v1}
+# Temporary migration fallback for workers built before the lease protocol declared an affinity.
+# An explicit but mismatched affinity is always rejected regardless of this setting.
+floecat.reconciler.allow-unversioned-workers=${FLOECAT_RECONCILER_ALLOW_UNVERSIONED_WORKERS:true}
 reconciler.max-parallelism=${FLOECAT_RECONCILER_MAX_PARALLELISM:1}
 # Empty queues are probed by one worker slot per executor JVM. Consecutive empty sweeps back off
 # with jitter; finding work resets the delay and immediately fills available worker capacity.

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -177,7 +177,7 @@ floecat.reconciler.worker.mode=${FLOECAT_RECONCILER_WORKER_MODE:local}
 # each other's trees should share a cohort, and only a breaking change to the tree should fork it.
 # Every job a cohort enqueues is leasable only by that cohort, so a cohort that goes away leaves its
 # queued jobs unclaimed until they are cancelled or re-planned.
-floecat.reconciler.worker-affinity=${FLOECAT_RECONCILER_WORKER_AFFINITY:}
+floecat.reconciler.worker-affinity=${FLOECAT_RECONCILER_WORKER_AFFINITY:reconciler-v1}
 reconciler.max-parallelism=${FLOECAT_RECONCILER_MAX_PARALLELISM:1}
 # Empty queues are probed by one worker slot per executor JVM. Consecutive empty sweeps back off
 # with jitter; finding work resets the delay and immediately fills available worker capacity.

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -168,6 +168,16 @@ floecat.reconciler.executor.snapshot-finalize.enabled=${FLOECAT_RECONCILER_SNAPS
 # `local` runs worker loops in this JVM for single-node dev/test.
 # `remote` runs remote-style workers; set `reconciler.max-parallelism=0` on control-plane-only nodes.
 floecat.reconciler.worker.mode=${FLOECAT_RECONCILER_WORKER_MODE:local}
+# Optional deployment-cohort affinity. When set, the job store stamps this cohort on every reconcile
+# job it enqueues and constrains every lease to it, so Floecat versions that cannot process each
+# other's job trees can share one durable queue -- during a rolling upgrade, or when a staging
+# deployment points at a shared table.
+#
+# Set this to the job-tree contract version, not the build version: versions that can safely process
+# each other's trees should share a cohort, and only a breaking change to the tree should fork it.
+# Every job a cohort enqueues is leasable only by that cohort, so a cohort that goes away leaves its
+# queued jobs unclaimed until they are cancelled or re-planned.
+floecat.reconciler.worker-affinity=${FLOECAT_RECONCILER_WORKER_AFFINITY:}
 reconciler.max-parallelism=${FLOECAT_RECONCILER_MAX_PARALLELISM:1}
 # Empty queues are probed by one worker slot per executor JVM. Consecutive empty sweeps back off
 # with jitter; finding work resets the delay and immediately fills available worker capacity.

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -178,9 +178,6 @@ floecat.reconciler.worker.mode=${FLOECAT_RECONCILER_WORKER_MODE:local}
 # Every job a cohort enqueues is leasable only by that cohort, so a cohort that goes away leaves its
 # queued jobs unclaimed until they are cancelled or re-planned.
 floecat.reconciler.worker-affinity=${FLOECAT_RECONCILER_WORKER_AFFINITY:reconciler-v1}
-# Temporary migration fallback for workers built before the lease protocol declared an affinity.
-# An explicit but mismatched affinity is always rejected regardless of this setting.
-floecat.reconciler.allow-unversioned-workers=${FLOECAT_RECONCILER_ALLOW_UNVERSIONED_WORKERS:true}
 reconciler.max-parallelism=${FLOECAT_RECONCILER_MAX_PARALLELISM:1}
 # Empty queues are probed by one worker slot per executor JVM. Consecutive empty sweeps back off
 # with jitter; finding work resets the delay and immediately fills available worker capacity.

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileControlImplTest.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.reconciler.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,12 +37,14 @@ import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.reconciler.impl.ReconcileCancellationRegistry;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileFileGroupTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotSelection;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.reconciler.rpc.CancelReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.CaptureNowRequest;
 import ai.floedb.floecat.reconciler.rpc.CaptureOutput;
@@ -243,6 +246,31 @@ class ReconcileControlImplTest {
             .indefinitely();
 
     assertEquals("job-1", response.getJobId());
+  }
+
+  @Test
+  void startCaptureLeavesWorkerAffinityToTheJobStore() {
+    // Affinity is stamped by the job store on every enqueue path, so no producer sets it.
+    when(service.jobs.enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), any(), anyString()))
+        .thenReturn("job-1");
+    ArgumentCaptor<ReconcileExecutionPolicy> policyCaptor =
+        ArgumentCaptor.forClass(ReconcileExecutionPolicy.class);
+
+    service
+        .startCapture(
+            ai.floedb.floecat.reconciler.rpc.StartCaptureRequest.newBuilder()
+                .setMode(ai.floedb.floecat.reconciler.rpc.CaptureMode.CM_METADATA_AND_CAPTURE)
+                .setScope(captureScope())
+                .build())
+        .await()
+        .indefinitely();
+
+    verify(service.jobs)
+        .enqueuePlan(
+            anyString(), anyString(), anyBoolean(), any(), any(), policyCaptor.capture(), eq(""));
+    assertThat(policyCaptor.getValue().attributes())
+        .doesNotContainKey(ReconcileWorkerAffinity.ATTRIBUTE);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
@@ -106,6 +106,7 @@ class ReconcileExecutorControlImplTest {
     service.leasedSnapshotFinalizeExecutionService =
         mock(LeasedSnapshotFinalizeExecutionService.class);
     service.leasedPlannerWorkerService = mock(LeasedPlannerWorkerService.class);
+    service.affinityGuard = mock(ReconcileWorkerAffinityGuard.class);
 
     PrincipalContext principalContext = mock(PrincipalContext.class);
     when(service.principalProvider.get()).thenReturn(principalContext);
@@ -160,6 +161,19 @@ class ReconcileExecutorControlImplTest {
             .indefinitely();
 
     assertTrue(!response.getFound());
+  }
+
+  @Test
+  void leaseReconcileJobPassesWorkerAffinityToProtocolGuard() {
+    when(service.jobs.leaseNext(any())).thenReturn(Optional.empty());
+
+    service
+        .leaseReconcileJob(
+            LeaseReconcileJobRequest.newBuilder().setWorkerAffinity("reconciler-v1").build())
+        .await()
+        .indefinitely();
+
+    verify(service.affinityGuard).requireLeaseRequestAffinity("reconciler-v1");
   }
 
   @Test
@@ -252,7 +266,9 @@ class ReconcileExecutorControlImplTest {
                     CaptureMode.METADATA_AND_CAPTURE,
                     ReconcileScope.of(java.util.List.of(), "orders", List.of(), capturePolicy),
                     ReconcileExecutionPolicy.of(
-                        ReconcileExecutionClass.HEAVY, "remote", Map.of("tier", "gold")),
+                        ReconcileExecutionClass.HEAVY,
+                        "remote",
+                        Map.of("tier", "gold", "floecat.worker-affinity", "reconciler-v1")),
                     "lease-1",
                     "remote-executor",
                     "")));
@@ -281,6 +297,7 @@ class ReconcileExecutorControlImplTest {
             .getCapturePolicy()
             .getPropertiesOrDefault("engine.option", ""));
     assertEquals("remote-executor", response.getJob().getPinnedExecutorId());
+    assertEquals("reconciler-v1", response.getJob().getWorkerAffinity());
     verify(service.jobs)
         .leaseNext(
             argThat(
@@ -589,6 +606,7 @@ class ReconcileExecutorControlImplTest {
 
     assertTrue(response.getRenewed());
     assertTrue(response.getCancellationRequested());
+    verify(service.affinityGuard).requireJobAffinity("job-1");
   }
 
   private static ResourceId deletedConnectorId() {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileWorkerAffinityGuardTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileWorkerAffinityGuardTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ReconcileWorkerAffinityGuardTest {
+  private ReconcileWorkerAffinityGuard guard;
+
+  @BeforeEach
+  void setUp() {
+    guard = new ReconcileWorkerAffinityGuard();
+    guard.jobs = mock(ReconcileJobStore.class);
+    guard.configuredAffinity = "reconciler-v1";
+    guard.allowUnversionedWorkers = true;
+  }
+
+  @Test
+  void acceptsMatchingAndLegacyLeaseRequests() {
+    assertDoesNotThrow(() -> guard.requireLeaseRequestAffinity("reconciler-v1"));
+    assertDoesNotThrow(() -> guard.requireLeaseRequestAffinity(""));
+  }
+
+  @Test
+  void rejectsExplicitlyMismatchedLeaseRequestWithoutFallingBack() {
+    StatusRuntimeException error =
+        assertThrows(
+            StatusRuntimeException.class, () -> guard.requireLeaseRequestAffinity("reconciler-v2"));
+
+    assertEquals(Status.Code.FAILED_PRECONDITION, error.getStatus().getCode());
+  }
+
+  @Test
+  void legacyFallbackCanBeDisabled() {
+    guard.allowUnversionedWorkers = false;
+
+    StatusRuntimeException error =
+        assertThrows(StatusRuntimeException.class, () -> guard.requireLeaseRequestAffinity(""));
+
+    assertEquals(Status.Code.FAILED_PRECONDITION, error.getStatus().getCode());
+  }
+
+  @Test
+  void rejectsLeaseBoundCallRoutedThroughAnotherCohort() {
+    when(guard.jobs.getCompactLeaseView("job-1"))
+        .thenReturn(
+            Optional.of(
+                job(
+                    ReconcileWorkerAffinity.of("reconciler-v2")
+                        .applyTo(ReconcileExecutionPolicy.defaults()))));
+
+    StatusRuntimeException error =
+        assertThrows(StatusRuntimeException.class, () -> guard.requireJobAffinity("job-1"));
+
+    assertEquals(Status.Code.FAILED_PRECONDITION, error.getStatus().getCode());
+  }
+
+  @Test
+  void acceptsLeaseBoundCallForThisCohort() {
+    when(guard.jobs.getCompactLeaseView("job-1"))
+        .thenReturn(
+            Optional.of(
+                job(
+                    ReconcileWorkerAffinity.of("reconciler-v1")
+                        .applyTo(ReconcileExecutionPolicy.defaults()))));
+
+    assertDoesNotThrow(() -> guard.requireJobAffinity("job-1"));
+  }
+
+  private static ReconcileJobStore.ReconcileJob job(ReconcileExecutionPolicy policy) {
+    return new ReconcileJobStore.ReconcileJob(
+        "job-1",
+        "acct",
+        "connector",
+        "JS_LEASED",
+        "",
+        0L,
+        0L,
+        0L,
+        0L,
+        0L,
+        false,
+        CaptureMode.METADATA_AND_CAPTURE,
+        0L,
+        0L,
+        ReconcileScope.empty(),
+        policy,
+        "floescan_ingest");
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileWorkerAffinityGuardTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileWorkerAffinityGuardTest.java
@@ -41,17 +41,15 @@ class ReconcileWorkerAffinityGuardTest {
     guard = new ReconcileWorkerAffinityGuard();
     guard.jobs = mock(ReconcileJobStore.class);
     guard.configuredAffinity = "reconciler-v1";
-    guard.allowUnversionedWorkers = true;
   }
 
   @Test
-  void acceptsMatchingAndLegacyLeaseRequests() {
+  void acceptsMatchingLeaseRequest() {
     assertDoesNotThrow(() -> guard.requireLeaseRequestAffinity("reconciler-v1"));
-    assertDoesNotThrow(() -> guard.requireLeaseRequestAffinity(""));
   }
 
   @Test
-  void rejectsExplicitlyMismatchedLeaseRequestWithoutFallingBack() {
+  void rejectsMismatchedLeaseRequest() {
     StatusRuntimeException error =
         assertThrows(
             StatusRuntimeException.class, () -> guard.requireLeaseRequestAffinity("reconciler-v2"));
@@ -60,9 +58,7 @@ class ReconcileWorkerAffinityGuardTest {
   }
 
   @Test
-  void legacyFallbackCanBeDisabled() {
-    guard.allowUnversionedWorkers = false;
-
+  void rejectsUnversionedLeaseRequest() {
     StatusRuntimeException error =
         assertThrows(StatusRuntimeException.class, () -> guard.requireLeaseRequestAffinity(""));
 

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -3654,6 +3654,8 @@ class DurableReconcileJobStoreTest {
     StoredReconcileJob queued = readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, jobId));
     assertEquals("", queued.executionPolicy().lane());
     assertFalse(queued.laneKey.isBlank());
+    ReconcileWorkerAffinity workerAffinity =
+        ReconcileWorkerAffinity.fromPolicy(queued.executionPolicy());
 
     @SuppressWarnings("unchecked")
     List<String> readyKeys =
@@ -3666,14 +3668,16 @@ class DurableReconcileJobStoreTest {
             .anyMatch(
                 key ->
                     key.startsWith(
-                        Keys.reconcileReadyByExecutionLanePointerPrefix(queued.laneKey))));
+                        Keys.reconcileReadyByExecutionLanePointerPrefix(
+                            workerAffinity.indexFilterValue(queued.laneKey)))));
     assertTrue(
         readyKeys.stream()
             .anyMatch(
                 key ->
                     key.startsWith(
                         Keys.reconcileReadyByJobKindPointerPrefix(
-                            ReconcileJobKind.EXEC_FILE_GROUP.name()))));
+                            workerAffinity.indexFilterValue(
+                                ReconcileJobKind.EXEC_FILE_GROUP.name())))));
 
     var lease =
         store
@@ -7536,19 +7540,23 @@ class DurableReconcileJobStoreTest {
   }
 
   private boolean findAndDeleteReadyEntry(StoredReconcileJob record, String readyPointerKey) {
+    ReconcileWorkerAffinity workerAffinity =
+        ReconcileWorkerAffinity.fromPolicy(record.executionPolicy());
     List<ReconcileReadyQueueBackend.ReadyQueueSlice> slices =
         List.of(
             new ReconcileReadyQueueBackend.ReadyQueueSlice(
                 ReconcileReadyQueueStore.ReadyIndexType.GLOBAL, ""),
             new ReconcileReadyQueueBackend.ReadyQueueSlice(
                 ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_CLASS,
-                record.executionPolicy().executionClass().name()),
+                workerAffinity.indexFilterValue(record.executionPolicy().executionClass().name())),
             new ReconcileReadyQueueBackend.ReadyQueueSlice(
-                ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE, record.laneKey),
+                ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE,
+                workerAffinity.indexFilterValue(record.laneKey)),
             new ReconcileReadyQueueBackend.ReadyQueueSlice(
                 ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR, record.pinnedExecutorId()),
             new ReconcileReadyQueueBackend.ReadyQueueSlice(
-                ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND, record.jobKind().name()));
+                ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND,
+                workerAffinity.indexFilterValue(record.jobKind().name())));
     for (ReconcileReadyQueueBackend.ReadyQueueSlice slice : slices) {
       var page = store.readyQueueBackend.scanReadySlice(slice, 100, "", null);
       for (var entry : page.entries()) {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -3713,6 +3713,8 @@ class DurableReconcileJobStoreTest {
             "remote-executor");
 
     StoredReconcileJob queued = readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, jobId));
+    ReconcileWorkerAffinity workerAffinity =
+        ReconcileWorkerAffinity.fromPolicy(queued.executionPolicy());
     @SuppressWarnings("unchecked")
     List<String> readyKeys =
         (List<String>)
@@ -3721,7 +3723,12 @@ class DurableReconcileJobStoreTest {
 
     assertEquals(1, readyKeys.size());
     assertTrue(
-        readyKeys.get(0).contains("/reconcile/jobs/ready/by-pinned-executor/remote-executor/"));
+        readyKeys
+            .get(0)
+            .startsWith(
+                Keys.reconcileReadyByPinnedExecutorPointerPrefix(
+                    workerAffinity.indexFilterValue("remote-executor"))));
+    assertEquals("remote-executor", queued.pinnedExecutorId());
 
     var otherExecutorLease =
         store.leaseNext(
@@ -7553,7 +7560,8 @@ class DurableReconcileJobStoreTest {
                 ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE,
                 workerAffinity.indexFilterValue(record.laneKey)),
             new ReconcileReadyQueueBackend.ReadyQueueSlice(
-                ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR, record.pinnedExecutorId()),
+                ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR,
+                workerAffinity.indexFilterValue(record.pinnedExecutorId())),
             new ReconcileReadyQueueBackend.ReadyQueueSlice(
                 ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND,
                 workerAffinity.indexFilterValue(record.jobKind().name())));

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -46,6 +46,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotSelection;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileTableTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.reconciler.jobs.SnapshotPlanManifestIds;
 import ai.floedb.floecat.reconciler.rpc.ReusableArtifactIndexObjectReference;
 import ai.floedb.floecat.reconciler.rpc.ReusableArtifactIndexReference;
@@ -188,6 +189,43 @@ class DurableReconcileJobStoreTest {
 
   @AfterEach
   void tearDown() {}
+
+  @Test
+  void storeStampsItsCohortOnEveryProducerAndConstrainsLeasesToIt() {
+    // Regression: affinity used to be stamped by individual producers, so a producer that built its
+    // own execution policy (post-commit capture) enqueued uncohorted work that no worker in an
+    // affinity-configured deployment would ever lease.
+    System.setProperty("floecat.reconciler.worker-affinity", "ci-branch");
+    try {
+      store.init();
+      ReconcileScope scope = ReconcileScope.of(List.of(), "tbl");
+
+      String jobId =
+          store.enqueuePlan(
+              ACCOUNT_ID,
+              CONNECTOR_ID,
+              false,
+              CaptureMode.METADATA_AND_CAPTURE,
+              scope,
+              ReconcileExecutionPolicy.of(
+                  ReconcileExecutionClass.DEFAULT,
+                  "",
+                  Map.of("post_commit_transaction_id", "tx-1")),
+              "");
+
+      ReconcileJobStore.LeasedJob lease = store.leaseNext().orElseThrow();
+
+      assertEquals(jobId, lease.jobId);
+      assertEquals(
+          ReconcileWorkerAffinity.of("ci-branch"),
+          ReconcileWorkerAffinity.fromPolicy(lease.executionPolicy));
+      // The cohort is a first-class constraint, not an executor pin.
+      assertEquals("", lease.pinnedExecutorId == null ? "" : lease.pinnedExecutorId);
+    } finally {
+      System.clearProperty("floecat.reconciler.worker-affinity");
+      store.init();
+    }
+  }
 
   @Test
   void enqueueDedupesWhileJobIsActive() {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreBudgetTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeaseRequest;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeasedJob;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueBackend.ReadyQueueSlice;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileReadyQueueStore.LeaseScanStats;
@@ -116,6 +117,30 @@ class NativeReconcileReadyQueueStoreBudgetTest {
         ReconcileReadyQueueStore.ReadyIndexType.JOB_KIND, backend.slices.get(1).indexType());
     assertEquals(ReconcileJobKind.EXEC_FILE_GROUP.name(), backend.slices.get(1).filterValue());
     assertEquals(List.of(16, 16), backend.pageSizes);
+  }
+
+  @Test
+  void pinnedExecutorScanUsesTheCohortQualifiedSlice() {
+    SliceRecordingBackend backend = new SliceRecordingBackend();
+    NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
+    store.bind(backend, null, null, 128, record -> true, record -> false);
+    ReconcileWorkerAffinity affinity = ReconcileWorkerAffinity.of("ci-branch");
+
+    store.leaseReadyDue(
+        System.currentTimeMillis(),
+        LeaseRequest.of(
+                Set.of(),
+                Set.of(),
+                Set.of("floescan_ingest"),
+                Set.of(ReconcileJobKind.EXEC_FILE_GROUP))
+            .withWorkerAffinity(affinity),
+        new LeaseScanStats());
+
+    assertEquals(
+        ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR,
+        backend.slices.getFirst().indexType());
+    assertEquals(
+        affinity.indexFilterValue("floescan_ingest"), backend.slices.getFirst().filterValue());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreCohortTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreCohortTest.java
@@ -110,6 +110,70 @@ class NativeReconcileReadyQueueStoreCohortTest {
     assertTrue(keys.get(0).contains("by-pinned-executor"));
   }
 
+  @Test
+  void cohortsGetDistinctPinnedSlicesForTheSameExecutor() {
+    NativeReconcileReadyQueueStore store = store();
+    StoredReconcileJob branch = record(ReconcileWorkerAffinity.of("ci-branch"));
+    StoredReconcileJob steady = record(ReconcileWorkerAffinity.of("steady-state"));
+    StoredReconcileJob unversioned = record(ReconcileWorkerAffinity.DISABLED);
+    branch.pinnedExecutorId = "executor-1";
+    steady.pinnedExecutorId = "executor-1";
+    unversioned.pinnedExecutorId = "executor-1";
+
+    String branchKey = store.readyPointerKeys(branch).getFirst();
+    String steadyKey = store.readyPointerKeys(steady).getFirst();
+    String unversionedKey = store.readyPointerKeys(unversioned).getFirst();
+
+    assertFalse(branchKey.equals(steadyKey));
+    assertFalse(branchKey.equals(unversionedKey));
+    assertEquals("executor-1", branch.pinnedExecutorId());
+  }
+
+  @Test
+  void pinnedPointerValidationRequiresTheCohortQualifiedExecutor() {
+    NativeReconcileReadyQueueStore store = store();
+    ReconcileWorkerAffinity affinity = ReconcileWorkerAffinity.of("ci-branch");
+    StoredReconcileJob record = record(affinity);
+    record.pinnedExecutorId = "executor-1";
+    String qualifiedExecutor = affinity.indexFilterValue(record.pinnedExecutorId());
+    String qualifiedKey =
+        store.readyPointerKeyFor(
+            record,
+            ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR,
+            DUE_AT_MS,
+            qualifiedExecutor);
+
+    assertTrue(
+        store.readyPointerMatchesRecord(
+            new ReconcileReadyQueueStore.ReadyQueueEntry(
+                qualifiedKey,
+                "canonical-1",
+                record.accountId,
+                record.jobId,
+                DUE_AT_MS,
+                ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR,
+                qualifiedExecutor),
+            record));
+
+    String rawKey =
+        store.readyPointerKeyFor(
+            record,
+            ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR,
+            DUE_AT_MS,
+            record.pinnedExecutorId());
+    assertFalse(
+        store.readyPointerMatchesRecord(
+            new ReconcileReadyQueueStore.ReadyQueueEntry(
+                rawKey,
+                "canonical-1",
+                record.accountId,
+                record.jobId,
+                DUE_AT_MS,
+                ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR,
+                record.pinnedExecutorId()),
+            record));
+  }
+
   private static String onlyMatching(List<String> keys, String fragment) {
     return keys.stream().filter(key -> key.contains(fragment)).findFirst().orElseThrow();
   }

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreCohortTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreCohortTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.jobs.durable.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeaseRequest;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
+import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the production ready-queue store rather than the in-memory double: cohort isolation and
+ * cohort-partitioned ready indexes both live here.
+ */
+class NativeReconcileReadyQueueStoreCohortTest {
+
+  private static final long DUE_AT_MS = 1_000L;
+
+  @Test
+  void jobIsOnlyLeasableByItsOwnCohort() {
+    NativeReconcileReadyQueueStore store = store();
+    StoredReconcileJob record = record(ReconcileWorkerAffinity.of("ci-branch"));
+
+    assertTrue(
+        store.matchesLeaseRequest(
+            record, request().withWorkerAffinity(ReconcileWorkerAffinity.of("ci-branch"))));
+    assertFalse(
+        store.matchesLeaseRequest(
+            record, request().withWorkerAffinity(ReconcileWorkerAffinity.of("steady-state"))));
+    // An unconfigured deployment must not pick up a cohorted job.
+    assertFalse(store.matchesLeaseRequest(record, request()));
+  }
+
+  @Test
+  void cohortedWorkerDoesNotLeaseLegacyUncohortedJob() {
+    NativeReconcileReadyQueueStore store = store();
+    StoredReconcileJob record = record(ReconcileWorkerAffinity.DISABLED);
+
+    assertTrue(store.matchesLeaseRequest(record, request()));
+    assertFalse(
+        store.matchesLeaseRequest(
+            record, request().withWorkerAffinity(ReconcileWorkerAffinity.of("ci-branch"))));
+  }
+
+  @Test
+  void cohortedJobKeepsTheFilteredReadyIndexesInsteadOfOnePinnedSlice() {
+    NativeReconcileReadyQueueStore store = store();
+    StoredReconcileJob record = record(ReconcileWorkerAffinity.of("ci-branch"));
+
+    List<String> keys = store.readyPointerKeys(record);
+
+    // The regression this guards: overloading pinnedExecutorId collapsed every cohorted job into a
+    // single pinned slice and emitted exactly one pointer.
+    assertEquals(4, keys.size());
+    assertTrue(keys.stream().anyMatch(key -> key.contains("by-job-kind")));
+    assertTrue(keys.stream().anyMatch(key -> key.contains("by-execution-class")));
+    assertTrue(keys.stream().anyMatch(key -> key.contains("by-execution-lane")));
+    assertTrue(keys.stream().noneMatch(key -> key.contains("by-pinned-executor")));
+  }
+
+  @Test
+  void cohortsGetDistinctSlicesOfTheSameIndex() {
+    NativeReconcileReadyQueueStore store = store();
+
+    List<String> branchKeys =
+        store.readyPointerKeys(record(ReconcileWorkerAffinity.of("ci-branch")));
+    List<String> steadyKeys =
+        store.readyPointerKeys(record(ReconcileWorkerAffinity.of("steady-state")));
+    List<String> legacyKeys = store.readyPointerKeys(record(ReconcileWorkerAffinity.DISABLED));
+
+    String branchJobKind = onlyMatching(branchKeys, "by-job-kind");
+    String steadyJobKind = onlyMatching(steadyKeys, "by-job-kind");
+    String legacyJobKind = onlyMatching(legacyKeys, "by-job-kind");
+
+    assertFalse(branchJobKind.equals(steadyJobKind));
+    assertFalse(branchJobKind.equals(legacyJobKind));
+  }
+
+  @Test
+  void anExplicitExecutorPinStillUsesThePinnedIndexAlone() {
+    NativeReconcileReadyQueueStore store = store();
+    StoredReconcileJob record = record(ReconcileWorkerAffinity.of("ci-branch"));
+    record.pinnedExecutorId = "executor-1";
+
+    List<String> keys = store.readyPointerKeys(record);
+
+    assertEquals(1, keys.size());
+    assertTrue(keys.get(0).contains("by-pinned-executor"));
+  }
+
+  private static String onlyMatching(List<String> keys, String fragment) {
+    return keys.stream().filter(key -> key.contains(fragment)).findFirst().orElseThrow();
+  }
+
+  private static LeaseRequest request() {
+    return LeaseRequest.of(
+        Set.of(), Set.of(), Set.of(), EnumSet.of(ReconcileJobKind.PLAN_CONNECTOR));
+  }
+
+  private static NativeReconcileReadyQueueStore store() {
+    NativeReconcileReadyQueueStore store = new NativeReconcileReadyQueueStore();
+    store.bind(null, null, null, 128, record -> true, record -> false);
+    return store;
+  }
+
+  private static StoredReconcileJob record(ReconcileWorkerAffinity workerAffinity) {
+    StoredReconcileJob record = new StoredReconcileJob();
+    record.jobId = "job-1";
+    record.accountId = "acct-1";
+    record.jobKind = ReconcileJobKind.PLAN_CONNECTOR.name();
+    record.state = "JS_QUEUED";
+    record.executionClass = "DEFAULT";
+    record.executionLane = "default";
+    record.laneKey = "default";
+    record.nextAttemptAtMs = DUE_AT_MS;
+    record.executionAttributes =
+        workerAffinity == null || !workerAffinity.enabled()
+            ? Map.of()
+            : Map.of(ReconcileWorkerAffinity.ATTRIBUTE, workerAffinity.value());
+    return record;
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
@@ -171,10 +171,16 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
     }
     long dueAtMs = readyPointerDueAt(record);
     List<String> keys = new java.util.ArrayList<>();
+    ReconcileWorkerAffinity workerAffinity =
+        ReconcileWorkerAffinity.fromPolicy(record.executionPolicy());
     String pinnedExecutorId = record.pinnedExecutorId();
     if (!blank(pinnedExecutorId)) {
       String pinnedExecutorKey =
-          readyPointerKeyFor(record, ReadyIndexType.PINNED_EXECUTOR, dueAtMs, pinnedExecutorId);
+          readyPointerKeyFor(
+              record,
+              ReadyIndexType.PINNED_EXECUTOR,
+              dueAtMs,
+              workerAffinity.indexFilterValue(pinnedExecutorId));
       return pinnedExecutorKey.isBlank() ? List.of() : List.of(pinnedExecutorKey);
     }
     keys.add(readyPointerKeyFor(record, dueAtMs));
@@ -320,6 +326,7 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
         request.executorIds.stream()
             .map(InMemoryReconcileReadyQueueStore::blankToEmpty)
             .filter(executorId -> !executorId.isBlank())
+            .map(request.workerAffinity::indexFilterValue)
             .sorted()
             .toList();
     if (executorIds.isEmpty()) {
@@ -469,7 +476,10 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
           candidate
               .filterValue()
               .equals(workerAffinity.indexFilterValue(blankToEmpty(record.laneKey)));
-      case PINNED_EXECUTOR -> candidate.filterValue().equals(record.pinnedExecutorId());
+      case PINNED_EXECUTOR ->
+          candidate
+              .filterValue()
+              .equals(workerAffinity.indexFilterValue(record.pinnedExecutorId()));
       case JOB_KIND ->
           candidate.filterValue().equals(workerAffinity.indexFilterValue(record.jobKind().name()));
     };

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.reconciler.jobs.durable.store.inmemory;
 import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeaseRequest;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeasedJob;
+import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.CanonicalPointerSnapshot;
 import ai.floedb.floecat.service.reconciler.jobs.durable.store.ReconcileJobIndexStore;
@@ -102,26 +103,15 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
 
   @Override
   public boolean matchesLeaseRequest(StoredReconcileJob record, LeaseRequest request) {
-    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
-    String pinnedExecutorId = record == null ? "" : record.pinnedExecutorId();
-    if (!blank(pinnedExecutorId) && !effective.executorIds.contains(pinnedExecutorId)) {
-      return false;
-    }
     if (record == null) {
       return false;
     }
-    ReconcileExecutionPolicy policy = record.executionPolicy();
-    boolean classMatches =
-        effective.executionClasses.isEmpty()
-            || effective.executionClasses.contains(policy.executionClass());
-    boolean laneMatches =
-        effective.lanes.isEmpty()
-            || effective.lanes.contains(LeaseRequest.anyLaneToken())
-            || effective.lanes.contains(policy.lane())
-            || effective.lanes.contains(blankToEmpty(record.laneKey));
-    boolean kindMatches =
-        effective.jobKinds.isEmpty() || effective.jobKinds.contains(record.jobKind());
-    return classMatches && laneMatches && kindMatches;
+    LeaseRequest effective = request == null ? LeaseRequest.all() : request;
+    return effective.matches(
+        record.executionPolicy(),
+        record.pinnedExecutorId(),
+        record.jobKind(),
+        blankToEmpty(record.laneKey));
   }
 
   @Override
@@ -347,6 +337,7 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
         request.lanes.stream()
             .map(InMemoryReconcileReadyQueueStore::blankToEmpty)
             .filter(lane -> !lane.isBlank() && !LeaseRequest.anyLaneToken().equals(lane))
+            .map(request.workerAffinity::indexFilterValue)
             .sorted()
             .toList();
     if (!lanes.isEmpty()) {
@@ -355,7 +346,12 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
           new ReadyIndexSelection(
               new ReconcileReadyQueueBackend.ReadyQueueSlice(ReadyIndexType.EXECUTION_LANE, lane)));
     }
-    List<String> jobKinds = request.jobKinds.stream().sorted().map(Enum::name).toList();
+    List<String> jobKinds =
+        request.jobKinds.stream()
+            .map(Enum::name)
+            .map(request.workerAffinity::indexFilterValue)
+            .sorted()
+            .toList();
     if (!jobKinds.isEmpty()) {
       String jobKind = jobKinds.get(nextIndex(unpinnedSelectionCursor, jobKinds.size()));
       return Optional.of(
@@ -363,7 +359,11 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
               new ReconcileReadyQueueBackend.ReadyQueueSlice(ReadyIndexType.JOB_KIND, jobKind)));
     }
     List<String> executionClasses =
-        request.executionClasses.stream().sorted().map(Enum::name).toList();
+        request.executionClasses.stream()
+            .map(Enum::name)
+            .map(request.workerAffinity::indexFilterValue)
+            .sorted()
+            .toList();
     if (!executionClasses.isEmpty()) {
       String executionClass =
           executionClasses.get(nextIndex(unpinnedSelectionCursor, executionClasses.size()));
@@ -458,12 +458,20 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
   private boolean readyIndexFilterMatchesRecord(
       ReadyQueueEntry candidate, StoredReconcileJob record) {
     ReconcileExecutionPolicy policy = record.executionPolicy();
+    ReconcileWorkerAffinity workerAffinity = ReconcileWorkerAffinity.fromPolicy(policy);
     return switch (candidate.indexType()) {
       case GLOBAL -> true;
-      case EXECUTION_CLASS -> candidate.filterValue().equals(policy.executionClass().name());
-      case EXECUTION_LANE -> candidate.filterValue().equals(blankToEmpty(record.laneKey));
+      case EXECUTION_CLASS ->
+          candidate
+              .filterValue()
+              .equals(workerAffinity.indexFilterValue(policy.executionClass().name()));
+      case EXECUTION_LANE ->
+          candidate
+              .filterValue()
+              .equals(workerAffinity.indexFilterValue(blankToEmpty(record.laneKey)));
       case PINNED_EXECUTOR -> candidate.filterValue().equals(record.pinnedExecutorId());
-      case JOB_KIND -> candidate.filterValue().equals(record.jobKind().name());
+      case JOB_KIND ->
+          candidate.filterValue().equals(workerAffinity.indexFilterValue(record.jobKind().name()));
     };
   }
 


### PR DESCRIPTION
## Summary

Two Floecat deployments that share a durable job queue currently lease each other's
reconcile jobs. That is fine while both understand the same job-tree contract, and
harmful when they do not: a job tree planned by one version gets continued by another
that interprets its payloads differently. This blocks two things we want - rolling
upgrades across a breaking job-tree change, and pointing a staging or CI deployment at
a shared Dynamo table.

This adds an optional deployment cohort. When `floecat.reconciler.worker-affinity` is
set, the job store stamps that cohort onto every job it enqueues and constrains every
lease to it, so a cohort only ever processes its own trees.

The cohort is a property of the deployment, not of a producer or an executor, so both
stamps live at the job-store boundary - `ReconcileJobEnqueuer` on the way in and
`leaseNext` on the way out. That is deliberate: an earlier shape had each producer stamp
its own execution policy, which meant any code path that built a policy from scratch
silently enqueued unstamped work that no worker in an affinity-configured deployment
would ever lease. Stamping at the single choke point each store already has makes that
class of bug unrepresentable, and `ReconcileControlImpl`, `ReconcilePlannerScheduler`
and `TransactionsServiceImpl` need no affinity awareness at all.

The cohort is carried in the execution policy's attributes, which are already persisted
and already propagate to every child enqueue, so a whole job tree inherits its cohort
with no extra plumbing and no schema change.

Ready-queue indexes are partitioned per cohort by qualifying the execution-class,
execution-lane and job-kind filter values. Those values are percent-encoded into a
single key segment, so this needs no key-format change, and each cohort keeps its own
slice of every filtered index rather than sharing one undifferentiated scan. Notably
the cohort is not modelled as an executor pin: `pinnedExecutorId` sends a record to
the pinned index alone, which would have collapsed every cohorted job into one slice
and discarded lane and class routing entirely.

Also folds the duplicated eligibility rules into one implementation each, since the
duplication is what made the above easy to get wrong:

- `ReconcileExecutorRegistry.pinExcludes` is now the only definition of executor-pin
  eligibility, used by both `executorFor` and the lease poller.
- `LeaseRequest.matches` is now the only definition of job-vs-request eligibility; the
  native store, its in-memory double and the in-memory job store all delegate to it.


## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [X] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [X] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

