### PR TITLE
iceberg: skip variant column bounds instead of failing planning

### DIFF
--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergPlanner.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergPlanner.java
@@ -273,7 +273,7 @@ final class IcebergPlanner implements Planner<Integer> {
     return prefix + ":" + (effectiveSequence == null ? "" : effectiveSequence) + ":" + recordCount;
   }
 
-  private Map<Integer, Object> decodeBounds(Map<Integer, ByteBuffer> raw) {
+  Map<Integer, Object> decodeBounds(Map<Integer, ByteBuffer> raw) {
     if (raw == null || raw.isEmpty()) {
       return null;
     }
@@ -297,7 +297,13 @@ final class IcebergPlanner implements Planner<Integer> {
           dup.get(bytes);
           decoded = new String(bytes, StandardCharsets.UTF_8);
         }
-      } catch (IllegalArgumentException | BufferUnderflowException e) {
+      } catch (IllegalArgumentException
+          | BufferUnderflowException
+          | UnsupportedOperationException e) {
+        // UnsupportedOperationException covers bound types Conversions cannot decode.
+        // Iceberg v3 variant bounds are the known case: the spec stores them as a
+        // serialized Variant keyed by normalized JSON path, which Conversions (a
+        // primitives-only decoder) rejects. Drop the stat rather than fail planning.
         logSkippedBound(id, type, e.getClass().getSimpleName() + ": " + e.getMessage());
         continue;
       }

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergPlannerTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergPlannerTest.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.connector.iceberg.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Proxy;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -145,5 +146,75 @@ class IcebergPlannerTest {
             Types.TimestampNanoType.withZone(), 1_735_734_896_123_456_789L);
 
     assertThat(canonical).isEqualTo(Instant.parse("2025-01-01T12:34:56.123456789Z"));
+  }
+
+  @Test
+  void decodeBoundsSkipsVariantBoundsAndKeepsPrimitives() {
+    // Iceberg v3 stores variant bounds as a serialized Variant keyed by normalized
+    // JSON path, which Conversions (primitives only) rejects with
+    // UnsupportedOperationException. Planning must drop the stat, not fail.
+    // Payload below is a real DuckDB-written lower bound: root path '$' -> "apple".
+    byte[] variantBound = {
+      0x11, 0x01, 0x00, 0x01, '$', 0x02, 0x01, 0x00, 0x00, 0x06, 0x15, 'a', 'p', 'p', 'l', 'e'
+    };
+
+    Schema schema =
+        new Schema(
+            1,
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "var", Types.VariantType.get()));
+    Table table = tableWithSchema(schema, 1);
+
+    try (IcebergPlanner planner =
+        new IcebergPlanner(table, 1L, Set.of(1, 2), Set.of(), null, false)) {
+      Map<Integer, Object> decoded =
+          planner.decodeBounds(
+              Map.of(
+                  1, ByteBuffer.wrap(new byte[] {0x2A, 0x00, 0x00, 0x00}),
+                  2, ByteBuffer.wrap(variantBound)));
+
+      // int bounds are widened to long by LogicalCoercions.coerceStatValue
+      assertThat(decoded).containsEntry(1, 42L).doesNotContainKey(2);
+    }
+  }
+
+  @Test
+  void decodeBoundsReturnsNullWhenOnlyVariantBoundsArePresent() {
+    byte[] variantBound = {
+      0x11, 0x01, 0x00, 0x01, '$', 0x02, 0x01, 0x00, 0x00, 0x06, 0x15, 'a', 'p', 'p', 'l', 'e'
+    };
+
+    Schema schema = new Schema(1, Types.NestedField.optional(2, "var", Types.VariantType.get()));
+    Table table = tableWithSchema(schema, 1);
+
+    try (IcebergPlanner planner = new IcebergPlanner(table, 1L, Set.of(2), Set.of(), null, false)) {
+      assertThat(planner.decodeBounds(Map.of(2, ByteBuffer.wrap(variantBound)))).isNull();
+    }
+  }
+
+  private static Table tableWithSchema(Schema schema, int schemaId) {
+    Snapshot snapshot =
+        (Snapshot)
+            Proxy.newProxyInstance(
+                Snapshot.class.getClassLoader(),
+                new Class<?>[] {Snapshot.class},
+                (proxy, method, args) ->
+                    switch (method.getName()) {
+                      case "schemaId" -> schemaId;
+                      default -> throw new UnsupportedOperationException(method.getName());
+                    });
+    return (Table)
+        Proxy.newProxyInstance(
+            Table.class.getClassLoader(),
+            new Class<?>[] {Table.class},
+            (proxy, method, args) ->
+                switch (method.getName()) {
+                  case "snapshot" -> snapshot;
+                  case "schema" -> schema;
+                  case "schemas" -> Map.of(schemaId, schema);
+                  case "specs" -> Map.of();
+                  case "spec" -> null;
+                  default -> throw new UnsupportedOperationException(method.getName());
+                });
   }
 }


