### PR TITLE
delta: vend storage credentials from Unity Catalog

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnector.java
@@ -17,10 +17,13 @@
 package ai.floedb.floecat.connector.delta.uc.impl;
 
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
+import ai.floedb.floecat.client.unity.TemporaryTableCredentials;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
+import ai.floedb.floecat.client.unity.UnityCatalogException;
 import ai.floedb.floecat.client.unity.UnityCatalogTable;
 import ai.floedb.floecat.connector.spi.AuthProvider;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
+import ai.floedb.floecat.connector.spi.SourceCatalogAccessException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.delta.kernel.engine.Engine;
 import java.util.ArrayList;
@@ -175,6 +178,63 @@ public final class UnityDeltaConnector extends DeltaConnector {
                     buildSchemaJson(table)));
   }
 
+  @Override
+  public Optional<FloecatConnector.VendedStorageCredentials> vendStorageCredentials(
+      String namespaceFq, String tableName) {
+    String fullName = namespaceFq + "." + tableName;
+    try {
+      Optional<UnityCatalogTable> table = catalog.getTable(fullName);
+      if (table.isEmpty()) {
+        LOG.warnf("Unity Catalog table %s not found; cannot vend credentials", fullName);
+        return Optional.empty();
+      }
+      String tableId = table.get().tableId();
+      if (tableId == null || tableId.isBlank()) {
+        // Terminal, and typed so it reads as one. The credentials endpoint keys on table_id, and a
+        // catalog that omits it for a table will keep omitting it. A bare IllegalStateException
+        // escapes classifyAccessFailure, reaches the service unrecognised, and comes back as a
+        // retryable INTERNAL -- the reconcile loop this classification exists to close.
+        throw new SourceCatalogAccessException(
+            SourceCatalogAccessException.Denial.UNSUPPORTED,
+            "Unity Catalog table has no table_id: " + fullName);
+      }
+
+      TemporaryTableCredentials credentials =
+          catalog.generateTemporaryTableCredentials(
+              tableId, UnityCatalogClient.TableOperation.READ);
+      TemporaryTableCredentials.AwsCredentials aws = credentials.awsCredentials();
+      if (aws == null) {
+        // No credential shape this connector recognises -- either a cloud it does not map, or a
+        // field Unity Catalog added after this code was written. Both are "cannot vend", not
+        // "vended nothing": returning a credential object with an empty property map would reach
+        // the service's usability check and fail the reconcile job terminally, when the correct
+        // answer is the same fallback to a configured storage authority the non-AWS branch takes.
+        LOG.warnf(
+            "Unity Catalog vended no AWS credentials for %s (unsupportedCloud=%s); "
+                + "falling back to a storage authority",
+            fullName, credentials.hasUnsupportedCredentials());
+        return Optional.empty();
+      }
+
+      Map<String, String> properties = new LinkedHashMap<>();
+      putIfNonBlank(properties, "s3.access-key-id", aws.accessKeyId());
+      putIfNonBlank(properties, "s3.secret-access-key", aws.secretAccessKey());
+      putIfNonBlank(properties, "s3.session-token", aws.sessionToken());
+      putIfNonBlank(properties, "s3.access-point", aws.accessPoint());
+      // An incomplete tuple is deliberately passed through rather than dropped: the service decides
+      // how strict to be, because the reconcile path needs a renewable session tuple and the query
+      // path does not. Only "no credentials at all" is handled here, above.
+      return Optional.of(
+          new FloecatConnector.VendedStorageCredentials(
+              properties,
+              FloecatConnector.VendedStorageCredentials.expiryFromEpochMillis(
+                  credentials.expirationEpochMillis()),
+              credentials.storageUrl()));
+    } catch (UnityCatalogException e) {
+      throw classifyAccessFailure(e);
+    }
+  }
+
   /**
    * Releases the catalog client's transport and the auth provider's.
    *
@@ -220,6 +280,45 @@ public final class UnityDeltaConnector extends DeltaConnector {
     return catalog
         .getTable(fullName)
         .orElseThrow(() -> new IllegalStateException("Unity Catalog table not found: " + fullName));
+  }
+
+  /**
+   * Turns a Unity Catalog failure into the typed signal the storage service classifies on.
+   *
+   * <p>Every permanent refusal must be named here, not just 401 and 403. Databricks answers the
+   * credentials endpoint with {@code 400} plus an {@code error_code} when the workspace lacks
+   * {@code EXTERNAL USE SCHEMA} or the table has external access turned off, and with {@code 404}
+   * for a table id it no longer knows -- none of which change on retry. Anything left unclassified
+   * escapes as a plain {@link UnityCatalogException}, which the service maps to a retryable {@code
+   * INTERNAL}, so the reconciler would loop on a job that can never succeed.
+   *
+   * <p>Transient failures -- 5xx, rate limits, transport errors, and a malformed body, which is
+   * usually a proxy error page rather than the catalog itself -- stay unclassified on purpose.
+   *
+   * <p>A 404 is permanent only when Databricks answered it. The client types 404 as {@code
+   * NOT_FOUND} on status alone, so an HTML 404 from a load balancer or WAF in front of the
+   * workspace -- what one briefly serves mid-deploy -- arrives here looking identical to an unknown
+   * table id. Its {@code error_code} envelope is what separates them, and without one the failure
+   * stays unclassified so the reconciler retries instead of permanently failing a job that would
+   * have succeeded a minute later.
+   */
+  private static RuntimeException classifyAccessFailure(UnityCatalogException failure) {
+    if (failure.failure() == UnityCatalogException.Failure.NOT_FOUND
+        && failure.errorCode() == null) {
+      return failure;
+    }
+    return switch (failure.failure()) {
+      case UNAUTHENTICATED ->
+          new SourceCatalogAccessException(
+              SourceCatalogAccessException.Denial.UNAUTHENTICATED, failure.getMessage());
+      case PERMISSION_DENIED ->
+          new SourceCatalogAccessException(
+              SourceCatalogAccessException.Denial.PERMISSION_DENIED, failure.getMessage());
+      case NOT_FOUND, INVALID_REQUEST ->
+          new SourceCatalogAccessException(
+              SourceCatalogAccessException.Denial.UNSUPPORTED, failure.getMessage());
+      default -> failure;
+    };
   }
 
   private static Namespace parseNamespace(String namespaceFq) {
@@ -274,6 +373,16 @@ public final class UnityDeltaConnector extends DeltaConnector {
     if (value != null) {
       values.put(key, value);
     }
+  }
+
+  private static void putIfNonBlank(Map<String, String> values, String key, String value) {
+    if (!isBlank(value)) {
+      values.put(key, value);
+    }
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
   }
 
   private static String nullToEmpty(String value) {

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnector.java
@@ -59,18 +59,14 @@ public final class UnityDeltaConnector extends DeltaConnector {
 
   @Override
   public List<String> listNamespaces() {
-    try {
-      List<String> namespaces = new ArrayList<>();
-      for (String catalogName : catalog.listCatalogs()) {
-        for (String schemaName : catalog.listSchemas(catalogName)) {
-          namespaces.add(catalogName + "." + schemaName);
-        }
+    List<String> namespaces = new ArrayList<>();
+    for (String catalogName : catalog.listCatalogs()) {
+      for (String schemaName : catalog.listSchemas(catalogName)) {
+        namespaces.add(catalogName + "." + schemaName);
       }
-      namespaces.sort(String::compareTo);
-      return namespaces;
-    } catch (RuntimeException e) {
-      throw new RuntimeException("listNamespaces failed", e);
     }
+    namespaces.sort(String::compareTo);
+    return namespaces;
   }
 
   @Override
@@ -79,15 +75,11 @@ public final class UnityDeltaConnector extends DeltaConnector {
     if (namespace == null) {
       return List.of();
     }
-    try {
-      return catalog.listTables(namespace.catalog(), namespace.schema()).stream()
-          .filter(table -> "DELTA".equalsIgnoreCase(table.dataSourceFormat()))
-          .map(UnityCatalogTable::name)
-          .sorted()
-          .toList();
-    } catch (RuntimeException e) {
-      throw new RuntimeException("listTables failed", e);
-    }
+    return catalog.listTables(namespace.catalog(), namespace.schema()).stream()
+        .filter(table -> "DELTA".equalsIgnoreCase(table.dataSourceFormat()))
+        .map(UnityCatalogTable::name)
+        .sorted()
+        .toList();
   }
 
   @Override

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnectorTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnectorTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.connector.delta.uc.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -24,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
+import ai.floedb.floecat.client.unity.UnityCatalogException;
 import ai.floedb.floecat.client.unity.UnityCatalogTable;
 import ai.floedb.floecat.connector.spi.AuthProvider;
 import java.util.List;
@@ -61,6 +63,18 @@ class UnityDeltaConnectorTest {
                 table("a_orders", "EXTERNAL", "delta")));
 
     assertThat(connector.listTables("cat.schema")).containsExactly("a_orders", "z_orders");
+  }
+
+  @Test
+  void listingPreservesUnityCatalogFailureClassification() {
+    var failure =
+        new UnityCatalogException(
+            UnityCatalogException.Failure.PERMISSION_DENIED, 403, "catalog denied request");
+    when(catalog.listCatalogs()).thenThrow(failure);
+    when(catalog.listTables("cat", "schema")).thenThrow(failure);
+
+    assertThatThrownBy(connector::listNamespaces).isSameAs(failure);
+    assertThatThrownBy(() -> connector.listTables("cat.schema")).isSameAs(failure);
   }
 
   @Test

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnectorTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/UnityDeltaConnectorTest.java
@@ -24,10 +24,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.client.unity.TemporaryTableCredentials;
 import ai.floedb.floecat.client.unity.UnityCatalogClient;
 import ai.floedb.floecat.client.unity.UnityCatalogException;
 import ai.floedb.floecat.client.unity.UnityCatalogTable;
 import ai.floedb.floecat.connector.spi.AuthProvider;
+import ai.floedb.floecat.connector.spi.SourceCatalogAccessException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -172,12 +175,185 @@ class UnityDeltaConnectorTest {
   }
 
   @Test
+  void vendStorageCredentialsMapsAwsCredentials() {
+    when(catalog.getTable("cat.schema.orders"))
+        .thenReturn(Optional.of(table("orders", "table-id", "EXTERNAL", "DELTA", null)));
+    Instant expiry = Instant.parse("2030-01-01T00:00:00Z");
+    when(catalog.generateTemporaryTableCredentials(
+            "table-id", UnityCatalogClient.TableOperation.READ))
+        .thenReturn(
+            new TemporaryTableCredentials(
+                new TemporaryTableCredentials.AwsCredentials(
+                    "key", "secret", "token", "arn:aws:s3:us-east-1:123:accesspoint/orders"),
+                false,
+                Long.toString(expiry.toEpochMilli()),
+                "s3://bucket/orders"));
+
+    var result = connector.vendStorageCredentials("cat.schema", "orders");
+
+    assertThat(result).isPresent();
+    assertThat(result.orElseThrow().properties())
+        .containsEntry("s3.access-key-id", "key")
+        .containsEntry("s3.secret-access-key", "secret")
+        .containsEntry("s3.session-token", "token")
+        .containsEntry("s3.access-point", "arn:aws:s3:us-east-1:123:accesspoint/orders");
+    assertThat(result.orElseThrow().expiresAt()).isEqualTo(expiry);
+    assertThat(result.orElseThrow().scopePrefix()).isEqualTo("s3://bucket/orders");
+  }
+
+  @Test
+  void vendStorageCredentialsFallsBackForMissingTableOrUnsupportedCloud() {
+    when(catalog.getTable("cat.schema.missing")).thenReturn(Optional.empty());
+    when(catalog.getTable("cat.schema.azure"))
+        .thenReturn(Optional.of(table("azure", "id", "EXTERNAL", "DELTA", null)));
+    when(catalog.generateTemporaryTableCredentials("id", UnityCatalogClient.TableOperation.READ))
+        .thenReturn(new TemporaryTableCredentials(null, true, null, null));
+
+    assertThat(connector.vendStorageCredentials("cat.schema", "missing")).isEmpty();
+    assertThat(connector.vendStorageCredentials("cat.schema", "azure")).isEmpty();
+  }
+
+  @Test
+  void vendStorageCredentialsFallsBackForAnUnrecognizedCredentialShape() {
+    // Neither an AWS tuple nor a cloud this client knows about -- a UC response shape newer than
+    // this code. "Cannot vend" must stay a fallback to a storage authority: handing back an empty
+    // credential object instead would reach the service's usability check and fail the reconcile
+    // job terminally on a condition the caller can recover from.
+    when(catalog.getTable("cat.schema.orders"))
+        .thenReturn(Optional.of(table("orders", "id", "EXTERNAL", "DELTA", null)));
+    when(catalog.generateTemporaryTableCredentials("id", UnityCatalogClient.TableOperation.READ))
+        .thenReturn(new TemporaryTableCredentials(null, false, "1893456000000", "s3://b/orders"));
+
+    assertThat(connector.vendStorageCredentials("cat.schema", "orders")).isEmpty();
+  }
+
+  @Test
+  void vendStorageCredentialsClassifiesPermanentNonAuthRefusalsAsTerminal() {
+    // Databricks answers with 400 + error_code when the workspace lacks EXTERNAL USE SCHEMA, and
+    // with 404 for a table id it no longer knows. Both are permanent; left unclassified they
+    // escape as a retryable INTERNAL and the reconciler loops on a job that can never succeed.
+    when(catalog.getTable("cat.schema.orders"))
+        .thenReturn(Optional.of(table("orders", "id", "EXTERNAL", "DELTA", null)));
+    for (UnityCatalogException.Failure failure :
+        new UnityCatalogException.Failure[] {
+          UnityCatalogException.Failure.INVALID_REQUEST, UnityCatalogException.Failure.NOT_FOUND
+        }) {
+      // doThrow, not when(...).thenThrow: when() would evaluate the already-stubbed call and
+      // rethrow the previous iteration's exception before it could re-stub.
+      // errorCode set: only a failure Databricks itself envelopes is permanent. See
+      // notFoundWithoutAnErrorEnvelopeStaysRetryable.
+      doThrow(new UnityCatalogException(failure, 400, "RESOURCE_DOES_NOT_EXIST", "refused", null))
+          .when(catalog)
+          .generateTemporaryTableCredentials("id", UnityCatalogClient.TableOperation.READ);
+
+      assertThatThrownBy(() -> connector.vendStorageCredentials("cat.schema", "orders"))
+          .as(failure.name())
+          .isInstanceOfSatisfying(
+              SourceCatalogAccessException.class,
+              error ->
+                  assertThat(error.denial())
+                      .isEqualTo(SourceCatalogAccessException.Denial.UNSUPPORTED));
+    }
+  }
+
+  @Test
+  void notFoundWithoutAnErrorEnvelopeStaysRetryable() {
+    // The client types 404 as NOT_FOUND on status alone, so an HTML 404 from a load balancer in
+    // front of the workspace -- what one serves mid-deploy -- is indistinguishable here from an
+    // unknown table id except by the error_code envelope. Without one it must stay unclassified:
+    // classifying it terminally fails the reconcile job on a condition that recovers by itself.
+    when(catalog.getTable("cat.schema.orders"))
+        .thenReturn(Optional.of(table("orders", "id", "EXTERNAL", "DELTA", null)));
+    doThrow(new UnityCatalogException(UnityCatalogException.Failure.NOT_FOUND, 404, "<html/>"))
+        .when(catalog)
+        .generateTemporaryTableCredentials("id", UnityCatalogClient.TableOperation.READ);
+
+    assertThatThrownBy(() -> connector.vendStorageCredentials("cat.schema", "orders"))
+        .isInstanceOf(UnityCatalogException.class)
+        .isNotInstanceOf(SourceCatalogAccessException.class);
+  }
+
+  /**
+   * The credentials endpoint keys on table_id, so a table without one can never be vended for, and
+   * a catalog that omits it will keep omitting it. An untyped failure escapes classification and
+   * comes back from the service as a retryable INTERNAL, looping the reconcile job forever.
+   */
+  @Test
+  void vendStorageCredentialsTreatsAMissingTableIdAsTerminal() {
+    when(catalog.getTable("cat.schema.orders"))
+        .thenReturn(Optional.of(table("orders", " ", "EXTERNAL", "DELTA", null)));
+
+    assertThatThrownBy(() -> connector.vendStorageCredentials("cat.schema", "orders"))
+        .isInstanceOfSatisfying(
+            SourceCatalogAccessException.class,
+            error ->
+                assertThat(error.denial())
+                    .isEqualTo(SourceCatalogAccessException.Denial.UNSUPPORTED));
+  }
+
+  @Test
   void closeReleasesTheCatalogTransport() {
     connector.close();
 
     verify(catalog).close();
   }
 
+  @Test
+  void vendStorageCredentialsPreservesIncompleteAwsTupleForServiceValidation() {
+    when(catalog.getTable("cat.schema.orders"))
+        .thenReturn(Optional.of(table("orders", "id", "EXTERNAL", "DELTA", null)));
+    when(catalog.generateTemporaryTableCredentials("id", UnityCatalogClient.TableOperation.READ))
+        .thenReturn(
+            new TemporaryTableCredentials(
+                new TemporaryTableCredentials.AwsCredentials("key", "secret", null, null),
+                false,
+                "not-a-number",
+                null));
+
+    var result = connector.vendStorageCredentials("cat.schema", "orders");
+
+    assertThat(result).isPresent();
+    assertThat(result.orElseThrow().properties())
+        .containsEntry("s3.access-key-id", "key")
+        .containsEntry("s3.secret-access-key", "secret")
+        .doesNotContainKey("s3.session-token");
+    // A malformed expiry folds to null rather than failing the vend, per the shared parser.
+    assertThat(result.orElseThrow().expiresAt()).isNull();
+  }
+
+  @Test
+  void vendStorageCredentialsClassifiesAuthenticationFailures() {
+    when(catalog.getTable("cat.schema.orders"))
+        .thenThrow(
+            new UnityCatalogException(
+                UnityCatalogException.Failure.UNAUTHENTICATED, 401, "HTTP 401"));
+
+    assertThatThrownBy(() -> connector.vendStorageCredentials("cat.schema", "orders"))
+        .isInstanceOfSatisfying(
+            SourceCatalogAccessException.class,
+            error ->
+                assertThat(error.denial())
+                    .isEqualTo(SourceCatalogAccessException.Denial.UNAUTHENTICATED));
+  }
+
+  @Test
+  void vendStorageCredentialsLeavesServerFailuresRetryable() {
+    when(catalog.getTable("cat.schema.orders"))
+        .thenReturn(Optional.of(table("orders", "id", "EXTERNAL", "DELTA", null)));
+    when(catalog.generateTemporaryTableCredentials("id", UnityCatalogClient.TableOperation.READ))
+        .thenThrow(
+            new UnityCatalogException(UnityCatalogException.Failure.SERVER_ERROR, 503, "HTTP 503"));
+
+    assertThatThrownBy(() -> connector.vendStorageCredentials("cat.schema", "orders"))
+        .isInstanceOf(UnityCatalogException.class)
+        .isNotInstanceOf(SourceCatalogAccessException.class);
+  }
+
+  /**
+   * A connector is built per vend, so an auth provider that owns an HTTP client leaks a selector
+   * thread and an executor on every call unless {@code close()} releases it alongside the catalog
+   * transport.
+   */
   @Test
   void closeReleasesTheAuthProvider() {
     var auth = new ClosableAuthProvider();

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
@@ -1860,6 +1860,10 @@ public abstract class IcebergConnector implements FloecatConnector {
           // misconfigures FileIO for any other region, a custom endpoint, or path-style access.
           "s3.region",
           "s3.endpoint",
+          // Deliberately no "s3.access-point": Iceberg has no such property. S3FileIOProperties
+          // keys access points per bucket as "s3.access-points.<bucket>", so a literal lookup can
+          // never match and listing it would read as coverage that does not exist. Unity Catalog
+          // is the only source that vends an access point today, through the Delta connector.
           "s3.path-style-access");
 
   /** Iceberg's key for when vended session credentials stop working. */
@@ -1899,7 +1903,8 @@ public abstract class IcebergConnector implements FloecatConnector {
     if (!vended.containsKey("s3.access-key-id")) {
       return Optional.empty();
     }
-    return Optional.of(new VendedStorageCredentials(vended, parseVendedExpiry(ioProps)));
+    return Optional.of(
+        new VendedStorageCredentials(vended, parseVendedExpiry(ioProps), table.location()));
   }
 
   /**
@@ -1946,7 +1951,10 @@ public abstract class IcebergConnector implements FloecatConnector {
     if (!vended.containsKey("s3.access-key-id")) {
       return Optional.empty();
     }
-    return Optional.of(new VendedStorageCredentials(vended, parseVendedExpiry(best.config())));
+    String scopePrefix =
+        best.prefix() == null || best.prefix().isBlank() ? table.location() : best.prefix();
+    return Optional.of(
+        new VendedStorageCredentials(vended, parseVendedExpiry(best.config()), scopePrefix));
   }
 
   private static Map<String, String> filterVendedKeys(Map<String, String> source) {
@@ -1964,18 +1972,10 @@ public abstract class IcebergConnector implements FloecatConnector {
    * Reads the credential expiry, or null when absent or unparseable.
    *
    * <p>Null is deliberately not "never expires": callers are documented to treat it as "do not
-   * cache". Guessing a TTL here would produce credentials that fail mid-read.
+   * cache". Guessing a TTL here would produce credentials that fail mid-read. Delegates to the
+   * shared parser so every vending connector agrees on the epoch-millis semantics.
    */
   private static Instant parseVendedExpiry(Map<String, String> ioProps) {
-    String raw = ioProps.get(VENDED_EXPIRY_KEY);
-    if (raw == null || raw.isBlank()) {
-      return null;
-    }
-    try {
-      return Instant.ofEpochMilli(Long.parseLong(raw.trim()));
-    } catch (NumberFormatException e) {
-      LOG.warnf("ignoring unparseable %s from delegated loadTable: %s", VENDED_EXPIRY_KEY, raw);
-      return null;
-    }
+    return VendedStorageCredentials.expiryFromEpochMillis(ioProps.get(VENDED_EXPIRY_KEY));
   }
 }

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorVendedCredentialsTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorVendedCredentialsTest.java
@@ -66,6 +66,7 @@ class IcebergConnectorVendedCredentialsTest {
                 (proxy, method, args) ->
                     switch (method.getName()) {
                       case "io" -> io;
+                      case "location" -> "s3://warehouse/tpch_10/customer";
                       case "name" -> "fake-table";
                       case "toString" -> "fake-table";
                       case "hashCode" -> System.identityHashCode(proxy);
@@ -194,6 +195,7 @@ class IcebergConnectorVendedCredentialsTest {
     assertEquals("ASIAVENDED", vended.get().properties().get("s3.access-key-id"));
     assertEquals("vended-session", vended.get().properties().get("s3.session-token"));
     assertEquals(Instant.ofEpochMilli(1786000000000L), vended.get().expiresAt());
+    assertEquals("s3://warehouse/tpch", vended.get().scopePrefix());
   }
 
   @Test
@@ -211,6 +213,7 @@ class IcebergConnectorVendedCredentialsTest {
 
     assertTrue(vended.isPresent());
     assertEquals("EXACT", vended.get().properties().get("s3.access-key-id"));
+    assertEquals("s3://warehouse/tpch/region", vended.get().scopePrefix());
   }
 
   @Test
@@ -254,6 +257,7 @@ class IcebergConnectorVendedCredentialsTest {
     assertEquals("vended-secret", vended.get().properties().get("s3.secret-access-key"));
     assertEquals("vended-session", vended.get().properties().get("s3.session-token"));
     assertEquals(Instant.ofEpochMilli(1786000000000L), vended.get().expiresAt());
+    assertEquals("s3://warehouse/tpch_10/customer", vended.get().scopePrefix());
   }
 
   /**

--- a/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClient.java
+++ b/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -55,24 +56,7 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
       Duration connectTimeout,
       Duration requestTimeout,
       UnityCatalogAuthentication authentication) {
-    this(
-        baseUri,
-        requestTimeout,
-        authentication,
-        // The JDK default is Redirect.NEVER, which turns an ordinary workspace redirect -- an
-        // http:// base URI upgraded to HTTPS, a renamed workspace host -- into a bare 3xx that no
-        // caller can act on. NORMAL follows it, and still refuses an HTTPS-to-HTTP downgrade; a
-        // 3xx that survives that is classified permanent below rather than retried forever.
-        //
-        // NORMAL re-issues a followed 301/302/303 as a bodyless GET, so the one POST here -- the
-        // credentials call -- does not survive a redirect: what surfaces is the redirect target's
-        // 404 or 405, not the 3xx. Both are permanent, so retry behaviour is unchanged, but the
-        // status alone would read as a missing endpoint; the failure message therefore names the
-        // effective URI whenever it differs from the one requested.
-        HttpClient.newBuilder()
-            .connectTimeout(connectTimeout)
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build());
+    this(baseUri, requestTimeout, authentication, newHttpClient(baseUri, connectTimeout));
   }
 
   HttpUnityCatalogClient(
@@ -83,6 +67,10 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
     Objects.requireNonNull(baseUri, "baseUri");
     if (!baseUri.isAbsolute()) {
       throw new IllegalArgumentException("Unity Catalog base URI must be absolute: " + baseUri);
+    }
+    if ("http".equalsIgnoreCase(baseUri.getScheme()) && !isLoopbackHost(baseUri.getHost())) {
+      throw new IllegalArgumentException(
+          "Unity Catalog base URI must use HTTPS unless it is loopback: " + baseUri);
     }
     this.baseUri = stripTrailingSlash(baseUri.toString());
     this.requestTimeout = Objects.requireNonNull(requestTimeout, "requestTimeout");
@@ -118,7 +106,12 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
   @Override
   public Optional<UnityCatalogTable> getTable(String fullName) {
     try {
-      return Optional.of(table(get(API_ROOT + "/tables/" + encode(fullName))));
+      String path = API_ROOT + "/tables/" + encode(fullName);
+      JsonNode response = get(path);
+      if (!response.isObject()) {
+        throw invalidResponse("Expected object response from " + path, null);
+      }
+      return Optional.of(table(response));
     } catch (UnityCatalogException e) {
       if (e.failure() == UnityCatalogException.Failure.NOT_FOUND) {
         return Optional.empty();
@@ -203,17 +196,16 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
   }
 
   private JsonNode send(HttpRequest.Builder builder, String path) {
-    builder
-        .uri(URI.create(baseUri + path))
-        .timeout(requestTimeout)
-        .header("Accept", "application/json");
-    Map<String, String> headers = authentication.headers();
-    if (headers != null) {
-      headers.forEach(builder::header);
-    }
-
     HttpResponse<String> response;
     try {
+      builder
+          .uri(URI.create(baseUri + path))
+          .timeout(requestTimeout)
+          .header("Accept", "application/json");
+      Map<String, String> headers = authentication.headers();
+      if (headers != null) {
+        headers.forEach(builder::header);
+      }
       response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -229,23 +221,26 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
 
     int status = response.statusCode();
     String target = describeTarget(path, response.uri());
+    boolean includeResponseBody = !TEMPORARY_TABLE_CREDENTIALS_PATH.equals(path);
     if (status < 200 || status >= 300) {
-      throw httpFailure(status, target, response.body());
+      throw httpFailure(status, target, response.body(), includeResponseBody);
     }
     try {
       return JSON.readTree(response.body());
     } catch (JsonProcessingException e) {
       throw invalidResponse(
-          status, "Invalid JSON from Unity Catalog for " + target, response.body(), e);
+          status,
+          "Invalid JSON from Unity Catalog for " + target,
+          includeResponseBody ? response.body() : null,
+          includeResponseBody ? e : null);
     }
   }
 
   /**
    * The request target for a failure message: the path, plus where a followed redirect landed.
    *
-   * <p>With {@link HttpClient.Redirect#NORMAL} the response can come from somewhere other than the
-   * URI built here, and a 404 from a redirect target reads as a missing endpoint unless the message
-   * says which URI actually answered.
+   * <p>A caller of the package-private constructor may supply a redirecting client. Keeping the
+   * effective URI in that case makes the resulting failure diagnosable.
    */
   private String describeTarget(String path, URI effectiveUri) {
     String requested = baseUri + path;
@@ -332,8 +327,9 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
    * {@code OTHER}, retryable. The 4xx statuses that are never permanent are still named explicitly
    * first, so an envelope-bearing 408 or 429 is not swept into the default either.
    */
-  private static UnityCatalogException httpFailure(int status, String path, String body) {
-    String responseBody = truncate(body);
+  private static UnityCatalogException httpFailure(
+      int status, String path, String body, boolean includeResponseBody) {
+    String responseBody = includeResponseBody ? truncate(body) : "";
     String errorCode = errorCode(body);
     // Only for 4xx. A 5xx is transient whatever its body says, and letting an error_code override
     // it would turn a retryable outage into a terminal refusal.
@@ -374,7 +370,11 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
         failure,
         status,
         errorCode,
-        "Unity Catalog returned HTTP " + status + " for " + path + ": " + responseBody,
+        "Unity Catalog returned HTTP "
+            + status
+            + " for "
+            + path
+            + (responseBody.isEmpty() ? "" : ": " + responseBody),
         null);
   }
 
@@ -454,5 +454,46 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
 
   private static String stripTrailingSlash(String value) {
     return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+  }
+
+  private static HttpClient newHttpClient(URI baseUri, Duration connectTimeout) {
+    Objects.requireNonNull(baseUri, "baseUri");
+    if ("http".equalsIgnoreCase(baseUri.getScheme()) && !isLoopbackHost(baseUri.getHost())) {
+      throw new IllegalArgumentException(
+          "Unity Catalog base URI must use HTTPS unless it is loopback: " + baseUri);
+    }
+    return HttpClient.newBuilder()
+        .connectTimeout(connectTimeout)
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .build();
+  }
+
+  private static boolean isLoopbackHost(String host) {
+    if (host == null) {
+      return false;
+    }
+    String normalized = host.toLowerCase(Locale.ROOT);
+    if (normalized.startsWith("[") && normalized.endsWith("]")) {
+      normalized = normalized.substring(1, normalized.length() - 1);
+    }
+    if (normalized.endsWith(".")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    if (normalized.equals("localhost") || normalized.endsWith(".localhost")) {
+      return true;
+    }
+    boolean numeric =
+        normalized.indexOf(':') >= 0
+            || normalized
+                .chars()
+                .allMatch(character -> Character.isDigit(character) || character == '.');
+    if (!numeric) {
+      return false;
+    }
+    try {
+      return InetAddress.getByName(normalized).isLoopbackAddress();
+    } catch (IOException e) {
+      return false;
+    }
   }
 }

--- a/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClient.java
+++ b/connectors/clients/unity-catalog/src/main/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClient.java
@@ -202,15 +202,16 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
           .uri(URI.create(baseUri + path))
           .timeout(requestTimeout)
           .header("Accept", "application/json");
-      Map<String, String> headers = authentication.headers();
-      if (headers != null) {
-        headers.forEach(builder::header);
-      }
+      applyAuthentication(builder);
       response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new UnityCatalogException(
           UnityCatalogException.Failure.TRANSPORT, -1, "Unity Catalog request interrupted", e);
+    } catch (UnityCatalogException e) {
+      // Already classified. Must precede the catch below: this type is a RuntimeException, and
+      // re-wrapping a permanent authentication failure as TRANSPORT would make it retryable.
+      throw e;
     } catch (IOException | RuntimeException e) {
       throw new UnityCatalogException(
           UnityCatalogException.Failure.TRANSPORT,
@@ -233,6 +234,32 @@ public final class HttpUnityCatalogClient implements UnityCatalogClient {
           "Invalid JSON from Unity Catalog for " + target,
           includeResponseBody ? response.body() : null,
           includeResponseBody ? e : null);
+    }
+  }
+
+  /**
+   * Puts the authentication headers on a request.
+   *
+   * <p>Two failures with opposite retry semantics live here, so they are separated deliberately.
+   * Producing the header map can fail transiently -- a token endpoint that is briefly unreachable
+   * -- so an exception from the provider falls through to the transport classification and stays
+   * retryable. Turning that map into request headers cannot: a name or value the HTTP client
+   * rejects, or a null value, is a property of what the provider returned, and returning it again
+   * will fail identically. That is classified permanent so the reconciler stops rather than loops.
+   */
+  private void applyAuthentication(HttpRequest.Builder builder) {
+    Map<String, String> headers = authentication.headers();
+    if (headers == null || headers.isEmpty()) {
+      return;
+    }
+    try {
+      headers.forEach(builder::header);
+    } catch (RuntimeException e) {
+      throw new UnityCatalogException(
+          UnityCatalogException.Failure.INVALID_REQUEST,
+          -1,
+          "Unity Catalog authentication produced headers this request cannot carry",
+          e);
     }
   }
 

--- a/connectors/clients/unity-catalog/src/test/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClientTest.java
+++ b/connectors/clients/unity-catalog/src/test/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClientTest.java
@@ -509,6 +509,47 @@ class HttpUnityCatalogClientTest {
    * discarded.
    */
   @Test
+  void anUnusableAuthenticationHeaderIsPermanent() {
+    // A header value the client refuses is a property of what the provider returned, so returning
+    // it again fails identically. Classified retryable it would loop a reconcile job forever.
+    var nullValued = new java.util.HashMap<String, String>();
+    nullValued.put("Authorization", null);
+    try (var badAuth =
+        new HttpUnityCatalogClient(
+            URI.create("http://127.0.0.1:" + server.getAddress().getPort()),
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(5),
+            () -> nullValued)) {
+      assertThatThrownBy(badAuth::listCatalogs)
+          .isInstanceOfSatisfying(
+              UnityCatalogException.class,
+              failure ->
+                  assertThat(failure.failure())
+                      .isEqualTo(UnityCatalogException.Failure.INVALID_REQUEST));
+    }
+  }
+
+  @Test
+  void anAuthenticationProviderFailureStaysRetryable() {
+    // The other half of the split: producing the header map can fail transiently -- a token
+    // endpoint briefly unreachable -- and must not be classified terminally.
+    try (var failingAuth =
+        new HttpUnityCatalogClient(
+            URI.create("http://127.0.0.1:" + server.getAddress().getPort()),
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(5),
+            () -> {
+              throw new IllegalStateException("token endpoint unreachable");
+            })) {
+      assertThatThrownBy(failingAuth::listCatalogs)
+          .isInstanceOfSatisfying(
+              UnityCatalogException.class,
+              failure ->
+                  assertThat(failure.failure()).isEqualTo(UnityCatalogException.Failure.TRANSPORT));
+    }
+  }
+
+  @Test
   void malformedSuccessResponseIsAnInvalidResponse() {
     server.createContext(
         "/api/2.1/unity-catalog/catalogs", exchange -> respond(exchange, 200, "not-json"));

--- a/connectors/clients/unity-catalog/src/test/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClientTest.java
+++ b/connectors/clients/unity-catalog/src/test/java/ai/floedb/floecat/client/unity/HttpUnityCatalogClientTest.java
@@ -119,6 +119,19 @@ class HttpUnityCatalogClientTest {
   }
 
   @Test
+  void rejectsCleartextForNonLoopbackHosts() {
+    assertThatThrownBy(
+            () ->
+                new HttpUnityCatalogClient(
+                    URI.create("http://catalog.example.com"),
+                    Duration.ofSeconds(1),
+                    Duration.ofSeconds(5),
+                    Map::of))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must use HTTPS");
+  }
+
+  @Test
   void getTableDecodesWireShapesIntoNormalizedMetadata() {
     var rawPath = new AtomicReference<String>();
     server.createContext(
@@ -170,6 +183,19 @@ class HttpUnityCatalogClientTest {
   }
 
   @Test
+  void getTableRejectsANonObjectSuccessResponse() {
+    server.createContext(
+        "/api/2.1/unity-catalog/tables/", exchange -> respond(exchange, 200, "[]"));
+
+    assertThatThrownBy(() -> client.getTable("cat.schema.invalid"))
+        .isInstanceOfSatisfying(
+            UnityCatalogException.class,
+            failure ->
+                assertThat(failure.failure())
+                    .isEqualTo(UnityCatalogException.Failure.INVALID_RESPONSE));
+  }
+
+  @Test
   void temporaryCredentialsAreTypedAndPostReadOperation() {
     var requestBody = new AtomicReference<String>();
     server.createContext(
@@ -204,6 +230,52 @@ class HttpUnityCatalogClientTest {
     // Carried through unparsed: the epoch-millis rule lives once, in the connector SPI.
     assertThat(credentials.expirationEpochMillis()).isEqualTo("1893456000000");
     assertThat(credentials.storageUrl()).isEqualTo("s3://bucket/table");
+  }
+
+  @Test
+  void malformedCredentialResponseDoesNotLeakItsBody() {
+    String secret = "credential-secret-that-must-not-be-logged";
+    server.createContext(
+        "/api/2.0/unity-catalog/temporary-table-credentials",
+        exchange ->
+            respond(
+                exchange,
+                200,
+                "{\"aws_temp_credentials\":{\"secret_access_key\":\"" + secret + "\""));
+
+    assertThatThrownBy(
+            () ->
+                client.generateTemporaryTableCredentials(
+                    "table-id", UnityCatalogClient.TableOperation.READ))
+        .isInstanceOfSatisfying(
+            UnityCatalogException.class,
+            failure -> {
+              assertThat(failure.failure())
+                  .isEqualTo(UnityCatalogException.Failure.INVALID_RESPONSE);
+              assertThat(failure.getMessage()).doesNotContain(secret, "secret_access_key");
+              assertThat(failure).hasNoCause();
+            });
+  }
+
+  @Test
+  void authenticationFailureIsTranslated() {
+    client.close();
+    client =
+        new HttpUnityCatalogClient(
+            URI.create("http://127.0.0.1:" + server.getAddress().getPort()),
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(5),
+            () -> {
+              throw new IllegalStateException("token unavailable");
+            });
+
+    assertThatThrownBy(client::listCatalogs)
+        .isInstanceOfSatisfying(
+            UnityCatalogException.class,
+            failure -> {
+              assertThat(failure.failure()).isEqualTo(UnityCatalogException.Failure.TRANSPORT);
+              assertThat(failure).hasCauseInstanceOf(IllegalStateException.class);
+            });
   }
 
   @Test
@@ -282,6 +354,7 @@ class HttpUnityCatalogClientTest {
                   .isEqualTo(UnityCatalogException.Failure.PERMISSION_DENIED);
               assertThat(failure.statusCode()).isEqualTo(400);
               assertThat(failure.errorCode()).isEqualTo("PERMISSION_DENIED");
+              assertThat(failure.getMessage()).doesNotContain("missing EXTERNAL USE SCHEMA");
             });
   }
 
@@ -352,22 +425,32 @@ class HttpUnityCatalogClientTest {
                 assertThat(failure.failure()).isEqualTo(UnityCatalogException.Failure.OTHER));
   }
 
-  /**
-   * The JDK's default redirect policy is NEVER, which surfaced an ordinary workspace redirect as an
-   * unusable 3xx. A moved workspace host has to be followed like any other client would.
-   */
   @Test
-  void aRedirectIsFollowed() {
+  void aCredentialRedirectIsNotFollowed() {
+    var redirectedRequests = new AtomicInteger();
     server.createContext(
-        "/api/2.1/unity-catalog/catalogs",
+        "/api/2.0/unity-catalog/temporary-table-credentials",
         exchange -> {
-          exchange.getResponseHeaders().add("Location", "/moved/catalogs");
-          respond(exchange, 301, "");
+          exchange.getResponseHeaders().add("Location", "/moved/credentials");
+          respond(exchange, 302, "");
         });
     server.createContext(
-        "/moved/catalogs", exchange -> respond(exchange, 200, "{\"catalogs\":[{\"name\":\"c\"}]}"));
+        "/moved/credentials",
+        exchange -> {
+          redirectedRequests.incrementAndGet();
+          respond(exchange, 200, "{}");
+        });
 
-    assertThat(client.listCatalogs()).containsExactly("c");
+    assertThatThrownBy(
+            () ->
+                client.generateTemporaryTableCredentials(
+                    "table-id", UnityCatalogClient.TableOperation.READ))
+        .isInstanceOfSatisfying(
+            UnityCatalogException.class,
+            failure ->
+                assertThat(failure.failure())
+                    .isEqualTo(UnityCatalogException.Failure.INVALID_REQUEST));
+    assertThat(redirectedRequests).hasValue(0);
   }
 
   /**
@@ -439,26 +522,6 @@ class HttpUnityCatalogClientTest {
               assertThat(failure.statusCode()).isEqualTo(200);
               assertThat(failure.getMessage()).contains("not-json");
             });
-  }
-
-  /**
-   * With Redirect.NORMAL the response can come from a URI other than the one requested, and a 404
-   * from a redirect target reads as a missing endpoint unless the message says where it landed.
-   */
-  @Test
-  void aFailureAfterAFollowedRedirectNamesTheEffectiveUri() {
-    server.createContext(
-        "/api/2.1/unity-catalog/catalogs",
-        exchange -> {
-          exchange.getResponseHeaders().add("Location", "/moved/catalogs");
-          respond(exchange, 301, "");
-        });
-    server.createContext("/moved/catalogs", exchange -> respond(exchange, 404, "no such endpoint"));
-
-    assertThatThrownBy(client::listCatalogs)
-        .isInstanceOfSatisfying(
-            UnityCatalogException.class,
-            failure -> assertThat(failure.getMessage()).contains("/moved/catalogs"));
   }
 
   private static void respond(HttpExchange exchange, int status, String body) throws IOException {

--- a/core/connectors/spi/pom.xml
+++ b/core/connectors/spi/pom.xml
@@ -41,5 +41,24 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- JUnit for tests -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/DatabricksAccessDelegation.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/DatabricksAccessDelegation.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.spi;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Reads the vend-credentials opt-in off a Databricks / Unity Catalog connector's configuration.
+ *
+ * <p>The Unity Catalog analog of Iceberg's {@link IcebergAccessDelegation} is the <a
+ * href="https://docs.databricks.com/api/workspace/temporarytablecredentials">temporary table
+ * credentials</a> API: given a table id, UC hands back short-lived cloud credentials scoped to that
+ * table's storage location. Unlike Iceberg REST there is no request header that declares the intent
+ * -- vending is a server capability gated by the {@code EXTERNAL USE SCHEMA} privilege -- so the
+ * connector opts in explicitly through a property instead.
+ *
+ * <p>The opt-in is required rather than implicit for the same reason Iceberg's header is: the
+ * reconciler absorbs a missing-storage-authority error <em>only</em> when vending was declared.
+ * Making it implicit for every Unity connector would silently swallow a genuinely misconfigured
+ * storage authority and resurface it far away as an opaque FileIO read failure. Both gates read
+ * this one parser so they cannot drift apart -- the same invariant {@link IcebergAccessDelegation}
+ * documents.
+ */
+public final class DatabricksAccessDelegation {
+
+  /**
+   * The property that turns on source-catalog vending for a Delta/Unity connector.
+   *
+   * <p>Set with {@code --props databricks.access-delegation=vended-credentials}. Honored only for a
+   * Delta connector whose {@code delta.source} is Unity Catalog; a stray copy on an Iceberg
+   * connector is ignored, since that path is governed by {@link
+   * IcebergAccessDelegation#HEADER_PROPERTY} instead.
+   *
+   * <p>The key ends in {@code access-delegation} rather than {@code vend-credentials} on purpose:
+   * the connector-property secret guard rejects any key whose canonical form ends in {@code
+   * _credentials} (to keep plaintext secrets out of connector metadata), and this is a non-secret
+   * boolean opt-in. The name also mirrors the Iceberg gate's {@code X-Iceberg-Access-Delegation}
+   * header, whose {@code vended-credentials} value {@link #isTruthy} already accepts.
+   */
+  public static final String VEND_OPTION = "databricks.access-delegation";
+
+  private static final String DELTA_SOURCE_OPTION = "delta.source";
+
+  private static final Set<String> TRUTHY = Set.of("true", "1", "yes", "vended-credentials");
+
+  private static final Set<String> FALSY = Set.of("false", "0", "no", "none");
+
+  private DatabricksAccessDelegation() {}
+
+  /**
+   * Whether {@code config} is a Delta/Unity connector that has opted in to catalog vending.
+   *
+   * <p>Answerable from {@link ConnectorConfig} alone because both gates run before the connector
+   * factory builds the connector, exactly as the Iceberg gate requires.
+   */
+  public static boolean declaresVendedCredentials(ConnectorConfig config) {
+    if (config == null) {
+      return false;
+    }
+    if (!usesUnityCatalog(config)) {
+      return false;
+    }
+    return isTruthy(config.options().get(VEND_OPTION));
+  }
+
+  /**
+   * Whether this Delta connector is pointed at Unity Catalog.
+   *
+   * <p>The catalog, not the format, is what can vend: {@code delta.source=glue} has no equivalent
+   * API and {@code delta.source=filesystem} has no catalog at all, so both keep using a storage
+   * authority.
+   *
+   * <p>An absent {@code delta.source} still reads as Unity Catalog because that has always been
+   * {@code DeltaConnectorFactory.selectSource}'s default, and connectors persisted before the
+   * option was required rely on it. New connectors must state it explicitly -- the service rejects
+   * a Delta spec without it -- so this fallback only ever applies to legacy configuration.
+   */
+  private static boolean usesUnityCatalog(ConnectorConfig config) {
+    if (config.kind() != ConnectorConfig.Kind.DELTA) {
+      return false;
+    }
+    String source = config.options().get(DELTA_SOURCE_OPTION);
+    return source == null || source.isBlank() || source.trim().equalsIgnoreCase("unity");
+  }
+
+  /**
+   * Whether a value for {@link #VEND_OPTION} means anything to this parser.
+   *
+   * <p>Exists so the service can reject a typo at create/update time. {@link #isTruthy} answers
+   * {@code false} for everything it does not recognise, which is the only safe reading at request
+   * time but makes {@code vended_credentials} (underscore) or {@code vended-credential} (singular)
+   * indistinguishable from a deliberate opt-out -- and because the "attempt vending" gate and the
+   * reconciler's "absorb the missing-authority error" gate both read this parser, the two agree
+   * that the connector never opted in and nothing anywhere reports why reads fall back to a storage
+   * authority that was never configured.
+   *
+   * <p>A blank value is recognised: an absent or cleared property is simply "not opted in".
+   */
+  public static boolean isRecognizedValue(String value) {
+    if (value == null || value.isBlank()) {
+      return true;
+    }
+    return isTruthy(value) || FALSY.contains(value.trim().toLowerCase(Locale.ROOT));
+  }
+
+  private static boolean isTruthy(String value) {
+    if (value == null || value.isBlank()) {
+      return false;
+    }
+    return TRUTHY.contains(value.trim().toLowerCase(Locale.ROOT));
+  }
+}

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
@@ -1174,14 +1174,44 @@ public interface FloecatConnector extends Closeable {
    * @param expiresAt when the credentials stop working, or null if the catalog did not say. Null is
    *     meaningful — callers that cache must treat it as "do not cache" rather than "never
    *     expires".
+   * @param scopePrefix catalog-issued storage prefix to which the credentials apply, or null when
+   *     the catalog did not provide one. Callers may fall back to the requested table location but
+   *     must prefer this value when producing a scoped credential response.
    */
-  record VendedStorageCredentials(Map<String, String> properties, Instant expiresAt) {
+  record VendedStorageCredentials(
+      Map<String, String> properties, Instant expiresAt, String scopePrefix) {
+    public VendedStorageCredentials(Map<String, String> properties, Instant expiresAt) {
+      this(properties, expiresAt, null);
+    }
+
     public VendedStorageCredentials {
       properties = properties == null ? Map.of() : Map.copyOf(properties);
+      scopePrefix = scopePrefix == null || scopePrefix.isBlank() ? null : scopePrefix.trim();
     }
 
     public boolean isEmpty() {
       return properties.isEmpty();
+    }
+
+    /**
+     * Parses a vended expiry expressed as epoch milliseconds, shared by every connector that vends.
+     *
+     * <p>Null (absent, blank, non-positive, or unparseable) is deliberately not "never expires":
+     * callers that cache must treat it as "do not cache", and the reconcile path refuses a
+     * credential with no expiry because it cannot schedule a renewal for one. A malformed value is
+     * folded into the same null rather than failing the vend -- the credential still reads, it just
+     * cannot be cached or refreshed.
+     */
+    public static Instant expiryFromEpochMillis(String rawEpochMillis) {
+      if (rawEpochMillis == null || rawEpochMillis.isBlank()) {
+        return null;
+      }
+      try {
+        long millis = Long.parseLong(rawEpochMillis.trim());
+        return millis > 0 ? Instant.ofEpochMilli(millis) : null;
+      } catch (NumberFormatException e) {
+        return null;
+      }
     }
   }
 }

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/SourceCatalogAccessException.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/SourceCatalogAccessException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.spi;
+
+/**
+ * A source catalog permanently refused to vend storage credentials -- a condition that must be
+ * classified <em>terminal</em>, not retried.
+ *
+ * <p>The storage service classifies a vend failure by exception type, not by substring-matching the
+ * message: a transient failure whose text merely contains "403" (a gateway page, an IAM-propagation
+ * denial, a URL with 403 in it) must stay retryable. Iceberg REST surfaces these as its own {@code
+ * NotAuthorizedException}/{@code ForbiddenException}; a connector that speaks a different protocol
+ * (Unity Catalog over plain HTTP, for example) has no such typed signal, so it throws this instead.
+ * Without it, a hard 401/403 escapes as a generic {@link RuntimeException}, is classified {@code
+ * INTERNAL} (retryable), and the reconciler retries a job that can never succeed -- exactly the
+ * loop a Databricks workspace missing the {@code EXTERNAL USE SCHEMA} privilege would fall into.
+ */
+public class SourceCatalogAccessException extends RuntimeException {
+
+  /** Which refusal this is, mapped by the caller to the corresponding terminal gRPC status. */
+  public enum Denial {
+    /** The caller was not authenticated (e.g. a bad or expired token; HTTP 401). */
+    UNAUTHENTICATED,
+    /** The caller was authenticated but lacks the privilege to vend (e.g. HTTP 403). */
+    PERMISSION_DENIED,
+    /**
+     * The catalog will not vend for this table for a reason that is neither 401 nor 403 and will
+     * not change on retry: Databricks answers the credentials endpoint with HTTP 400 plus an {@code
+     * error_code} when a table has external access disabled, and with HTTP 404 for a table id it no
+     * longer knows. Not an authorization failure, so it maps to a precondition rather than a denial
+     * -- but equally permanent, and equally wrong to retry.
+     */
+    UNSUPPORTED
+  }
+
+  private final Denial denial;
+
+  public SourceCatalogAccessException(Denial denial, String message) {
+    super(message);
+    this.denial = denial;
+  }
+
+  public Denial denial() {
+    return denial;
+  }
+}

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/SourceCatalogVending.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/SourceCatalogVending.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.spi;
+
+/**
+ * Format-neutral entry point for "does this connector ask its source catalog to vend storage
+ * credentials?".
+ *
+ * <p>Two gates depend on the answer and must agree: the storage service decides whether to
+ * <em>attempt</em> source-catalog vending for a table with no matching storage authority, and the
+ * reconciler's config resolver decides whether to <em>absorb</em> the resulting missing-authority
+ * error. Each catalog format declares vending its own way -- Iceberg REST through the {@code
+ * X-Iceberg-Access-Delegation} header, a Delta connector pointed at Unity Catalog through an
+ * explicit opt-in property -- so both gates route through this single dispatcher rather than
+ * special-casing formats independently and drifting apart.
+ */
+public final class SourceCatalogVending {
+
+  private SourceCatalogVending() {}
+
+  /** Whether {@code config} declares that its source catalog vends storage credentials. */
+  public static boolean declaresVendedCredentials(ConnectorConfig config) {
+    if (config == null) {
+      return false;
+    }
+    return switch (config.kind()) {
+      case ICEBERG -> IcebergAccessDelegation.declaresVendedCredentials(config);
+      case DELTA -> DatabricksAccessDelegation.declaresVendedCredentials(config);
+      case GLUE -> false;
+    };
+  }
+
+  /**
+   * Whether a connector's own catalog client already carries vended storage credentials once a
+   * table is loaded -- i.e. whether an <em>untouched</em> config is enough to read the table's
+   * data.
+   *
+   * <p>Distinct from {@link #declaresVendedCredentials}, and deliberately narrower. Declaring
+   * vending is what makes the storage service <em>attempt</em> a source-catalog vend; this is what
+   * makes it safe for the reconciler's config resolver to <em>absorb</em> a missing-authority error
+   * and hand the connector back unchanged. Only Iceberg REST satisfies it: {@code loadTable}
+   * returns storage-credentials and the {@code FileIO} built from that response uses them.
+   *
+   * <p>Delta and Unity Catalog do not. Their connector vends only when asked, through {@code
+   * vendStorageCredentials}, and the Delta engine's S3 client is built once from the connector's
+   * own {@code s3.*} options -- so an untouched config carries no storage credentials at all.
+   * Absorbing there would trade a precise "no authority covers this location" failure for an opaque
+   * {@code 403 AccessDenied} on the first read.
+   */
+  public static boolean clientAppliesVendedCredentials(ConnectorConfig config) {
+    if (config == null) {
+      return false;
+    }
+    return switch (config.kind()) {
+      case ICEBERG -> IcebergAccessDelegation.declaresVendedCredentials(config);
+      case DELTA, GLUE -> false;
+    };
+  }
+}

--- a/core/connectors/spi/src/test/java/ai/floedb/floecat/connector/spi/SourceCatalogVendingTest.java
+++ b/core/connectors/spi/src/test/java/ai/floedb/floecat/connector/spi/SourceCatalogVendingTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the two vend gates that live in this module. They ship here, beside every connector that
+ * depends on them, so the rules are exercised by this module's own build rather than only when a
+ * downstream connector module happens to be built.
+ */
+class SourceCatalogVendingTest {
+
+  private static ConnectorConfig config(ConnectorConfig.Kind kind, Map<String, String> options) {
+    return new ConnectorConfig(kind, "display", "https://example", options, null);
+  }
+
+  @Test
+  void unityBackedDeltaConnectorOptsInWhenFlagIsTruthy() {
+    for (String truthy : new String[] {"true", "1", "yes", "vended-credentials", "TRUE"}) {
+      var cfg =
+          config(
+              ConnectorConfig.Kind.DELTA,
+              Map.of("delta.source", "unity", DatabricksAccessDelegation.VEND_OPTION, truthy));
+      assertThat(DatabricksAccessDelegation.declaresVendedCredentials(cfg)).as(truthy).isTrue();
+    }
+  }
+
+  @Test
+  void anOmittedSourceStillReadsAsUnityForLegacyConfiguration() {
+    // Connectors persisted before delta.source was required rely on the factory's Unity default;
+    // the service now demands the property on create, so this only covers existing records.
+    var cfg =
+        config(ConnectorConfig.Kind.DELTA, Map.of(DatabricksAccessDelegation.VEND_OPTION, "true"));
+    assertThat(DatabricksAccessDelegation.declaresVendedCredentials(cfg)).isTrue();
+  }
+
+  @Test
+  void nonUnityDeltaSourcesIgnoreTheOptIn() {
+    for (String source : new String[] {"glue", "filesystem"}) {
+      var cfg =
+          config(
+              ConnectorConfig.Kind.DELTA,
+              Map.of("delta.source", source, DatabricksAccessDelegation.VEND_OPTION, "true"));
+      assertThat(DatabricksAccessDelegation.declaresVendedCredentials(cfg)).as(source).isFalse();
+    }
+  }
+
+  @Test
+  void absentOrFalsyFlagIsNotDeclared() {
+    assertThat(
+            DatabricksAccessDelegation.declaresVendedCredentials(
+                config(ConnectorConfig.Kind.DELTA, Map.of("delta.source", "unity"))))
+        .isFalse();
+    assertThat(
+            DatabricksAccessDelegation.declaresVendedCredentials(
+                config(
+                    ConnectorConfig.Kind.DELTA,
+                    Map.of(
+                        "delta.source", "unity", DatabricksAccessDelegation.VEND_OPTION, "false"))))
+        .isFalse();
+  }
+
+  @Test
+  void icebergKindIgnoresTheDatabricksFlag() {
+    // The Databricks opt-in must not fire on an Iceberg connector; that path uses the delegation
+    // header instead. A stray copy of the property is simply ignored.
+    var cfg =
+        config(
+            ConnectorConfig.Kind.ICEBERG, Map.of(DatabricksAccessDelegation.VEND_OPTION, "true"));
+    assertThat(DatabricksAccessDelegation.declaresVendedCredentials(cfg)).isFalse();
+  }
+
+  @Test
+  void neutralDispatcherAcceptsBothFormats() {
+    // Unity-backed Delta via the opt-in option...
+    assertThat(
+            SourceCatalogVending.declaresVendedCredentials(
+                config(
+                    ConnectorConfig.Kind.DELTA,
+                    Map.of(
+                        "delta.source", "unity", DatabricksAccessDelegation.VEND_OPTION, "true"))))
+        .isTrue();
+    // ...and Iceberg via its access-delegation header.
+    assertThat(
+            SourceCatalogVending.declaresVendedCredentials(
+                config(
+                    ConnectorConfig.Kind.ICEBERG,
+                    Map.of(IcebergAccessDelegation.HEADER_PROPERTY, "vended-credentials"))))
+        .isTrue();
+    // A Delta connector that opted into neither declares nothing.
+    assertThat(
+            SourceCatalogVending.declaresVendedCredentials(
+                config(ConnectorConfig.Kind.DELTA, Map.of())))
+        .isFalse();
+  }
+
+  @Test
+  void glueDeclaresNothing() {
+    // Glue has no vending channel at all; the dispatcher must answer false rather than fall through
+    // to a Databricks or Iceberg reading of a stray property.
+    assertThat(
+            SourceCatalogVending.declaresVendedCredentials(
+                config(
+                    ConnectorConfig.Kind.GLUE,
+                    Map.of(
+                        DatabricksAccessDelegation.VEND_OPTION,
+                        "true",
+                        IcebergAccessDelegation.HEADER_PROPERTY,
+                        "vended-credentials"))))
+        .isFalse();
+  }
+
+  @Test
+  void aNullConfigDeclaresNothing() {
+    assertThat(SourceCatalogVending.declaresVendedCredentials(null)).isFalse();
+    assertThat(DatabricksAccessDelegation.declaresVendedCredentials(null)).isFalse();
+  }
+
+  /**
+   * Declaring vending and applying it at load time are different questions. Only Iceberg REST
+   * answers yes to the second: Delta/Unity vend on request and build their S3 client from the
+   * connector's own options, so an untouched config carries no storage credentials.
+   */
+  @Test
+  void onlyIcebergAppliesVendedCredentialsWhenLoading() {
+    ConnectorConfig unity =
+        config(
+            ConnectorConfig.Kind.DELTA,
+            Map.of("delta.source", "unity", DatabricksAccessDelegation.VEND_OPTION, "true"));
+    ConnectorConfig delta =
+        config(ConnectorConfig.Kind.DELTA, Map.of(DatabricksAccessDelegation.VEND_OPTION, "true"));
+    ConnectorConfig iceberg =
+        config(
+            ConnectorConfig.Kind.ICEBERG,
+            Map.of(IcebergAccessDelegation.HEADER_PROPERTY, "vended-credentials"));
+
+    assertThat(SourceCatalogVending.declaresVendedCredentials(unity)).isTrue();
+    assertThat(SourceCatalogVending.clientAppliesVendedCredentials(unity)).isFalse();
+    assertThat(SourceCatalogVending.clientAppliesVendedCredentials(delta)).isFalse();
+    assertThat(SourceCatalogVending.clientAppliesVendedCredentials(iceberg)).isTrue();
+    assertThat(
+            SourceCatalogVending.clientAppliesVendedCredentials(
+                config(ConnectorConfig.Kind.ICEBERG, Map.of())))
+        .isFalse();
+    assertThat(SourceCatalogVending.clientAppliesVendedCredentials(null)).isFalse();
+  }
+
+  @Test
+  void neutralDispatcherDoesNotCrossFormatBoundaries() {
+    assertThat(
+            SourceCatalogVending.declaresVendedCredentials(
+                config(
+                    ConnectorConfig.Kind.DELTA,
+                    Map.of(
+                        "delta.source",
+                        "unity",
+                        IcebergAccessDelegation.HEADER_PROPERTY,
+                        "vended-credentials"))))
+        .isFalse();
+    assertThat(
+            SourceCatalogVending.declaresVendedCredentials(
+                config(
+                    ConnectorConfig.Kind.ICEBERG,
+                    Map.of(DatabricksAccessDelegation.VEND_OPTION, "true"))))
+        .isFalse();
+  }
+}

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/errors/SourceCatalogVendingGrpcStatus.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/errors/SourceCatalogVendingGrpcStatus.java
@@ -54,6 +54,13 @@ public final class SourceCatalogVendingGrpcStatus {
   public static final String VENDED_CREDENTIALS_NOT_REFRESHABLE_REASON =
       "VENDED_CREDENTIALS_NOT_REFRESHABLE";
 
+  /**
+   * The source catalog permanently refused to vend for this table for a reason that is neither
+   * authentication nor authorization -- Databricks' HTTP 400 for a table without external access,
+   * or a 404 for a table id it no longer knows. Terminal: the answer will not change on retry.
+   */
+  public static final String SOURCE_CATALOG_VEND_REFUSED_REASON = "SOURCE_CATALOG_VEND_REFUSED";
+
   private static final String REASON_PARAM = "reason";
 
   private SourceCatalogVendingGrpcStatus() {}
@@ -81,6 +88,18 @@ public final class SourceCatalogVendingGrpcStatus {
   public static boolean isVendedCredentialsNotRefreshable(Throwable error) {
     return hasReason(
         error, Status.Code.FAILED_PRECONDITION, VENDED_CREDENTIALS_NOT_REFRESHABLE_REASON);
+  }
+
+  public static StatusRuntimeException sourceCatalogVendRefused(String description) {
+    return withReason(
+        Status.Code.FAILED_PRECONDITION,
+        ErrorCode.MC_PRECONDITION_FAILED,
+        SOURCE_CATALOG_VEND_REFUSED_REASON,
+        description);
+  }
+
+  public static boolean isSourceCatalogVendRefused(Throwable error) {
+    return hasReason(error, Status.Code.FAILED_PRECONDITION, SOURCE_CATALOG_VEND_REFUSED_REASON);
   }
 
   private static StatusRuntimeException withReason(

--- a/docs/connectors-delta.md
+++ b/docs/connectors-delta.md
@@ -126,6 +126,13 @@ Important connector properties:
 - `delta.table-root` – Required for `delta.source=filesystem`, pointing at a Delta table root.
 - `external.namespace`, `external.table-name` – Optional overrides for filesystem connector naming.
 - `http.connect.ms`, `http.read.ms` – Timeout controls for Unity Catalog HTTP calls.
+- `databricks.access-delegation=vended-credentials` – Explicitly enables table-scoped temporary
+  AWS credentials from Unity Catalog when no storage authority matches the table. The Databricks
+  metastore must allow external access and the caller needs `EXTERNAL USE SCHEMA` on the parent
+  schema. Azure, GCP, and R2 credential shapes are not yet consumed and fall back to a configured
+  storage authority. Accepted values are `vended-credentials`, `true`, `1`, `yes` (enabled) and
+  `false`, `0`, `no`, `none` (disabled); anything else is rejected at create/update time rather
+  than read as "disabled".
 - `s3.region` / `aws.region` – Region for the S3 client used to read Parquet files.
 - `stats.ndv.*` – Sampling knobs identical to the Iceberg connector.
 - Authentication-specific options (`auth.scheme`, `auth.properties`) – `auth.scheme=oauth2`

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileFailureClassifier.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileFailureClassifier.java
@@ -50,8 +50,11 @@ final class ReconcileFailureClassifier {
         }
         // Matched by structured reason, not by status code: FAILED_PRECONDITION is shared with
         // lease-precondition failures, which are retryable by design. A catalog that vends an
-        // incomplete session tuple or no expiry will keep doing so, so retrying only loops.
-        if (SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(sre)) {
+        // incomplete session tuple or no expiry will keep doing so, and one that refuses to vend
+        // for this table at all (external access disabled, unknown table id) will keep refusing --
+        // so retrying either only loops.
+        if (SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(sre)
+            || SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(sre)) {
           return terminalInternal(sre.getMessage(), sre);
         }
       }

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -49,6 +49,7 @@ import ai.floedb.floecat.connector.spi.ConnectorConfig;
 import ai.floedb.floecat.connector.spi.ConnectorConfig.Kind;
 import ai.floedb.floecat.connector.spi.ConnectorFactory;
 import ai.floedb.floecat.connector.spi.CredentialResolver;
+import ai.floedb.floecat.connector.spi.DatabricksAccessDelegation;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
 import ai.floedb.floecat.service.common.Canonicalizer;
 import ai.floedb.floecat.service.common.IdempotencyGuard;
@@ -242,6 +243,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
 
                   var display = mustNonEmpty(spec.getDisplayName(), "display_name", corr);
                   var uri = mustNonEmpty(spec.getUri(), "uri", corr);
+                  validateAccessDelegation(spec.getKind(), spec.getPropertiesMap(), corr);
                   validateConnectorProperties(spec.getKind(), spec.getPropertiesMap(), corr);
                   validatePersistedAuthConfig(spec.getAuth(), corr);
                   validateReconcilePolicy(spec.getPolicy(), corr);
@@ -523,6 +525,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                           .toBuilder()
                           .setUpdatedAt(nowTs())
                           .build();
+                  validateAccessDelegation(desired.getKind(), desired.getPropertiesMap(), corr);
                   validateConnectorProperties(
                       desired.getKind(), desired.getPropertiesMap(), corr, "properties");
                   validatePersistedAuthConfig(desired.getAuth(), corr);
@@ -709,6 +712,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                           mustNonEmpty(spec.getUri(), "uri", corr),
                           spec.getPropertiesMap(),
                           auth);
+                  validateAccessDelegation(spec.getKind(), spec.getPropertiesMap(), corr);
                   validateConnectorProperties(spec.getKind(), spec.getPropertiesMap(), corr);
                   validatePersistedAuthConfig(spec.getAuth(), corr);
                   validateReconcilePolicy(spec.getPolicy(), corr);
@@ -933,6 +937,28 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
       }
     }
     return false;
+  }
+
+  /**
+   * Checks the vend-credentials opt-in a Delta connector spelled out.
+   *
+   * <p>{@code DatabricksAccessDelegation} reads any unrecognized value as "not opted in", which is
+   * the only safe reading at request time but makes {@code vended_credentials} (underscore) or
+   * {@code vended-credential} (singular) silently disable vending. Both gates that consult it --
+   * the one that attempts vending and the one that lets the reconciler absorb the resulting
+   * missing-authority error -- then agree, so a typo surfaces far away as reads falling back to a
+   * storage authority that was never configured.
+   */
+  private static void validateAccessDelegation(
+      ConnectorKind kind, Map<String, String> properties, String corr) {
+    if (kind != ConnectorKind.CK_DELTA || properties == null) {
+      return;
+    }
+    String value = properties.get(DatabricksAccessDelegation.VEND_OPTION);
+    if (!DatabricksAccessDelegation.isRecognizedValue(value)) {
+      throw GrpcErrors.invalidArgument(
+          corr, null, Map.of("field", "properties", "key", DatabricksAccessDelegation.VEND_OPTION));
+    }
   }
 
   private static void validateConnectorProperties(

--- a/service/src/test/java/ai/floedb/floecat/service/common/PersistedSecretPropertyValidatorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/common/PersistedSecretPropertyValidatorTest.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.common;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.floedb.floecat.connector.spi.DatabricksAccessDelegation;
 import org.junit.jupiter.api.Test;
 
 class PersistedSecretPropertyValidatorTest {
@@ -33,6 +34,11 @@ class PersistedSecretPropertyValidatorTest {
     assertTrue(PersistedSecretPropertyValidator.isForbiddenPersistedSecretKey("s3.access-key-id"));
     assertTrue(
         PersistedSecretPropertyValidator.isForbiddenPersistedSecretKey("fs.s3a.secret-access-key"));
+    // The original Databricks vend opt-in name canonicalized to *_credentials and tripped this
+    // guard, which is why it was renamed; keep the assertion so the reason stays documented.
+    assertTrue(
+        PersistedSecretPropertyValidator.isForbiddenPersistedSecretKey(
+            "databricks.vend-credentials"));
   }
 
   @Test
@@ -43,6 +49,11 @@ class PersistedSecretPropertyValidatorTest {
     assertFalse(
         PersistedSecretPropertyValidator.isForbiddenPersistedSecretKey("write.metadata.path"));
     assertFalse(PersistedSecretPropertyValidator.isForbiddenPersistedSecretKey("token_type"));
+    // The Databricks vend opt-in is a non-secret boolean flag and must clear the guard. Pinned to
+    // the constant so a future rename back into a *_credentials/*_key form fails here.
+    assertFalse(
+        PersistedSecretPropertyValidator.isForbiddenPersistedSecretKey(
+            DatabricksAccessDelegation.VEND_OPTION));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Stack 4/7. Base: `kw-uc-vending-03-client-hardening` (#468).

Extends the existing source-catalog credential-vending contract to Databricks Unity Catalog. When no storage authority covers a table, an explicitly opted-in Delta connector can request short-lived, table-scoped AWS credentials from the Unity temporary-table-credentials API.

Changes:

- Gate vending on `databricks.access-delegation=vended-credentials` and reject unrecognized values during create/update.
- Share the opt-in dispatcher between both service gates so they cannot disagree.
- Fall back to a storage authority when Unity returns no recognized credential shape.
- Classify permanent credential refusals as terminal while preserving retryability for transient failures.
- Carry non-authorization terminal refusals as their own structured reason.
- Add catalog scope to the shared vending record and centralize epoch-millis expiry parsing.

The scope/expiry changes also affect the existing Iceberg vending contract; scope enforcement lands in stack PR 5/7.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Full build, 0 failures. Formatting clean.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [x] Config/env var changes (describe below)

Unity credential vending is disabled unless the connector explicitly sets `databricks.access-delegation=vended-credentials` (accepted boolean aliases are also validated). Existing connectors retain storage-authority behavior.

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Not covered: `delta.source=glue`, `delta.source=filesystem`, or Azure/GCP/R2 credential consumption. Unsupported cloud credential shapes continue to fall back to storage authorities. The shared Iceberg expiry behavior changes slightly: non-positive epoch values now mean no expiry.
