### PR TITLE
reconciler: stamp jobs with the current ready-index version

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -492,7 +492,10 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
                 Long.class)
             .orElse(60_000L));
     projectionMaintenanceService.bind(
-        pointerStore, this::refreshProjectedParentAndAdvance, readyScanLimit);
+        pointerStore,
+        this::refreshProjectedParentAndAdvance,
+        Keys.reconcileDirtyParentPointerPrefix(workerAffinity.value()),
+        readyScanLimit);
     return projectionMaintenanceService;
   }
 
@@ -4232,7 +4235,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     if (effectiveAccountId.isBlank() || effectiveParentJobId.isBlank()) {
       return null;
     }
-    String key = Keys.reconcileDirtyParentPointer(effectiveAccountId, effectiveParentJobId);
+    String key =
+        Keys.reconcileDirtyParentPointer(
+            workerAffinity.value(), effectiveAccountId, effectiveParentJobId);
     long generation = System.currentTimeMillis();
     long markerToken = ThreadLocalRandom.current().nextLong(1L, Long.MAX_VALUE);
     String payload =

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/model/StoredReconcileJob.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/model/StoredReconcileJob.java
@@ -23,6 +23,8 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import java.util.Map;
 
 public class StoredReconcileJob {
+  public static final int CURRENT_READY_INDEX_VERSION = 2;
+
   public String jobId;
   public String accountId;
   public String connectorId;
@@ -125,6 +127,7 @@ public class StoredReconcileJob {
   public String laneKey;
   public String dedupeKeyHash;
   public String readyPointerKey;
+  public int readyIndexVersion;
   public String connectorIndexPointerKey;
   public String canonicalPointerKey;
   public long createdAtMs;

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileJobEnqueuer.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileJobEnqueuer.java
@@ -519,6 +519,7 @@ public class ReconcileJobEnqueuer {
     rec.laneKey = laneKey;
     rec.dedupeKeyHash = dedupeKeyHash;
     rec.readyPointerKey = readyPointerKey;
+    rec.readyIndexVersion = StoredReconcileJob.CURRENT_READY_INDEX_VERSION;
     rec.connectorIndexPointerKey = connectorIndexPointerKey;
     rec.createdAtMs = now;
     rec.updatedAtMs = now;

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileProjectionMaintenanceService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileProjectionMaintenanceService.java
@@ -143,8 +143,7 @@ public class ReconcileProjectionMaintenanceService {
       }
       StringBuilder next = new StringBuilder();
       List<Pointer> pointers =
-          pointerStore.listPointersByPrefix(
-              dirtyParentPointerPrefix, readyScanLimit, token, next);
+          pointerStore.listPointersByPrefix(dirtyParentPointerPrefix, readyScanLimit, token, next);
       if (pointers.isEmpty()) {
         dirtyParentScanToken = "";
         return new DirtyParentStats(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileProjectionMaintenanceService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileProjectionMaintenanceService.java
@@ -17,7 +17,6 @@
 package ai.floedb.floecat.service.reconciler.jobs.durable.queue;
 
 import ai.floedb.floecat.common.rpc.Pointer;
-import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -48,6 +47,7 @@ public class ReconcileProjectionMaintenanceService {
 
   private PointerStore pointerStore;
   private RefreshDirtyParentProjection refreshDirtyParentProjection;
+  private String dirtyParentPointerPrefix;
   private int readyScanLimit;
   private int maxMarkersPerTick = Integer.MAX_VALUE;
 
@@ -61,9 +61,14 @@ public class ReconcileProjectionMaintenanceService {
   public void bind(
       PointerStore pointerStore,
       RefreshDirtyParentProjection refreshDirtyParentProjection,
+      String dirtyParentPointerPrefix,
       int readyScanLimit) {
     this.pointerStore = pointerStore;
     this.refreshDirtyParentProjection = refreshDirtyParentProjection;
+    if (dirtyParentPointerPrefix == null || dirtyParentPointerPrefix.isBlank()) {
+      throw new IllegalArgumentException("dirtyParentPointerPrefix is required");
+    }
+    this.dirtyParentPointerPrefix = dirtyParentPointerPrefix;
     this.readyScanLimit = readyScanLimit;
   }
 
@@ -139,7 +144,7 @@ public class ReconcileProjectionMaintenanceService {
       StringBuilder next = new StringBuilder();
       List<Pointer> pointers =
           pointerStore.listPointersByPrefix(
-              Keys.reconcileDirtyParentPointerPrefix(), readyScanLimit, token, next);
+              dirtyParentPointerPrefix, readyScanLimit, token, next);
       if (pointers.isEmpty()) {
         dirtyParentScanToken = "";
         return new DirtyParentStats(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileJobIndexStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileJobIndexStore.java
@@ -971,6 +971,7 @@ public class NativeReconcileJobIndexStore implements ReconcileJobIndexStore {
     copy.laneKey = source.laneKey;
     copy.dedupeKeyHash = source.dedupeKeyHash;
     copy.readyPointerKey = source.readyPointerKey;
+    copy.readyIndexVersion = source.readyIndexVersion;
     copy.connectorIndexPointerKey = source.connectorIndexPointerKey;
     copy.canonicalPointerKey = source.canonicalPointerKey;
     copy.createdAtMs = source.createdAtMs;

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -1104,14 +1104,24 @@ public final class Keys {
         + String.format("%019d", sid);
   }
 
-  public static String reconcileDirtyParentPointerPrefix() {
-    return "/accounts/by-id/reconcile/jobs/dirty-parents/";
+  public static String reconcileDirtyParentPointerRootPrefix() {
+    // This namespace deliberately does not descend from the legacy "dirty-parents/" prefix.
+    // Older deployments scan that entire prefix and delete markers whose payload schema they do
+    // not understand.
+    return "/accounts/by-id/reconcile/jobs/dirty-parents-by-worker-affinity/";
   }
 
-  public static String reconcileDirtyParentPointer(String accountId, String parentJobId) {
+  public static String reconcileDirtyParentPointerPrefix(String workerAffinity) {
+    String affinity = req("worker_affinity", workerAffinity);
+    return reconcileDirtyParentPointerRootPrefix() + encode(affinity) + "/";
+  }
+
+  public static String reconcileDirtyParentPointer(
+      String workerAffinity, String accountId, String parentJobId) {
+    String affinity = req("worker_affinity", workerAffinity);
     String tid = req("account_id", accountId);
     String pid = req("parent_job_id", parentJobId);
-    return reconcileDirtyParentPointerPrefix() + encode(tid) + "/" + encode(pid);
+    return reconcileDirtyParentPointerPrefix(affinity) + encode(tid) + "/" + encode(pid);
   }
 
   public static String reconcileCancellationCleanupPointerPrefix() {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -1246,11 +1246,7 @@ class DurableReconcileJobStoreTest {
     StoredReconcileJob parentRecord =
         readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, connectorJobId));
     assertEquals(1L, parentRecord.expectedDirectChildren);
-    assertTrue(
-        store
-            .pointerStore
-            .get(dirtyParentKey(ACCOUNT_ID, connectorJobId))
-            .isPresent());
+    assertTrue(store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, connectorJobId)).isPresent());
     assertEquals("JS_WAITING", parentRecord.state);
     assertEquals(1, store.childJobs(ACCOUNT_ID, connectorJobId).size());
   }
@@ -2052,11 +2048,7 @@ class DurableReconcileJobStoreTest {
 
     assertEquals("JS_SUCCEEDED", tableCanonical.state);
     assertEquals("JS_WAITING", connectorCanonical.state);
-    assertTrue(
-        store
-            .pointerStore
-            .get(dirtyParentKey(ACCOUNT_ID, connectorJobId))
-            .isPresent());
+    assertTrue(store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, connectorJobId)).isPresent());
   }
 
   @Test
@@ -2646,11 +2638,7 @@ class DurableReconcileJobStoreTest {
 
     assertEquals(tableGenerationBefore, tableAfterProgress.projectionRequestedGeneration);
     assertEquals(connectorGenerationBefore, connectorAfterProgress.projectionRequestedGeneration);
-    assertTrue(
-        store
-            .pointerStore
-            .get(dirtyParentKey(ACCOUNT_ID, tableJobId))
-            .isPresent());
+    assertTrue(store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, tableJobId)).isPresent());
 
     runProjectionMaintenance(4);
 
@@ -2701,11 +2689,7 @@ class DurableReconcileJobStoreTest {
     store.markRunning(tableJobId, tableLease.leaseEpoch, 100L, "executor-table");
     store.markProgress(tableJobId, tableLease.leaseEpoch, 0L, 0L, 0L, 0L, 0L, 1L, 0L, "progress");
     runProjectionMaintenance(4);
-    assertTrue(
-        store
-            .pointerStore
-            .get(dirtyParentKey(ACCOUNT_ID, connectorJobId))
-            .isEmpty());
+    assertTrue(store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, connectorJobId)).isEmpty());
     assertEquals(
         1L, projectionStore().load(ACCOUNT_ID, connectorJobId).orElseThrow().snapshotsProcessed());
 
@@ -3514,9 +3498,7 @@ class DurableReconcileJobStoreTest {
         readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, parentJobId));
     assertEquals(before.projectionRequestedGeneration, after.projectionRequestedGeneration);
     assertEquals(before.expectedDirectChildren, after.expectedDirectChildren);
-    assertEquals(
-        markerBefore,
-        store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, parentJobId)));
+    assertEquals(markerBefore, store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, parentJobId)));
   }
 
   @Test
