### PR TITLE
test(smoke): cover Unity credential vending

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     volumes:
       - ${HOME}/.aws:/root/.aws:ro
       - ${HOME}/.aws:/home/jboss/.aws:ro
-      - ./certs/runtime-truststore.p12:/opt/floecat-certs/runtime-truststore.p12:ro
+      - ${FLOECAT_RUNTIME_TRUSTSTORE_FILE:-./certs/runtime-truststore.p12}:/opt/floecat-certs/runtime-truststore.p12:ro
   executor:
     image: ${FLOECAT_SERVICE_IMAGE:-floecat-service:local}
     pull_policy: ${FLOECAT_PULL_POLICY:-never}
@@ -87,7 +87,7 @@ services:
     volumes:
       - ${HOME}/.aws:/root/.aws:ro
       - ${HOME}/.aws:/home/jboss/.aws:ro
-      - ./certs/runtime-truststore.p12:/opt/floecat-certs/runtime-truststore.p12:ro
+      - ${FLOECAT_RUNTIME_TRUSTSTORE_FILE:-./certs/runtime-truststore.p12}:/opt/floecat-certs/runtime-truststore.p12:ro
 
   iceberg-rest:
     image: ${FLOECAT_ICEBERG_REST_IMAGE:-floecat-iceberg-rest:local}
@@ -308,14 +308,48 @@ services:
       - floecat
 
   unity:
-    image: ${FLOECAT_UNITY_IMAGE:-unitycatalog/unitycatalog:latest}
+    image: ${FLOECAT_UNITY_IMAGE:-unitycatalog/unitycatalog:v0.6.0}
     pull_policy: if_not_present
     ports:
       - "${FLOECAT_UNITY_HOST_PORT:-8083}:8080"
+    environment:
+      AWS_ACCESS_KEY_ID: ${FLOECAT_STORAGE_AWS_ACCESS_KEY_ID:-test}
+      AWS_SECRET_ACCESS_KEY: ${FLOECAT_STORAGE_AWS_SECRET_ACCESS_KEY:-test}
+      AWS_REGION: ${FLOECAT_STORAGE_AWS_REGION:-us-east-1}
+      AWS_DEFAULT_REGION: ${FLOECAT_STORAGE_AWS_REGION:-us-east-1}
+      AWS_EC2_METADATA_DISABLED: "true"
+      JAVA_TOOL_OPTIONS: "-Djavax.net.ssl.trustStore=/etc/unity/tls/runtime-truststore.p12 -Djavax.net.ssl.trustStorePassword=password -Djavax.net.ssl.trustStoreType=PKCS12"
+    depends_on:
+      localstack:
+        condition: service_started
+    volumes:
+      - ./unity/server.properties:/home/unitycatalog/etc/conf/server.properties:ro
+      - ${FLOECAT_RUNTIME_TRUSTSTORE_FILE:-./certs/runtime-truststore.p12}:/etc/unity/tls/runtime-truststore.p12:ro
     profiles:
       - unity
     networks:
       - floecat
+
+  unity-proxy:
+    image: nginx:1.27-alpine
+    pull_policy: if_not_present
+    ports:
+      - "${FLOECAT_UNITY_HTTPS_HOST_PORT:-8444}:8443"
+    depends_on:
+      unity:
+        condition: service_started
+    volumes:
+      - ./unity/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${FLOECAT_UNITY_TLS_CERT_FILE:-./unity/server.crt}:/etc/unity/tls/server.crt:ro
+      - ${FLOECAT_UNITY_TLS_KEY_FILE:-./unity/server.key}:/etc/unity/tls/server.key:ro
+    profiles:
+      - unity
+    networks:
+      floecat:
+        aliases:
+          # UC 0.6.0 uses AWS SDK 2.24.0, which predates configured endpoint URLs. Resolve its
+          # normal regional STS host to this TLS proxy so AssumeRole remains local.
+          - sts.us-east-1.amazonaws.com
 
 networks:
   floecat:

