### PR TITLE
fix: scope vended credentials to storage authority definition exactly  

### DIFF
--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -703,6 +703,7 @@ public class Shell implements Runnable {
     queryScan = QueryScanServiceGrpc.newBlockingStub(overrideChannel);
     querySchema = QuerySchemaServiceGrpc.newBlockingStub(overrideChannel);
     accounts = AccountServiceGrpc.newBlockingStub(overrideChannel);
+    storageAuthorities = StorageAuthoritiesGrpc.newBlockingStub(overrideChannel);
   }
 
   static GrpcEndpointOverride resolveGrpcEndpointOverride(

--- a/docs/storage-authorities.md
+++ b/docs/storage-authorities.md
@@ -13,6 +13,13 @@ Storage authorities are generic storage infrastructure, not Iceberg-specific. Ic
 credential vending is one consumer of this layer, but the same model also applies to server-side
 Floecat workflows such as reconciliation and register/import flows that need to reach S3.
 
+For authority-backed vending, the selected authority's `location-prefix` is both the inline STS
+session-policy boundary and the prefix returned with the credential. A reconcile lease or table
+location authorizes whether credentials may be vended, but does not narrow the resulting session
+below the authority prefix. A bucket-root authority therefore vends read access across that bucket;
+a narrower authority vends read access only at and beneath its configured prefix. The assumed
+role's base IAM policy is still intersected with this session policy.
+
 Storage authorities are separate from connector auth:
 
 - connector auth is how Floecat reaches upstream catalogs or services such as Glue, Unity Catalog,
@@ -107,6 +114,10 @@ storage access and the table location matches an authority prefix.
 Use one storage authority per bucket or per major prefix boundary when you want clean separation of
 permissions and easy auditability.
 
+This is also a security boundary. A caller authorized to vend for one location receives credentials
+covering the full selected authority prefix. Use separate, narrower authorities when tables or
+workloads within one bucket must not share the same vended credential scope.
+
 ### Cross-Account Read-Only Access
 
 For a production bucket in another AWS account:
@@ -122,6 +133,8 @@ both.
 ## Common Failure Modes
 
 - prefix mismatch: the requested table location does not match any configured `location-prefix`
+- invalid authority: S3 authorities require `type=s3` and a concrete S3 bucket; blank, malformed,
+  bucketless, wildcard-containing, and otherwise invalid prefixes are rejected
 - missing trust policy: Floecat can resolve the authority but cannot assume the target role
 - missing S3 permissions: temporary credentials are minted but the bucket or prefix access is too narrow
 - auth confusion: connector auth is configured correctly, but no storage authority exists for the

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
@@ -81,12 +81,7 @@ public class ServerSideFileIoPropertiesResolver {
       // no-matching-authority error rather than silently returning no credentials.
     }
     ResolveStorageAuthorityResponse response =
-        resolver.buildResponse(
-            authority,
-            locationPrefix,
-            locationPrefix == null ? java.util.List.of() : java.util.List.of(locationPrefix),
-            tableId.getAccountId(),
-            true);
+        resolver.buildResponse(authority, tableId.getAccountId(), true);
     return mergeStorageAuthorityFileIoConfig(response);
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityResolver.java
@@ -31,15 +31,12 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
@@ -82,22 +79,7 @@ public class StorageAuthorityResolver {
   }
 
   ResolveStorageAuthorityResponse buildResponse(
-      StorageAuthority authority,
-      String locationPrefix,
-      List<String> sessionScopeLocations,
-      String accountId,
-      boolean serverSide) {
-    return buildResponse(
-        authority, locationPrefix, sessionScopeLocations, accountId, serverSide, false);
-  }
-
-  ResolveStorageAuthorityResponse buildResponse(
-      StorageAuthority authority,
-      String locationPrefix,
-      List<String> sessionScopeLocations,
-      String accountId,
-      boolean serverSide,
-      boolean exactObjectScope) {
+      StorageAuthority authority, String accountId, boolean serverSide) {
     if (authority == null) {
       // Carries a structured reason rather than a bare IllegalArgumentException. Both map to
       // INVALID_ARGUMENT, but so do account_id, execution_binding and location_prefix validation
@@ -108,6 +90,7 @@ public class StorageAuthorityResolver {
               "Credential vending was requested but no storage credential authority is configured"
                   + " for this table");
     }
+    requireValidAuthorityLocation(authority);
 
     ResolveStorageAuthorityResponse.Builder response =
         ResolveStorageAuthorityResponse.newBuilder().setAuthorityId(authority.getResourceId());
@@ -116,17 +99,13 @@ public class StorageAuthorityResolver {
         resolveAuthoritySecret(accountId, authority.getResourceId().getId()).orElse(null);
     ResolvedStorageCredentials resolved;
     if (!serverSide) {
-      resolved =
-          mintTemporaryCredentials(
-              authority, authoritySecret, sessionScopeLocations, exactObjectScope);
+      resolved = mintTemporaryCredentials(authority, authoritySecret);
       if (!resolved.hasKnownExpiry()) {
         throw new IllegalArgumentException(
             "Credential vending requires credentials with a known expiry minted from a storage authority role");
       }
     } else {
-      resolved =
-          resolveServerSideCredentials(
-              authority, authoritySecret, sessionScopeLocations, exactObjectScope);
+      resolved = resolveServerSideCredentials(authority, authoritySecret);
     }
 
     LinkedHashMap<String, String> storageConfig = new LinkedHashMap<>();
@@ -135,7 +114,7 @@ public class StorageAuthorityResolver {
     storageConfig.putAll(resolved.asS3Properties());
     VendedStorageCredential.Builder credential =
         VendedStorageCredential.newBuilder()
-            .setPrefix(locationPrefix)
+            .setPrefix(authority.getLocationPrefix())
             .putAllConfig(Map.copyOf(storageConfig));
     if (resolved.expiresAt() != null) {
       credential.setExpiresAt(
@@ -163,24 +142,13 @@ public class StorageAuthorityResolver {
   }
 
   ResolvedStorageCredentials mintTemporaryCredentials(
-      StorageAuthority authority,
-      AuthCredentials authoritySecret,
-      List<String> sessionScopeLocations) {
-    return mintTemporaryCredentials(authority, authoritySecret, sessionScopeLocations, false);
-  }
-
-  ResolvedStorageCredentials mintTemporaryCredentials(
-      StorageAuthority authority,
-      AuthCredentials authoritySecret,
-      List<String> sessionScopeLocations,
-      boolean exactObjectScope) {
+      StorageAuthority authority, AuthCredentials authoritySecret) {
     Optional<ResolvedStorageCredentials> resolved =
         authoritySecret == null
             ? Optional.empty()
             : CredentialResolverSupport.resolveStorageCredentials(authoritySecret);
     if (authority.hasAssumeRoleArn() && !authority.getAssumeRoleArn().isBlank()) {
-      return assumeRoleCredentials(
-          authority, authoritySecret, sessionScopeLocations, exactObjectScope);
+      return assumeRoleCredentials(authority, authoritySecret);
     }
     if (resolved.isPresent() && resolved.get().hasKnownExpiry()) {
       return resolved.get();
@@ -190,20 +158,9 @@ public class StorageAuthorityResolver {
   }
 
   ResolvedStorageCredentials resolveServerSideCredentials(
-      StorageAuthority authority,
-      AuthCredentials authoritySecret,
-      List<String> sessionScopeLocations) {
-    return resolveServerSideCredentials(authority, authoritySecret, sessionScopeLocations, false);
-  }
-
-  ResolvedStorageCredentials resolveServerSideCredentials(
-      StorageAuthority authority,
-      AuthCredentials authoritySecret,
-      List<String> sessionScopeLocations,
-      boolean exactObjectScope) {
+      StorageAuthority authority, AuthCredentials authoritySecret) {
     if (authority.hasAssumeRoleArn() && !authority.getAssumeRoleArn().isBlank()) {
-      return assumeRoleCredentials(
-          authority, authoritySecret, sessionScopeLocations, exactObjectScope);
+      return assumeRoleCredentials(authority, authoritySecret);
     }
     if (authoritySecret == null) {
       throw new IllegalArgumentException("Unsupported storage credential authority");
@@ -233,21 +190,16 @@ public class StorageAuthorityResolver {
   }
 
   ResolvedStorageCredentials assumeRoleCredentials(
-      StorageAuthority authority,
-      AuthCredentials authoritySecret,
-      List<String> sessionScopeLocations,
-      boolean exactObjectScope) {
-    AssumeRoleCacheKey key =
-        AssumeRoleCacheKey.of(authority, authoritySecret, sessionScopeLocations, exactObjectScope);
+      StorageAuthority authority, AuthCredentials authoritySecret) {
+    AssumeRoleCacheKey key = AssumeRoleCacheKey.of(authority, authoritySecret);
     return cachedAssumeRole(
         key,
         () -> {
           if (authoritySecret != null
               && authoritySecret.getCredentialCase() == AuthCredentials.CredentialCase.AWS) {
-            return assumeRoleFromStaticSource(
-                authority, authoritySecret.getAws(), sessionScopeLocations, exactObjectScope);
+            return assumeRoleFromStaticSource(authority, authoritySecret.getAws());
           }
-          return assumeRoleFromAmbientSource(authority, sessionScopeLocations, exactObjectScope);
+          return assumeRoleFromAmbientSource(authority);
         });
   }
 
@@ -393,10 +345,7 @@ public class StorageAuthorityResolver {
   }
 
   ResolvedStorageCredentials assumeRoleFromStaticSource(
-      StorageAuthority authority,
-      AuthCredentials.AwsCredentials source,
-      List<String> sessionScopeLocations,
-      boolean exactObjectScope) {
+      StorageAuthority authority, AuthCredentials.AwsCredentials source) {
     AwsCredentialsProvider provider =
         source.getSessionToken() == null || source.getSessionToken().isBlank()
             ? StaticCredentialsProvider.create(
@@ -407,13 +356,11 @@ public class StorageAuthorityResolver {
                     source.getSecretAccessKey(),
                     source.getSessionToken()));
 
-    return assumeRole(authority, () -> provider, sessionScopeLocations, exactObjectScope);
+    return assumeRole(authority, () -> provider);
   }
 
-  ResolvedStorageCredentials assumeRoleFromAmbientSource(
-      StorageAuthority authority, List<String> sessionScopeLocations, boolean exactObjectScope) {
-    return assumeRole(
-        authority, this::ambientCredentialsProvider, sessionScopeLocations, exactObjectScope);
+  ResolvedStorageCredentials assumeRoleFromAmbientSource(StorageAuthority authority) {
+    return assumeRole(authority, this::ambientCredentialsProvider);
   }
 
   AwsCredentialsProvider ambientCredentialsProvider() {
@@ -421,14 +368,11 @@ public class StorageAuthorityResolver {
   }
 
   private ResolvedStorageCredentials assumeRole(
-      StorageAuthority authority,
-      Supplier<AwsCredentialsProvider> providerFactory,
-      List<String> sessionScopeLocations,
-      boolean exactObjectScope) {
+      StorageAuthority authority, Supplier<AwsCredentialsProvider> providerFactory) {
     RuntimeException lastFailure = null;
     for (int attempt = 1; attempt <= ASSUME_ROLE_MAX_ATTEMPTS; attempt++) {
       try {
-        return assumeRoleOnce(authority, providerFactory, sessionScopeLocations, exactObjectScope);
+        return assumeRoleOnce(authority, providerFactory);
       } catch (RuntimeException error) {
         if (!retryableAssumeRoleFailure(error) || attempt == ASSUME_ROLE_MAX_ATTEMPTS) {
           if (retryableAssumeRoleFailure(error)) {
@@ -448,10 +392,7 @@ public class StorageAuthorityResolver {
   }
 
   private ResolvedStorageCredentials assumeRoleOnce(
-      StorageAuthority authority,
-      Supplier<AwsCredentialsProvider> providerFactory,
-      List<String> sessionScopeLocations,
-      boolean exactObjectScope) {
+      StorageAuthority authority, Supplier<AwsCredentialsProvider> providerFactory) {
     Integer duration = authority.hasDurationSeconds() ? authority.getDurationSeconds() : null;
     AssumeRoleRequest request =
         AssumeRoleRequest.builder()
@@ -464,7 +405,7 @@ public class StorageAuthorityResolver {
                     "floecat-storage-authority"))
             .externalId(
                 authority.hasAssumeRoleExternalId() ? authority.getAssumeRoleExternalId() : null)
-            .policy(scopedSessionPolicy(sessionScopeLocations, exactObjectScope))
+            .policy(scopedSessionPolicy(authority.getLocationPrefix()))
             .durationSeconds(duration != null && duration > 0 ? duration : null)
             .build();
 
@@ -526,20 +467,11 @@ public class StorageAuthorityResolver {
   }
 
   private record AssumeRoleCacheKey(
-      String authorityFingerprint,
-      String sourceCredentialFingerprint,
-      List<String> scopes,
-      boolean exactObjectScope) {
+      String authorityFingerprint, String sourceCredentialFingerprint) {
     private static AssumeRoleCacheKey of(
-        StorageAuthority authority,
-        AuthCredentials authoritySecret,
-        List<String> sessionScopeLocations,
-        boolean exactObjectScope) {
+        StorageAuthority authority, AuthCredentials authoritySecret) {
       return new AssumeRoleCacheKey(
-          sha256(authority.toByteArray()),
-          sha256(canonicalBytes(authoritySecret)),
-          List.copyOf(normalizeS3Scopes(sessionScopeLocations)),
-          exactObjectScope);
+          sha256(authority.toByteArray()), sha256(canonicalBytes(authoritySecret)));
     }
 
     /**
@@ -591,89 +523,36 @@ public class StorageAuthorityResolver {
   }
 
   static String scopedSessionPolicy(String locationPrefix) {
-    return scopedSessionPolicy(locationPrefix == null ? List.of() : List.of(locationPrefix));
-  }
-
-  static String scopedSessionPolicy(List<String> locationPrefixes) {
-    return scopedSessionPolicy(locationPrefixes, false);
-  }
-
-  static String scopedSessionPolicy(List<String> locationPrefixes, boolean exactObject) {
-    List<S3Location> scopes =
-        normalizeS3Scopes(locationPrefixes).stream()
-            .map(S3Location::parse)
-            .filter(scope -> scope != null)
-            .toList();
-    if (scopes.isEmpty()) {
-      return null;
-    }
-    if (exactObject) {
-      scopes.forEach(scope -> requireLiteralObjectKey(scope.keyPrefix()));
-    }
-    ArrayList<String> statements = new ArrayList<>();
-    for (S3BucketScope bucketScope : groupByBucket(scopes)) {
-      statements.add(bucketScope.listStatementJson(exactObject));
-      statements.add(bucketScope.objectStatementJson(exactObject));
+    S3Location scope = S3Location.parse(locationPrefix);
+    if (scope == null) {
+      throw new IllegalArgumentException(
+          "S3 storage authority location_prefix must identify a concrete bucket");
     }
     return """
         {
           "Version":"2012-10-17",
-          "Statement":[%s]
+          "Statement":[%s,%s]
         }
         """
-        .formatted(String.join(",", statements))
+        .formatted(scope.listStatementJson(), scope.objectStatementJson())
         .replace('\n', ' ')
         .replaceAll("\\s+", " ")
         .trim();
   }
 
-  /**
-   * Refuses an exact-object scope whose key carries an IAM wildcard metacharacter.
-   *
-   * <p>An exact-object scope promises credentials for one named file. The key goes into the policy
-   * resource ARN verbatim, and IAM reads {@code *} and {@code ?} there as wildcards -- both are
-   * legal in an S3 object key, so a planned file named {@code part-*.parquet} would silently mint
-   * access to every sibling it matches, which is the opposite of the guarantee.
-   *
-   * <p>Rejection rather than escaping, because IAM has no escape for these: a resource ARN cannot
-   * express a literal {@code *}. Widening the grant is not an acceptable fallback, so a key that
-   * cannot be expressed exactly is refused and the caller configures a storage authority instead.
-   */
-  private static void requireLiteralObjectKey(String keyPrefix) {
-    if (keyPrefix == null || keyPrefix.isEmpty()) {
-      return;
-    }
-    if (keyPrefix.indexOf('*') >= 0 || keyPrefix.indexOf('?') >= 0) {
+  static boolean isValidAuthorityLocation(String type, String locationPrefix) {
+    return isSupportedAuthorityType(type) && S3Location.parse(locationPrefix) != null;
+  }
+
+  static boolean isSupportedAuthorityType(String type) {
+    return "s3".equalsIgnoreCase(firstNonBlank(type, "s3"));
+  }
+
+  private static void requireValidAuthorityLocation(StorageAuthority authority) {
+    if (!isValidAuthorityLocation(authority.getType(), authority.getLocationPrefix())) {
       throw new IllegalArgumentException(
-          "Cannot mint an exact-object credential scope for a key containing an IAM wildcard"
-              + " metacharacter (* or ?); the resulting policy would match more than the named"
-              + " object");
+          "Storage authority must use type s3 and a location_prefix identifying a concrete bucket");
     }
-  }
-
-  private static List<String> normalizeS3Scopes(List<String> locationPrefixes) {
-    if (locationPrefixes == null || locationPrefixes.isEmpty()) {
-      return List.of();
-    }
-    TreeSet<String> normalized = new TreeSet<>();
-    for (String locationPrefix : locationPrefixes) {
-      S3Location scope = S3Location.parse(locationPrefix);
-      if (scope != null) {
-        normalized.add(scope.canonicalUri());
-      }
-    }
-    return List.copyOf(normalized);
-  }
-
-  private static List<S3BucketScope> groupByBucket(List<S3Location> scopes) {
-    LinkedHashMap<String, ArrayList<S3Location>> grouped = new LinkedHashMap<>();
-    for (S3Location scope : scopes) {
-      grouped.computeIfAbsent(scope.bucket(), ignored -> new ArrayList<>()).add(scope);
-    }
-    ArrayList<S3BucketScope> bucketScopes = new ArrayList<>();
-    grouped.forEach(
-        (bucket, bucketLocations) -> bucketScopes.add(new S3BucketScope(bucket, bucketLocations)));
-    return List.copyOf(bucketScopes);
   }
 
   private static String jsonEscape(String value) {
@@ -702,37 +581,24 @@ public class StorageAuthorityResolver {
       String bucket =
           (slash < 0 ? normalized : normalized.substring(0, slash))
               .toLowerCase(java.util.Locale.ROOT);
-      if (bucket.isBlank()) {
+      if (!bucket.matches("[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]")) {
         return null;
       }
       String prefix = slash < 0 ? "" : normalized.substring(slash + 1);
       while (prefix.endsWith("/")) {
         prefix = prefix.substring(0, prefix.length() - 1);
       }
+      if (prefix.indexOf('*') >= 0
+          || prefix.indexOf('?') >= 0
+          || prefix.chars().anyMatch(Character::isISOControl)) {
+        return null;
+      }
       return new S3Location(bucket, prefix);
     }
 
-    String canonicalUri() {
-      return keyPrefix.isBlank() ? "s3://" + bucket : "s3://" + bucket + "/" + keyPrefix;
-    }
-
-    String listPrefix() {
-      return keyPrefix;
-    }
-
-    String objectResourceJson() {
-      if (keyPrefix.isBlank()) {
-        return "[\"arn:aws:s3:::%s/*\"]".formatted(jsonEscape(bucket));
-      }
-      String objectArn = jsonEscape("arn:aws:s3:::%s/%s".formatted(bucket, keyPrefix));
-      return "[\"%s\",\"%s/*\"]".formatted(objectArn, objectArn);
-    }
-  }
-
-  private record S3BucketScope(String bucket, List<S3Location> scopes) {
-    String listStatementJson(boolean exactObject) {
+    String listStatementJson() {
       String escapedBucket = jsonEscape(bucket);
-      if (scopes.stream().anyMatch(scope -> scope.keyPrefix().isBlank())) {
+      if (keyPrefix.isBlank()) {
         return """
             {
               "Effect":"Allow",
@@ -745,43 +611,28 @@ public class StorageAuthorityResolver {
             .replaceAll("\\s+", " ")
             .trim();
       }
-      ArrayList<String> prefixes = new ArrayList<>();
-      for (S3Location scope : scopes) {
-        String prefix = jsonEscape(scope.listPrefix());
-        prefixes.add("\"" + prefix + "\"");
-        // For an exact-object scope the key names a single object, not a prefix, so the
-        // child-prefix clause that would authorize everything beneath it is suppressed.
-        if (!exactObject) {
-          prefixes.add("\"" + prefix + "/*\"");
-        }
-      }
+      String prefix = jsonEscape(keyPrefix);
       return """
           {
             "Effect":"Allow",
             "Action":["s3:ListBucket","s3:GetBucketLocation"],
             "Resource":["arn:aws:s3:::%s"],
-            "Condition":{"StringLike":{"s3:prefix":[%s]}}
+            "Condition":{"StringLike":{"s3:prefix":["%s","%s/*"]}}
           }
           """
-          .formatted(escapedBucket, String.join(",", prefixes))
+          .formatted(escapedBucket, prefix, prefix)
           .replace('\n', ' ')
           .replaceAll("\\s+", " ")
           .trim();
     }
 
-    String objectStatementJson(boolean exactObject) {
-      LinkedHashSet<String> resources = new LinkedHashSet<>();
-      for (S3Location scope : scopes) {
-        if (scope.keyPrefix().isBlank()) {
-          resources.add("\"arn:aws:s3:::%s/*\"".formatted(jsonEscape(bucket)));
-          continue;
-        }
-        String objectArn = jsonEscape("arn:aws:s3:::%s/%s".formatted(bucket, scope.keyPrefix()));
-        resources.add("\"" + objectArn + "\"");
-        // Exact-object scope grants the object itself and nothing beneath its key.
-        if (!exactObject) {
-          resources.add("\"" + objectArn + "/*\"");
-        }
+    String objectStatementJson() {
+      String resources;
+      if (keyPrefix.isBlank()) {
+        resources = "\"arn:aws:s3:::%s/*\"".formatted(jsonEscape(bucket));
+      } else {
+        String objectArn = jsonEscape("arn:aws:s3:::%s/%s".formatted(bucket, keyPrefix));
+        resources = "\"%s\",\"%s/*\"".formatted(objectArn, objectArn);
       }
       return """
           {
@@ -790,7 +641,7 @@ public class StorageAuthorityResolver {
             "Resource":[%s]
           }
           """
-          .formatted(String.join(",", resources))
+          .formatted(resources)
           .replace('\n', ' ')
           .replaceAll("\\s+", " ")
           .trim();
@@ -811,6 +662,7 @@ public class StorageAuthorityResolver {
           || !authority.getEnabled()
           || authority.getLocationPrefix() == null
           || authority.getLocationPrefix().isBlank()
+          || !isValidAuthorityLocation(authority.getType(), authority.getLocationPrefix())
           || !matchesLocationPrefix(locationPrefix, authority.getLocationPrefix())) {
         continue;
       }

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
@@ -312,56 +312,27 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
               List<StorageAuthority> authorities =
                   repo.list(accountId, Integer.MAX_VALUE, "", new StringBuilder());
               StorageAuthority authority =
-                  StorageAuthorityResolver.resolveBest(
-                          authorities, credentialScope.authorityLookupLocationPrefix())
+                  StorageAuthorityResolver.resolveBest(authorities, credentialScope.location())
                       .orElse(null);
               if (authority == null) {
                 // No authority covers this location. Before failing, ask the source catalog: an
                 // Iceberg REST catalog with access delegation issues its own short-lived
                 // credentials, which makes a separately configured authority unnecessary.
                 //
-                // Deliberately a fallback rather than the first choice -- an existing authority
-                // stays authoritative, so this cannot change behaviour for any catalog that
-                // already works.
-                //
-                // An exact-object scope is the one case that must not take it. That scope exists to
-                // promise credentials for a single named file, and it is enforced by the session
-                // policy this service mints when assuming an authority's role. A delegating catalog
-                // mints its own credentials -- table-scoped, by its own choice -- and we hold no
-                // role to narrow them with, so accepting them here would quietly answer a
-                // single-object request with table-wide access. Refuse instead: the caller gets the
-                // usual missing-authority error, which is the honest answer, and in practice
-                // table-scoped credentials would not have covered the file anyway -- an exact
-                // object scope arises precisely when a leased file sits outside the table location.
-                if (credentialScope.exactObjectScope()) {
-                  LOG.infof(
-                      "source-catalog vending skipped: request needs an exact-object credential"
-                          + " scope for %s, which a delegating catalog cannot express",
-                      credentialScope.responseLocationPrefix());
-                }
                 ResourceId sourceTableId =
-                    credentialScope.exactObjectScope()
-                        ? null
-                        : sourceCatalogTableId(request, accountId, authorized.job());
+                    credentialScope.sourceCatalogDelegationAllowed()
+                        ? sourceCatalogTableId(request, accountId, authorized.job())
+                        : null;
                 if (sourceTableId != null) {
                   ResolveStorageAuthorityResponse vended =
-                      vendFromSourceCatalog(
-                          accountId, sourceTableId, credentialScope.responseLocationPrefix());
+                      vendFromSourceCatalog(accountId, sourceTableId, credentialScope.location());
                   if (vended != null) {
                     return vended;
                   }
                 }
               }
-              validateAuthorityCoversSessionScope(
-                  authority, credentialScope.sessionScopeLocations());
               try {
-                return resolver.buildResponse(
-                    authority,
-                    credentialScope.responseLocationPrefix(),
-                    credentialScope.sessionScopeLocations(),
-                    accountId,
-                    serverSide,
-                    credentialScope.exactObjectScope());
+                return resolver.buildResponse(authority, accountId, serverSide);
               } catch (StorageAuthorityResolver.CredentialVendingUnavailableException error) {
                 throw GrpcErrors.unavailable(
                     correlationId(), null, Map.of("operation", "assume-role"), error);
@@ -433,6 +404,14 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
       throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "spec.display_name"));
     }
     if (trimToNull(spec.getLocationPrefix()) == null) {
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "spec.location_prefix"));
+    }
+    if (!StorageAuthorityResolver.isSupportedAuthorityType(
+        spec.hasType() ? spec.getType() : null)) {
+      throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "spec.type"));
+    }
+    if (!StorageAuthorityResolver.isValidAuthorityLocation(
+        spec.hasType() ? spec.getType() : null, spec.getLocationPrefix())) {
       throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "spec.location_prefix"));
     }
     if (creating
@@ -540,13 +519,13 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
       VendStorageCredentialsRequest request, ReconcileJobStore.ReconcileJob job) {
     String requestedLocationPrefix = validateExplicitLocation(request);
     CredentialScope scope = resolveLeaseScopedLocation(job);
-    if ((scope == null || scope.authorityLookupLocationPrefix() == null) && request.hasTableId()) {
+    if ((scope == null || scope.location() == null) && request.hasTableId()) {
       scope = resolveDiscoveryTableLocation(request.getTableId(), job);
     }
-    if (scope == null || scope.authorityLookupLocationPrefix() == null) {
+    if (scope == null || scope.location() == null) {
       scope = resolvePlannerBootstrapLocation(requestedLocationPrefix, job);
     }
-    if (scope == null || scope.authorityLookupLocationPrefix() == null) {
+    if (scope == null || scope.location() == null) {
       throw io.grpc.Status.FAILED_PRECONDITION
           .withDescription("reconcile lease is not bound to a concrete storage location")
           .asRuntimeException();
@@ -560,17 +539,19 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
       // files planned for this job, so a request for one of them is in scope even though it sits
       // under a different prefix.
       //
-      // Scope to the requested file rather than widening the table scope: authority lookup and the
-      // minted session policy then follow the location actually being read, and a table whose data
-      // does live under its own location is unaffected.
+      // Use the requested file for authority lookup. Exact membership authorizes this vending
+      // request; once an authority is selected, its configured prefix defines the credential scope.
       if (isLeasedFilePath(job, requestedLocationPrefix)) {
-        return CredentialScope.forSingleObject(requestedLocationPrefix);
+        return CredentialScope.forLeasedFile(requestedLocationPrefix);
       }
       throw io.grpc.Status.PERMISSION_DENIED
           .withDescription("requested location is outside the leased reconcile storage scope")
           .asRuntimeException();
     }
-    return scope.withResponseLocationPrefix(requestedLocationPrefix);
+    if (StorageAuthorityResolver.matchesLocationPrefix(requestedLocationPrefix, scope.location())) {
+      return CredentialScope.forSingleLocation(requestedLocationPrefix);
+    }
+    return scope;
   }
 
   private static StorageCredentialUsage usage(VendStorageCredentialsRequest request) {
@@ -829,37 +810,11 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
     if (requestedLocationPrefix == null || scope == null) {
       return false;
     }
-    List<String> sessionScopes = scope.sessionScopeLocations();
-    if (sessionScopes == null || sessionScopes.isEmpty()) {
-      return StorageAuthorityResolver.matchesLocationPrefix(
-          requestedLocationPrefix, scope.authorityLookupLocationPrefix());
-    }
-    for (String sessionScope : sessionScopes) {
-      if (StorageAuthorityResolver.matchesLocationPrefix(sessionScope, requestedLocationPrefix)
-          || StorageAuthorityResolver.matchesLocationPrefix(
-              requestedLocationPrefix, sessionScope)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static void validateAuthorityCoversSessionScope(
-      StorageAuthority authority, List<String> sessionScopeLocations) {
-    if (authority == null
-        || sessionScopeLocations == null
-        || sessionScopeLocations.isEmpty()
-        || authority.getLocationPrefix().isBlank()) {
-      return;
-    }
-    for (String sessionScopeLocation : sessionScopeLocations) {
-      if (!StorageAuthorityResolver.matchesLocationPrefix(
-          sessionScopeLocation, authority.getLocationPrefix())) {
-        throw io.grpc.Status.FAILED_PRECONDITION
-            .withDescription("leased reconcile storage scope spans multiple storage authorities")
-            .asRuntimeException();
-      }
-    }
+    String authorizedLocation = scope.location();
+    return StorageAuthorityResolver.matchesLocationPrefix(
+            requestedLocationPrefix, authorizedLocation)
+        || StorageAuthorityResolver.matchesLocationPrefix(
+            authorizedLocation, requestedLocationPrefix);
   }
 
   /**
@@ -943,35 +898,15 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
     storeCredentials(secretsManager, accountId, authorityId, spec.getCredentials());
   }
 
-  private record CredentialScope(
-      String authorityLookupLocationPrefix,
-      String responseLocationPrefix,
-      List<String> sessionScopeLocations,
-      boolean exactObjectScope) {
+  private record CredentialScope(String location, boolean sourceCatalogDelegationAllowed) {
     static CredentialScope forSingleLocation(String locationPrefix) {
-      return new CredentialScope(
-          locationPrefix,
-          locationPrefix,
-          locationPrefix == null ? List.of() : List.of(locationPrefix),
-          false);
+      return new CredentialScope(locationPrefix, true);
     }
 
-    /**
-     * A scope over a single concrete object rather than a prefix. The minted session policy grants
-     * exactly that key -- no child wildcard -- so admitting one leased data file cannot hand out
-     * credentials for anything sharing its path as a prefix.
-     */
-    static CredentialScope forSingleObject(String location) {
-      return new CredentialScope(
-          location, location, location == null ? List.of() : List.of(location), true);
-    }
-
-    CredentialScope withResponseLocationPrefix(String responseLocationPrefix) {
-      return new CredentialScope(
-          authorityLookupLocationPrefix,
-          responseLocationPrefix,
-          sessionScopeLocations,
-          exactObjectScope);
+    static CredentialScope forLeasedFile(String location) {
+      // Upstream catalog credentials keep whatever scope the catalog minted. Do not reinterpret a
+      // single leased-file authorization as permission to return those table-scoped credentials.
+      return new CredentialScope(location, false);
     }
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityResolverTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityResolverTest.java
@@ -60,13 +60,7 @@ class StorageAuthorityResolverTest {
 
   @Test
   void buildResponseAllowsStaticAwsSecretsForServerSideAccess() {
-    ResolveStorageAuthorityResponse response =
-        resolver.buildResponse(
-            authority(),
-            "s3://warehouse/orders",
-            java.util.List.of("s3://warehouse/orders"),
-            "acct",
-            true);
+    ResolveStorageAuthorityResponse response = resolver.buildResponse(authority(), "acct", true);
 
     assertEquals("us-east-1", response.getClientSafeConfigMap().get("s3.region"));
     assertEquals(1, response.getStorageCredentialsCount());
@@ -107,12 +101,7 @@ class StorageAuthorityResolverTest {
         };
 
     ResolveStorageAuthorityResponse response =
-        resolverWithSessionToken.buildResponse(
-            authority(),
-            "s3://warehouse/orders",
-            java.util.List.of("s3://warehouse/orders"),
-            "acct",
-            true);
+        resolverWithSessionToken.buildResponse(authority(), "acct", true);
 
     assertEquals("akid", response.getStorageCredentials(0).getConfigMap().get("s3.access-key-id"));
     assertEquals(
@@ -131,13 +120,7 @@ class StorageAuthorityResolverTest {
     var error =
         assertThrows(
             io.grpc.StatusRuntimeException.class,
-            () ->
-                resolver.buildResponse(
-                    null,
-                    "s3://warehouse/orders",
-                    java.util.List.of("s3://warehouse/orders"),
-                    "acct",
-                    false));
+            () -> resolver.buildResponse(null, "acct", false));
     assertTrue(
         ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus
             .isNoMatchingStorageAuthority(error),
@@ -148,27 +131,13 @@ class StorageAuthorityResolverTest {
   void buildResponseForServerSideNoAuthorityFails() {
     var error =
         assertThrows(
-            io.grpc.StatusRuntimeException.class,
-            () ->
-                resolver.buildResponse(
-                    null,
-                    "s3://warehouse/orders",
-                    java.util.List.of("s3://warehouse/orders"),
-                    "acct",
-                    true));
+            io.grpc.StatusRuntimeException.class, () -> resolver.buildResponse(null, "acct", true));
   }
 
   @Test
   void buildResponseRejectsStaticAwsSecretsForClientVending() {
     assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            resolver.buildResponse(
-                authority(),
-                "s3://warehouse/orders",
-                java.util.List.of("s3://warehouse/orders"),
-                "acct",
-                false));
+        IllegalArgumentException.class, () -> resolver.buildResponse(authority(), "acct", false));
   }
 
   @Test
@@ -177,10 +146,7 @@ class StorageAuthorityResolverTest {
         new StorageAuthorityResolver() {
           @Override
           ResolvedStorageCredentials assumeRoleFromStaticSource(
-              StorageAuthority authority,
-              AuthCredentials.AwsCredentials source,
-              java.util.List<String> sessionScopeLocations,
-              boolean exactObjectScope) {
+              StorageAuthority authority, AuthCredentials.AwsCredentials source) {
             return new ResolvedStorageCredentials(
                 "temp-akid", "temp-secret", "temp-token", Instant.parse("2026-06-19T12:00:00Z"));
           }
@@ -206,8 +172,6 @@ class StorageAuthorityResolverTest {
             authority().toBuilder()
                 .setAssumeRoleArn("arn:aws:iam::123456789012:role/customer-ro")
                 .build(),
-            "s3://warehouse/orders",
-            java.util.List.of("s3://warehouse/orders"),
             "acct",
             true);
 
@@ -221,16 +185,13 @@ class StorageAuthorityResolverTest {
   }
 
   @Test
-  void buildResponseReusesFreshAssumeRoleCredentialsForMatchingScope() {
+  void buildResponseReusesFreshAssumeRoleCredentialsForMatchingAuthority() {
     AtomicInteger resolutions = new AtomicInteger();
     StorageAuthorityResolver assumeRoleResolver =
         new StorageAuthorityResolver() {
           @Override
           ResolvedStorageCredentials assumeRoleFromStaticSource(
-              StorageAuthority authority,
-              AuthCredentials.AwsCredentials source,
-              java.util.List<String> sessionScopeLocations,
-              boolean exactObjectScope) {
+              StorageAuthority authority, AuthCredentials.AwsCredentials source) {
             resolutions.incrementAndGet();
             return new ResolvedStorageCredentials(
                 "temp-akid", "temp-secret", "temp-token", Instant.now().plusSeconds(3600));
@@ -242,92 +203,10 @@ class StorageAuthorityResolverTest {
             .setAssumeRoleArn("arn:aws:iam::123456789012:role/customer-ro")
             .build();
 
-    assumeRoleResolver.buildResponse(
-        authority,
-        "s3://warehouse/orders",
-        java.util.List.of("s3://warehouse/orders"),
-        "acct",
-        true);
-    assumeRoleResolver.buildResponse(
-        authority,
-        "s3://warehouse/orders",
-        java.util.List.of("s3://warehouse/orders"),
-        "acct",
-        true);
+    assumeRoleResolver.buildResponse(authority, "acct", true);
+    assumeRoleResolver.buildResponse(authority, "acct", true);
 
     assertEquals(1, resolutions.get());
-  }
-
-  @Test
-  void assumeRoleCacheCanonicalizesEquivalentScopeSets() {
-    AtomicInteger resolutions = new AtomicInteger();
-    StorageAuthorityResolver assumeRoleResolver =
-        new StorageAuthorityResolver() {
-          @Override
-          ResolvedStorageCredentials assumeRoleFromStaticSource(
-              StorageAuthority authority,
-              AuthCredentials.AwsCredentials source,
-              java.util.List<String> sessionScopeLocations,
-              boolean exactObjectScope) {
-            resolutions.incrementAndGet();
-            return new ResolvedStorageCredentials(
-                "temp-akid", "temp-secret", "temp-token", Instant.now().plusSeconds(3600));
-          }
-        };
-    StorageAuthority authority =
-        authority().toBuilder()
-            .setAssumeRoleArn("arn:aws:iam::123456789012:role/customer-ro")
-            .build();
-    AuthCredentials source =
-        AuthCredentials.newBuilder()
-            .setAws(
-                AuthCredentials.AwsCredentials.newBuilder()
-                    .setAccessKeyId("akid")
-                    .setSecretAccessKey("secret"))
-            .build();
-
-    assumeRoleResolver.assumeRoleCredentials(
-        authority, source, java.util.List.of("s3://warehouse/two/", "s3://warehouse/one"), false);
-    assumeRoleResolver.assumeRoleCredentials(
-        authority, source, java.util.List.of("S3A://WAREHOUSE/one/", "s3n://warehouse/two"), false);
-
-    assertEquals(1, resolutions.get());
-  }
-
-  @Test
-  void assumeRoleCacheSeparatesPrefixAndExactObjectScopes() {
-    AtomicInteger resolutions = new AtomicInteger();
-    StorageAuthorityResolver assumeRoleResolver =
-        new StorageAuthorityResolver() {
-          @Override
-          ResolvedStorageCredentials assumeRoleFromStaticSource(
-              StorageAuthority authority,
-              AuthCredentials.AwsCredentials source,
-              java.util.List<String> sessionScopeLocations,
-              boolean exactObjectScope) {
-            resolutions.incrementAndGet();
-            return new ResolvedStorageCredentials(
-                "temp-akid", "temp-secret", "temp-token", Instant.now().plusSeconds(3600));
-          }
-        };
-    StorageAuthority authority =
-        authority().toBuilder()
-            .setAssumeRoleArn("arn:aws:iam::123456789012:role/customer-ro")
-            .build();
-    AuthCredentials source =
-        AuthCredentials.newBuilder()
-            .setAws(
-                AuthCredentials.AwsCredentials.newBuilder()
-                    .setAccessKeyId("akid")
-                    .setSecretAccessKey("secret"))
-            .build();
-
-    assumeRoleResolver.assumeRoleCredentials(
-        authority, source, java.util.List.of("s3://warehouse/orders"), false);
-    assumeRoleResolver.assumeRoleCredentials(
-        authority, source, java.util.List.of("s3://warehouse/orders"), true);
-
-    assertEquals(2, resolutions.get());
   }
 
   @Test
@@ -337,10 +216,7 @@ class StorageAuthorityResolverTest {
         new StorageAuthorityResolver() {
           @Override
           ResolvedStorageCredentials assumeRoleFromStaticSource(
-              StorageAuthority authority,
-              AuthCredentials.AwsCredentials source,
-              java.util.List<String> sessionScopeLocations,
-              boolean exactObjectScope) {
+              StorageAuthority authority, AuthCredentials.AwsCredentials source) {
             resolutions.incrementAndGet();
             return new ResolvedStorageCredentials(
                 "temp-akid", "temp-secret", "temp-token", Instant.now().plusSeconds(3600));
@@ -373,18 +249,13 @@ class StorageAuthorityResolverTest {
             .putHeaders("x-one", "a")
             .build();
 
-    assumeRoleResolver.assumeRoleCredentials(
-        authority, forward, java.util.List.of("s3://warehouse/one"), false);
-    assumeRoleResolver.assumeRoleCredentials(
-        authority, reversed, java.util.List.of("s3://warehouse/one"), false);
+    assumeRoleResolver.assumeRoleCredentials(authority, forward);
+    assumeRoleResolver.assumeRoleCredentials(authority, reversed);
 
     assertEquals(1, resolutions.get());
 
     assumeRoleResolver.assumeRoleCredentials(
-        authority,
-        base.clone().putProperties("alpha", "changed").build(),
-        java.util.List.of("s3://warehouse/one"),
-        false);
+        authority, base.clone().putProperties("alpha", "changed").build());
 
     assertEquals(2, resolutions.get());
   }
@@ -396,10 +267,7 @@ class StorageAuthorityResolverTest {
         new StorageAuthorityResolver(2) {
           @Override
           ResolvedStorageCredentials assumeRoleFromStaticSource(
-              StorageAuthority authority,
-              AuthCredentials.AwsCredentials source,
-              java.util.List<String> sessionScopeLocations,
-              boolean exactObjectScope) {
+              StorageAuthority authority, AuthCredentials.AwsCredentials source) {
             int resolution = resolutions.incrementAndGet();
             return new ResolvedStorageCredentials(
                 "temp-akid-" + resolution,
@@ -420,16 +288,13 @@ class StorageAuthorityResolverTest {
                     .setSecretAccessKey("secret"))
             .build();
 
+    assumeRoleResolver.assumeRoleCredentials(withLocation(authority, "s3://warehouse/one"), source);
+    assumeRoleResolver.assumeRoleCredentials(withLocation(authority, "s3://warehouse/two"), source);
     assumeRoleResolver.assumeRoleCredentials(
-        authority, source, java.util.List.of("s3://warehouse/one"), false);
-    assumeRoleResolver.assumeRoleCredentials(
-        authority, source, java.util.List.of("s3://warehouse/two"), false);
-    assumeRoleResolver.assumeRoleCredentials(
-        authority, source, java.util.List.of("s3://warehouse/three"), false);
+        withLocation(authority, "s3://warehouse/three"), source);
 
     assertEquals(2, assumeRoleResolver.assumeRoleCacheSize());
-    assumeRoleResolver.assumeRoleCredentials(
-        authority, source, java.util.List.of("s3://warehouse/one"), false);
+    assumeRoleResolver.assumeRoleCredentials(withLocation(authority, "s3://warehouse/one"), source);
     assertEquals(4, resolutions.get());
     assertEquals(2, assumeRoleResolver.assumeRoleCacheSize());
   }
@@ -445,10 +310,7 @@ class StorageAuthorityResolverTest {
         new StorageAuthorityResolver(2) {
           @Override
           ResolvedStorageCredentials assumeRoleFromStaticSource(
-              StorageAuthority authority,
-              AuthCredentials.AwsCredentials source,
-              java.util.List<String> sessionScopeLocations,
-              boolean exactObjectScope) {
+              StorageAuthority authority, AuthCredentials.AwsCredentials source) {
             int resolution = resolutions.incrementAndGet();
             if (resolution <= 2) {
               firstTwoStarted.countDown();
@@ -488,18 +350,18 @@ class StorageAuthorityResolverTest {
           executor.submit(
               () ->
                   assumeRoleResolver.assumeRoleCredentials(
-                      authority, source, java.util.List.of("s3://warehouse/one"), false));
+                      withLocation(authority, "s3://warehouse/one"), source));
       java.util.concurrent.Future<?> second =
           executor.submit(
               () ->
                   assumeRoleResolver.assumeRoleCredentials(
-                      authority, source, java.util.List.of("s3://warehouse/two"), false));
+                      withLocation(authority, "s3://warehouse/two"), source));
       assertTrue(firstTwoStarted.await(5, java.util.concurrent.TimeUnit.SECONDS));
       java.util.concurrent.Future<?> third =
           executor.submit(
               () ->
                   assumeRoleResolver.assumeRoleCredentials(
-                      authority, source, java.util.List.of("s3://warehouse/three"), false));
+                      withLocation(authority, "s3://warehouse/three"), source));
 
       assertFalse(thirdStarted.await(200, java.util.concurrent.TimeUnit.MILLISECONDS));
       assertEquals(2, assumeRoleResolver.assumeRoleCacheSize());
@@ -526,11 +388,8 @@ class StorageAuthorityResolverTest {
         new StorageAuthorityResolver(2) {
           @Override
           ResolvedStorageCredentials assumeRoleFromStaticSource(
-              StorageAuthority authority,
-              AuthCredentials.AwsCredentials source,
-              java.util.List<String> sessionScopeLocations,
-              boolean exactObjectScope) {
-            String location = sessionScopeLocations.getFirst();
+              StorageAuthority authority, AuthCredentials.AwsCredentials source) {
+            String location = authority.getLocationPrefix();
             java.util.concurrent.CountDownLatch release = null;
             if (location.endsWith("/one")) {
               firstStarted.countDown();
@@ -574,19 +433,19 @@ class StorageAuthorityResolverTest {
           executor.submit(
               () ->
                   assumeRoleResolver.assumeRoleCredentials(
-                      authority, source, java.util.List.of("s3://warehouse/one"), false));
+                      withLocation(authority, "s3://warehouse/one"), source));
       assertTrue(firstStarted.await(5, java.util.concurrent.TimeUnit.SECONDS));
       java.util.concurrent.Future<?> second =
           executor.submit(
               () ->
                   assumeRoleResolver.assumeRoleCredentials(
-                      authority, source, java.util.List.of("s3://warehouse/two"), false));
+                      withLocation(authority, "s3://warehouse/two"), source));
       assertTrue(secondStarted.await(5, java.util.concurrent.TimeUnit.SECONDS));
       java.util.concurrent.Future<?> third =
           executor.submit(
               () ->
                   assumeRoleResolver.assumeRoleCredentials(
-                      authority, source, java.util.List.of("s3://warehouse/three"), false));
+                      withLocation(authority, "s3://warehouse/three"), source));
 
       assertFalse(thirdStarted.await(200, java.util.concurrent.TimeUnit.MILLISECONDS));
       releaseSecond.countDown();
@@ -610,10 +469,7 @@ class StorageAuthorityResolverTest {
     StorageAuthorityResolver assumeRoleResolver =
         new StorageAuthorityResolver() {
           @Override
-          ResolvedStorageCredentials assumeRoleFromAmbientSource(
-              StorageAuthority authority,
-              java.util.List<String> sessionScopeLocations,
-              boolean exactObjectScope) {
+          ResolvedStorageCredentials assumeRoleFromAmbientSource(StorageAuthority authority) {
             return new ResolvedStorageCredentials(
                 "temp-akid", "temp-secret", "temp-token", Instant.parse("2026-06-19T12:00:00Z"));
           }
@@ -625,8 +481,6 @@ class StorageAuthorityResolverTest {
             authority().toBuilder()
                 .setAssumeRoleArn("arn:aws:iam::123456789012:role/customer-ro")
                 .build(),
-            "s3://warehouse/orders",
-            java.util.List.of("s3://warehouse/orders"),
             "acct",
             true);
 
@@ -677,9 +531,7 @@ class StorageAuthorityResolverTest {
         assumeRoleResolver.assumeRoleFromAmbientSource(
             authority().toBuilder()
                 .setAssumeRoleArn("arn:aws:iam::123456789012:role/customer-ro")
-                .build(),
-            java.util.List.of("s3://warehouse/orders"),
-            false);
+                .build());
 
     assertEquals("temp-akid", credentials.accessKeyId());
     assertEquals(2, clientBuilds.get());
@@ -726,9 +578,7 @@ class StorageAuthorityResolverTest {
         assumeRoleResolver.assumeRoleFromAmbientSource(
             authority().toBuilder()
                 .setAssumeRoleArn("arn:aws:iam::123456789012:role/customer-ro")
-                .build(),
-            java.util.List.of("s3://warehouse/orders"),
-            false);
+                .build());
 
     assertEquals("temp-akid", credentials.accessKeyId());
     assertEquals(2, clientBuilds.get());
@@ -736,7 +586,7 @@ class StorageAuthorityResolverTest {
 
   @Test
   void scopedSessionPolicyOmitsEmptyListPrefixConditionForBucketRoot() {
-    String policy = StorageAuthorityResolver.scopedSessionPolicy("s3://warehouse");
+    String policy = StorageAuthorityResolver.scopedSessionPolicy("s3://warehouse/");
 
     assertTrue(policy.contains("\"Resource\":[\"arn:aws:s3:::warehouse\"]"));
     assertFalse(policy.contains("\"s3:prefix\""));
@@ -744,95 +594,84 @@ class StorageAuthorityResolverTest {
   }
 
   @Test
-  void scopedSessionPolicyForExactObjectOmitsChildWildcard() {
-    String location = "s3://warehouse/orders/data/part-000.parquet";
-    String objectArn = "arn:aws:s3:::warehouse/orders/data/part-000.parquet";
+  void scopedSessionPolicyForAuthorityPrefixRestrictsListingAndObjects() throws Exception {
+    String policy = StorageAuthorityResolver.scopedSessionPolicy("s3://warehouse/warehouse/");
+    ObjectMapper mapper =
+        new ObjectMapper(
+            JsonFactory.builder().enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION).build());
 
-    String prefixPolicy = StorageAuthorityResolver.scopedSessionPolicy(java.util.List.of(location));
-    // The default (prefix) scope grants the object and everything beneath its key.
-    assertTrue(prefixPolicy.contains("\"" + objectArn + "/*\""));
+    JsonNode root = mapper.readTree(policy);
 
-    String exactPolicy =
-        StorageAuthorityResolver.scopedSessionPolicy(java.util.List.of(location), true);
-    // The exact-object scope grants the object itself and nothing beneath it -- no child wildcard
-    // on the object resource, and no child-prefix in the list condition.
-    assertTrue(exactPolicy.contains("\"" + objectArn + "\""));
-    assertFalse(exactPolicy.contains(objectArn + "/*"));
-    assertFalse(exactPolicy.contains("orders/data/part-000.parquet/*"));
+    assertEquals("2012-10-17", root.get("Version").asText());
+    assertEquals(2, root.get("Statement").size());
+    assertEquals("Allow", root.get("Statement").get(0).get("Effect").asText());
+    assertEquals("Allow", root.get("Statement").get(1).get("Effect").asText());
+    assertTrue(policy.contains("\"s3:prefix\":[\"warehouse\",\"warehouse/*\"]"));
+    assertTrue(policy.contains("arn:aws:s3:::warehouse/warehouse/*"));
+    assertFalse(policy.contains("\"Resource\":[\"arn:aws:s3:::warehouse/*\"]"));
   }
 
   @Test
-  void exactObjectScopeRefusesKeysCarryingIamWildcardMetacharacters() {
-    // `*` and `?` are legal in an S3 object key and are wildcards in an IAM resource ARN, so a
-    // planned file named part-*.parquet would mint access to every sibling it matches -- the
-    // opposite of what an exact-object scope promises. IAM cannot express a literal `*`, so the
-    // only safe answer is refusal; widening the grant is not an acceptable fallback.
-    for (String key : java.util.List.of("part-*.parquet", "part-00?.parquet", "*")) {
-      String location = "s3://warehouse/orders/data/" + key;
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> StorageAuthorityResolver.scopedSessionPolicy(java.util.List.of(location), true),
-          "expected refusal for key " + key);
+  void authorityPolicyCoversDeletionVectorSiblingBeneathAuthorityPrefix() {
+    String policy =
+        StorageAuthorityResolver.scopedSessionPolicy(
+            "s3://floedb-databricks-metastore-367509577365/metastore/metastore-id/tables/");
+
+    assertTrue(
+        policy.contains(
+            "arn:aws:s3:::floedb-databricks-metastore-367509577365/metastore/metastore-id/tables/*"));
+    assertFalse(policy.contains("table-uuid"));
+  }
+
+  @Test
+  void invalidS3AuthorityLocationsCannotProduceAnUnscopedPolicy() {
+    for (String location :
+        new String[] {
+          null,
+          "",
+          " ",
+          "s3://",
+          "s3:///warehouse",
+          "not-an-s3-uri",
+          "s3://bad bucket",
+          "s3://warehouse/prefix*"
+        }) {
+      IllegalArgumentException error =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> StorageAuthorityResolver.scopedSessionPolicy(location));
+      assertTrue(error.getMessage().contains("concrete bucket"));
+      if (location != null) {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> resolver.buildResponse(withLocation(authority(), location), "acct", true));
+      }
     }
   }
 
   @Test
-  void wildcardKeysStillAllowedForPrefixScopesWhichNeverPromisedASingleObject() {
-    // Only the exact-object contract is broken by a metacharacter. A prefix scope is broad by
-    // construction, so refusing here would reject working authority configurations for no gain.
-    String policy =
-        StorageAuthorityResolver.scopedSessionPolicy(
-            java.util.List.of("s3://warehouse/orders/data/part-*.parquet"));
-    assertTrue(policy.contains("arn:aws:s3:::warehouse/orders/data/part-*.parquet"));
+  void resolveBestSelectsTheLongestMatchingEnabledAuthority() {
+    StorageAuthority bucket = withLocation(authority(), "s3://warehouse/");
+    StorageAuthority warehouse =
+        withLocation(authority(), "s3://warehouse/warehouse/").toBuilder()
+            .setResourceId(authority().getResourceId().toBuilder().setId("sa-2"))
+            .build();
+    StorageAuthority disabledNarrower =
+        withLocation(authority(), "s3://warehouse/warehouse/orders/").toBuilder()
+            .setResourceId(authority().getResourceId().toBuilder().setId("sa-3"))
+            .setEnabled(false)
+            .build();
+
+    Optional<StorageAuthority> resolved =
+        StorageAuthorityResolver.resolveBest(
+            java.util.List.of(bucket, disabledNarrower, warehouse),
+            "s3://warehouse/warehouse/orders/data.parquet");
+
+    assertEquals(warehouse, resolved.orElseThrow());
   }
 
-  @Test
-  void scopedSessionPolicyForNonRootParsesAsValidJson() throws Exception {
-    String policy = StorageAuthorityResolver.scopedSessionPolicy("s3://warehouse/orders");
-    ObjectMapper mapper =
-        new ObjectMapper(
-            JsonFactory.builder().enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION).build());
-
-    JsonNode root = mapper.readTree(policy);
-
-    assertEquals("2012-10-17", root.get("Version").asText());
-    assertEquals(2, root.get("Statement").size());
-    assertEquals("Allow", root.get("Statement").get(0).get("Effect").asText());
-    assertEquals("Allow", root.get("Statement").get(1).get("Effect").asText());
-  }
-
-  @Test
-  void scopedSessionPolicyForMultipleFilePathsParsesAsValidJson() throws Exception {
-    String policy =
-        StorageAuthorityResolver.scopedSessionPolicy(
-            java.util.List.of(
-                "s3://warehouse/orders/data/part-000.parquet",
-                "s3://warehouse/orders/data/part-001.parquet",
-                "s3://warehouse/orders/metadata/delete-000.parquet"));
-    ObjectMapper mapper =
-        new ObjectMapper(
-            JsonFactory.builder().enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION).build());
-
-    JsonNode root = mapper.readTree(policy);
-
-    assertEquals("2012-10-17", root.get("Version").asText());
-    assertEquals(2, root.get("Statement").size());
-    assertEquals("Allow", root.get("Statement").get(0).get("Effect").asText());
-    assertEquals("Allow", root.get("Statement").get(1).get("Effect").asText());
-    assertTrue(policy.contains("part-000.parquet"));
-    assertTrue(policy.contains("delete-000.parquet"));
-  }
-
-  @Test
-  void scopedSessionPolicyCanonicalizesScopeOrderAndSchemes() {
-    String first =
-        StorageAuthorityResolver.scopedSessionPolicy(
-            java.util.List.of("s3://warehouse/two/", "s3://warehouse/one"));
-    String second =
-        StorageAuthorityResolver.scopedSessionPolicy(
-            java.util.List.of("S3A://WAREHOUSE/one/", "s3n://warehouse/two"));
-
-    assertEquals(first, second);
+  private static StorageAuthority withLocation(StorageAuthority authority, String locationPrefix) {
+    return authority.toBuilder().setLocationPrefix(locationPrefix).build();
   }
 
   private static StorageAuthority authority() {

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
@@ -233,6 +233,47 @@ class StorageAuthorityServiceImplTest {
   }
 
   @Test
+  void updateRejectsNonConcreteS3AuthorityLocation() {
+    StatusRuntimeException error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .updateStorageAuthority(
+                        UpdateStorageAuthorityRequest.newBuilder()
+                            .setAuthorityId(AUTHORITY_ID)
+                            .setSpec(StorageAuthoritySpec.newBuilder().setLocationPrefix("s3://"))
+                            .setUpdateMask(
+                                FieldMask.newBuilder().addPaths("location_prefix").build())
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(io.grpc.Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    verify(repo, never()).update(any(StorageAuthority.class), anyLong());
+  }
+
+  @Test
+  void updateRejectsUnsupportedAuthorityType() {
+    StatusRuntimeException error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .updateStorageAuthority(
+                        UpdateStorageAuthorityRequest.newBuilder()
+                            .setAuthorityId(AUTHORITY_ID)
+                            .setSpec(StorageAuthoritySpec.newBuilder().setType("gcs"))
+                            .setUpdateMask(FieldMask.newBuilder().addPaths("type").build())
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    assertEquals(io.grpc.Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+    verify(repo, never()).update(any(StorageAuthority.class), anyLong());
+  }
+
+  @Test
   void deleteScopesAuthorityIdToPrincipalAccount() {
     service
         .deleteStorageAuthority(
@@ -318,6 +359,55 @@ class StorageAuthorityServiceImplTest {
             .indefinitely();
 
     assertEquals(DATARBRICKS_AUTHORITY_ID, response.getAuthorityId());
+    assertEquals(
+        "s3://floedb-databricks-metastore-367509577365",
+        response.getStorageCredentials(0).getPrefix());
+  }
+
+  @Test
+  void twoTablesCoveredByOneAuthorityUseOneAuthorityScopedCredential() {
+    ResourceId customersTableId = TABLE_ID.toBuilder().setId("tbl-2").build();
+    StorageAuthority bucketAuthority =
+        currentAuthority().toBuilder()
+            .setLocationPrefix("s3://warehouse/")
+            .setAssumeRoleArn("arn:aws:iam::123456789012:role/customer-ro")
+            .build();
+    when(repo.list(eq("acct"), anyInt(), any(), any()))
+        .thenReturn(java.util.List.of(bucketAuthority));
+    when(tableRepo.getById(customersTableId))
+        .thenReturn(
+            Optional.of(
+                ai.floedb.floecat.catalog.rpc.Table.newBuilder()
+                    .setResourceId(customersTableId)
+                    .putProperties("location", "s3://warehouse/customers")
+                    .build()));
+    java.util.List<String> policies = new java.util.ArrayList<>();
+    service.resolver =
+        new StorageAuthorityResolver() {
+          @Override
+          ai.floedb.floecat.connector.common.auth.ResolvedStorageCredentials
+              assumeRoleFromStaticSource(
+                  StorageAuthority authority, AuthCredentials.AwsCredentials source) {
+            policies.add(
+                StorageAuthorityResolver.scopedSessionPolicy(authority.getLocationPrefix()));
+            return new ai.floedb.floecat.connector.common.auth.ResolvedStorageCredentials(
+                "temp-akid",
+                "temp-secret",
+                "temp-token",
+                java.time.Instant.now().plusSeconds(3600));
+          }
+        };
+    service.resolver.secretsManager = secretsManager;
+
+    ResolveStorageAuthorityResponse orders = vendServerCredentialsForTable(TABLE_ID);
+    ResolveStorageAuthorityResponse customers = vendServerCredentialsForTable(customersTableId);
+
+    assertEquals("s3://warehouse/", orders.getStorageCredentials(0).getPrefix());
+    assertEquals("s3://warehouse/", customers.getStorageCredentials(0).getPrefix());
+    assertEquals(1, policies.size(), "the authority-scoped cache must be shared across tables");
+    assertTrue(policies.getFirst().contains("arn:aws:s3:::warehouse/*"));
+    assertFalse(policies.getFirst().contains("orders"));
+    assertFalse(policies.getFirst().contains("customers"));
   }
 
   @Test
@@ -432,6 +522,68 @@ class StorageAuthorityServiceImplTest {
     verify(reconcileJobs).renewLease("job-1", "lease-1");
     verify(reconcileJobs).getLeaseView("job-1");
     assertEquals(AUTHORITY_ID, response.getAuthorityId());
+  }
+
+  @Test
+  void executionBoundRequestSelectsLongestAuthorityMatchingRequestedLocation() {
+    StorageAuthority dataAuthority =
+        currentAuthority().toBuilder()
+            .setResourceId(DATARBRICKS_AUTHORITY_ID)
+            .setLocationPrefix("s3://warehouse/orders/data/")
+            .build();
+    when(repo.list(eq("acct"), anyInt(), any(), any()))
+        .thenReturn(java.util.List.of(currentAuthority(), dataAuthority));
+
+    ResolveStorageAuthorityResponse response =
+        service
+            .vendStorageCredentials(
+                VendStorageCredentialsRequest.newBuilder()
+                    .setAccountId("acct")
+                    .setLocationPrefix("s3://warehouse/orders/data/part-000.parquet")
+                    .setUsage(StorageCredentialUsage.SCU_SERVER)
+                    .setExecutionBinding(
+                        ai.floedb.floecat.storage.rpc.ExecutionBinding.newBuilder()
+                            .setReconcileLease(
+                                ai.floedb.floecat.storage.rpc.ReconcileLeaseBinding.newBuilder()
+                                    .setJobId("job-1")
+                                    .setLeaseEpoch("lease-1")))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(DATARBRICKS_AUTHORITY_ID, response.getAuthorityId());
+    assertEquals("s3://warehouse/orders/data/", response.getStorageCredentials(0).getPrefix());
+  }
+
+  @Test
+  void executionBoundParentRequestRemainsPinnedToLeasedTableLocation() {
+    StorageAuthority bucketAuthority =
+        currentAuthority().toBuilder()
+            .setResourceId(DATARBRICKS_AUTHORITY_ID)
+            .setLocationPrefix("s3://warehouse/")
+            .build();
+    when(repo.list(eq("acct"), anyInt(), any(), any()))
+        .thenReturn(java.util.List.of(bucketAuthority, currentAuthority()));
+
+    ResolveStorageAuthorityResponse response =
+        service
+            .vendStorageCredentials(
+                VendStorageCredentialsRequest.newBuilder()
+                    .setAccountId("acct")
+                    .setLocationPrefix("s3://warehouse")
+                    .setUsage(StorageCredentialUsage.SCU_SERVER)
+                    .setExecutionBinding(
+                        ai.floedb.floecat.storage.rpc.ExecutionBinding.newBuilder()
+                            .setReconcileLease(
+                                ai.floedb.floecat.storage.rpc.ReconcileLeaseBinding.newBuilder()
+                                    .setJobId("job-1")
+                                    .setLeaseEpoch("lease-1")))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(AUTHORITY_ID, response.getAuthorityId());
+    assertEquals("s3://warehouse/orders", response.getStorageCredentials(0).getPrefix());
   }
 
   @Test
@@ -921,12 +1073,82 @@ class StorageAuthorityServiceImplTest {
     assertTrue(
         ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus
             .isNoMatchingStorageAuthority(error));
-    // ...but source-catalog vending is deliberately NOT consulted. This request carries an
-    // exact-object scope, and a delegating catalog mints its own table-scoped credentials that we
-    // hold no role to narrow -- answering a single-file request with table-wide access. Failing
-    // with the missing-authority error is the honest answer. This assertion previously required
-    // the opposite, pinning exactly that widening as intended.
+    // Source-catalog vending is deliberately not consulted. Exact leased-file membership
+    // authorizes the request, but an upstream catalog chooses its own credential scope and Floecat
+    // must not reinterpret table-scoped credentials as a single-file grant.
     verify(connectorRepo, never()).getById(CONNECTOR_ID);
+  }
+
+  @Test
+  void icebergExternalLeasedFileUsesMatchingAuthorityPrefix() {
+    String externalFile = "s3://elsewhere/registered/part-000.parquet";
+    StorageAuthority externalAuthority =
+        currentAuthority().toBuilder().setLocationPrefix("s3://elsewhere/").build();
+    when(repo.list(eq("acct"), anyInt(), any(), any()))
+        .thenReturn(java.util.List.of(externalAuthority));
+    when(reconcileJobs.getLeaseView("job-1"))
+        .thenReturn(
+            Optional.of(
+                activeLeaseView("job-1", "acct", "JS_RUNNING", java.util.List.of(externalFile))));
+
+    ResolveStorageAuthorityResponse response =
+        service
+            .vendStorageCredentials(
+                VendStorageCredentialsRequest.newBuilder()
+                    .setAccountId("acct")
+                    .setLocationPrefix(externalFile)
+                    .setUsage(StorageCredentialUsage.SCU_SERVER)
+                    .setExecutionBinding(
+                        ai.floedb.floecat.storage.rpc.ExecutionBinding.newBuilder()
+                            .setReconcileLease(
+                                ai.floedb.floecat.storage.rpc.ReconcileLeaseBinding.newBuilder()
+                                    .setJobId("job-1")
+                                    .setLeaseEpoch("lease-1")))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(AUTHORITY_ID, response.getAuthorityId());
+    assertEquals("s3://elsewhere/", response.getStorageCredentials(0).getPrefix());
+  }
+
+  @Test
+  void deltaDeletionVectorSiblingUsesBucketAuthorityPrefix() {
+    String deletionVector =
+        "s3://floedb-databricks-metastore-367509577365/metastore/metastore-id/tables/deletion_vector_uuid.bin";
+    StorageAuthority databricksAuthority =
+        currentAuthority().toBuilder()
+            .setResourceId(DATARBRICKS_AUTHORITY_ID)
+            .setLocationPrefix("s3://floedb-databricks-metastore-367509577365/")
+            .build();
+    when(repo.list(eq("acct"), anyInt(), any(), any()))
+        .thenReturn(java.util.List.of(databricksAuthority));
+    when(reconcileJobs.getLeaseView("job-1"))
+        .thenReturn(
+            Optional.of(
+                activeLeaseView("job-1", "acct", "JS_RUNNING", java.util.List.of(deletionVector))));
+
+    ResolveStorageAuthorityResponse response =
+        service
+            .vendStorageCredentials(
+                VendStorageCredentialsRequest.newBuilder()
+                    .setAccountId("acct")
+                    .setLocationPrefix(deletionVector)
+                    .setUsage(StorageCredentialUsage.SCU_SERVER)
+                    .setExecutionBinding(
+                        ai.floedb.floecat.storage.rpc.ExecutionBinding.newBuilder()
+                            .setReconcileLease(
+                                ai.floedb.floecat.storage.rpc.ReconcileLeaseBinding.newBuilder()
+                                    .setJobId("job-1")
+                                    .setLeaseEpoch("lease-1")))
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(DATARBRICKS_AUTHORITY_ID, response.getAuthorityId());
+    assertEquals(
+        "s3://floedb-databricks-metastore-367509577365/",
+        response.getStorageCredentials(0).getPrefix());
   }
 
   /**
@@ -1167,8 +1389,6 @@ class StorageAuthorityServiceImplTest {
 
   @Test
   void resolveForAccountLocationFailsForNoAuthority() {
-    when(repo.list(eq("acct"), anyInt(), any(), any())).thenReturn(java.util.List.of());
-
     var ex =
         assertThrows(
             StatusRuntimeException.class,
@@ -1177,7 +1397,7 @@ class StorageAuthorityServiceImplTest {
                     .vendStorageCredentials(
                         VendStorageCredentialsRequest.newBuilder()
                             .setAccountId("acct")
-                            .setLocationPrefix("s3://warehouse/orders/data/part-000.parquet")
+                            .setLocationPrefix("s3://elsewhere/data/part-000.parquet")
                             .setUsage(StorageCredentialUsage.SCU_SERVER)
                             .build())
                     .await()
@@ -1340,9 +1560,7 @@ class StorageAuthorityServiceImplTest {
     IllegalArgumentException ex =
         assertThrows(
             IllegalArgumentException.class,
-            () ->
-                resolver.mintTemporaryCredentials(
-                    authority, temporaryCredentials, java.util.List.of("s3://warehouse/orders")));
+            () -> resolver.mintTemporaryCredentials(authority, temporaryCredentials));
 
     assertTrue(ex.getMessage().contains("known expiry"));
   }
@@ -1387,6 +1605,18 @@ class StorageAuthorityServiceImplTest {
     assertEquals("renamed", response.getAuthority().getDisplayName());
     assertEquals("s3://warehouse/renamed", response.getAuthority().getLocationPrefix());
     assertEquals("us-east-2", response.getAuthority().getRegion());
+  }
+
+  private ResolveStorageAuthorityResponse vendServerCredentialsForTable(ResourceId tableId) {
+    return service
+        .vendStorageCredentials(
+            VendStorageCredentialsRequest.newBuilder()
+                .setAccountId("acct")
+                .setTableId(tableId)
+                .setUsage(StorageCredentialUsage.SCU_SERVER)
+                .build())
+        .await()
+        .indefinitely();
   }
 
   private static StorageAuthority currentAuthority() {


### PR DESCRIPTION
## Summary

Usually a Storage Authority is created with permissions defined at the bucket-level. However, the code aggressively tries to scope the policy of the vended credential down further to the root of the table being accessed. 

The issue is that this fails for delta tables that have deletion vectors. For example, the scoped session policy becomes:

``
{
  "Action": ["s3:ListBucket"],
  "Resource": "arn:aws:s3:::floedb-databricks-metastore-367509577365",
  "Condition": {
    "StringLike": {
      "s3:prefix": [
        "metastore/.../tables/<table-uuid>",
        "metastore/.../tables/<table-uuid>/*"
      ]
    }
  }
}
``

The problem is that delta table lay deletion vectors out in:

``
metastore/.../tables/deletion_vector_<uuid>.bin
``

This is outside of the scope that a reconciler or worker is allowed to read, because the storage auth code deliberately narrowed the scope.

The fix is to remove the scope narrowing and to scope the validity of the vended credentials at exactly the S3 bucket location/prefix defined in the storage-authority definition.

An unrealated fix to the `storage-authorities` command is also made in this PR.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