@@ -4968,11 +4950,7 @@ class DurableReconcileJobStoreTest {
     var execLease = leaseJob(execJobId);
     store.markRunning(execJobId, execLease.leaseEpoch, 150L, "executor-exec");
     store.pointerStore.delete(dirtyParentKey(ACCOUNT_ID, snapshotJobId));
-    assertTrue(
-        store
-            .pointerStore
-            .get(dirtyParentKey(ACCOUNT_ID, snapshotJobId))
-            .isEmpty());
+    assertTrue(store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, snapshotJobId)).isEmpty());
     persistFileGroupResult(
         store,
         execJobId,
@@ -4989,11 +4967,7 @@ class DurableReconcileJobStoreTest {
                     2L,
                     ReconcileIndexArtifactResult.of("s3://bucket/index/file-1.idx", "parquet", 1)),
                 ReconcileFileResult.succeeded("s3://bucket/data/file-2.parquet", 3L))));
-    assertTrue(
-        store
-            .pointerStore
-            .get(dirtyParentKey(ACCOUNT_ID, snapshotJobId))
-            .isPresent());
+    assertTrue(store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, snapshotJobId)).isPresent());
     runProjectionMaintenance();
 
     StoredReconcileJobProjection snapshotProjection =
@@ -5164,11 +5138,7 @@ class DurableReconcileJobStoreTest {
             "",
             "");
 
