### PR TITLE
Shard account deletion fences to eliminate write contention

### DIFF
--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStoreKeys.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/spi/PointerStoreKeys.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package ai.floedb.floecat.storage.spi;
+
+/** Physical routing constants shared by pointer-store producers and consumers. */
+public final class PointerStoreKeys {
+  public static final String ACCOUNT_DELETION_FENCE_PREFIX = "/account-deletion-fences/";
+  public static final String ACCOUNT_DELETION_FENCE_PARTITION_PREFIX = "_ACCOUNT_DELETION_FENCE/";
+  public static final String ACCOUNT_DELETION_FENCE_SORT_KEY = "gate";
+
+  private PointerStoreKeys() {}
+}

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -406,7 +406,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                   var accountId = request.getAccountId();
                   ensureKind(accountId, ResourceKind.RK_ACCOUNT, "account_id", corr);
 
-                  var deletionMeta = accountDeletionMeta(accountId.getId());
+                  var deletionMeta = loadAndRepairAccountDeletionFence(accountId.getId());
                   MutationMeta meta;
                   try {
                     meta = accountRepo.metaFor(accountId);
@@ -471,24 +471,45 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
         .invoke(L::ok);
   }
 
-  private java.util.Optional<MutationMeta> accountDeletionMeta(String accountId) {
-    return pointerStore.get(Keys.accountDeletionMarker(accountId)).map(this::decodeDeletionMeta);
+  private java.util.Optional<MutationMeta> loadAndRepairAccountDeletionFence(String accountId) {
+    var marker = pointerStore.get(Keys.accountDeletionMarker(accountId));
+    return marker.map(
+        existing -> decodeDeletionMeta(repairAccountDeletionFence(accountId, existing).marker()));
   }
 
   private MutationMeta ensureAccountDeletionFence(String accountId, MutationMeta meta) {
     String key = Keys.accountDeletionMarker(accountId);
-    var existing = pointerStore.get(key);
-    if (existing.isPresent()) return decodeDeletionMeta(existing.get());
     String payload = Base64.getEncoder().encodeToString(meta.toByteArray());
     Pointer marker = PointerReferences.opaqueMarkerPointer(key, payload, 1L);
-    if (pointerStore.compareAndSet(key, 0L, marker)) return meta;
-    return pointerStore
-        .get(key)
-        .map(this::decodeDeletionMeta)
-        .orElseThrow(
-            () ->
-                new BaseResourceRepository.AbortRetryableException(
-                    "account deletion fence not visible"));
+    List<String> shardKeys = Keys.accountDeletionFenceShards(accountId);
+    for (int attempt = 0; attempt < 8; attempt++) {
+      var existing = pointerStore.get(key);
+      if (existing.isPresent()) {
+        return decodeDeletionMeta(repairAccountDeletionFence(accountId, existing.get()).marker());
+      }
+
+      Map<String, Pointer> orphanedShards = pointerStore.getBatch(shardKeys);
+      if (!orphanedShards.isEmpty()) {
+        List<PointerStore.CasOp> cleanup = new ArrayList<>(orphanedShards.size() + 1);
+        cleanup.add(new PointerStore.CasCheckAbsent(key));
+        orphanedShards.forEach(
+            (shardKey, shard) ->
+                cleanup.add(new PointerStore.CasDelete(shardKey, shard.getVersion())));
+        pointerStore.compareAndSetBatch(cleanup);
+        continue;
+      }
+
+      List<PointerStore.CasOp> fenceCreates = new ArrayList<>(shardKeys.size() + 1);
+      fenceCreates.add(new PointerStore.CasUpsert(key, 0L, marker));
+      for (String shardKey : shardKeys) {
+        fenceCreates.add(
+            new PointerStore.CasUpsert(
+                shardKey, 0L, PointerReferences.opaqueMarkerPointer(shardKey, "deleting", 1L)));
+      }
+      if (pointerStore.compareAndSetBatch(fenceCreates)) return meta;
+    }
+    throw new BaseResourceRepository.AbortRetryableException(
+        "account deletion fence could not be established");
   }
 
   private MutationMeta decodeDeletionMeta(Pointer marker) {
@@ -498,6 +519,47 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
       throw new BaseResourceRepository.CorruptionException(
           "invalid account deletion fence: " + marker.getKey(), e);
     }
+  }
+
+  private CompleteAccountDeletionFence repairAccountDeletionFence(
+      String accountId, Pointer initialMarker) {
+    String markerKey = Keys.accountDeletionMarker(accountId);
+    List<String> shardKeys = Keys.accountDeletionFenceShards(accountId);
+    Pointer marker = initialMarker;
+    for (int attempt = 0; attempt < 8; attempt++) {
+      Map<String, Pointer> shards = pointerStore.getBatch(shardKeys);
+      if (shards.size() == shardKeys.size()) {
+        return new CompleteAccountDeletionFence(marker, shards);
+      }
+
+      List<PointerStore.CasOp> repair = new ArrayList<>(shardKeys.size() - shards.size() + 1);
+      repair.add(new PointerStore.CasCheck(markerKey, marker.getVersion()));
+      for (String shardKey : shardKeys) {
+        if (!shards.containsKey(shardKey)) {
+          repair.add(
+              new PointerStore.CasUpsert(
+                  shardKey, 0L, PointerReferences.opaqueMarkerPointer(shardKey, "deleting", 1L)));
+        }
+      }
+      if (pointerStore.compareAndSetBatch(repair)) {
+        Map<String, Pointer> completed = new java.util.LinkedHashMap<>(shards);
+        for (PointerStore.CasOp operation : repair) {
+          if (operation instanceof PointerStore.CasUpsert upsert) {
+            completed.put(upsert.key(), upsert.next());
+          }
+        }
+        return new CompleteAccountDeletionFence(marker, Map.copyOf(completed));
+      }
+      marker =
+          pointerStore
+              .get(markerKey)
+              .orElseThrow(
+                  () ->
+                      new BaseResourceRepository.AbortRetryableException(
+                          "account deletion fence disappeared while repairing"));
+    }
+    throw new BaseResourceRepository.AbortRetryableException(
+        "account deletion fence could not be repaired");
   }
 
   private void advanceAccountDeletionFence(
@@ -522,11 +584,25 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
 
   private void clearAccountDeletionFence(String accountId, MutationMeta expectedMeta) {
     String key = Keys.accountDeletionMarker(accountId);
-    pointerStore
-        .get(key)
-        .filter(marker -> decodeDeletionMeta(marker).equals(expectedMeta))
-        .ifPresent(marker -> pointerStore.compareAndDelete(key, marker.getVersion()));
+    Pointer marker = pointerStore.get(key).orElse(null);
+    if (marker == null) return;
+    if (!decodeDeletionMeta(marker).equals(expectedMeta)) return;
+    CompleteAccountDeletionFence fence = repairAccountDeletionFence(accountId, marker);
+    marker = fence.marker();
+    List<String> shardKeys = Keys.accountDeletionFenceShards(accountId);
+    List<PointerStore.CasOp> fenceDeletes = new ArrayList<>(shardKeys.size() + 1);
+    fenceDeletes.add(new PointerStore.CasDelete(key, marker.getVersion()));
+    for (String shardKey : shardKeys) {
+      fenceDeletes.add(
+          new PointerStore.CasDelete(shardKey, fence.shards().get(shardKey).getVersion()));
+    }
+    if (!pointerStore.compareAndSetBatch(fenceDeletes)) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "account deletion fence changed while clearing");
+    }
   }
