### PR TITLE
connector: retire the unused CK_UNITY kind

### DIFF
--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/ConnectorCliSupport.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/ConnectorCliSupport.java
@@ -204,7 +204,7 @@ final class ConnectorCliSupport {
       case "create" -> {
         if (args.size() < 6) {
           out.println(
-              "usage: connector create <display_name> <kind (ICEBERG|DELTA|GLUE|UNITY)> <uri>"
+              "usage: connector create <display_name> <kind (ICEBERG|DELTA|GLUE)> <uri>"
                   + " <source_namespace (a[.b[.c]...])> <destination_catalog (name)>"
                   + " [--source-table <name>] [--source-cols c1,#id2,...] [--dest-ns <a.b[.c]>]"
                   + " [--dest-table <name>] [--desc <text>] [--auth-scheme <scheme>] [--auth k=v"
@@ -2099,7 +2099,6 @@ final class ConnectorCliSupport {
       case "ICEBERG" -> ConnectorKind.CK_ICEBERG;
       case "DELTA" -> ConnectorKind.CK_DELTA;
       case "GLUE" -> ConnectorKind.CK_GLUE;
-      case "UNITY" -> ConnectorKind.CK_UNITY;
       default -> ConnectorKind.CK_UNSPECIFIED;
     };
   }

--- a/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
+++ b/client-cli/src/main/java/ai/floedb/floecat/client/cli/Shell.java
@@ -601,7 +601,7 @@ public class Shell implements Runnable {
          connectors
          connector list [--kind <KIND>]
          connector get <display_name|id>
-         connector create <display_name> <source_type (ICEBERG|DELTA|GLUE|UNITY)> <uri> <source_namespace (a[.b[.c]...])> <destination_catalog (name)>
+         connector create <display_name> <source_type (ICEBERG|DELTA|GLUE)> <uri> <source_namespace (a[.b[.c]...])> <destination_catalog (name)>
              [--source-table <name>] [--source-cols c1,#id2,...]
              [--dest-ns <a.b[.c]>] [--dest-table <name>]
              [--desc <text>] [--auth-scheme <scheme>] [--auth k=v ...]

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/ConnectorConfig.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/ConnectorConfig.java
@@ -34,8 +34,7 @@ public record ConnectorConfig(
   public enum Kind {
     ICEBERG,
     DELTA,
-    GLUE,
-    UNITY
+    GLUE
   }
 
   public record Auth(String scheme, Map<String, String> props, Map<String, String> headerHints) {

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/ConnectorConfigMapper.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/ConnectorConfigMapper.java
@@ -26,7 +26,6 @@ public final class ConnectorConfigMapper {
           case CK_ICEBERG -> ConnectorConfig.Kind.ICEBERG;
           case CK_DELTA -> ConnectorConfig.Kind.DELTA;
           case CK_GLUE -> ConnectorConfig.Kind.GLUE;
-          case CK_UNITY -> ConnectorConfig.Kind.UNITY;
           default -> throw new IllegalArgumentException("unsupported kind: " + c.getKind());
         };
 

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/ConnectorFactory.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/ConnectorFactory.java
@@ -39,7 +39,6 @@ public final class ConnectorFactory {
           case ICEBERG -> "iceberg";
           case DELTA -> "delta";
           case GLUE -> "glue";
-          case UNITY -> "unity";
         };
     ConnectorProvider p = PROVIDERS.get(kindId);
     if (p == null) {

--- a/core/proto/src/main/proto/floecat/connector/connector.proto
+++ b/core/proto/src/main/proto/floecat/connector/connector.proto
@@ -24,11 +24,13 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/field_mask.proto";
 
 enum ConnectorKind {
+  reserved 4;
+  reserved "CK_UNITY";
+
   CK_UNSPECIFIED = 0;
   CK_ICEBERG = 1;
   CK_DELTA = 2;
   CK_GLUE = 3;
-  CK_UNITY = 4;
 }
 
 message NamespacePath {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -107,7 +107,7 @@ overlay delete <name|id> [--etag <etag>]
 connectors
 connector list [--kind <KIND>]
 connector get <display_name|id>
-connector create <display_name> <source_type (ICEBERG|DELTA|GLUE|UNITY)> <uri> <source_namespace (a[.b[.c]...])> <destination_catalog (name)>
+connector create <display_name> <source_type (ICEBERG|DELTA|GLUE)> <uri> <source_namespace (a[.b[.c]...])> <destination_catalog (name)>
     [--source-table <name>] [--source-cols c1,#id2,...]
     [--dest-ns <a.b[.c]>] [--dest-table <name>]
     [--desc <text>] [--auth-scheme <scheme>] [--auth k=v ...]

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -142,11 +142,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
           "assertion",
           "external_id");
   private static final Set<ConnectorKind> CONNECTOR_KINDS_WITH_FORBIDDEN_SECRET_PROPERTIES =
-      Set.of(
-          ConnectorKind.CK_ICEBERG,
-          ConnectorKind.CK_DELTA,
-          ConnectorKind.CK_GLUE,
-          ConnectorKind.CK_UNITY);
+      Set.of(ConnectorKind.CK_ICEBERG, ConnectorKind.CK_DELTA, ConnectorKind.CK_GLUE);
 
   @Override
   public Uni<ListConnectorsResponse> listConnectors(ListConnectorsRequest request) {
@@ -723,7 +719,6 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                         case CK_ICEBERG -> Kind.ICEBERG;
                         case CK_DELTA -> Kind.DELTA;
                         case CK_GLUE -> Kind.GLUE;
-                        case CK_UNITY -> Kind.UNITY;
                         default ->
                             throw GrpcErrors.invalidArgument(corr, null, Map.of("field", "kind"));
                       };

--- a/service/src/test/java/ai/floedb/floecat/connector/dummy/DummyConnectorProvider.java
+++ b/service/src/test/java/ai/floedb/floecat/connector/dummy/DummyConnectorProvider.java
@@ -26,7 +26,7 @@ public final class DummyConnectorProvider implements ConnectorProvider {
 
   @Override
   public String kind() {
-    return "unity";
+    return "glue";
   }
 
   @Override

--- a/service/src/test/java/ai/floedb/floecat/service/it/AuthCredentialsMarshallingIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/AuthCredentialsMarshallingIT.java
@@ -45,7 +45,7 @@ class AuthCredentialsMarshallingIT {
     var spec =
         ConnectorSpec.newBuilder()
             .setDisplayName("dummy")
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("https://example.invalid")
             .setAuth(
                 AuthConfig.newBuilder()

--- a/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ConnectorIT.java
@@ -163,7 +163,7 @@ public class ConnectorIT {
     var proto =
         Connector.newBuilder()
             .setDisplayName("dummy-conn")
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://ignored")
             .setDestination(dest("cat-e2e"))
             .build();
@@ -183,7 +183,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("dummy-conn")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://ignored")
                 .setSource(source(List.of("db")))
                 .setDestination(dest("cat-e2e"))
@@ -200,7 +200,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("dummy-conn2")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://ignored")
                 .setSource(source(List.of("examples", "iceberg")))
                 .setDestination(dest("cat-e2e"))
@@ -276,7 +276,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("dummy-stats")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://ignored")
                 .setSource(source(List.of("db")))
                 .setDestination(dest("cat-stats"))
@@ -1006,7 +1006,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("dummy-dest-table")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://ignored")
                 .setSource(src)
                 .setDestination(dest)
@@ -1047,7 +1047,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("dummy-scope-miss")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://ignored")
                 .setSource(source(List.of("db")))
                 .setDestination(dest("cat-scope-miss"))
@@ -1080,7 +1080,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("dummy-plan-views")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://ignored")
                 .setSource(source(List.of("db")))
                 .setDestination(
@@ -1783,7 +1783,7 @@ public class ConnectorIT {
     var proto =
         Connector.newBuilder()
             .setDisplayName("dummy-conn-nested")
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://ignored")
             .setDestination(dest("cat-e2e"))
             .build();
@@ -1896,7 +1896,7 @@ public class ConnectorIT {
     var spec =
         ConnectorSpec.newBuilder()
             .setDisplayName("idem-1")
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://x")
             .setSource(source(List.of("a", "b")))
             .setDestination(dest("cat-idem"))
@@ -1922,7 +1922,7 @@ public class ConnectorIT {
     var spec =
         ConnectorSpec.newBuilder()
             .setDisplayName("kind-check")
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://x")
             .setSource(source(List.of("a", "b")))
             .setDestination(dest("cat-kind"))
@@ -1969,7 +1969,7 @@ public class ConnectorIT {
     var spec =
         ConnectorSpec.newBuilder()
             .setDisplayName("auth-mask")
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://x")
             .setSource(source(List.of("a", "b")))
             .setDestination(dest("cat-auth"))
@@ -2008,7 +2008,7 @@ public class ConnectorIT {
                         .setSpec(
                             ConnectorSpec.newBuilder()
                                 .setDisplayName("auth-reject")
-                                .setKind(ConnectorKind.CK_UNITY)
+                                .setKind(ConnectorKind.CK_GLUE)
                                 .setUri("dummy://x")
                                 .setSource(source(List.of("a", "b")))
                                 .setDestination(dest("cat-auth-reject"))
@@ -2191,36 +2191,12 @@ public class ConnectorIT {
   }
 
   @Test
-  void unityConnectorRejectsInlineStaticS3Credentials() throws Exception {
-    TestSupport.createCatalog(catalogService, "cat-unity-props", "");
-
-    var createEx =
-        assertThrows(
-            StatusRuntimeException.class,
-            () ->
-                connectors.createConnector(
-                    CreateConnectorRequest.newBuilder()
-                        .setSpec(
-                            ConnectorSpec.newBuilder()
-                                .setDisplayName("unity-inline-s3-creds")
-                                .setKind(ConnectorKind.CK_UNITY)
-                                .setUri("dummy://x")
-                                .setSource(source(List.of("main", "sales")))
-                                .setDestination(dest("cat-unity-props"))
-                                .putProperties("s3.secret-access-key", "should-not-store")
-                                .build())
-                        .build()));
-    TestSupport.assertGrpcAndMc(
-        createEx, Status.Code.INVALID_ARGUMENT, ErrorCode.MC_INVALID_ARGUMENT, "Invalid argument");
-  }
-
-  @Test
   void createConnectorIdempotencyMismatchOnUri() throws Exception {
     TestSupport.createCatalog(catalogService, "cat-idem-2", "");
     var specA =
         ConnectorSpec.newBuilder()
             .setDisplayName("idem-2")
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://x")
             .setSource(source(List.of("a", "b")))
             .setDestination(dest("cat-idem-2"))
@@ -2229,7 +2205,7 @@ public class ConnectorIT {
     var specB =
         ConnectorSpec.newBuilder()
             .setDisplayName("idem-2")
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://y")
             .setSource(source(List.of("a", "b")))
             .setDestination(dest("cat-idem-2"))
@@ -2278,7 +2254,7 @@ public class ConnectorIT {
           connectors,
           ConnectorSpec.newBuilder()
               .setDisplayName("p-" + i)
-              .setKind(ConnectorKind.CK_UNITY)
+              .setKind(ConnectorKind.CK_GLUE)
               .setUri("dummy://x")
               .setSource(source(List.of("a", "b")))
               .setDestination(dest("cat-p"))
@@ -2309,7 +2285,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("u-a")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://x")
                 .setSource(source(List.of("a", "b")))
                 .setDestination(dest("cat-u"))
@@ -2320,7 +2296,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("u-b")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://x")
                 .setSource(source(List.of("a", "b")))
                 .setDestination(dest("cat-u"))
@@ -2361,7 +2337,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("pre-a")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://x")
                 .setSource(source(List.of("a", "b")))
                 .setDestination(dest("cat-pre"))
@@ -2398,7 +2374,7 @@ public class ConnectorIT {
                         .setSpec(
                             ConnectorSpec.newBuilder()
                                 .setDisplayName("policy-create-invalid")
-                                .setKind(ConnectorKind.CK_UNITY)
+                                .setKind(ConnectorKind.CK_GLUE)
                                 .setUri("dummy://x")
                                 .setSource(source(List.of("a", "b")))
                                 .setDestination(dest("cat-policy-create"))
@@ -2421,7 +2397,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("policy-update-invalid")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://x")
                 .setSource(source(List.of("a", "b")))
                 .setDestination(dest("cat-policy-update"))
@@ -2456,7 +2432,7 @@ public class ConnectorIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("del-1")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://x")
                 .setSource(source(List.of("a", "b")))
                 .setDestination(dest("cat-del"))
@@ -2515,7 +2491,7 @@ public class ConnectorIT {
                 .setSpec(
                     ConnectorSpec.newBuilder()
                         .setDisplayName("v-ok")
-                        .setKind(ConnectorKind.CK_UNITY)
+                        .setKind(ConnectorKind.CK_GLUE)
                         .setUri("dummy://x")
                         .setDestination(dest("cat-v")))
                 .build());

--- a/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/QueryScanServiceIT.java
@@ -357,7 +357,7 @@ class QueryScanServiceIT {
     var spec =
         ConnectorSpec.newBuilder()
             .setDisplayName("qs-" + suffix)
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://ignored")
             .setSource(source)
             .setDestination(destination)

--- a/service/src/test/java/ai/floedb/floecat/service/it/ReconcileLaneIsolationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ReconcileLaneIsolationIT.java
@@ -87,7 +87,7 @@ class ReconcileLaneIsolationIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName("lane-isolation")
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://lane-isolation")
                 .setSource(
                     SourceSelector.newBuilder()

--- a/service/src/test/java/ai/floedb/floecat/service/it/StatsOrchestratorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/StatsOrchestratorIT.java
@@ -371,7 +371,7 @@ class StatsOrchestratorIT {
     var spec =
         ConnectorSpec.newBuilder()
             .setDisplayName(PREFIX + suffix)
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://ignored")
             .setSource(source)
             .setDestination(destination)

--- a/service/src/test/java/ai/floedb/floecat/service/it/UserObjectsServiceIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/UserObjectsServiceIT.java
@@ -411,7 +411,7 @@ class UserObjectsServiceIT {
     ConnectorSpec spec =
         ConnectorSpec.newBuilder()
             .setDisplayName("qc-" + suffix)
-            .setKind(ConnectorKind.CK_UNITY)
+            .setKind(ConnectorKind.CK_GLUE)
             .setUri("dummy://ignored")
             .setSource(source)
             .setDestination(destination)

--- a/service/src/test/java/ai/floedb/floecat/service/it/cost/WarmRequestStoreCostIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/cost/WarmRequestStoreCostIT.java
@@ -368,7 +368,7 @@ class WarmRequestStoreCostIT {
             connectors,
             ConnectorSpec.newBuilder()
                 .setDisplayName(connectorName)
-                .setKind(ConnectorKind.CK_UNITY)
+                .setKind(ConnectorKind.CK_GLUE)
                 .setUri("dummy://ignored")
                 .setSource(source)
                 .setDestination(


### PR DESCRIPTION
## Summary

Retires the unused `CK_UNITY` connector kind. Unity Catalog remains represented by a Delta connector (`CK_DELTA`) whose source is Unity.

Changes:

- Reserve enum number 4 and the `CK_UNITY` name for wire compatibility.
- Remove `UNITY` from connector-kind mapping, service acceptance, and CLI input/help.
- Move test fixtures off the retired kind.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Full build: 4,631 tests, 0 failures. Formatting clean.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [ ] No breaking changes
- [x] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

Callers can no longer create `CK_UNITY` connectors. Use `CK_DELTA` for Delta tables backed by Unity Catalog. This PR does not change `delta.source` validation or its existing default.

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

`CK_UNITY = 4` is reserved rather than reused so previously serialized enum values cannot acquire a different meaning.

