### PR TITLE
fix: execution policy lane index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,8 @@ SUREFIRE_SELECTOR_ARGS := -Dsurefire.failIfNoSpecifiedTests=false
 LOCALSTACK_TEST_HAS_IT := $(findstring IT,$(TEST))
 LOCALSTACK_TEST_GOAL := $(if $(strip $(TEST)),$(if $(strip $(LOCALSTACK_TEST_HAS_IT)),verify,test),verify)
 LOCALSTACK_TEST_SKIP_ITS := $(if $(strip $(TEST)),$(if $(strip $(LOCALSTACK_TEST_HAS_IT)),,-DskipITs=true),)
-LOCALSTACK_TEST_PROJECTS := $(if $(strip $(TEST)),$(if $(strip $(LOCALSTACK_TEST_HAS_IT)),protocol-gateway/iceberg-rest,service),service,protocol-gateway/iceberg-rest,client-cli)
+LOCALSTACK_IT_PROJECTS := service,protocol-gateway/iceberg-rest
+LOCALSTACK_TEST_PROJECTS := $(if $(strip $(TEST)),$(if $(strip $(LOCALSTACK_TEST_HAS_IT)),$(LOCALSTACK_IT_PROJECTS),service),service,protocol-gateway/iceberg-rest,client-cli)
 TEST_RECONCILER_PROPS := -Dfloecat.reconciler.worker.auth.required=false
 SITE_MAKEFILE ?= tools/site/make/site.mk
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -123,7 +123,7 @@ floecat.reconciler.oidc.client-secret
 floecat.reconciler.oidc.token-refresh-skew-seconds
 floecat.reconciler.oidc.connect-timeout
 floecat.reconciler.auto.execution-class