-    assertTrue(
-        store
-            .pointerStore
-            .get(dirtyParentKey(ACCOUNT_ID, snapshotJobId))
-            .isEmpty());
+    assertTrue(store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, snapshotJobId)).isEmpty());
   }
 
   @Test
@@ -7821,8 +7791,7 @@ class DurableReconcileJobStoreTest {
           && ops.stream()
               .filter(UnconditionalUpsert.class::isInstance)
               .map(UnconditionalUpsert.class::cast)
-              .anyMatch(
-                  upsert -> upsert.key().startsWith(dirtyParentPrefix()))) {
+              .anyMatch(upsert -> upsert.key().startsWith(dirtyParentPrefix()))) {
         return false;
       }
       return delegate.compareAndSetBatch(ops);

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -798,6 +798,7 @@ class DurableReconcileJobStoreTest {
         firstPredecessor,
         store.get(ACCOUNT_ID, jobId).orElseThrow().snapshotTask.indexPredecessor());
     StoredReconcileJob stored = readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, jobId));
+    assertEquals(StoredReconcileJob.CURRENT_READY_INDEX_VERSION, stored.readyIndexVersion);
     assertTrue(stored.snapshotTaskIndexPredecessorPresent);
     assertFalse(stored.snapshotTaskIndexPredecessorPinPending);
     assertEquals(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -122,6 +122,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 class DurableReconcileJobStoreTest {
   private static final String ACCOUNT_ID = "acct-1";
   private static final String CONNECTOR_ID = "conn-1";
+  private static final String WORKER_AFFINITY = "reconciler-v1";
 
   private static DynamoDbClient sharedDynamoDbClient;
   private static DynamoDbAsyncClient sharedDynamoDbAsyncClient;
@@ -1248,7 +1249,7 @@ class DurableReconcileJobStoreTest {
     assertTrue(
         store
             .pointerStore
-            .get(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, connectorJobId))
+            .get(dirtyParentKey(ACCOUNT_ID, connectorJobId))
             .isPresent());
     assertEquals("JS_WAITING", parentRecord.state);
     assertEquals(1, store.childJobs(ACCOUNT_ID, connectorJobId).size());
@@ -2054,7 +2055,7 @@ class DurableReconcileJobStoreTest {
     assertTrue(
         store
             .pointerStore
-            .get(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, connectorJobId))
+            .get(dirtyParentKey(ACCOUNT_ID, connectorJobId))
             .isPresent());
   }
 
@@ -2648,7 +2649,7 @@ class DurableReconcileJobStoreTest {
     assertTrue(
         store
             .pointerStore
-            .get(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, tableJobId))
+            .get(dirtyParentKey(ACCOUNT_ID, tableJobId))
             .isPresent());
 
     runProjectionMaintenance(4);
@@ -2703,7 +2704,7 @@ class DurableReconcileJobStoreTest {
     assertTrue(
         store
             .pointerStore
-            .get(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, connectorJobId))
+            .get(dirtyParentKey(ACCOUNT_ID, connectorJobId))
             .isEmpty());
     assertEquals(
         1L, projectionStore().load(ACCOUNT_ID, connectorJobId).orElseThrow().snapshotsProcessed());
@@ -3452,7 +3453,7 @@ class DurableReconcileJobStoreTest {
   @Test
   void projectionMaintenanceDeletesMarkerForMissingParent() {
     String missingParentJobId = "missing-parent";
-    String dirtyMarkerKey = Keys.reconcileDirtyParentPointer(ACCOUNT_ID, missingParentJobId);
+    String dirtyMarkerKey = dirtyParentKey(ACCOUNT_ID, missingParentJobId);
 
     requestProjectionRefresh(missingParentJobId);
     assertTrue(store.pointerStore.get(dirtyMarkerKey).isPresent());
@@ -3469,7 +3470,7 @@ class DurableReconcileJobStoreTest {
             false,
             CaptureMode.METADATA_AND_CAPTURE,
             ReconcileScope.empty());
-    String markerKey = Keys.reconcileDirtyParentPointer(ACCOUNT_ID, parentJobId);
+    String markerKey = dirtyParentKey(ACCOUNT_ID, parentJobId);
 
     requestProjectionRefresh(parentJobId);
     Pointer first = store.pointerStore.get(markerKey).orElseThrow();
@@ -3493,7 +3494,7 @@ class DurableReconcileJobStoreTest {
     StoredReconcileJob before =
         readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, parentJobId));
     Optional<Pointer> markerBefore =
-        store.pointerStore.get(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, parentJobId));
+        store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, parentJobId));
     PointerStore originalPointerStore = store.pointerStore;
     store.pointerStore = new DirtyParentFailingPointerStore(originalPointerStore);
 