### PR DESCRIPTION
`IcebergPlanner.decodeBounds` decodes every manifest bound through `Conversions.fromByteBuffer`, which only handles primitives. Iceberg v3 stores a `variant` bound as a serialized Variant keyed by normalized JSON path, so `Conversions` throws `UnsupportedOperationException` on it.

`decodeBounds` already intends to skip bounds it cannot decode, but its catch listed only `IllegalArgumentException | BufferUnderflowException` — and `UnsupportedOperationException` is a subclass of neither. The exception escaped and failed the entire `PLAN_TABLE` reconcile job:

```
RuntimeException: Iceberg planning failed (snapshot 4020003771620410424)
  | caused by: UnsupportedOperationException: Cannot deserialize type: variant
	at org.apache.iceberg.types.Conversions.internalFromByteBuffer(Conversions.java:181)
	at ai.floedb.floecat.connector.iceberg.impl.IcebergPlanner.decodeBounds(IcebergPlanner.java:266)
	at ai.floedb.floecat.connector.iceberg.impl.IcebergPlanner.toPlanned(IcebergPlanner.java:224)
```

## Change

Add `UnsupportedOperationException` to the existing catch so the bound takes the `logSkippedBound` path. A variant bound carries no pruning information Floecat can use today, so dropping it costs nothing — whereas failing loses the whole table's planning.

`decodeBounds` becomes package-private so the test can call it directly, matching how `canonicalizeDecodedBound` is already exposed to `IcebergPlannerTest`.

## Not a producer bug

DuckDB writes these bounds deliberately (duckdb/duckdb-iceberg#1050) and conformantly: the v3 spec defines variant bounds as a serialized Variant keyed by normalized JSON path ([spec: Bounds for Variant](https://github.com/apache/iceberg/blob/main/format/spec.md#bounds-for-variant)). Observed payload for `variant_tests.variant_array_array_string` (schema `1: id int`, `2: var variant`):

```
lower_bounds: {2: b'\x11\x01\x00\x01$\x02\x01\x00\x00\x06\x15apple', 1: b'\x01\x00\x00\x00'}
```

Field 2's object key is `$` — the spec's normalized path for a variant root of uniform primitive type. No `write.metadata.metrics.*` table property suppresses them (verified), and Iceberg Java decodes variant bounds on a separate path (`InclusiveMetricsEvaluator.parseBounds`), not through `Conversions` — so no Iceberg upgrade makes this work either. apache/iceberg#15384 is the in-flight upstream work.

Proper variant-bound decoding is tracked in eng-floe/core#2289.

## Tests

Two additions to `IcebergPlannerTest`, using the real DuckDB payload above:

- `decodeBoundsSkipsVariantBoundsAndKeepsPrimitives` — variant bound dropped, the sibling int bound still decoded
- `decodeBoundsReturnsNullWhenOnlyVariantBoundsArePresent`

Module suite: **98 passed**, `mvn fmt:check` clean.

End-to-end, with the companion floescan fix (eng-floe/iceberg-rust `skip-non-primitive-bounds`), `integration/tests/sql/variant` passes **1062 tests** (3 pre-existing skips, #1922) against tables carrying real DuckDB variant bounds.

## Note for the core submodule bump

This branch is based on `main`. core currently pins `1532bab6f`, whose sha is not an ancestor of `main` — core pinned the pre-merge commit from `origin/jho-nested-stable` and was never re-pinned after it landed. The work itself *is* on `main` as `3bab135b2` (identical patch-id `168fb622`), so bumping core to a `main`-based commit loses nothing; it just also picks up the 18 commits `main` has gained since. This is what `validate-floecat-submodule` warns about in core CI.
