### PR TITLE
storage: wire Unity Catalog vended credentials into read paths

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClient.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/S3V2FileSystemClient.java
@@ -42,6 +42,18 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 final class S3V2FileSystemClient implements FileIO {
   private final RefreshingAwsClient<S3Client> s3;
 
+  /**
+   * Addresses the bucket named in each URI, always.
+   *
+   * <p>There is deliberately no override. Substituting a vended S3 access-point ARN for the host
+   * was tried and removed: it retargets every URI, including the absolute paths in another bucket
+   * that a Delta log may carry and a shallow clone always does, so a foreign path would be read
+   * from the access point's bucket -- silently, when a key happens to exist there. A vend carrying
+   * an access point has the ARN dropped at {@code SourceCatalogCredentialVendor} and is used
+   * against the bucket, so nothing here is retargeted -- but do not read that as a guarantee that
+   * no such credential arrives: one does, minus its ARN, and a grant that is genuinely
+   * access-point-only fails at storage rather than here.
+   */
   S3V2FileSystemClient(RefreshingAwsClient<S3Client> s3) {
     this.s3 = s3;
   }

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/SourceCatalogVending.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/SourceCatalogVending.java
@@ -84,9 +84,19 @@ public final class SourceCatalogVending {
   /**
    * Whether an Iceberg connector reads a table directly rather than through a catalog.
    *
-   * <p>The one Iceberg source with no {@code loadTable} to carry credentials, so absorbing a
-   * missing-authority error for it hands back a config that cannot read. A connector migrated from
-   * REST keeps its delegation header, which is all the gate above would otherwise look at.
+   * <p>The one Iceberg source with no {@code loadTable} to carry credentials, and the reason the
+   * gate above is not simply "declares vending". It is consulted only from inside the catch that
+   * already caught "no authority covers this location", so a filesystem connector reading through a
+   * matching authority never arrives here -- the only config whose behaviour turns on this is one
+   * with a leftover delegation header, an {@code s3://} URI and no matching authority.
+   *
+   * <p>For that config, absorbing is not merely a lost diagnostic. {@code IcebergConnectorFactory}
+   * accepts {@code auth.scheme=none} for an S3 URI, so such a connector may carry no {@code s3.*}
+   * credentials at all, and an S3 client built from it resolves through the AWS default chain --
+   * floecat's own instance role. The read would then succeed under floecat's identity with the
+   * tenant's authority requirement silently gone, which is worse than the precise missing-authority
+   * error it replaces. Supporting a filesystem connector that legitimately reads through the
+   * ambient chain is a separate decision and wants an explicit opt-in, not a stale header.
    *
    * <p>Spelled here rather than read from {@code IcebergConnectorFactory}: connectors-spi cannot
    * depend on the Iceberg connector module. A source it stops accepting under this spelling makes

--- a/core/connectors/spi/src/test/java/ai/floedb/floecat/connector/spi/SourceCatalogVendingTest.java
+++ b/core/connectors/spi/src/test/java/ai/floedb/floecat/connector/spi/SourceCatalogVendingTest.java
@@ -387,9 +387,8 @@ class SourceCatalogVendingTest {
     assertThat(SourceCatalogVending.clientAppliesVendedCredentials(unity)).isFalse();
     assertThat(SourceCatalogVending.clientAppliesVendedCredentials(delta)).isFalse();
     assertThat(SourceCatalogVending.clientAppliesVendedCredentials(iceberg)).isTrue();
-    // Per source, because absorbing a missing-authority error is only safe where the client fetches
-    // credentials itself. glue and rest are the same REST client here; filesystem reads a static
-    // table and would be handed a config it cannot read from.
+    // Per source, because absorbing is only safe where the client fetches credentials itself. glue
+    // and rest are the same REST client here, so their FileIO uses what loadTable vended.
     for (String reachesACatalog : new String[] {"rest", "glue", "GLUE"}) {
       assertThat(
               SourceCatalogVending.clientAppliesVendedCredentials(
@@ -403,6 +402,10 @@ class SourceCatalogVendingTest {
           .as(reachesACatalog)
           .isTrue();
     }
+    // filesystem must not absorb. It has no loadTable to carry credentials, and auth.scheme=none is
+    // legal for an s3:// URI, so the untouched config can resolve through the AWS default chain --
+    // floecat's own role. Absorbing would turn a missing authority into a read under the wrong
+    // principal rather than into an error.
     for (String staticTable : new String[] {"filesystem", "FileSystem", " filesystem "}) {
       assertThat(
               SourceCatalogVending.clientAppliesVendedCredentials(

--- a/docs/connectors-delta.md
+++ b/docs/connectors-delta.md
@@ -166,7 +166,13 @@ Important connector properties:
   spelling DuckDB sends works here too; anything else is rejected at create/update time rather
   than read as "disabled". Honored only for `delta.source=unity` (the default): on
   `delta.source=glue` or `delta.source=filesystem` the option is accepted and then ignored, since
-  neither has a Unity credential endpoint to vend from.
+  neither has a Unity credential endpoint to vend from. If the credentials response carries an
+  `access_point` ARN, it is dropped and the rest of the tuple is used against the bucket named in
+  the object URI, logging the table at INFO. Nothing here addresses an access point, and the grant
+  behind one commonly permits bucket addressing anyway. Where it does not, reads fail at storage
+  with a 403; that log line is what points at the cause. Recover by having the workspace
+  vend bucket-scoped credentials for the external location, or by configuring a storage authority
+  covering it -- vending is reached only when no authority matches.
 - `s3.region` / `aws.region` – Region for the S3 client used to read Parquet files.
 - `stats.ndv.*` – Sampling knobs identical to the Iceberg connector.
 - Authentication-specific options (`auth.scheme`, `auth.properties`) – `auth.scheme=oauth2`

--- a/docs/connectors-iceberg.md
+++ b/docs/connectors-iceberg.md
@@ -172,6 +172,20 @@ To extend behavior:
   If the upstream REST catalog ignores that header, normal REST behavior still applies and success
   depends on some other valid storage credential path. If the upstream catalog rejects delegated
   access requests, connector planning or table load will fail on the REST call.
+
+  The header only does something useful for `iceberg.source=rest` and `iceberg.source=glue`, whose
+  catalog client applies whatever `loadTable` vends. `iceberg.source=filesystem` reads a metadata
+  JSON directly and has no catalog to vend from, so such a connector needs a storage authority
+  covering its location, or its own `s3.*` credentials.
+
+  The header is not currently *rejected* for a filesystem source, though, and it is worth knowing
+  what actually happens: a vend is still attempted, which for this source means loading the
+  metadata JSON while the connector is constructed, once per file group. Nothing is vended, so a
+  connector matching no storage authority then fails reconcile with a missing-authority error
+  rather than falling back — which is what keeps it from silently reading under floecat's own AWS
+  identity. If that metadata load is itself what fails, the job sees a retryable internal error
+  instead. Skipping the attempt for this source is deferred along with the rest of the connector
+  path, which catalog integrations replace.
 - **Filesystem (single table)** – CLI example using the metadata JSON as the connector URI:
   ```
   connector create "Filesystem Iceberg" ICEBERG \

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolver.java
@@ -23,7 +23,7 @@ import ai.floedb.floecat.connector.common.auth.ResolvedStorageCredentials;
 import ai.floedb.floecat.connector.common.auth.TerminalCredentialRefreshException;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.spi.ConnectorConfig;
-import ai.floedb.floecat.connector.spi.IcebergAccessDelegation;
+import ai.floedb.floecat.connector.spi.SourceCatalogVending;
 import ai.floedb.floecat.reconciler.spi.ReconcileContext;
 import ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus;
 import ai.floedb.floecat.storage.rpc.ResolveStorageAuthorityResponse;
@@ -289,10 +289,14 @@ public class ServerSideStorageConfigResolver {
       // validation failures, so matching the code alone turned a real configuration error into a
       // silent fallback whose cause only resurfaced as an opaque FileIO failure much later.
       //
-      // Only "no authority covers this location" is recoverable by delegation: the catalog client
-      // holds vended credentials of its own, so the untouched config is what it needs.
+      // Only "no authority covers this location" is recoverable by delegation, and only for a
+      // catalog whose own client applies vended credentials when it loads the table -- for that
+      // one the untouched config is exactly what it needs. Deliberately not the broader
+      // "declares vending" gate: Delta/Unity vend only on request and build their S3 client from
+      // the connector's own s3.* options, so absorbing there would replace a precise
+      // missing-authority failure with an opaque 403 on the first read.
       if (SourceCatalogVendingGrpcStatus.isNoMatchingStorageAuthority(e)
-          && IcebergAccessDelegation.declaresVendedCredentials(config)) {
+          && SourceCatalogVending.clientAppliesVendedCredentials(config)) {
         return config;
       }
       throw e;
@@ -381,13 +385,26 @@ public class ServerSideStorageConfigResolver {
       return base;
     }
     LinkedHashMap<String, String> merged = new LinkedHashMap<>(base);
-    if (refreshableExecutionCredentials) {
+    boolean replacesCredentials =
+        includeStorageCredentials && response.getStorageCredentialsCount() > 0;
+    // Cleared whenever a fresh tuple is about to land, not only on the refreshable path. The
+    // response is applied key by key, so it overwrites only what it carries: a vend of key and
+    // secret with no session token would otherwise leave the connector's own stale s3.session-token
+    // beside it, and a mismatched triple fails at storage as a 403 that reads like a bad vend
+    // rather than a bad merge.
+    //
+    // The provider keys go too, and that is the part that matters most here: a leftover provider id
+    // does not merely linger, it wins. IcebergConnectorFactory.applyStorageAuth short-circuits on
+    // it and then deletes s3.access-key-id, s3.secret-access-key and s3.session-token outright,
+    // and DeltaConnectorFactory.resolveCredentials returns the registry-backed provider before it
+    // ever reads them -- so leaving a stale id here silently discards the credentials just vended.
+    if (refreshableExecutionCredentials || replacesCredentials) {
       clearStorageCredentialProperties(merged);
     }
     response
         .getClientSafeConfigMap()
         .forEach((key, value) -> putStorageProperty(merged, key, value));
-    if (!includeStorageCredentials || response.getStorageCredentialsCount() == 0) {
+    if (!replacesCredentials) {
       return Map.copyOf(merged);
     }
     if (refreshableExecutionCredentials) {
@@ -447,11 +464,25 @@ public class ServerSideStorageConfigResolver {
                         + " session token, and expiresAt"));
   }
 
+  /**
+   * Whether a failed refresh will keep failing.
+   *
+   * <p>The two structured vending reasons belong here as well as in {@code
+   * ReconcileFailureClassifier}: a refresh failure that is merely "ordinary" is suppressed by
+   * {@code RefreshingAwsCredentialsProviderRegistry} while the previous tuple is still valid, so a
+   * source catalog that refuses to vend for this table -- or vends an unrenewable tuple -- would be
+   * re-asked on every refresh until the tuple expires, instead of failing the job at once. Matched
+   * by reason, not by code: {@code FAILED_PRECONDITION} also carries conditions this method
+   * classifies on their own terms -- a lease-precondition failure is terminal here by the first
+   * clause -- so the code alone cannot tell the two apart.
+   */
   static boolean isTerminalExecutionCredentialRefresh(StatusRuntimeException error) {
     Status.Code code = error.getStatus().getCode();
     return ReconcileLeaseGrpcStatus.isLeasePreconditionFailure(error)
         || code == Status.Code.UNAUTHENTICATED
-        || code == Status.Code.PERMISSION_DENIED;
+        || code == Status.Code.PERMISSION_DENIED
+        || SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(error)
+        || SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(error);
   }
 
   static Optional<ResolvedStorageCredentials> resolvedStorageCredentials(

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ServerSideStorageConfigResolverTest.java
@@ -418,6 +418,38 @@ class ServerSideStorageConfigResolverTest {
   }
 
   /**
+   * Unity declares vending, but its connector applies vended credentials only when asked: the Delta
+   * engine's S3 client is built from the connector's own {@code s3.*} options. An untouched config
+   * therefore carries no storage credentials, so the missing-authority error must propagate rather
+   * than be absorbed into an opaque 403 on the first read.
+   */
+  @Test
+  void delegatingUnityConnectorPropagatesMissingAuthority() {
+    ConnectorConfig config =
+        new ConnectorConfig(
+            ConnectorConfig.Kind.DELTA,
+            "unity",
+            "https://workspace.example.com",
+            Map.of(
+                "storage_location", "s3://8c554103--table-s3",
+                "databricks.access-delegation", "vended-credentials"),
+            new ConnectorConfig.Auth("oauth2", Map.of("token", "secret"), Map.of()));
+    ServerSideStorageConfigResolver resolver =
+        new ServerSideStorageConfigResolver(java.util.Optional.empty(), java.util.Optional.empty());
+    resolver.storageAuthorities = mock(StorageAuthoritiesGrpc.StorageAuthoritiesBlockingStub.class);
+    when(resolver.storageAuthorities.withInterceptors(any()))
+        .thenReturn(resolver.storageAuthorities);
+    when(resolver.storageAuthorities.vendStorageCredentials(any()))
+        .thenThrow(SourceCatalogVendingGrpcStatus.noMatchingStorageAuthority("none matches"));
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () -> resolveWithStorageLocation(resolver, unityConnector(), config));
+
+    verify(resolver.storageAuthorities).vendStorageCredentials(any());
+  }
+
+  /**
    * INVALID_ARGUMENT alone must not trigger the fallback. vendStorageCredentials returns it for
    * account_id, execution_binding and location_prefix validation failures too, and turning those
    * into a silent "use the catalog instead" hides the real cause behind a later FileIO error.
@@ -583,15 +615,11 @@ class ServerSideStorageConfigResolverTest {
 
   private static ServerSideStorageConfigResolver.ResolvedConnectorConfig resolveWithStorageLocation(
       ServerSideStorageConfigResolver resolver, ConnectorConfig config) {
-    Connector connector =
-        Connector.newBuilder()
-            .setKind(ConnectorKind.CK_ICEBERG)
-            .setResourceId(
-                ResourceId.newBuilder()
-                    .setAccountId("acct")
-                    .setId("conn")
-                    .setKind(ResourceKind.RK_CONNECTOR))
-            .build();
+    return resolveWithStorageLocation(resolver, icebergConnector(), config);
+  }
+
+  private static ServerSideStorageConfigResolver.ResolvedConnectorConfig resolveWithStorageLocation(
+      ServerSideStorageConfigResolver resolver, Connector connector, ConnectorConfig config) {
     return resolver.resolveManagedWithAuthorization(
         java.util.Optional.empty(),
         java.util.Optional.empty(),
@@ -600,6 +628,30 @@ class ServerSideStorageConfigResolverTest {
         java.util.Optional.empty(),
         connector,
         config);
+  }
+
+  private static Connector icebergConnector() {
+    return Connector.newBuilder()
+        .setKind(ConnectorKind.CK_ICEBERG)
+        .setResourceId(
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setId("conn")
+                .setKind(ResourceKind.RK_CONNECTOR))
+        .build();
+  }
+
+  private static Connector unityConnector() {
+    Connector connector =
+        Connector.newBuilder()
+            .setKind(ConnectorKind.CK_DELTA)
+            .setResourceId(
+                ResourceId.newBuilder()
+                    .setAccountId("acct")
+                    .setId("conn")
+                    .setKind(ResourceKind.RK_CONNECTOR))
+            .build();
+    return connector;
   }
 
   @Test
@@ -624,6 +676,40 @@ class ServerSideStorageConfigResolverTest {
     assertEquals("minio", merged.get("s3.access-key-id"));
     assertEquals("miniostorage", merged.get("s3.secret-access-key"));
     assertNull(merged.get("type"));
+  }
+
+  @Test
+  void aVendWithoutASessionTokenDoesNotInheritTheConnectorsStaleOne() {
+    // The response is applied key by key, so it overwrites only what it carries. A client-path vend
+    // may legitimately be key + secret only -- Unity omits the session token for long-lived keys --
+    // and pairing it with the connector's own stale token yields a mismatched triple and a 403 that
+    // reads like a bad vend rather than a bad merge.
+    ResolveStorageAuthorityResponse response =
+        ResolveStorageAuthorityResponse.newBuilder()
+            .addStorageCredentials(
+                VendedStorageCredential.newBuilder()
+                    .putConfig("type", "s3")
+                    .putConfig("s3.access-key-id", "VENDED")
+                    .putConfig("s3.secret-access-key", "vended-secret"))
+            .build();
+
+    Map<String, String> merged =
+        ServerSideStorageConfigResolver.mergeResolvedStorageConfig(
+            Map.of(
+                "s3.access-key-id", "CONNECTOR",
+                "s3.secret-access-key", "connector-secret",
+                "s3.session-token", "stale-session-token",
+                "client.credentials-provider", "com.example.CallerProvider"),
+            response);
+
+    assertEquals("VENDED", merged.get("s3.access-key-id"));
+    assertEquals("vended-secret", merged.get("s3.secret-access-key"));
+    assertNull(merged.get("s3.session-token"));
+    // The provider key goes too. A leftover id does not sit harmlessly beside the static triple --
+    // IcebergConnectorFactory.applyStorageAuth short-circuits on it and deletes the triple, and
+    // DeltaConnectorFactory.resolveCredentials returns the registry provider without reading it --
+    // so leaving it would silently discard the credentials this response just vended.
+    assertNull(merged.get("client.credentials-provider"));
   }
 
   @Test

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
@@ -108,7 +108,15 @@ public class LeasedFileGroupExecutionService extends BaseServiceImpl {
           .withDescription("table upstream connector metadata is required for file-group execution")
           .asRuntimeException();
     }
-    ResourceId connectorId = table.getUpstream().getConnectorId();
+    // Scoped to the table's own account rather than trusting the reference. validateUpstreamRef
+    // checks the connector's resource kind, not its account, and ConnectorRepository.getById keys
+    // on the account inside the id it is handed -- so a ref naming another tenant would resolve
+    // that tenant's connector here, and resolvedConnectorPayload would put its resolved secret in
+    // the worker payload. SourceCatalogCredentialVendor rebuilds the id the same way.
+    ResourceId connectorId =
+        table.getUpstream().getConnectorId().toBuilder()
+            .setAccountId(table.getResourceId().getAccountId())
+            .build();
     Connector connector =
         connectorRepo
             .getById(connectorId)
@@ -217,6 +225,14 @@ public class LeasedFileGroupExecutionService extends BaseServiceImpl {
     return pinned;
   }
 
+  /**
+   * Stamps the table's {@code storage_location} onto the connector payload the worker receives.
+   *
+   * <p>The only writer of the property that {@code ReconcilerService.sourceStorageLocation} and
+   * {@code StorageAuthorityServiceImpl.connectorSourceStorageLocation} read to decide which storage
+   * authority covers a table -- and, when none does, whether to ask the source catalog to vend. A
+   * kind missing here silently skips both.
+   */
   private Connector withTableStorageLocation(Connector connector, Table table) {
     if (connector == null
         || table == null

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
@@ -31,6 +31,14 @@ import java.util.Map;
 
 @ApplicationScoped
 public class ServerSideFileIoPropertiesResolver {
+  /**
+   * The FileIO properties a resolved storage answer owns end to end -- replaced wholesale rather
+   * than merged, so a stale value never survives alongside a fresh credential.
+   *
+   * <p>No {@code s3.access-point}: nothing downstream addresses an access point, so a vend that
+   * carries one has the ARN dropped at {@code SourceCatalogCredentialVendor} and is used against
+   * the bucket in the object URI.
+   */
   private static final List<String> FILE_IO_PROPERTY_KEYS =
       List.of(
           "s3.region",

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendor.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.storage.impl;
 
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.UpstreamRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.common.auth.CredentialResolverSupport;
 import ai.floedb.floecat.connector.rpc.AuthConfig;
 import ai.floedb.floecat.connector.rpc.AuthCredentials;
@@ -27,7 +28,9 @@ import ai.floedb.floecat.connector.spi.ConnectorConfigMapper;
 import ai.floedb.floecat.connector.spi.ConnectorFactory;
 import ai.floedb.floecat.connector.spi.CredentialResolver;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
-import ai.floedb.floecat.connector.spi.IcebergAccessDelegation;
+import ai.floedb.floecat.connector.spi.LogSafeText;
+import ai.floedb.floecat.connector.spi.SourceCatalogAccessException;
+import ai.floedb.floecat.connector.spi.SourceCatalogVending;
 import ai.floedb.floecat.service.credentials.AuthResolutionContexts;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.storage.rpc.ResolveStorageAuthorityResponse;
@@ -41,6 +44,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
@@ -65,6 +70,33 @@ public class SourceCatalogCredentialVendor {
   private static final org.jboss.logging.Logger LOG =
       org.jboss.logging.Logger.getLogger(SourceCatalogCredentialVendor.class);
 
+  /** Cap on the gRPC status description built from a catalog failure. See catalogFailureStatus. */
+  private static final int MAX_STATUS_DESCRIPTION = 512;
+
+  /**
+   * A catalog-supplied table identifier, flattened and bounded for a status or a log line.
+   *
+   * <p>Both halves come off the persisted {@code UpstreamRef}, so neither has a length or character
+   * bound. A status description becomes percent-encoded grpc-message trailer metadata that travels
+   * to every consumer and competes with HTTP/2 header limits, and {@code withReason} copies the
+   * same text into two {@code Any} details -- three carriages of whatever the catalog named its
+   * table. Flattening matters for the log line too: a name containing a newline would forge one.
+   */
+  private static String boundedTable(String namespaceFq, String tableName) {
+    return LogSafeText.bounded(namespaceFq + "." + tableName, MAX_LOGGED_PREFIX_CHARS);
+  }
+
+  /**
+   * Bound on the refusal detail written to the server log.
+   *
+   * <p>Far above {@link #MAX_STATUS_DESCRIPTION} on purpose: the status carries a summary and the
+   * log carries the diagnostic, so this exists to cap a flood rather than to summarize.
+   */
+  private static final int MAX_LOGGED_DETAIL_CHARS = 8_192;
+
+  /** Bound on a catalog-supplied prefix in a log line; long enough to be recognizable. */
+  private static final int MAX_LOGGED_PREFIX_CHARS = 256;
+
   /**
    * Non-secret S3 routing keys a vended credential carries, safe to expose in client_safe_config.
    */
@@ -73,6 +105,15 @@ public class SourceCatalogCredentialVendor {
 
   /** Region aliases, matching what {@code StorageAuthorityResolver.putRegionConfig} writes. */
   private static final List<String> REGION_KEYS = List.of("s3.region", "region", "client.region");
+
+  /**
+   * Where a connector's own region may be spelled. A superset of {@link #REGION_KEYS}: {@code
+   * aws.region} is documented for Delta and Iceberg connector options ({@code
+   * DeltaConnectorFactory} reads it) but is not one of the keys written back, so it is read-only
+   * here.
+   */
+  private static final List<String> REGION_ALIAS_KEYS =
+      Stream.concat(REGION_KEYS.stream(), Stream.of("aws.region")).toList();
 
   /**
    * What the caller will do with the credentials. Selects how strictly they are validated: only the
@@ -87,6 +128,7 @@ public class SourceCatalogCredentialVendor {
 
   @Inject ConnectorRepository connectorRepo;
   @Inject CredentialResolver credentialResolver;
+  Function<ConnectorConfig, FloecatConnector> connectorFactory = ConnectorFactory::create;
 
   @ConfigProperty(name = "floecat.storage.aws.region", defaultValue = "us-east-1")
   String defaultRegion;
@@ -111,11 +153,21 @@ public class SourceCatalogCredentialVendor {
           "source-catalog vending skipped: table %s has no upstream connector reference", tableId);
       return null;
     }
-    Connector connector = connectorRepo.getById(upstream.getConnectorId()).orElse(null);
+    // Scoped to the table's own account rather than trusting the reference. The upstream ref is
+    // stored verbatim from spec.upstream on table create -- validateUpstreamRef checks the resource
+    // kind, not the account -- and ConnectorRepository.getById keys on the account inside the id it
+    // is handed. A ref naming another tenant would otherwise resolve that tenant's connector, its
+    // secret, and vend through it for a caller authorized only here. The catalog-integration path
+    // rebuilds its id the same way.
+    ResourceId connectorId =
+        upstream.getConnectorId().toBuilder()
+            .setAccountId(table.getResourceId().getAccountId())
+            .build();
+    Connector connector = connectorRepo.getById(connectorId).orElse(null);
     if (connector == null) {
       LOG.infof(
           "source-catalog vending skipped: upstream connector %s of table %s not found",
-          upstream.getConnectorId().getId(), tableId);
+          LogSafeText.bounded(connectorId.getId(), MAX_LOGGED_PREFIX_CHARS), tableId);
       return null;
     }
 
@@ -139,7 +191,7 @@ public class SourceCatalogCredentialVendor {
 
     String namespaceFq = String.join(".", upstream.getNamespacePathList());
     Optional<FloecatConnector.VendedStorageCredentials> vended;
-    try (FloecatConnector source = ConnectorFactory.create(resolvedConfig)) {
+    try (FloecatConnector source = connectorFactory.apply(resolvedConfig)) {
       vended = source.vendStorageCredentials(namespaceFq, upstream.getTableDisplayName());
     } catch (StatusRuntimeException e) {
       throw e;
@@ -148,13 +200,19 @@ public class SourceCatalogCredentialVendor {
       // principal without TABLE_READ_DATA. Letting it escape as INTERNAL makes the reconciler treat
       // it as transient and retry the job forever, so classify it terminally. Anything that is not
       // recognisably an authorization refusal stays retryable.
-      throw catalogFailureStatus(e, connector, namespaceFq, upstream.getTableDisplayName());
+      throw catalogFailureStatus(e, connector, namespaceFq, upstream.getTableDisplayName(), use);
     }
+    // Empty and absent are the same answer. A connector that hands back a credential object with
+    // no properties has vended nothing, and falling through would reach requireUsableCredentials
+    // and fail the job terminally on a condition the caller can recover from by using a storage
+    // authority. Partial credentials are deliberately *not* screened here -- those do reach the
+    // usability check, which is where "the catalog vended something unusable" belongs.
     if (vended.isEmpty() || vended.get().isEmpty()) {
       LOG.infof(
-          "source-catalog vending skipped: connector %s returned no credentials for %s.%s"
+          "source-catalog vending skipped: connector %s returned no credentials for %s"
               + " (catalog does not delegate)",
-          connector.getResourceId().getId(), namespaceFq, upstream.getTableDisplayName());
+          connector.getResourceId().getId(),
+          boundedTable(namespaceFq, upstream.getTableDisplayName()));
       return null;
     }
 
@@ -166,11 +224,13 @@ public class SourceCatalogCredentialVendor {
     if (configuredAccessKey != null && configuredAccessKey.equals(vendedAccessKey)) {
       LOG.infof(
           "source-catalog vending skipped: connector %s returned its own configured credentials"
-              + " for %s.%s (catalog did not delegate)",
-          connector.getResourceId().getId(), namespaceFq, upstream.getTableDisplayName());
+              + " for %s (catalog did not delegate)",
+          connector.getResourceId().getId(),
+          boundedTable(namespaceFq, upstream.getTableDisplayName()));
       return null;
     }
 
+    noteIgnoredAccessPoint(vended.get(), namespaceFq, upstream.getTableDisplayName());
     requireUsableCredentials(vended.get(), namespaceFq, upstream.getTableDisplayName(), use);
 
     // A delegating catalog vends credentials, not routing. Polaris returns the session triple and
@@ -186,17 +246,28 @@ public class SourceCatalogCredentialVendor {
     storageConfig.put("type", "s3");
     storageConfig.putAll(vended.get().properties());
     storageConfig.putAll(routing);
+    // Dropped rather than forwarded: the ARN is not acted on anywhere here, and advertising a
+    // routing key no consumer honours invites one to start honouring it inconsistently. Same
+    // reason FILE_IO_PROPERTY_KEYS omits it. noteIgnoredAccessPoint has already logged it.
+    storageConfig.remove("s3.access-point");
     VendedStorageCredential.Builder credential =
         VendedStorageCredential.newBuilder()
-            .setPrefix(responseLocationPrefix == null ? "" : responseLocationPrefix)
+            .setPrefix(
+                responsePrefix(
+                    vended.get(),
+                    responseLocationPrefix,
+                    namespaceFq,
+                    upstream.getTableDisplayName()))
             .putAllConfig(Map.copyOf(storageConfig));
     Instant expiresAt = vended.get().expiresAt();
     if (expiresAt != null) {
       credential.setExpiresAt(Timestamps.fromMillis(expiresAt.toEpochMilli()));
     }
     LOG.infof(
-        "vended storage credentials from source catalog connector=%s table=%s.%s expiresAt=%s",
-        connector.getResourceId().getId(), namespaceFq, upstream.getTableDisplayName(), expiresAt);
+        "vended storage credentials from source catalog connector=%s table=%s expiresAt=%s",
+        connector.getResourceId().getId(),
+        boundedTable(namespaceFq, upstream.getTableDisplayName()),
+        expiresAt);
     // Non-secret routing properties must also travel in client_safe_config. The reconcile worker's
     // execution-bound (refreshable) merge path applies client_safe_config plus the refreshed
     // credential triple and never reads storage_credentials[0].config, so region and endpoint
@@ -207,6 +278,84 @@ public class SourceCatalogCredentialVendor {
         .putAllClientSafeConfig(routing)
         .addStorageCredentials(credential)
         .build();
+  }
+
+  /**
+   * The prefix to stamp on the vended credential: the vended scope when it narrows the request,
+   * otherwise the location the caller was authorized for.
+   *
+   * <p>The vended scope is taken only downwards, and it is whatever the catalog named -- the
+   * Iceberg connector passes the catalog's prefix through and leaves it null when the catalog named
+   * nothing, deliberately refusing to substitute the table location because {@code write.data.path}
+   * and {@code add_files} can put files outside it. So the scope is a bound to intersect with
+   * rather than an assertion about what the credential covers, and a null one bounds nothing.
+   * {@code requestedPrefix} is {@code credentialScope.location()}, the same value {@code
+   * isWithinExecutionScope} and {@code resolvePlannerBootstrapLocation} use to refuse out-of-scope
+   * requests, so letting a broader scope replace it would hand back a credential stamped for more
+   * than the caller may read: a table at {@code s3://warehouse/tpch_10/customer} covered by a
+   * credential scoped to {@code s3://warehouse/tpch} would come back claiming all of {@code
+   * s3://warehouse/tpch*}, and the consumers that key their client cache on this prefix would apply
+   * it to sibling prefixes. The credential itself may well be broader; what travels back is bounded
+   * by the authorization.
+   */
+  static String responsePrefix(
+      FloecatConnector.VendedStorageCredentials vended,
+      String requestedPrefix,
+      String namespaceFq,
+      String tableName) {
+    // Both sides normalized, not just the vended one: three of the four exits below return the
+    // requested prefix, and that is the common path. The trailing-slash hazard described for the
+    // scope applies identically -- credentialScope.location() resolves from table properties or a
+    // client-supplied location on the REST request, both of which routinely carry one. The record's
+    // "trimming a bound widens it" caution does not apply here: this is the authorization floecat
+    // computed, not a bound the catalog handed us.
+    String requested =
+        requestedPrefix == null
+            ? ""
+            : StorageAuthorityResolver.stripTrailingSlash(requestedPrefix.trim());
+    // Trimmed here rather than in the record. The record keeps a prefix as the catalog sent it,
+    // because that value is a bound and trimming one widens it; this method produces the value that
+    // travels back and that consumers key a client cache on, so " s3://x " and "s3://x" naming two
+    // different scopes is this method's problem to prevent. Trimming cannot widen past the
+    // authorization: what is returned still had to clear the containment check below.
+    String raw = vended == null ? null : vended.scopePrefix();
+    // Trailing slash normalized alongside the whitespace, for the same reason: this value travels
+    // back as storage_credentials[].prefix, and TableLoadService keys a merged map on it, so
+    // "s3://bucket/table/" and "s3://bucket/table" would become two entries and two client FileIO
+    // instances for one scope. matchesLocationPrefix strips the slash from its prefix argument
+    // only, so the slashed form clears containment and would otherwise be returned verbatim.
+    // stripTrailingSlash is what every other location comparison in this package normalizes with.
+    String scope = raw == null ? null : StorageAuthorityResolver.stripTrailingSlash(raw.trim());
+    if (scope == null || scope.isEmpty()) {
+      return requested;
+    }
+    // Blank request: nothing to bound against, so the vended scope is the only answer available
+    // and is narrower than the unbounded alternative. Otherwise containment is decided by the same
+    // path-boundary rule the authority resolver uses -- a plain startsWith would accept
+    // "s3://warehouse/tpch_other" as inside "s3://warehouse/tpch".
+    if (requested.isBlank() || StorageAuthorityResolver.matchesLocationPrefix(scope, requested)) {
+      return scope;
+    }
+    // WARN here, unlike the access-point line below, and the difference is the point: a vended
+    // access point is benign and common, while a disjoint scope means the credential travels
+    // stamped for a location it does not cover and the read will fail. Both repeat per file group,
+    // but only one of them is reporting that something is actually wrong.
+    //
+    // Not inside the request, which splits two ways. A scope that *contains* the request is the
+    // ordinary case -- the catalog scoped broadly, and narrowing to what the caller asked for is
+    // the whole point of this method. Disjoint is different: there is no intersection to return, so
+    // the credential travels stamped for a location it does not cover and the worker finds out at
+    // storage. Still returns the requested prefix, because it is the only bound the caller was
+    // authorized for; the log is what turns an opaque 403 into something traceable to the catalog.
+    if (!StorageAuthorityResolver.matchesLocationPrefix(requested, scope)) {
+      LOG.warnf(
+          "source catalog vended a scope disjoint from the requested location for %s:"
+              + " vended=%s requested=%s; returning the requested prefix",
+          boundedTable(namespaceFq, tableName),
+          LogSafeText.location(scope, MAX_LOGGED_PREFIX_CHARS),
+          LogSafeText.location(requested, MAX_LOGGED_PREFIX_CHARS));
+    }
+    return requested;
   }
 
   static Map<String, String> clientSafeRoutingProperties(Map<String, String> props) {
@@ -233,16 +382,24 @@ public class SourceCatalogCredentialVendor {
    * falls back to the connector's own configuration and then to the deployment's configured region,
    * mirroring {@code resolveSnapshotCompatStorageSettings}, which synthesizes exactly these
    * settings when no authority exists. A wrong region announces itself immediately as an S3
-   * redirect; an absent one fails mid-scan with nothing pointing at the cause.
+   * redirect; an absent one fails mid-scan with nothing pointing at the cause. The connector's
+   * region is read under every documented alias, {@link #REGION_ALIAS_KEYS}, so a connector
+   * configured with {@code aws.region} is not silently replaced by the deployment default.
    */
   Map<String, String> routingProperties(
       Map<String, String> vendedProps, Map<String, String> connectorOptions) {
     LinkedHashMap<String, String> routing =
         new LinkedHashMap<>(clientSafeRoutingProperties(vendedProps));
+    // A Unity response carries only the credential tuple and an optional access point, so anything
+    // else the reader needs to reach the bucket at all -- a MinIO/S3-compatible endpoint,
+    // path-style
+    // addressing -- can only come from the connector. Vended wins where both are present.
+    clientSafeRoutingProperties(connectorOptions).forEach(routing::putIfAbsent);
     String region =
         firstNonBlank(
             firstNonBlank(REGION_KEYS.stream().map(vendedProps::get).toArray(String[]::new)),
-            firstNonBlank(REGION_KEYS.stream().map(connectorOptions::get).toArray(String[]::new)),
+            firstNonBlank(
+                REGION_ALIAS_KEYS.stream().map(connectorOptions::get).toArray(String[]::new)),
             defaultRegion);
     if (region != null) {
       // Same three keys putRegionConfig writes for an authority-backed response.
@@ -266,11 +423,14 @@ public class SourceCatalogCredentialVendor {
   /**
    * Whether the connector asked its catalog to vend credentials.
    *
-   * <p>Delegates to the shared parser so this gate and the reconciler's -- which decides whether to
-   * absorb the resulting missing-authority error -- cannot drift apart.
+   * <p>The broad predicate: it decides whether a vend is attempted at all, and answers true for
+   * Delta and Unity as well as Iceberg. The reconciler's absorb gate is deliberately narrower --
+   * {@code clientAppliesVendedCredentials}, false for Delta and Unity and for a static-table
+   * Iceberg source -- so the two do not answer alike and are not meant to. Both spellings live in
+   * {@code SourceCatalogVending} so that the difference stays deliberate rather than emergent.
    */
   static boolean connectorDeclaresVendedDelegation(Connector connector) {
-    return IcebergAccessDelegation.declaresVendedCredentials(
+    return SourceCatalogVending.declaresVendedCredentials(
         ConnectorConfigMapper.fromProto(connector));
   }
 
@@ -296,8 +456,17 @@ public class SourceCatalogCredentialVendor {
       String tableName,
       CredentialUse use) {
     Map<String, String> props = vended.properties();
+    // A tuple with neither a session token nor an expiry is a long-lived static key, not a session
+    // credential missing its renewal fields, and reconcile can use one: it fails
+    // isRefreshableExecutionCredential, so the merge path embeds it statically -- which is the
+    // right answer for a credential that never expires. Unity returns this shape for an external
+    // location backed by long-lived keys, and refusing it here would leave such a table queryable
+    // but never capturable.
+    String sessionToken = props.get("s3.session-token");
+    boolean longLivedStaticKey =
+        (sessionToken == null || sessionToken.isBlank()) && vended.expiresAt() == null;
     List<String> required =
-        use == CredentialUse.RECONCILE
+        use == CredentialUse.RECONCILE && !longLivedStaticKey
             ? List.of("s3.access-key-id", "s3.secret-access-key", "s3.session-token")
             : List.of("s3.access-key-id", "s3.secret-access-key");
     List<String> missing = new java.util.ArrayList<>();
@@ -307,7 +476,18 @@ public class SourceCatalogCredentialVendor {
         missing.add(key);
       }
     }
-    if (use == CredentialUse.RECONCILE && vended.expiresAt() == null) {
+    // Already-expired counts as missing, not as present. RefreshingAwsCredentialsProviderRegistry
+    // reads a past expiry as "refresh now" -- computeRefreshSkew returns Duration.ZERO and
+    // shouldRefresh is then true on every resolveCredentials call -- so a catalog that keeps
+    // returning the same stale timestamp is re-vended once per credential resolution and still
+    // hands back credentials S3 will refuse. Failing here instead names the field once, terminally.
+    // Skipped for the static key above, which has nothing to expire. What stays terminal is the
+    // dangerous middle case: a session token present with an expiry missing or already past. That
+    // one is a session credential floecat cannot renew, so it would lapse mid-capture with nothing
+    // to recover it.
+    if (use == CredentialUse.RECONCILE
+        && !longLivedStaticKey
+        && (vended.expiresAt() == null || !vended.expiresAt().isAfter(Instant.now()))) {
       missing.add("s3.session-token-expires-at-ms");
     }
     if (missing.isEmpty()) {
@@ -324,11 +504,41 @@ public class SourceCatalogCredentialVendor {
     throw ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus
         .vendedCredentialsNotRefreshable(
             "source catalog vended unusable storage credentials for "
-                + namespaceFq
-                + "."
-                + tableName
+                + boundedTable(namespaceFq, tableName)
                 + "; missing "
                 + String.join(", ", missing));
+  }
+
+  /**
+   * Notes that a vended access point is being ignored, and uses the credential regardless.
+   *
+   * <p>Unity returns {@code access_point} on the credentials response for an external location that
+   * has one configured. That is routing, not a statement that bucket-addressed requests will be
+   * refused: the underlying grant commonly permits addressing the bucket directly, and every read
+   * path here addresses the bucket named in the object URI. So the ARN is dropped and the rest of
+   * the tuple is used, rather than refusing a credential that most likely reads.
+   *
+   * <p>Logged rather than silent, because the case it cannot serve is a grant that really is
+   * access-point-only: those reads fail at storage with a 403 that says nothing about why, and this
+   * line is the breadcrumb. At INFO, not WARN: vending runs per file group, so a workspace whose
+   * external location has an access point -- an ordinary setup, and one this reads fine -- would
+   * otherwise raise a warning per group of every table indefinitely, which trains operators to
+   * filter away the very line they need when the 403 does come. Addressing the ARN properly means
+   * threading the table's own bucket through both readers so a foreign absolute path in a Delta log
+   * is not retargeted, and Iceberg has no property for it at all -- see the enhancement issue.
+   */
+  private static void noteIgnoredAccessPoint(
+      FloecatConnector.VendedStorageCredentials vended, String namespaceFq, String tableName) {
+    String accessPoint = vended.properties().get("s3.access-point");
+    if (accessPoint == null || accessPoint.isBlank()) {
+      return;
+    }
+    LOG.infof(
+        "source catalog vended an S3 access point for %s, which floecat does not address;"
+            + " using the credential against the bucket in the object URI. A read that fails with"
+            + " 403 here means the grant is access-point-only: accessPoint=%s",
+        boundedTable(namespaceFq, tableName),
+        LogSafeText.bounded(accessPoint, MAX_LOGGED_PREFIX_CHARS));
   }
 
   /**
@@ -339,13 +549,70 @@ public class SourceCatalogCredentialVendor {
    * -- a connection reset, a 5xx, a timeout -- is genuinely transient and keeps INTERNAL so the
    * existing retry behaviour still applies.
    */
-  private static StatusRuntimeException catalogFailureStatus(
-      RuntimeException cause, Connector connector, String namespaceFq, String tableName) {
-    String detail =
+  static StatusRuntimeException catalogFailureStatus(
+      RuntimeException cause,
+      Connector connector,
+      String namespaceFq,
+      String tableName,
+      CredentialUse use) {
+    // Every interpolated value here is catalog-influenced: the two identifiers come off the
+    // persisted UpstreamRef, and cause carries whatever the catalog -- or a proxy in front of it --
+    // returned. Flattened before it reaches the log, because a newline in any of them forges an
+    // entry, and bounded because an HTML error page in an exception message is a flood. Generously
+    // bounded rather than tightly: the split below deliberately puts the diagnostic in the log and
+    // a summary in the status, so cutting this to the status's size would defeat it.
+    String raw =
         String.format(
-            "source catalog %s refused credentials for %s.%s: %s",
-            connector.getResourceId().getId(), namespaceFq, tableName, cause);
+            "source catalog %s failed to vend credentials for %s: %s",
+            connector.getResourceId().getId(), boundedTable(namespaceFq, tableName), cause);
+    String detail = LogSafeText.bounded(raw, MAX_LOGGED_DETAIL_CHARS);
+    // Bounded far tighter for the status than for the log. grpc-message is percent-encoded trailer
+    // metadata that travels to every consumer and competes with HTTP/2's header-size limits, so an
+    // HTML error page there is unreadable noise; the log above holds the longer form. Through the
+    // same helper rather than substring, which can cut a surrogate pair in half and emit a lone
+    // surrogate into that metadata -- bounded cuts on a code-point boundary and marks the elision.
+    //
+    // From raw rather than from detail: bounded reports the length of whatever it was handed, so
+    // bounding an already-bounded string makes the marker describe the intermediate truncation
+    // instead of the original -- understating what was dropped, and cutting away the accurate
+    // marker to do it.
+    String description = LogSafeText.bounded(raw, MAX_STATUS_DESCRIPTION);
 
+    StatusRuntimeException terminal = terminalStatus(cause, description);
+    if (terminal != null) {
+      // cause is passed so the stack trace survives: which of the several refusal sites fired is
+      // the diagnostic. Its message reappears in the trace unflattened, which a determined catalog
+      // could use to forge a line, but a trace is multi-line by nature and any consumer parsing
+      // this log already handles that -- losing the throw site to close a weaker version of a
+      // vector already closed above is a bad trade.
+      LOG.warnf(cause, "%s", detail);
+      return terminal;
+    }
+    // Retryable, and the level depends on who is behind the call. Reconcile work vends per file
+    // group and its failure is reported by the reconciler anyway, so a WARN there would write a
+    // stack trace per group per attempt, all describing the one outage. A query vend has neither
+    // property: it runs once per scan session, and nothing else reports it -- at DEBUG a transient
+    // catalog outage would leave the caller a bare INTERNAL and the server log empty.
+    if (use == CredentialUse.RECONCILE) {
+      LOG.debugf(cause, "%s", detail);
+    } else {
+      LOG.warnf(cause, "%s", detail);
+    }
+    // Unrecognised stays retryable: an over-eager terminal permanently fails a job, an over-eager
+    // retry only costs time.
+    return io.grpc.Status.INTERNAL
+        .withDescription(description)
+        .withCause(cause)
+        .asRuntimeException();
+  }
+
+  /**
+   * The terminal status for a recognised refusal, or null when the failure is retryable.
+   *
+   * <p>Separate from its caller so the log level can follow the verdict: a permanent refusal is
+   * worth a stack trace, a timeout on a per-file-group path is not.
+   */
+  private static StatusRuntimeException terminalStatus(RuntimeException cause, String description) {
     // Typed exceptions only. Substring-matching the cause chain for 401/403/"access denied" gets
     // the risk backwards: a transient failure whose text merely contains one of those tokens -- a
     // gateway page echoing "Access Denied", an S3 denial during IAM propagation lag, a URL with 403
@@ -359,20 +626,42 @@ public class SourceCatalogCredentialVendor {
     for (Throwable c = cause; c != null && seen.add(c); c = c.getCause()) {
       if (c instanceof org.apache.iceberg.exceptions.NotAuthorizedException) {
         return io.grpc.Status.UNAUTHENTICATED
-            .withDescription(detail)
+            .withDescription(description)
             .withCause(cause)
             .asRuntimeException();
       }
       if (c instanceof org.apache.iceberg.exceptions.ForbiddenException) {
         return io.grpc.Status.PERMISSION_DENIED
-            .withDescription(detail)
+            .withDescription(description)
             .withCause(cause)
             .asRuntimeException();
       }
+      // Format-neutral refusal for connectors that do not speak Iceberg REST (e.g. Unity Catalog
+      // over HTTP): they raise a typed SourceCatalogAccessException rather than an Iceberg
+      // exception, carrying whether it was an authentication or authorization failure.
+      if (c instanceof SourceCatalogAccessException access) {
+        return switch (access.denial()) {
+          case UNAUTHENTICATED ->
+              io.grpc.Status.UNAUTHENTICATED
+                  .withDescription(description)
+                  .withCause(cause)
+                  .asRuntimeException();
+          case PERMISSION_DENIED ->
+              io.grpc.Status.PERMISSION_DENIED
+                  .withDescription(description)
+                  .withCause(cause)
+                  .asRuntimeException();
+          // Terminal, but not a denial, so it must not travel as one: PERMISSION_DENIED here would
+          // report "you may not read this table" for a catalog that simply cannot vend for it. It
+          // goes back as the structured vend-refused reason, which the reconciler matches by reason
+          // rather than by the shared FAILED_PRECONDITION code.
+          case UNSUPPORTED ->
+              ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus
+                  .sourceCatalogVendRefused(description);
+        };
+      }
     }
-    // Unrecognised stays retryable: an over-eager terminal permanently fails a job, an over-eager
-    // retry only costs time.
-    return io.grpc.Status.INTERNAL.withDescription(detail).withCause(cause).asRuntimeException();
+    return null;
   }
 
   /** Mirrors the resolution the reconciler uses so a connector authenticates identically here. */

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
@@ -331,8 +331,19 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
                         ? sourceCatalogTableId(request, accountId, authorized.job())
                         : null;
                 if (sourceTableId != null) {
+                  // Only an execution-bound request renews: it registers a refresh provider keyed
+                  // on the lease. A client vend reaches this same handler and reads the tuple once,
+                  // so requiring a renewable one there would refuse credentials that read fine --
+                  // Unity omits the session token for long-lived keys -- and refuse them
+                  // terminally, on a path with nothing retrying.
                   ResolveStorageAuthorityResponse vended =
-                      vendFromSourceCatalog(accountId, sourceTableId, credentialScope.location());
+                      vendFromSourceCatalog(
+                          accountId,
+                          sourceTableId,
+                          credentialScope.location(),
+                          isExecutionBound(request)
+                              ? SourceCatalogCredentialVendor.CredentialUse.RECONCILE
+                              : SourceCatalogCredentialVendor.CredentialUse.QUERY);
                   if (vended != null) {
                     return vended;
                   }
@@ -732,7 +743,10 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
    * because the invalidation policy is a design decision, not an implementation detail.
    */
   private ResolveStorageAuthorityResponse vendFromSourceCatalog(
-      String accountId, ResourceId requestedTableId, String responseLocationPrefix) {
+      String accountId,
+      ResourceId requestedTableId,
+      String responseLocationPrefix,
+      SourceCatalogCredentialVendor.CredentialUse use) {
     Table table;
     try {
       table = loadVisibleTable(scopedTableId(accountId, requestedTableId, correlationId()));
@@ -749,8 +763,7 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
           requestedTableId.getId(), e.getStatus());
       return null;
     }
-    return sourceCatalogVendor.vendForTable(
-        table, responseLocationPrefix, SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+    return sourceCatalogVendor.vendForTable(table, responseLocationPrefix, use);
   }
 
   private CredentialScope resolvePlannerBootstrapLocation(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionServiceTest.java
@@ -1332,6 +1332,69 @@ class LeasedFileGroupExecutionServiceTest {
   }
 
   @Test
+  void anUpstreamConnectorNamingAnotherAccountIsNeverOpened() {
+    // The upstream ref is stored verbatim from spec.upstream and validateUpstreamRef checks the
+    // connector's resource kind, not its account, so a table here can name a connector in another
+    // tenant. ConnectorRepository.getById keys on the account inside the id it is handed, and
+    // resolvedConnectorPayload puts the resolved connector secret into the worker payload -- so an
+    // unscoped lookup would ship another tenant's credential to this job's worker.
+    ResourceId foreignConnectorId =
+        ResourceId.newBuilder()
+            .setAccountId("other-tenant")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .setId(CONNECTOR_ID)
+            .build();
+    ReconcileFileGroupTask group =
+        ReconcileFileGroupTask.of(
+            "plan-1", "group-1", TABLE_ID, SNAPSHOT_ID, List.of("s3://bucket/data/file-1.parquet"));
+
+    when(jobs.renewLease(CHILD_JOB_ID, LEASE_EPOCH)).thenReturn(true);
+    when(jobs.getLeaseView(CHILD_JOB_ID))
+        .thenReturn(
+            Optional.of(
+                job(
+                    CHILD_JOB_ID,
+                    ReconcileJobKind.EXEC_FILE_GROUP,
+                    ReconcileSnapshotTask.empty(),
+                    group.asReference(),
+                    PARENT_JOB_ID)));
+    when(jobs.get(ACCOUNT_ID, PARENT_JOB_ID))
+        .thenReturn(
+            Optional.of(
+                job(
+                    PARENT_JOB_ID,
+                    ReconcileJobKind.PLAN_SNAPSHOT,
+                    ReconcileSnapshotTask.of(
+                        TABLE_ID,
+                        SNAPSHOT_ID,
+                        "db",
+                        "events",
+                        List.of(group),
+                        true,
+                        ReconcileSnapshotTask.CompletionMode.FILE_GROUPS,
+                        "/accounts/acct/reconcile/jobs/parent-job/snapshot-plan/blob.json",
+                        1),
+                    ReconcileFileGroupTask.empty(),
+                    "")));
+    when(tableRepo.getById(tableId()))
+        .thenReturn(
+            Optional.of(
+                table().toBuilder()
+                    .setUpstream(
+                        table().getUpstream().toBuilder().setConnectorId(foreignConnectorId))
+                    .build()));
+    // Present and willing in the other tenant; absent in this one.
+    when(connectorRepo.getById(foreignConnectorId)).thenReturn(Optional.of(connector()));
+    when(connectorRepo.getById(connectorId())).thenReturn(Optional.empty());
+    stubIndexedPlan(group);
+
+    assertThrows(
+        StatusRuntimeException.class, () -> service.resolve(principal, CHILD_JOB_ID, LEASE_EPOCH));
+
+    verify(connectorRepo, never()).getById(foreignConnectorId);
+  }
+
+  @Test
   void resolveDerivesIcebergStorageLocationFromCurrentSnapshotMetadata() {
     ReconcileFileGroupTask group =
         ReconcileFileGroupTask.of(

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendorTest.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.storage.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.rpc.Table;
+import ai.floedb.floecat.catalog.rpc.UpstreamRef;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.connector.rpc.Connector;
+import ai.floedb.floecat.connector.rpc.ConnectorKind;
+import ai.floedb.floecat.connector.rpc.ConnectorState;
+import ai.floedb.floecat.connector.spi.DatabricksAccessDelegation;
+import ai.floedb.floecat.connector.spi.FloecatConnector;
+import ai.floedb.floecat.connector.spi.SourceCatalogAccessException;
+import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class SourceCatalogCredentialVendorTest {
+
+  private static final Connector CONNECTOR =
+      Connector.newBuilder().setResourceId(ResourceId.newBuilder().setId("c1")).build();
+
+  @Test
+  void routingPropertiesKeepConnectorEndpointAndRegionAlias() {
+    // A Unity vend response carries only the credential tuple, so endpoint and path-style can come
+    // from nowhere but the connector: dropping them sends the reader at standard AWS S3 instead of
+    // the configured S3-compatible endpoint. aws.region is a documented alias, so a connector
+    // configured with it must not be overwritten by the deployment default either.
+    SourceCatalogCredentialVendor vendor = new SourceCatalogCredentialVendor();
+    vendor.defaultRegion = "us-east-1";
+
+    Map<String, String> routing =
+        vendor.routingProperties(
+            Map.of(),
+            Map.of(
+                "s3.endpoint",
+                "https://minio.internal:9000",
+                "s3.path-style-access",
+                "true",
+                "aws.region",
+                "us-west-2"));
+
+    assertThat(routing)
+        .containsEntry("s3.endpoint", "https://minio.internal:9000")
+        .containsEntry("s3.path-style-access", "true")
+        .containsEntry("s3.region", "us-west-2")
+        .containsEntry("region", "us-west-2")
+        .containsEntry("client.region", "us-west-2");
+  }
+
+  @Test
+  void routingPropertiesPreferVendedValuesOverConnectorConfiguration() {
+    SourceCatalogCredentialVendor vendor = new SourceCatalogCredentialVendor();
+    vendor.defaultRegion = "us-east-1";
+
+    Map<String, String> routing =
+        vendor.routingProperties(
+            Map.of("s3.endpoint", "https://vended:9000", "s3.region", "eu-west-1"),
+            Map.of("s3.endpoint", "https://connector:9000", "aws.region", "us-west-2"));
+
+    assertThat(routing)
+        .containsEntry("s3.endpoint", "https://vended:9000")
+        .containsEntry("s3.region", "eu-west-1");
+  }
+
+  @Test
+  void permissionDeniedAccessExceptionIsClassifiedTerminal() {
+    // Regression guard for the misclassification bug: a non-Iceberg connector (e.g. Unity Catalog)
+    // raises SourceCatalogAccessException, which must map to a terminal PERMISSION_DENIED rather
+    // than a retryable INTERNAL that loops the reconcile job forever.
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new SourceCatalogAccessException(
+                SourceCatalogAccessException.Denial.PERMISSION_DENIED, "HTTP 403"),
+            CONNECTOR,
+            "cat.schema",
+            "orders",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  @Test
+  void unauthenticatedAccessExceptionIsClassifiedTerminal() {
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new SourceCatalogAccessException(
+                SourceCatalogAccessException.Denial.UNAUTHENTICATED, "HTTP 401"),
+            CONNECTOR,
+            "cat.schema",
+            "orders",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.UNAUTHENTICATED);
+  }
+
+  @Test
+  void accessExceptionWrappedInCauseChainIsStillClassifiedTerminal() {
+    // The classifier walks the cause chain, so a wrapped access exception is still terminal.
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new RuntimeException(
+                "vend failed",
+                new SourceCatalogAccessException(
+                    SourceCatalogAccessException.Denial.PERMISSION_DENIED, "HTTP 403")),
+            CONNECTOR,
+            "cat.schema",
+            "orders",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  @Test
+  void catalogSuppliedTextCannotForgeALogLineOrOverrunTheStatus() {
+    // Both identifiers come off a persisted UpstreamRef and the cause message is whatever the
+    // catalog returned, so all three are attacker-influenced. This status is built with
+    // withDescription directly -- GrpcErrors.clampDetail is not on this path -- so an unflattened
+    // newline here would travel as-is into trailer metadata and forge an entry in the server log.
+    String forged = "orders\nWARN  [floecat] credentials vended successfully";
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new RuntimeException("<html>\r\n<body>" + "x".repeat(20_000) + "</body>\r\n</html>"),
+            CONNECTOR,
+            "cat.schema",
+            forged,
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    String description = status.getStatus().getDescription();
+    assertThat(description).doesNotContain("\n").doesNotContain("\r");
+    // Bounded, and the elision is marked rather than silent.
+    assertThat(description.length()).isLessThan(1_024);
+    // The elision marker must report the size of the original text, not of an intermediate
+    // truncation: bounding an already-bounded string makes it describe the 8k log form instead of
+    // the 20k original, and cuts the accurate marker away in the process.
+    var elision =
+        java.util.regex.Pattern.compile("\\.\\.\\.\\((\\d+) chars\\)$").matcher(description);
+    assertThat(elision.find()).as(description).isTrue();
+    assertThat(Integer.parseInt(elision.group(1))).isGreaterThan(20_000);
+  }
+
+  @Test
+  void unrecognizedFailureStaysRetryableInternal() {
+    // A plain RuntimeException (a 5xx, a timeout) is genuinely transient and must stay retryable.
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new RuntimeException("UC temporary-table-credentials returned HTTP 503"),
+            CONNECTOR,
+            "cat.schema",
+            "orders",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.INTERNAL);
+  }
+
+  @Test
+  void catalogIssuedScopeWinsWhenItNarrowsTheRequest() {
+    var vended =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"),
+            "  s3://warehouse/tpch/region/data  ",
+            Instant.parse("2030-01-01T00:00:00Z"));
+
+    assertThat(
+            SourceCatalogCredentialVendor.responsePrefix(
+                vended, "s3://warehouse/tpch/region", "cat.schema", "orders"))
+        .isEqualTo("s3://warehouse/tpch/region/data");
+  }
+
+  @Test
+  void catalogIssuedScopeCannotWidenBeyondTheAuthorizedPrefix() {
+    // The requested prefix is the authorized location -- the same value that raises
+    // PERMISSION_DENIED for an out-of-scope request. A catalog credential covering a broader tree
+    // (Iceberg vends one scoped to "s3://warehouse/tpch" for a table under
+    // "s3://warehouse/tpch_10") must not come back stamped with that broader prefix, or consumers
+    // would apply the credential to sibling prefixes like "s3://warehouse/tpch_other".
+    var vended =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"),
+            "s3://warehouse/tpch",
+            Instant.parse("2030-01-01T00:00:00Z"));
+
+    assertThat(
+            SourceCatalogCredentialVendor.responsePrefix(
+                vended, "s3://warehouse/tpch_10/customer", "cat.schema", "orders"))
+        .isEqualTo("s3://warehouse/tpch_10/customer");
+  }
+
+  @Test
+  void aSiblingScopeSharingATextualPrefixDoesNotCount() {
+    // Containment is by path boundary, not by string prefix: "s3://warehouse/tpch_other" starts
+    // with "s3://warehouse/tpch" but is a different tree.
+    var vended =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"),
+            "s3://warehouse/tpch_other",
+            Instant.parse("2030-01-01T00:00:00Z"));
+
+    assertThat(
+            SourceCatalogCredentialVendor.responsePrefix(
+                vended, "s3://warehouse/tpch", "cat.schema", "orders"))
+        .isEqualTo("s3://warehouse/tpch");
+  }
+
+  @Test
+  void aDisjointVendedScopeStillReturnsTheAuthorizedPrefix() {
+    // Neither contains the other -- reachable when the lease authorizes an absolute path in another
+    // bucket, which a Delta log may carry. There is no intersection to return, so the requested
+    // prefix stands: it is the only bound the caller was authorized for. A warning names the
+    // mismatch, because the read then fails at storage with nothing pointing back at the catalog.
+    var disjoint =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"),
+            "s3://table-bucket/table",
+            Instant.parse("2030-01-01T00:00:00Z"));
+
+    assertThat(
+            SourceCatalogCredentialVendor.responsePrefix(
+                disjoint, "s3://other-bucket/file.parquet", "cat.schema", "orders"))
+        .isEqualTo("s3://other-bucket/file.parquet");
+  }
+
+  @Test
+  void aBroaderVendedScopeIsNarrowedToTheRequestWithoutComplaint() {
+    // The ordinary case the method exists for, kept distinct from disjoint: a catalog that scoped
+    // to the bucket gets narrowed to the table, and that is not worth a warning.
+    var broader =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"),
+            "s3://warehouse",
+            Instant.parse("2030-01-01T00:00:00Z"));
+
+    assertThat(
+            SourceCatalogCredentialVendor.responsePrefix(
+                broader, "s3://warehouse/tpch/orders", "cat.schema", "orders"))
+        .isEqualTo("s3://warehouse/tpch/orders");
+  }
+
+  @Test
+  void requestedPrefixIsFallbackForLegacyConnector() {
+    var vended =
+        new FloecatConnector.VendedStorageCredentials(
+            Map.of("s3.access-key-id", "key"), null, Instant.parse("2030-01-01T00:00:00Z"));
+
+    assertThat(
+            SourceCatalogCredentialVendor.responsePrefix(
+                vended, "s3://requested/table", "cat.schema", "orders"))
+        .isEqualTo("s3://requested/table");
+  }
+
+  @Test
+  void anEmptyCredentialObjectFallsBackRatherThanFailingTerminally() {
+    // "The catalog handed back a credential object with no credentials" is the same answer as
+    // "the catalog does not delegate": the caller must be able to fall back to a storage authority.
+    // Letting it reach requireUsableCredentials would fail the reconcile job permanently.
+    ResourceId connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .setId("catalog-1")
+            .build();
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setState(ConnectorState.CS_ACTIVE)
+            .putProperties("iceberg.source", "rest")
+            .putProperties("header.X-Iceberg-Access-Delegation", "vended-credentials")
+            .build();
+    ConnectorRepository connectorRepo = mock(ConnectorRepository.class);
+    when(connectorRepo.getById(connectorId)).thenReturn(Optional.of(connector));
+
+    FloecatConnector source = mock(FloecatConnector.class);
+    when(source.vendStorageCredentials("cat.schema", "orders"))
+        .thenReturn(
+            Optional.of(
+                new FloecatConnector.VendedStorageCredentials(
+                    Map.of(), "s3://warehouse/orders", Instant.parse("2030-01-01T00:00:00Z"))));
+
+    SourceCatalogCredentialVendor vendor = new SourceCatalogCredentialVendor();
+    vendor.connectorRepo = connectorRepo;
+    vendor.connectorFactory = ignored -> source;
+    vendor.defaultRegion = "us-east-1";
+
+    assertThat(
+            vendor.vendForTable(
+                tableFor(connectorId),
+                "s3://warehouse/orders/data.parquet",
+                SourceCatalogCredentialVendor.CredentialUse.RECONCILE))
+        .isNull();
+  }
+
+  @Test
+  void anUnsupportedRefusalTravelsAsTheStructuredVendRefusedReason() {
+    // Terminal, but not a denial: reporting PERMISSION_DENIED would say "you may not read this
+    // table" for a catalog that simply cannot vend for it.
+    StatusRuntimeException status =
+        SourceCatalogCredentialVendor.catalogFailureStatus(
+            new SourceCatalogAccessException(
+                SourceCatalogAccessException.Denial.UNSUPPORTED, "HTTP 400 external access off"),
+            CONNECTOR,
+            "cat.schema",
+            "orders",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertThat(status.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertThat(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(status)).isTrue();
+  }
+
+  @Test
+  void incompleteConnectorTupleIsAServiceLevelTerminalFailure() {
+    ResourceId connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .setId("catalog-1")
+            .build();
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setKind(ConnectorKind.CK_ICEBERG)
+            .setState(ConnectorState.CS_ACTIVE)
+            .putProperties("iceberg.source", "rest")
+            .putProperties("header.X-Iceberg-Access-Delegation", "vended-credentials")
+            .build();
+    ConnectorRepository connectorRepo = mock(ConnectorRepository.class);
+    when(connectorRepo.getById(connectorId)).thenReturn(Optional.of(connector));
+
+    FloecatConnector source = mock(FloecatConnector.class);
+    when(source.vendStorageCredentials("cat.schema", "orders"))
+        .thenReturn(
+            Optional.of(
+                new FloecatConnector.VendedStorageCredentials(
+                    Map.of("s3.access-key-id", "key", "s3.secret-access-key", "secret"),
+                    "s3://warehouse/orders",
+                    Instant.parse("2030-01-01T00:00:00Z"))));
+
+    SourceCatalogCredentialVendor vendor = new SourceCatalogCredentialVendor();
+    vendor.connectorRepo = connectorRepo;
+    vendor.connectorFactory = ignored -> source;
+    vendor.defaultRegion = "us-east-1";
+    Table table = tableFor(connectorId);
+
+    assertThatThrownBy(
+            () ->
+                vendor.vendForTable(
+                    table,
+                    "s3://warehouse/orders/data.parquet",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE))
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            failure -> {
+              assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+              assertThat(SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(failure))
+                  .isTrue();
+            });
+  }
+
+  @Test
+  void anAlreadyExpiredVendIsAsUnusableAsOneWithNoExpiry() {
+    // A past expiry is non-null, so a null check alone lets it through.
+    // RefreshingAwsCredentialsProviderRegistry then
+    // reads it as "refresh now" on every resolveCredentials call, so a catalog that keeps sending
+    // the same stale timestamp is re-vended once per resolution and still yields credentials S3
+    // refuses. Terminal here instead, naming the field.
+    Map<String, String> tuple =
+        Map.of(
+            "s3.access-key-id",
+            "key",
+            "s3.secret-access-key",
+            "secret",
+            "s3.session-token",
+            "token");
+
+    assertThatThrownBy(
+            () ->
+                SourceCatalogCredentialVendor.requireUsableCredentials(
+                    new FloecatConnector.VendedStorageCredentials(
+                        tuple, "s3://warehouse/orders", Instant.parse("1970-01-01T00:00:01Z")),
+                    "cat.schema",
+                    "orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE))
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            failure -> {
+              assertThat(SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(failure))
+                  .isTrue();
+              assertThat(failure.getStatus().getDescription())
+                  .contains("s3.session-token-expires-at-ms");
+            });
+
+    // The two sides of the boundary this narrows: a live expiry still passes, and the query path is
+    // deliberately unchanged -- it never renews, so a stale expiry there is a read that fails at S3
+    // either way and rejecting it would only move the error earlier.
+    SourceCatalogCredentialVendor.requireUsableCredentials(
+        new FloecatConnector.VendedStorageCredentials(
+            tuple, "s3://warehouse/orders", Instant.now().plusSeconds(600)),
+        "cat.schema",
+        "orders",
+        SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+    SourceCatalogCredentialVendor.requireUsableCredentials(
+        new FloecatConnector.VendedStorageCredentials(
+            tuple, "s3://warehouse/orders", Instant.parse("1970-01-01T00:00:01Z")),
+        "cat.schema",
+        "orders",
+        SourceCatalogCredentialVendor.CredentialUse.QUERY);
+  }
+
+  @Test
+  void anAccessPointScopedVendIsUsedAgainstTheBucketRatherThanRefused() {
+    // Unity returns access_point for any external location that has one configured, and the grant
+    // behind it commonly still permits addressing the bucket. Refusing on the field's presence
+    // alone would fail closed on a tuple that reads fine, so the ARN is dropped and the rest used.
+    // It must also not travel onward: nothing downstream addresses an access point.
+    ResourceId connectorId =
+        ResourceId.newBuilder()
+            .setAccountId("acct")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .setId("catalog-1")
+            .build();
+    Connector connector =
+        Connector.newBuilder()
+            .setResourceId(connectorId)
+            .setKind(ConnectorKind.CK_DELTA)
+            .setState(ConnectorState.CS_ACTIVE)
+            .putProperties("delta.source", "unity")
+            .putProperties(DatabricksAccessDelegation.VEND_OPTION, "vended-credentials")
+            .build();
+    ConnectorRepository connectorRepo = mock(ConnectorRepository.class);
+    when(connectorRepo.getById(connectorId)).thenReturn(Optional.of(connector));
+
+    FloecatConnector source = mock(FloecatConnector.class);
+    when(source.vendStorageCredentials("cat.schema", "orders"))
+        .thenReturn(
+            Optional.of(
+                new FloecatConnector.VendedStorageCredentials(
+                    Map.of(
+                        "s3.access-key-id", "key",
+                        "s3.secret-access-key", "secret",
+                        "s3.session-token", "token",
+                        "s3.access-point", "arn:aws:s3:eu-west-1:123:accesspoint/orders"),
+                    "s3://warehouse/orders",
+                    Instant.now().plusSeconds(3600))));
+
+    SourceCatalogCredentialVendor vendor = new SourceCatalogCredentialVendor();
+    vendor.connectorRepo = connectorRepo;
+    vendor.connectorFactory = ignored -> source;
+    vendor.defaultRegion = "us-east-1";
+
+    var response =
+        vendor.vendForTable(
+            tableFor(connectorId),
+            "s3://warehouse/orders/data.parquet",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertThat(response).isNotNull();
+    assertThat(response.getStorageCredentialsList()).hasSize(1);
+    assertThat(response.getStorageCredentialsList().get(0).getConfigMap())
+        .containsEntry("s3.access-key-id", "key")
+        .doesNotContainKey("s3.access-point");
+  }
+
+  private static Table tableFor(ResourceId connectorId) {
+    return Table.newBuilder()
+        .setResourceId(
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setKind(ResourceKind.RK_TABLE)
+                .setId("table-1"))
+        .setUpstream(
+            UpstreamRef.newBuilder()
+                .setConnectorId(connectorId)
+                .addAllNamespacePath(List.of("cat", "schema"))
+                .setTableDisplayName("orders"))
+        .build();
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.common.rpc.MutationMeta;
@@ -789,7 +790,10 @@ class StorageAuthorityServiceImplTest {
         props, null, expiry);
   }
 
-  private static final java.time.Instant EXPIRY = java.time.Instant.ofEpochMilli(1786000000000L);
+  // Relative, not a literal: requireUsableCredentials now rejects an expiry that has already
+  // passed, so a hardcoded "future" epoch becomes a test that starts failing on a calendar date.
+  private static final java.time.Instant EXPIRY =
+      java.time.Instant.now().plus(java.time.Duration.ofHours(1));
 
   /**
    * Every field of the session tuple is required, not just the expiry. Access key plus secret plus
@@ -835,6 +839,34 @@ class StorageAuthorityServiceImplTest {
         "tpch_10",
         "customer",
         SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+  }
+
+  @Test
+  void reconcileAcceptsALongLivedStaticKey() {
+    // Neither a session token nor an expiry means a long-lived key, not a session credential with
+    // its renewal fields missing. Capture handles it: isRefreshableExecutionCredential is false, so
+    // mergeResolvedStorageConfig embeds the tuple statically, which is correct for a credential
+    // that never expires. Unity returns this shape for an external location backed by long-lived
+    // keys, and refusing it would leave such a table queryable but never capturable.
+    SourceCatalogCredentialVendor.requireUsableCredentials(
+        vendedTuple("AKIA", "secret", null, null),
+        "tpch_10",
+        "customer",
+        SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    // The middle case stays terminal: a session token floecat cannot renew because the expiry is
+    // absent or already past would lapse mid-capture with nothing to recover it.
+    for (java.time.Instant expiry : new java.time.Instant[] {null, java.time.Instant.EPOCH}) {
+      assertThrows(
+          StatusRuntimeException.class,
+          () ->
+              SourceCatalogCredentialVendor.requireUsableCredentials(
+                  vendedTuple("ASIA", "secret", "token", expiry),
+                  "tpch_10",
+                  "customer",
+                  SourceCatalogCredentialVendor.CredentialUse.RECONCILE),
+          String.valueOf(expiry));
+    }
   }
 
   @Test
@@ -993,6 +1025,176 @@ class StorageAuthorityServiceImplTest {
    * table on that path, or a view-lease holder could steer which catalog vends -- the confused
    * deputy the leased-table path was built to prevent. Proof: the caller's table is never loaded.
    */
+  @Test
+  void aClientVendIsNotHeldToTheReconcilePathsRenewabilityRequirement() {
+    // This handler serves both usages, and only an execution-bound request registers a refresh
+    // provider. A client loadTable reads the tuple once, so validating it as RECONCILE would refuse
+    // credentials that read perfectly well -- Unity omits the session token for long-lived keys --
+    // and refuse them terminally, on a path where nothing retries. Neither the session token nor
+    // the expiry is required of it: the fixture below carries an expiry only because a realistic
+    // Unity response does, and the null-expiry case is pinned separately.
+    when(repo.list(eq("acct"), anyInt(), any(), any())).thenReturn(java.util.List.of());
+    when(tableRepo.getById(TABLE_ID)).thenReturn(Optional.of(currentTable()));
+    when(connectorRepo.getById(CONNECTOR_ID))
+        .thenReturn(
+            Optional.of(
+                Connector.newBuilder()
+                    .setResourceId(CONNECTOR_ID)
+                    .setKind(ConnectorKind.CK_DELTA)
+                    .setState(ConnectorState.CS_ACTIVE)
+                    .putProperties("delta.source", "unity")
+                    .putProperties(
+                        ai.floedb.floecat.connector.spi.DatabricksAccessDelegation.VEND_OPTION,
+                        "vended-credentials")
+                    .build()));
+
+    ai.floedb.floecat.connector.spi.FloecatConnector source =
+        mock(ai.floedb.floecat.connector.spi.FloecatConnector.class);
+    when(source.vendStorageCredentials(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(
+            Optional.of(
+                new ai.floedb.floecat.connector.spi.FloecatConnector.VendedStorageCredentials(
+                    java.util.Map.of(
+                        "s3.access-key-id", "AKIA",
+                        "s3.secret-access-key", "secret"),
+                    "s3://warehouse/orders",
+                    java.time.Instant.now().plusSeconds(3600))));
+    service.sourceCatalogVendor.connectorFactory = ignored -> source;
+    service.sourceCatalogVendor.defaultRegion = "us-east-1";
+
+    ResolveStorageAuthorityResponse response =
+        service
+            .vendStorageCredentials(
+                VendStorageCredentialsRequest.newBuilder()
+                    .setAccountId("acct")
+                    .setTableId(TABLE_ID)
+                    .setLocationPrefix("s3://warehouse/orders/data.parquet")
+                    .setUsage(StorageCredentialUsage.SCU_CLIENT)
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(1, response.getStorageCredentialsCount());
+    assertEquals("AKIA", response.getStorageCredentials(0).getConfigMap().get("s3.access-key-id"));
+  }
+
+  @Test
+  void aClientVendWithNoExpiryAtAllIsStillAccepted() {
+    // The deliberate shape, not an accident: CredentialUse.QUERY registers no refresh provider and
+    // reads the tuple once, so an absent expiry says nothing about whether the read works. The
+    // consequence is on the record in the PR -- the credential's expires_at is then unset, which a
+    // consumer cannot tell from "never expires" -- and is why this is pinned rather than implied.
+    when(repo.list(eq("acct"), anyInt(), any(), any())).thenReturn(java.util.List.of());
+    when(tableRepo.getById(TABLE_ID)).thenReturn(Optional.of(currentTable()));
+    when(connectorRepo.getById(CONNECTOR_ID))
+        .thenReturn(
+            Optional.of(
+                Connector.newBuilder()
+                    .setResourceId(CONNECTOR_ID)
+                    .setKind(ConnectorKind.CK_DELTA)
+                    .setState(ConnectorState.CS_ACTIVE)
+                    .putProperties("delta.source", "unity")
+                    .putProperties(
+                        ai.floedb.floecat.connector.spi.DatabricksAccessDelegation.VEND_OPTION,
+                        "vended-credentials")
+                    .build()));
+
+    ai.floedb.floecat.connector.spi.FloecatConnector source =
+        mock(ai.floedb.floecat.connector.spi.FloecatConnector.class);
+    when(source.vendStorageCredentials(
+            org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(
+            Optional.of(
+                new ai.floedb.floecat.connector.spi.FloecatConnector.VendedStorageCredentials(
+                    java.util.Map.of(
+                        "s3.access-key-id", "AKIA",
+                        "s3.secret-access-key", "secret"),
+                    "s3://warehouse/orders",
+                    null)));
+    service.sourceCatalogVendor.connectorFactory = ignored -> source;
+    service.sourceCatalogVendor.defaultRegion = "us-east-1";
+
+    ResolveStorageAuthorityResponse response =
+        service
+            .vendStorageCredentials(
+                VendStorageCredentialsRequest.newBuilder()
+                    .setAccountId("acct")
+                    .setTableId(TABLE_ID)
+                    .setLocationPrefix("s3://warehouse/orders/data.parquet")
+                    .setUsage(StorageCredentialUsage.SCU_CLIENT)
+                    .build())
+            .await()
+            .indefinitely();
+
+    assertEquals(1, response.getStorageCredentialsCount());
+    assertFalse(response.getStorageCredentials(0).hasExpiresAt());
+  }
+
+  @Test
+  void anUpstreamConnectorNamingAnotherAccountIsNeverOpened() {
+    // The upstream ref is stored verbatim from spec.upstream, and validateUpstreamRef checks the
+    // resource kind rather than the account, so a table here can name a connector in another
+    // tenant. ConnectorRepository.getById keys on the account inside the id it is handed, so an
+    // unscoped lookup would resolve that tenant's connector and its secret and vend through it for
+    // a caller authorized only in this account.
+    ResourceId foreignConnectorId =
+        ResourceId.newBuilder()
+            .setAccountId("other-tenant")
+            .setKind(ResourceKind.RK_CONNECTOR)
+            .setId("conn-1")
+            .build();
+    ai.floedb.floecat.catalog.rpc.Table table =
+        ai.floedb.floecat.catalog.rpc.Table.newBuilder()
+            .setResourceId(TABLE_ID)
+            .putProperties("location", "s3://warehouse/orders")
+            .setUpstream(
+                ai.floedb.floecat.catalog.rpc.UpstreamRef.newBuilder()
+                    .setConnectorId(foreignConnectorId)
+                    .addNamespacePath("src")
+                    .setTableDisplayName("orders"))
+            .build();
+
+    when(repo.list(eq("acct"), anyInt(), any(), any())).thenReturn(java.util.List.of());
+    when(tableRepo.getById(TABLE_ID)).thenReturn(Optional.of(table));
+    // Present in the other tenant and willing to vend; absent in this one.
+    when(connectorRepo.getById(foreignConnectorId))
+        .thenReturn(
+            Optional.of(
+                Connector.newBuilder()
+                    .setResourceId(foreignConnectorId)
+                    .setKind(ConnectorKind.CK_DELTA)
+                    .setState(ConnectorState.CS_ACTIVE)
+                    .putProperties("delta.source", "unity")
+                    .putProperties(
+                        ai.floedb.floecat.connector.spi.DatabricksAccessDelegation.VEND_OPTION,
+                        "vended-credentials")
+                    .build()));
+    when(connectorRepo.getById(CONNECTOR_ID)).thenReturn(Optional.empty());
+
+    ai.floedb.floecat.connector.spi.FloecatConnector source =
+        mock(ai.floedb.floecat.connector.spi.FloecatConnector.class);
+    service.sourceCatalogVendor.connectorFactory = ignored -> source;
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            service
+                .vendStorageCredentials(
+                    VendStorageCredentialsRequest.newBuilder()
+                        .setAccountId("acct")
+                        .setTableId(TABLE_ID)
+                        .setLocationPrefix("s3://warehouse/orders/data.parquet")
+                        .setUsage(StorageCredentialUsage.SCU_CLIENT)
+                        .build())
+                .await()
+                .indefinitely());
+
+    // The foreign connector is never read, and nothing is ever asked to vend through it.
+    verify(connectorRepo, never()).getById(foreignConnectorId);
+    verifyNoInteractions(source);
+  }
+
   @Test
   void planViewLeaseCannotVendFromCallerSuppliedTable() {
     when(repo.list(eq("acct"), anyInt(), any(), any())).thenReturn(java.util.List.of());


### PR DESCRIPTION
## Summary

Wires Unity Catalog-vended credentials through the storage and execution paths that read Delta data, completing the end-to-end feature.

Changes:

- Bound vended credentials to the narrower of the catalog scope and the caller-authorized location.
- Treat an empty credential property map as “did not vend” while sending partial credentials to centralized usability validation.
- Preserve typed terminal refusal reasons.
- Include table storage location on leased file-group connector payloads so authority resolution and source vending run there.
- Absorb missing-authority errors only for a catalog whose client applies vended credentials at load time — not for Delta or Unity, and not for a static-table Iceberg source, which may carry no credentials and would otherwise read under floecat's own role.
- Use a vend that carries an S3 access point against the bucket named in the object URI, dropping the ARN and logging that it was ignored.
- Log a source-catalog vend failure at the level its classification implies: a stack trace at WARN for a terminal refusal, debug for a retryable one the reconciler already reports.

## Type of Change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Full build: 4,628 tests, 0 failures. Formatting clean. Not yet validated against a live Databricks workspace.

- [x] `make fmt`
- [x] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Known gaps:

- The gateway S3 Delta reader duplicates the connector's file-IO logic. The duplication is unchanged
  by this PR; the two copies now agree, since neither addresses anything but the bucket named in the
  URI.
- Vending builds a connector per request/file group. Production use should add an expiry-bounded table credential cache with an explicit invalidation policy.

## Reviewers

- **S3 access points are not addressed, and a vend that carries one is used anyway.** Unity returns
  `access_point` on the credentials response for an external location that has one configured. That
  is routing information, not a statement that bucket-addressed requests will be denied — the grant
  behind it commonly permits addressing the bucket, which is what every read path here does. Refusing such a
  vend was considered and rejected: refusing on the presence of a field fails closed on tuples that
  read fine, so the ARN is dropped, the rest of the tuple is used, and the table is logged at INFO -- not WARN, since vending runs per file group and an ordinary workspace with an access point configured would otherwise warn per group of every table indefinitely, training operators to filter the one line they need when a 403 does arrive. The case that cannot be served is a grant that
  really is access-point-only: those reads fail at storage with a bare 403, and that line is the
  breadcrumb. The ARN is also stripped from the outgoing `storage_credentials[].config` rather than
  advertised, for the same reason `FILE_IO_PROPERTY_KEYS` omits it — no consumer honours it, and
  publishing a key nobody honours invites one to start. Addressing it properly needs the table's own
  bucket threaded through both readers so a foreign absolute path in a Delta log is not retargeted,
  and Iceberg has no property for it at all; that belongs in its own change.

- **`iceberg.source=filesystem` is excluded from the missing-authority absorb gate, and the reason
  is credential scope rather than diagnostics.** The gate is consulted only from inside the catch
  that already caught "no authority covers this location", so a filesystem connector reading
  through a matching authority never reaches it. The only config it decides is one carrying a
  leftover `header.X-Iceberg-Access-Delegation`, an `s3://` URI and no matching authority — and
  `IcebergConnectorFactory` accepts `auth.scheme=none` for an S3 URI, so that connector may hold no
  `s3.*` credentials at all. Absorbing there hands back a config whose S3 client resolves through
  the AWS default chain, i.e. floecat's own instance role: the read succeeds under floecat's
  identity with the tenant's authority requirement silently gone. Failing with the precise
  missing-authority error is the safer answer. Supporting a filesystem connector that legitimately
  reads through the ambient chain is a separate decision and belongs on an explicit opt-in, not on
  the presence of a stale header.

- **A client-path vend may carry no expiry, and that differs from the authority branch of the same
  RPC on purpose.** `StorageAuthorityResolver` refuses to mint a client-facing credential without a
  known expiry; the source-catalog branch accepts what the catalog sent. Requiring an expiry here
  was considered and declined: `CredentialUse.QUERY` exists because that path registers no refresh
  provider and reads the tuple once, so a missing expiry says nothing about whether the read works
  — and refusing it would fail a readable credential terminally, on a path with nothing retrying
  and no job to fail. The cost is real and worth knowing: the vended credential's `expires_at` is
  then unset, which an RPC consumer cannot distinguish from "never expires", so a client cache may
  hold it longer than the grant lives. The SPI's own contract calls a null expiry "do-not-cache",
  and the proto has no way to say that. Closing the gap properly means expressing do-not-cache on
  the wire rather than refusing the vend.

- **Two known rough edges on the connector vend path are left alone, because that path is being
  retired.** Both are real and both are declined on the same ground: the connector architecture is
  being replaced by catalog integrations plus overlays, so hardening it further spends review effort
  on code with a known end date.
  - *The vend-attempt gate still admits `iceberg.source=filesystem`.* `readsAStaticTable` narrows
    the reconciler's absorb gate but not `declaresVendedCredentials`, so a filesystem connector
    carrying a stale `X-Iceberg-Access-Delegation` header still reaches `connectorFactory.apply`.
    For that source the factory loads the metadata JSON during construction, so this is an S3 read
    per file group for a connector that can never vend anything, and a failure in that read arrives
    as retryable `INTERNAL` rather than the precise missing-authority error. Gating the attempt on
    the same static-table check would close both halves.
  - *`CredentialUse` is chosen from `isExecutionBound`, so a non-leased server-side resolve gets
    `QUERY`.* The direct in-process reconciler entrypoints carry `usage=SCU_SERVER` with no
    execution binding, so they take the relaxed rule and then embed the tuple statically for the
    life of the job. `usage(request) == SCU_SERVER` is the closer predicate for "a server-side job
    will hold this" — worth knowing that `QUERY` here does not imply a client read.

- **Storage-authority mismatch and fallback under credential vending are out of scope here.** The
  connector architecture this PR wires is being deprecated in favour of catalog integrations plus
  catalog overlays. Findings about which property key a storage location is resolved from, or about
  vending falling back to a storage authority, describe behaviour that is on its way out rather than
  behaviour to correct. A later PR in this stack introduces the Unity catalog integration, and it
  does not fall back to a storage authority unless the caller opts in — as against the transparent
  fallback the connector path performs.

- **The reconcile expiry check has no minimum-remaining-lifetime floor, deliberately for now.** It
  rejects an expiry already in the past, not one about to lapse. `computeRefreshSkew` is
  `min(lifetime / 3, 5m)`, so a tuple with a second of life registers a sub-second skew and
  `shouldRefresh` is true on the first `resolveCredentials()` — a catalog answering with
  near-expired tuples still produces a catalog round-trip per credential resolution. Not fixed here
  because a later PR in this stack adds its own clock-based expiry check on the same path, and the
  floor belongs in one place rather than two that can disagree. Worth knowing when it is taken:
  this is the only entry in the unusable-credential list that is time-dependent rather than a
  structural property of the catalog's response, yet it lands on the same terminal reason — so NTP
  drift on the floecat host permanently fails a reconcile job, and the log should name both the
  observed expiry and the server's clock so an operator can tell the two apart. That also means an
  expiry the catalog *did* send, merely in the past, is currently reported as the field being
  missing, which points an operator at the response shape rather than at a clock. Splitting the two
  messages belongs with the floor, in the PR that takes both.

- **`connectorFactory` is a mutable package-private field rather than an overridable method.** It is
  a test seam on an application-scoped bean, unannotated and non-final, written only by tests. A
  `protected` factory method would give the same seam immutably. Left as is: it is a mechanical
  change across the vendor's tests with no behavioural gain, on a class a later PR in this stack
  refactors further.

- **A vended scope disjoint from the requested location returns the requested prefix**, which is the
  only bound the caller was authorised for, and logs a warning naming the mismatch. Without the log
  the read fails at storage with nothing pointing back at the catalog. Returning a failure instead
  was considered and left alone: nothing unsafe is published, and the cost is diagnostic.

- **`responsePrefix` normalises the vended scope; the credential record preserves it byte-for-byte.**
  A finding reads the trim as corrupting a storage bound, since an S3 key may legally end in a
  space. The split is deliberate: `VendedStorageCredentials.scopePrefix` is the authorization bound
  and is kept exactly as the catalog sent it, while `responsePrefix` produces the value that travels
  back as `storage_credentials[].prefix` and that consumers key a client-side cache on — where a
  padded and an unpadded spelling of one location are two entries for the same grant. Trimming
  cannot widen anything: what is returned still had to clear the containment check. Note also that
  `StorageAuthorityResolver.matchesLocationPrefix` trims its own `location` argument, so containment
  on this path was never whitespace-exact; making it so would change a helper shared with the whole
  storage-authority path, which is outside this PR.

- **The refusal warning keeps the throwable, so the stack trace survives.** Its `detail` is built
  from bounded, flattened catalog text — the identifiers and the cause summary both go through
  `LogSafeText` — so a newline in a table name or an HTML error page in a cause message can no
  longer forge a log entry or flood one. The cause is still passed to the logger, which reprints its
  message unflattened inside the trace. That is a weaker version of the same vector, kept
  knowingly: which of several refusal sites fired is the diagnostic here, a stack trace is
  multi-line by nature, and dropping the throw site to close it would trade real diagnostics for
  little.