@@ -3515,7 +3516,7 @@ class DurableReconcileJobStoreTest {
     assertEquals(before.expectedDirectChildren, after.expectedDirectChildren);
     assertEquals(
         markerBefore,
-        store.pointerStore.get(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, parentJobId)));
+        store.pointerStore.get(dirtyParentKey(ACCOUNT_ID, parentJobId)));
   }
 
   @Test
@@ -4966,11 +4967,11 @@ class DurableReconcileJobStoreTest {
 
     var execLease = leaseJob(execJobId);
     store.markRunning(execJobId, execLease.leaseEpoch, 150L, "executor-exec");
-    store.pointerStore.delete(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, snapshotJobId));
+    store.pointerStore.delete(dirtyParentKey(ACCOUNT_ID, snapshotJobId));
     assertTrue(
         store
             .pointerStore
-            .get(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, snapshotJobId))
+            .get(dirtyParentKey(ACCOUNT_ID, snapshotJobId))
             .isEmpty());
     persistFileGroupResult(
         store,
@@ -4991,7 +4992,7 @@ class DurableReconcileJobStoreTest {
     assertTrue(
         store
             .pointerStore
-            .get(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, snapshotJobId))
+            .get(dirtyParentKey(ACCOUNT_ID, snapshotJobId))
             .isPresent());
     runProjectionMaintenance();
 
@@ -5166,7 +5167,7 @@ class DurableReconcileJobStoreTest {
     assertTrue(
         store
             .pointerStore
-            .get(Keys.reconcileDirtyParentPointer(ACCOUNT_ID, snapshotJobId))
+            .get(dirtyParentKey(ACCOUNT_ID, snapshotJobId))
             .isEmpty());
   }
 
@@ -7651,6 +7652,14 @@ class DurableReconcileJobStoreTest {
                 parentJobId));
   }
 
