### PR TITLE
test(smoke): force Polaris credential vending path

### DIFF
--- a/tools/compose-smoke.sh
+++ b/tools/compose-smoke.sh
@@ -915,6 +915,16 @@ EOF
       local access_delegation_arg=""
 
       if [ "$expect_vended_creds" = "true" ]; then
+        # The baseline scenario deliberately proves the storage-authority path. Remove that
+        # authority before the delegated scenario so a successful import cannot silently use the
+        # same authority and pass without ever consuming the credentials returned by Polaris.
+        local authority_remove_out
+        authority_remove_out=$(run_cli_script "$compose_cmd" "account t-0001
+storage-authority delete $scenario_storage_authority_name
+quit")
+        echo "$authority_remove_out"
+        assert_contains "$label upstream iceberg ${scenario_key} storage authority removal" "$authority_remove_out" "ok"
+
         local load_table_resp
         load_table_resp=$(docker run --rm --network "${compose_project}_floecat" curlimages/curl:8.12.1 -k -sS \
           -X GET "${COMPOSE_SMOKE_POLARIS_BASE_URI}/api/catalog/v1/$warehouse/namespaces/$source_namespace/tables/$source_table?snapshots=all" \
@@ -931,7 +941,7 @@ if not isinstance(creds, list) or not creds:
 PY
         then
           echo "[FAIL] $label upstream iceberg ${scenario_key} Polaris loadTable did not return storage-credentials"
-          echo "$load_table_resp"
+          echo "[FAIL] Polaris response omitted because it may contain storage credentials"
           return 1
         fi
         access_delegation_arg=" --head X-Iceberg-Access-Delegation=${access_delegation_header}"
@@ -974,6 +984,17 @@ quit")
         "$scenario_expected_table" \
         "${COMPOSE_SMOKE_STATS_RETRIES:-45}" \
         "${COMPOSE_SMOKE_STATS_SLEEP_SECONDS:-2}"
+
+      if [ "$expect_vended_creds" = "true" ]; then
+        # Later smoke sections still exercise authority-backed reads. Restore the authority only
+        # after every delegated assertion has completed, keeping the vending scenario honest.
+        local authority_restore_out
+        authority_restore_out=$(run_cli_script "$compose_cmd" "account t-0001
+storage-authority create $scenario_storage_authority_name --location-prefix s3://floecat/ --type s3 --region us-east-1 --endpoint http://localstack:4566 --path-style-access true --assume-role-arn arn:aws:iam::000000000000:role/polaris --duration-seconds 900 --cred-type aws --cred access_key_id=test --cred secret_access_key=test
+quit")
+        echo "$authority_restore_out"
+        assert_contains "$label upstream iceberg ${scenario_key} storage authority restoration" "$authority_restore_out" "$scenario_storage_authority_name"
+      fi
     }
 
     if [ "$smoke_scope" = "full" ]; then


### PR DESCRIPTION
## Summary

Stack 6/7. Base: `kw-uc-vending-05-wiring` (#470).

Makes the existing Polaris credential-vending smoke authoritative. The delegated scenario now runs without the covering `s3://floecat/` storage authority, so it cannot pass without consuming credentials returned by Polaris.

Changes:

- Remove the covering storage authority before the delegated scenario.
- Validate that Polaris returns non-empty `storage-credentials` without logging the secret-bearing response.
- Run reconciliation, stats, and index capture through vending alone.
- Restore the storage authority after delegated assertions for later scenarios.

## Type of Change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Validated shell syntax and diff hygiene. The source build compiled all modules before the compose target reached container-image creation. A live compose run was unavailable because the local Docker daemon was not running.

- [ ] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

The Polaris response body is intentionally omitted from failures because it can contain live temporary storage credentials.