-floecat.reconciler.auto.execution-lane
+floecat.reconciler.execution-lane
 ```
 
 Recommended split deployment:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -173,9 +173,17 @@ layouts rather than broad generic prefix scans:
 - projection state is separate from queue ownership and is not part of lease/read repair
 
 If `PLAN_CONNECTOR` jobs can be enqueued, at least one enabled executor must support that job kind.
-Planner jobs also need to remain leaseable under the configured execution lane semantics: planner
-executors advertise wildcard lane support, while child planning and file-group execution jobs carry
-the concrete lane policy that remote or local workers enforce later.
+Planner executors lease only the configured execution lane, and child planning, file-group, and
+finalizer jobs preserve that lane. The snapshot-finalizer publication scheduler also requires an
+exact lane match before publishing an accepted result. A blank configured lane matches only
+unlabelled jobs; it is not a wildcard. The `*` token is reserved for internal queue scans and is
+rejected in deployment configuration and job execution policies. The authenticated worker-control
+protocol may carry `*` for an intentional internal scan, but normal executor polling substitutes
+the deployment's configured lane before making that request.
+
+Before renaming a lane or decommissioning its last Floecat instance, stop enqueueing new work on
+that lane and allow its accepted snapshot-finalizer intents to publish. Publication has no
+cross-lane fallback: an accepted intent remains owned by the exact lane recorded on its job.
 
 To scale executors horizontally, add more executor-plane instances. They greedily lease eligible jobs from the shared durable queue, so no leader election is required at the executor layer.
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -32,7 +33,7 @@ import org.eclipse.microprofile.config.Config;
 @ApplicationScoped
 public class ReconcileExecutorRegistry {
   private final List<ReconcileExecutor> executors;
-  private final String plannerExecutionLane;
+  private final String executionLane;
 
   @Inject
   public ReconcileExecutorRegistry(Instance<ReconcileExecutor> executors, Config config) {
@@ -49,8 +50,8 @@ public class ReconcileExecutorRegistry {
     this(executors, "");
   }
 
-  ReconcileExecutorRegistry(List<ReconcileExecutor> executors, String plannerExecutionLane) {
-    this.plannerExecutionLane = plannerExecutionLane == null ? "" : plannerExecutionLane.trim();
+  ReconcileExecutorRegistry(List<ReconcileExecutor> executors, String executionLane) {
+    this.executionLane = ReconcileExecutionPolicy.normalizeLane(executionLane);
     this.executors =
         (executors == null ? List.<ReconcileExecutor>of() : executors)
             .stream()
@@ -104,15 +105,11 @@ public class ReconcileExecutorRegistry {
                     () ->
                         EnumSet.noneOf(
                             ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass.class)));
-    boolean wildcardLane =
-        executors.stream().anyMatch(executor -> executor.supportedLanes().isEmpty());
     Set<String> lanes =
-        wildcardLane
-            ? Set.of(ReconcileJobStore.LeaseRequest.anyLaneToken())
-            : executors.stream()
-                .flatMap(executor -> executor.supportedLanes().stream())
-                .map(lane -> lane == null ? "" : lane.trim())
-                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        executors.stream()
+            .flatMap(executor -> supportedLanesFor(executor).stream())
+            .map(lane -> lane == null ? "" : lane.trim())
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
     Set<String> executorIds =
         executors.stream()
             .map(ReconcileExecutor::id)
@@ -143,11 +140,9 @@ public class ReconcileExecutorRegistry {
                                 ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass.class)));
     Set<String> supportedLanes = supportedLanesFor(executor);
     Set<String> lanes =
-        supportedLanes == null || supportedLanes.isEmpty()
-            ? Set.of(ReconcileJobStore.LeaseRequest.anyLaneToken())
-            : supportedLanes.stream()
-                .map(lane -> lane == null ? "" : lane.trim())
-                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        supportedLanes.stream()
+            .map(lane -> lane == null ? "" : lane.trim())
+            .collect(java.util.stream.Collectors.toUnmodifiableSet());
     Set<String> executorIds =
         executor.id() == null || executor.id().trim().isEmpty()
             ? Set.of()
@@ -164,12 +159,15 @@ public class ReconcileExecutorRegistry {
 
   private Set<String> supportedLanesFor(ReconcileExecutor executor) {
     Set<ReconcileJobKind> jobKinds = executor.supportedJobKinds();
-    if (jobKinds != null
-        && !jobKinds.isEmpty()
-        && jobKinds.stream().allMatch(ReconcileExecutorRegistry::isPlanningJob)) {
-      return Set.of(plannerExecutionLane);
+    Set<String> supportedLanes = executor.supportedLanes();
+    if (supportedLanes == null
+        || supportedLanes.isEmpty()
+        || (jobKinds != null
+            && !jobKinds.isEmpty()
+            && jobKinds.stream().allMatch(ReconcileExecutorRegistry::isPlanningJob))) {
+      return Set.of(executionLane);
     }
-    return executor.supportedLanes();
+    return supportedLanes;
   }
 
   private static boolean isPlanningJob(ReconcileJobKind jobKind) {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistry.java
@@ -26,18 +26,31 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.eclipse.microprofile.config.Config;
 
 /** Resolves the executor that should execute a leased reconcile job. */
 @ApplicationScoped
 public class ReconcileExecutorRegistry {
   private final List<ReconcileExecutor> executors;
+  private final String plannerExecutionLane;
 
   @Inject
-  public ReconcileExecutorRegistry(Instance<ReconcileExecutor> executors) {
-    this(executors == null ? List.of() : executors.stream().toList());
+  public ReconcileExecutorRegistry(Instance<ReconcileExecutor> executors, Config config) {
+    this(
+        executors == null ? List.of() : executors.stream().toList(),
+        config == null
+            ? ""
+            : config
+                .getOptionalValue("floecat.reconciler.execution-lane", String.class)
+                .orElse(""));
   }
 
   ReconcileExecutorRegistry(List<ReconcileExecutor> executors) {
+    this(executors, "");
+  }
+
+  ReconcileExecutorRegistry(List<ReconcileExecutor> executors, String plannerExecutionLane) {
+    this.plannerExecutionLane = plannerExecutionLane == null ? "" : plannerExecutionLane.trim();
     this.executors =
         (executors == null ? List.<ReconcileExecutor>of() : executors)
             .stream()
@@ -128,7 +141,7 @@ public class ReconcileExecutorRegistry {
                         () ->
                             EnumSet.noneOf(
                                 ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass.class)));
-    Set<String> supportedLanes = executor.supportedLanes();
+    Set<String> supportedLanes = supportedLanesFor(executor);
     Set<String> lanes =
         supportedLanes == null || supportedLanes.isEmpty()
             ? Set.of(ReconcileJobStore.LeaseRequest.anyLaneToken())
@@ -147,5 +160,22 @@ public class ReconcileExecutorRegistry {
                     java.util.stream.Collectors.toCollection(
                         () -> EnumSet.noneOf(ReconcileJobKind.class)));
     return ReconcileJobStore.LeaseRequest.of(executionClasses, lanes, executorIds, jobKinds);
+  }
+
+  private Set<String> supportedLanesFor(ReconcileExecutor executor) {
+    Set<ReconcileJobKind> jobKinds = executor.supportedJobKinds();
+    if (jobKinds != null
+        && !jobKinds.isEmpty()
+        && jobKinds.stream().allMatch(ReconcileExecutorRegistry::isPlanningJob)) {
+      return Set.of(plannerExecutionLane);
+    }
+    return executor.supportedLanes();
+  }
+
+  private static boolean isPlanningJob(ReconcileJobKind jobKind) {
+    return jobKind == ReconcileJobKind.PLAN_CONNECTOR
+        || jobKind == ReconcileJobKind.PLAN_TABLE
+        || jobKind == ReconcileJobKind.PLAN_VIEW
+        || jobKind == ReconcileJobKind.PLAN_SNAPSHOT;
   }
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileExecutionPolicy.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileExecutionPolicy.java
@@ -21,12 +21,13 @@ import java.util.TreeMap;
 
 public record ReconcileExecutionPolicy(
     ReconcileExecutionClass executionClass, String lane, Map<String, String> attributes) {
+  private static final String INTERNAL_ANY_LANE_TOKEN = "*";
   private static final ReconcileExecutionPolicy DEFAULT_POLICY =
       new ReconcileExecutionPolicy(ReconcileExecutionClass.DEFAULT, "", Map.of());
 
   public ReconcileExecutionPolicy {
     executionClass = executionClass == null ? ReconcileExecutionClass.DEFAULT : executionClass;
-    lane = lane == null ? "" : lane.trim();
+    lane = normalizeLane(lane);
 
     Map<String, String> normalized = new TreeMap<>();
     if (attributes != null) {
@@ -53,6 +54,15 @@ public record ReconcileExecutionPolicy(
       return DEFAULT_POLICY;
     }
     return new ReconcileExecutionPolicy(executionClass, lane, attributes);
+  }
+
+  /** Normalizes an externally configurable lane and rejects the internal lease wildcard token. */
+  public static String normalizeLane(String lane) {
+    String normalized = lane == null ? "" : lane.trim();
+    if (INTERNAL_ANY_LANE_TOKEN.equals(normalized)) {
+      throw new IllegalArgumentException("execution lane '*' is reserved for internal lease scans");
+    }
+    return normalized;
   }
 
   public boolean isDefaultPolicy() {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
@@ -88,6 +88,7 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
   private volatile long reclaimIntervalMs = DEFAULT_RECLAIM_INTERVAL_MS;
   private volatile long lastReclaimAtMs;
   private volatile ReconcileWorkerAffinity workerAffinity = ReconcileWorkerAffinity.DISABLED;
+  private volatile String executionLane = "";
 
   public InMemoryReconcileJobStore() {
     reloadConfig();
@@ -116,6 +117,23 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
             readLong(
                 "floecat.reconciler.job-store.reclaim-interval-ms", DEFAULT_RECLAIM_INTERVAL_MS));
     workerAffinity = readWorkerAffinity("floecat.reconciler.worker-affinity");
+    executionLane = readExecutionLane("floecat.reconciler.execution-lane");
+  }
+
+  private String readExecutionLane(String key) {
+    try {
+      var container = Arc.container();
+      if (container != null) {
+        var config = container.instance(org.eclipse.microprofile.config.Config.class);
+        if (config.isAvailable()) {
+          return ReconcileExecutionPolicy.normalizeLane(
+              config.get().getOptionalValue(key, String.class).orElse(""));
+        }
+      }
+    } catch (RuntimeException ignored) {
+      // Fall back to system properties for plain unit construction.
+    }
+    return ReconcileExecutionPolicy.normalizeLane(System.getProperty(key));
   }
 
   private ReconcileWorkerAffinity readWorkerAffinity(String key) {
@@ -1133,6 +1151,11 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
     List<SnapshotFinalizeCommitIntent> pending =
         snapshotFinalizeCommitIntents.entrySet().stream()
             .filter(entry -> snapshotFinalizeCommits.contains(entry.getKey()))
+            .filter(
+                entry -> {
+                  ReconcileJob job = jobs.get(entry.getKey());
+                  return job != null && executionLane.equals(job.executionPolicy.lane());
+                })
             .map(Map.Entry::getValue)
             .limit(limit)
             .toList();

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
@@ -215,15 +215,38 @@ class ReconcileExecutorRegistryTest {
   }
 
   @Test
-  void leaseRequestForSingleExecutorKeepsExecutorCapabilitiesScoped() {
+  void leaseRequestForPlannerUsesConfiguredExecutionLane() {
     ReconcileExecutor planner = new KindExecutor("planner", ReconcileJobKind.PLAN_CONNECTOR);
     ReconcileExecutor snapshots = new KindExecutor("snapshots", ReconcileJobKind.PLAN_SNAPSHOT);
-    ReconcileExecutorRegistry registry = new ReconcileExecutorRegistry(List.of(planner, snapshots));
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(List.of(planner, snapshots), "ci-run-a");
 
     var request = registry.leaseRequestFor(snapshots);
 
     assertThat(request.executorIds).containsExactly("snapshots");
     assertThat(request.jobKinds).containsExactly(ReconcileJobKind.PLAN_SNAPSHOT);
+    assertThat(request.lanes).containsExactly("ci-run-a");
+  }
+
+  @Test
+  void leaseRequestForPlannerDefaultsToUnlabelledLaneInsteadOfWildcard() {
+    ReconcileExecutor planner = new KindExecutor("planner", ReconcileJobKind.PLAN_TABLE);
+    ReconcileExecutorRegistry registry = new ReconcileExecutorRegistry(List.of(planner));
+
+    var request = registry.leaseRequestFor(planner);
+
+    assertThat(request.lanes).containsExactly("");
+    assertThat(request.lanes).doesNotContain(ReconcileJobStore.LeaseRequest.anyLaneToken());
+  }
+
+  @Test
+  void leaseRequestForNonPlannerKeepsExecutorLaneCapabilities() {
+    ReconcileExecutor executor = new KindExecutor("file-groups", ReconcileJobKind.EXEC_FILE_GROUP);
+    ReconcileExecutorRegistry registry =
+        new ReconcileExecutorRegistry(List.of(executor), "ci-run-a");
+
+    var request = registry.leaseRequestFor(executor);
+
     assertThat(request.lanes).containsExactly(ReconcileJobStore.LeaseRequest.anyLaneToken());
   }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcileExecutorRegistryTest.java
@@ -179,7 +179,7 @@ class ReconcileExecutorRegistryTest {
   }
 
   @Test
-  void leaseRequestTreatsEmptySupportedLanesAsWildcard() {
+  void leaseRequestConstrainsWildcardExecutorToConfiguredLane() {
     ReconcileExecutor wildcardLaneExecutor =
         new ReconcileExecutor() {
           @Override
@@ -199,18 +199,17 @@ class ReconcileExecutorRegistryTest {
         };
 
     ReconcileExecutorRegistry registry =
-        new ReconcileExecutorRegistry(List.of(wildcardLaneExecutor));
+        new ReconcileExecutorRegistry(List.of(wildcardLaneExecutor), "ci-run-a");
 
     var request = registry.leaseRequest();
 
-    assertThat(request.lanes).containsExactly(ReconcileJobStore.LeaseRequest.anyLaneToken());
+    assertThat(request.lanes).containsExactly("ci-run-a");
     assertThat(
             request.matches(
-                ReconcileExecutionPolicy.of(
-                    ReconcileExecutionClass.HEAVY, "planner-lane", Map.of()),
+                ReconcileExecutionPolicy.of(ReconcileExecutionClass.HEAVY, "ci-run-a", Map.of()),
                 "",
                 ai.floedb.floecat.reconciler.jobs.ReconcileJobKind.PLAN_CONNECTOR,
-                "planner-lane"))
+                "ci-run-a"))
         .isTrue();
   }
 
@@ -240,14 +239,14 @@ class ReconcileExecutorRegistryTest {
   }
 
   @Test
-  void leaseRequestForNonPlannerKeepsExecutorLaneCapabilities() {
+  void leaseRequestForNonPlannerWildcardUsesConfiguredExecutionLane() {
     ReconcileExecutor executor = new KindExecutor("file-groups", ReconcileJobKind.EXEC_FILE_GROUP);
     ReconcileExecutorRegistry registry =
         new ReconcileExecutorRegistry(List.of(executor), "ci-run-a");
 
     var request = registry.leaseRequestFor(executor);
 
-    assertThat(request.lanes).containsExactly(ReconcileJobStore.LeaseRequest.anyLaneToken());
+    assertThat(request.lanes).containsExactly("ci-run-a");
   }
 
   @Test

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/ReconcileExecutionPolicyTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/ReconcileExecutionPolicyTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.jobs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReconcileExecutionPolicyTest {
+  @Test
+  void allowsConcreteAndUnlabelledLanes() {
+    assertThat(ReconcileExecutionPolicy.of(null, " ci-run-a ", Map.of()).lane())
+        .isEqualTo("ci-run-a");
+    assertThat(ReconcileExecutionPolicy.defaults().lane()).isEmpty();
+  }
+
+  @Test
+  void rejectsInternalWildcardAsJobLane() {
+    assertThatThrownBy(() -> ReconcileExecutionPolicy.of(null, " * ", Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("execution lane '*' is reserved for internal lease scans");
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
@@ -772,8 +772,10 @@ class InMemoryReconcileJobStoreTest {
   void acceptedSnapshotFinalizePublishesAfterWorkerLeaseAndGraceExpire() throws Exception {
     String leaseKey = "floecat.reconciler.job-store.lease-ms";
     String reclaimKey = "floecat.reconciler.job-store.reclaim-interval-ms";
+    String laneKey = "floecat.reconciler.execution-lane";
     String previousLease = System.getProperty(leaseKey);
     String previousReclaim = System.getProperty(reclaimKey);
+    String previousLane = System.getProperty(laneKey);
     try {
       System.setProperty(leaseKey, "1000");
       System.setProperty(reclaimKey, "1000");
@@ -808,6 +810,14 @@ class InMemoryReconcileJobStoreTest {
               0L,
               0L);
       assertTrue(store.beginSnapshotFinalizeCommit(finalizerJobId, lease.leaseEpoch, intent));
+      assertEquals(List.of(intent), store.pendingSnapshotFinalizeCommits(100, "").intents());
+
+      System.setProperty(laneKey, "other-lane");
+      store.init();
+      assertTrue(store.pendingSnapshotFinalizeCommits(100, "").intents().isEmpty());
+      restoreProperty(laneKey, previousLane);
+      store.init();
+      assertEquals(List.of(intent), store.pendingSnapshotFinalizeCommits(100, "").intents());
 
       Thread.sleep(1150L);
 
@@ -831,6 +841,7 @@ class InMemoryReconcileJobStoreTest {
     } finally {
       restoreProperty(leaseKey, previousLease);
       restoreProperty(reclaimKey, previousReclaim);
+      restoreProperty(laneKey, previousLane);
     }
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutionLaneConfiguration.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutionLaneConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.impl;
+
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import java.util.Optional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/** Validates the externally configured execution lane before workers or schedulers start. */
+@ApplicationScoped
+public class ReconcileExecutionLaneConfiguration {
+  @ConfigProperty(name = "floecat.reconciler.execution-lane")
+  Optional<String> configuredLane = Optional.empty();
+
+  void validate(@Observes StartupEvent startup) {
+    ReconcileExecutionPolicy.normalizeLane(configuredLane.orElse(""));
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -215,6 +215,7 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
   long leaseAcquireTimeoutMs = DEFAULT_LEASE_ACQUIRE_TIMEOUT_MS;
   private long leaseScanBudgetMs = DEFAULT_LEASE_SCAN_BUDGET_MS;
   private ReconcileWorkerAffinity workerAffinity = ReconcileWorkerAffinity.DISABLED;
+  private String executionLane = "";
   long snapshotCoverageClaimRetentionMs = DEFAULT_SNAPSHOT_COVERAGE_CLAIM_RETENTION_MS;
   private final Map<String, String> snapshotCoverageClaimGcTokens = new ConcurrentHashMap<>();
   volatile Semaphore leaseScanPermits = new Semaphore(DEFAULT_LEASE_MAX_CONCURRENCY, true);
@@ -639,6 +640,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     workerAffinity =
         ReconcileWorkerAffinity.of(
             config.getOptionalValue("floecat.reconciler.worker-affinity", String.class).orElse(""));
+    executionLane =
+        ReconcileExecutionPolicy.normalizeLane(
+            config.getOptionalValue("floecat.reconciler.execution-lane", String.class).orElse(""));
     snapshotCoverageClaimRetentionMs =
         Math.max(
             1_000L,
@@ -2623,7 +2627,8 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
     for (StoredReconcileJob record : page.records()) {
       if (record == null
           || record.jobKind() != ReconcileJobKind.FINALIZE_SNAPSHOT_CAPTURE
-          || !record.hasPublishableSnapshotFinalizeIntent()) {
+          || !record.hasPublishableSnapshotFinalizeIntent()
+          || !executionLane.equals(record.executionPolicy().lane())) {
         continue;
       }
       SnapshotFinalizeCommitIntent intent = snapshotFinalizeCommitIntent(record);

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/ReconcilePlannerScheduler.java
@@ -226,7 +226,7 @@ public class ReconcilePlannerScheduler {
         ReconcileExecutionClass.fromString(
             cfg.getOptionalValue("floecat.reconciler.auto.execution-class", String.class)
                 .orElse("DEFAULT")),
-        cfg.getOptionalValue("floecat.reconciler.auto.execution-lane", String.class).orElse(""),
+        cfg.getOptionalValue("floecat.reconciler.execution-lane", String.class).orElse(""),
         java.util.Map.of());
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
@@ -495,9 +495,14 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
               .filterValue()
               .equals(workerAffinity.indexFilterValue(policy.executionClass().name()));
       case EXECUTION_LANE ->
-          candidate
-              .filterValue()
-              .equals(workerAffinity.indexFilterValue(blankToEmpty(record.laneKey)));
+          (!blank(policy.lane())
+                  && candidate
+                      .filterValue()
+                      .equals(workerAffinity.indexFilterValue(policy.lane())))
+              || (!blank(record.laneKey)
+                  && candidate
+                      .filterValue()
+                      .equals(workerAffinity.indexFilterValue(record.laneKey)));
       case PINNED_EXECUTOR ->
           candidate
               .filterValue()

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStore.java
@@ -496,9 +496,7 @@ public class NativeReconcileReadyQueueStore implements ReconcileReadyQueueStore 
               .equals(workerAffinity.indexFilterValue(policy.executionClass().name()));
       case EXECUTION_LANE ->
           (!blank(policy.lane())
-                  && candidate
-                      .filterValue()
-                      .equals(workerAffinity.indexFilterValue(policy.lane())))
+                  && candidate.filterValue().equals(workerAffinity.indexFilterValue(policy.lane())))
               || (!blank(record.laneKey)
                   && candidate
                       .filterValue()

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueKeys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/ReadyQueueKeys.java
@@ -19,8 +19,9 @@ package ai.floedb.floecat.service.reconciler.jobs.durable.store;
 import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
 import ai.floedb.floecat.service.repo.model.Keys;
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 public final class ReadyQueueKeys {
@@ -88,7 +89,7 @@ public final class ReadyQueueKeys {
         || dueAtMs <= 0L) {
       return List.of();
     }
-    List<String> keys = new ArrayList<>();
+    Set<String> keys = new LinkedHashSet<>();
     ReconcileWorkerAffinity workerAffinity =
         ReconcileWorkerAffinity.fromPolicy(record.executionPolicy());
     String pinnedExecutorId = record.pinnedExecutorId();
@@ -113,16 +114,18 @@ public final class ReadyQueueKeys {
     if (!executionClassKey.isBlank()) {
       keys.add(executionClassKey);
     }
-    String executionLaneKey =
-        blank(record.laneKey)
-            ? ""
-            : readyPointerKeyFor(
-                record,
-                ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE,
-                dueAtMs,
-                workerAffinity.indexFilterValue(record.laneKey));
-    if (!executionLaneKey.isBlank()) {
-      keys.add(executionLaneKey);
+    for (String lane : new String[] {record.executionPolicy().lane(), record.laneKey}) {
+      String executionLaneKey =
+          blank(lane)
+              ? ""
+              : readyPointerKeyFor(
+                  record,
+                  ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE,
+                  dueAtMs,
+                  workerAffinity.indexFilterValue(lane));
+      if (!executionLaneKey.isBlank()) {
+        keys.add(executionLaneKey);
+      }
     }
     String jobKindKey =
         readyPointerKeyFor(

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -207,7 +207,7 @@ floecat.reconciler.auto.connectors-page-size=${FLOECAT_RECONCILER_AUTO_CONNECTOR
 floecat.reconciler.auto.account-tag-filter=${FLOECAT_RECONCILER_AUTO_ACCOUNT_TAG_FILTER:}
 # Routing policy for planner-enqueued jobs.
 floecat.reconciler.auto.execution-class=${FLOECAT_RECONCILER_AUTO_EXECUTION_CLASS:DEFAULT}
-floecat.reconciler.auto.execution-lane=${FLOECAT_RECONCILER_AUTO_EXECUTION_LANE:}
+floecat.reconciler.execution-lane=${FLOECAT_RECONCILER_EXECUTION_LANE:}
 floecat.reconciler.default-interval=${FLOECAT_RECONCILER_DEFAULT_INTERVAL:10m}
 floecat.reconciler.default-mode=${FLOECAT_RECONCILER_DEFAULT_MODE:RM_INCREMENTAL}
 floecat.reconciler.capture-now.default-wait=${FLOECAT_RECONCILER_CAPTURE_NOW_DEFAULT_WAIT:10s}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -207,6 +207,7 @@ floecat.reconciler.auto.connectors-page-size=${FLOECAT_RECONCILER_AUTO_CONNECTOR
 floecat.reconciler.auto.account-tag-filter=${FLOECAT_RECONCILER_AUTO_ACCOUNT_TAG_FILTER:}
 # Routing policy for planner-enqueued jobs.
 floecat.reconciler.auto.execution-class=${FLOECAT_RECONCILER_AUTO_EXECUTION_CLASS:DEFAULT}
+# Empty selects only the unlabelled lane. `*` is an internal token and fails startup validation.
 floecat.reconciler.execution-lane=${FLOECAT_RECONCILER_EXECUTION_LANE:}
 floecat.reconciler.default-interval=${FLOECAT_RECONCILER_DEFAULT_INTERVAL:10m}
 floecat.reconciler.default-mode=${FLOECAT_RECONCILER_DEFAULT_MODE:RM_INCREMENTAL}

--- a/service/src/test/java/ai/floedb/floecat/service/it/ReconcileLaneIsolationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ReconcileLaneIsolationIT.java
@@ -161,8 +161,7 @@ class ReconcileLaneIsolationIT {
             .setWorkerAffinity(WORKER_AFFINITY)
             .addExecutionClasses(ExecutionClass.EC_DEFAULT)
             .addLanes(lane)
-            .addJobKinds(
-                ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_FILE_GROUP)
+            .addJobKinds(ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_FILE_GROUP)
             .addJobKinds(
                 ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_FINALIZE_SNAPSHOT_CAPTURE)
             .build());

--- a/service/src/test/java/ai/floedb/floecat/service/it/ReconcileLaneIsolationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ReconcileLaneIsolationIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.catalog.rpc.CatalogServiceGrpc;
+import ai.floedb.floecat.connector.rpc.AuthConfig;
+import ai.floedb.floecat.connector.rpc.ConnectorKind;
+import ai.floedb.floecat.connector.rpc.ConnectorSpec;
+import ai.floedb.floecat.connector.rpc.ConnectorsGrpc;
+import ai.floedb.floecat.connector.rpc.DestinationTarget;
+import ai.floedb.floecat.connector.rpc.NamespacePath;
+import ai.floedb.floecat.connector.rpc.SourceSelector;
+import ai.floedb.floecat.reconciler.impl.ReconcilerService.CaptureMode;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionClass;
+import ai.floedb.floecat.reconciler.jobs.ReconcileExecutionPolicy;
+import ai.floedb.floecat.reconciler.jobs.ReconcileFileGroupTask;
+import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
+import ai.floedb.floecat.reconciler.jobs.ReconcileScope;
+import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
+import ai.floedb.floecat.reconciler.rpc.ExecutionClass;
+import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobRequest;
+import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobResponse;
+import ai.floedb.floecat.reconciler.rpc.ReconcileExecutorControlGrpc;
+import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
+import ai.floedb.floecat.service.it.profiles.ReconcileJobStoreControlPlaneProfile;
+import ai.floedb.floecat.service.util.TestDataResetter;
+import ai.floedb.floecat.service.util.TestSupport;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(ReconcileJobStoreControlPlaneProfile.class)
+class ReconcileLaneIsolationIT {
+  private static final String EXPECTED_LANE = "ci-run-a";
+  private static final String OTHER_LANE = "ci-run-b";
+  private static final String WORKER_AFFINITY = "reconciler-v1";
+
+  @GrpcClient("floecat")
+  ConnectorsGrpc.ConnectorsBlockingStub connectors;
+
+  @GrpcClient("floecat")
+  CatalogServiceGrpc.CatalogServiceBlockingStub catalogs;
+
+  @GrpcClient("floecat")
+  ReconcileExecutorControlGrpc.ReconcileExecutorControlBlockingStub executorControl;
+
+  @Inject ReconcileJobStore jobs;
+  @Inject TestDataResetter resetter;
+  @Inject SeedRunner seeder;
+
+  private String accountId;
+  private String connectorId;
+
+  @BeforeEach
+  void setUp() {
+    resetter.wipeAll();
+    seeder.seedData();
+
+    TestSupport.createCatalog(catalogs, "lane-isolation", "");
+    var connector =
+        TestSupport.createConnector(
+            connectors,
+            ConnectorSpec.newBuilder()
+                .setDisplayName("lane-isolation")
+                .setKind(ConnectorKind.CK_UNITY)
+                .setUri("dummy://lane-isolation")
+                .setSource(
+                    SourceSelector.newBuilder()
+                        .setNamespace(
+                            NamespacePath.newBuilder().addSegments("lane-isolation").build())
+                        .build())
+                .setDestination(
+                    DestinationTarget.newBuilder().setCatalogDisplayName("lane-isolation").build())
+                .setAuth(AuthConfig.newBuilder().setScheme("none").build())
+                .build());
+    accountId = connector.getResourceId().getAccountId();
+    connectorId = connector.getResourceId().getId();
+  }
+
+  @Test
+  void fileGroupAndFinalizerJobsAreLeasedOnlyByTheirExecutionLane() {
+    ReconcileExecutionPolicy policy =
+        ReconcileExecutionPolicy.of(ReconcileExecutionClass.DEFAULT, EXPECTED_LANE, Map.of());
+    String fileGroupJobId =
+        jobs.enqueueFileGroupExecution(
+            accountId,
+            connectorId,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.of(List.of(), "table-1"),
+            ReconcileFileGroupTask.of(
+                "plan-1",
+                "snapshot-55-group-0",
+                "table-1",
+                55L,
+                List.of("s3://bucket/data.parquet")),
+            policy,
+            "",
+            "");
+    String finalizerJobId =
+        jobs.enqueueSnapshotFinalization(
+            accountId,
+            connectorId,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.of(List.of(), "table-1"),
+            ReconcileSnapshotTask.of("table-1", 56L, "db", "events", List.of(), true),
+            policy,
+            "",
+            "");
+
+    assertFalse(lease(OTHER_LANE).getFound());
+
+    Map<String, ai.floedb.floecat.reconciler.rpc.ReconcileJobKind> leasedJobs =
+        new LinkedHashMap<>();
+    for (int i = 0; i < 2; i++) {
+      LeaseReconcileJobResponse response = lease(EXPECTED_LANE);
+      assertTrue(response.getFound());
+      leasedJobs.put(response.getJob().getJobId(), response.getJob().getKind());
+    }
+
+    assertEquals(
+        Map.of(
+            fileGroupJobId,
+            ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_FILE_GROUP,
+            finalizerJobId,
+            ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_FINALIZE_SNAPSHOT_CAPTURE),
+        leasedJobs);
+    assertFalse(lease(EXPECTED_LANE).getFound());
+  }
+
+  private LeaseReconcileJobResponse lease(String lane) {
+    return executorControl.leaseReconcileJob(
+        LeaseReconcileJobRequest.newBuilder()
+            .setExecutorId("lane-isolation-worker")
+            .setWorkerAffinity(WORKER_AFFINITY)
+            .addExecutionClasses(ExecutionClass.EC_DEFAULT)
+            .addLanes(lane)
+            .addJobKinds(
+                ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_EXEC_FILE_GROUP)
+            .addJobKinds(
+                ai.floedb.floecat.reconciler.rpc.ReconcileJobKind.RJK_FINALIZE_SNAPSHOT_CAPTURE)
+            .build());
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutionLaneConfigurationTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutionLaneConfigurationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.reconciler.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ReconcileExecutionLaneConfigurationTest {
+  @Test
+  void acceptsConcreteAndUnlabelledLanes() {
+    ReconcileExecutionLaneConfiguration configuration = new ReconcileExecutionLaneConfiguration();
+
+    configuration.configuredLane = Optional.of("ci-run-a");
+    assertDoesNotThrow(() -> configuration.validate(null));
+    configuration.configuredLane = Optional.empty();
+    assertDoesNotThrow(() -> configuration.validate(null));
+  }
+
+  @Test
+  void rejectsWildcardLaneAtStartup() {
+    ReconcileExecutionLaneConfiguration configuration = new ReconcileExecutionLaneConfiguration();
+    configuration.configuredLane = Optional.of(" * ");
+
+    IllegalArgumentException error =
+        assertThrows(IllegalArgumentException.class, () -> configuration.validate(null));
+
+    assertEquals("execution lane '*' is reserved for internal lease scans", error.getMessage());
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/ReconcileExecutorControlImplTest.java
@@ -247,6 +247,23 @@ class ReconcileExecutorControlImplTest {
   }
 
   @Test
+  void leaseReconcileJobAcceptsInternalWildcardLane() {
+    when(service.jobs.leaseNext(any())).thenReturn(Optional.empty());
+
+    service
+        .leaseReconcileJob(LeaseReconcileJobRequest.newBuilder().addLanes("*").build())
+        .await()
+        .indefinitely();
+
+    verify(service.jobs)
+        .leaseNext(
+            argThat(
+                request ->
+                    request != null
+                        && request.lanes.contains(ReconcileJobStore.LeaseRequest.anyLaneToken())));
+  }
+
+  @Test
   void leaseReconcileJobUsesExecutorAwareLeaseFilterAndMapsLease() {
     ReconcileCapturePolicy capturePolicy =
         ReconcileCapturePolicy.of(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -7741,6 +7741,9 @@ class DurableReconcileJobStoreTest {
                 workerAffinity.indexFilterValue(record.executionPolicy().executionClass().name())),
             new ReconcileReadyQueueBackend.ReadyQueueSlice(
                 ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE,
+                workerAffinity.indexFilterValue(record.executionPolicy().lane())),
+            new ReconcileReadyQueueBackend.ReadyQueueSlice(
+                ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE,
                 workerAffinity.indexFilterValue(record.laneKey)),
             new ReconcileReadyQueueBackend.ReadyQueueSlice(
                 ReconcileReadyQueueStore.ReadyIndexType.PINNED_EXECUTOR,

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -6796,6 +6796,30 @@ class DurableReconcileJobStoreTest {
     assertEquals(intent, store.snapshotFinalizeCommitIntent(finalizerJobId).orElseThrow());
     assertEquals(List.of(intent), store.pendingSnapshotFinalizeCommits(100, "").intents());
 
+    store.jobIndexStore.mutateByJobIdReturningRecord(
+        finalizerJobId,
+        record -> {
+          record.executionLane = "ci-run-a";
+          return record;
+        });
+    assertTrue(store.pendingSnapshotFinalizeCommits(100, "").intents().isEmpty());
+    System.setProperty("floecat.reconciler.execution-lane", "ci-run-a");
+    try {
+      store.init();
+      assertEquals(List.of(intent), store.pendingSnapshotFinalizeCommits(100, "").intents());
+    } finally {
+      System.clearProperty("floecat.reconciler.execution-lane");
+      store.init();
+    }
+    assertTrue(store.pendingSnapshotFinalizeCommits(100, "").intents().isEmpty());
+    store.jobIndexStore.mutateByJobIdReturningRecord(
+        finalizerJobId,
+        record -> {
+          record.executionLane = "";
+          return record;
+        });
+    assertEquals(List.of(intent), store.pendingSnapshotFinalizeCommits(100, "").intents());
+
     configureLeaseRenewGraceMs(0L);
     reclaimExpiredLease(finalizerJobId);
 

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreCohortTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/NativeReconcileReadyQueueStoreCohortTest.java
@@ -24,6 +24,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore.LeaseRequest;
 import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import ai.floedb.floecat.service.reconciler.jobs.durable.model.StoredReconcileJob;
+import ai.floedb.floecat.service.repo.model.Keys;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -73,11 +74,56 @@ class NativeReconcileReadyQueueStoreCohortTest {
 
     // The regression this guards: overloading pinnedExecutorId collapsed every cohorted job into a
     // single pinned slice and emitted exactly one pointer.
-    assertEquals(4, keys.size());
+    assertEquals(5, keys.size());
     assertTrue(keys.stream().anyMatch(key -> key.contains("by-job-kind")));
     assertTrue(keys.stream().anyMatch(key -> key.contains("by-execution-class")));
     assertTrue(keys.stream().anyMatch(key -> key.contains("by-execution-lane")));
     assertTrue(keys.stream().noneMatch(key -> key.contains("by-pinned-executor")));
+  }
+
+  @Test
+  void executionPolicyLaneAndCanonicalLaneKeyHaveDistinctReadyIndexes() {
+    NativeReconcileReadyQueueStore store = store();
+    ReconcileWorkerAffinity affinity = ReconcileWorkerAffinity.of("ci-branch");
+
+    for (ReconcileJobKind kind :
+        List.of(ReconcileJobKind.EXEC_FILE_GROUP, ReconcileJobKind.FINALIZE_SNAPSHOT_CAPTURE)) {
+      StoredReconcileJob record = record(affinity);
+      record.jobKind = kind.name();
+
+      List<String> keys = store.readyPointerKeys(record);
+      String policyLane = affinity.indexFilterValue(record.executionPolicy().lane());
+      String canonicalLane = affinity.indexFilterValue(record.laneKey);
+      String policyLaneKey =
+          keys.stream()
+              .filter(
+                  key ->
+                      key.startsWith(Keys.reconcileReadyByExecutionLanePointerPrefix(policyLane)))
+              .findFirst()
+              .orElseThrow();
+      String canonicalLaneKey =
+          keys.stream()
+              .filter(
+                  key ->
+                      key.startsWith(
+                          Keys.reconcileReadyByExecutionLanePointerPrefix(canonicalLane)))
+              .findFirst()
+              .orElseThrow();
+
+      assertEquals(2, keys.stream().filter(key -> key.contains("by-execution-lane")).count());
+      assertTrue(readyPointerMatches(store, record, policyLaneKey, policyLane));
+      assertTrue(readyPointerMatches(store, record, canonicalLaneKey, canonicalLane));
+      assertTrue(
+          store.matchesLeaseRequest(
+              record,
+              LeaseRequest.of(Set.of(), Set.of("ci-run"), Set.of(), EnumSet.of(kind))
+                  .withWorkerAffinity(affinity)));
+      assertFalse(
+          store.matchesLeaseRequest(
+              record,
+              LeaseRequest.of(Set.of(), Set.of("other-run"), Set.of(), EnumSet.of(kind))
+                  .withWorkerAffinity(affinity)));
+    }
   }
 
   @Test
@@ -178,6 +224,23 @@ class NativeReconcileReadyQueueStoreCohortTest {
     return keys.stream().filter(key -> key.contains(fragment)).findFirst().orElseThrow();
   }
 
+  private static boolean readyPointerMatches(
+      NativeReconcileReadyQueueStore store,
+      StoredReconcileJob record,
+      String readyPointerKey,
+      String lane) {
+    return store.readyPointerMatchesRecord(
+        new ReconcileReadyQueueStore.ReadyQueueEntry(
+            readyPointerKey,
+            "canonical-1",
+            record.accountId,
+            record.jobId,
+            DUE_AT_MS,
+            ReconcileReadyQueueStore.ReadyIndexType.EXECUTION_LANE,
+            lane),
+        record);
+  }
+
   private static LeaseRequest request() {
     return LeaseRequest.of(
         Set.of(), Set.of(), Set.of(), EnumSet.of(ReconcileJobKind.PLAN_CONNECTOR));
@@ -196,8 +259,8 @@ class NativeReconcileReadyQueueStoreCohortTest {
     record.jobKind = ReconcileJobKind.PLAN_CONNECTOR.name();
     record.state = "JS_QUEUED";
     record.executionClass = "DEFAULT";
-    record.executionLane = "default";
-    record.laneKey = "default";
+    record.executionLane = "ci-run";
+    record.laneKey = "file-group|table-1|snapshot-1|group-0";
     record.nextAttemptAtMs = DUE_AT_MS;
     record.executionAttributes =
         workerAffinity == null || !workerAffinity.enabled()

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
@@ -170,7 +170,7 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
       return List.of();
     }
     long dueAtMs = readyPointerDueAt(record);
-    List<String> keys = new java.util.ArrayList<>();
+    java.util.Set<String> keys = new java.util.LinkedHashSet<>();
     ReconcileWorkerAffinity workerAffinity =
         ReconcileWorkerAffinity.fromPolicy(record.executionPolicy());
     String pinnedExecutorId = record.pinnedExecutorId();
@@ -189,17 +189,29 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
             record,
             ReadyIndexType.EXECUTION_CLASS,
             dueAtMs,
-            record.executionPolicy().executionClass().name());
+            workerAffinity.indexFilterValue(record.executionPolicy().executionClass().name()));
     if (!executionClassKey.isBlank()) {
       keys.add(executionClassKey);
     }
-    String executionLaneKey =
-        readyPointerKeyFor(record, ReadyIndexType.EXECUTION_LANE, dueAtMs, record.laneKey);
-    if (!executionLaneKey.isBlank()) {
-      keys.add(executionLaneKey);
+    for (String lane : new String[] {record.executionPolicy().lane(), record.laneKey}) {
+      String executionLaneKey =
+          blank(lane)
+              ? ""
+              : readyPointerKeyFor(
+                  record,
+                  ReadyIndexType.EXECUTION_LANE,
+                  dueAtMs,
+                  workerAffinity.indexFilterValue(lane));
+      if (!executionLaneKey.isBlank()) {
+        keys.add(executionLaneKey);
+      }
     }
     String jobKindKey =
-        readyPointerKeyFor(record, ReadyIndexType.JOB_KIND, dueAtMs, record.jobKind().name());
+        readyPointerKeyFor(
+            record,
+            ReadyIndexType.JOB_KIND,
+            dueAtMs,
+            workerAffinity.indexFilterValue(record.jobKind().name()));
     if (!jobKindKey.isBlank()) {
       keys.add(jobKindKey);
     }
@@ -473,9 +485,14 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
               .filterValue()
               .equals(workerAffinity.indexFilterValue(policy.executionClass().name()));
       case EXECUTION_LANE ->
-          candidate
-              .filterValue()
-              .equals(workerAffinity.indexFilterValue(blankToEmpty(record.laneKey)));
+          (!blank(policy.lane())
+                  && candidate
+                      .filterValue()
+                      .equals(workerAffinity.indexFilterValue(policy.lane())))
+              || (!blank(record.laneKey)
+                  && candidate
+                      .filterValue()
+                      .equals(workerAffinity.indexFilterValue(record.laneKey)));
       case PINNED_EXECUTOR ->
           candidate
               .filterValue()

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/inmemory/InMemoryReconcileReadyQueueStore.java
@@ -486,9 +486,7 @@ public final class InMemoryReconcileReadyQueueStore implements ReconcileReadyQue
               .equals(workerAffinity.indexFilterValue(policy.executionClass().name()));
       case EXECUTION_LANE ->
           (!blank(policy.lane())
-                  && candidate
-                      .filterValue()
-                      .equals(workerAffinity.indexFilterValue(policy.lane())))
+                  && candidate.filterValue().equals(workerAffinity.indexFilterValue(policy.lane())))
               || (!blank(record.laneKey)
                   && candidate
                       .filterValue()


### PR DESCRIPTION
## Summary

This is a fix to enable lane labels to be applied and for jobs in labelled lanes to be leased.

Lane labelling propagates correctly, but planning, file-group and finalizer jobs were indexed using the job’s canonical/default lane rather than executionPolicy.lane. Workers polling the labelled lane therefore could not discover or lease those jobs.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