+  private static String dirtyParentKey(String accountId, String parentJobId) {
+    return Keys.reconcileDirtyParentPointer(WORKER_AFFINITY, accountId, parentJobId);
+  }
+
+  private static String dirtyParentPrefix() {
+    return Keys.reconcileDirtyParentPointerPrefix(WORKER_AFFINITY);
+  }
+
   private StoredReconcileJob readStoredRecord(String canonicalPointerKey) {
     return assertDoesNotThrow(
             () -> store.jobIndexStore.readCanonicalRecordByKey(canonicalPointerKey))
@@ -7790,7 +7799,7 @@ class DurableReconcileJobStoreTest {
 
     @Override
     public boolean compareAndSet(String key, long expectedVersion, Pointer next) {
-      if (key != null && key.startsWith(Keys.reconcileDirtyParentPointerPrefix())) {
+      if (key != null && key.startsWith(dirtyParentPrefix())) {
         return false;
       }
       return delegate.compareAndSet(key, expectedVersion, next);
@@ -7813,7 +7822,7 @@ class DurableReconcileJobStoreTest {
               .filter(UnconditionalUpsert.class::isInstance)
               .map(UnconditionalUpsert.class::cast)
               .anyMatch(
-                  upsert -> upsert.key().startsWith(Keys.reconcileDirtyParentPointerPrefix()))) {
+                  upsert -> upsert.key().startsWith(dirtyParentPrefix()))) {
         return false;
       }
       return delegate.compareAndSetBatch(ops);

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
@@ -48,6 +48,43 @@ import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.Test;
 
 class ReconcileMaintenanceServicesTest {
+  private static final String WORKER_AFFINITY = "reconciler-v1";
+  private static final String DIRTY_PARENT_PREFIX =
+      Keys.reconcileDirtyParentPointerPrefix(WORKER_AFFINITY);
+
+  @Test
+  void projectionMaintenanceOnlyConsumesItsWorkerAffinityNamespace() {
+    PointerStore pointerStore = new TestPointerStore();
+    ReconcileProjectionMaintenanceService service = new ReconcileProjectionMaintenanceService();
+    List<String> refreshed = new ArrayList<>();
+    putDirtyMarker(pointerStore, WORKER_AFFINITY, "acct", "owned-parent", 1L, 0L);
+    putDirtyMarker(pointerStore, "reconciler-v2", "acct", "other-parent", 1L, 0L);
+    String legacyKey = "/accounts/by-id/reconcile/jobs/dirty-parents/acct/legacy-parent";
+    pointerStore.compareAndSet(
+        legacyKey,
+        0L,
+        PointerReferences.opaqueMarkerPointer(
+            legacyKey, "acct\nlegacy-parent", 1L));
+
+    service.bind(
+        pointerStore,
+        (accountId, parentJobId, generation, markerKey, markerVersion) -> {
+          refreshed.add(parentJobId);
+          return RefreshResult.OBSOLETE;
+        },
+        DIRTY_PARENT_PREFIX,
+        10);
+
+    service.runProjectionMaintenanceOnce(200L);
+
+    assertEquals(List.of("owned-parent"), refreshed);
+    assertTrue(pointerStore.get(legacyKey).isPresent());
+    assertTrue(
+        pointerStore
+            .get(dirtyParentKey("reconciler-v2", "acct", "other-parent"))
+            .isPresent());
+  }
+
   @Test
   void refreshDirtyParentsAdvancesPaginationTokenUnderChurn() {
     PointerStore pointerStore = new TestPointerStore();
@@ -68,6 +105,7 @@ class ReconcileMaintenanceServicesTest {
           }
           return RefreshResult.OBSOLETE;
         },
+        DIRTY_PARENT_PREFIX,
         1);
 
     service.runProjectionMaintenanceOnce(200L);
@@ -101,6 +139,7 @@ class ReconcileMaintenanceServicesTest {
           }
           return RefreshResult.OBSOLETE;
         },
+        DIRTY_PARENT_PREFIX,
         1);
 
     service.runProjectionMaintenanceOnce(1L);
@@ -136,13 +175,14 @@ class ReconcileMaintenanceServicesTest {
           events.add("refresh:" + parentJobId);
           return RefreshResult.OBSOLETE;
         },
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(200L);
 
     assertTrue(events.size() == 1);
     assertTrue("refresh:parent".equals(events.get(0)));
-    assertTrue(pointerStore.get(Keys.reconcileDirtyParentPointer("acct", "parent")).isEmpty());
+    assertTrue(pointerStore.get(dirtyParentKey("acct", "parent")).isEmpty());
   }
 
   @Test
@@ -156,13 +196,14 @@ class ReconcileMaintenanceServicesTest {
     service.bind(
         pointerStore,
         (accountId, parentJobId, generation, markerKey, markerVersion) -> RefreshResult.OBSOLETE,
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(200L);
 
     assertTrue(events.isEmpty());
     assertTrue(
-        pointerStore.get(Keys.reconcileDirtyParentPointer("acct", "cancelled-child")).isEmpty());
+        pointerStore.get(dirtyParentKey("acct", "cancelled-child")).isEmpty());
   }
 
   @Test