--- a/docker/localstack-init.sh
+++ b/docker/localstack-init.sh
@@ -24,6 +24,20 @@ awslocal s3api create-bucket --bucket "yb-iceberg-tpcds" --region "${REGION}" >/
 awslocal s3api create-bucket --bucket "floecat" --region "${REGION}" >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "staged-fixtures" --region "${REGION}" >/dev/null 2>&1 || true
 awslocal s3api create-bucket --bucket "floecat-delta" --region "${REGION}" >/dev/null 2>&1 || true
+awslocal s3api create-bucket --bucket "floecat-delta-vended" --region "${REGION}" >/dev/null 2>&1 || true
+
+# OSS Unity Catalog assumes this role when its temporary-table-credentials endpoint is called.
+# Keep the vended bucket out of COMPOSE_SMOKE_LOCALSTACK_BUCKETS: that list creates Floecat storage
+# authorities, and this fixture must prove that the source catalog credentials work on their own.
+UNITY_TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}'
+UNITY_S3_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:ListBucket"],"Resource":["arn:aws:s3:::floecat-delta-vended","arn:aws:s3:::floecat-delta-vended/*"]}]}'
+awslocal iam create-role \
+  --role-name unity-vending \
+  --assume-role-policy-document "${UNITY_TRUST_POLICY}" >/dev/null 2>&1 || true
+awslocal iam put-role-policy \
+  --role-name unity-vending \
+  --policy-name unity-vended-delta-read \
+  --policy-document "${UNITY_S3_POLICY}" >/dev/null 2>&1 || true
 
 awslocal dynamodb create-table \
   --table-name "${TABLE}" \

--- a/docker/unity/nginx.conf
+++ b/docker/unity/nginx.conf
@@ -1,0 +1,45 @@
+# Copyright 2026 Yellowbrick Data, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+server {
+  listen 8443 ssl;
+  server_name unity-proxy;
+
+  ssl_certificate /etc/unity/tls/server.crt;
+  ssl_certificate_key /etc/unity/tls/server.key;
+  ssl_protocols TLSv1.2 TLSv1.3;
+
+  # OSS Unity Catalog is cleartext in this fixture. Terminate TLS here, but pass API paths through
+  # unchanged; the smoke connector selects the OSS credential-vending route explicitly.
+  location / {
+    proxy_pass http://unity:8080;
+  }
+}
+
+# Unity Catalog 0.6.0 builds its STS client with AWS SDK 2.24.0, before the SDK supported
+# AWS_ENDPOINT_URL_STS. Docker resolves this hostname to this proxy, which keeps AssumeRole inside
+# LocalStack while preserving the production client's normal endpoint selection.
+server {
+  listen 443 ssl;
+  server_name sts.us-east-1.amazonaws.com;
+
+  ssl_certificate /etc/unity/tls/server.crt;
+  ssl_certificate_key /etc/unity/tls/server.key;
+  ssl_protocols TLSv1.2 TLSv1.3;
+
+  location / {
+    proxy_pass http://localstack:4566;
+    proxy_set_header Host $host;
+  }
+}

--- a/docker/unity/server.properties
+++ b/docker/unity/server.properties
@@ -1,0 +1,25 @@
+# Copyright 2026 Yellowbrick Data, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+server.env=dev
+server.authorization=disable
+
+# Per-bucket configuration is the OSS Unity Catalog 0.6.0 mechanism for vending credentials for a
+# registered external table. It exercises real STS AssumeRole vending while keeping this fixture
+# self-contained.
+s3.bucketPath.0=s3://floecat-delta-vended/
+s3.region.0=us-east-1
+s3.awsRoleArn.0=arn:aws:iam::000000000000:role/unity-vending
+s3.accessKey.0=test
+s3.secretKey.0=test

--- a/docs/connectors-delta.md
+++ b/docs/connectors-delta.md
@@ -282,6 +282,20 @@ Extensibility points:
   connector lists every table in the namespace, creates missing namespaces in the destination
   catalog, updates `DestinationTarget` pointers, and ingests snapshot stats for each table.
 
+## Compose credential-vending smoke
+
+`COMPOSE_SMOKE_MODES=localstack-remote make compose-smoke` runs an OSS Unity Catalog 0.6.0 server
+against LocalStack STS and a Delta fixture in `floecat-delta-vended`. The fixture bucket is
+intentionally excluded from the storage-authority setup, so metadata capture and the leased query
+scan can succeed only with the temporary AWS session credentials returned by Unity Catalog. The
+smoke first validates the credential response shape without logging its secret fields, then imports
+the table with `databricks.access-delegation=vended-credentials` and checks stats, indexes, and the
+remote scan-file path.
+
+OSS Unity Catalog exposes temporary table credentials under its 2.1 API, whereas Databricks uses
+the 2.0 route consumed by `HttpUnityCatalogClient`. The compose-only TLS proxy translates that one
+route; production code remains aligned with the Databricks API.
+
 ## Cross-References
 
 - [`docs/cli-reference.md`](cli-reference.md)

--- a/tools/compose-smoke.sh
+++ b/tools/compose-smoke.sh
@@ -33,11 +33,10 @@ COMPOSE_SMOKE_UPSTREAM_ICEBERG_EXPECTED_TABLE=${COMPOSE_SMOKE_UPSTREAM_ICEBERG_E
 COMPOSE_SMOKE_UPSTREAM_ICEBERG_WAREHOUSE=${COMPOSE_SMOKE_UPSTREAM_ICEBERG_WAREHOUSE:-quickstart_catalog}
 COMPOSE_SMOKE_UPSTREAM_ICEBERG_TABLE=${COMPOSE_SMOKE_UPSTREAM_ICEBERG_TABLE:-trino_types}
 COMPOSE_SMOKE_UPSTREAM_ICEBERG_METADATA_PREFIX=${COMPOSE_SMOKE_UPSTREAM_ICEBERG_METADATA_PREFIX:-s3://floecat/sales/us/trino_types/metadata/}
-# Disabled until PR 474 fronts the compose Unity endpoint with the TLS-backed unity-proxy. Until
-# then COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_URI below is cleartext and the client rejects it, so
-# setting IMPORT=true alone will not run this scenario.
-COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT:-false}
-COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_URI=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_URI:-http://unity:8080}
+# Enabled through the TLS-backed unity-proxy configured by this smoke scenario.
+COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT:-true}
+COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_URI=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_URI:-https://unity-proxy:8443}
+COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_VEND_PATH=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_VEND_PATH:-/api/2.1/unity-catalog/temporary-table-credentials}
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_SOURCE_NS=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_SOURCE_NS:-unity.default}
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_SOURCE_TABLE=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_SOURCE_TABLE:-call_center}
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_DEST_CATALOG=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_DEST_CATALOG:-unity_import}
@@ -45,11 +44,9 @@ COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_DEST_NS=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_EXPECTED_TABLE=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_EXPECTED_TABLE:-unity_import.unity_smoke.call_center}
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_CONNECTOR_ARGS=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_CONNECTOR_ARGS:---auth-scheme none}
 COMPOSE_SMOKE_UNITY_HEALTH_PATH=${COMPOSE_SMOKE_UNITY_HEALTH_PATH:-/api/2.1/unity-catalog/catalogs}
-COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_STORAGE_LOCATION=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_STORAGE_LOCATION:-s3://floecat-delta/call_center}
+COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_STORAGE_LOCATION=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_STORAGE_LOCATION:-s3://floecat-delta-vended/call_center}
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ENDPOINT=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ENDPOINT:-http://localstack:4566}
 COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_REGION=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_REGION:-us-east-1}
-COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ACCESS_KEY_ID=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ACCESS_KEY_ID:-test}
-COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_SECRET_ACCESS_KEY=${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_SECRET_ACCESS_KEY:-test}
 COMPOSE_SMOKE_LOCALSTACK_BUCKETS="${COMPOSE_SMOKE_LOCALSTACK_BUCKETS:-bucket floecat floecat-delta floecat-dev staged-fixtures warehouse yb-iceberg-tpcds}"
 COMPOSE_SMOKE_ICEBERG_FORMAT_MATRIX=${COMPOSE_SMOKE_ICEBERG_FORMAT_MATRIX:-true}
 COMPOSE_SMOKE_STATS_RETRIES=${COMPOSE_SMOKE_STATS_RETRIES:-45}
@@ -217,6 +214,22 @@ assert_contains() {
     echo "[PASS] $check_name"
   else
     echo "[FAIL] $check_name (missing: $pattern)"
+    echo "---- output begin ----"
+    echo "$output"
+    echo "---- output end ----"
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local check_name="$1"
+  local output="$2"
+  local pattern="$3"
+
+  if [[ "$output" != *"$pattern"* ]]; then
+    echo "[PASS] $check_name"
+  else
+    echo "[FAIL] $check_name (unexpected: $pattern)"
     echo "---- output begin ----"
     echo "$output"
     echo "---- output end ----"
@@ -446,6 +459,58 @@ cleanup_mode() {
   eval "$compose_cmd down --remove-orphans -v" >/dev/null 2>&1 || true
 }
 
+prepare_unity_tls() {
+  local tls_dir="$1"
+  local cert_file="$tls_dir/server.crt"
+  local key_file="$tls_dir/server.key"
+  local truststore_file="$tls_dir/runtime-truststore.p12"
+
+  cp docker/certs/runtime-truststore.p12 "$truststore_file"
+  openssl req \
+    -x509 \
+    -nodes \
+    -newkey rsa:2048 \
+    -keyout "$key_file" \
+    -out "$cert_file" \
+    -days 1 \
+    -subj /CN=unity-proxy \
+    -addext 'subjectAltName=DNS:unity-proxy,DNS:localhost,IP:127.0.0.1,DNS:sts.us-east-1.amazonaws.com' \
+    >/dev/null 2>&1
+  keytool -delete \
+    -alias unity-proxy \
+    -keystore "$truststore_file" \
+    -storepass password \
+    >/dev/null 2>&1 || true
+  keytool -importcert \
+    -noprompt \
+    -alias unity-proxy \
+    -file "$cert_file" \
+    -keystore "$truststore_file" \
+    -storepass password \
+    >/dev/null
+  chmod 600 "$key_file"
+  chmod 644 "$cert_file" "$truststore_file"
+}
+
+cleanup_unity_tls() {
+  local tls_dir="$1"
+  if [ -z "$tls_dir" ]; then
+    return 0
+  fi
+  case "${tls_dir##*/}" in
+    floecat-unity-tls.*) ;;
+    *)
+      echo "refusing to clean unexpected Unity TLS directory: $tls_dir" >&2
+      return 1
+      ;;
+  esac
+  rm -f \
+    "$tls_dir/server.crt" \
+    "$tls_dir/server.key" \
+    "$tls_dir/runtime-truststore.p12"
+  rmdir "$tls_dir" 2>/dev/null || true
+}
+
 save_mode_logs() {
   local compose_cmd="$1"
   local label="$2"
@@ -518,6 +583,25 @@ wait_for_url() {
   done
 }
 
+wait_for_url_with_ca() {
+  local url="$1"
+  local timeout_seconds="$2"
+  local label="$3"
+  local ca_file="$4"
+  local i
+
+  for i in $(seq 1 "$timeout_seconds"); do
+    if curl -fsS --cacert "$ca_file" "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ "$i" -eq "$timeout_seconds" ]; then
+      echo "$label timed out" >&2
+      return 1
+    fi
+    sleep 1
+  done
+}
+
 wait_for_url_auth() {
   local url="$1"
   local timeout_seconds="$2"
@@ -572,11 +656,35 @@ run_mode() {
   if [ "$smoke_scope" = "full" ] && { [ "$profile" = "localstack" ] || [ "$profile" = "localstack-oidc" ]; } && should_run_client trino; then
     compose_profiles="${compose_profiles},trino"
   fi
+
+  local unity_tls_dir=""
+  local unity_tls_cert_file=""
+  local unity_tls_key_file=""
+  local unity_runtime_truststore_file=""
+  if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT"; then
+    unity_tls_dir=$(mktemp -d "${TMPDIR:-/tmp}/floecat-unity-tls.XXXXXX")
+    unity_tls_cert_file="$unity_tls_dir/server.crt"
+    unity_tls_key_file="$unity_tls_dir/server.key"
+    unity_runtime_truststore_file="$unity_tls_dir/runtime-truststore.p12"
+    if ! prepare_unity_tls "$unity_tls_dir"; then
+      cleanup_unity_tls "$unity_tls_dir"
+      return 1
+    fi
+  fi
+
   local -a mode_env_args=(
     "FLOECAT_ENV_FILE=$env_file"
     "COMPOSE_PROFILES=$compose_profiles"
     "COMPOSE_PROJECT_NAME=$compose_project"
   )
+
+  if [ -n "$unity_tls_dir" ]; then
+    mode_env_args+=(
+      "FLOECAT_RUNTIME_TRUSTSTORE_FILE=$unity_runtime_truststore_file"
+      "FLOECAT_UNITY_TLS_CERT_FILE=$unity_tls_cert_file"
+      "FLOECAT_UNITY_TLS_KEY_FILE=$unity_tls_key_file"
+    )
+  fi
 
   if [ -n "$kc_host" ]; then
     mode_env_args+=("KC_HOSTNAME=$kc_host")
@@ -627,6 +735,7 @@ run_mode() {
         echo "==> [SMOKE][KEEP] preserving compose stack for mode=$label (COMPOSE_SMOKE_KEEP_ON_EXIT=$COMPOSE_SMOKE_KEEP_ON_EXIT)"
       else
         cleanup_mode "$compose_cmd"
+        cleanup_unity_tls "$unity_tls_dir"
       fi
     else
       save_mode_logs "$compose_cmd" "${label}-fail"
@@ -635,6 +744,7 @@ run_mode() {
         echo "==> [SMOKE][KEEP] preserving compose stack for mode=$label (COMPOSE_SMOKE_KEEP_ON_FAIL=$COMPOSE_SMOKE_KEEP_ON_FAIL)"
       else
         cleanup_mode "$compose_cmd"
+        cleanup_unity_tls "$unity_tls_dir"
       fi
     fi
     return "$rc"
@@ -653,9 +763,9 @@ run_mode() {
   fi
   if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT"; then
     if [ -z "$pre_services" ]; then
-      pre_services="localstack unity"
+      pre_services="localstack unity unity-proxy"
     elif [[ ",$pre_services," != *",unity,"* ]]; then
-      pre_services="$pre_services unity"
+      pre_services="$pre_services unity unity-proxy"
     fi
   fi
 
@@ -680,6 +790,12 @@ run_mode() {
   if [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT"; then
     local unity_host_port="${FLOECAT_UNITY_HOST_PORT:-8083}"
     wait_for_url "http://localhost:${unity_host_port}${COMPOSE_SMOKE_UNITY_HEALTH_PATH}" 180 "Unity Catalog health"
+    local unity_https_host_port="${FLOECAT_UNITY_HTTPS_HOST_PORT:-8444}"
+    wait_for_url_with_ca \
+      "https://localhost:${unity_https_host_port}${COMPOSE_SMOKE_UNITY_HEALTH_PATH}" \
+      180 \
+      "Unity Catalog TLS proxy health" \
+      "$unity_tls_cert_file"
   fi
 
   local compose_up_cmd="$compose_cmd up -d"
@@ -1072,6 +1188,16 @@ quit")
       return 1
     fi
 
+    # SeedRunner writes the canonical Delta fixture to floecat-delta. Copy it to a bucket that is
+    # deliberately absent from COMPOSE_SMOKE_LOCALSTACK_BUCKETS, so no Floecat storage authority
+    # can make this test pass without Unity Catalog vending credentials.
+    local unity_aws_cli
+    unity_aws_cli="docker run --rm --network ${compose_project}_floecat -e AWS_ACCESS_KEY_ID=test -e AWS_SECRET_ACCESS_KEY=test -e AWS_DEFAULT_REGION=us-east-1 amazon/aws-cli:2.17.50"
+    $unity_aws_cli --endpoint-url http://localstack:4566 s3 cp \
+      s3://floecat-delta/call_center/ \
+      "$unity_storage_location/" \
+      --recursive >/dev/null
+
     local unity_catalog_resp
     unity_catalog_resp=$(docker run --rm --network "${compose_project}_floecat" curlimages/curl:8.12.1 -sS \
       -w "\n%{http_code}\n" \
@@ -1120,13 +1246,65 @@ quit")
       return 1
     fi
 
+    # Exercise the same OSS credential-vending route configured on the connector below. The proxy
+    # only terminates TLS; it does not rewrite API paths. Never print either response: the second
+    # one contains live session credentials.
+    local unity_table_get_resp
+    unity_table_get_resp=$(docker run --rm --network "${compose_project}_floecat" curlimages/curl:8.12.1 -k -fsS \
+      "${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_URI}/api/2.1/unity-catalog/tables/${unity_catalog}.${unity_schema}.${unity_source_table}")
+    local unity_table_id
+    unity_table_id=$(python3 - "$unity_table_get_resp" <<'PY'
+import json
+import sys
+
+table_id = json.loads(sys.argv[1]).get("table_id")
+if isinstance(table_id, str) and table_id.strip():
+    print(table_id)
+PY
+    )
+    if [ -z "$unity_table_id" ]; then
+      echo "[FAIL] $label Unity Catalog table response omitted table_id"
+      return 1
+    fi
+
+    local unity_vend_resp
+    unity_vend_resp=$(docker run --rm --network "${compose_project}_floecat" curlimages/curl:8.12.1 -k -fsS \
+      -X POST "${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_URI}${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_VEND_PATH}" \
+      -H "Content-Type: application/json" \
+      -d "{\"table_id\":\"$unity_table_id\",\"operation\":\"READ\"}")
+    if ! python3 - "$unity_vend_resp" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+creds = payload.get("aws_temp_credentials")
+required = ("access_key_id", "secret_access_key", "session_token")
+if not isinstance(creds, dict) or any(not str(creds.get(key, "")).strip() for key in required):
+    sys.exit(1)
+try:
+    if int(payload.get("expiration_time", 0)) <= 0:
+        sys.exit(1)
+except (TypeError, ValueError):
+    sys.exit(1)
+PY
+    then
+      echo "[FAIL] $label Unity Catalog did not vend a complete expiring AWS session tuple"
+      echo "[FAIL] Unity response omitted because it contains storage credentials"
+      return 1
+    fi
+
     local unity_setup_out
     unity_setup_out=$(run_cli_script "$compose_cmd" "account t-0001
 catalog create $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_DEST_CATALOG --desc compose-smoke-upstream-delta-unity
-connector create smoke-upstream-delta-unity DELTA $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_URI $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_SOURCE_NS $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_DEST_CATALOG --source-table $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_SOURCE_TABLE --dest-ns $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_DEST_NS --props delta.source=unity --props s3.endpoint=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ENDPOINT --props s3.path-style-access=true --props s3.region=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_REGION --cred-type aws --cred access_key_id=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ACCESS_KEY_ID --cred secret_access_key=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_SECRET_ACCESS_KEY $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_CONNECTOR_ARGS
+connector create smoke-upstream-delta-unity DELTA $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_URI $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_SOURCE_NS $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_DEST_CATALOG --source-table $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_SOURCE_TABLE --dest-ns $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_DEST_NS --props delta.source=unity --props unity.temporary-table-vend-path=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_VEND_PATH --props databricks.access-delegation=vended-credentials --props s3.endpoint=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_ENDPOINT --props s3.path-style-access=true --props s3.region=$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_S3_REGION $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_CONNECTOR_ARGS
 quit")
     echo "$unity_setup_out"
-    assert_contains "$label upstream delta unity connector setup" "$unity_setup_out" "smoke-upstream-delta-unity"
+    # CONNECTOR_ID is the header of the row a successful create prints; the connector name alone
+    # also appears in the CLI's error text, so it cannot distinguish success from failure. The
+    # shell prefixes every reported error with "! ".
+    assert_contains "$label upstream delta unity connector setup" "$unity_setup_out" "CONNECTOR_ID"
+    assert_contains "$label upstream delta unity connector setup names the connector" "$unity_setup_out" "smoke-upstream-delta-unity"
+    assert_not_contains "$label upstream delta unity connector setup reported no error" "$unity_setup_out" "! "
 
     run_connector_trigger_and_wait \
       "$compose_cmd" \
@@ -1157,6 +1335,41 @@ quit")
       "$COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_EXPECTED_TABLE" \
       "${COMPOSE_SMOKE_STATS_RETRIES:-45}" \
       "${COMPOSE_SMOKE_STATS_SLEEP_SECONDS:-2}"
+
+    if [ "$label" = "localstack-remote" ]; then
+      local unity_query_begin_out
+      unity_query_begin_out=$(run_cli_script "$compose_cmd" "account t-0001
+catalog use $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_DEST_CATALOG
+query begin table $COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_EXPECTED_TABLE
+quit")
+      echo "$unity_query_begin_out"
+      assert_contains "$label upstream delta unity query lease" "$unity_query_begin_out" "query id:"
+
+      local unity_query_id
+      local unity_floecat_table_id
+      unity_query_id=$(printf "%s\n" "$unity_query_begin_out" | sed -n 's/.*query id: //p' | tail -n1)
+      unity_floecat_table_id=$(printf "%s\n" "$out_upstream_delta_unity" | sed -n 's/.*table id: //p' | tail -n1)
+      if [ -z "$unity_query_id" ] || [ -z "$unity_floecat_table_id" ]; then
+        echo "[FAIL] $label could not resolve Unity query and table ids"
+        return 1
+      fi
+
+      local unity_scan_out
+      unity_scan_out=$(run_cli_script "$compose_cmd" "account t-0001
+query fetch-scan $unity_query_id $unity_floecat_table_id
+query end $unity_query_id --commit
+quit")
+      echo "$unity_scan_out"
+      assert_contains "$label upstream delta unity remote scan" "$unity_scan_out" "data_files:"
+      assert_contains "$label upstream delta unity remote scan location" "$unity_scan_out" "$unity_storage_location"
+
+      local unity_vending_logs
+      unity_vending_logs=$(eval "$compose_cmd logs --no-color service executor" 2>&1)
+      assert_contains \
+        "$label upstream delta unity source-catalog vending path" \
+        "$unity_vending_logs" \
+        "vended storage credentials from source catalog"
+    fi
   elif [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ]; then
     echo "==> [SMOKE] skipping upstream delta unity import (set COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT=true to enable)"
   fi


### PR DESCRIPTION
## Summary

Stack 7/7. Base: `kw-uc-vending-06-smoke-oracle` (#473).

Adds the Unity Catalog counterpart to the Polaris vending oracle using OSS Unity Catalog 0.6.0 and LocalStack STS. The Delta fixture lives in a bucket deliberately excluded from Floecat storage authorities, and the remote query path asserts that source-catalog vending actually occurred.

Changes:

- Pin OSS Unity Catalog and configure it to assume a LocalStack IAM role.
- Add a compose-only TLS proxy that terminates test TLS and keeps OSS Unity Catalog STS calls inside LocalStack.
- Select the OSS 2.1 temporary-credentials route through the typed client configuration.
- Trust the proxy certificate in the Floecat runtime truststore.
- Validate a complete, expiring AWS session tuple without logging its secret values.
- Create the Delta connector without static AWS credentials and explicitly enable vending.
- Assert reconciliation, stats, indexes, leased query scan files, and the source-catalog vending log.
- Document the smoke topology and explicit OSS route selection.

## Type of Change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [x] chore (build/tooling/maintenance)

## Testing

Validated shell syntax, compose configuration, certificate SANs, runtime truststore contents, and diff hygiene. A live compose run was unavailable because the local Docker daemon was not running.

- [ ] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [x] Config/env var changes (describe below)

Compose smoke gains the `unity-proxy` service, host TLS port 8444, a pinned Unity image, LocalStack IAM/bucket fixtures, and a test CA entry in the runtime truststore. Production configuration is unchanged.

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No live credentials, tokens, or secrets are included; AWS values are public local-test fixtures and TLS material is generated at runtime
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

The smoke harness generates its self-signed certificate and key at runtime. The proxy terminates TLS for the cleartext OSS fixture and routes its STS hostname to LocalStack; Unity API paths pass through unchanged, and the connector explicitly selects the OSS vending route. Production client behavior remains Databricks-compatible by default.
