### PR TITLE
storage: wire Unity Catalog vended credentials into read paths

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorFactory.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorFactory.java
@@ -232,6 +232,8 @@ final class DeltaConnectorFactory {
 
     boolean pathStyle =
         Boolean.parseBoolean(resolveOption(options, "s3.path-style-access", "false"));
+    String accessPoint =
+        S3V2FileSystemClient.blankToNull(resolveOption(options, "s3.access-point", null));
 
     var credentials = credentialsProviderFactory(options);
 
@@ -244,7 +246,10 @@ final class DeltaConnectorFactory {
                   S3Client.builder()
                       .region(region)
                       .serviceConfiguration(
-                          S3Configuration.builder().pathStyleAccessEnabled(pathStyle).build())
+                          S3Configuration.builder()
+                              .pathStyleAccessEnabled(pathStyle)
+                              .useArnRegionEnabled(accessPoint != null)
+                              .build())
                       .credentialsProvider(provider);
               try {
                 if (endpoint != null && !endpoint.isBlank()) {
@@ -257,8 +262,8 @@ final class DeltaConnectorFactory {
                 throw e;
               }
             });
-    Engine engine = DefaultEngine.create(new S3V2FileSystemClient(s3Client));
-    Function<String, InputFile> inputFn = p -> new ParquetS3V2InputFile(s3Client, p);
+    Engine engine = DefaultEngine.create(new S3V2FileSystemClient(s3Client, accessPoint));
+    Function<String, InputFile> inputFn = p -> new ParquetS3V2InputFile(s3Client, p, accessPoint);
     return new EngineContext(engine, inputFn);
   }
 

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/ParquetS3V2InputFile.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/ParquetS3V2InputFile.java
@@ -29,9 +29,13 @@ public class ParquetS3V2InputFile implements InputFile {
   private final String bucket;
   private final String key;
 
-  ParquetS3V2InputFile(RefreshingAwsClient<S3Client> s3, String s3Uri) {
+  /**
+   * @param bucketOverride the S3 access point ARN to address instead of the bucket named in the
+   *     URI, or null/blank to address the bucket directly
+   */
+  ParquetS3V2InputFile(RefreshingAwsClient<S3Client> s3, String s3Uri, String bucketOverride) {
     var u = URI.create(s3Uri.startsWith("s3a://") ? "s3://" + s3Uri.substring(6) : s3Uri);
-    this.bucket = u.getHost();
+    this.bucket = S3V2FileSystemClient.requestBucket(u, bucketOverride);
     this.key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
     try {
       this.reader = new S3RangeReader(s3, bucket, key);

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClient.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClient.java
@@ -41,9 +41,16 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 
 final class S3V2FileSystemClient implements FileIO {
   private final RefreshingAwsClient<S3Client> s3;
+  private final String bucketOverride;
 
-  S3V2FileSystemClient(RefreshingAwsClient<S3Client> s3) {
+  /**
+   * @param bucketOverride the S3 access point ARN to address instead of the bucket named in each
+   *     URI, or null/blank to address the bucket directly. Vended Unity Catalog credentials are
+   *     only valid against the access point when the catalog supplies one.
+   */
+  S3V2FileSystemClient(RefreshingAwsClient<S3Client> s3, String bucketOverride) {
     this.s3 = s3;
+    this.bucketOverride = blankToNull(bucketOverride);
   }
 
   @Override
@@ -52,7 +59,7 @@ final class S3V2FileSystemClient implements FileIO {
     if (isMissingCheckpoint(resolved)) {
       return new MissingInputFile(resolved);
     }
-    return new S3InputFile(s3, resolved);
+    return new S3InputFile(s3, resolved, bucketOverride);
   }
 
   @Override
@@ -87,7 +94,7 @@ final class S3V2FileSystemClient implements FileIO {
   @Override
   public FileStatus getFileStatus(String path) throws IOException {
     var u = URI.create(resolvePath(path));
-    var bucket = u.getHost();
+    var bucket = requestBucket(u);
     var key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
     try {
       var head = s3.call(client -> client.headObject(b -> b.bucket(bucket).key(key)));
@@ -103,7 +110,7 @@ final class S3V2FileSystemClient implements FileIO {
       return false;
     }
     URI u = URI.create(resolvedPath);
-    String bucket = u.getHost();
+    String bucket = requestBucket(u);
     String key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
     try {
       s3.callUnchecked(client -> client.headObject(b -> b.bucket(bucket).key(key)));
@@ -120,10 +127,11 @@ final class S3V2FileSystemClient implements FileIO {
   public CloseableIterator<FileStatus> listFrom(String filePath) throws IOException {
     final String resolved = resolvePath(filePath);
     final URI u = URI.create(resolved);
-    final String bucket = u.getHost();
-    if (bucket == null || bucket.isEmpty()) {
+    final String logicalBucket = u.getHost();
+    if (logicalBucket == null || logicalBucket.isEmpty()) {
       throw new IOException("Invalid S3 path for listFrom: " + filePath);
     }
+    final String bucket = requestBucket(u);
     final String fullKey = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
 
     final int lastSlash = fullKey.lastIndexOf('/');
@@ -232,7 +240,7 @@ final class S3V2FileSystemClient implements FileIO {
               continue;
             }
 
-            String fullPath = "s3://" + bucket + "/" + key;
+            String fullPath = "s3://" + logicalBucket + "/" + key;
             long size = (o.size() != null) ? o.size() : 0L;
             long mod =
                 (o.lastModified() != null)
@@ -266,6 +274,19 @@ final class S3V2FileSystemClient implements FileIO {
     return Optional.empty();
   }
 
+  private String requestBucket(URI location) {
+    return requestBucket(location, bucketOverride);
+  }
+
+  static String requestBucket(URI location, String bucketOverride) {
+    String override = blankToNull(bucketOverride);
+    return override == null ? location.getHost() : override;
+  }
+
+  static String blankToNull(String value) {
+    return value == null || value.isBlank() ? null : value.trim();
+  }
+
   static final class S3InputFile implements InputFile {
     private final RefreshingAwsClient<S3Client> s3;
     private final String resolvedPath;
@@ -274,12 +295,12 @@ final class S3V2FileSystemClient implements FileIO {
     private final String key;
     private final S3RangeReader rangeReader;
 
-    S3InputFile(RefreshingAwsClient<S3Client> s3, String resolvedPath) {
+    S3InputFile(RefreshingAwsClient<S3Client> s3, String resolvedPath, String bucketOverride) {
       this.s3 = s3;
       this.resolvedPath = resolvedPath;
 
       var u = URI.create(resolvedPath);
-      this.bucket = u.getHost();
+      this.bucket = requestBucket(u, bucketOverride);
       this.key = u.getPath().startsWith("/") ? u.getPath().substring(1) : u.getPath();
 
       try {

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClientTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClientTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.delta.uc.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class S3V2FileSystemClientTest {
+  @Test
+  void accessPointArnOverridesLogicalBucketForRequests() {
+    String accessPoint = "arn:aws:s3:eu-west-1:123456789012:accesspoint/orders";
+
+    assertThat(
+            S3V2FileSystemClient.requestBucket(
+                URI.create("s3://physical-bucket/table/_delta_log/000.json"), accessPoint))
+        .isEqualTo(accessPoint);
+  }
+
+  @Test
+  void logicalBucketIsUsedWithoutAccessPoint() {
+    assertThat(
+            S3V2FileSystemClient.requestBucket(
+                URI.create("s3://physical-bucket/table/data.parquet"), null))
+        .isEqualTo("physical-bucket");
+  }
+
+  @Test
+  void blankAccessPointIsIgnored() {
+    assertThat(
+            S3V2FileSystemClient.requestBucket(
+                URI.create("s3://physical-bucket/table/data.parquet"), "  "))
+        .isEqualTo("physical-bucket");
+  }
+}

--- a/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/compat/DeltaManifestMaterializer.java
+++ b/protocol-gateway/iceberg-rest/src/main/java/ai/floedb/floecat/gateway/iceberg/rest/services/compat/DeltaManifestMaterializer.java
@@ -450,9 +450,13 @@ public class DeltaManifestMaterializer {
   protected DeltaEngineContext newDeltaEngineContext(
       SourceTableAccess sourceAccess, String tableRoot) {
     if (tableRoot != null && tableRoot.toLowerCase(Locale.ROOT).startsWith("s3://")) {
-      RefreshingAwsClient<S3Client> s3 =
-          buildS3Client(sourceAccess == null ? Map.of() : sourceAccess.fileIoProperties());
-      return new DeltaEngineContext(DefaultEngine.create(new S3FileSystemClient(s3)), s3);
+      Map<String, String> fileIoProperties =
+          sourceAccess == null ? Map.of() : sourceAccess.fileIoProperties();
+      RefreshingAwsClient<S3Client> s3 = buildS3Client(fileIoProperties);
+      return new DeltaEngineContext(
+          DefaultEngine.create(
+              new S3FileSystemClient(s3, resolveOption(fileIoProperties, "s3.access-point", null))),
+          s3);
     }
     FileIO sourceFileIo = sourceAccess == null ? null : sourceAccess.sourceFileIo();
     if (sourceFileIo == null) {
@@ -1032,6 +1036,11 @@ public class DeltaManifestMaterializer {
         Boolean.parseBoolean(resolveOption(sourceProps, "s3.path-style-access", "false"));
     Supplier<AwsCredentialsProvider> credentials = () -> resolveCredentials(sourceProps);
     String endpoint = resolveOption(sourceProps, "s3.endpoint", null);
+    // Unity Catalog vends an access point ARN alongside the session tuple for buckets behind a
+    // firewall or an access-point policy, and those credentials only authorize requests addressed
+    // to the access point. Cross-region ARNs are then legal, which is what useArnRegionEnabled
+    // permits -- mirroring how DeltaConnectorFactory builds the same client on the reconcile side.
+    String accessPoint = resolveOption(sourceProps, "s3.access-point", null);
     return RefreshingAwsClient.withResourceFactory(
         () -> {
           AwsCredentialsProvider provider = credentials.get();
@@ -1039,7 +1048,10 @@ public class DeltaManifestMaterializer {
               S3Client.builder()
                   .region(region)
                   .serviceConfiguration(
-                      S3Configuration.builder().pathStyleAccessEnabled(pathStyle).build())
+                      S3Configuration.builder()
+                          .pathStyleAccessEnabled(pathStyle)
+                          .useArnRegionEnabled(accessPoint != null)
+                          .build())
                   .credentialsProvider(provider);
           try {
             if (endpoint != null && !endpoint.isBlank()) {
@@ -1066,6 +1078,10 @@ public class DeltaManifestMaterializer {
       return StaticCredentialsProvider.create(creds);
     }
     return DefaultCredentialsProvider.builder().build();
+  }
+
+  private static String blankToNull(String value) {
+    return value == null || value.isBlank() ? null : value.trim();
   }
 
   private String resolveOption(Map<String, String> props, String key, String defaultValue) {
@@ -1335,9 +1351,26 @@ public class DeltaManifestMaterializer {
   private static final class S3FileSystemClient
       implements io.delta.kernel.defaults.engine.fileio.FileIO {
     private final RefreshingAwsClient<S3Client> s3;
+    private final String bucketOverride;
 
-    private S3FileSystemClient(RefreshingAwsClient<S3Client> s3) {
+    /**
+     * @param bucketOverride the S3 access point ARN to address instead of the bucket named in each
+     *     URI, or null/blank to address the bucket directly. Credentials vended with an access
+     *     point are only valid for requests that target it, so addressing the raw bucket returns
+     *     403 for every read.
+     */
+    private S3FileSystemClient(RefreshingAwsClient<S3Client> s3, String bucketOverride) {
       this.s3 = s3;
+      this.bucketOverride = blankToNull(bucketOverride);
+    }
+
+    /**
+     * The bucket name to put on a request: the access point when one was vended, otherwise the URI
+     * host. Paths handed back to Delta Kernel keep the logical host, which is what the Delta log
+     * records.
+     */
+    private String requestBucket(URI location) {
+      return bucketOverride == null ? location.getHost() : bucketOverride;
     }
 
     @Override
@@ -1347,7 +1380,7 @@ public class DeltaManifestMaterializer {
       if (isMissingCheckpoint(resolved)) {
         return new MissingInputFile(resolved);
       }
-      return new S3InputFile(s3, resolved);
+      return new S3InputFile(s3, resolved, bucketOverride);
     }
 
     @Override
@@ -1382,7 +1415,7 @@ public class DeltaManifestMaterializer {
     @Override
     public FileStatus getFileStatus(String path) throws IOException {
       URI uri = URI.create(resolvePath(path));
-      String bucket = uri.getHost();
+      String bucket = requestBucket(uri);
       String key = uri.getPath().startsWith("/") ? uri.getPath().substring(1) : uri.getPath();
       try {
         HeadObjectResponse head =
@@ -1402,10 +1435,11 @@ public class DeltaManifestMaterializer {
     public CloseableIterator<FileStatus> listFrom(String filePath) throws IOException {
       String resolved = resolvePath(filePath);
       URI uri = URI.create(resolved);
-      String bucket = uri.getHost();
-      if (bucket == null || bucket.isEmpty()) {
+      String logicalBucket = uri.getHost();
+      if (logicalBucket == null || logicalBucket.isEmpty()) {
         throw new IOException("Invalid S3 path for listFrom: " + filePath);
       }
+      String bucket = requestBucket(uri);
       String fullKey = uri.getPath().startsWith("/") ? uri.getPath().substring(1) : uri.getPath();
       int lastSlash = fullKey.lastIndexOf('/');
       String dirPrefix = lastSlash < 0 ? "" : fullKey.substring(0, lastSlash + 1);
@@ -1483,7 +1517,7 @@ public class DeltaManifestMaterializer {
               }
               bufferedNext =
                   FileStatus.of(
-                      "s3://" + bucket + "/" + key,
+                      "s3://" + logicalBucket + "/" + key,
                       object.size() == null ? 0L : object.size(),
                       object.lastModified() == null
                           ? Instant.now().toEpochMilli()
@@ -1528,7 +1562,7 @@ public class DeltaManifestMaterializer {
         return false;
       }
       URI uri = URI.create(resolvedPath);
-      String bucket = uri.getHost();
+      String bucket = requestBucket(uri);
       String key = uri.getPath().startsWith("/") ? uri.getPath().substring(1) : uri.getPath();
       try {
         s3.callUnchecked(
@@ -1552,11 +1586,13 @@ public class DeltaManifestMaterializer {
     private final String key;
     private final long length;
 
-    private S3InputFile(RefreshingAwsClient<S3Client> s3, String resolvedPath) {
+    private S3InputFile(
+        RefreshingAwsClient<S3Client> s3, String resolvedPath, String bucketOverride) {
       this.s3 = s3;
       this.resolvedPath = resolvedPath;
       URI uri = URI.create(resolvedPath);
-      this.bucket = uri.getHost();
+      String accessPoint = blankToNull(bucketOverride);
+      this.bucket = accessPoint == null ? uri.getHost() : accessPoint;
       this.key = uri.getPath().startsWith("/") ? uri.getPath().substring(1) : uri.getPath();
       try {
         this.length = new S3RangeReader(s3, bucket, key).length();

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
@@ -23,7 +23,7 @@ import ai.floedb.floecat.connector.common.auth.ResolvedStorageCredentials;
 import ai.floedb.floecat.connector.common.auth.TerminalCredentialRefreshException;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.spi.ConnectorConfig;
-import ai.floedb.floecat.connector.spi.IcebergAccessDelegation;
+import ai.floedb.floecat.connector.spi.SourceCatalogVending;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus;
 import ai.floedb.floecat.storage.rpc.ResolveStorageAuthorityResponse;
@@ -289,10 +289,14 @@ public class ServerSideStorageConfigResolver {
       // validation failures, so matching the code alone turned a real configuration error into a
       // silent fallback whose cause only resurfaced as an opaque FileIO failure much later.
       //
-      // Only "no authority covers this location" is recoverable by delegation: the catalog client
-      // holds vended credentials of its own, so the untouched config is what it needs.
+      // Only "no authority covers this location" is recoverable by delegation, and only for a
+      // catalog whose own client applies vended credentials when it loads the table -- for that
+      // one the untouched config is exactly what it needs. Deliberately not the broader
+      // "declares vending" gate: Delta/Unity vend only on request and build their S3 client from
+      // the connector's own s3.* options, so absorbing there would replace a precise
+      // missing-authority failure with an opaque 403 on the first read.
       if (SourceCatalogVendingGrpcStatus.isNoMatchingStorageAuthority(e)
-          && IcebergAccessDelegation.declaresVendedCredentials(config)) {
+          && SourceCatalogVending.clientAppliesVendedCredentials(config)) {
         return config;
       }
       throw e;
@@ -447,11 +451,24 @@ public class ServerSideStorageConfigResolver {
                         + " session token, and expiresAt"));
   }
 
+  /**
+   * Whether a failed refresh will keep failing.
+   *
+   * <p>The two structured vending reasons belong here as well as in {@code
+   * ReconcileFailureClassifier}: a refresh failure that is merely "ordinary" is suppressed by
+   * {@code RefreshingAwsCredentialsProviderRegistry} while the previous tuple is still valid, so a
+   * source catalog that refuses to vend for this table -- or vends an unrenewable tuple -- would be
+   * re-asked on every refresh until the tuple expires, instead of failing the job at once. Matched
+   * by reason, not by code: they share {@code FAILED_PRECONDITION} with lease-precondition
+   * failures, which are retryable by design.
+   */
   static boolean isTerminalExecutionCredentialRefresh(StatusRuntimeException error) {
     Status.Code code = error.getStatus().getCode();
     return ReconcileLeaseGrpcStatus.isLeasePreconditionFailure(error)
         || code == Status.Code.UNAUTHENTICATED
-        || code == Status.Code.PERMISSION_DENIED;
+        || code == Status.Code.PERMISSION_DENIED
+        || SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(error)
+        || SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(error);
   }
 
   static Optional<ResolvedStorageCredentials> resolvedStorageCredentials(

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
@@ -418,6 +418,38 @@ class ServerSideStorageConfigResolverTest {
   }
 
   /**
+   * Unity declares vending, but its connector applies vended credentials only when asked: the Delta
+   * engine's S3 client is built from the connector's own {@code s3.*} options. An untouched config
+   * therefore carries no storage credentials, so the missing-authority error must propagate rather
+   * than be absorbed into an opaque 403 on the first read.
+   */
+  @Test
+  void delegatingUnityConnectorPropagatesMissingAuthority() {
+    ConnectorConfig config =
+        new ConnectorConfig(
+            ConnectorConfig.Kind.DELTA,
+            "unity",
+            "https://workspace.example.com",
+            Map.of(
+                "storage_location", "s3://8c554103--table-s3",
+                "databricks.access-delegation", "vended-credentials"),
+            new ConnectorConfig.Auth("oauth2", Map.of("token", "secret"), Map.of()));
+    ServerSideStorageConfigResolver resolver =
+        new ServerSideStorageConfigResolver(java.util.Optional.empty(), java.util.Optional.empty());
+    resolver.storageAuthorities = mock(StorageAuthoritiesGrpc.StorageAuthoritiesBlockingStub.class);
+    when(resolver.storageAuthorities.withInterceptors(any()))
+        .thenReturn(resolver.storageAuthorities);
+    when(resolver.storageAuthorities.vendStorageCredentials(any()))
+        .thenThrow(SourceCatalogVendingGrpcStatus.noMatchingStorageAuthority("none matches"));
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () -> resolveWithStorageLocation(resolver, unityConnector(), config));
+
+    verify(resolver.storageAuthorities).vendStorageCredentials(any());
+  }
+
+  /**
    * INVALID_ARGUMENT alone must not trigger the fallback. vendStorageCredentials returns it for
    * account_id, execution_binding and location_prefix validation failures too, and turning those
    * into a silent "use the catalog instead" hides the real cause behind a later FileIO error.
@@ -583,15 +615,11 @@ class ServerSideStorageConfigResolverTest {
 
   private static ServerSideStorageConfigResolver.ResolvedConnectorConfig resolveWithStorageLocation(
       ServerSideStorageConfigResolver resolver, ConnectorConfig config) {
-    Connector connector =
-        Connector.newBuilder()
-            .setKind(ConnectorKind.CK_ICEBERG)
-            .setResourceId(
-                ResourceId.newBuilder()
-                    .setAccountId("acct")
-                    .setId("conn")
-                    .setKind(ResourceKind.RK_CONNECTOR))
-            .build();
+    return resolveWithStorageLocation(resolver, icebergConnector(), config);
+  }
+
+  private static ServerSideStorageConfigResolver.ResolvedConnectorConfig resolveWithStorageLocation(
+      ServerSideStorageConfigResolver resolver, Connector connector, ConnectorConfig config) {
     return resolver.resolveManagedWithAuthorization(
         java.util.Optional.empty(),
         java.util.Optional.empty(),
@@ -600,6 +628,30 @@ class ServerSideStorageConfigResolverTest {
         java.util.Optional.empty(),
         connector,
         config);
+  }
+
+  private static Connector icebergConnector() {
+    return Connector.newBuilder()
+        .setKind(ConnectorKind.CK_ICEBERG)
+        .setResourceId(
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setId("conn")
+                .setKind(ResourceKind.RK_CONNECTOR))
+        .build();
+  }
+
+  private static Connector unityConnector() {
+    Connector connector =
+        Connector.newBuilder()
+            .setKind(ConnectorKind.CK_DELTA)
+            .setResourceId(
+                ResourceId.newBuilder()
+                    .setAccountId("acct")
+                    .setId("conn")
+                    .setKind(ResourceKind.RK_CONNECTOR))
+            .build();
+    return connector;
   }
 
   @Test

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
@@ -208,6 +208,14 @@ public class LeasedFileGroupExecutionService extends BaseServiceImpl {
     return pinned;
   }
 
+  /**
+   * Stamps the table's {@code storage_location} onto the connector payload the worker receives.
+   *
+   * <p>The only writer of the property that {@code ReconcilerService.sourceStorageLocation} and
+   * {@code StorageAuthorityServiceImpl.connectorSourceStorageLocation} read to decide which storage
+   * authority covers a table -- and, when none does, whether to ask the source catalog to vend. A
+   * kind missing here silently skips both.
+   */
   private Connector withTableStorageLocation(Connector connector, Table table) {
     if (connector == null
         || table == null

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
@@ -31,11 +31,21 @@ import java.util.Map;
 
 @ApplicationScoped
 public class ServerSideFileIoPropertiesResolver {
+  /**
+   * The FileIO properties a resolved storage answer owns end to end -- replaced wholesale rather
+   * than merged, so a stale value never survives alongside a fresh credential.
+   *
+   * <p>{@code s3.access-point} is here because Unity Catalog vends an access point ARN for buckets
+   * behind an access-point policy, and those credentials only authorize requests addressed to the
+   * ARN. The Delta compat path in the Iceberg REST gateway reads it back when it builds its S3
+   * client; addressing the raw bucket instead returns 403 for every read.
+   */
   private static final List<String> FILE_IO_PROPERTY_KEYS =
       List.of(
           "s3.region",
           "s3.endpoint",
           "s3.path-style-access",
+          "s3.access-point",
           "s3.access-key-id",
           "s3.secret-access-key",
           "s3.session-token");

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendor.java
@@ -27,7 +27,8 @@ import ai.floedb.floecat.connector.spi.ConnectorConfigMapper;
 import ai.floedb.floecat.connector.spi.ConnectorFactory;
 import ai.floedb.floecat.connector.spi.CredentialResolver;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
-import ai.floedb.floecat.connector.spi.IcebergAccessDelegation;
+import ai.floedb.floecat.connector.spi.SourceCatalogAccessException;
+import ai.floedb.floecat.connector.spi.SourceCatalogVending;
 import ai.floedb.floecat.service.credentials.AuthResolutionContexts;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.storage.rpc.ResolveStorageAuthorityResponse;
@@ -41,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
@@ -65,14 +67,26 @@ public class SourceCatalogCredentialVendor {
   private static final org.jboss.logging.Logger LOG =
       org.jboss.logging.Logger.getLogger(SourceCatalogCredentialVendor.class);
 
+  /** Cap on the gRPC status description built from a catalog failure. See catalogFailureStatus. */
+  private static final int MAX_STATUS_DESCRIPTION = 512;
+
   /**
    * Non-secret S3 routing keys a vended credential carries, safe to expose in client_safe_config.
    */
   private static final List<String> VENDED_ROUTING_KEYS =
-      List.of("s3.region", "s3.endpoint", "s3.path-style-access");
+      List.of("s3.region", "s3.endpoint", "s3.path-style-access", "s3.access-point");
 
   /** Region aliases, matching what {@code StorageAuthorityResolver.putRegionConfig} writes. */
   private static final List<String> REGION_KEYS = List.of("s3.region", "region", "client.region");
+
+  /**
+   * Where a connector's own region may be spelled. A superset of {@link #REGION_KEYS}: {@code
+   * aws.region} is documented for Delta and Iceberg connector options ({@code
+   * DeltaConnectorFactory} reads it) but is not one of the keys written back, so it is read-only
+   * here.
+   */
+  private static final List<String> REGION_ALIAS_KEYS =
+      List.of("s3.region", "region", "client.region", "aws.region");
 
   /**
    * What the caller will do with the credentials. Selects how strictly they are validated: only the
@@ -87,6 +101,7 @@ public class SourceCatalogCredentialVendor {
 
   @Inject ConnectorRepository connectorRepo;
   @Inject CredentialResolver credentialResolver;
+  Function<ConnectorConfig, FloecatConnector> connectorFactory = ConnectorFactory::create;
 
   @ConfigProperty(name = "floecat.storage.aws.region", defaultValue = "us-east-1")
   String defaultRegion;
@@ -139,7 +154,7 @@ public class SourceCatalogCredentialVendor {
 
     String namespaceFq = String.join(".", upstream.getNamespacePathList());
     Optional<FloecatConnector.VendedStorageCredentials> vended;
-    try (FloecatConnector source = ConnectorFactory.create(resolvedConfig)) {
+    try (FloecatConnector source = connectorFactory.apply(resolvedConfig)) {
       vended = source.vendStorageCredentials(namespaceFq, upstream.getTableDisplayName());
     } catch (StatusRuntimeException e) {
       throw e;
@@ -150,6 +165,11 @@ public class SourceCatalogCredentialVendor {
       // recognisably an authorization refusal stays retryable.
       throw catalogFailureStatus(e, connector, namespaceFq, upstream.getTableDisplayName());
     }
+    // Empty and absent are the same answer. A connector that hands back a credential object with
+    // no properties has vended nothing, and falling through would reach requireUsableCredentials
+    // and fail the job terminally on a condition the caller can recover from by using a storage
+    // authority. Partial credentials are deliberately *not* screened here -- those do reach the
+    // usability check, which is where "the catalog vended something unusable" belongs.
     if (vended.isEmpty() || vended.get().isEmpty()) {
       LOG.infof(
           "source-catalog vending skipped: connector %s returned no credentials for %s.%s"
@@ -188,7 +208,7 @@ public class SourceCatalogCredentialVendor {
     storageConfig.putAll(routing);
     VendedStorageCredential.Builder credential =
         VendedStorageCredential.newBuilder()
-            .setPrefix(responseLocationPrefix == null ? "" : responseLocationPrefix)
+            .setPrefix(responsePrefix(vended.get(), responseLocationPrefix))
             .putAllConfig(Map.copyOf(storageConfig));
     Instant expiresAt = vended.get().expiresAt();
     if (expiresAt != null) {
@@ -207,6 +227,36 @@ public class SourceCatalogCredentialVendor {
         .putAllClientSafeConfig(routing)
         .addStorageCredentials(credential)
         .build();
+  }
+
+  /**
+   * The prefix to stamp on the vended credential: the catalog's own scope when it narrows the
+   * request, otherwise the location the caller was authorized for.
+   *
+   * <p>The catalog-issued scope is preferred because it is the truth about what the credential
+   * covers -- but only downwards. {@code requestedPrefix} is {@code credentialScope.location()},
+   * the same value {@code isWithinExecutionScope} and {@code resolvePlannerBootstrapLocation} use
+   * to refuse out-of-scope requests, so letting a broader catalog scope replace it would hand back
+   * a credential stamped for more than the caller may read: a table at {@code
+   * s3://warehouse/tpch_10/customer} covered by a catalog credential scoped to {@code
+   * s3://warehouse/tpch} would come back claiming all of {@code s3://warehouse/tpch*}, and the
+   * consumers that key their client cache on this prefix would apply it to sibling prefixes. The
+   * credential itself may well be broader; what travels back is bounded by the authorization.
+   */
+  static String responsePrefix(
+      FloecatConnector.VendedStorageCredentials vended, String requestedPrefix) {
+    String requested = requestedPrefix == null ? "" : requestedPrefix;
+    String scope = vended == null ? null : vended.scopePrefix();
+    if (scope == null) {
+      return requested;
+    }
+    // Blank request: nothing to bound against, so the catalog's scope is the only answer available
+    // and is narrower than the unbounded alternative. Otherwise containment is decided by the same
+    // path-boundary rule the authority resolver uses -- a plain startsWith would accept
+    // "s3://warehouse/tpch_other" as inside "s3://warehouse/tpch".
+    return requested.isBlank() || StorageAuthorityResolver.matchesLocationPrefix(scope, requested)
+        ? scope
+        : requested;
   }
 
   static Map<String, String> clientSafeRoutingProperties(Map<String, String> props) {
@@ -233,16 +283,24 @@ public class SourceCatalogCredentialVendor {
    * falls back to the connector's own configuration and then to the deployment's configured region,
    * mirroring {@code resolveSnapshotCompatStorageSettings}, which synthesizes exactly these
    * settings when no authority exists. A wrong region announces itself immediately as an S3
-   * redirect; an absent one fails mid-scan with nothing pointing at the cause.
+   * redirect; an absent one fails mid-scan with nothing pointing at the cause. The connector's
+   * region is read under every documented alias, {@link #REGION_ALIAS_KEYS}, so a connector
+   * configured with {@code aws.region} is not silently replaced by the deployment default.
    */
   Map<String, String> routingProperties(
       Map<String, String> vendedProps, Map<String, String> connectorOptions) {
     LinkedHashMap<String, String> routing =
         new LinkedHashMap<>(clientSafeRoutingProperties(vendedProps));
+    // A Unity response carries only the credential tuple and an optional access point, so anything
+    // else the reader needs to reach the bucket at all -- a MinIO/S3-compatible endpoint,
+    // path-style
+    // addressing -- can only come from the connector. Vended wins where both are present.
+    clientSafeRoutingProperties(connectorOptions).forEach(routing::putIfAbsent);
     String region =
         firstNonBlank(
             firstNonBlank(REGION_KEYS.stream().map(vendedProps::get).toArray(String[]::new)),
-            firstNonBlank(REGION_KEYS.stream().map(connectorOptions::get).toArray(String[]::new)),
+            firstNonBlank(
+                REGION_ALIAS_KEYS.stream().map(connectorOptions::get).toArray(String[]::new)),
             defaultRegion);
     if (region != null) {
       // Same three keys putRegionConfig writes for an authority-backed response.
@@ -270,7 +328,7 @@ public class SourceCatalogCredentialVendor {
    * absorb the resulting missing-authority error -- cannot drift apart.
    */
   static boolean connectorDeclaresVendedDelegation(Connector connector) {
-    return IcebergAccessDelegation.declaresVendedCredentials(
+    return SourceCatalogVending.declaresVendedCredentials(
         ConnectorConfigMapper.fromProto(connector));
   }
 
@@ -339,12 +397,22 @@ public class SourceCatalogCredentialVendor {
    * -- a connection reset, a 5xx, a timeout -- is genuinely transient and keeps INTERNAL so the
    * existing retry behaviour still applies.
    */
-  private static StatusRuntimeException catalogFailureStatus(
+  static StatusRuntimeException catalogFailureStatus(
       RuntimeException cause, Connector connector, String namespaceFq, String tableName) {
     String detail =
         String.format(
             "source catalog %s refused credentials for %s.%s: %s",
             connector.getResourceId().getId(), namespaceFq, tableName, cause);
+    // The cause's message can carry a snippet of whatever the catalog -- or a proxy in front of it
+    // -- returned. That belongs in the server log, not in the status: grpc-message is
+    // percent-encoded trailer metadata that travels to every consumer and competes with HTTP/2's
+    // header-size limits, and an HTML error page there is unreadable noise. The full text is
+    // logged here; the status carries a bounded summary that says where to find the rest.
+    LOG.warnf(cause, "%s", detail);
+    String description =
+        detail.length() <= MAX_STATUS_DESCRIPTION
+            ? detail
+            : detail.substring(0, MAX_STATUS_DESCRIPTION) + "... (truncated; see server log)";
 
     // Typed exceptions only. Substring-matching the cause chain for 401/403/"access denied" gets
     // the risk backwards: a transient failure whose text merely contains one of those tokens -- a
@@ -359,20 +427,47 @@ public class SourceCatalogCredentialVendor {
     for (Throwable c = cause; c != null && seen.add(c); c = c.getCause()) {
       if (c instanceof org.apache.iceberg.exceptions.NotAuthorizedException) {
         return io.grpc.Status.UNAUTHENTICATED
-            .withDescription(detail)
+            .withDescription(description)
             .withCause(cause)
             .asRuntimeException();
       }
       if (c instanceof org.apache.iceberg.exceptions.ForbiddenException) {
         return io.grpc.Status.PERMISSION_DENIED
-            .withDescription(detail)
+            .withDescription(description)
             .withCause(cause)
             .asRuntimeException();
+      }
+      // Format-neutral refusal for connectors that do not speak Iceberg REST (e.g. Unity Catalog
+      // over HTTP): they raise a typed SourceCatalogAccessException rather than an Iceberg
+      // exception, carrying whether it was an authentication or authorization failure.
+      if (c instanceof SourceCatalogAccessException access) {
+        return switch (access.denial()) {
+          case UNAUTHENTICATED ->
+              io.grpc.Status.UNAUTHENTICATED
+                  .withDescription(description)
+                  .withCause(cause)
+                  .asRuntimeException();
+          case PERMISSION_DENIED ->
+              io.grpc.Status.PERMISSION_DENIED
+                  .withDescription(description)
+                  .withCause(cause)
+                  .asRuntimeException();
+          // Terminal, but not a denial, so it must not travel as one: PERMISSION_DENIED here would
+          // report "you may not read this table" for a catalog that simply cannot vend for it. It
+          // goes back as the structured vend-refused reason, which the reconciler matches by reason
+          // rather than by the shared FAILED_PRECONDITION code.
+          case UNSUPPORTED ->
+              ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus
+                  .sourceCatalogVendRefused(description);
+        };
       }
     }
     // Unrecognised stays retryable: an over-eager terminal permanently fails a job, an over-eager
     // retry only costs time.
-    return io.grpc.Status.INTERNAL.withDescription(detail).withCause(cause).asRuntimeException();
+    return io.grpc.Status.INTERNAL
+        .withDescription(description)
+        .withCause(cause)
+        .asRuntimeException();
   }
 
   /** Mirrors the resolution the reconciler uses so a connector authenticates identically here. */

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendorTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.storage.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.rpc.Table;
+import ai.floedb.floecat.catalog.rpc.UpstreamRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorKind;
+import ai.floedb.floecat.connector.rpc.ConnectorState;
+import ai.floedb.floecat.connector.spi.FloecatConnector;
+import ai.floedb.floecat.connector.spi.SourceCatalogAccessException;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class SourceCatalogCredentialVendorTest {
+
+  private static final Connector CONNECTOR =
+      Connector.newBuilder().setResourceId(ResourceId.newBuilder().setId("c1")).build();
+
+  @Test
+  void routingPropertiesKeepConnectorEndpointAndRegionAlias() {
+    // A Unity vend response carries only the credential tuple, so endpoint and path-style can come
+    // from nowhere but the connector: dropping them sends the reader at standard AWS S3 instead of
+    // the configured S3-compatible endpoint. aws.region is a documented alias, so a connector
+    // configured with it must not be overwritten by the deployment default either.
+    SourceCatalogCredentialVendor vendor = new SourceCatalogCredentialVendor();
+    vendor.defaultRegion = "us-east-1";
+
+    Map<String, String> routing =
+        vendor.routingProperties(
+            Map.of("s3.access-point", "arn:aws:s3:us-west-2:1:accesspoint/ap"),
+            Map.of(
+                "s3.endpoint",
+                "https://minio.internal:9000",
+                "s3.path-style-access",
+                "true",
+                "aws.region",
+                "us-west-2"));
+
+    assertThat(routing)
+        .containsEntry("s3.endpoint", "https://minio.internal:9000")
+        .containsEntry("s3.path-style-access", "true")
+        .containsEntry("s3.access-point", "arn:aws:s3:us-west-2:1:accesspoint/ap")
+        .containsEntry("s3.region", "us-west-2")
+        .containsEntry("region", "us-west-2")
+        .containsEntry("client.region", "us-west-2");
+  }
+
+  @Test
+  void routingPropertiesPreferVendedValuesOverConnectorConfiguration() {
+    SourceCatalogCredentialVendor vendor = new SourceCatalogCredentialVendor();
+    vendor.defaultRegion = "us-east-1";
+
+    Map<String, String> routing =
+        vendor.routingProperties(
+            Map.of("s3.endpoint", "https://vended:9000", "s3.region", "eu-west-1"),
+            Map.of("s3.endpoint", "https://connector:9000", "aws.region", "us-west-2"));
+
+    assertThat(routing)
+        .containsEntry("s3.endpoint", "https://vended:9000")
+        .containsEntry("s3.region", "eu-west-1");
+  }
+
+  @Test
+  void permissionDeniedAccessExceptionIsClassifiedTerminal() {
+    // Regression guard for the misclassification bug: a non-Iceberg connector (e.g. Unity Catalog)
+    // raises SourceCatalogAccessException, which must map to a terminal PERMISSION_DENIED rather
+    // than a retryable INTERNAL that loops the reconcile job forever.
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new SourceCatalogAccessException(
+                SourceCatalogAccessException.Denial.PERMISSION_DENIED, "HTTP 403"),
+            CONNECTOR,
+            "cat.schema",
+            "orders");
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  @Test
+  void unauthenticatedAccessExceptionIsClassifiedTerminal() {
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new SourceCatalogAccessException(
+                SourceCatalogAccessException.Denial.UNAUTHENTICATED, "HTTP 401"),
+            CONNECTOR,
+            "cat.schema",
+            "orders");
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.UNAUTHENTICATED);
+  }
+
+  @Test
+  void accessExceptionWrappedInCauseChainIsStillClassifiedTerminal() {
+    // The classifier walks the cause chain, so a wrapped access exception is still terminal.
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new RuntimeException(
+                "vend failed",
+                new SourceCatalogAccessException(
+                    SourceCatalogAccessException.Denial.PERMISSION_DENIED, "HTTP 403")),
+            CONNECTOR,
+            "cat.schema",
+            "orders");
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  @Test
+  void unrecognizedFailureStaysRetryableInternal() {
+    // A plain RuntimeException (a 5xx, a timeout) is genuinely transient and must stay retryable.
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new RuntimeException("UC temporary-table-credentials returned HTTP 503"),
+            CONNECTOR,
+            "cat.schema",
+            "orders");
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.INTERNAL);
+  }
+
+  @Test
+  void catalogIssuedScopeWinsWhenItNarrowsTheRequest() {
+    var vended =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"),
+            Instant.parse("2030-01-01T00:00:00Z"),
+            "  s3://warehouse/tpch/region/data  ");
+
+    assertThat(SourceCatalogCredentialVendor.responsePrefix(vended, "s3://warehouse/tpch/region"))
+        .isEqualTo("s3://warehouse/tpch/region/data");
+  }
+
+  @Test
+  void catalogIssuedScopeCannotWidenBeyondTheAuthorizedPrefix() {
+    // The requested prefix is the authorized location -- the same value that raises
+    // PERMISSION_DENIED for an out-of-scope request. A catalog credential covering a broader tree
+    // (Iceberg vends one scoped to "s3://warehouse/tpch" for a table under
+    // "s3://warehouse/tpch_10") must not come back stamped with that broader prefix, or consumers
+    // would apply the credential to sibling prefixes like "s3://warehouse/tpch_other".
+    var vended =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"),
+            Instant.parse("2030-01-01T00:00:00Z"),
+            "s3://warehouse/tpch");
+
+    assertThat(
+            SourceCatalogCredentialVendor.responsePrefix(vended, "s3://warehouse/tpch_10/customer"))
+        .isEqualTo("s3://warehouse/tpch_10/customer");
+  }
+
+  @Test
+  void aSiblingScopeSharingATextualPrefixDoesNotCount() {
+    // Containment is by path boundary, not by string prefix: "s3://warehouse/tpch_other" starts
+    // with "s3://warehouse/tpch" but is a different tree.
+    var vended =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"),
+            Instant.parse("2030-01-01T00:00:00Z"),
+            "s3://warehouse/tpch_other");
+
+    assertThat(SourceCatalogCredentialVendor.responsePrefix(vended, "s3://warehouse/tpch"))
+        .isEqualTo("s3://warehouse/tpch");
+  }
+
+  @Test
+  void requestedPrefixIsFallbackForLegacyConnector() {
+    var vended =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"), Instant.parse("2030-01-01T00:00:00Z"));
+
+    assertThat(SourceCatalogCredentialVendor.responsePrefix(vended, "s3://requested/table"))
+        .isEqualTo("s3://requested/table");
+  }
+
+  @Test
+  void anEmptyCredentialObjectFallsBackRatherThanFailingTerminally() {
+    // "The catalog handed back a credential object with no credentials" is the same answer as
+    // "the catalog does not delegate": the caller must be able to fall back to a storage authority.
+    // Letting it reach requireUsableCredentials would fail the reconcile job permanently.
+    ResourceId connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .setId("catalog-1")
+            .build();
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setState(ConnectorState.CS_ACTIVE)
+            .putProperties("iceberg.source", "rest")
+            .putProperties("header.X-Iceberg-Access-Delegation", "vended-credentials")
+            .build();
+    ConnectorRepository connectorRepo = mock(ConnectorRepository.class);
+    when(connectorRepo.getById(connectorId)).thenReturn(Optional.of(connector));
+
+    FloecatConnector source = mock(FloecatConnector.class);
+    when(source.vendStorageCredentials("cat.schema", "orders"))
+        .thenReturn(
+            Optional.of(
+                new FloecatConnector.VendedStorageCredentials(
+                    Map.of(), Instant.parse("2030-01-01T00:00:00Z"), "s3://warehouse/orders")));
+
+    SourceCatalogCredentialVendor vendor = new SourceCatalogCredentialVendor();
+    vendor.connectorRepo = connectorRepo;
+    vendor.connectorFactory = ignored -> source;
+    vendor.defaultRegion = "us-east-1";
+
+    assertThat(
+            vendor.vendForTable(
+                tableFor(connectorId),
+                "s3://warehouse/orders/data.parquet",
+                SourceCatalogCredentialVendor.CredentialUse.RECONCILE))
+        .isNull();
+  }
+
+  @Test
+  void anUnsupportedRefusalTravelsAsTheStructuredVendRefusedReason() {
+    // Terminal, but not a denial: reporting PERMISSION_DENIED would say "you may not read this
+    // table" for a catalog that simply cannot vend for it.
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new SourceCatalogAccessException(
+                SourceCatalogAccessException.Denial.UNSUPPORTED, "HTTP 400 external access off"),
+            CONNECTOR,
+            "cat.schema",
+            "orders");
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertThat(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(status)).isTrue();
+  }
+
+  @Test
+  void incompleteConnectorTupleIsAServiceLevelTerminalFailure() {
+    ResourceId connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .setId("catalog-1")
+            .build();
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setState(ConnectorState.CS_ACTIVE)
+            .putProperties("iceberg.source", "rest")
+            .putProperties("header.X-Iceberg-Access-Delegation", "vended-credentials")
+            .build();
+    ConnectorRepository connectorRepo = mock(ConnectorRepository.class);
+    when(connectorRepo.getById(connectorId)).thenReturn(Optional.of(connector));
+
+    FloecatConnector source = mock(FloecatConnector.class);
+    when(source.vendStorageCredentials("cat.schema", "orders"))
+        .thenReturn(
+            Optional.of(
+                new FloecatConnector.VendedStorageCredentials(
+                    Map.of("s3.access-key-id", "key", "s3.secret-access-key", "secret"),
+                    Instant.parse("2030-01-01T00:00:00Z"),
+                    "s3://warehouse/orders")));
+
+    SourceCatalogCredentialVendor vendor = new SourceCatalogCredentialVendor();
+    vendor.connectorRepo = connectorRepo;
+    vendor.connectorFactory = ignored -> source;
+    vendor.defaultRegion = "us-east-1";
+    Table table = tableFor(connectorId);
+
+    assertThatThrownBy(
+            () ->
+                vendor.vendForTable(
+                    table,
+                    "s3://warehouse/orders/data.parquet",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE))
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            failure -> {
+              assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+              assertThat(SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(failure))
+                  .isTrue();
+            });
+  }
+
+  private static Table tableFor(ResourceId connectorId) {
+    return Table.newBuilder()
+        .setResourceId(
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setKind(ResourceKind.RK_TABLE)
+                .setId("table-1"))
+        .setUpstream(
+            UpstreamRef.newBuilder()
+                .setConnectorId(connectorId)
+                .addAllNamespacePath(List.of("cat", "schema"))
+                .setTableDisplayName("orders"))
+        .build();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
@@ -913,11 +913,13 @@ class StorageAuthorityServiceImplTest {
                 "s3.session-token", "token",
                 "s3.region", "eu-west-1",
                 "s3.endpoint", "https://s3.eu-west-1.example",
-                "s3.path-style-access", "true"));
+                "s3.path-style-access", "true",
+                "s3.access-point", "arn:aws:s3:eu-west-1:123:accesspoint/orders"));
 
     assertEquals("eu-west-1", routing.get("s3.region"));
     assertEquals("https://s3.eu-west-1.example", routing.get("s3.endpoint"));
     assertEquals("true", routing.get("s3.path-style-access"));
+    assertEquals("arn:aws:s3:eu-west-1:123:accesspoint/orders", routing.get("s3.access-point"));
     assertFalse(routing.containsKey("s3.access-key-id"));
     assertFalse(routing.containsKey("s3.secret-access-key"));
     assertFalse(routing.containsKey("s3.session-token"));


### PR DESCRIPTION
## Summary

Stack 5/7. Base: `kw-uc-vending-04-vend-contract` (#469).

Wires Unity Catalog-vended credentials through the storage and execution paths that read Delta data, completing the end-to-end feature.

Changes:

- Bound vended credentials to the narrower of the catalog scope and the caller-authorized location.
- Treat an empty credential property map as “did not vend” while sending partial credentials to centralized usability validation.
- Preserve typed terminal refusal reasons.
- Include table storage location on leased file-group connector payloads so authority resolution and source vending run there.
- Absorb missing-authority errors only for catalog clients that actually apply vended credentials.
- Support vended S3 access points, including cross-region ARNs, in the connector and gateway Delta reader.
- Advertise access-point routing through client-safe and FileIO configuration.

## Type of Change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Full build: 4,628 tests, 0 failures. Formatting clean. Not yet validated against a live Databricks workspace.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Known gaps:

- Query scan advertises a vended S3 access point but still addresses the bucket URI, so access-point-only policies can fail there.
- The gateway S3 Delta reader duplicates connector logic and only one copy has an access-point test.
- Vending builds a connector per request/file group. Production use should add an expiry-bounded table credential cache with an explicit invalidation policy.