@@ -177,6 +218,7 @@ class ReconcileMaintenanceServicesTest {
           events.add(parentJobId);
           return RefreshResult.OBSOLETE;
         },
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(200L);
@@ -185,7 +227,7 @@ class ReconcileMaintenanceServicesTest {
 
     assertTrue(events.isEmpty());
     assertEquals(readsAfterFirstTick, pointerStore.prefixReads.get());
-    assertTrue(pointerStore.get(Keys.reconcileDirtyParentPointer("acct", "parent")).isPresent());
+    assertTrue(pointerStore.get(dirtyParentKey("acct", "parent")).isPresent());
   }
 
   @Test
@@ -202,14 +244,15 @@ class ReconcileMaintenanceServicesTest {
           }
           return RefreshResult.OBSOLETE;
         },
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(200L);
-    assertTrue(pointerStore.get(Keys.reconcileDirtyParentPointer("acct", "parent")).isPresent());
+    assertTrue(pointerStore.get(dirtyParentKey("acct", "parent")).isPresent());
     service.runProjectionMaintenanceOnce(200L);
 
     assertEquals(2, refreshes.get());
-    assertTrue(pointerStore.get(Keys.reconcileDirtyParentPointer("acct", "parent")).isEmpty());
+    assertTrue(pointerStore.get(dirtyParentKey("acct", "parent")).isEmpty());
   }
 
   @Test