+
+  private record CompleteAccountDeletionFence(Pointer marker, Map<String, Pointer> shards) {}
 
   private void cleanupAccountResources(ResourceId accountId) {
     var accountKey = accountId.getId();

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueue.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueue.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.service.catalog.impl;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -64,15 +65,13 @@ public class RootResyncQueue {
   public void enqueue(ResourceId tableId) {
     String key = Keys.rootResyncPendingPointer(tableId.getAccountId(), tableId.getId());
     String fenceKey = Keys.accountDeletionMarker(tableId.getAccountId());
+    var writerGate = AccountDeletionFence.checkForAccountWrite(tableId.getAccountId(), key);
     RuntimeException lastFailure = null;
     for (int attempt = 0; attempt < ENQUEUE_ATTEMPTS; attempt++) {
       try {
-        if (pointerStore.get(fenceKey).isPresent()) {
-          return;
-        }
         if (pointerStore.compareAndSetBatch(
             List.of(
-                new PointerStore.CasCheckAbsent(fenceKey),
+                writerGate,
                 new PointerStore.CasUpsert(key, 0L, PointerReferences.blobPointer(key, "", 1L))))) {
           return;
         }
@@ -85,7 +84,7 @@ public class RootResyncQueue {
         }
         if (pointerStore.compareAndSetBatch(
             List.of(
-                new PointerStore.CasCheckAbsent(fenceKey),
+                writerGate,
                 new PointerStore.CasUpsert(
                     key,
                     existing.getVersion(),

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlayReconciler.java
@@ -576,7 +576,6 @@ public class CatalogOverlayReconciler {
             Keys.catalogIntegrationPointerById(accountId, integration.getResourceId().getId()),
             integrationMeta.getPointerVersion()),
         Set.of(
-            Keys.accountDeletionMarker(accountId),
             Keys.catalogOverlayDeletionMarker(accountId, overlay.getResourceId().getId()),
             Keys.catalogIntegrationDeletionMarker(accountId, integration.getResourceId().getId())),
         Map.of());

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/DynamoReconcileJobIndexBackend.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.aws.DynamoDbClientManager;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.spi.PointerStore;
+import ai.floedb.floecat.storage.spi.PointerStoreKeys;
 import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -2366,6 +2367,17 @@ public class DynamoReconcileJobIndexBackend implements ReconcileJobIndexBackend 
     String accountRootPrefix = stripLeadingSlash(Keys.accountRootPrefix());
     if (k.startsWith(accountByIdPrefix) || k.startsWith(accountByNamePrefix)) {
       return new GenericPointerKey(GENERIC_POINTER_GLOBAL_PK, k);
+    }
+    String fencePrefix = stripLeadingSlash(PointerStoreKeys.ACCOUNT_DELETION_FENCE_PREFIX);
+    if (k.startsWith(fencePrefix)) {
+      String remainder = k.substring(fencePrefix.length());
+      int slash = remainder.indexOf('/');
+      if (slash <= 0 || slash == remainder.length() - 1) {
+        throw new IllegalArgumentException("bad account deletion fence key: " + pointerKey);
+      }
+      return new GenericPointerKey(
+          PointerStoreKeys.ACCOUNT_DELETION_FENCE_PARTITION_PREFIX + remainder,
+          PointerStoreKeys.ACCOUNT_DELETION_FENCE_SORT_KEY);
     }
     if (!k.startsWith(accountRootPrefix)) {
       throw new IllegalArgumentException("unexpected key: " + pointerKey);

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepository.java
@@ -14,6 +14,7 @@ import ai.floedb.floecat.service.repo.model.CatalogIntegrationKey;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.model.Schemas;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository.PointerConditions;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta;
@@ -157,8 +158,7 @@ public class CatalogIntegrationRepository {
     return pointerStore.compareAndSetBatch(
         List.of(
             new PointerStore.CasCheck(canonical, expectedPointerVersion),
-            new PointerStore.CasCheckAbsent(
-                Keys.accountDeletionMarker(integrationId.getAccountId())),
+            AccountDeletionFence.checkForAccountWrite(integrationId.getAccountId(), fence),
             new PointerStore.CasUpsert(
                 fence, 0L, PointerReferences.opaqueMarkerPointer(fence, fence, 1L))));
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogOverlayRepository.java
@@ -14,6 +14,7 @@ import ai.floedb.floecat.service.repo.model.CatalogOverlayKey;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.model.Schemas;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository.PointerConditions;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta;
@@ -104,7 +105,7 @@ public class CatalogOverlayRepository {
     return pointerStore.compareAndSetBatch(
         List.of(
             new PointerStore.CasCheck(canonical, expectedPointerVersion),
-            new PointerStore.CasCheckAbsent(Keys.accountDeletionMarker(overlayId.getAccountId())),
+            AccountDeletionFence.checkForAccountWrite(overlayId.getAccountId(), fence),
             new PointerStore.CasUpsert(
                 fence, 0L, PointerReferences.opaqueMarkerPointer(fence, fence, 1L))));
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -1424,7 +1424,7 @@ public class StatsRepository implements StatsStore {
             tableId.getAccountId(), tableId.getId(), snapshotId, generationId);
     markGenerationPublishing(tableId, snapshotId, generationId);
     StringValue manifest = StringValue.of(generationId);
-    targetStatsStorage.putManifestBlob(tableId.getAccountId(), manifestBlobUri, manifest);
+    targetStatsStorage.putManifestBlob(manifestBlobUri, manifest);
     if (blobCache != null) {
       // Write-through the DECODED form readGenerationId caches: the first scan/planner read after
       // this publish pays neither a cold fetch nor a parse (URI is per-generation, immutable).
@@ -1795,8 +1795,7 @@ public class StatsRepository implements StatsStore {
     String manifestBlobUri =
         Keys.snapshotTargetStatsManifestBlobUri(
             tableId.getAccountId(), tableId.getId(), snapshotId, generationId);
-    targetStatsStorage.putManifestBlob(
-        tableId.getAccountId(), manifestBlobUri, StringValue.of(generationId));
+    targetStatsStorage.putManifestBlob(manifestBlobUri, StringValue.of(generationId));
     Pointer created = PointerReferences.blobPointer(manifestPointer, manifestBlobUri, 1L);
     String lifecyclePointer = generationLifecyclePointer(tableId, snapshotId, generationId);
     Pointer published =
@@ -2829,7 +2828,6 @@ public class StatsRepository implements StatsStore {
       }
       List<TargetStatsWrite> pending = new ArrayList<>(uniqueWrites.values());
       String accountId = targetStatsAccountId(pending);
-      AccountDeletionFence.requireAbsent(mutationPointerStore, accountId);
       Set<String> blobsCreatedByCall = new LinkedHashSet<>();
       try {
         for (TargetStatsWrite write : pending) {
@@ -2854,7 +2852,6 @@ public class StatsRepository implements StatsStore {
         uniqueWrites.put(write.pointerKey(), write);
       }
       List<TargetStatsWrite> pending = new ArrayList<>(uniqueWrites.values());
-      AccountDeletionFence.requireAbsent(mutationPointerStore, targetStatsAccountId(pending));
       for (TargetStatsWrite write : pending) {
         overwrite(write.pointerKey(), write.blobUri(), write.value());
       }
@@ -3041,7 +3038,6 @@ public class StatsRepository implements StatsStore {
       }
       List<TargetStatsWrite> remaining = new ArrayList<>(uniqueWrites.values());
       String accountId = targetStatsAccountId(remaining);
-      AccountDeletionFence.requireAbsent(mutationPointerStore, accountId);
       List<TargetStatsRecord> created = new ArrayList<>(remaining.size());
       Set<String> blobsCreatedByCall = new LinkedHashSet<>();
       try {
@@ -3106,12 +3102,8 @@ public class StatsRepository implements StatsStore {
       }
     }
 
-    private void putManifestBlob(String accountId, String blobUri, StringValue manifest) {
+    private void putManifestBlob(String blobUri, StringValue manifest) {
       putBlobStrictBytes(blobUri, manifest.toByteArray());
-      if (mutationPointerStore.get(Keys.accountDeletionMarker(accountId)).isPresent()) {
-        deleteBlobQuietly(blobUri);
-        throw new AccountDeletionInProgressException(accountId);
-      }
     }
 
     private MutationMeta metaForPointer(String pointerKey, String blobUri, Timestamp nowTs) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/model/Keys.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.service.repo.model;
 
+import ai.floedb.floecat.storage.spi.PointerStoreKeys;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -24,6 +25,17 @@ import java.util.List;
 import java.util.Objects;
 
 public final class Keys {
+  public static final int ACCOUNT_DELETION_FENCE_SHARDS = 64;
+  private static final int DYNAMODB_TRANSACTION_ITEM_LIMIT = 100;
+
+  static {
+    if (ACCOUNT_DELETION_FENCE_SHARDS < 2
+        || ACCOUNT_DELETION_FENCE_SHARDS + 1 > DYNAMODB_TRANSACTION_ITEM_LIMIT) {
+      throw new ExceptionInInitializerError(
+          "account deletion fence must have at least two shards and fit with its marker in one "
+              + "DynamoDB transaction");
+    }
+  }
 
   public static final String SEG_ACCOUNT = "/account/";
   public static final String SEG_CATALOG = "/catalog/";
@@ -173,7 +185,7 @@ public final class Keys {
     return "/accounts/by-name/";
   }
 
-  /** Durable fence that prevents new account-scoped writes once deletion begins. */
+  /** Durable state marker recording that account deletion has begun. */
   public static String accountDeletionMarker(String accountId) {
     return accountDeletionMarkerForEncodedSegment(encode(req("account_id", accountId)));
   }
@@ -185,6 +197,44 @@ public final class Keys {
       throw new IllegalArgumentException("encoded_account_segment must be one path segment");
     }
     return accountRootPrefix() + segment + "/deleting";
+  }
+
+  /**
+   * One of the independent writer gates installed atomically when account deletion begins.
+   *
+   * <p>The gates live outside the account pointer prefix so teardown can sweep that prefix without
+   * reopening writes. A writer checks only the shard selected by its primary pointer key; unrelated
+   * writes therefore do not make every DynamoDB transaction read the same item.
+   */
+  public static String accountDeletionFenceShard(String accountId, String writeKey) {
+    return accountDeletionFenceShardForEncodedSegment(
+        encode(req("account_id", accountId)), writeKey);
+  }
+
+  public static String accountDeletionFenceShardForEncodedSegment(
+      String encodedAccountSegment, String writeKey) {
+    String segment = req("encoded_account_segment", encodedAccountSegment);
+    if (segment.indexOf('/') >= 0) {
+      throw new IllegalArgumentException("encoded_account_segment must be one path segment");
+    }
+    int hash = req("write_key", writeKey).hashCode();
+    hash ^= hash >>> 16;
+    return accountDeletionFenceShardKey(
+        segment, Math.floorMod(hash, ACCOUNT_DELETION_FENCE_SHARDS));
+  }
+
+  public static List<String> accountDeletionFenceShards(String accountId) {
+    String segment = encode(req("account_id", accountId));
+    return java.util.stream.IntStream.range(0, ACCOUNT_DELETION_FENCE_SHARDS)
+        .mapToObj(shard -> accountDeletionFenceShardKey(segment, shard))
+        .toList();
+  }
+
+  private static String accountDeletionFenceShardKey(String encodedAccountSegment, int shard) {
+    return PointerStoreKeys.ACCOUNT_DELETION_FENCE_PREFIX
+        + encodedAccountSegment
+        + "/"
+        + String.format("%02d", shard);
   }
 
   public static String accountBlobUri(String accountId, String sha256) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/AccountDeletionFence.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/AccountDeletionFence.java
@@ -11,19 +11,15 @@ import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /** Account-deletion exclusion for repositories that publish raw pointer transactions. */
 public final class AccountDeletionFence {
   private AccountDeletionFence() {}
-
-  public static void requireAbsent(PointerStore pointerStore, String accountId) {
-    if (pointerStore.get(Keys.accountDeletionMarker(accountId)).isPresent()) {
-      throw new BaseResourceRepository.AccountDeletionInProgressException(accountId);
-    }
-  }
 
   public static boolean compareAndSet(
       PointerStore pointerStore, String accountId, String key, long expectedVersion, Pointer next) {
@@ -33,39 +29,47 @@ public final class AccountDeletionFence {
 
   public static boolean compareAndSetBatch(
       PointerStore pointerStore, String accountId, List<? extends PointerStore.CasOp> operations) {
-    String fenceKey = Keys.accountDeletionMarker(accountId);
+    if (operations == null || operations.isEmpty()) {
+      throw new IllegalArgumentException("operations must not be empty");
+    }
+    String fenceKey = Keys.accountDeletionFenceShard(accountId, operations.get(0).key());
     List<PointerStore.CasOp> fenced = new ArrayList<>(operations.size() + 1);
     fenced.add(new PointerStore.CasCheckAbsent(fenceKey));
     fenced.addAll(operations);
     boolean committed = pointerStore.compareAndSetBatch(fenced);
-    if (!committed && pointerStore.get(fenceKey).isPresent()) {
+    if (!committed && pointerStore.get(Keys.accountDeletionMarker(accountId)).isPresent()) {
       throw new BaseResourceRepository.AccountDeletionInProgressException(accountId);
     }
     return committed;
   }
 
-  /** Returns exact fence checks for every account touched by a pointer upsert. */
+  /** Returns one deterministic writer-gate check for every account touched by pointer upserts. */
   public static List<PointerStore.CasCheckAbsent> checksForAccountWrites(
       List<? extends PointerStore.CasOp> operations) {
-    Set<String> fenceKeys = new LinkedHashSet<>();
+    Map<String, String> firstWriteKeyByAccount = new LinkedHashMap<>();
     Set<String> existingChecks = new LinkedHashSet<>();
     if (operations != null) {
       for (PointerStore.CasOp operation : operations) {
         if (operation instanceof PointerStore.CasUpsert upsert) {
-          collectFenceKey(upsert.key(), fenceKeys);
+          collectAccountWrite(upsert.key(), firstWriteKeyByAccount);
           if (PointerReferences.isPointerKeyPointer(upsert.next())) {
-            collectFenceKey(upsert.next().getBlobUri(), fenceKeys);
+            collectAccountWrite(upsert.next().getBlobUri(), firstWriteKeyByAccount);
           }
         } else if (operation instanceof PointerStore.UnconditionalUpsert upsert) {
-          collectFenceKey(upsert.key(), fenceKeys);
+          collectAccountWrite(upsert.key(), firstWriteKeyByAccount);
           if (PointerReferences.isPointerKeyPointer(upsert.next())) {
-            collectFenceKey(upsert.next().getBlobUri(), fenceKeys);
+            collectAccountWrite(upsert.next().getBlobUri(), firstWriteKeyByAccount);
           }
         } else if (operation instanceof PointerStore.CasCheckAbsent check) {
           existingChecks.add(check.key());
         }
       }
     }
+    Set<String> fenceKeys = new LinkedHashSet<>();
+    firstWriteKeyByAccount.forEach(
+        (accountSegment, writeKey) ->
+            fenceKeys.add(
+                Keys.accountDeletionFenceShardForEncodedSegment(accountSegment, writeKey)));
     fenceKeys.removeAll(existingChecks);
     return fenceKeys.stream().map(PointerStore.CasCheckAbsent::new).toList();
   }
@@ -80,7 +84,13 @@ public final class AccountDeletionFence {
     return List.copyOf(fenced);
   }
 
-  private static void collectFenceKey(String pointerKey, Set<String> fenceKeys) {
+  public static PointerStore.CasCheckAbsent checkForAccountWrite(
+      String accountId, String writeKey) {
+    return new PointerStore.CasCheckAbsent(Keys.accountDeletionFenceShard(accountId, writeKey));
+  }
+
+  private static void collectAccountWrite(
+      String pointerKey, Map<String, String> firstWriteKeyByAccount) {
     if (pointerKey == null || pointerKey.isBlank()) {
       return;
     }
@@ -97,6 +107,6 @@ public final class AccountDeletionFence {
     if (accountSegment.isBlank() || Keys.isReservedAccountDirectorySegment(accountSegment)) {
       return;
     }
-    fenceKeys.add(Keys.accountDeletionMarkerForEncodedSegment(accountSegment));
+    firstWriteKeyByAccount.putIfAbsent(accountSegment, normalized);
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -395,12 +395,11 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
         () -> {
           K resourceKey = schema.keyFromValue.apply(value);
           String accountDeletionMarker = Keys.accountDeletionMarker(resourceKey.accountId());
-          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
-            throw accountDeletionInProgress(resourceKey);
-          }
           PreparedCreate prepared = prepareCreate(value);
           Set<String> effectiveRequiredAbsent = new HashSet<>(conditions.requiredAbsent());
-          effectiveRequiredAbsent.add(accountDeletionMarker);
+          effectiveRequiredAbsent.add(
+              Keys.accountDeletionFenceShard(
+                  resourceKey.accountId(), prepared.canonicalPointerKey));
           List<PointerStore.CasOp> ops =
               new ArrayList<>(
                   prepared.ops.size()
@@ -700,17 +699,13 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           List<String> pointerKeys = new ArrayList<>(uniqueKeys);
 
           String accountDeletionMarker = Keys.accountDeletionMarker(key.accountId());
-          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
-            cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
-            throw accountDeletionInProgress(key);
-          }
           List<PointerStore.CasOp> ops = new ArrayList<>(pointerKeys.size() + 1);
           for (String pointerKey : pointerKeys) {
             ops.add(
                 new PointerStore.CasUpsert(
                     pointerKey, 0L, reserve(pointerKey, blobUri, value, blobBytes)));
           }
-          ops.add(new PointerStore.CasCheckAbsent(accountDeletionMarker));
+          ops.add(AccountDeletionFence.checkForAccountWrite(key.accountId(), canonicalPointer));
 
           if (mutationPointerStore.compareAndSetBatch(ops)) {
             healCanonicalBlobIfMissing(blobUri, value);
@@ -990,9 +985,6 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
         () -> {
           K key = schema.keyFromValue.apply(updatedValue);
           String accountDeletionMarker = Keys.accountDeletionMarker(key.accountId());
-          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
-            throw accountDeletionInProgress(key);
-          }
           String canonicalPointer = schema.canonicalPointerForKey.apply(key);
           PreparedUpdate prepared = prepareUpdate(updatedValue, expectedCanonicalVersion);
           String blobUri = prepared.blobUri;
@@ -1001,8 +993,10 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           List<PointerStore.CasOp> ops = new ArrayList<>(prepared.ops);
           Pointer committedCanonical = prepared.committedCanonical;
           addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
-          if (batchedKeys.add(accountDeletionMarker)) {
-            ops.add(new PointerStore.CasCheckAbsent(accountDeletionMarker));
+          String accountDeletionFence =
+              Keys.accountDeletionFenceShard(key.accountId(), canonicalPointer);
+          if (batchedKeys.add(accountDeletionFence)) {
+            ops.add(new PointerStore.CasCheckAbsent(accountDeletionFence));
           }
           addMarkerAdvances(markerVersions, batchedKeys, ops, "update");
           for (PointerStore.CasOp companion : companions) {
@@ -1118,10 +1112,6 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
             throw new IllegalArgumentException("replacement cannot cross accounts");
           }
           String accountDeletionMarker = Keys.accountDeletionMarker(currentKey.accountId());
-          if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
-            throw accountDeletionInProgress(currentKey);
-          }
-
           String currentCanonical = schema.canonicalPointerForKey.apply(currentKey);
           String replacementCanonical = schema.canonicalPointerForKey.apply(replacementKey);
           if (currentCanonical.equals(replacementCanonical)) {
@@ -1207,8 +1197,10 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
           addPointerDeletes(pointerVersionsToDelete, batchedKeys, ops);
           addPointerConditions(requiredPointerVersions, requiredAbsentPointers, batchedKeys, ops);
-          if (batchedKeys.add(accountDeletionMarker)) {
-            ops.add(new PointerStore.CasCheckAbsent(accountDeletionMarker));
+          String accountDeletionFence =
+              Keys.accountDeletionFenceShard(currentKey.accountId(), currentCanonical);
+          if (batchedKeys.add(accountDeletionFence)) {
+            ops.add(new PointerStore.CasCheckAbsent(accountDeletionFence));
           }
           addMarkerAdvances(markerVersions, batchedKeys, ops, "replacement");
           for (PointerStore.CasOp companion : companions) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -34,6 +34,7 @@ import ai.floedb.floecat.telemetry.Telemetry.TagKey;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -435,7 +436,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           }
 
           if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
-            cleanupCreateIfAbsentBlobOnCasMiss(
+            cleanupUncommittedCasBlob(
                 prepared.canonicalPointerKey, prepared.blobUri, prepared.blobExistedBefore);
             throw accountDeletionInProgress(resourceKey);
           }
@@ -712,7 +713,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
             return true;
           }
           if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
-            cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
+            cleanupUncommittedCasBlob(canonicalPointer, blobUri, blobExistedBefore);
             throw accountDeletionInProgress(key);
           }
           return classifyCreateIfAbsentConflict(
@@ -727,7 +728,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       boolean blobExistedBefore) {
     // The batch committed nothing, so this call did not create the resource. Reclaim the blob we
     // optimistically wrote (best-effort, content-addressed) before classifying the outcome.
-    cleanupCreateIfAbsentBlobOnCasMiss(canonicalPointer, blobUri, blobExistedBefore);
+    cleanupUncommittedCasBlob(canonicalPointer, blobUri, blobExistedBefore);
 
     Pointer canonical = mutationPointerStore.get(canonicalPointer).orElse(null);
     if (canonical != null) {
@@ -801,7 +802,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     return new CorruptionException(message);
   }
 
-  private void cleanupCreateIfAbsentBlobOnCasMiss(
+  private void cleanupUncommittedCasBlob(
       String canonicalPointer, String blobUri, boolean blobExistedBefore) {
     // For casBlobs schemas the URI is content-addressed (SHA256): concurrent writers with
     // identical content share a URI and no cleanup is needed. For distinct content, deleteQuietly
@@ -813,6 +814,28 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
     Pointer pointer = mutationPointerStore.get(canonicalPointer).orElse(null);
     if (pointer != null && blobUri.equals(pointer.getBlobUri())) {
       return;
+    }
+    deleteQuietly(() -> mutationBlobStore.delete(blobUri));
+  }
+
+  /**
+   * Reclaims the body a write left behind when the account-deletion fence rejected its pointer
+   * batch. Unlike {@link #cleanupUncommittedCasBlob} this deletes the blob even when the same
+   * content-addressed URI already existed before the call: the account (its whole blob prefix
+   * included) is being torn down, so a body no live pointer names is garbage either way. The
+   * pointer recheck is what keeps it safe — if any pointer this write would have bound still
+   * resolves to the URI, a concurrent writer committed the identical content and owns the blob.
+   */
+  private void cleanupBlobRejectedByAccountDeletion(
+      String blobUri, Collection<String> referencingPointers) {
+    if (!schema.casBlobs || blobUri.isBlank()) {
+      return;
+    }
+    for (String pointer : referencingPointers) {
+      Pointer existing = mutationPointerStore.get(pointer).orElse(null);
+      if (existing != null && blobUri.equals(existing.getBlobUri())) {
+        return;
+      }
     }
     deleteQuietly(() -> mutationBlobStore.delete(blobUri));
   }
@@ -1019,6 +1042,10 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           if (!pointerConditionsStillMatch(requiredPointerVersions, requiredAbsentPointers))
             return Optional.empty();
           if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
+            Set<String> boundByThisWrite = new HashSet<>();
+            boundByThisWrite.add(canonicalPointer);
+            boundByThisWrite.addAll(schema.secondaryPointersFromValue.apply(updatedValue).values());
+            cleanupBlobRejectedByAccountDeletion(blobUri, boundByThisWrite);
             throw accountDeletionInProgress(key);
           }
           if (!markerVersionsStillMatch(markerVersions)) return Optional.empty();
@@ -1213,7 +1240,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
           if (!mutationPointerStore.compareAndSetBatch(ops)) {
             if (mutationPointerStore.get(accountDeletionMarker).isPresent()) {
-              cleanupCreateIfAbsentBlobOnCasMiss(
+              cleanupUncommittedCasBlob(
                   replacementCanonical, replacementBlobUri, replacementBlobExistedBefore);
               throw accountDeletionInProgress(currentKey);
             }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/MarkerStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/MarkerStore.java
@@ -74,12 +74,12 @@ public class MarkerStore {
 
   private void bumpMarker(String accountId, String key) {
     for (int i = 0; i < CAS_MAX; i++) {
-      if (pointerStore.get(Keys.accountDeletionMarker(accountId)).isPresent()) {
-        return;
-      }
       var current = pointerStore.get(key).orElse(null);
       long expected = current == null ? 0L : current.getVersion();
       if (tryAdvanceMarker(accountId, key, expected)) {
+        return;
+      }
+      if (pointerStore.get(Keys.accountDeletionMarker(accountId)).isPresent()) {
         return;
       }
     }
@@ -87,9 +87,6 @@ public class MarkerStore {
 
   private boolean advanceMarker(String accountId, String key, long expectedVersion) {
     String fenceKey = Keys.accountDeletionMarker(accountId);
-    if (pointerStore.get(fenceKey).isPresent()) {
-      throw new BaseResourceRepository.AccountDeletionInProgressException(accountId);
-    }
     boolean advanced = tryAdvanceMarker(accountId, key, expectedVersion);
     if (!advanced && pointerStore.get(fenceKey).isPresent()) {
       throw new BaseResourceRepository.AccountDeletionInProgressException(accountId);
@@ -101,7 +98,7 @@ public class MarkerStore {
     var next = PointerReferences.opaqueMarkerPointer(key, key, expectedVersion + 1);
     return pointerStore.compareAndSetBatch(
         List.of(
-            new PointerStore.CasCheckAbsent(Keys.accountDeletionMarker(accountId)),
+            AccountDeletionFence.checkForAccountWrite(accountId, key),
             new PointerStore.CasUpsert(key, expectedVersion, next)));
   }
 }

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.service.repo.util.AccountDeletionFence;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import ai.floedb.floecat.systemcatalog.graph.SystemResourceIdGenerator;
@@ -354,6 +355,7 @@ public class TransactionIntentApplierSupport {
 
   private ApplyOutcome appendAccountDeletionFenceChecks(
       List<TransactionIntent> intents, Set<String> touchedKeys, List<PointerStore.CasOp> ops) {
+    Set<String> fencedAccounts = new HashSet<>();
     for (TransactionIntent intent : intents) {
       if (intent == null || intent.getAccountId().isBlank()) {
         return ApplyOutcome.conflict(
@@ -363,12 +365,11 @@ public class TransactionIntentApplierSupport {
             null,
             null);
       }
-      String markerKey = Keys.accountDeletionMarker(intent.getAccountId());
-      if (pointerStore.get(markerKey).isPresent()) {
-        return accountDeletionConflict(intent.getAccountId());
-      }
-      if (touchedKeys.add(markerKey)) {
-        ops.add(new PointerStore.CasCheckAbsent(markerKey));
+      if (fencedAccounts.add(intent.getAccountId())) {
+        PointerStore.CasCheckAbsent check =
+            AccountDeletionFence.checkForAccountWrite(
+                intent.getAccountId(), intent.getTargetPointerKey());
+        if (touchedKeys.add(check.key())) ops.add(check);
       }
     }
     return ApplyOutcome.applied();

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -52,6 +52,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import jakarta.enterprise.inject.Instance;
 import java.lang.reflect.Field;
+import java.util.Base64;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -130,6 +131,9 @@ class AccountServiceImplTest {
             "acct", StorageAuthorityResolver.STORAGE_AUTHORITY_SECRET_TYPE, authorityId.getId());
     assertTrue(pointers.get(authorityPointer).isEmpty());
     assertTrue(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
+    assertTrue(
+        Keys.accountDeletionFenceShards("acct").stream()
+            .allMatch(key -> pointers.get(key).isPresent()));
   }
 
   @Test
@@ -285,7 +289,47 @@ class AccountServiceImplTest {
 
     assertEquals(missing, response.getMeta());
     assertFalse(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
+    assertTrue(
+        Keys.accountDeletionFenceShards("acct").stream()
+            .allMatch(key -> pointers.get(key).isEmpty()));
     assertEquals(0, pointers.excludedSweepCalls);
+  }
+
+  @Test
+  void existingDeletionMarkerRepairsMissingFenceShards() {
+    MutationMeta meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    installDeletionMarker(meta);
+    String existingShard = Keys.accountDeletionFenceShards("acct").get(17);
+    pointers.compareAndSet(
+        existingShard, 0L, PointerReferences.opaqueMarkerPointer(existingShard, "deleting", 1L));
+    when(service.accountRepo.metaFor(accountId)).thenReturn(meta);
+    when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
+
+    service
+        .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
+        .await()
+        .indefinitely();
+
+    assertTrue(
+        Keys.accountDeletionFenceShards("acct").stream()
+            .allMatch(key -> pointers.get(key).isPresent()));
+  }
+
+  @Test
+  void orphanedFenceShardIsRemovedBeforeFenceCreationRetries() {
+    MutationMeta meta = MutationMeta.newBuilder().setPointerVersion(7L).build();
+    String orphan = Keys.accountDeletionFenceShards("acct").get(23);
+    pointers.compareAndSet(orphan, 0L, PointerReferences.opaqueMarkerPointer(orphan, "orphan", 9L));
+    when(service.accountRepo.metaFor(accountId)).thenReturn(meta);
+    when(service.accountRepo.deleteWithPrecondition(accountId, 7L)).thenReturn(true);
+
+    service
+        .deleteAccount(DeleteAccountRequest.newBuilder().setAccountId(accountId).build())
+        .await()
+        .indefinitely();
+
+    assertEquals(1L, pointers.get(orphan).orElseThrow().getVersion());
+    assertTrue(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
   }
 
   @Test
@@ -346,8 +390,11 @@ class AccountServiceImplTest {
                 .await()
                 .indefinitely());
 
-    assertEquals(1, pointers.compareAndDeleteCalls);
+    assertEquals(0, pointers.compareAndDeleteCalls);
     assertFalse(pointers.get(Keys.accountDeletionMarker("acct")).isPresent());
+    assertTrue(
+        Keys.accountDeletionFenceShards("acct").stream()
+            .allMatch(key -> pointers.get(key).isEmpty()));
   }
 
   @Test
@@ -424,6 +471,12 @@ class AccountServiceImplTest {
 
   private void putPointer(String key, String blobUri) {
     pointers.compareAndSet(key, 0L, PointerReferences.blobPointer(key, blobUri, 1L));
+  }
+
+  private void installDeletionMarker(MutationMeta meta) {
+    String key = Keys.accountDeletionMarker("acct");
+    String payload = Base64.getEncoder().encodeToString(meta.toByteArray());
+    pointers.compareAndSet(key, 0L, PointerReferences.opaqueMarkerPointer(key, payload, 1L));
   }
 
   private static final class TrackingPointerStore extends InMemoryPointerStore {

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueueTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/RootResyncQueueTest.java
@@ -72,8 +72,16 @@ class RootResyncQueueTest {
             .setId("tbl-deleting")
             .setKind(ResourceKind.RK_TABLE)
             .build();
-    String fence = Keys.accountDeletionMarker("acct");
-    pointers.compareAndSet(fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "acct", 1L));
+    String marker = Keys.accountDeletionMarker("acct");
+    String writeKey = Keys.rootResyncPendingPointer("acct", "tbl-deleting");
+    String gate = Keys.accountDeletionFenceShard("acct", writeKey);
+    assertTrue(
+        pointers.compareAndSetBatch(
+            List.of(
+                new PointerStore.CasUpsert(
+                    marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "deleting", 1L)),
+                new PointerStore.CasUpsert(
+                    gate, 0L, PointerReferences.opaqueMarkerPointer(gate, "deleting", 1L)))));
 
     queue.enqueue(tableId);
 

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootCommitterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootCommitterTest.java
@@ -29,10 +29,13 @@ import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.repo.impl.TableRootRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.TableBlobReachabilityGuard;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -94,12 +97,16 @@ class TableRootCommitterTest {
 
   @Test
   void accountDeletionFenceIsNotWrappedAsCommitFailure() {
-    String fence = ai.floedb.floecat.service.repo.model.Keys.accountDeletionMarker("acct");
-    pointers.compareAndSet(
-        fence,
-        0L,
-        ai.floedb.floecat.service.repo.model.PointerReferences.opaqueMarkerPointer(
-            fence, "acct", 1L));
+    String marker = Keys.accountDeletionMarker("acct");
+    String writeKey = Keys.tableRootByTable("acct", "tbl");
+    String gate = Keys.accountDeletionFenceShard("acct", writeKey);
+    assertTrue(
+        pointers.compareAndSetBatch(
+            List.of(
+                new PointerStore.CasUpsert(
+                    marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "deleting", 1L)),
+                new PointerStore.CasUpsert(
+                    gate, 0L, PointerReferences.opaqueMarkerPointer(gate, "deleting", 1L)))));
 
     assertThrows(
         BaseResourceRepository.AccountDeletionInProgressException.class,

--- a/service/src/test/java/ai/floedb/floecat/service/it/StatsOrchestratorIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/StatsOrchestratorIT.java
@@ -313,30 +313,34 @@ class StatsOrchestratorIT {
     CompletableFuture<StatsResolutionResult> future =
         CompletableFuture.supplyAsync(() -> orchestrator.resolve(req));
 
-    // Poll for the newly-created queued root for this connector. This test's profile disables
-    // workers so the root cannot advance and enqueue children before cancellation.
-    ReconcileJobStore.ReconcileJob syncJob = null;
+    // Cancel every newly-created queued root for this connector until resolve observes a
+    // cancellation. Attaching the connector can publish a root concurrently, so selecting only
+    // the first new root can cancel that job instead of the synchronous capture root.
+    Set<String> cancelledJobIds = new java.util.HashSet<>();
     long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
-    while (syncJob == null && System.nanoTime() < deadline) {
+    while (!future.isDone() && System.nanoTime() < deadline) {
       var page = jobStore.list(tableId.getAccountId(), 100, "", "", Set.of("JS_QUEUED"));
-      syncJob =
-          page.jobs.stream()
-              .filter(job -> !existingRootJobIds.contains(job.jobId))
-              .filter(job -> job.parentJobId == null || job.parentJobId.isBlank())
-              .filter(job -> connectorId.equals(job.connectorId))
-              .findFirst()
-              .orElse(null);
-      if (syncJob == null) {
+      boolean cancelledAny = false;
+      for (var job : page.jobs) {
+        if (existingRootJobIds.contains(job.jobId)
+            || (job.parentJobId != null && !job.parentJobId.isBlank())
+            || !connectorId.equals(job.connectorId)
+            || cancelledJobIds.contains(job.jobId)) {
+          continue;
+        }
+        var cancelled = jobStore.cancel(tableId.getAccountId(), job.jobId, "test_cancel");
+        assertTrue(cancelled.isPresent(), "new capture root job must be cancellable");
+        assertTrue(
+            Set.of("JS_CANCELLED", "JS_CANCELLING").contains(cancelled.get().state),
+            "new capture root job must enter a cancellation state");
+        cancelledJobIds.add(job.jobId);
+        cancelledAny = true;
+      }
+      if (!cancelledAny) {
         Thread.sleep(20);
       }
     }
-    assertNotNull(syncJob, "sync capture root job must appear in job store within 3s");
-
-    var cancelled = jobStore.cancel(tableId.getAccountId(), syncJob.jobId, "test_cancel");
-    assertTrue(cancelled.isPresent(), "sync capture root job must be cancellable");
-    assertTrue(
-        Set.of("JS_CANCELLED", "JS_CANCELLING").contains(cancelled.get().state),
-        "sync capture root job must enter a cancellation state");
+    assertFalse(cancelledJobIds.isEmpty(), "sync capture root job must appear within 3s");
     StatsResolutionResult result = future.get(5, TimeUnit.SECONDS);
 
     assertEquals(StatsSyncOutcome.FAILED, result.outcome());

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -260,11 +260,7 @@ class DurableReconcileJobStoreTest {
             .findFirst()
             .orElseThrow();
     String deletionFence = Keys.accountDeletionMarker(ACCOUNT_ID);
-    assertTrue(
-        store.pointerStore.compareAndSet(
-            deletionFence,
-            0L,
-            PointerReferences.opaqueMarkerPointer(deletionFence, "deleting", 1L)));
+    installAccountDeletionFence(ACCOUNT_ID);
 
     assertEquals(1, store.cleanupAccount(ACCOUNT_ID));
 
@@ -357,11 +353,7 @@ class DurableReconcileJobStoreTest {
             0L,
             PointerReferences.opaqueMarkerPointer(cancellationMarkerKey, cancellationPayload, 1L)));
     String deletionFence = Keys.accountDeletionMarker(ACCOUNT_ID);
-    assertTrue(
-        store.pointerStore.compareAndSet(
-            deletionFence,
-            0L,
-            PointerReferences.opaqueMarkerPointer(deletionFence, "deleting", 1L)));
+    installAccountDeletionFence(ACCOUNT_ID);
 
     assertEquals(2, store.cleanupAccount(ACCOUNT_ID));
 
@@ -385,10 +377,7 @@ class DurableReconcileJobStoreTest {
             false,
             CaptureMode.METADATA_AND_CAPTURE,
             ReconcileScope.empty());
-    String fence = Keys.accountDeletionMarker(ACCOUNT_ID);
-    assertTrue(
-        store.pointerStore.compareAndSet(
-            fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "deleting", 1L)));
+    installAccountDeletionFence(ACCOUNT_ID);
 
     assertTrue(store.leaseNext().isEmpty());
     assertTrue(
@@ -7897,6 +7886,18 @@ class DurableReconcileJobStoreTest {
 
   private void runCancellationMaintenance() {
     store.runCancellationMaintenanceOnce(isDynamoMode() ? 10_000L : 100L);
+  }
+
+  private void installAccountDeletionFence(String accountId) {
+    String marker = Keys.accountDeletionMarker(accountId);
+    assertTrue(
+        store.pointerStore.compareAndSet(
+            marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "deleting", 1L)));
+    for (String shard : Keys.accountDeletionFenceShards(accountId)) {
+      assertTrue(
+          store.pointerStore.compareAndSet(
+              shard, 0L, PointerReferences.opaqueMarkerPointer(shard, "deleting", 1L)));
+    }
   }
 
   private void runStatsCleanupMaintenance() {

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileJobIndexBackendTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/durable/store/MemoryReconcileJobIndexBackendTest.java
@@ -53,6 +53,11 @@ class MemoryReconcileJobIndexBackendTest {
     assertTrue(
         pointers.compareAndSet(
             fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "deleting", 1L)));
+    for (String shard : Keys.accountDeletionFenceShards(accountId)) {
+      assertTrue(
+          pointers.compareAndSet(
+              shard, 0L, PointerReferences.opaqueMarkerPointer(shard, "deleting", 1L)));
+    }
 
     assertFalse(
         backend.compareAndSetBatch(

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/CatalogIntegrationRepositoryTest.java
@@ -22,7 +22,9 @@ import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.rpc.IdempotencyRecord;
+import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.Timestamp;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -176,9 +178,15 @@ class CatalogIntegrationRepositoryTest {
     var pointers = new InMemoryPointerStore();
     var repo = new CatalogIntegrationRepository(pointers, new InMemoryBlobStore());
     String marker = Keys.accountDeletionMarker("account");
+    String writeKey = Keys.catalogIntegrationPointerById("account", "integration");
+    String gate = Keys.accountDeletionFenceShard("account", writeKey);
     assertTrue(
-        pointers.compareAndSet(
-            marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "deleting", 1L)));
+        pointers.compareAndSetBatch(
+            List.of(
+                new PointerStore.CasUpsert(
+                    marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "deleting", 1L)),
+                new PointerStore.CasUpsert(
+                    gate, 0L, PointerReferences.opaqueMarkerPointer(gate, "deleting", 1L)))));
     var integration =
         CatalogIntegration.newBuilder()
             .setResourceId(

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
@@ -144,15 +144,49 @@ class GenericResourceRepositoryCreateTest {
             Catalog::toByteArray,
             "application/x-protobuf");
     var current = catalog("catalog-1", "alpha");
+    var updated = current.toBuilder().setDisplayName("beta").build();
+    String updatedBlobUri =
+        Schemas.CATALOG.blobUriForKey.apply(Schemas.CATALOG.keyFromValue.apply(updated));
     repo.create(current);
     installAccountDeletionFence("acct");
 
-    assertThatThrownBy(() -> repo.update(current.toBuilder().setDisplayName("beta").build(), 1L))
+    assertThatThrownBy(() -> repo.update(updated, 1L))
         .isInstanceOf(BaseResourceRepository.AccountDeletionInProgressException.class);
 
     assertThat(repo.getByKey(new CatalogKey("acct", "catalog-1"))).contains(current);
     assertThat(ptr.get(Keys.catalogPointerByName("acct", "alpha"))).isPresent();
     assertThat(ptr.get(Keys.catalogPointerByName("acct", "beta"))).isEmpty();
+    assertThat(blobs.head(updatedBlobUri)).isEmpty();
+  }
+
+  @Test
+  void updateDuringAccountDeletionReclaimsBodyMaterializedByAnEarlierWrite() {
+    var repo =
+        new GenericResourceRepository<>(
+            ptr,
+            blobs,
+            Schemas.CATALOG,
+            Catalog::parseFrom,
+            Catalog::toByteArray,
+            "application/x-protobuf");
+    var original = catalog("catalog-1", "alpha");
+    var renamed = original.toBuilder().setDisplayName("beta").build();
+    String originalBlobUri =
+        Schemas.CATALOG.blobUriForKey.apply(Schemas.CATALOG.keyFromValue.apply(original));
+    repo.create(original);
+    assertThat(repo.update(renamed, 1L)).isTrue();
+    // The rename left the original body behind, so reverting to it re-PUTs an already-present
+    // content-addressed URI that no live pointer names any more.
+    assertThat(blobs.head(originalBlobUri)).isPresent();
+    installAccountDeletionFence("acct");
+
+    assertThatThrownBy(() -> repo.update(original, 2L))
+        .isInstanceOf(BaseResourceRepository.AccountDeletionInProgressException.class);
+
+    assertThat(blobs.head(originalBlobUri)).isEmpty();
+    assertThat(repo.getByKey(new CatalogKey("acct", "catalog-1"))).contains(renamed);
+    assertThat(ptr.get(Keys.catalogPointerByName("acct", "beta"))).isPresent();
+    assertThat(ptr.get(Keys.catalogPointerByName("acct", "alpha"))).isEmpty();
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/GenericResourceRepositoryCreateTest.java
@@ -83,9 +83,16 @@ class GenericResourceRepositoryCreateTest {
 
   private void installAccountDeletionFence(String accountId) {
     String key = Keys.accountDeletionMarker(accountId);
-    assertThat(
-            ptr.compareAndSet(key, 0L, PointerReferences.opaqueMarkerPointer(key, "deleting", 1L)))
-        .isTrue();
+    List<PointerStore.CasOp> creates = new ArrayList<>();
+    creates.add(
+        new PointerStore.CasUpsert(
+            key, 0L, PointerReferences.opaqueMarkerPointer(key, "deleting", 1L)));
+    for (String shardKey : Keys.accountDeletionFenceShards(accountId)) {
+      creates.add(
+          new PointerStore.CasUpsert(
+              shardKey, 0L, PointerReferences.opaqueMarkerPointer(shardKey, "deleting", 1L)));
+    }
+    assertThat(ptr.compareAndSetBatch(creates)).isTrue();
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
@@ -43,6 +43,7 @@ import ai.floedb.floecat.reconciler.rpc.ReusableArtifactBundlePayload;
 import ai.floedb.floecat.reconciler.rpc.SnapshotCaptureManifest;
 import ai.floedb.floecat.service.repo.cache.ImmutableBlobCache;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.TableBlobReachabilityGuard;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
@@ -76,6 +77,20 @@ class IndexArtifactRepositoryTest {
     return new IndexArtifactRepository(pointers, blobs, cache, new TableBlobReachabilityGuard());
   }
 
+  private static void installAccountDeletionFence(InMemoryPointerStore pointers, String accountId) {
+    List<PointerStore.CasOp> creates = new ArrayList<>();
+    String markerKey = Keys.accountDeletionMarker(accountId);
+    creates.add(
+        new PointerStore.CasUpsert(
+            markerKey, 0L, PointerReferences.opaqueMarkerPointer(markerKey, "deleting", 1L)));
+    for (String shardKey : Keys.accountDeletionFenceShards(accountId)) {
+      creates.add(
+          new PointerStore.CasUpsert(
+              shardKey, 0L, PointerReferences.opaqueMarkerPointer(shardKey, "deleting", 1L)));
+    }
+    assertThat(pointers.compareAndSetBatch(creates)).isTrue();
+  }
+
   @Test
   void directArtifactWriteDeletesBlobWhenAccountFenceWinsPublicationRace() {
     InMemoryPointerStore pointers = new InMemoryPointerStore();
@@ -87,12 +102,7 @@ class IndexArtifactRepositoryTest {
             super.put(uri, bytes, contentType);
             if (uri.startsWith(Keys.tableBlobPrefix(TABLE_ID.getAccountId(), TABLE_ID.getId()))
                 && installFence.compareAndSet(true, false)) {
-              String fence = Keys.accountDeletionMarker(TABLE_ID.getAccountId());
-              pointers.compareAndSet(
-                  fence,
-                  0L,
-                  ai.floedb.floecat.service.repo.model.PointerReferences.opaqueMarkerPointer(
-                      fence, "deleting", 1L));
+              installAccountDeletionFence(pointers, TABLE_ID.getAccountId());
             }
           }
         };

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/StatsRepositoryTargetStorageTest.java
@@ -75,6 +75,20 @@ class StatsRepositoryTargetStorageTest {
   private static final ResourceId TABLE_ID =
       ResourceId.newBuilder().setAccountId("a").setId("t").setKind(ResourceKind.RK_TABLE).build();
 
+  private static void installAccountDeletionFence(InMemoryPointerStore pointers, String accountId) {
+    List<PointerStore.CasOp> creates = new ArrayList<>();
+    String markerKey = Keys.accountDeletionMarker(accountId);
+    creates.add(
+        new PointerStore.CasUpsert(
+            markerKey, 0L, PointerReferences.opaqueMarkerPointer(markerKey, "deleting", 1L)));
+    for (String shardKey : Keys.accountDeletionFenceShards(accountId)) {
+      creates.add(
+          new PointerStore.CasUpsert(
+              shardKey, 0L, PointerReferences.opaqueMarkerPointer(shardKey, "deleting", 1L)));
+    }
+    assertThat(pointers.compareAndSetBatch(creates)).isTrue();
+  }
+
   @Test
   void targetStatsWriteDeletesBlobWhenAccountFenceWinsPublicationRace() {
     InMemoryPointerStore pointers = new InMemoryPointerStore();
@@ -96,9 +110,7 @@ class StatsRepositoryTargetStorageTest {
             if (uri.startsWith(Keys.tableBlobPrefix(TABLE_ID.getAccountId(), TABLE_ID.getId()))
                 && installFence.compareAndSet(true, false)) {
               racedBlob.set(uri);
-              String fence = Keys.accountDeletionMarker(TABLE_ID.getAccountId());
-              pointers.compareAndSet(
-                  fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "deleting", 1L));
+              installAccountDeletionFence(pointers, TABLE_ID.getAccountId());
             }
           }
         };
@@ -1399,9 +1411,7 @@ class StatsRepositoryTargetStorageTest {
           public void put(String uri, byte[] bytes, String contentType) {
             super.put(uri, bytes, contentType);
             if (preexistingBlob.equals(uri) && installFence.compareAndSet(true, false)) {
-              String fence = Keys.accountDeletionMarker(TABLE_ID.getAccountId());
-              pointers.compareAndSet(
-                  fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "deleting", 1L));
+              installAccountDeletionFence(pointers, TABLE_ID.getAccountId());
             }
           }
         };

--- a/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/model/KeysTest.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.service.repo.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.types.Hashing;
 import java.util.List;
@@ -67,6 +68,38 @@ class KeysTest {
     assertEquals(
         "/accounts/acct%20id/catalog-overlays/deleting/overlay%2Fid",
         Keys.catalogOverlayDeletionMarker("acct id", "overlay/id"));
+  }
+
+  @Test
+  void accountDeletionFenceShardsAreExternalAndPathSafe() {
+    List<String> shards = Keys.accountDeletionFenceShards("acct id/encoded");
+
+    assertEquals(Keys.ACCOUNT_DELETION_FENCE_SHARDS, shards.size());
+    assertEquals("/account-deletion-fences/acct%20id%2Fencoded/00", shards.getFirst());
+    assertEquals("/account-deletion-fences/acct%20id%2Fencoded/63", shards.getLast());
+  }
+
+  @Test
+  void everyDerivedFenceShardBelongsToTheAccountFenceSet() {
+    List<String> shards = Keys.accountDeletionFenceShards("account/with encoding");
+
+    for (int i = 0; i < 1024; i++) {
+      assertTrue(
+          shards.contains(
+              Keys.accountDeletionFenceShard(
+                  "account/with encoding", "/accounts/account/write-" + i)));
+    }
+  }
+
+  @Test
+  void representativeWritesUseMostFenceShards() {
+    long distinct =
+        java.util.stream.IntStream.range(0, 1024)
+            .mapToObj(i -> Keys.accountDeletionFenceShard("account", "write-" + i))
+            .distinct()
+            .count();
+
+    assertTrue(distinct >= 48, "expected useful distribution but used " + distinct + " shards");
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/util/AccountDeletionFenceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/util/AccountDeletionFenceTest.java
@@ -16,10 +16,13 @@
 package ai.floedb.floecat.service.repo.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.model.PointerReferences;
+import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -41,14 +44,68 @@ class AccountDeletionFenceTest {
   @Test
   void accountScopedWriteCreatesItsExactFenceCheck() {
     String accountId = "account/with+encoding";
+    String writeKey = Keys.reconcileJobPointerById(accountId, "job");
 
     assertEquals(
-        List.of(new PointerStore.CasCheckAbsent(Keys.accountDeletionMarker(accountId))),
+        List.of(
+            new PointerStore.CasCheckAbsent(Keys.accountDeletionFenceShard(accountId, writeKey))),
         AccountDeletionFence.checksForAccountWrites(
-            List.of(
-                new PointerStore.CasUpsert(
-                    Keys.reconcileJobPointerById(accountId, "job"),
-                    0L,
-                    Pointer.getDefaultInstance()))));
+            List.of(new PointerStore.CasUpsert(writeKey, 0L, Pointer.getDefaultInstance()))));
+  }
+
+  @Test
+  void accountScopedBatchUsesOnlyOneShardPerAccount() {
+    String accountId = "account";
+
+    assertEquals(
+        1,
+        AccountDeletionFence.checksForAccountWrites(
+                List.of(
+                    new PointerStore.CasUpsert(
+                        Keys.reconcileJobPointerById(accountId, "job-a"),
+                        0L,
+                        Pointer.getDefaultInstance()),
+                    new PointerStore.CasUpsert(
+                        Keys.reconcileJobPointerById(accountId, "job-b"),
+                        0L,
+                        Pointer.getDefaultInstance())))
+            .size());
+  }
+
+  @Test
+  void independentWritesSpreadAcrossShards() {
+    String accountId = "account";
+
+    long distinctShards =
+        java.util.stream.IntStream.range(0, 64)
+            .mapToObj(i -> Keys.reconcileJobPointerById(accountId, "job-" + i))
+            .map(key -> Keys.accountDeletionFenceShard(accountId, key))
+            .distinct()
+            .count();
+
+    assertTrue(distinctShards > 1);
+  }
+
+  @Test
+  void selectedNonzeroShardBlocksItsWrite() {
+    String accountId = "account";
+    String firstShard = Keys.accountDeletionFenceShards(accountId).getFirst();
+    String writeKey =
+        java.util.stream.IntStream.range(0, 1024)
+            .mapToObj(i -> Keys.reconcileJobPointerById(accountId, "job-" + i))
+            .filter(key -> !Keys.accountDeletionFenceShard(accountId, key).equals(firstShard))
+            .findFirst()
+            .orElseThrow();
+    String selectedShard = Keys.accountDeletionFenceShard(accountId, writeKey);
+    InMemoryPointerStore pointers = new InMemoryPointerStore();
+    assertTrue(
+        pointers.compareAndSet(
+            selectedShard,
+            0L,
+            PointerReferences.opaqueMarkerPointer(selectedShard, "deleting", 1L)));
+
+    assertFalse(
+        AccountDeletionFence.compareAndSet(
+            pointers, accountId, writeKey, 0L, Pointer.getDefaultInstance()));
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/util/MarkerStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/util/MarkerStoreTest.java
@@ -42,8 +42,16 @@ class MarkerStoreTest {
             .setId("catalog")
             .setKind(ResourceKind.RK_CATALOG)
             .build();
-    String fence = Keys.accountDeletionMarker("acct");
-    pointers.compareAndSet(fence, 0L, PointerReferences.opaqueMarkerPointer(fence, "acct", 1L));
+    String marker = Keys.accountDeletionMarker("acct");
+    String writeKey = Keys.catalogChildrenMarker("acct", "catalog");
+    String gate = Keys.accountDeletionFenceShard("acct", writeKey);
+    assertTrue(
+        pointers.compareAndSetBatch(
+            List.of(
+                new PointerStore.CasUpsert(
+                    marker, 0L, PointerReferences.opaqueMarkerPointer(marker, "deleting", 1L)),
+                new PointerStore.CasUpsert(
+                    gate, 0L, PointerReferences.opaqueMarkerPointer(gate, "deleting", 1L)))));
 
     markers.bumpCatalogMarker(catalogId);
 

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionIntentApplierSupportTest.java
@@ -136,8 +136,16 @@ class TransactionIntentApplierSupportTest {
     var support = newSupport(pointers, blobs);
     String targetKey = "/accounts/acct/custom/key-1";
     String markerKey = Keys.accountDeletionMarker("acct");
-    pointers.compareAndSet(
-        markerKey, 0L, PointerReferences.opaqueMarkerPointer(markerKey, "deleting", 1L));
+    List<ai.floedb.floecat.storage.spi.PointerStore.CasOp> creates = new ArrayList<>();
+    creates.add(
+        new ai.floedb.floecat.storage.spi.PointerStore.CasUpsert(
+            markerKey, 0L, PointerReferences.opaqueMarkerPointer(markerKey, "deleting", 1L)));
+    for (String shardKey : Keys.accountDeletionFenceShards("acct")) {
+      creates.add(
+          new ai.floedb.floecat.storage.spi.PointerStore.CasUpsert(
+              shardKey, 0L, PointerReferences.opaqueMarkerPointer(shardKey, "deleting", 1L)));
+    }
+    assertTrue(pointers.compareAndSetBatch(creates));
     TransactionIntent intent =
         TransactionIntent.newBuilder()
             .setAccountId("acct")
@@ -184,9 +192,18 @@ class TransactionIntentApplierSupportTest {
     intentRepo.create(intent);
     String markerKey = Keys.accountDeletionMarker(accountId);
     pointers.beforeBatch(
-        () ->
-            pointers.compareAndSet(
-                markerKey, 0L, PointerReferences.opaqueMarkerPointer(markerKey, "deleting", 1L)));
+        () -> {
+          List<ai.floedb.floecat.storage.spi.PointerStore.CasOp> creates = new ArrayList<>();
+          creates.add(
+              new ai.floedb.floecat.storage.spi.PointerStore.CasUpsert(
+                  markerKey, 0L, PointerReferences.opaqueMarkerPointer(markerKey, "deleting", 1L)));
+          for (String shardKey : Keys.accountDeletionFenceShards(accountId)) {
+            creates.add(
+                new ai.floedb.floecat.storage.spi.PointerStore.CasUpsert(
+                    shardKey, 0L, PointerReferences.opaqueMarkerPointer(shardKey, "deleting", 1L)));
+          }
+          pointers.compareAndSetBatch(creates);
+        });
     Transaction appliedTxn =
         currentTxn.toBuilder()
             .setState(TransactionState.TS_APPLIED)

--- a/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetter.java
+++ b/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetter.java
@@ -21,6 +21,7 @@ import ai.floedb.floecat.service.reconciler.jobs.durable.store.MemoryReconcileJo
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
+import ai.floedb.floecat.storage.spi.PointerStoreKeys;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -82,6 +83,9 @@ public class TestDataResetter {
       }
       ptr.deleteByPrefix("/accounts/");
       ptr.deleteByPrefix("accounts/");
+      if (!"dynamodb".equalsIgnoreCase(kvMode)) {
+        ptr.deleteByPrefix(PointerStoreKeys.ACCOUNT_DELETION_FENCE_PREFIX);
+      }
       if (memoryReconcileJobIndexBackend != null && memoryReconcileJobIndexBackend.isResolvable()) {
         memoryReconcileJobIndexBackend.get().clearInMemoryState();
       }

--- a/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/util/TestDataResetterTest.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.util;
 import static org.junit.jupiter.api.Assertions.*;
 
 import ai.floedb.floecat.common.rpc.Pointer;
+import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import java.util.ArrayList;
@@ -84,6 +85,20 @@ public class TestDataResetterTest {
     TestDataResetter resetter = resetter(ptr, new FakeBlobStore());
     resetter.wipeAll();
     assertTrue(ptr.isEmpty());
+  }
+
+  @Test
+  void wipeAll_removes_fences_for_an_account_already_deleted() {
+    FakePointerStore ptr = new FakePointerStore();
+    String fence = Keys.accountDeletionFenceShards("deleted-account").getFirst();
+    ptr.putPointer(fence, 1L);
+    ptr.putPointer("/other/keep", 1L);
+
+    TestDataResetter resetter = resetter(ptr, new FakeBlobStore());
+    resetter.wipeAll();
+
+    assertFalse(ptr.containsKey(fence));
+    assertTrue(ptr.containsKey("/other/keep"));
   }
 
   @Test

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntity.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.storage.kv.KvStore;
 import ai.floedb.floecat.storage.kv.KvStore.Key;
 import ai.floedb.floecat.storage.kv.cdi.KvTable;
 import ai.floedb.floecat.storage.spi.PointerStore;
+import ai.floedb.floecat.storage.spi.PointerStoreKeys;
 import com.google.protobuf.util.Timestamps;
 import io.quarkus.arc.properties.IfBuildProperty;
 import io.smallrye.mutiny.Uni;
@@ -86,6 +87,10 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
     if (k.startsWith("accounts/by-id/") || k.startsWith("accounts/by-name/")) {
       return new KvStore.Key(GLOBAL_PK, k);
     }
+    String fencePrefix = stripLeadingSlash(PointerStoreKeys.ACCOUNT_DELETION_FENCE_PREFIX);
+    if (k.startsWith(fencePrefix)) {
+      return accountDeletionFenceKey(k, fencePrefix);
+    }
     if (k.startsWith(CREDENTIAL_CLEANUP_PREFIX)) {
       return new KvStore.Key(CREDENTIAL_CLEANUP_PK, k);
     }
@@ -119,6 +124,10 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
 
     if (p.startsWith("accounts/by-id/") || p.startsWith("accounts/by-name/")) {
       return new KvStore.Key(GLOBAL_PK, p);
+    }
+    String fencePrefix = stripLeadingSlash(PointerStoreKeys.ACCOUNT_DELETION_FENCE_PREFIX);
+    if (p.startsWith(fencePrefix)) {
+      return accountDeletionFenceKey(p, fencePrefix);
     }
     if (p.equals("catalog-integration-credential-cleanup")
         || p.startsWith(CREDENTIAL_CLEANUP_PREFIX)) {
@@ -420,9 +429,32 @@ public final class PointerStoreEntity extends AbstractEntity<Pointer> {
   private String keyOf(Key key) {
     if (key.partitionKey().equals(GLOBAL_PK) || key.partitionKey().equals(CREDENTIAL_CLEANUP_PK)) {
       return "/" + key.sortKey();
+    } else if (key.partitionKey()
+        .startsWith(PointerStoreKeys.ACCOUNT_DELETION_FENCE_PARTITION_PREFIX)) {
+      String fenceSegment =
+          key.partitionKey()
+              .substring(PointerStoreKeys.ACCOUNT_DELETION_FENCE_PARTITION_PREFIX.length());
+      return PointerStoreKeys.ACCOUNT_DELETION_FENCE_PREFIX + fenceSegment;
     } else {
       return key.toString();
     }
+  }
+
+  private static KvStore.Key accountDeletionFenceKey(String key, String fencePrefix) {
+    String remainder = key.substring(fencePrefix.length());
+    int slash = remainder.indexOf('/');
+    if (slash <= 0 || slash == remainder.length() - 1 || remainder.indexOf('/', slash + 1) >= 0) {
+      throw new IllegalArgumentException("bad account deletion fence key: " + key);
+    }
+    String accountSegment = remainder.substring(0, slash);
+    String shard = remainder.substring(slash + 1);
+    return new KvStore.Key(
+        PointerStoreKeys.ACCOUNT_DELETION_FENCE_PARTITION_PREFIX + accountSegment + "/" + shard,
+        PointerStoreKeys.ACCOUNT_DELETION_FENCE_SORT_KEY);
+  }
+
+  private static String stripLeadingSlash(String value) {
+    return value.startsWith("/") ? value.substring(1) : value;
   }
 
   static KvStore.Key _testKey(String key) {

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/ps/PointerStoreEntityContractTest.java
@@ -78,6 +78,21 @@ public class PointerStoreEntityContractTest extends AbstractEntityTest<Pointer> 
   }
 
   @Test
+  void pointerKey_account_deletion_fence_routes_to_account_fence_partition() {
+    KvStore.Key key = PointerStoreEntity._testKey("/account-deletion-fences/acct/07");
+    assertEquals("_ACCOUNT_DELETION_FENCE/acct/07", key.partitionKey());
+    assertEquals("gate", key.sortKey());
+  }
+
+  @Test
+  void pointerKey_account_deletion_fence_shard_changes_partition() {
+    KvStore.Key shard07 = PointerStoreEntity._testKey("/account-deletion-fences/acct/07");
+    KvStore.Key shard08 = PointerStoreEntity._testKey("/account-deletion-fences/acct/08");
+
+    assertFalse(shard07.partitionKey().equals(shard08.partitionKey()));
+  }
+
+  @Test
   void pointerKey_account_scoped_routes_to_partition_accounts_accountId() {
     KvStore.Key key = PointerStoreEntity._testKey("accounts/77/catalog/xyz");
     assertEquals("accounts/77", key.partitionKey());


### PR DESCRIPTION
## Summary

This removes the account-deletion fence hotspot while preserving deletion safety.

- Replace the single per-account deletion fence with 64 independently partitioned fence shards.
- Atomically install, repair, and clear all shards during account deletion.
- Route writers through a deterministic shard and remove deletion-marker pre-reads from successful write paths.
- Preserve marker reads only for classifying failed writes as account deletion conflicts.
- Add coverage for shard distribution, DynamoDB routing, fence lifecycle, and affected writer paths.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