@@ -217,7 +260,7 @@ class ReconcileMaintenanceServicesTest {
     PointerStore pointerStore = new TestPointerStore();
     ReconcileProjectionMaintenanceService service = new ReconcileProjectionMaintenanceService();
     AtomicInteger attempts = new AtomicInteger();
-    String markerKey = Keys.reconcileDirtyParentPointer("acct", "parent");
+    String markerKey = dirtyParentKey("acct", "parent");
     putDirtyMarker(pointerStore, "acct", "parent", 1L, 0L);
     service.bind(
         pointerStore,
@@ -225,6 +268,7 @@ class ReconcileMaintenanceServicesTest {
             attempts.incrementAndGet() == 1
                 ? RefreshResult.PROJECTION_CONFLICT
                 : RefreshResult.OBSOLETE,
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(200L);
@@ -240,7 +284,7 @@ class ReconcileMaintenanceServicesTest {
     PointerStore pointerStore = new TestPointerStore();
     ReconcileProjectionMaintenanceService service = new ReconcileProjectionMaintenanceService();
     AtomicInteger attempts = new AtomicInteger();
-    String markerKey = Keys.reconcileDirtyParentPointer("acct", "parent");
+    String markerKey = dirtyParentKey("acct", "parent");
     putDirtyMarker(pointerStore, "acct", "parent", 1L, 0L);
     service.bind(
         pointerStore,
@@ -251,6 +295,7 @@ class ReconcileMaintenanceServicesTest {
           }
           return RefreshResult.OBSOLETE;
         },
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(200L);
@@ -275,6 +320,7 @@ class ReconcileMaintenanceServicesTest {
           refreshed.add(parentJobId);
           return RefreshResult.OBSOLETE;
         },
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(1_000L, 2);
@@ -290,6 +336,7 @@ class ReconcileMaintenanceServicesTest {
     service.bind(
         pointerStore,
         (accountId, parentJobId, generation, markerKey, markerVersion) -> RefreshResult.OBSOLETE,
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(200L);
@@ -311,6 +358,7 @@ class ReconcileMaintenanceServicesTest {
     service.bind(
         pointerStore,
         (accountId, parentJobId, generation, markerKey, markerVersion) -> RefreshResult.OBSOLETE,
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(200L);
@@ -331,6 +379,7 @@ class ReconcileMaintenanceServicesTest {
           service.signalWork();
           return RefreshResult.OBSOLETE;
         },
+        DIRTY_PARENT_PREFIX,
         10);
 
     service.runProjectionMaintenanceOnce(200L);
@@ -446,11 +495,31 @@ class ReconcileMaintenanceServicesTest {
       String parentJobId,
       long generation,
       long dirtyAtMs) {
-    String key = Keys.reconcileDirtyParentPointer(accountId, parentJobId);
+    putDirtyMarker(
+        pointerStore, WORKER_AFFINITY, accountId, parentJobId, generation, dirtyAtMs);
+  }
+
+  private static void putDirtyMarker(
+      PointerStore pointerStore,
+      String workerAffinity,
+      String accountId,
+      String parentJobId,
+      long generation,
+      long dirtyAtMs) {
+    String key = dirtyParentKey(workerAffinity, accountId, parentJobId);
     String payload = accountId + "\n" + parentJobId + "\n" + generation + "\n" + dirtyAtMs;
     long nextVersion = pointerStore.get(key).map(Pointer::getVersion).orElse(0L) + 1L;
     pointerStore.compareAndSet(
         key, nextVersion - 1L, PointerReferences.opaqueMarkerPointer(key, payload, nextVersion));
+  }
+
+  private static String dirtyParentKey(String accountId, String parentJobId) {
+    return dirtyParentKey(WORKER_AFFINITY, accountId, parentJobId);
+  }
+
+  private static String dirtyParentKey(
+      String workerAffinity, String accountId, String parentJobId) {
+    return Keys.reconcileDirtyParentPointer(workerAffinity, accountId, parentJobId);
   }
 
   private static void putCancellationMarker(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/queue/ReconcileMaintenanceServicesTest.java
@@ -61,10 +61,7 @@ class ReconcileMaintenanceServicesTest {
     putDirtyMarker(pointerStore, "reconciler-v2", "acct", "other-parent", 1L, 0L);
     String legacyKey = "/accounts/by-id/reconcile/jobs/dirty-parents/acct/legacy-parent";
     pointerStore.compareAndSet(
-        legacyKey,
-        0L,
-        PointerReferences.opaqueMarkerPointer(
-            legacyKey, "acct\nlegacy-parent", 1L));
+        legacyKey, 0L, PointerReferences.opaqueMarkerPointer(legacyKey, "acct\nlegacy-parent", 1L));
 
     service.bind(
         pointerStore,
@@ -80,9 +77,7 @@ class ReconcileMaintenanceServicesTest {
     assertEquals(List.of("owned-parent"), refreshed);
     assertTrue(pointerStore.get(legacyKey).isPresent());
     assertTrue(
-        pointerStore
-            .get(dirtyParentKey("reconciler-v2", "acct", "other-parent"))
-            .isPresent());
+        pointerStore.get(dirtyParentKey("reconciler-v2", "acct", "other-parent")).isPresent());
   }
 
   @Test
@@ -202,8 +197,7 @@ class ReconcileMaintenanceServicesTest {
     service.runProjectionMaintenanceOnce(200L);
 
     assertTrue(events.isEmpty());
-    assertTrue(
-        pointerStore.get(dirtyParentKey("acct", "cancelled-child")).isEmpty());
+    assertTrue(pointerStore.get(dirtyParentKey("acct", "cancelled-child")).isEmpty());
   }
 
   @Test
@@ -495,8 +489,7 @@ class ReconcileMaintenanceServicesTest {
       String parentJobId,
       long generation,
       long dirtyAtMs) {
-    putDirtyMarker(
-        pointerStore, WORKER_AFFINITY, accountId, parentJobId, generation, dirtyAtMs);
+    putDirtyMarker(pointerStore, WORKER_AFFINITY, accountId, parentJobId, generation, dirtyAtMs);
   }
 
   private static void putDirtyMarker(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackendTest.java
@@ -838,7 +838,7 @@ class DynamoReconcileJobIndexBackendTest {
         .thenReturn(TransactWriteItemsResponse.builder().build());
     DynamoReconcileJobIndexBackend backend = new DynamoReconcileJobIndexBackend();
     backend.bind(() -> dynamoDb, TABLE);
-    String markerKey = Keys.reconcileDirtyParentPointer(ACCOUNT_ID, JOB_ID);
+    String markerKey = Keys.reconcileDirtyParentPointer("reconciler-v1", ACCOUNT_ID, JOB_ID);
 
     assertTrue(
         backend.compareAndSetBatch(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileLeaseBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileLeaseBackendTest.java
@@ -68,8 +68,7 @@ class MemoryReconcileLeaseBackendTest {
         new MemoryReconcileLeaseBackend(pointers, jobIndexBackend);
     ReconcileJobIndexCleanupManifest manifest =
         new ReconcileJobIndexCleanupManifest(List.of("index-1"), List.of("ready-1"));
-    String markerKey =
-        Keys.reconcileDirtyParentPointer("reconciler-v1", ACCOUNT_ID, "parent-1");
+    String markerKey = Keys.reconcileDirtyParentPointer("reconciler-v1", ACCOUNT_ID, "parent-1");
     PointerStore.UnconditionalUpsert markerTouch =
         new PointerStore.UnconditionalUpsert(
             markerKey,
@@ -125,8 +124,7 @@ class MemoryReconcileLeaseBackendTest {
     MemoryReconcileJobIndexBackend jobIndexBackend = new MemoryReconcileJobIndexBackend(pointers);
     MemoryReconcileLeaseBackend leaseBackend =
         new MemoryReconcileLeaseBackend(pointers, jobIndexBackend);
-    String markerKey =
-        Keys.reconcileDirtyParentPointer("reconciler-v1", ACCOUNT_ID, "parent-1");
+    String markerKey = Keys.reconcileDirtyParentPointer("reconciler-v1", ACCOUNT_ID, "parent-1");
     PointerStore.UnconditionalUpsert markerTouch =
         new PointerStore.UnconditionalUpsert(
             markerKey,

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileLeaseBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileLeaseBackendTest.java
@@ -68,7 +68,8 @@ class MemoryReconcileLeaseBackendTest {
         new MemoryReconcileLeaseBackend(pointers, jobIndexBackend);
     ReconcileJobIndexCleanupManifest manifest =
         new ReconcileJobIndexCleanupManifest(List.of("index-1"), List.of("ready-1"));
-    String markerKey = Keys.reconcileDirtyParentPointer(ACCOUNT_ID, "parent-1");
+    String markerKey =
+        Keys.reconcileDirtyParentPointer("reconciler-v1", ACCOUNT_ID, "parent-1");
     PointerStore.UnconditionalUpsert markerTouch =
         new PointerStore.UnconditionalUpsert(
             markerKey,
@@ -124,7 +125,8 @@ class MemoryReconcileLeaseBackendTest {
     MemoryReconcileJobIndexBackend jobIndexBackend = new MemoryReconcileJobIndexBackend(pointers);
     MemoryReconcileLeaseBackend leaseBackend =
         new MemoryReconcileLeaseBackend(pointers, jobIndexBackend);
-    String markerKey = Keys.reconcileDirtyParentPointer(ACCOUNT_ID, "parent-1");
+    String markerKey =
+        Keys.reconcileDirtyParentPointer("reconciler-v1", ACCOUNT_ID, "parent-1");
     PointerStore.UnconditionalUpsert markerTouch =
         new PointerStore.UnconditionalUpsert(
             markerKey,

--- a/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetter.java
+++ b/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetter.java
@@ -49,7 +49,7 @@ public class TestDataResetter {
   private static final List<String> GLOBAL_RECONCILE_PREFIXES =
       List.of(
           Keys.reconcileJobLookupPointerByIdPrefix(),
-          Keys.reconcileDirtyParentPointerPrefix(),
+          Keys.reconcileDirtyParentPointerRootPrefix(),
           Keys.reconcileJobByStatePointerPrefix(),
           Keys.reconcileReadyPointerPrefix(),
           Keys.reconcileReadyByExecutionClassPointerPrefix(),

--- a/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetterTest.java
@@ -89,8 +89,12 @@ public class TestDataResetterTest {
   @Test
   void wipeAll_removes_global_reconcile_pointers_with_or_without_leading_slash() {
     FakePointerStore ptr = new FakePointerStore();
-    ptr.putPointer("/accounts/by-id/reconcile/jobs/dirty-parents/acct/job", 1L);
-    ptr.putPointer("accounts/by-id/reconcile/jobs/dirty-parents/acct/job2", 1L);
+    ptr.putPointer(
+        "/accounts/by-id/reconcile/jobs/dirty-parents-by-worker-affinity/reconciler-v1/acct/job",
+        1L);
+    ptr.putPointer(
+        "accounts/by-id/reconcile/jobs/dirty-parents-by-worker-affinity/reconciler-v1/acct/job2",
+        1L);
     ptr.putPointer("/accounts/by-id/reconcile/jobs/ready/0000000000000000001/acct/lane/job", 1L);
     ptr.putPointer(
         "accounts/by-id/reconcile/jobs/ready/by-execution-class/DEFAULT/0000000000000000001/acct/job",


### PR DESCRIPTION
## Summary

Persist ready-index version 2 on newly enqueued reconcile jobs and preserve it across canonical record cloning. This prevents another Floecat deployment sharing the queue from unnecessarily repairing and rewriting these jobs, which could remove newer job fields and expose cohort-scoped work through legacy ready keys. Add coverage confirming the version is persisted.

## Type of Change

- [X] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [ ] Commit messages follow conventional commit style where practical
- [ ] Documentation updated where needed
- [ ] No credentials, tokens, or secrets are included
- [ ] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

