### PR TITLE
fix(idempotency): commit receipts atomically with keyed mutations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     if: needs.detect-core-changes.outputs.core_changed == 'true'
     name: ci-localstack
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-localstack
       cancel-in-progress: false

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/errors/StorageTransactionConflictException.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/errors/StorageTransactionConflictException.java
@@ -16,12 +16,9 @@
 
 package ai.floedb.floecat.storage.errors;
 
-public class StorageAbortRetryableException extends StorageException {
-  public StorageAbortRetryableException(String message) {
-    super(message);
-  }
-
-  public StorageAbortRetryableException(String message, Throwable cause) {
+/** A storage transaction was definitively cancelled without applying any of its mutations. */
+public final class StorageTransactionConflictException extends StorageAbortRetryableException {
+  public StorageTransactionConflictException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/kv/KvStore.java
@@ -208,6 +208,8 @@ public interface KvStore {
    * Transactionally perform CAS puts/deletes.
    *
    * @return true if committed; false if any condition failed
+   * @throws ai.floedb.floecat.storage.errors.StorageTransactionConflictException if the backend
+   *     definitively cancelled the transaction without applying any mutation
    */
   Uni<Boolean> txnWriteCas(List<TxnOp> ops);
 

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/ReconcileJobStore.java
@@ -2077,6 +2077,7 @@ public interface ReconcileJobStore {
     public final Set<String> lanes;
     public final Set<String> executorIds;
     public final Set<ReconcileJobKind> jobKinds;
+    private final String deploymentLane;
 
     /**
      * Deployment cohort this worker belongs to, or empty when affinity is disabled. The job store
@@ -2098,8 +2099,20 @@ public interface ReconcileJobStore {
         Set<String> executorIds,
         Set<ReconcileJobKind> jobKinds,
         ReconcileWorkerAffinity workerAffinity) {
+      this(executionClasses, lanes, executorIds, jobKinds, workerAffinity, null);
+    }
+
+    private LeaseRequest(
+        Set<ReconcileExecutionClass> executionClasses,
+        Set<String> lanes,
+        Set<String> executorIds,
+        Set<ReconcileJobKind> jobKinds,
+        ReconcileWorkerAffinity workerAffinity,
+        String deploymentLane) {
       this.workerAffinity =
           workerAffinity == null ? ReconcileWorkerAffinity.DISABLED : workerAffinity;
+      this.deploymentLane =
+          deploymentLane == null ? null : ReconcileExecutionPolicy.normalizeLane(deploymentLane);
       this.executionClasses =
           executionClasses == null
               ? Set.of()
@@ -2176,7 +2189,14 @@ public interface ReconcileJobStore {
       String effectivePinnedExecutorId = pinnedExecutorId == null ? "" : pinnedExecutorId.trim();
       boolean executorMatches =
           effectivePinnedExecutorId.isEmpty() || executorIds.contains(effectivePinnedExecutorId);
-      return classMatches && laneMatches && kindMatches && executorMatches && cohortMatches(policy);
+      boolean deploymentLaneMatches =
+          deploymentLane == null || deploymentLane.equals(effective.lane());
+      return classMatches
+          && laneMatches
+          && kindMatches
+          && executorMatches
+          && deploymentLaneMatches
+          && cohortMatches(policy);
     }
 
     /**
@@ -2193,7 +2213,17 @@ public interface ReconcileJobStore {
           workerAffinity == null ? ReconcileWorkerAffinity.DISABLED : workerAffinity;
       return effective.equals(this.workerAffinity)
           ? this
-          : new LeaseRequest(executionClasses, lanes, executorIds, jobKinds, effective);
+          : new LeaseRequest(
+              executionClasses, lanes, executorIds, jobKinds, effective, deploymentLane);
+    }
+
+    /** Returns this request constrained to the Floecat deployment's configured execution lane. */
+    public LeaseRequest withDeploymentLane(String deploymentLane) {
+      String effective = ReconcileExecutionPolicy.normalizeLane(deploymentLane);
+      return effective.equals(this.deploymentLane)
+          ? this
+          : new LeaseRequest(
+              executionClasses, lanes, executorIds, jobKinds, workerAffinity, effective);
     }
 
     public static String anyLaneToken() {

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStore.java
@@ -978,7 +978,9 @@ public class InMemoryReconcileJobStore implements ReconcileJobStore {
     long now = System.currentTimeMillis();
     reclaimExpiredLeasesIfDue(now);
     LeaseRequest effective =
-        (request == null ? LeaseRequest.all() : request).withWorkerAffinity(workerAffinity);
+        (request == null ? LeaseRequest.all() : request)
+            .withWorkerAffinity(workerAffinity)
+            .withDeploymentLane(executionLane);
     int attempts = Math.max(1, ready.size());
     for (int i = 0; i < attempts; i++) {
       String jobId = ready.poll();

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/jobs/impl/InMemoryReconcileJobStoreTest.java
@@ -36,6 +36,7 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileViewTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileWorkerAffinity;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -266,6 +267,26 @@ class InMemoryReconcileJobStoreTest {
     assertFalse(
         request.withWorkerAffinity(ReconcileWorkerAffinity.of("ci-branch")).cohortMatches(legacy));
     assertTrue(request.cohortMatches(legacy));
+  }
+
+  @Test
+  void deploymentLaneIsAnIndependentServerOwnedLeaseConstraint() {
+    ReconcileJobStore.LeaseRequest request =
+        new ReconcileJobStore.LeaseRequest(
+            null,
+            Set.of(ReconcileJobStore.LeaseRequest.anyLaneToken()),
+            Set.of(),
+            EnumSet.of(ReconcileJobKind.EXEC_FILE_GROUP));
+    ReconcileExecutionPolicy configuredLane =
+        ReconcileExecutionPolicy.of(ReconcileExecutionClass.DEFAULT, "ci-run", Map.of());
+    ReconcileExecutionPolicy foreignLane =
+        ReconcileExecutionPolicy.of(ReconcileExecutionClass.DEFAULT, "other-run", Map.of());
+
+    ReconcileJobStore.LeaseRequest constrained = request.withDeploymentLane("ci-run");
+
+    assertTrue(
+        constrained.matches(configuredLane, "", ReconcileJobKind.EXEC_FILE_GROUP, "group-1"));
+    assertFalse(constrained.matches(foreignLane, "", ReconcileJobKind.EXEC_FILE_GROUP, "group-1"));
   }
 
   @Test

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -214,41 +214,66 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                         .build();
                   }
 
+                  var existingForIdempotency = accountRepo.getByName(normName);
                   var result =
-                      runIdempotentCreate(
+                      MutationOps.createProtoRecoverable(
+                          idempotencyAccount,
+                          "CreateAccount",
+                          idempotencyKey,
+                          () -> fingerprint,
                           () ->
-                              MutationOps.createProto(
-                                  idempotencyAccount,
-                                  "CreateAccount",
-                                  idempotencyKey,
-                                  () -> fingerprint,
-                                  () -> {
-                                    try {
-                                      accountRepo.create(desiredAccount);
-                                    } catch (BaseResourceRepository.NameConflictException nce) {
-                                      var existingOpt = accountRepo.getByName(normName);
-                                      if (existingOpt.isPresent()) {
-                                        var existingSpec = specFromAccount(existingOpt.get());
-                                        if (Arrays.equals(
-                                            fingerprint, canonicalFingerprint(existingSpec))) {
-                                          return new IdempotencyGuard.CreateResult<>(
-                                              existingOpt.get(), existingOpt.get().getResourceId());
-                                        }
-                                      }
-                                      throw GrpcErrors.alreadyExists(
-                                          corr,
-                                          ACCOUNT_ALREADY_EXISTS,
-                                          Map.of("display_name", normName));
-                                    }
-                                    return new IdempotencyGuard.CreateResult<>(
-                                        desiredAccount, resourceId);
-                                  },
-                                  (t) -> accountRepo.metaFor(t.getResourceId()),
-                                  idempotencyStore,
-                                  tsNow,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  Account::parseFrom));
+                              existingForIdempotency
+                                  .filter(
+                                      existing ->
+                                          Arrays.equals(
+                                              fingerprint,
+                                              canonicalFingerprint(specFromAccount(existing))))
+                                  .map(Account::getResourceId)
+                                  .orElse(resourceId),
+                          (reservedId, committer) -> {
+                            var existingOpt = accountRepo.getByName(normName);
+                            if (existingOpt.isPresent()) {
+                              var existing = existingOpt.get();
+                              if (!existing.getResourceId().equals(reservedId)
+                                  || !Arrays.equals(
+                                      fingerprint,
+                                      canonicalFingerprint(specFromAccount(existing)))) {
+                                throw GrpcErrors.alreadyExists(
+                                    corr, ACCOUNT_ALREADY_EXISTS, Map.of("display_name", normName));
+                              }
+                              var currentMeta = accountRepo.metaFor(reservedId);
+                              var completed =
+                                  accountRepo.completeWithMetaIfUnchanged(
+                                      existing,
+                                      currentMeta.getPointerVersion(),
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              if (completed.isEmpty()) {
+                                throw new BaseResourceRepository.AbortRetryableException(
+                                    "account changed while committing idempotency receipt");
+                              }
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  existing, reservedId, completed.get());
+                            }
+                            var reserved =
+                                desiredAccount.toBuilder().setResourceId(reservedId).build();
+                            var committed =
+                                accountRepo.createWithCompletion(
+                                    reserved,
+                                    resource ->
+                                        committer.prepareOps(
+                                            new IdempotencyGuard.CommittedCreate<>(
+                                                resource.value(), reservedId, resource.meta())));
+                            return new IdempotencyGuard.CommittedCreate<>(
+                                committed.value(), reservedId, committed.meta());
+                          },
+                          idempotencyStore,
+                          tsNow,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          Account::parseFrom);
 
                   return CreateAccountResponse.newBuilder()
                       .setAccount(result.body)

--- a/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/account/impl/AccountServiceImpl.java
@@ -53,6 +53,7 @@ import ai.floedb.floecat.service.repo.impl.TableRootRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.service.storage.impl.StorageAuthorityResolver;
@@ -247,7 +248,7 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                                       existing,
                                       currentMeta.getPointerVersion(),
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               if (completed.isEmpty()) {
@@ -259,13 +260,19 @@ public class AccountServiceImpl extends BaseServiceImpl implements AccountServic
                             }
                             var reserved =
                                 desiredAccount.toBuilder().setResourceId(reservedId).build();
-                            var committed =
-                                accountRepo.createWithCompletion(
-                                    reserved,
-                                    resource ->
-                                        committer.prepareOps(
-                                            new IdempotencyGuard.CommittedCreate<>(
-                                                resource.value(), reservedId, resource.meta())));
+                            final GenericResourceRepository.ResourceWithMeta<Account> committed;
+                            try {
+                              committed =
+                                  accountRepo.createWithCompletion(
+                                      reserved,
+                                      resource ->
+                                          committer.prepareSuccessOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                            } catch (BaseResourceRepository.NameConflictException conflict) {
+                              throw GrpcErrors.alreadyExists(
+                                  corr, ACCOUNT_ALREADY_EXISTS, Map.of("display_name", normName));
+                            }
                             return new IdempotencyGuard.CommittedCreate<>(
                                 committed.value(), reservedId, committed.meta());
                           },

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImpl.java
@@ -176,43 +176,67 @@ public class CatalogServiceImpl extends BaseServiceImpl implements CatalogServic
                         .build();
                   }
 
+                  var existingForIdempotency = catalogRepo.getByName(accountId, normName);
                   var result =
-                      runIdempotentCreate(
+                      MutationOps.createProtoRecoverable(
+                          accountId,
+                          "CreateCatalog",
+                          idempotencyKey,
+                          () -> fingerprint,
                           () ->
-                              MutationOps.createProto(
-                                  accountId,
-                                  "CreateCatalog",
-                                  idempotencyKey,
-                                  () -> fingerprint,
-                                  () -> {
-                                    try {
-                                      catalogRepo.create(built);
-                                    } catch (BaseResourceRepository.NameConflictException nce) {
-                                      var existingOpt = catalogRepo.getByName(accountId, normName);
-                                      if (existingOpt.isPresent()) {
-                                        var existingSpec = specFromCatalog(existingOpt.get());
-                                        if (Arrays.equals(
-                                            fingerprint, canonicalFingerprint(existingSpec))) {
-                                          metadataGraph.invalidate(
-                                              existingOpt.get().getResourceId());
-                                          return new IdempotencyGuard.CreateResult<>(
-                                              existingOpt.get(), existingOpt.get().getResourceId());
-                                        }
-                                      }
-                                      throw GrpcErrors.alreadyExists(
-                                          corr,
-                                          CATALOG_ALREADY_EXISTS,
-                                          Map.of("display_name", normName));
-                                    }
-                                    metadataGraph.invalidate(catalogId);
-                                    return new IdempotencyGuard.CreateResult<>(built, catalogId);
-                                  },
-                                  c -> catalogRepo.metaForSafe(c.getResourceId()),
-                                  idempotencyStore,
-                                  tsNow,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  Catalog::parseFrom));
+                              existingForIdempotency
+                                  .filter(
+                                      existing ->
+                                          Arrays.equals(
+                                              fingerprint,
+                                              canonicalFingerprint(specFromCatalog(existing))))
+                                  .map(Catalog::getResourceId)
+                                  .orElse(catalogId),
+                          (reservedId, committer) -> {
+                            var existingOpt = catalogRepo.getByName(accountId, normName);
+                            if (existingOpt.isPresent()) {
+                              var existing = existingOpt.get();
+                              if (!existing.getResourceId().equals(reservedId)
+                                  || !Arrays.equals(
+                                      fingerprint,
+                                      canonicalFingerprint(specFromCatalog(existing)))) {
+                                throw GrpcErrors.alreadyExists(
+                                    corr, CATALOG_ALREADY_EXISTS, Map.of("display_name", normName));
+                              }
+                              var currentMeta = catalogRepo.metaForSafe(reservedId);
+                              var completed =
+                                  catalogRepo.completeWithMetaIfUnchanged(
+                                      existing,
+                                      currentMeta.getPointerVersion(),
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              if (completed.isEmpty()) {
+                                throw new BaseResourceRepository.AbortRetryableException(
+                                    "catalog changed while committing idempotency receipt");
+                              }
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  existing, reservedId, completed.get());
+                            }
+                            var reserved = built.toBuilder().setResourceId(reservedId).build();
+                            var committed =
+                                catalogRepo.createWithCompletion(
+                                    reserved,
+                                    resource ->
+                                        committer.prepareOps(
+                                            new IdempotencyGuard.CommittedCreate<>(
+                                                resource.value(), reservedId, resource.meta())));
+                            return new IdempotencyGuard.CommittedCreate<>(
+                                committed.value(), reservedId, committed.meta());
+                          },
+                          idempotencyStore,
+                          tsNow,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          Catalog::parseFrom);
+
+                  metadataGraph.invalidate(result.body.getResourceId());
 
                   return CreateCatalogResponse.newBuilder()
                       .setCatalog(result.body)

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImpl.java
@@ -50,6 +50,7 @@ import ai.floedb.floecat.service.repo.impl.CatalogOverlayRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.impl.NamespaceRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
@@ -209,7 +210,7 @@ public class CatalogServiceImpl extends BaseServiceImpl implements CatalogServic
                                       existing,
                                       currentMeta.getPointerVersion(),
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               if (completed.isEmpty()) {
@@ -220,13 +221,19 @@ public class CatalogServiceImpl extends BaseServiceImpl implements CatalogServic
                                   existing, reservedId, completed.get());
                             }
                             var reserved = built.toBuilder().setResourceId(reservedId).build();
-                            var committed =
-                                catalogRepo.createWithCompletion(
-                                    reserved,
-                                    resource ->
-                                        committer.prepareOps(
-                                            new IdempotencyGuard.CommittedCreate<>(
-                                                resource.value(), reservedId, resource.meta())));
+                            final GenericResourceRepository.ResourceWithMeta<Catalog> committed;
+                            try {
+                              committed =
+                                  catalogRepo.createWithCompletion(
+                                      reserved,
+                                      resource ->
+                                          committer.prepareSuccessOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                            } catch (BaseResourceRepository.NameConflictException conflict) {
+                              throw GrpcErrors.alreadyExists(
+                                  corr, CATALOG_ALREADY_EXISTS, Map.of("display_name", normName));
+                            }
                             return new IdempotencyGuard.CommittedCreate<>(
                                 committed.value(), reservedId, committed.meta());
                           },

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CurrentSnapshotPointerService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/CurrentSnapshotPointerService.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -66,7 +67,9 @@ public class CurrentSnapshotPointerService {
     }
     switch (result) {
       case TABLE_MISSING -> throw GrpcErrors.notFound(corr, TABLE, Map.of("id", tableId.getId()));
-      case CONFLICT -> throw GrpcErrors.aborted(corr, Map.of("id", tableId.getId()));
+      case CONFLICT ->
+          throw new BaseResourceRepository.AbortRetryableException(
+              "current snapshot pointer changed for table " + tableId.getId());
       default -> {}
     }
     rootWriter.commitSnapshotEntry(tableId, candidate.getSnapshotId());
@@ -78,6 +81,11 @@ public class CurrentSnapshotPointerService {
       // later finalize to attach that generation ref, so reconcile it now through the finalize
       // path: a no-op when the gate is off, when the candidate is not yet finalized (its own
       // finalize will publish it), or when the root entry already carries the ref.
+      //
+      // A failed publication leaves a durable root-resync marker before propagating. A retry that
+      // now observes UNCHANGED still skips this synchronous publication, so visibility may converge
+      // on the GC cadence. Removing the guard would close that window at the cost of an extra root
+      // read and commit attempt for every snapshot write; keep that measurable trade separate.
       rootWriter.commitStatsGeneration(tableId, candidate.getSnapshotId());
     }
   }

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
@@ -219,89 +219,117 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                           ? request.getIdempotency().getKey()
                           : null;
 
+                  if (!parents.isEmpty()) {
+                    ensurePathChainExists(
+                        accountId, spec.getCatalogId(), parents, tsNow, correlationId);
+                  }
+
+                  var existingForIdempotency =
+                      namespaceRepo.getByPath(accountId, spec.getCatalogId().getId(), fullPath);
+
                   var namespaceProto =
-                      runIdempotentCreate(
+                      MutationOps.createProtoRecoverable(
+                          accountId,
+                          "CreateNamespace",
+                          idempotencyKey,
+                          () -> fingerprint,
                           () ->
-                              MutationOps.createProto(
-                                  accountId,
-                                  "CreateNamespace",
-                                  idempotencyKey,
-                                  () -> fingerprint,
-                                  () -> {
-                                    if (!parents.isEmpty()) {
-                                      ensurePathChainExists(
-                                          accountId,
-                                          spec.getCatalogId(),
-                                          parents,
-                                          tsNow,
-                                          correlationId);
-                                    }
-
-                                    var namespaceId =
-                                        randomResourceId(accountId, ResourceKind.RK_NAMESPACE);
-
-                                    var built =
-                                        Namespace.newBuilder()
-                                            .setResourceId(namespaceId)
-                                            .setDisplayName(display)
-                                            .clearParents()
-                                            .addAllParents(parents)
-                                            .setDescription(spec.getDescription())
-                                            .putAllProperties(spec.getPropertiesMap())
-                                            .setCatalogId(spec.getCatalogId())
-                                            .setCreatedAt(tsNow)
-                                            .build();
-
-                                    try {
-                                      namespaceRepo.create(built);
-                                    } catch (BaseResourceRepository.NameConflictException nce) {
-                                      var existingOpt =
-                                          namespaceRepo.getByPath(
-                                              accountId, spec.getCatalogId().getId(), fullPath);
-                                      if (existingOpt.isPresent()) {
-                                        var existing = existingOpt.get();
+                              existingForIdempotency
+                                  .filter(
+                                      existing -> {
                                         var existingSpec = specFromNamespace(existing);
-                                        var existingFingerprint =
+                                        return Arrays.equals(
+                                            fingerprint,
                                             canonicalFingerprint(
                                                 existing.getCatalogId(),
                                                 existing.getParentsList(),
                                                 existing.getDisplayName(),
-                                                existingSpec);
-                                        if (Arrays.equals(fingerprint, existingFingerprint)) {
-                                          markerStore.bumpCatalogMarker(existing.getCatalogId());
-                                          bumpParentNamespaceMarker(
-                                              accountId,
-                                              existing.getCatalogId(),
-                                              existing.getParentsList());
-                                          metadataGraph.invalidate(existing.getResourceId());
-                                          topology.evictNamespaceRefs(existing.getCatalogId());
-                                          return new IdempotencyGuard.CreateResult<>(
-                                              existing, existing.getResourceId());
-                                        }
-                                      }
-                                      throw GrpcErrors.alreadyExists(
-                                          correlationId,
-                                          GeneratedErrorMessages.MessageKey
-                                              .NAMESPACE_ALREADY_EXISTS,
-                                          Map.of(
-                                              "catalog",
-                                              catalogName,
-                                              "path",
-                                              String.join(".", fullPath)));
-                                    }
-                                    markerStore.bumpCatalogMarker(spec.getCatalogId());
-                                    bumpParentNamespaceMarker(
-                                        accountId, spec.getCatalogId(), parents);
-                                    metadataGraph.invalidate(namespaceId);
-                                    topology.evictNamespaceRefs(spec.getCatalogId());
-                                    return new IdempotencyGuard.CreateResult<>(built, namespaceId);
-                                  },
-                                  (ns) -> namespaceRepo.metaForSafe(ns.getResourceId()),
-                                  idempotencyStore,
-                                  tsNow,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  Namespace::parseFrom));
+                                                existingSpec));
+                                      })
+                                  .map(Namespace::getResourceId)
+                                  .orElseGet(
+                                      () -> randomResourceId(accountId, ResourceKind.RK_NAMESPACE)),
+                          (reservedId, committer) -> {
+                            var built =
+                                Namespace.newBuilder()
+                                    .setResourceId(reservedId)
+                                    .setDisplayName(display)
+                                    .clearParents()
+                                    .addAllParents(parents)
+                                    .setDescription(spec.getDescription())
+                                    .putAllProperties(spec.getPropertiesMap())
+                                    .setCatalogId(spec.getCatalogId())
+                                    .setCreatedAt(tsNow)
+                                    .build();
+                            var existingOpt =
+                                namespaceRepo.getByPath(
+                                    accountId, spec.getCatalogId().getId(), fullPath);
+                            if (existingOpt.isPresent()) {
+                              var existing = existingOpt.get();
+                              var existingFingerprint =
+                                  canonicalFingerprint(
+                                      existing.getCatalogId(),
+                                      existing.getParentsList(),
+                                      existing.getDisplayName(),
+                                      specFromNamespace(existing));
+                              if (!existing.getResourceId().equals(reservedId)
+                                  || !Arrays.equals(fingerprint, existingFingerprint)) {
+                                throw GrpcErrors.alreadyExists(
+                                    correlationId,
+                                    GeneratedErrorMessages.MessageKey.NAMESPACE_ALREADY_EXISTS,
+                                    Map.of(
+                                        "catalog",
+                                        catalogName,
+                                        "path",
+                                        String.join(".", fullPath)));
+                              }
+                              var currentMeta = namespaceRepo.metaForSafe(reservedId);
+                              var completed =
+                                  namespaceRepo.completeWithMetaIfUnchanged(
+                                      existing,
+                                      currentMeta.getPointerVersion(),
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              if (completed.isEmpty()) {
+                                throw new BaseResourceRepository.AbortRetryableException(
+                                    "namespace changed while committing idempotency receipt");
+                              }
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  existing, reservedId, completed.get());
+                            }
+                            try {
+                              var committed =
+                                  namespaceRepo.createWithCompletion(
+                                      built,
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  committed.value(), reservedId, committed.meta());
+                            } catch (BaseResourceRepository.NameConflictException nce) {
+                              throw GrpcErrors.alreadyExists(
+                                  correlationId,
+                                  GeneratedErrorMessages.MessageKey.NAMESPACE_ALREADY_EXISTS,
+                                  Map.of(
+                                      "catalog", catalogName, "path", String.join(".", fullPath)));
+                            }
+                          },
+                          idempotencyStore,
+                          tsNow,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          Namespace::parseFrom);
+
+                  markerStore.bumpCatalogMarker(namespaceProto.body.getCatalogId());
+                  bumpParentNamespaceMarker(
+                      accountId,
+                      namespaceProto.body.getCatalogId(),
+                      namespaceProto.body.getParentsList());
+                  metadataGraph.invalidate(namespaceProto.body.getResourceId());
+                  topology.evictNamespaceRefs(namespaceProto.body.getCatalogId());
 
                   return CreateNamespaceResponse.newBuilder()
                       .setNamespace(namespaceProto.body)

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/NamespaceServiceImpl.java
@@ -289,7 +289,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                                       existing,
                                       currentMeta.getPointerVersion(),
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               if (completed.isEmpty()) {
@@ -304,7 +304,7 @@ public class NamespaceServiceImpl extends BaseServiceImpl implements NamespaceSe
                                   namespaceRepo.createWithCompletion(
                                       built,
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               return new IdempotencyGuard.CommittedCreate<>(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
@@ -427,46 +427,70 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
                   }
 
                   var result =
-                      runIdempotentCreate(
-                          () ->
-                              MutationOps.createProto(
-                                  accountId,
-                                  "CreateSnapshot",
-                                  idempotencyKey,
-                                  () -> fingerprint,
-                                  () -> {
-                                    try {
-                                      snapshotRepo.create(snap);
-                                    } catch (BaseResourceRepository.NameConflictException nce) {
-                                      var existing =
-                                          snapshotRepo.getById(tableId, snap.getSnapshotId());
-                                      if (existing.isPresent()) {
-                                        var stored = normalizeSnapshotForComparison(existing.get());
-                                        var incoming = normalizeSnapshotForComparison(snap);
-                                        if (stored.equals(incoming)) {
-                                          maybeAdvanceCurrentSnapshot(
-                                              tableId, existing.get(), corr);
-                                          return new IdempotencyGuard.CreateResult<>(
-                                              existing.get(), existing.get().getTableId());
-                                        }
-                                      }
-                                      throw GrpcErrors.conflict(
-                                          corr,
-                                          SNAPSHOT_MISMATCH,
-                                          Map.of(
-                                              "table_id", tableId.getId(),
-                                              "snapshot_id", Long.toString(snap.getSnapshotId())));
-                                    }
-                                    maybeAdvanceCurrentSnapshot(tableId, snap, corr);
-                                    return new IdempotencyGuard.CreateResult<>(
-                                        snap, snap.getTableId());
-                                  },
-                                  s -> snapshotRepo.metaForSafe(s.getTableId(), s.getSnapshotId()),
-                                  idempotencyStore,
-                                  tsNow,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  Snapshot::parseFrom));
+                      MutationOps.createProtoRecoverable(
+                          accountId,
+                          "CreateSnapshot",
+                          idempotencyKey,
+                          () -> fingerprint,
+                          snap::getTableId,
+                          (reservedId, committer) -> {
+                            var existing = snapshotRepo.getById(tableId, snap.getSnapshotId());
+                            if (existing.isPresent()) {
+                              var stored = normalizeSnapshotForComparison(existing.get());
+                              var incoming = normalizeSnapshotForComparison(snap);
+                              if (!stored.equals(incoming)) {
+                                throw GrpcErrors.conflict(
+                                    corr,
+                                    SNAPSHOT_MISMATCH,
+                                    Map.of(
+                                        "table_id",
+                                        tableId.getId(),
+                                        "snapshot_id",
+                                        Long.toString(snap.getSnapshotId())));
+                              }
+                              var currentMeta =
+                                  snapshotRepo.metaForSafe(tableId, snap.getSnapshotId());
+                              var completed =
+                                  snapshotRepo.completeWithMetaIfUnchanged(
+                                      existing.get(),
+                                      currentMeta.getPointerVersion(),
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              if (completed.isEmpty()) {
+                                throw new BaseResourceRepository.AbortRetryableException(
+                                    "snapshot changed while committing idempotency receipt");
+                              }
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  existing.get(), reservedId, completed.get());
+                            }
+                            try {
+                              var committed =
+                                  snapshotRepo.createWithCompletion(
+                                      snap,
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  committed.value(), reservedId, committed.meta());
+                            } catch (BaseResourceRepository.NameConflictException nce) {
+                              throw GrpcErrors.conflict(
+                                  corr,
+                                  SNAPSHOT_MISMATCH,
+                                  Map.of(
+                                      "table_id", tableId.getId(),
+                                      "snapshot_id", Long.toString(snap.getSnapshotId())));
+                            }
+                          },
+                          idempotencyStore,
+                          tsNow,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          Snapshot::parseFrom);
+
+                  maybeAdvanceCurrentSnapshot(tableId, result.body, corr);
 
                   return CreateSnapshotResponse.newBuilder()
                       .setSnapshot(result.body)

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
@@ -455,7 +455,7 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
                                       existing.get(),
                                       currentMeta.getPointerVersion(),
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               if (completed.isEmpty()) {
@@ -470,7 +470,7 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
                                   snapshotRepo.createWithCompletion(
                                       snap,
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               return new IdempotencyGuard.CommittedCreate<>(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableIndexServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableIndexServiceImpl.java
@@ -286,18 +286,37 @@ public class TableIndexServiceImpl extends BaseServiceImpl implements TableIndex
               "index_artifact",
               hashString(targetStorageId(item.getRecord().getTarget())));
 
-      MutationOps.createProto(
+      var record = item.getRecord();
+      var contentType =
+          item.getContentType() == null || item.getContentType().isBlank()
+              ? DEFAULT_INDEX_CONTENT_TYPE
+              : item.getContentType();
+      blobStore.put(record.getArtifactUri(), item.getContent().toByteArray(), contentType);
+      var etag =
+          blobStore
+              .head(record.getArtifactUri())
+              .map(h -> h.getEtag())
+              .orElse(record.getContentEtag());
+      var committedItem =
+          item.toBuilder().setRecord(record.toBuilder().setContentEtag(etag)).build();
+
+      MutationOps.commitProto(
           accountId,
           "PutIndexArtifacts",
           itemKey,
           item::toByteArray,
-          () -> {
-            persistItem(item);
-            return new IdempotencyGuard.CreateResult<>(item, next.tableId());
+          next.tableId(),
+          committer -> {
+            var meta =
+                indexArtifacts.putIndexArtifactWithCompletion(
+                    committedItem.getRecord(),
+                    nowTs,
+                    committedMeta ->
+                        committer.prepareOps(
+                            new IdempotencyGuard.CommittedCreate<>(
+                                committedItem, next.tableId(), committedMeta)));
+            return new IdempotencyGuard.CommittedCreate<>(committedItem, next.tableId(), meta);
           },
-          staged ->
-              indexArtifacts.metaForIndexArtifact(
-                  next.tableId(), next.snapshotId(), staged.getRecord().getTarget(), nowTs),
           idempotencyStore,
           nowTs,
           idempotencyTtlSeconds(),

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableIndexServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableIndexServiceImpl.java
@@ -312,9 +312,10 @@ public class TableIndexServiceImpl extends BaseServiceImpl implements TableIndex
                     committedItem.getRecord(),
                     nowTs,
                     committedMeta ->
-                        committer.prepareOps(
+                        committer.prepareSuccessOps(
                             new IdempotencyGuard.CommittedCreate<>(
-                                committedItem, next.tableId(), committedMeta)));
+                                committedItem, next.tableId(), committedMeta)),
+                    committer::discardPreparedSuccessOps);
             return new IdempotencyGuard.CommittedCreate<>(committedItem, next.tableId(), meta);
           },
           idempotencyStore,

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
@@ -56,6 +56,7 @@ public class TableRootWriter {
   private final SnapshotRepository snapshots;
   private final ConstraintRepository constraints;
   private final StatsStore statsStore;
+  private final RootResyncQueue rootResyncQueue;
 
   @Inject
   public TableRootWriter(
@@ -64,13 +65,15 @@ public class TableRootWriter {
       TableRepository tables,
       SnapshotRepository snapshots,
       ConstraintRepository constraints,
-      StatsStore statsStore) {
+      StatsStore statsStore,
+      RootResyncQueue rootResyncQueue) {
     this.roots = roots;
     this.committer = committer;
     this.tables = tables;
     this.snapshots = snapshots;
     this.constraints = constraints;
     this.statsStore = statsStore;
+    this.rootResyncQueue = rootResyncQueue;
   }
 
   /**
@@ -183,36 +186,54 @@ public class TableRootWriter {
    * their pinned root references, so a new generation becomes visible when it lands here — stats
    * are deterministic at a given pointer for a query's lifetime. Every stats write is
    * floecat-mediated (floescan submits through the leased reconcile protocol, other engines via
-   * PutTargetStats), so the root stays in sync with the stats family.
+   * PutTargetStats), so the root stays in sync with the stats family. If publication fails after
+   * the stats mutation is durable, a re-drive marker is recorded before the original failure is
+   * rethrown: acknowledgement still follows visibility, while the marker guarantees eventual
+   * convergence if the caller does not retry.
    */
   public void commitStatsGeneration(ResourceId tableId, long snapshotId) {
     if (!StatsVisibilityGate.gateOnFinalize(statsStore)) {
       return;
     }
-    committer.commit(
-        tableId,
-        current -> {
-          // Read the active generation INSIDE the mutator: concurrent activations race, and a
-          // ref captured before a lost CAS could land last, leaving the root referencing a
-          // superseded generation forever. Re-reading per attempt makes the last commit reflect
-          // the last published generation.
-          BlobRef generationRef =
-              statsStore
-                  .activeStatsGeneration(tableId, snapshotId)
-                  .map(uri -> BlobRef.newBuilder().setUri(uri).build())
-                  .orElse(null);
-          // Read /snapshots/current INSIDE the mutator (like the resync): the finalize advances
-          // currency only when this snapshot IS the committed current, so a lost CAS must re-read
-          // the authoritative selection per attempt rather than a value captured before the winner.
-          Long committedCurrentSnapshotId =
-              snapshots
-                  .latestRegisteredSnapshotPointer(tableId)
-                  .map(CurrentSnapshotPointer::getSnapshotId)
-                  .orElse(null);
-          return TableRootMutations.setStatsGeneration(
-                  roots, tableId, snapshotId, generationRef, committedCurrentSnapshotId)
-              .apply(current);
-        });
+    try {
+      committer.commit(
+          tableId,
+          current -> {
+            // Read the active generation INSIDE the mutator: concurrent activations race, and a
+            // ref captured before a lost CAS could land last, leaving the root referencing a
+            // superseded generation forever. Re-reading per attempt makes the last commit reflect
+            // the last published generation.
+            BlobRef generationRef =
+                statsStore
+                    .activeStatsGeneration(tableId, snapshotId)
+                    .map(uri -> BlobRef.newBuilder().setUri(uri).build())
+                    .orElse(null);
+            // Read /snapshots/current INSIDE the mutator (like the resync): the finalize advances
+            // currency only when this snapshot IS the committed current, so a lost CAS must re-read
+            // the authoritative selection per attempt rather than a value captured before the
+            // winner.
+            Long committedCurrentSnapshotId =
+                snapshots
+                    .latestRegisteredSnapshotPointer(tableId)
+                    .map(CurrentSnapshotPointer::getSnapshotId)
+                    .orElse(null);
+            return TableRootMutations.setStatsGeneration(
+                    roots, tableId, snapshotId, generationRef, committedCurrentSnapshotId)
+                .apply(current);
+          });
+    } catch (RuntimeException publicationFailure) {
+      try {
+        rootResyncQueue.enqueue(tableId);
+      } catch (RuntimeException markerFailure) {
+        publicationFailure.addSuppressed(markerFailure);
+        LOG.errorf(
+            publicationFailure,
+            "stats generation root commit for table %s failed AND its re-drive marker could not"
+                + " be recorded; the root stays divergent until the table's next write",
+            tableId.getId());
+      }
+      throw publicationFailure;
+    }
   }
 
   /**
@@ -227,6 +248,20 @@ public class TableRootWriter {
             tableId,
             snapshotId,
             BlobRefs.refFrom(constraints.metaForSafe(tableId, snapshotId))));
+  }
+
+  /**
+   * Publishes constraints derived from an already-durable constraints-family mutation. Failure is
+   * absorbed so the caller can leave a durable root-resync marker.
+   */
+  public boolean commitConstraintsFromCommittedState(ResourceId tableId, long snapshotId) {
+    return absorb(
+        tableId,
+        "constraints commit",
+        () -> {
+          commitConstraints(tableId, snapshotId);
+          return true;
+        });
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
@@ -244,58 +244,96 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                     return CreateTableResponse.newBuilder().setTable(table).setMeta(meta).build();
                   }
 
+                  var existingForIdempotency =
+                      tableRepo.getByName(
+                          accountId,
+                          spec.getCatalogId().getId(),
+                          spec.getNamespaceId().getId(),
+                          normName);
                   var result =
-                      runIdempotentCreate(
+                      MutationOps.createProtoRecoverable(
+                          accountId,
+                          "CreateTable",
+                          idempotencyKey,
+                          () -> fingerprint,
                           () ->
-                              MutationOps.createProto(
-                                  accountId,
-                                  "CreateTable",
-                                  idempotencyKey,
-                                  () -> fingerprint,
-                                  () -> {
-                                    try {
-                                      tableRepo.create(table);
-                                    } catch (BaseResourceRepository.NameConflictException nce) {
-                                      var existingOpt =
-                                          tableRepo.getByName(
-                                              accountId,
-                                              spec.getCatalogId().getId(),
-                                              spec.getNamespaceId().getId(),
-                                              normName);
-                                      if (existingOpt.isPresent()) {
-                                        var existingSpec = specFromTable(existingOpt.get());
-                                        if (Arrays.equals(
-                                            fingerprint, canonicalFingerprint(existingSpec))) {
-                                          markerStore.bumpNamespaceMarker(
-                                              existingOpt.get().getNamespaceId());
-                                          metadataGraph.invalidate(
-                                              existingOpt.get().getResourceId());
-                                          topology.evictRelationRefs(
-                                              existingOpt.get().getNamespaceId());
-                                          return new IdempotencyGuard.CreateResult<>(
-                                              existingOpt.get(), existingOpt.get().getResourceId());
-                                        }
-                                      }
-                                      throw GrpcErrors.alreadyExists(
-                                          corr,
-                                          TABLE_ALREADY_EXISTS,
-                                          Map.of(
-                                              "display_name", normName,
-                                              "catalog_id", spec.getCatalogId().getId(),
-                                              "namespace_id", spec.getNamespaceId().getId()));
-                                    }
-                                    markerStore.bumpNamespaceMarker(table.getNamespaceId());
-                                    metadataGraph.invalidate(tableResourceId);
-                                    topology.evictRelationRefs(table.getNamespaceId());
-                                    return new IdempotencyGuard.CreateResult<>(
-                                        table, tableResourceId);
-                                  },
-                                  t -> tableRepo.metaForSafe(t.getResourceId()),
-                                  idempotencyStore,
-                                  tsNow,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  Table::parseFrom));
+                              existingForIdempotency
+                                  .filter(
+                                      existing ->
+                                          Arrays.equals(
+                                              fingerprint,
+                                              canonicalFingerprint(specFromTable(existing))))
+                                  .map(Table::getResourceId)
+                                  .orElse(tableResourceId),
+                          (reservedId, committer) -> {
+                            var existingOpt =
+                                tableRepo.getByName(
+                                    accountId,
+                                    spec.getCatalogId().getId(),
+                                    spec.getNamespaceId().getId(),
+                                    normName);
+                            if (existingOpt.isPresent()) {
+                              var existing = existingOpt.get();
+                              if (!existing.getResourceId().equals(reservedId)
+                                  || !Arrays.equals(
+                                      fingerprint, canonicalFingerprint(specFromTable(existing)))) {
+                                throw GrpcErrors.alreadyExists(
+                                    corr,
+                                    TABLE_ALREADY_EXISTS,
+                                    Map.of(
+                                        "display_name",
+                                        normName,
+                                        "catalog_id",
+                                        spec.getCatalogId().getId(),
+                                        "namespace_id",
+                                        spec.getNamespaceId().getId()));
+                              }
+                              var currentMeta = tableRepo.metaForSafe(reservedId);
+                              var completed =
+                                  tableRepo.completeWithMetaIfUnchanged(
+                                      existing,
+                                      currentMeta.getPointerVersion(),
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              if (completed.isEmpty()) {
+                                throw new BaseResourceRepository.AbortRetryableException(
+                                    "table changed while committing idempotency receipt");
+                              }
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  existing, reservedId, completed.get());
+                            }
+                            try {
+                              var reserved = table.toBuilder().setResourceId(reservedId).build();
+                              var committed =
+                                  tableRepo.createWithCompletion(
+                                      reserved,
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  committed.value(), reservedId, committed.meta());
+                            } catch (BaseResourceRepository.NameConflictException nce) {
+                              throw GrpcErrors.alreadyExists(
+                                  corr,
+                                  TABLE_ALREADY_EXISTS,
+                                  Map.of(
+                                      "display_name", normName,
+                                      "catalog_id", spec.getCatalogId().getId(),
+                                      "namespace_id", spec.getNamespaceId().getId()));
+                            }
+                          },
+                          idempotencyStore,
+                          tsNow,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          Table::parseFrom);
+
+                  markerStore.bumpNamespaceMarker(result.body.getNamespaceId());
+                  metadataGraph.invalidate(result.body.getResourceId());
+                  topology.evictRelationRefs(result.body.getNamespaceId());
 
                   // Parity with the non-idempotent path: record the definition on the root at
                   // create time. Idempotent (the committer no-ops when the ref already matches), so

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableServiceImpl.java
@@ -294,7 +294,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                                       existing,
                                       currentMeta.getPointerVersion(),
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               if (completed.isEmpty()) {
@@ -310,7 +310,7 @@ public class TableServiceImpl extends BaseServiceImpl implements TableService {
                                   tableRepo.createWithCompletion(
                                       reserved,
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               return new IdempotencyGuard.CommittedCreate<>(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
@@ -286,7 +286,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                                   .completeWithMetaIfUnchanged(
                                       stored,
                                       meta.getPointerVersion(),
-                                      ignored -> committer.prepareOps(committed))
+                                      ignored -> committer.prepareSuccessOps(committed))
                                   .orElseThrow(
                                       () ->
                                           new BaseResourceRepository.AbortRetryableException(
@@ -303,7 +303,7 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                                         var success =
                                             new IdempotencyGuard.CommittedCreate<>(
                                                 resource.value(), reservedId, resource.meta());
-                                        return committer.prepareOps(success);
+                                        return committer.prepareSuccessOps(success);
                                       });
                             } catch (BaseResourceRepository.NameConflictException nce) {
                               throw relationNameConflict(corr, accountId, spec, normName);

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/ViewServiceImpl.java
@@ -50,6 +50,7 @@ import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.ViewRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import com.google.protobuf.FieldMask;
@@ -241,54 +242,83 @@ public class ViewServiceImpl extends BaseServiceImpl implements ViewService {
                     return CreateViewResponse.newBuilder().setView(view).setMeta(meta).build();
                   }
 
+                  var existingForIdempotency =
+                      viewRepo.getByName(
+                          accountId,
+                          spec.getCatalogId().getId(),
+                          spec.getNamespaceId().getId(),
+                          normName);
                   var result =
-                      runIdempotentCreate(
+                      MutationOps.createProtoRecoverable(
+                          accountId,
+                          "CreateView",
+                          idempotencyKey,
+                          () -> fingerprint,
                           () ->
-                              MutationOps.createProto(
-                                  accountId,
-                                  "CreateView",
-                                  idempotencyKey,
-                                  () -> fingerprint,
-                                  () -> {
-                                    try {
-                                      viewRepo.create(view);
-                                    } catch (BaseResourceRepository.NameConflictException nce) {
-                                      var existingOpt =
-                                          viewRepo.getByName(
-                                              accountId,
-                                              spec.getCatalogId().getId(),
-                                              spec.getNamespaceId().getId(),
-                                              normName);
-                                      if (existingOpt.isPresent()) {
-                                        var existingSpec = specFromView(existingOpt.get());
-                                        if (Arrays.equals(
-                                            fingerprint, canonicalFingerprint(existingSpec))) {
-                                          metadataGraph.invalidate(
-                                              existingOpt.get().getResourceId());
-                                          topology.evictRelationRefs(
-                                              existingOpt.get().getNamespaceId());
-                                          return new IdempotencyGuard.CreateResult<>(
-                                              existingOpt.get(), existingOpt.get().getResourceId());
-                                        }
-                                      }
-                                      // A same-kind view with a different fingerprint is a genuine
-                                      // VIEW_ALREADY_EXISTS; an absent view means the shared claim
-                                      // is
-                                      // held by another relation kind (see relationNameConflict).
-                                      throw relationNameConflict(corr, accountId, spec, normName);
-                                    }
-                                    metadataGraph.invalidate(viewResourceId);
-                                    topology.evictRelationRefs(view.getNamespaceId());
-                                    return new IdempotencyGuard.CreateResult<>(
-                                        view, viewResourceId);
-                                  },
-                                  v -> viewRepo.metaForSafe(v.getResourceId()),
-                                  idempotencyStore,
-                                  tsNow,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  View::parseFrom));
+                              existingForIdempotency
+                                  .filter(
+                                      existing ->
+                                          Arrays.equals(
+                                              fingerprint,
+                                              canonicalFingerprint(specFromView(existing))))
+                                  .map(View::getResourceId)
+                                  .orElseGet(
+                                      () -> randomResourceId(accountId, ResourceKind.RK_VIEW)),
+                          (reservedId, committer) -> {
+                            var existing =
+                                viewRepo.getByName(
+                                    accountId,
+                                    spec.getCatalogId().getId(),
+                                    spec.getNamespaceId().getId(),
+                                    normName);
+                            if (existing.isPresent()) {
+                              var stored = existing.get();
+                              if (!reservedId.equals(stored.getResourceId())
+                                  || !Arrays.equals(
+                                      fingerprint, canonicalFingerprint(specFromView(stored)))) {
+                                throw relationNameConflict(corr, accountId, spec, normName);
+                              }
+                              var meta = viewRepo.metaForSafe(stored.getResourceId());
+                              var committed =
+                                  new IdempotencyGuard.CommittedCreate<>(
+                                      stored, stored.getResourceId(), meta);
+                              viewRepo
+                                  .completeWithMetaIfUnchanged(
+                                      stored,
+                                      meta.getPointerVersion(),
+                                      ignored -> committer.prepareOps(committed))
+                                  .orElseThrow(
+                                      () ->
+                                          new BaseResourceRepository.AbortRetryableException(
+                                              "view changed before atomic completion"));
+                              return committed;
+                            }
+                            var reservedView = view.toBuilder().setResourceId(reservedId).build();
+                            GenericResourceRepository.ResourceWithMeta<View> committed;
+                            try {
+                              committed =
+                                  viewRepo.createWithCompletion(
+                                      reservedView,
+                                      resource -> {
+                                        var success =
+                                            new IdempotencyGuard.CommittedCreate<>(
+                                                resource.value(), reservedId, resource.meta());
+                                        return committer.prepareOps(success);
+                                      });
+                            } catch (BaseResourceRepository.NameConflictException nce) {
+                              throw relationNameConflict(corr, accountId, spec, normName);
+                            }
+                            return new IdempotencyGuard.CommittedCreate<>(
+                                committed.value(), reservedId, committed.meta());
+                          },
+                          idempotencyStore,
+                          tsNow,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          View::parseFrom);
 
+                  metadataGraph.invalidate(result.body.getResourceId());
+                  topology.evictRelationRefs(result.body.getNamespaceId());
                   return CreateViewResponse.newBuilder()
                       .setView(result.body)
                       .setMeta(result.meta)

--- a/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/BaseServiceImpl.java
@@ -40,7 +40,6 @@ import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
-import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import io.opentelemetry.context.Context;
@@ -67,7 +66,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
@@ -286,7 +284,8 @@ public abstract class BaseServiceImpl {
       return GrpcErrors.notFound(corrId, null, null, t);
     }
     if (t instanceof BaseResourceRepository.AbortRetryableException
-        || t instanceof StorageAbortRetryableException) {
+        || t instanceof StorageAbortRetryableException
+        || t instanceof IdempotencyInProgressException) {
       return GrpcErrors.aborted(corrId, null, t);
     }
     if (t instanceof BaseResourceRepository.CorruptionException
@@ -372,46 +371,6 @@ public abstract class BaseServiceImpl {
 
   protected String randomUuid() {
     return UUID.randomUUID().toString();
-  }
-
-  protected <T> MutationOps.OpResult<T> runIdempotentCreate(
-      Supplier<MutationOps.OpResult<T>> supplier) {
-    int attempts = 0;
-    while (true) {
-      try {
-        return supplier.get();
-      } catch (StatusRuntimeException sre) {
-        if (sre.getStatus().getCode() == Status.Code.ABORTED && attempts++ < RETRIES) {
-          sleepBackoff(attempts);
-          continue;
-        }
-        throw sre;
-      } catch (StorageAbortRetryableException sare) {
-        if (attempts++ < RETRIES) {
-          sleepBackoff(attempts);
-          continue;
-        }
-        throw sare;
-      }
-    }
-  }
-
-  private void sleepBackoff(int attempts) {
-    long baseMs = BACKOFF_MIN.toMillis();
-    long maxMs = BACKOFF_MAX.toMillis();
-    long delayMs = Math.max(1L, baseMs);
-    int steps = Math.min(attempts, 10);
-    for (int i = 0; i < steps && delayMs < maxMs; i++) {
-      delayMs = Math.min(maxMs, delayMs * 2L);
-    }
-    double jitter = 1.0 + ((ThreadLocalRandom.current().nextDouble() * 2.0 - 1.0) * JITTER);
-    long sleepMs = Math.max(1L, (long) (delayMs * jitter));
-    try {
-      Thread.sleep(sleepMs);
-    } catch (InterruptedException ie) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException("idempotent retry backoff interrupted", ie);
-    }
   }
 
   protected static String prettyNamespacePath(List<String> parents, String leaf) {

--- a/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
+import ai.floedb.floecat.storage.errors.StorageTransactionConflictException;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
@@ -32,6 +33,7 @@ import com.google.protobuf.util.Timestamps;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -46,7 +48,7 @@ public final class IdempotencyGuard {
 
   @FunctionalInterface
   public interface SuccessCommitter<T> {
-    PointerStore.CasUpsert prepare(CommittedCreate<T> committed);
+    List<PointerStore.CasOp> prepareOps(CommittedCreate<T> committed);
   }
 
   public record Result<T>(T resource, MutationMeta meta) {}
@@ -57,7 +59,9 @@ public final class IdempotencyGuard {
    * Idempotent resource creation with a durable identity reservation. A pending record contains the
    * resource id before the create transaction runs. The creator must publish the immutable success
    * receipt in the same pointer transaction as the resource; retries never reconstruct a receipt
-   * from mutable resource state.
+   * from mutable resource state. A retryable failure deliberately retains the reservation: a later
+   * attempt adopts its stable resource id and reruns the recoverable creator, rather than releasing
+   * and allocating a different identity.
    */
   public static <T> Result<T> runOnceReserved(
       String accountId,
@@ -73,13 +77,7 @@ public final class IdempotencyGuard {
       Timestamp now,
       Supplier<String> corrId) {
     if (idempotencyKey == null || idempotencyKey.isBlank()) {
-      var created =
-          creator.apply(
-              resourceIdAllocator.get(),
-              ignored -> {
-                throw new IllegalStateException(
-                    "idempotency completion requested without an idempotency key");
-              });
+      var created = creator.apply(resourceIdAllocator.get(), ignored -> List.of());
       return new Result<>(created.resource(), created.meta());
     }
 
@@ -147,16 +145,17 @@ public final class IdempotencyGuard {
       Timestamp commitExpiresAt = reservationExpiresAt;
       SuccessCommitter<T> committer =
           created ->
-              store.prepareSuccess(
-                  accountId,
-                  key,
-                  opName,
-                  requestHash,
-                  created.resourceId(),
-                  created.meta(),
-                  serializer.apply(created.resource()),
-                  commitCreatedAt,
-                  commitExpiresAt);
+              List.of(
+                  store.prepareSuccess(
+                      accountId,
+                      key,
+                      opName,
+                      requestHash,
+                      created.resourceId(),
+                      created.meta(),
+                      serializer.apply(created.resource()),
+                      commitCreatedAt,
+                      commitExpiresAt));
       CommittedCreate<T> created = creator.apply(reservedId, committer);
       committed = true;
       var completed = store.get(key);
@@ -196,6 +195,121 @@ public final class IdempotencyGuard {
     }
   }
 
+  /**
+   * Idempotent mutation of a known resource. The callback must publish the prepared success receipt
+   * in the same pointer transaction as its business mutation.
+   */
+  public static <T> Result<T> runOnceCommitted(
+      String accountId,
+      String opName,
+      String idempotencyKey,
+      byte[] requestBytes,
+      ResourceId resourceId,
+      Function<SuccessCommitter<T>, CommittedCreate<T>> mutation,
+      Function<T, byte[]> serializer,
+      Function<byte[], T> parser,
+      IdempotencyRepository store,
+      long ttlSeconds,
+      Timestamp now,
+      Supplier<String> corrId) {
+    if (idempotencyKey == null || idempotencyKey.isBlank()) {
+      throw new IllegalArgumentException("runOnceCommitted requires an idempotency key");
+    }
+
+    String key = Keys.idempotencyKey(accountId, opName, idempotencyKey);
+    String requestHash = sha256B64(requestBytes);
+    Optional<ai.floedb.floecat.storage.rpc.IdempotencyRecord> existing = store.get(key);
+    if (existing.isPresent()) {
+      var replay = existing.get();
+      requireMatchingRequest(replay.getRequestHash(), requestHash, opName, idempotencyKey, corrId);
+      if (replay.getStatus() == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.SUCCEEDED) {
+        if (!replay.hasMeta()) {
+          throw new BaseResourceRepository.CorruptionException(
+              "idempotency meta missing for succeeded record: key=" + key, null);
+        }
+        return new Result<>(parser.apply(replay.getPayload().toByteArray()), replay.getMeta());
+      }
+      throw new IdempotencyInProgressException("idempotency record pending: key=" + key);
+    }
+
+    Timestamp expiresAt = expiresAt(now, ttlSeconds);
+    if (!store.createPending(accountId, key, opName, requestHash, resourceId, now, expiresAt)) {
+      var winner = store.get(key);
+      if (winner.isEmpty()) {
+        throw new StorageAbortRetryableException("idempotency record not yet visible: key=" + key);
+      }
+      var replay = winner.get();
+      requireMatchingRequest(replay.getRequestHash(), requestHash, opName, idempotencyKey, corrId);
+      if (replay.getStatus() == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.SUCCEEDED) {
+        if (!replay.hasMeta()) {
+          throw new BaseResourceRepository.CorruptionException(
+              "idempotency meta missing for succeeded record: key=" + key, null);
+        }
+        return new Result<>(parser.apply(replay.getPayload().toByteArray()), replay.getMeta());
+      }
+      throw new IdempotencyInProgressException("idempotency record pending: key=" + key);
+    }
+
+    try {
+      SuccessCommitter<T> committer =
+          committed -> {
+            if (!resourceId.equals(committed.resourceId())) {
+              throw new IllegalArgumentException("committed resource identity changed");
+            }
+            return List.of(
+                store.prepareSuccess(
+                    accountId,
+                    key,
+                    opName,
+                    requestHash,
+                    resourceId,
+                    committed.meta(),
+                    serializer.apply(committed.resource()),
+                    now,
+                    expiresAt));
+          };
+      CommittedCreate<T> committed = mutation.apply(committer);
+      if (!resourceId.equals(committed.resourceId())) {
+        throw new IllegalArgumentException("committed resource identity changed");
+      }
+      var completed = store.get(key);
+      if (completed.isPresent()
+          && completed.get().getStatus()
+              == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.SUCCEEDED) {
+        var exact = completed.get();
+        requireMatchingRequest(exact.getRequestHash(), requestHash, opName, idempotencyKey, corrId);
+        return new Result<>(parser.apply(exact.getPayload().toByteArray()), exact.getMeta());
+      }
+      deletePendingIfOwned(store, key, opName, requestHash, now, expiresAt, corrId);
+      throw new StorageAbortRetryableException(
+          "atomic mutation returned without an idempotency receipt: key=" + key);
+    } catch (Throwable failure) {
+      var completed = store.get(key);
+      if (completed.isPresent()
+          && completed.get().getStatus()
+              == ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.SUCCEEDED) {
+        var exact = completed.get();
+        requireMatchingRequest(exact.getRequestHash(), requestHash, opName, idempotencyKey, corrId);
+        if (!exact.hasMeta()) {
+          throw new BaseResourceRepository.CorruptionException(
+              "idempotency meta missing for succeeded record: key=" + key, null);
+        }
+        return new Result<>(parser.apply(exact.getPayload().toByteArray()), exact.getMeta());
+      }
+      // Repository aborts are safe to release only because this helper's callback contract permits
+      // one pointer transaction containing all business mutations and the receipt. They therefore
+      // cannot represent a pre-receipt partial commit.
+      boolean knownAbort =
+          failure instanceof BaseResourceRepository.AbortRetryableException
+              || failure instanceof StorageTransactionConflictException;
+      boolean retryable = failure instanceof StorageAbortRetryableException || knownAbort;
+      if (!retryable || knownAbort) {
+        deletePendingIfOwned(store, key, opName, requestHash, now, expiresAt, corrId);
+      }
+      throw failure;
+    }
+  }
+
   private static void requireMatchingRequest(
       String storedHash,
       String requestHash,
@@ -218,7 +332,11 @@ public final class IdempotencyGuard {
             .build());
   }
 
-  public static <T> Result<T> runOnce(
+  /**
+   * Runs an operation whose callback has no durable side effect. If the receipt transaction is
+   * definitively cancelled, the caller's pending claim is released so an outer retry can rerun it.
+   */
+  public static <T> Result<T> runOnceReceiptOnly(
       String accountId,
       String opName,
       String idempotencyKey,
@@ -231,6 +349,69 @@ public final class IdempotencyGuard {
       long ttlSeconds,
       Timestamp now,
       Supplier<String> corrId) {
+    return executeClaimedEffect(
+        accountId,
+        opName,
+        idempotencyKey,
+        requestBytes,
+        creator,
+        metaExtractor,
+        serializer,
+        parser,
+        store,
+        ttlSeconds,
+        now,
+        corrId,
+        true);
+  }
+
+  /**
+   * Runs an effect whose durable writes have natural deduplication and therefore converge when the
+   * whole callback is repeated. This is intentionally separate from pointer-atomic mutations.
+   */
+  public static <T> Result<T> runOnceConvergentEffects(
+      String accountId,
+      String opName,
+      String idempotencyKey,
+      byte[] requestBytes,
+      Supplier<CreateResult<T>> effect,
+      Function<T, MutationMeta> metaExtractor,
+      Function<T, byte[]> serializer,
+      Function<byte[], T> parser,
+      IdempotencyRepository store,
+      long ttlSeconds,
+      Timestamp now,
+      Supplier<String> corrId) {
+    return executeClaimedEffect(
+        accountId,
+        opName,
+        idempotencyKey,
+        requestBytes,
+        effect,
+        metaExtractor,
+        serializer,
+        parser,
+        store,
+        ttlSeconds,
+        now,
+        corrId,
+        true);
+  }
+
+  private static <T> Result<T> executeClaimedEffect(
+      String accountId,
+      String opName,
+      String idempotencyKey,
+      byte[] requestBytes,
+      Supplier<CreateResult<T>> creator,
+      Function<T, MutationMeta> metaExtractor,
+      Function<T, byte[]> serializer,
+      Function<byte[], T> parser,
+      IdempotencyRepository store,
+      long ttlSeconds,
+      Timestamp now,
+      Supplier<String> corrId,
+      boolean releaseConfirmedAbort) {
     if (idempotencyKey == null || idempotencyKey.isBlank()) {
       var created = creator.get();
       var meta = metaExtractor.apply(created.resource());
@@ -247,6 +428,7 @@ public final class IdempotencyGuard {
     long finalizeSuccessNanos = 0L;
     long getAfterCreatePendingNanos = 0L;
     String outcome = "unknown";
+    String failurePhase = "creator";
 
     long getStartNanos = logTiming ? System.nanoTime() : 0L;
     var existingOpt = store.get(key);
@@ -304,7 +486,7 @@ public final class IdempotencyGuard {
               getAfterCreatePendingNanos,
               creatorNanos,
               finalizeSuccessNanos);
-          throw new StorageAbortRetryableException("idempotency record pending: key=" + key);
+          throw new IdempotencyInProgressException("idempotency record pending: key=" + key);
         }
         default -> {
           logTiming(
@@ -408,7 +590,7 @@ public final class IdempotencyGuard {
               getAfterCreatePendingNanos,
               creatorNanos,
               finalizeSuccessNanos);
-          throw new StorageAbortRetryableException("idempotency record pending: key=" + key);
+          throw new IdempotencyInProgressException("idempotency record pending: key=" + key);
         }
         default -> {
           logTiming(
@@ -433,9 +615,12 @@ public final class IdempotencyGuard {
       if (logTiming) {
         creatorNanos = System.nanoTime() - creatorStartNanos;
       }
+      failurePhase = "meta_extractor";
       var meta = metaExtractor.apply(created.resource());
+      failurePhase = "serializer";
       var payload = serializer.apply(created.resource());
 
+      failurePhase = "finalize_success";
       long finalizeStartNanos = logTiming ? System.nanoTime() : 0L;
       store.finalizeSuccess(
           accountId, key, opName, requestHash, created.resourceId(), meta, payload, now, expiresAt);
@@ -471,8 +656,18 @@ public final class IdempotencyGuard {
       boolean retryable =
           (t instanceof BaseResourceRepository.AbortRetryableException)
               || (t instanceof StorageAbortRetryableException);
-      if (!retryable) {
+      boolean confirmedAbort = t instanceof StorageTransactionConflictException;
+      if (!retryable || (releaseConfirmedAbort && confirmedAbort)) {
+        LOG.warnf(t, "idempotency.callback_failed op=%s key=%s corr=%s", opName, key, corrId.get());
         deletePendingIfOwned(store, key, opName, requestHash, now, expiresAt, corrId);
+      } else {
+        LOG.warnf(
+            t,
+            "idempotency.retryable_failure_retained op=%s key=%s phase=%s corr=%s",
+            opName,
+            key,
+            failurePhase,
+            corrId.get());
       }
       throw t;
     }

--- a/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyGuard.java
@@ -46,9 +46,10 @@ public final class IdempotencyGuard {
 
   public record CommittedCreate<T>(T resource, ResourceId resourceId, MutationMeta meta) {}
 
-  @FunctionalInterface
   public interface SuccessCommitter<T> {
-    List<PointerStore.CasOp> prepareOps(CommittedCreate<T> committed);
+    List<PointerStore.CasOp> prepareSuccessOps(CommittedCreate<T> committed);
+
+    default void discardPreparedSuccessOps(List<PointerStore.CasOp> prepared) {}
   }
 
   public record Result<T>(T resource, MutationMeta meta) {}
@@ -144,18 +145,16 @@ public final class IdempotencyGuard {
       Timestamp commitCreatedAt = reservationCreatedAt;
       Timestamp commitExpiresAt = reservationExpiresAt;
       SuccessCommitter<T> committer =
-          created ->
-              List.of(
-                  store.prepareSuccess(
-                      accountId,
-                      key,
-                      opName,
-                      requestHash,
-                      created.resourceId(),
-                      created.meta(),
-                      serializer.apply(created.resource()),
-                      commitCreatedAt,
-                      commitExpiresAt));
+          successCommitter(
+              store,
+              accountId,
+              key,
+              opName,
+              requestHash,
+              commitCreatedAt,
+              commitExpiresAt,
+              reservedId,
+              serializer);
       CommittedCreate<T> created = creator.apply(reservedId, committer);
       committed = true;
       var completed = store.get(key);
@@ -252,22 +251,8 @@ public final class IdempotencyGuard {
 
     try {
       SuccessCommitter<T> committer =
-          committed -> {
-            if (!resourceId.equals(committed.resourceId())) {
-              throw new IllegalArgumentException("committed resource identity changed");
-            }
-            return List.of(
-                store.prepareSuccess(
-                    accountId,
-                    key,
-                    opName,
-                    requestHash,
-                    resourceId,
-                    committed.meta(),
-                    serializer.apply(committed.resource()),
-                    now,
-                    expiresAt));
-          };
+          successCommitter(
+              store, accountId, key, opName, requestHash, now, expiresAt, resourceId, serializer);
       CommittedCreate<T> committed = mutation.apply(committer);
       if (!resourceId.equals(committed.resourceId())) {
         throw new IllegalArgumentException("committed resource identity changed");
@@ -361,8 +346,7 @@ public final class IdempotencyGuard {
         store,
         ttlSeconds,
         now,
-        corrId,
-        true);
+        corrId);
   }
 
   /**
@@ -394,8 +378,7 @@ public final class IdempotencyGuard {
         store,
         ttlSeconds,
         now,
-        corrId,
-        true);
+        corrId);
   }
 
   private static <T> Result<T> executeClaimedEffect(
@@ -410,8 +393,7 @@ public final class IdempotencyGuard {
       IdempotencyRepository store,
       long ttlSeconds,
       Timestamp now,
-      Supplier<String> corrId,
-      boolean releaseConfirmedAbort) {
+      Supplier<String> corrId) {
     if (idempotencyKey == null || idempotencyKey.isBlank()) {
       var created = creator.get();
       var meta = metaExtractor.apply(created.resource());
@@ -653,24 +635,58 @@ public final class IdempotencyGuard {
           getAfterCreatePendingNanos,
           creatorNanos,
           finalizeSuccessNanos);
-      boolean retryable =
-          (t instanceof BaseResourceRepository.AbortRetryableException)
-              || (t instanceof StorageAbortRetryableException);
-      boolean confirmedAbort = t instanceof StorageTransactionConflictException;
-      if (!retryable || (releaseConfirmedAbort && confirmedAbort)) {
-        LOG.warnf(t, "idempotency.callback_failed op=%s key=%s corr=%s", opName, key, corrId.get());
-        deletePendingIfOwned(store, key, opName, requestHash, now, expiresAt, corrId);
-      } else {
-        LOG.warnf(
-            t,
-            "idempotency.retryable_failure_retained op=%s key=%s phase=%s corr=%s",
-            opName,
-            key,
-            failurePhase,
-            corrId.get());
-      }
+      LOG.warnf(
+          t,
+          "idempotency.repeatable_effect_failed op=%s key=%s phase=%s corr=%s",
+          opName,
+          key,
+          failurePhase,
+          corrId.get());
+      // Both callers of this helper explicitly promise that the callback has no durable effect or
+      // is safe to repeat. Releasing an owned PENDING claim is therefore safe for every failure,
+      // including acknowledgement-uncertain receipt writes; a receipt that actually committed is
+      // SUCCEEDED and cannot be removed by deletePendingIfOwned.
+      deletePendingIfOwned(store, key, opName, requestHash, now, expiresAt, corrId);
       throw t;
     }
+  }
+
+  private static <T> SuccessCommitter<T> successCommitter(
+      IdempotencyRepository store,
+      String accountId,
+      String key,
+      String opName,
+      String requestHash,
+      Timestamp createdAt,
+      Timestamp expiresAt,
+      ResourceId expectedResourceId,
+      Function<T, byte[]> serializer) {
+    return new SuccessCommitter<>() {
+      @Override
+      public List<PointerStore.CasOp> prepareSuccessOps(CommittedCreate<T> committed) {
+        if (!expectedResourceId.equals(committed.resourceId())) {
+          throw new IllegalArgumentException("committed resource identity changed");
+        }
+        return List.of(
+            store.prepareSuccess(
+                accountId,
+                key,
+                opName,
+                requestHash,
+                committed.resourceId(),
+                committed.meta(),
+                serializer.apply(committed.resource()),
+                createdAt,
+                expiresAt));
+      }
+
+      @Override
+      public void discardPreparedSuccessOps(List<PointerStore.CasOp> prepared) {
+        if (prepared != null) {
+          prepared.forEach(store::discardPreparedSuccess);
+        }
+      }
+    };
   }
 
   private static void deletePendingIfOwned(

--- a/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyInProgressException.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/IdempotencyInProgressException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.service.common;
+
+/** Indicates that another attempt currently owns an idempotency claim. */
+public final class IdempotencyInProgressException extends RuntimeException {
+  public IdempotencyInProgressException(String message) {
+    super(message);
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/common/MutationOps.java
+++ b/service/src/main/java/ai/floedb/floecat/service/common/MutationOps.java
@@ -58,39 +58,8 @@ public final class MutationOps {
     T parse(byte[] bytes) throws Exception;
   }
 
-  public static <T> OpResult<T> create(
-      String account,
-      String operationName,
-      String idempotencyKey,
-      Fingerprinter fingerprint,
-      Creator<T> creator,
-      Function<T, MutationMeta> metaOf,
-      Function<T, byte[]> serializer,
-      Function<byte[], T> parser,
-      IdempotencyRepository idemStore,
-      Timestamp now,
-      long ttlSeconds,
-      Supplier<String> corrIdSupplier) {
-
-    var result =
-        IdempotencyGuard.runOnce(
-            account,
-            operationName,
-            idempotencyKey,
-            fingerprint.fingerprint(),
-            creator::create,
-            metaOf,
-            serializer,
-            parser,
-            idemStore,
-            ttlSeconds,
-            now,
-            corrIdSupplier);
-
-    return new OpResult<>(result.resource(), result.meta());
-  }
-
-  public static <T extends Message> OpResult<T> createProto(
+  /** For callbacks whose only durable mutation is the idempotency receipt itself. */
+  public static <T extends Message> OpResult<T> createProtoReceiptOnly(
       String account,
       String operationName,
       String idempotencyKey,
@@ -102,26 +71,62 @@ public final class MutationOps {
       long ttlSeconds,
       Supplier<String> correlationIdSupplier,
       ThrowingParser<T> parser) {
+    var result =
+        IdempotencyGuard.runOnceReceiptOnly(
+            account,
+            operationName,
+            idempotencyKey,
+            fingerprint.fingerprint(),
+            creator::create,
+            metaOf,
+            Message::toByteArray,
+            bytes -> {
+              try {
+                return parser.parse(bytes);
+              } catch (Exception e) {
+                throw new BaseResourceRepository.CorruptionException("idempotency_parse_failed", e);
+              }
+            },
+            idempotencyStore,
+            ttlSeconds,
+            now,
+            correlationIdSupplier);
+    return new OpResult<>(result.resource(), result.meta());
+  }
 
-    return create(
-        account,
-        operationName,
-        idempotencyKey,
-        fingerprint,
-        creator,
-        metaOf,
-        Message::toByteArray,
-        bytes -> {
-          try {
-            return parser.parse(bytes);
-          } catch (Exception e) {
-            throw new BaseResourceRepository.CorruptionException("idempotency_parse_failed", e);
-          }
-        },
-        idempotencyStore,
-        now,
-        ttlSeconds,
-        correlationIdSupplier);
+  public static <T extends Message> OpResult<T> createProtoConvergentEffects(
+      String account,
+      String operationName,
+      String idempotencyKey,
+      Fingerprinter fingerprint,
+      Creator<T> effect,
+      Function<T, MutationMeta> metaOf,
+      IdempotencyRepository idempotencyStore,
+      Timestamp now,
+      long ttlSeconds,
+      Supplier<String> correlationIdSupplier,
+      ThrowingParser<T> parser) {
+    var result =
+        IdempotencyGuard.runOnceConvergentEffects(
+            account,
+            operationName,
+            idempotencyKey,
+            fingerprint.fingerprint(),
+            effect::create,
+            metaOf,
+            Message::toByteArray,
+            bytes -> {
+              try {
+                return parser.parse(bytes);
+              } catch (Exception e) {
+                throw new BaseResourceRepository.CorruptionException("idempotency_parse_failed", e);
+              }
+            },
+            idempotencyStore,
+            ttlSeconds,
+            now,
+            correlationIdSupplier);
+    return new OpResult<>(result.resource(), result.meta());
   }
 
   /** For creators that can find and return an already-committed resource after a retry. */
@@ -149,6 +154,42 @@ public final class MutationOps {
             fingerprint.fingerprint(),
             resourceIdAllocator,
             creator,
+            Message::toByteArray,
+            bytes -> {
+              try {
+                return parser.parse(bytes);
+              } catch (Exception e) {
+                throw new BaseResourceRepository.CorruptionException("idempotency_parse_failed", e);
+              }
+            },
+            idempotencyStore,
+            ttlSeconds,
+            now,
+            correlationIdSupplier);
+    return new OpResult<>(result.resource(), result.meta());
+  }
+
+  /** For known-resource mutations that atomically co-commit their exact success receipt. */
+  public static <T extends Message> OpResult<T> commitProto(
+      String account,
+      String operationName,
+      String idempotencyKey,
+      Fingerprinter fingerprint,
+      ai.floedb.floecat.common.rpc.ResourceId resourceId,
+      Function<IdempotencyGuard.SuccessCommitter<T>, IdempotencyGuard.CommittedCreate<T>> mutation,
+      IdempotencyRepository idempotencyStore,
+      Timestamp now,
+      long ttlSeconds,
+      Supplier<String> correlationIdSupplier,
+      ThrowingParser<T> parser) {
+    var result =
+        IdempotencyGuard.runOnceCommitted(
+            account,
+            operationName,
+            idempotencyKey,
+            fingerprint.fingerprint(),
+            resourceId,
+            mutation,
             Message::toByteArray,
             bytes -> {
               try {

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -412,69 +412,92 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                         .build();
                   }
 
+                  var existingForIdempotency = connectorRepo.getByName(accountId, display);
                   var result =
-                      runIdempotentCreate(
+                      MutationOps.createProtoRecoverable(
+                          accountId,
+                          "CreateConnector",
+                          idempotencyKey,
+                          () -> fp,
                           () ->
-                              MutationOps.createProto(
-                                  accountId,
-                                  "CreateConnector",
-                                  idempotencyKey,
-                                  () -> fp,
-                                  () -> {
-                                    AuthConfig storedAuth =
-                                        storeAuthCredentials(
-                                            spec.getAuth(), accountId, connectorId.getId());
-                                    boolean storedCredentials = hasAuthCredentials(spec.getAuth());
-                                    String secretId = connectorId.getId();
-                                    ensureNoStoredCredentials(storedAuth);
-                                    var connector = builder.setAuth(storedAuth).build();
-                                    try {
-                                      createConnectorWithCredentialCompensation(
-                                          connector, storedCredentials, accountId, secretId);
-                                    } catch (BaseResourceRepository.NameConflictException nce) {
-                                      if (storedCredentials) {
-                                        credentialResolver.delete(accountId, secretId);
-                                      }
-                                      var existingOpt = connectorRepo.getByName(accountId, display);
-                                      if (existingOpt.isPresent()) {
-                                        var existingSpec = specFromConnector(existingOpt.get());
-                                        if (hasAuthCredentials(spec.getAuth())) {
-                                          var existingAuth = existingSpec.getAuth();
-                                          String existingSecretId =
-                                              existingOpt.get().getResourceId().getId();
-                                          var resolved =
-                                              credentialResolver.resolve(
-                                                  accountId, existingSecretId);
-                                          if (resolved.isPresent()) {
-                                            existingSpec =
-                                                existingSpec.toBuilder()
-                                                    .setAuth(
-                                                        existingAuth.toBuilder()
-                                                            .setCredentials(resolved.get())
-                                                            .build())
-                                                    .build();
-                                          }
-                                        }
-                                        if (Arrays.equals(fp, canonicalFingerprint(existingSpec))) {
-                                          return new IdempotencyGuard.CreateResult<>(
-                                              existingOpt.get(), existingOpt.get().getResourceId());
-                                        }
-                                      }
-                                      throw GrpcErrors.alreadyExists(
-                                          corr,
-                                          GeneratedErrorMessages.MessageKey
-                                              .CONNECTOR_ALREADY_EXISTS,
-                                          Map.of("display_name", display));
-                                    }
-                                    return new IdempotencyGuard.CreateResult<>(
-                                        connector, connectorId);
-                                  },
-                                  c -> connectorRepo.metaFor(c.getResourceId()),
-                                  idempotencyStore,
-                                  tsNow,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  Connector::parseFrom));
+                              existingForIdempotency
+                                  .filter(
+                                      existing ->
+                                          Arrays.equals(
+                                              fp,
+                                              canonicalFingerprint(
+                                                  specFromConnectorWithResolvedCredentials(
+                                                      accountId, existing))))
+                                  .map(Connector::getResourceId)
+                                  .orElse(connectorId),
+                          (reservedId, committer) -> {
+                            var existingOpt = connectorRepo.getByName(accountId, display);
+                            if (existingOpt.isPresent()) {
+                              var existing = existingOpt.get();
+                              if (!existing.getResourceId().equals(reservedId)
+                                  || !Arrays.equals(
+                                      fp,
+                                      canonicalFingerprint(
+                                          specFromConnectorWithResolvedCredentials(
+                                              accountId, existing)))) {
+                                throw GrpcErrors.alreadyExists(
+                                    corr,
+                                    GeneratedErrorMessages.MessageKey.CONNECTOR_ALREADY_EXISTS,
+                                    Map.of("display_name", display));
+                              }
+                              var currentMeta = connectorRepo.metaFor(reservedId);
+                              var completed =
+                                  connectorRepo.completeWithMetaIfUnchanged(
+                                      existing,
+                                      currentMeta.getPointerVersion(),
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              if (completed.isEmpty()) {
+                                throw new BaseResourceRepository.AbortRetryableException(
+                                    "connector changed while committing idempotency receipt");
+                              }
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  existing, reservedId, completed.get());
+                            }
+                            AuthConfig storedAuth =
+                                storeAuthCredentials(spec.getAuth(), accountId, reservedId.getId());
+                            boolean storedCredentials = hasAuthCredentials(spec.getAuth());
+                            String secretId = reservedId.getId();
+                            ensureNoStoredCredentials(storedAuth);
+                            var connector =
+                                builder.setResourceId(reservedId).setAuth(storedAuth).build();
+                            try {
+                              var committed =
+                                  connectorRepo.createWithCompletion(
+                                      connector,
+                                      resource ->
+                                          committer.prepareOps(
+                                              new IdempotencyGuard.CommittedCreate<>(
+                                                  resource.value(), reservedId, resource.meta())));
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  committed.value(), reservedId, committed.meta());
+                            } catch (BaseResourceRepository.NameConflictException nce) {
+                              if (storedCredentials) {
+                                credentialResolver.delete(accountId, secretId);
+                              }
+                              throw GrpcErrors.alreadyExists(
+                                  corr,
+                                  GeneratedErrorMessages.MessageKey.CONNECTOR_ALREADY_EXISTS,
+                                  Map.of("display_name", display));
+                            } catch (BaseResourceRepository.AccountDeletionInProgressException e) {
+                              if (storedCredentials) {
+                                credentialResolver.delete(accountId, secretId);
+                              }
+                              throw e;
+                            }
+                          },
+                          idempotencyStore,
+                          tsNow,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          Connector::parseFrom);
 
                   return CreateConnectorResponse.newBuilder()
                       .setConnector(maskConnector(result.body))
@@ -805,6 +828,21 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
     credentialResolver.store(accountId, connectorId, safeAuth.getCredentials());
     // AuthCredentials are stored in the secrets manager; connector records must not persist them.
     return safeAuth.toBuilder().clearCredentials().build();
+  }
+
+  private ConnectorSpec specFromConnectorWithResolvedCredentials(
+      String accountId, Connector connector) {
+    var spec = specFromConnector(connector);
+    if (!hasAuthCredentials(spec.getAuth())) {
+      var resolved = credentialResolver.resolve(accountId, connector.getResourceId().getId());
+      if (resolved.isPresent()) {
+        spec =
+            spec.toBuilder()
+                .setAuth(spec.getAuth().toBuilder().setCredentials(resolved.get()).build())
+                .build();
+      }
+    }
+    return spec;
   }
 
   private static void ensureNoStoredCredentials(AuthConfig auth) {

--- a/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/connector/impl/ConnectorsImpl.java
@@ -451,7 +451,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                                       existing,
                                       currentMeta.getPointerVersion(),
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               if (completed.isEmpty()) {
@@ -473,7 +473,7 @@ public class ConnectorsImpl extends BaseServiceImpl implements Connectors {
                                   connectorRepo.createWithCompletion(
                                       connector,
                                       resource ->
-                                          committer.prepareOps(
+                                          committer.prepareSuccessOps(
                                               new IdempotencyGuard.CommittedCreate<>(
                                                   resource.value(), reservedId, resource.meta())));
                               return new IdempotencyGuard.CommittedCreate<>(

--- a/service/src/main/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImpl.java
@@ -88,6 +88,11 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
    * The constraints mutation is durable; publish its derived root ref or leave a re-drive marker.
    * Calling this after an idempotency replay is deliberate: replay doubles as a free convergence
    * pass for a previously absorbed root commit.
+   *
+   * <p>This acknowledgement contract intentionally differs from stats publication. Constraints are
+   * acknowledged once their authoritative constraints-family pointer is durable; the table-root ref
+   * is derived state that may converge through the durable marker. Stats generation publication is
+   * itself the visibility boundary for pinned reads, so that path records a marker and rethrows.
    */
   void publishCommittedConstraintsToRoot(ResourceId tableId, long snapshotId) {
     if (rootWriter == null || rootWriter.commitConstraintsFromCommittedState(tableId, snapshotId)) {
@@ -250,7 +255,7 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
                                       var success =
                                           new IdempotencyGuard.CommittedCreate<>(
                                               response, request.getTableId(), put.meta());
-                                      return committer.prepareOps(success);
+                                      return committer.prepareSuccessOps(success);
                                     });
                             return new IdempotencyGuard.CommittedCreate<>(
                                 PutTableConstraintsResponse.newBuilder()

--- a/service/src/main/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImpl.java
@@ -43,6 +43,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
 import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.scanner.spi.CatalogGraphView;
+import ai.floedb.floecat.service.catalog.impl.RootResyncQueue;
 import ai.floedb.floecat.service.catalog.impl.TableRootWriter;
 import ai.floedb.floecat.service.catalog.impl.surface.CatalogSurfaceWritePolicy;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
@@ -79,13 +80,27 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
   @Inject IdempotencyRepository idempotencyStore;
   @Inject CatalogGraphView graphView;
   @Inject TableRootWriter rootWriter;
+  @Inject RootResyncQueue rootResyncQueue;
 
   private static final Logger LOG = Logger.getLogger(TableConstraintsServiceImpl.class);
 
-  /** Record the snapshot's (possibly new or removed) constraints bundle on the table root. */
-  private void commitConstraintsToRoot(ResourceId tableId, long snapshotId) {
-    if (rootWriter != null) {
-      rootWriter.commitConstraints(tableId, snapshotId);
+  /**
+   * The constraints mutation is durable; publish its derived root ref or leave a re-drive marker.
+   * Calling this after an idempotency replay is deliberate: replay doubles as a free convergence
+   * pass for a previously absorbed root commit.
+   */
+  void publishCommittedConstraintsToRoot(ResourceId tableId, long snapshotId) {
+    if (rootWriter == null || rootWriter.commitConstraintsFromCommittedState(tableId, snapshotId)) {
+      return;
+    }
+    try {
+      rootResyncQueue.enqueue(tableId);
+    } catch (RuntimeException e) {
+      LOG.errorf(
+          e,
+          "constraints root commit for table %s failed AND its re-drive marker could not be"
+              + " recorded; the root stays divergent until the table's next write",
+          tableId.getId());
     }
   }
 
@@ -201,7 +216,8 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
                     boolean changed =
                         constraints.putSnapshotConstraints(
                             request.getTableId(), request.getSnapshotId(), normalized);
-                    commitConstraintsToRoot(request.getTableId(), request.getSnapshotId());
+                    publishCommittedConstraintsToRoot(
+                        request.getTableId(), request.getSnapshotId());
                     var meta =
                         constraints.metaFor(request.getTableId(), request.getSnapshotId(), tsNow);
                     return PutTableConstraintsResponse.newBuilder()
@@ -212,38 +228,47 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
                   }
 
                   var result =
-                      runIdempotentCreate(
-                          () ->
-                              MutationOps.createProto(
-                                  accountId,
-                                  "PutTableConstraints",
-                                  idempotencyKey,
-                                  () -> fingerprint,
-                                  () -> {
-                                    boolean changed =
-                                        constraints.putSnapshotConstraints(
-                                            request.getTableId(),
-                                            request.getSnapshotId(),
-                                            normalized);
-                                    commitConstraintsToRoot(
-                                        request.getTableId(), request.getSnapshotId());
-                                    return new IdempotencyGuard.CreateResult<>(
-                                        PutTableConstraintsResponse.newBuilder()
-                                            .setConstraints(normalized)
-                                            .setChanged(changed)
-                                            .build(),
-                                        request.getTableId());
-                                  },
-                                  response ->
-                                      constraints.metaFor(
-                                          request.getTableId(), request.getSnapshotId(), tsNow),
-                                  idempotencyStore,
-                                  tsNow,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  PutTableConstraintsResponse::parseFrom));
+                      MutationOps.commitProto(
+                          accountId,
+                          "PutTableConstraints",
+                          idempotencyKey,
+                          () -> fingerprint,
+                          request.getTableId(),
+                          committer -> {
+                            var committed =
+                                constraints.putSnapshotConstraintsWithCompletion(
+                                    request.getTableId(),
+                                    request.getSnapshotId(),
+                                    normalized,
+                                    put -> {
+                                      var response =
+                                          PutTableConstraintsResponse.newBuilder()
+                                              .setConstraints(put.constraints())
+                                              .setMeta(put.meta())
+                                              .setChanged(put.changed())
+                                              .build();
+                                      var success =
+                                          new IdempotencyGuard.CommittedCreate<>(
+                                              response, request.getTableId(), put.meta());
+                                      return committer.prepareOps(success);
+                                    });
+                            return new IdempotencyGuard.CommittedCreate<>(
+                                PutTableConstraintsResponse.newBuilder()
+                                    .setConstraints(committed.constraints())
+                                    .setMeta(committed.meta())
+                                    .setChanged(committed.changed())
+                                    .build(),
+                                request.getTableId(),
+                                committed.meta());
+                          },
+                          idempotencyStore,
+                          tsNow,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          PutTableConstraintsResponse::parseFrom);
 
-                  return result.body.toBuilder().setMeta(result.meta).build();
+                  publishCommittedConstraintsToRoot(request.getTableId(), request.getSnapshotId());
+                  return result.body;
                 }),
             correlationId())
         .onFailure()
@@ -367,10 +392,10 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
                     // idempotently before reporting not-found, so a pinned-ref never outlives the
                     // pointer it points at (new pins would copy a stale ref; root-chain GC would
                     // anchor the retired blob).
-                    commitConstraintsToRoot(tableId, snapshotId);
+                    publishCommittedConstraintsToRoot(tableId, snapshotId);
                     throw constraintsBundleNotFound(tableId, snapshotId);
                   }
-                  commitConstraintsToRoot(tableId, snapshotId);
+                  publishCommittedConstraintsToRoot(tableId, snapshotId);
 
                   return DeleteTableConstraintsResponse.newBuilder().setMeta(meta).build();
                 }),
@@ -537,7 +562,7 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
         }
         SnapshotConstraints created = mutator.apply(SnapshotConstraints.newBuilder().build());
         if (constraints.createSnapshotConstraintsIfAbsent(tableId, snapshotId, created)) {
-          commitConstraintsToRoot(tableId, snapshotId);
+          publishCommittedConstraintsToRoot(tableId, snapshotId);
           return constraints.getSnapshotConstraints(tableId, snapshotId).orElse(created);
         }
         continue;
@@ -554,7 +579,7 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
         // failed its root commit, leaving the root ref stale. Convergence is idempotent (it reads
         // the live bundle meta; a matching ref no-ops in the committer), so attempt it on this
         // exit path too rather than short-circuiting before the root catches up.
-        commitConstraintsToRoot(tableId, snapshotId);
+        publishCommittedConstraintsToRoot(tableId, snapshotId);
         return current;
       }
       try {
@@ -562,7 +587,7 @@ public class TableConstraintsServiceImpl extends BaseServiceImpl
             constraints.updateSnapshotConstraints(
                 tableId, snapshotId, next, currentMeta.getPointerVersion());
         if (updated) {
-          commitConstraintsToRoot(tableId, snapshotId);
+          publishCommittedConstraintsToRoot(tableId, snapshotId);
           return constraints.getSnapshotConstraints(tableId, snapshotId).orElse(next);
         }
       } catch (BaseResourceRepository.NotFoundException ignore) {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -567,7 +567,7 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                   row ->
                       (PointerStore.CasUpsert)
                           completion
-                              .prepareOps(
+                              .prepareSuccessOps(
                                   new IdempotencyGuard.CommittedCreate<>(
                                       row.value(), row.value().getResourceId(), row.meta()))
                               .getFirst());

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -65,6 +65,7 @@ import ai.floedb.floecat.service.repo.util.MarkerStore;
 import ai.floedb.floecat.service.security.RolePermissions;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.storage.spi.PointerStore;
 import com.google.protobuf.FieldMask;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Uni;
@@ -417,56 +418,52 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
                     }
                   }
                   var result =
-                      runIdempotentCreate(
+                      MutationOps.createProtoRecoverable(
+                          pc.getAccountId(),
+                          "CreateCatalogIntegration",
+                          key,
+                          () -> fingerprint,
                           () ->
-                              MutationOps.createProtoRecoverable(
-                                  pc.getAccountId(),
-                                  "CreateCatalogIntegration",
-                                  key,
-                                  () -> fingerprint,
-                                  () ->
-                                      randomResourceId(
-                                          pc.getAccountId(), ResourceKind.RK_CATALOG_INTEGRATION),
-                                  (reservedId, completion) -> {
-                                    var recovered = integrations.getByIdWithMeta(reservedId);
-                                    if (recovered.isPresent()) {
-                                      throw new BaseResourceRepository.AbortRetryableException(
-                                          "integration exists before its idempotency receipt committed");
-                                    }
-                                    credentialStore.store(
-                                        reservedId,
-                                        preparedAuthentication
-                                            .authentication()
-                                            .getCredentialGeneration(),
-                                        preparedAuthentication.credentials());
-                                    try {
-                                      var created =
-                                          createOrReplace(
-                                              reservedId,
-                                              name,
-                                              spec.getType(),
-                                              uri,
-                                              properties,
-                                              preparedAuthentication.authentication(),
-                                              CreateMode.CM_ERROR_IF_EXISTS,
-                                              true,
-                                              completion,
-                                              now,
-                                              corr);
-                                      return new IdempotencyGuard.CommittedCreate<>(
-                                          created.row().value(),
-                                          created.row().value().getResourceId(),
-                                          created.row().meta());
-                                    } catch (RuntimeException definiteFailure) {
-                                      cleanupPrepared(reservedId, preparedAuthentication);
-                                      throw definiteFailure;
-                                    }
-                                  },
-                                  idempotencyStore,
-                                  now,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  CatalogIntegration::parseFrom));
+                              randomResourceId(
+                                  pc.getAccountId(), ResourceKind.RK_CATALOG_INTEGRATION),
+                          (reservedId, completion) -> {
+                            var recovered = integrations.getByIdWithMeta(reservedId);
+                            if (recovered.isPresent()) {
+                              throw new BaseResourceRepository.AbortRetryableException(
+                                  "integration exists before its idempotency receipt committed");
+                            }
+                            credentialStore.store(
+                                reservedId,
+                                preparedAuthentication.authentication().getCredentialGeneration(),
+                                preparedAuthentication.credentials());
+                            try {
+                              var created =
+                                  createOrReplace(
+                                      reservedId,
+                                      name,
+                                      spec.getType(),
+                                      uri,
+                                      properties,
+                                      preparedAuthentication.authentication(),
+                                      CreateMode.CM_ERROR_IF_EXISTS,
+                                      true,
+                                      completion,
+                                      now,
+                                      corr);
+                              return new IdempotencyGuard.CommittedCreate<>(
+                                  created.row().value(),
+                                  created.row().value().getResourceId(),
+                                  created.row().meta());
+                            } catch (RuntimeException definiteFailure) {
+                              cleanupPrepared(reservedId, preparedAuthentication);
+                              throw definiteFailure;
+                            }
+                          },
+                          idempotencyStore,
+                          now,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          CatalogIntegration::parseFrom);
                   return CreateCatalogIntegrationResponse.newBuilder()
                       .setIntegration(result.body)
                       .setMeta(result.meta)
@@ -568,9 +565,12 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
               : integrations.createWithMetaAndCompletion(
                   desired,
                   row ->
-                      completion.prepare(
-                          new IdempotencyGuard.CommittedCreate<>(
-                              row.value(), row.value().getResourceId(), row.meta())));
+                      (PointerStore.CasUpsert)
+                          completion
+                              .prepareOps(
+                                  new IdempotencyGuard.CommittedCreate<>(
+                                      row.value(), row.value().getResourceId(), row.meta()))
+                              .getFirst());
       return new CreateOutcome(created, true);
     } catch (BaseResourceRepository.NameConflictException conflict) {
       if (reservedIdentity) {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
@@ -444,7 +444,7 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
               completion == null
                   ? null
                   : row ->
-                      completion.prepareOps(
+                      completion.prepareSuccessOps(
                           new IdempotencyGuard.CommittedCreate<>(
                               row.value(), row.value().getResourceId(), row.meta())))
           .orElseThrow(

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogOverlaysImpl.java
@@ -250,45 +250,40 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
                         .build();
                   }
                   var result =
-                      runIdempotentCreate(
+                      MutationOps.createProtoRecoverable(
+                          pc.getAccountId(),
+                          "CreateCatalogOverlay",
+                          key,
+                          () -> fingerprint,
                           () ->
-                              MutationOps.createProtoRecoverable(
-                                  pc.getAccountId(),
-                                  "CreateCatalogOverlay",
-                                  key,
-                                  () -> fingerprint,
-                                  () ->
-                                      randomResourceId(
-                                          pc.getAccountId(), ResourceKind.RK_CATALOG_OVERLAY),
-                                  (reservedId, completion) -> {
-                                    var recovered = overlays.getByIdWithMeta(reservedId);
-                                    if (recovered.isPresent()) {
-                                      throw new BaseResourceRepository.AbortRetryableException(
-                                          "overlay exists before its idempotency receipt committed");
-                                    }
-                                    var created =
-                                        createOrReplace(
-                                            reservedId,
-                                            name,
-                                            integrationId,
-                                            catalogId,
-                                            includes,
-                                            excludes,
-                                            CreateMode.CM_ERROR_IF_EXISTS,
-                                            true,
-                                            completion,
-                                            now,
-                                            corr);
-                                    return new IdempotencyGuard.CommittedCreate<>(
-                                        created.value(),
-                                        created.value().getResourceId(),
-                                        created.meta());
-                                  },
-                                  idempotencyStore,
-                                  now,
-                                  idempotencyTtlSeconds(),
-                                  this::correlationId,
-                                  CatalogOverlay::parseFrom));
+                              randomResourceId(pc.getAccountId(), ResourceKind.RK_CATALOG_OVERLAY),
+                          (reservedId, completion) -> {
+                            var recovered = overlays.getByIdWithMeta(reservedId);
+                            if (recovered.isPresent()) {
+                              throw new BaseResourceRepository.AbortRetryableException(
+                                  "overlay exists before its idempotency receipt committed");
+                            }
+                            var created =
+                                createOrReplace(
+                                    reservedId,
+                                    name,
+                                    integrationId,
+                                    catalogId,
+                                    includes,
+                                    excludes,
+                                    CreateMode.CM_ERROR_IF_EXISTS,
+                                    true,
+                                    completion,
+                                    now,
+                                    corr);
+                            return new IdempotencyGuard.CommittedCreate<>(
+                                created.value(), created.value().getResourceId(), created.meta());
+                          },
+                          idempotencyStore,
+                          now,
+                          idempotencyTtlSeconds(),
+                          this::correlationId,
+                          CatalogOverlay::parseFrom);
                   return CreateCatalogOverlayResponse.newBuilder()
                       .setOverlay(result.body)
                       .setMeta(result.meta)
@@ -449,10 +444,9 @@ public class CatalogOverlaysImpl extends BaseServiceImpl implements CatalogOverl
               completion == null
                   ? null
                   : row ->
-                      List.of(
-                          completion.prepare(
-                              new IdempotencyGuard.CommittedCreate<>(
-                                  row.value(), row.value().getResourceId(), row.meta()))))
+                      completion.prepareOps(
+                          new IdempotencyGuard.CommittedCreate<>(
+                              row.value(), row.value().getResourceId(), row.meta())))
           .orElseThrow(
               () ->
                   new BaseResourceRepository.AbortRetryableException(

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
@@ -675,25 +675,21 @@ public class LeasedFileGroupExecutionService extends BaseServiceImpl {
     String requiredResultId = requireResultId(resultId);
     String effectiveMessage = message == null ? "" : message;
     byte[] requestBytes = failurePayload(requiredResultId, effectiveMessage).toByteArray();
-    return runIdempotentCreate(
+    return MutationOps.createProtoReceiptOnly(
+            principalContext.getAccountId(),
+            "CommitLeasedFileGroupResult",
+            resultIdempotencyKey(jobId, requiredResultId),
+            () -> requestBytes,
             () ->
-                MutationOps.createProto(
-                    principalContext.getAccountId(),
-                    "CommitLeasedFileGroupResult",
-                    resultIdempotencyKey(jobId, requiredResultId),
-                    () -> requestBytes,
-                    () ->
-                        new IdempotencyGuard.CreateResult<>(
-                            CommitLeasedFileGroupResultResponse.newBuilder()
-                                .setAccepted(true)
-                                .build(),
-                            tableId),
-                    ignored -> MutationMeta.getDefaultInstance(),
-                    idempotencyStore,
-                    nowTs(),
-                    idempotencyTtlSeconds(),
-                    principalContext::getCorrelationId,
-                    CommitLeasedFileGroupResultResponse::parseFrom))
+                new IdempotencyGuard.CreateResult<>(
+                    CommitLeasedFileGroupResultResponse.newBuilder().setAccepted(true).build(),
+                    tableId),
+            ignored -> MutationMeta.getDefaultInstance(),
+            idempotencyStore,
+            nowTs(),
+            idempotencyTtlSeconds(),
+            principalContext::getCorrelationId,
+            CommitLeasedFileGroupResultResponse::parseFrom)
         .body
         .getAccepted();
   }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedPlannerWorkerService.java
@@ -346,29 +346,25 @@ public class LeasedPlannerWorkerService extends BaseServiceImpl {
               lease.jobId,
               lease.pinnedExecutorId));
     }
-    return runIdempotentCreate(
-                () ->
-                    MutationOps.createProto(
-                        principalContext.getAccountId(),
-                        "SubmitLeasedPlanTableResult",
-                        planTableChunkIdempotencyKey(
-                            jobId, leaseEpoch, stagedChunk.getChunkIndex()),
-                        () -> requestBytes,
-                        () -> {
-                          if (!childSpecs.isEmpty()) {
-                            ReconcileJobStore.BulkEnqueueResult enqueueResult =
-                                jobs.bulkEnqueue(childSpecs);
-                            enqueueResult.requireAllSucceeded("table snapshot child enqueue");
-                          }
-                          return new IdempotencyGuard.CreateResult<>(
-                              stagedChunk, connectorId(lease));
-                        },
-                        ignored -> MutationMeta.getDefaultInstance(),
-                        idempotencyStore,
-                        nowTs(),
-                        idempotencyTtlSeconds(),
-                        principalContext::getCorrelationId,
-                        SubmitLeasedPlanTableResultRequest.Chunk::parseFrom))
+    return MutationOps.createProtoConvergentEffects(
+                principalContext.getAccountId(),
+                "SubmitLeasedPlanTableResult",
+                planTableChunkIdempotencyKey(jobId, leaseEpoch, stagedChunk.getChunkIndex()),
+                () -> requestBytes,
+                () -> {
+                  if (!childSpecs.isEmpty()) {
+                    ReconcileJobStore.BulkEnqueueResult enqueueResult =
+                        jobs.bulkEnqueue(childSpecs);
+                    enqueueResult.requireAllSucceeded("table snapshot child enqueue");
+                  }
+                  return new IdempotencyGuard.CreateResult<>(stagedChunk, connectorId(lease));
+                },
+                ignored -> MutationMeta.getDefaultInstance(),
+                idempotencyStore,
+                nowTs(),
+                idempotencyTtlSeconds(),
+                principalContext::getCorrelationId,
+                SubmitLeasedPlanTableResultRequest.Chunk::parseFrom)
             .body
         != null;
   }
@@ -863,29 +859,26 @@ public class LeasedPlannerWorkerService extends BaseServiceImpl {
         existingFileGroupKeys.add(fileGroupKey);
       }
     }
-    return runIdempotentCreate(
-                () ->
-                    MutationOps.createProto(
-                        principalContext.getAccountId(),
-                        "SubmitLeasedPlanSnapshotResult",
-                        planSnapshotChunkIdempotencyKey(
-                            jobId, leaseEpoch, stagedChunk.getChunkIndex()),
-                        () -> requestBytes,
-                        () -> {
-                          if (!childSpecs.isEmpty()) {
-                            ReconcileJobStore.BulkEnqueueResult enqueueResult =
-                                jobs.bulkEnqueue(childSpecs);
-                            enqueueResult.requireAllSucceeded("snapshot file-group child enqueue");
-                          }
-                          return new IdempotencyGuard.CreateResult<>(
-                              stagedChunk, tableId(lease, durableSnapshotTask));
-                        },
-                        ignored -> MutationMeta.getDefaultInstance(),
-                        idempotencyStore,
-                        nowTs(),
-                        idempotencyTtlSeconds(),
-                        principalContext::getCorrelationId,
-                        SubmitLeasedPlanSnapshotResultRequest.Chunk::parseFrom))
+    return MutationOps.createProtoConvergentEffects(
+                principalContext.getAccountId(),
+                "SubmitLeasedPlanSnapshotResult",
+                planSnapshotChunkIdempotencyKey(jobId, leaseEpoch, stagedChunk.getChunkIndex()),
+                () -> requestBytes,
+                () -> {
+                  if (!childSpecs.isEmpty()) {
+                    ReconcileJobStore.BulkEnqueueResult enqueueResult =
+                        jobs.bulkEnqueue(childSpecs);
+                    enqueueResult.requireAllSucceeded("snapshot file-group child enqueue");
+                  }
+                  return new IdempotencyGuard.CreateResult<>(
+                      stagedChunk, tableId(lease, durableSnapshotTask));
+                },
+                ignored -> MutationMeta.getDefaultInstance(),
+                idempotencyStore,
+                nowTs(),
+                idempotencyTtlSeconds(),
+                principalContext::getCorrelationId,
+                SubmitLeasedPlanSnapshotResultRequest.Chunk::parseFrom)
             .body
         != null;
   }

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedSnapshotFinalizeExecutionService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedSnapshotFinalizeExecutionService.java
@@ -1021,31 +1021,27 @@ public class LeasedSnapshotFinalizeExecutionService extends BaseServiceImpl {
             : failureKind;
     byte[] requestBytes =
         failurePayload(requiredResultId, effectiveMessage, effectiveFailureKind).toByteArray();
-    // runIdempotentCreate replays the whole supplier on a retryable abort, so the creator must stay
-    // side-effect free; the replacement job is enqueued once, after the result is durably recorded.
     AtomicBoolean recorded = new AtomicBoolean();
     boolean accepted =
-        runIdempotentCreate(
-                () ->
-                    MutationOps.createProto(
-                        principalContext.getAccountId(),
-                        "SubmitLeasedSnapshotFinalizeResult",
-                        resultIdempotencyKey(jobId, requiredResultId),
-                        () -> requestBytes,
-                        () -> {
-                          recorded.set(true);
-                          return new IdempotencyGuard.CreateResult<>(
-                              SubmitLeasedSnapshotFinalizeResultResponse.newBuilder()
-                                  .setAccepted(true)
-                                  .build(),
-                              tableId);
-                        },
-                        ignored -> MutationMeta.getDefaultInstance(),
-                        idempotencyStore,
-                        nowTs(),
-                        idempotencyTtlSeconds(),
-                        principalContext::getCorrelationId,
-                        SubmitLeasedSnapshotFinalizeResultResponse::parseFrom))
+        MutationOps.createProtoReceiptOnly(
+                principalContext.getAccountId(),
+                "SubmitLeasedSnapshotFinalizeResult",
+                resultIdempotencyKey(jobId, requiredResultId),
+                () -> requestBytes,
+                () -> {
+                  recorded.set(true);
+                  return new IdempotencyGuard.CreateResult<>(
+                      SubmitLeasedSnapshotFinalizeResultResponse.newBuilder()
+                          .setAccepted(true)
+                          .build(),
+                      tableId);
+                },
+                ignored -> MutationMeta.getDefaultInstance(),
+                idempotencyStore,
+                nowTs(),
+                idempotencyTtlSeconds(),
+                principalContext::getCorrelationId,
+                SubmitLeasedSnapshotFinalizeResultResponse::parseFrom)
             .body
             .getAccepted();
     if (recorded.get()

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStore.java
@@ -1601,7 +1601,9 @@ public class DurableReconcileJobStore implements ReconcileJobStore {
           "reconcile lease scan capacity exhausted cap=" + leaseMaxConcurrency);
     }
     LeaseRequest effective =
-        (request == null ? LeaseRequest.all() : request).withWorkerAffinity(workerAffinity);
+        (request == null ? LeaseRequest.all() : request)
+            .withWorkerAffinity(workerAffinity)
+            .withDeploymentLane(executionLane);
     LeaseScanStats scanStats = new LeaseScanStats();
     configureLeaseScanStats(scanStats, startedAtMs);
     try {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/IdempotencyRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/IdempotencyRepository.java
@@ -71,6 +71,11 @@ public interface IdempotencyRepository {
     throw new UnsupportedOperationException("atomic idempotency completion is not supported");
   }
 
+  /**
+   * Discards the immutable success blob created for an operation that definitively did not commit.
+   */
+  default void discardPreparedSuccess(PointerStore.CasOp prepared) {}
+
   boolean delete(String key);
 
   boolean deletePendingIfOwned(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/AccountRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/AccountRepository.java
@@ -30,6 +30,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class AccountRepository {
@@ -50,6 +51,21 @@ public class AccountRepository {
 
   public void create(Account account) {
     repo.create(account);
+  }
+
+  public GenericResourceRepository.ResourceWithMeta<Account> createWithCompletion(
+      Account account,
+      Function<GenericResourceRepository.ResourceWithMeta<Account>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.createWithMeta(account, completionFactory);
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      Account account,
+      long expectedPointerVersion,
+      Function<GenericResourceRepository.ResourceWithMeta<Account>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.completeWithMetaIfUnchanged(account, expectedPointerVersion, completionFactory);
   }
 
   public boolean update(Account account, long expectedPointerVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/CatalogRepository.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class CatalogRepository {
@@ -64,6 +65,21 @@ public class CatalogRepository {
 
   public void create(Catalog catalog) {
     repo.create(catalog);
+  }
+
+  public GenericResourceRepository.ResourceWithMeta<Catalog> createWithCompletion(
+      Catalog catalog,
+      Function<GenericResourceRepository.ResourceWithMeta<Catalog>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.createWithMeta(catalog, completionFactory);
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      Catalog catalog,
+      long expectedPointerVersion,
+      Function<GenericResourceRepository.ResourceWithMeta<Catalog>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.completeWithMetaIfUnchanged(catalog, expectedPointerVersion, completionFactory);
   }
 
   public boolean update(Catalog catalog, long expectedPointerVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConnectorRepository.java
@@ -30,6 +30,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class ConnectorRepository {
@@ -50,6 +51,21 @@ public class ConnectorRepository {
 
   public void create(Connector connector) {
     repo.create(connector);
+  }
+
+  public GenericResourceRepository.ResourceWithMeta<Connector> createWithCompletion(
+      Connector connector,
+      Function<GenericResourceRepository.ResourceWithMeta<Connector>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.createWithMeta(connector, completionFactory);
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      Connector connector,
+      long expectedPointerVersion,
+      Function<GenericResourceRepository.ResourceWithMeta<Connector>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.completeWithMetaIfUnchanged(connector, expectedPointerVersion, completionFactory);
   }
 
   public boolean update(Connector connector, long expectedPointerVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConstraintRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ConstraintRepository.java
@@ -23,6 +23,7 @@ import ai.floedb.floecat.service.repo.cache.ImmutableBlobCache;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.model.SnapshotConstraintsKey;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.ConstraintNormalizer;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.storage.spi.BlobStore;
@@ -32,9 +33,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class ConstraintRepository {
+
+  public record PutResult(SnapshotConstraints constraints, MutationMeta meta, boolean changed) {}
 
   private final GenericResourceRepository<SnapshotConstraints, SnapshotConstraintsKey> repo;
 
@@ -89,6 +93,56 @@ public class ConstraintRepository {
     }
     MutationMeta meta = repo.metaFor(key);
     return repo.update(normalized, meta.getPointerVersion());
+  }
+
+  /**
+   * Puts constraints while publishing caller-supplied completion operations in the same pointer
+   * transaction. Exact replays commit only the completion while checking the current pointer.
+   */
+  public PutResult putSnapshotConstraintsWithCompletion(
+      ResourceId tableId,
+      long snapshotId,
+      SnapshotConstraints value,
+      Function<PutResult, List<PointerStore.CasOp>> completionFactory) {
+    SnapshotConstraints normalized = normalizeForKey(tableId, snapshotId, value);
+    SnapshotConstraintsKey key = key(tableId, snapshotId);
+    Optional<SnapshotConstraints> current = repo.getByKeyForMutation(key);
+    if (current.isEmpty()) {
+      var committed =
+          repo.createWithMeta(
+              normalized,
+              resource ->
+                  completionFactory.apply(new PutResult(resource.value(), resource.meta(), true)));
+      return new PutResult(committed.value(), committed.meta(), true);
+    }
+
+    MutationMeta observed = repo.metaFor(key);
+    if (current.get().equals(normalized)) {
+      MutationMeta committed =
+          repo.completeWithMetaIfUnchanged(
+                  current.get(),
+                  observed.getPointerVersion(),
+                  resource ->
+                      completionFactory.apply(
+                          new PutResult(resource.value(), resource.meta(), false)))
+              .orElseThrow(
+                  () ->
+                      new BaseResourceRepository.AbortRetryableException(
+                          "constraints changed before atomic completion"));
+      return new PutResult(current.get(), committed, false);
+    }
+
+    MutationMeta committed =
+        repo.updateWithCompletion(
+                normalized,
+                observed.getPointerVersion(),
+                resource ->
+                    completionFactory.apply(new PutResult(resource.value(), resource.meta(), true)))
+            .orElseThrow(
+                () ->
+                    new BaseResourceRepository.AbortRetryableException(
+                        "constraints changed before atomic update"));
+    return new PutResult(normalized, committed, true);
   }
 
   /**

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/IdempotencyRepositoryImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/IdempotencyRepositoryImpl.java
@@ -173,6 +173,19 @@ public final class IdempotencyRepositoryImpl implements IdempotencyRepository {
   }
 
   @Override
+  public void discardPreparedSuccess(PointerStore.CasOp prepared) {
+    if (prepared instanceof PointerStore.CasUpsert upsert
+        && !upsert.next().getBlobUri().isBlank()) {
+      try {
+        blobs.delete(upsert.next().getBlobUri());
+      } catch (RuntimeException ignored) {
+        // Best effort: the pointer transaction definitively did not publish this blob, and
+        // idempotency GC will reclaim the key prefix after expiry.
+      }
+    }
+  }
+
+  @Override
   public void finalizeSuccess(
       String accountId,
       String key,

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
@@ -56,6 +56,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class IndexArtifactRepository {
@@ -120,6 +121,72 @@ public class IndexArtifactRepository {
           putIndexArtifactGuarded(value);
           return null;
         });
+  }
+
+  public MutationMeta putIndexArtifactWithCompletion(
+      IndexArtifactRecord value,
+      Timestamp now,
+      Function<MutationMeta, List<PointerStore.CasOp>> completionFactory) {
+    requireValidRecord(value);
+    return reachabilityGuard.publishing(
+        value.getTableId(),
+        () -> putIndexArtifactWithCompletionGuarded(value, now, completionFactory));
+  }
+
+  private MutationMeta putIndexArtifactWithCompletionGuarded(
+      IndexArtifactRecord value,
+      Timestamp now,
+      Function<MutationMeta, List<PointerStore.CasOp>> completionFactory) {
+    ResourceId tableId = value.getTableId();
+    refreshSharedSidecars(tableId, List.of(value));
+    Optional<String> active = activeGeneration(tableId, value.getSnapshotId());
+    if (active.isPresent() && !DIRECT_GENERATION.equals(active.get())) {
+      throw new IllegalStateException(
+          "direct index artifact writes cannot mutate finalized generation " + active.get());
+    }
+    if (active.isEmpty() && !activateDirectGenerationIfAbsent(tableId, value.getSnapshotId())) {
+      active = activeGeneration(tableId, value.getSnapshotId());
+      if (active.filter(DIRECT_GENERATION::equals).isEmpty()) {
+        throw new BaseResourceRepository.AbortRetryableException(
+            "direct index artifact generation activation conflicted");
+      }
+    }
+
+    String targetStorageId = indexArtifactTargetStorageId(value.getTarget());
+    byte[] bytes = value.toByteArray();
+    String blobUri =
+        Keys.snapshotIndexArtifactGenerationBlobUri(
+            tableId.getAccountId(),
+            tableId.getId(),
+            value.getSnapshotId(),
+            DIRECT_GENERATION,
+            targetStorageId,
+            Hashing.sha256Hex(bytes));
+    blobStore.put(blobUri, bytes, "application/x-protobuf");
+    String pointerKey =
+        generationPointer(tableId, value.getSnapshotId(), DIRECT_GENERATION, targetStorageId);
+    Pointer current = pointerStore.get(pointerKey).orElse(null);
+    long expectedVersion = current == null ? 0L : current.getVersion();
+    long pointerVersion = expectedVersion + 1L;
+    MutationMeta meta =
+        MutationMeta.newBuilder()
+            .setPointerKey(pointerKey)
+            .setBlobUri(blobUri)
+            .setPointerVersion(pointerVersion)
+            .setUpdatedAt(now)
+            .build();
+    List<PointerStore.CasOp> ops = new ArrayList<>();
+    ops.add(
+        new PointerStore.CasUpsert(
+            pointerKey,
+            expectedVersion,
+            PointerReferences.blobPointer(pointerKey, blobUri, pointerVersion, bytes.length)));
+    ops.addAll(completionFactory.apply(meta));
+    if (!AccountDeletionFence.compareAndSetBatch(pointerStore, tableId.getAccountId(), ops)) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "index artifact changed while committing idempotency receipt");
+    }
+    return meta;
   }
 
   private void putIndexArtifactGuarded(IndexArtifactRecord value) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
@@ -36,6 +36,7 @@ import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.TableBlobReachabilityGuard;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.storage.errors.StorageNotFoundException;
+import ai.floedb.floecat.storage.errors.StorageTransactionConflictException;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import ai.floedb.floecat.types.Hashing;
@@ -56,6 +57,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 @ApplicationScoped
@@ -126,17 +128,21 @@ public class IndexArtifactRepository {
   public MutationMeta putIndexArtifactWithCompletion(
       IndexArtifactRecord value,
       Timestamp now,
-      Function<MutationMeta, List<PointerStore.CasOp>> completionFactory) {
+      Function<MutationMeta, List<PointerStore.CasOp>> completionFactory,
+      Consumer<List<PointerStore.CasOp>> completionDiscarder) {
     requireValidRecord(value);
     return reachabilityGuard.publishing(
         value.getTableId(),
-        () -> putIndexArtifactWithCompletionGuarded(value, now, completionFactory));
+        () ->
+            putIndexArtifactWithCompletionGuarded(
+                value, now, completionFactory, completionDiscarder));
   }
 
   private MutationMeta putIndexArtifactWithCompletionGuarded(
       IndexArtifactRecord value,
       Timestamp now,
-      Function<MutationMeta, List<PointerStore.CasOp>> completionFactory) {
+      Function<MutationMeta, List<PointerStore.CasOp>> completionFactory,
+      Consumer<List<PointerStore.CasOp>> completionDiscarder) {
     ResourceId tableId = value.getTableId();
     refreshSharedSidecars(tableId, List.of(value));
     Optional<String> active = activeGeneration(tableId, value.getSnapshotId());
@@ -151,6 +157,14 @@ public class IndexArtifactRepository {
             "direct index artifact generation activation conflicted");
       }
     }
+    String activePointerKey =
+        Keys.snapshotIndexArtifactActiveGenerationPointer(
+            tableId.getAccountId(), tableId.getId(), value.getSnapshotId());
+    Pointer activePointer = pointerStore.get(activePointerKey).orElse(null);
+    if (activePointer == null || !DIRECT_GENERATION.equals(activePointer.getBlobUri())) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "direct index artifact generation changed before commit");
+    }
 
     String targetStorageId = indexArtifactTargetStorageId(value.getTarget());
     byte[] bytes = value.toByteArray();
@@ -162,6 +176,7 @@ public class IndexArtifactRepository {
             DIRECT_GENERATION,
             targetStorageId,
             Hashing.sha256Hex(bytes));
+    boolean blobExistedBefore = blobStore.head(blobUri).isPresent();
     blobStore.put(blobUri, bytes, "application/x-protobuf");
     String pointerKey =
         generationPointer(tableId, value.getSnapshotId(), DIRECT_GENERATION, targetStorageId);
@@ -176,13 +191,30 @@ public class IndexArtifactRepository {
             .setUpdatedAt(now)
             .build();
     List<PointerStore.CasOp> ops = new ArrayList<>();
+    ops.add(new PointerStore.CasCheck(activePointerKey, activePointer.getVersion()));
     ops.add(
         new PointerStore.CasUpsert(
             pointerKey,
             expectedVersion,
             PointerReferences.blobPointer(pointerKey, blobUri, pointerVersion, bytes.length)));
-    ops.addAll(completionFactory.apply(meta));
-    if (!AccountDeletionFence.compareAndSetBatch(pointerStore, tableId.getAccountId(), ops)) {
+    List<PointerStore.CasOp> completionOps = completionFactory.apply(meta);
+    ops.addAll(completionOps);
+    final boolean committed;
+    try {
+      committed =
+          AccountDeletionFence.compareAndSetBatch(pointerStore, tableId.getAccountId(), ops);
+    } catch (StorageTransactionConflictException confirmedAbort) {
+      completionDiscarder.accept(completionOps);
+      if (!blobExistedBefore) {
+        deleteBlobQuietly(blobUri);
+      }
+      throw confirmedAbort;
+    }
+    if (!committed) {
+      completionDiscarder.accept(completionOps);
+      if (!blobExistedBefore) {
+        deleteBlobQuietly(blobUri);
+      }
       throw new BaseResourceRepository.AbortRetryableException(
           "index artifact changed while committing idempotency receipt");
     }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/NamespaceRepository.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class NamespaceRepository {
@@ -75,6 +76,21 @@ public class NamespaceRepository {
 
   public void create(Namespace namespace) {
     repo.create(namespace);
+  }
+
+  public GenericResourceRepository.ResourceWithMeta<Namespace> createWithCompletion(
+      Namespace namespace,
+      Function<GenericResourceRepository.ResourceWithMeta<Namespace>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.createWithMeta(namespace, completionFactory);
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      Namespace namespace,
+      long expectedPointerVersion,
+      Function<GenericResourceRepository.ResourceWithMeta<Namespace>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.completeWithMetaIfUnchanged(namespace, expectedPointerVersion, completionFactory);
   }
 
   public boolean createWhilePointersMatch(Namespace namespace, PointerConditions conditions) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/SnapshotRepository.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.Function;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -176,6 +177,21 @@ public class SnapshotRepository {
 
   public void create(Snapshot snapshot) {
     repo.create(snapshot);
+  }
+
+  public GenericResourceRepository.ResourceWithMeta<Snapshot> createWithCompletion(
+      Snapshot snapshot,
+      Function<GenericResourceRepository.ResourceWithMeta<Snapshot>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.createWithMeta(snapshot, completionFactory);
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      Snapshot snapshot,
+      long expectedPointerVersion,
+      Function<GenericResourceRepository.ResourceWithMeta<Snapshot>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.completeWithMetaIfUnchanged(snapshot, expectedPointerVersion, completionFactory);
   }
 
   public boolean update(Snapshot snapshot, long expectedPointerVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StatsRepository.java
@@ -234,6 +234,50 @@ public class StatsRepository implements StatsStore {
         canonicalRecord);
   }
 
+  public MutationMeta putTargetStatsWithCompletion(
+      TargetStatsRecord value,
+      Timestamp now,
+      java.util.function.Function<MutationMeta, List<PointerStore.CasOp>> completionFactory) {
+    TargetStatsRecord canonicalRecord = canonicalRecord(value);
+    ActiveSnapshotStats active =
+        ensureActiveGeneration(canonicalRecord.getTableId(), canonicalRecord.getSnapshotId());
+    String pointerKey = pointerKey(canonicalRecord, active.generationId());
+    String blobUri = blobUri(canonicalRecord, active.generationId());
+    targetStatsStorage.putBlob(blobUri, canonicalRecord);
+
+    Pointer current = pointerStore.get(pointerKey).orElse(null);
+    if (current != null && !blobUri.equals(current.getBlobUri())) {
+      throw new BaseResourceRepository.NameConflictException(
+          "target stats pointer bound to different blob: " + pointerKey);
+    }
+    long pointerVersion = current == null ? 1L : current.getVersion();
+    MutationMeta meta =
+        MutationMeta.newBuilder()
+            .setPointerKey(pointerKey)
+            .setBlobUri(blobUri)
+            .setPointerVersion(pointerVersion)
+            .setUpdatedAt(now)
+            .build();
+    List<PointerStore.CasOp> ops = new ArrayList<>();
+    if (current == null) {
+      ops.add(
+          new PointerStore.CasUpsert(
+              pointerKey,
+              0L,
+              PointerReferences.blobPointer(
+                  pointerKey, blobUri, 1L, canonicalRecord.getSerializedSize())));
+    } else {
+      ops.add(new PointerStore.CasCheck(pointerKey, current.getVersion()));
+    }
+    ops.addAll(completionFactory.apply(meta));
+    if (!AccountDeletionFence.compareAndSetBatch(
+        pointerStore, canonicalRecord.getTableId().getAccountId(), ops)) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "target stats changed while committing idempotency receipt");
+    }
+    return meta;
+  }
+
   @Override
   public void putTargetStatsBatch(
       ResourceId tableId, long snapshotId, List<TargetStatsRecord> records) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/StorageAuthorityRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/StorageAuthorityRepository.java
@@ -30,6 +30,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class StorageAuthorityRepository {
@@ -50,6 +51,25 @@ public class StorageAuthorityRepository {
 
   public void create(StorageAuthority authority) {
     repo.create(authority);
+  }
+
+  public GenericResourceRepository.ResourceWithMeta<StorageAuthority> createWithCompletion(
+      StorageAuthority authority,
+      Function<
+              GenericResourceRepository.ResourceWithMeta<StorageAuthority>,
+              List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.createWithMeta(authority, completionFactory);
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      StorageAuthority authority,
+      long expectedPointerVersion,
+      Function<
+              GenericResourceRepository.ResourceWithMeta<StorageAuthority>,
+              List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.completeWithMetaIfUnchanged(authority, expectedPointerVersion, completionFactory);
   }
 
   public boolean update(StorageAuthority authority, long expectedPointerVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TableRepository.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class TableRepository {
@@ -67,6 +68,21 @@ public class TableRepository {
 
   public void create(Table table) {
     repo.create(table);
+  }
+
+  public GenericResourceRepository.ResourceWithMeta<Table> createWithCompletion(
+      Table table,
+      Function<GenericResourceRepository.ResourceWithMeta<Table>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.createWithMeta(table, completionFactory);
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      Table table,
+      long expectedPointerVersion,
+      Function<GenericResourceRepository.ResourceWithMeta<Table>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.completeWithMetaIfUnchanged(table, expectedPointerVersion, completionFactory);
   }
 
   public Optional<MutationMeta> createWhilePointersMatch(

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TransactionRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TransactionRepository.java
@@ -28,6 +28,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 @ApplicationScoped
@@ -70,8 +71,10 @@ public class TransactionRepository {
       Transaction txn,
       long expectedPointerVersion,
       Function<GenericResourceRepository.ResourceWithMeta<Transaction>, List<PointerStore.CasOp>>
-          completionFactory) {
-    return repo.completeWithMetaIfUnchanged(txn, expectedPointerVersion, completionFactory);
+          completionFactory,
+      Consumer<List<PointerStore.CasOp>> completionDiscarder) {
+    return repo.completeWithMetaIfUnchanged(
+        txn, expectedPointerVersion, completionFactory, completionDiscarder);
   }
 
   public boolean update(Transaction txn, long expectedPointerVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/TransactionRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/TransactionRepository.java
@@ -26,7 +26,9 @@ import ai.floedb.floecat.transaction.rpc.Transaction;
 import com.google.protobuf.Timestamp;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class TransactionRepository {
@@ -47,6 +49,29 @@ public class TransactionRepository {
 
   public void create(Transaction txn) {
     repo.create(txn);
+  }
+
+  public GenericResourceRepository.ResourceWithMeta<Transaction> createWithCompletion(
+      Transaction txn,
+      Function<GenericResourceRepository.ResourceWithMeta<Transaction>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.createWithMeta(txn, completionFactory);
+  }
+
+  public Optional<MutationMeta> updateWithCompletion(
+      Transaction txn,
+      long expectedPointerVersion,
+      Function<GenericResourceRepository.ResourceWithMeta<Transaction>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.updateWithCompletion(txn, expectedPointerVersion, completionFactory);
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      Transaction txn,
+      long expectedPointerVersion,
+      Function<GenericResourceRepository.ResourceWithMeta<Transaction>, List<PointerStore.CasOp>>
+          completionFactory) {
+    return repo.completeWithMetaIfUnchanged(txn, expectedPointerVersion, completionFactory);
   }
 
   public boolean update(Transaction txn, long expectedPointerVersion) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/ViewRepository.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.service.repo.model.Schemas;
 import ai.floedb.floecat.service.repo.model.ViewKey;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository;
 import ai.floedb.floecat.service.repo.util.GenericResourceRepository.PointerConditions;
+import ai.floedb.floecat.service.repo.util.GenericResourceRepository.ResourceWithMeta;
 import ai.floedb.floecat.service.repo.util.MetadataRepositoryFactory;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class ViewRepository {
@@ -67,6 +69,18 @@ public class ViewRepository {
 
   public void create(View view) {
     repo.create(view);
+  }
+
+  public ResourceWithMeta<View> createWithCompletion(
+      View view, Function<ResourceWithMeta<View>, List<PointerStore.CasOp>> completionFactory) {
+    return repo.createWithMeta(view, completionFactory);
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      View view,
+      long expectedPointerVersion,
+      Function<ResourceWithMeta<View>, List<PointerStore.CasOp>> completionFactory) {
+    return repo.completeWithMetaIfUnchanged(view, expectedPointerVersion, completionFactory);
   }
 
   public boolean createWhilePointersMatch(View view, PointerConditions conditions) {

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -867,6 +867,21 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
         updatedValue, expectedCanonicalVersion, PointerConditions.none());
   }
 
+  /**
+   * Atomically updates a resource and publishes caller-supplied completion operations in the same
+   * pointer transaction. The factory receives the exact body and metadata that will commit.
+   */
+  public Optional<MutationMeta> updateWithCompletion(
+      T updatedValue,
+      long expectedCanonicalVersion,
+      Function<ResourceWithMeta<T>, List<PointerStore.CasOp>> completionFactory) {
+    return updateWithMetaWhilePointersMatchAndBumpMarkers(
+        updatedValue,
+        expectedCanonicalVersion,
+        PointerConditions.none(),
+        Objects.requireNonNull(completionFactory));
+  }
+
   private record PreparedUpdate(
       String blobUri,
       Pointer committedCanonical,
@@ -1000,6 +1015,16 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       long expectedCanonicalVersion,
       PointerConditions conditions,
       List<PointerStore.CasOp> companions) {
+    List<PointerStore.CasOp> stableCompanions = List.copyOf(companions);
+    return updateWithMetaWhilePointersMatchAndBumpMarkers(
+        updatedValue, expectedCanonicalVersion, conditions, ignored -> stableCompanions);
+  }
+
+  private Optional<MutationMeta> updateWithMetaWhilePointersMatchAndBumpMarkers(
+      T updatedValue,
+      long expectedCanonicalVersion,
+      PointerConditions conditions,
+      Function<ResourceWithMeta<T>, List<PointerStore.CasOp>> completionFactory) {
     Map<String, Long> requiredPointerVersions = conditions.requiredVersions();
     Set<String> requiredAbsentPointers = conditions.requiredAbsent();
     Map<String, Long> markerVersions = conditions.markerVersions();
@@ -1022,6 +1047,16 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
             ops.add(new PointerStore.CasCheckAbsent(accountDeletionFence));
           }
           addMarkerAdvances(markerVersions, batchedKeys, ops, "update");
+          MutationMeta committedMeta =
+              committedMeta(
+                  Optional.of(committedCanonical),
+                  canonicalPointer,
+                  blobUri,
+                  Timestamps.fromMillis(clock.millis()));
+          List<PointerStore.CasOp> companions =
+              completionFactory == null
+                  ? List.of()
+                  : completionFactory.apply(new ResourceWithMeta<>(updatedValue, committedMeta));
           for (PointerStore.CasOp companion : companions) {
             if (!batchedKeys.add(companion.key())) {
               throw new IllegalArgumentException(
@@ -1032,12 +1067,7 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
 
           if (mutationPointerStore.compareAndSetBatch(ops)) {
             healCanonicalBlobIfMissing(blobUri, updatedValue);
-            return Optional.of(
-                committedMeta(
-                    Optional.of(committedCanonical),
-                    canonicalPointer,
-                    blobUri,
-                    Timestamps.fromMillis(clock.millis())));
+            return Optional.of(committedMeta);
           }
           if (!pointerConditionsStillMatch(requiredPointerVersions, requiredAbsentPointers))
             return Optional.empty();
@@ -1051,6 +1081,58 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           if (!markerVersionsStillMatch(markerVersions)) return Optional.empty();
           classifyCompanionConflict(companions);
           classifyUpdateConflict(canonicalPointer, expectedCanonicalVersion, blobUri, toAdd);
+          return Optional.empty();
+        });
+  }
+
+  /**
+   * Publishes completion operations while asserting that an already-equal resource still has the
+   * observed canonical version. No resource pointer is advanced on this no-op path.
+   */
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      T currentValue,
+      long expectedCanonicalVersion,
+      Function<ResourceWithMeta<T>, List<PointerStore.CasOp>> completionFactory) {
+    return observeRepository(
+        "complete_if_unchanged",
+        () -> {
+          K key = schema.keyFromValue.apply(currentValue);
+          guardSystemObject(key);
+          String canonicalPointer = schema.canonicalPointerForKey.apply(key);
+          Pointer current = mutationPointerStore.get(canonicalPointer).orElse(null);
+          if (current == null || current.getVersion() != expectedCanonicalVersion) {
+            return Optional.empty();
+          }
+          String blobUri = requireBlobReference(current, canonicalPointer);
+          MutationMeta meta =
+              committedMeta(
+                  Optional.of(current),
+                  canonicalPointer,
+                  blobUri,
+                  Timestamps.fromMillis(clock.millis()));
+          List<PointerStore.CasOp> ops = new ArrayList<>();
+          ops.add(new PointerStore.CasCheck(canonicalPointer, expectedCanonicalVersion));
+          ops.add(
+              new PointerStore.CasCheckAbsent(
+                  Keys.accountDeletionFenceShard(key.accountId(), canonicalPointer)));
+          Set<String> keys = new HashSet<>();
+          keys.add(canonicalPointer);
+          keys.add(Keys.accountDeletionFenceShard(key.accountId(), canonicalPointer));
+          for (PointerStore.CasOp companion :
+              Objects.requireNonNull(completionFactory)
+                  .apply(new ResourceWithMeta<>(currentValue, meta))) {
+            if (!keys.add(companion.key())) {
+              throw new IllegalArgumentException(
+                  "duplicate companion pointer in atomic completion: " + companion.key());
+            }
+            ops.add(companion);
+          }
+          if (mutationPointerStore.compareAndSetBatch(ops)) {
+            return Optional.of(meta);
+          }
+          if (mutationPointerStore.get(Keys.accountDeletionMarker(key.accountId())).isPresent()) {
+            throw accountDeletionInProgress(key);
+          }
           return Optional.empty();
         });
   }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/util/GenericResourceRepository.java
@@ -26,6 +26,7 @@ import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.model.ResourceKey;
 import ai.floedb.floecat.service.repo.model.ResourceSchema;
 import ai.floedb.floecat.service.telemetry.ServiceMetrics;
+import ai.floedb.floecat.storage.errors.StorageTransactionConflictException;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import ai.floedb.floecat.systemcatalog.graph.SystemResourceIdGenerator;
@@ -42,6 +43,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import org.jboss.logging.Logger;
 
@@ -1093,6 +1095,15 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
       T currentValue,
       long expectedCanonicalVersion,
       Function<ResourceWithMeta<T>, List<PointerStore.CasOp>> completionFactory) {
+    return completeWithMetaIfUnchanged(
+        currentValue, expectedCanonicalVersion, completionFactory, ignored -> {});
+  }
+
+  public Optional<MutationMeta> completeWithMetaIfUnchanged(
+      T currentValue,
+      long expectedCanonicalVersion,
+      Function<ResourceWithMeta<T>, List<PointerStore.CasOp>> completionFactory,
+      Consumer<List<PointerStore.CasOp>> completionDiscarder) {
     return observeRepository(
         "complete_if_unchanged",
         () -> {
@@ -1118,18 +1129,27 @@ public class GenericResourceRepository<T, K extends ResourceKey> extends BaseRes
           Set<String> keys = new HashSet<>();
           keys.add(canonicalPointer);
           keys.add(Keys.accountDeletionFenceShard(key.accountId(), canonicalPointer));
-          for (PointerStore.CasOp companion :
+          List<PointerStore.CasOp> companions =
               Objects.requireNonNull(completionFactory)
-                  .apply(new ResourceWithMeta<>(currentValue, meta))) {
+                  .apply(new ResourceWithMeta<>(currentValue, meta));
+          for (PointerStore.CasOp companion : companions) {
             if (!keys.add(companion.key())) {
               throw new IllegalArgumentException(
                   "duplicate companion pointer in atomic completion: " + companion.key());
             }
             ops.add(companion);
           }
-          if (mutationPointerStore.compareAndSetBatch(ops)) {
+          final boolean committed;
+          try {
+            committed = mutationPointerStore.compareAndSetBatch(ops);
+          } catch (StorageTransactionConflictException confirmedAbort) {
+            completionDiscarder.accept(companions);
+            throw confirmedAbort;
+          }
+          if (committed) {
             return Optional.of(meta);
           }
+          completionDiscarder.accept(companions);
           if (mutationPointerStore.get(Keys.accountDeletionMarker(key.accountId())).isPresent()) {
             throw accountDeletionInProgress(key);
           }

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImpl.java
@@ -50,6 +50,7 @@ import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
+import ai.floedb.floecat.service.repo.impl.StatsRepository;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
 import ai.floedb.floecat.service.statistics.StatsOrchestrator;
@@ -76,6 +77,7 @@ public class TableStatisticsServiceImpl extends BaseServiceImpl implements Table
 
   @Inject SnapshotRepository snapshots;
   @Inject StatsStore statsStore;
+  @Inject StatsRepository atomicStatsRepository;
   @Inject PrincipalProvider principal;
   @Inject Authorizer authz;
   @Inject IdempotencyRepository idempotencyStore;
@@ -389,29 +391,33 @@ public class TableStatisticsServiceImpl extends BaseServiceImpl implements Table
 
       String targetKey = StatsTargetIdentity.storageId(targetRecord.getTarget());
       var itemKey = itemIdempotencyKey(next.idempotencyKey(), "target", hashString(targetKey));
-      runIdempotentCreate(
-          () ->
-              MutationOps.createProto(
-                  accountId,
-                  "PutTargetStats",
-                  itemKey,
-                  () -> fingerprint,
-                  () -> {
-                    statsStore.putTargetStats(targetRecord);
-                    statsOrchestrator.invalidateStatsCache(
-                        targetRecord.getTableId(),
-                        targetRecord.getSnapshotId(),
-                        targetRecord.getTarget());
-                    return new IdempotencyGuard.CreateResult<>(targetRecord, next.tableId());
-                  },
-                  rec ->
-                      statsStore.metaForTargetStats(
-                          next.tableId(), next.snapshotId(), rec.getTarget(), tsNow),
-                  idempotencyStore,
-                  tsNow,
-                  idempotencyTtlSeconds(),
-                  this::correlationId,
-                  TargetStatsRecord::parseFrom));
+      var result =
+          MutationOps.commitProto(
+              accountId,
+              "PutTargetStats",
+              itemKey,
+              () -> fingerprint,
+              next.tableId(),
+              committer -> {
+                var committedMeta =
+                    atomicStatsRepository.putTargetStatsWithCompletion(
+                        targetRecord,
+                        tsNow,
+                        meta ->
+                            committer.prepareOps(
+                                new IdempotencyGuard.CommittedCreate<>(
+                                    targetRecord, next.tableId(), meta)));
+                return new IdempotencyGuard.CommittedCreate<>(
+                    targetRecord, next.tableId(), committedMeta);
+              },
+              idempotencyStore,
+              tsNow,
+              idempotencyTtlSeconds(),
+              this::correlationId,
+              TargetStatsRecord::parseFrom);
+
+      statsOrchestrator.invalidateStatsCache(
+          result.body.getTableId(), result.body.getSnapshotId(), result.body.getTarget());
 
       upserted.incrementAndGet();
     }

--- a/service/src/main/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/statistics/impl/TableStatisticsServiceImpl.java
@@ -404,7 +404,7 @@ public class TableStatisticsServiceImpl extends BaseServiceImpl implements Table
                         targetRecord,
                         tsNow,
                         meta ->
-                            committer.prepareOps(
+                            committer.prepareSuccessOps(
                                 new IdempotencyGuard.CommittedCreate<>(
                                     targetRecord, next.tableId(), meta)));
                 return new IdempotencyGuard.CommittedCreate<>(

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
@@ -192,7 +192,7 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
                             repo.createWithCompletion(
                                 authority,
                                 resource ->
-                                    committer.prepareOps(
+                                    committer.prepareSuccessOps(
                                         new IdempotencyGuard.CommittedCreate<>(
                                             resource.value(), authorityId, resource.meta())));
                         return new IdempotencyGuard.CommittedCreate<>(

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImpl.java
@@ -29,6 +29,7 @@ import ai.floedb.floecat.reconciler.impl.ReconcileLeaseGrpcStatus;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.service.common.BaseServiceImpl;
+import ai.floedb.floecat.service.common.IdempotencyGuard;
 import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.error.impl.GeneratedErrorMessages;
 import ai.floedb.floecat.service.error.impl.GrpcErrors;
@@ -175,22 +176,28 @@ public class StorageAuthorityServiceImpl extends BaseServiceImpl implements Stor
               String idempotencyKey =
                   request.hasIdempotency() ? request.getIdempotency().getKey() : "";
               var op =
-                  MutationOps.createProto(
+                  MutationOps.createProtoRecoverable(
                       accountId,
                       "create-storage-authority",
                       idempotencyKey,
                       () -> spec.toByteArray(),
-                      () -> {
-                        ResourceId authorityId =
-                            randomResourceId(accountId, ResourceKind.RK_STORAGE_AUTHORITY);
+                      () -> randomResourceId(accountId, ResourceKind.RK_STORAGE_AUTHORITY),
+                      (authorityId, committer) -> {
                         StorageAuthority authority =
                             buildAuthority(authorityId, spec, null, nowTs());
-                        repo.create(authority);
+                        // Credentials use the reserved resource id and are an idempotent upsert.
+                        // A retry therefore converges before publishing the authority pointer.
                         storeCredentials(accountId, authorityId.getId(), spec);
-                        return new ai.floedb.floecat.service.common.IdempotencyGuard.CreateResult<>(
-                            authority, authorityId);
+                        var committed =
+                            repo.createWithCompletion(
+                                authority,
+                                resource ->
+                                    committer.prepareOps(
+                                        new IdempotencyGuard.CommittedCreate<>(
+                                            resource.value(), authorityId, resource.meta())));
+                        return new IdempotencyGuard.CommittedCreate<>(
+                            committed.value(), authorityId, committed.meta());
                       },
-                      authority -> repo.metaFor(authority.getResourceId()),
                       idempotencyStore,
                       nowTs(),
                       idempotencyTtlSeconds(),

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionIntentApplierSupport.java
@@ -291,6 +291,16 @@ public class TransactionIntentApplierSupport {
       long expectedTransactionPointerVersion,
       List<TransactionIntent> intents,
       TransactionIntentRepository intentRepo) {
+    return applyTransactionAtomically(
+        appliedTransaction, expectedTransactionPointerVersion, intents, intentRepo, List.of());
+  }
+
+  public ApplyOutcome applyTransactionAtomically(
+      Transaction appliedTransaction,
+      long expectedTransactionPointerVersion,
+      List<TransactionIntent> intents,
+      TransactionIntentRepository intentRepo,
+      List<PointerStore.CasOp> completionOps) {
     if (appliedTransaction == null) {
       return ApplyOutcome.retryable("MISSING_TRANSACTION", "applied transaction is required");
     }
@@ -317,7 +327,7 @@ public class TransactionIntentApplierSupport {
       if (cleanupOutcome.status != ApplyStatus.APPLIED) {
         return cleanupOutcome;
       }
-      if (ops.size() > MAX_POINTER_TXN_OPS - 1) {
+      if (ops.size() > MAX_POINTER_TXN_OPS - 1 - completionOps.size()) {
         return ApplyOutcome.conflict(
             "POINTER_TXN_TOO_LARGE",
             "transaction requires more than " + MAX_POINTER_TXN_OPS + " pointer operations",
@@ -332,6 +342,12 @@ public class TransactionIntentApplierSupport {
             appliedTransaction, expectedTransactionPointerVersion, touchedKeys, ops);
     if (txOutcome.status != ApplyStatus.APPLIED) {
       return txOutcome;
+    }
+    for (PointerStore.CasOp completionOp : completionOps) {
+      ApplyOutcome completionOutcome = addOp(completionOp, completionOp.key(), touchedKeys, ops);
+      if (completionOutcome.status != ApplyStatus.APPLIED) {
+        return completionOutcome;
+      }
     }
     if (ops.size() > MAX_POINTER_TXN_OPS) {
       return ApplyOutcome.conflict(

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
@@ -62,6 +62,7 @@ import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository.PreconditionFailedException;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.storage.errors.StorageTransactionConflictException;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import ai.floedb.floecat.storage.spi.PointerStore;
 import ai.floedb.floecat.systemcatalog.graph.SystemResourceIdGenerator;
@@ -196,7 +197,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
                                 txRepo.createWithCompletion(
                                     txn,
                                     resource ->
-                                        committer.prepareOps(
+                                        committer.prepareSuccessOps(
                                             new IdempotencyGuard.CommittedCreate<>(
                                                 resource.value(), reservedId, resource.meta())));
                             return new IdempotencyGuard.CommittedCreate<>(
@@ -520,7 +521,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
                 updated,
                 version,
                 resource ->
-                    committer.prepareOps(
+                    committer.prepareSuccessOps(
                         new IdempotencyGuard.CommittedCreate<>(
                             resource.value(),
                             transactionResourceId(accountId, txId),
@@ -565,9 +566,10 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
             transaction,
             meta.getPointerVersion(),
             resource ->
-                committer.prepareOps(
+                committer.prepareSuccessOps(
                     new IdempotencyGuard.CommittedCreate<>(
-                        resource.value(), resourceId, resource.meta())));
+                        resource.value(), resourceId, resource.meta())),
+            committer::discardPreparedSuccessOps);
     if (completed.isEmpty()) {
       throw new BaseResourceRepository.AbortRetryableException(
           "transaction changed while committing idempotency receipt");
@@ -882,15 +884,27 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     var completionOps =
         committer == null
             ? List.<PointerStore.CasOp>of()
-            : committer.prepareOps(
+            : committer.prepareSuccessOps(
                 new IdempotencyGuard.CommittedCreate<>(
                     appliedCandidate, appliedResourceId, appliedMeta));
-    var outcome =
-        committer == null
-            ? intentApplierSupport.applyTransactionAtomically(
-                appliedCandidate, transactionPointerVersion, intents, intentRepo)
-            : intentApplierSupport.applyTransactionAtomically(
-                appliedCandidate, transactionPointerVersion, intents, intentRepo, completionOps);
+    final TransactionIntentApplierSupport.ApplyOutcome outcome;
+    try {
+      outcome =
+          committer == null
+              ? intentApplierSupport.applyTransactionAtomically(
+                  appliedCandidate, transactionPointerVersion, intents, intentRepo)
+              : intentApplierSupport.applyTransactionAtomically(
+                  appliedCandidate, transactionPointerVersion, intents, intentRepo, completionOps);
+    } catch (StorageTransactionConflictException confirmedAbort) {
+      if (committer != null) {
+        committer.discardPreparedSuccessOps(completionOps);
+      }
+      throw confirmedAbort;
+    }
+    if (outcome.status() != TransactionIntentApplierSupport.ApplyStatus.APPLIED
+        && committer != null) {
+      committer.discardPreparedSuccessOps(completionOps);
+    }
     if (outcome.status() == TransactionIntentApplierSupport.ApplyStatus.APPLIED) {
       Transaction latest = getTransactionOrThrow(accountId, applyPhaseTxn.getTxId());
       Transaction applied =

--- a/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/transaction/impl/TransactionsServiceImpl.java
@@ -58,6 +58,7 @@ import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionIntentRepository;
 import ai.floedb.floecat.service.repo.impl.TransactionRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository.PreconditionFailedException;
 import ai.floedb.floecat.service.security.impl.Authorizer;
 import ai.floedb.floecat.service.security.impl.PrincipalProvider;
@@ -170,17 +171,37 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
                   }
 
                   var result =
-                      IdempotencyGuard.runOnce(
+                      IdempotencyGuard.runOnceReserved(
                           accountId,
                           "BeginTransaction",
                           idempotencyKey,
                           request.toByteArray(),
-                          () -> {
-                            Transaction txn = createTransaction(accountId, request, now);
-                            return new IdempotencyGuard.CreateResult<>(
-                                txn, transactionResourceId(accountId, txn.getTxId()));
+                          () -> transactionResourceId(accountId, randomUuid()),
+                          (reservedId, committer) -> {
+                            Timestamp expires =
+                                request.hasTtl()
+                                    ? Timestamps.add(now, request.getTtl())
+                                    : Timestamps.add(now, defaultTtl());
+                            Transaction txn =
+                                Transaction.newBuilder()
+                                    .setTxId(reservedId.getId())
+                                    .setAccountId(accountId)
+                                    .setState(TransactionState.TS_OPEN)
+                                    .setCreatedAt(now)
+                                    .setUpdatedAt(now)
+                                    .setExpiresAt(expires)
+                                    .putAllProperties(request.getPropertiesMap())
+                                    .build();
+                            var committed =
+                                txRepo.createWithCompletion(
+                                    txn,
+                                    resource ->
+                                        committer.prepareOps(
+                                            new IdempotencyGuard.CommittedCreate<>(
+                                                resource.value(), reservedId, resource.meta())));
+                            return new IdempotencyGuard.CommittedCreate<>(
+                                committed.value(), reservedId, committed.meta());
                           },
-                          txn -> txRepo.metaFor(accountId, txn.getTxId(), now),
                           Transaction::toByteArray,
                           bytes -> {
                             try {
@@ -220,22 +241,20 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
 
                   Timestamp now = Timestamps.fromMillis(clock.millis());
                   if (idempotencyKey == null) {
-                    Transaction updated = prepareTransaction(accountId, request, now);
+                    Transaction updated =
+                        prepareTransaction(accountId, request, now, null).resource();
                     return PrepareTransactionResponse.newBuilder().setTransaction(updated).build();
                   }
 
+                  var transactionId = transactionResourceId(accountId, request.getTxId());
                   var result =
-                      IdempotencyGuard.runOnce(
+                      IdempotencyGuard.runOnceCommitted(
                           accountId,
                           "PrepareTransaction",
                           idempotencyKey,
                           request.toByteArray(),
-                          () -> {
-                            Transaction updated = prepareTransaction(accountId, request, now);
-                            return new IdempotencyGuard.CreateResult<>(
-                                updated, transactionResourceId(accountId, updated.getTxId()));
-                          },
-                          txn -> txRepo.metaFor(accountId, txn.getTxId(), now),
+                          transactionId,
+                          committer -> prepareTransaction(accountId, request, now, committer),
                           Transaction::toByteArray,
                           bytes -> {
                             try {
@@ -290,22 +309,20 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
 
                   Timestamp now = Timestamps.fromMillis(clock.millis());
                   if (idempotencyKey == null) {
-                    Transaction committed = commitTransaction(accountId, request, now);
+                    Transaction committed =
+                        commitTransaction(accountId, request, now, null).resource();
                     return CommitTransactionResponse.newBuilder().setTransaction(committed).build();
                   }
 
+                  var transactionId = transactionResourceId(accountId, request.getTxId());
                   var result =
-                      IdempotencyGuard.runOnce(
+                      IdempotencyGuard.runOnceCommitted(
                           accountId,
                           "CommitTransaction",
                           idempotencyKey,
                           request.toByteArray(),
-                          () -> {
-                            Transaction committed = commitTransaction(accountId, request, now);
-                            return new IdempotencyGuard.CreateResult<>(
-                                committed, transactionResourceId(accountId, committed.getTxId()));
-                          },
-                          txn -> txRepo.metaFor(accountId, txn.getTxId(), now),
+                          transactionId,
+                          committer -> commitTransaction(accountId, request, now, committer),
                           Transaction::toByteArray,
                           bytes -> {
                             try {
@@ -464,8 +481,12 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     throw new PreconditionFailedException("transaction update conflict: " + txId);
   }
 
-  private Transaction transitionPreparedTransaction(
-      String accountId, String txId, int intentCount, Timestamp now) {
+  private IdempotencyGuard.CommittedCreate<Transaction> transitionPreparedTransaction(
+      String accountId,
+      String txId,
+      int intentCount,
+      Timestamp now,
+      IdempotencyGuard.SuccessCommitter<Transaction> committer) {
     if (intentCount <= 0) {
       throw new IllegalArgumentException("prepared transaction must include at least one intent");
     }
@@ -473,7 +494,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
       Transaction current = getTransactionOrThrow(accountId, txId);
       TransactionState currentState = current.getState();
       if (currentState == TransactionState.TS_PREPARED) {
-        return current;
+        return completeTransactionReceipt(accountId, current, now, committer);
       }
       if (currentState != TransactionState.TS_OPEN) {
         throw new PreconditionFailedException(
@@ -486,8 +507,28 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
               .setUpdatedAt(now)
               .putProperties(PREPARED_INTENT_COUNT_PROPERTY, Integer.toString(intentCount))
               .build();
-      if (txRepo.update(updated, version)) {
-        return updated;
+      if (committer == null) {
+        if (txRepo.update(updated, version)) {
+          return new IdempotencyGuard.CommittedCreate<>(
+              updated,
+              transactionResourceId(accountId, txId),
+              txRepo.metaFor(accountId, txId, now));
+        }
+      } else {
+        var meta =
+            txRepo.updateWithCompletion(
+                updated,
+                version,
+                resource ->
+                    committer.prepareOps(
+                        new IdempotencyGuard.CommittedCreate<>(
+                            resource.value(),
+                            transactionResourceId(accountId, txId),
+                            resource.meta())));
+        if (meta.isPresent()) {
+          return new IdempotencyGuard.CommittedCreate<>(
+              updated, transactionResourceId(accountId, txId), meta.get());
+        }
       }
     }
     throw new PreconditionFailedException("transaction update conflict: " + txId);
@@ -507,6 +548,31 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
       throw new IllegalArgumentException(
           "invalid prepared intent count on transaction: " + txn.getTxId(), e);
     }
+  }
+
+  private IdempotencyGuard.CommittedCreate<Transaction> completeTransactionReceipt(
+      String accountId,
+      Transaction transaction,
+      Timestamp now,
+      IdempotencyGuard.SuccessCommitter<Transaction> committer) {
+    var resourceId = transactionResourceId(accountId, transaction.getTxId());
+    var meta = txRepo.metaFor(accountId, transaction.getTxId(), now);
+    if (committer == null) {
+      return new IdempotencyGuard.CommittedCreate<>(transaction, resourceId, meta);
+    }
+    var completed =
+        txRepo.completeWithMetaIfUnchanged(
+            transaction,
+            meta.getPointerVersion(),
+            resource ->
+                committer.prepareOps(
+                    new IdempotencyGuard.CommittedCreate<>(
+                        resource.value(), resourceId, resource.meta())));
+    if (completed.isEmpty()) {
+      throw new BaseResourceRepository.AbortRetryableException(
+          "transaction changed while committing idempotency receipt");
+    }
+    return new IdempotencyGuard.CommittedCreate<>(transaction, resourceId, completed.get());
   }
 
   private ResourceId reserveTransactionTableId(
@@ -591,8 +657,11 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     return RESERVED_TABLE_ID_PROPERTY_PREFIX + URLEncoder.encode(tableFq, StandardCharsets.UTF_8);
   }
 
-  private Transaction prepareTransaction(
-      String accountId, PrepareTransactionRequest request, Timestamp now) {
+  private IdempotencyGuard.CommittedCreate<Transaction> prepareTransaction(
+      String accountId,
+      PrepareTransactionRequest request,
+      Timestamp now,
+      IdempotencyGuard.SuccessCommitter<Transaction> committer) {
     // Public prepare_transaction rejects direct CONNECTOR payloads. CONNECTOR changes processed
     // here must come only from service-side materialization of connector_provisioning hints.
     Transaction txn = getTransactionOrThrow(accountId, request.getTxId());
@@ -602,7 +671,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     }
     if (txn.getState() == TransactionState.TS_PREPARED) {
       ensurePreparedRequestMatchesExistingIntents(accountId, txn.getTxId(), request);
-      return txn;
+      return completeTransactionReceipt(accountId, txn, now, committer);
     }
     if (txn.getState() != TransactionState.TS_OPEN) {
       throw new IllegalArgumentException("transaction not open: " + txn.getState().name());
@@ -656,6 +725,9 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
       intents.add(intent);
     }
     estimatedOps += APPLY_OPS_FOR_TRANSACTION_FINALIZE;
+    if (committer != null) {
+      estimatedOps += 1;
+    }
     if (estimatedOps > MAX_POINTER_TXN_OPS) {
       throw new IllegalArgumentException(
           "transaction requires more than " + MAX_POINTER_TXN_OPS + " pointer operations");
@@ -688,7 +760,8 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     }
 
     try {
-      return transitionPreparedTransaction(accountId, txn.getTxId(), intents.size(), now);
+      return transitionPreparedTransaction(
+          accountId, txn.getTxId(), intents.size(), now, committer);
     } catch (RuntimeException e) {
       for (var intent : created) {
         intentRepo.deleteBothIndices(intent);
@@ -697,14 +770,22 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     }
   }
 
-  private Transaction commitTransaction(
-      String accountId, CommitTransactionRequest request, Timestamp now) {
+  private Transaction prepareTransaction(
+      String accountId, PrepareTransactionRequest request, Timestamp now) {
+    return prepareTransaction(accountId, request, now, null).resource();
+  }
+
+  private IdempotencyGuard.CommittedCreate<Transaction> commitTransaction(
+      String accountId,
+      CommitTransactionRequest request,
+      Timestamp now,
+      IdempotencyGuard.SuccessCommitter<Transaction> committer) {
     Transaction txn = getTransactionOrThrow(accountId, request.getTxId());
     if (txn.getState() == TransactionState.TS_APPLIED) {
-      return txn;
+      return completeTransactionReceipt(accountId, txn, now, committer);
     }
     if (txn.getState() == TransactionState.TS_APPLY_FAILED_CONFLICT) {
-      return txn;
+      return completeTransactionReceipt(accountId, txn, now, committer);
     }
     if (txn.getState() != TransactionState.TS_APPLYING && isExpired(txn, now)) {
       abortExpired(txn, now);
@@ -729,7 +810,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
               now,
               "prepared intent set is incomplete");
       if (failed.getState() == TransactionState.TS_APPLIED) {
-        return failed;
+        return completeTransactionReceipt(accountId, failed, now, committer);
       }
       logCommitFailure(
           accountId,
@@ -737,7 +818,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
           "PREPARED_INTENT_COUNT_MISMATCH",
           "prepared transaction intent count does not match by-tx enumeration",
           intents);
-      return failed;
+      return completeTransactionReceipt(accountId, failed, now, committer);
     }
     if (intents.isEmpty()) {
       throw new IllegalArgumentException("transaction has no intents");
@@ -770,7 +851,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         if (failed.getState() == TransactionState.TS_APPLIED) {
           schedulePostCommitCaptureBootstrap(accountId, failed.getTxId(), List.copyOf(intents));
           convergeAfterApply(intents);
-          return failed;
+          return completeTransactionReceipt(accountId, failed, now, committer);
         }
         logCommitFailure(
             accountId,
@@ -778,7 +859,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
             "LOCK_OWNERSHIP_MISMATCH",
             "lock ownership mismatch during apply",
             intents);
-        return failed;
+        return completeTransactionReceipt(accountId, failed, now, committer);
       }
     }
 
@@ -786,16 +867,40 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         txRepo.metaFor(accountId, applyPhaseTxn.getTxId()).getPointerVersion();
     Transaction appliedCandidate =
         applyPhaseTxn.toBuilder().setState(TransactionState.TS_APPLIED).setUpdatedAt(now).build();
+    var appliedResourceId = transactionResourceId(accountId, appliedCandidate.getTxId());
+    var appliedMeta =
+        MutationMeta.newBuilder()
+            .setPointerKey(Keys.transactionPointerById(accountId, appliedCandidate.getTxId()))
+            .setBlobUri(
+                Keys.transactionBlobUri(
+                    accountId,
+                    appliedCandidate.getTxId(),
+                    ai.floedb.floecat.types.Hashing.sha256Hex(appliedCandidate.toByteArray())))
+            .setPointerVersion(transactionPointerVersion + 1L)
+            .setUpdatedAt(now)
+            .build();
+    var completionOps =
+        committer == null
+            ? List.<PointerStore.CasOp>of()
+            : committer.prepareOps(
+                new IdempotencyGuard.CommittedCreate<>(
+                    appliedCandidate, appliedResourceId, appliedMeta));
     var outcome =
-        intentApplierSupport.applyTransactionAtomically(
-            appliedCandidate, transactionPointerVersion, intents, intentRepo);
+        committer == null
+            ? intentApplierSupport.applyTransactionAtomically(
+                appliedCandidate, transactionPointerVersion, intents, intentRepo)
+            : intentApplierSupport.applyTransactionAtomically(
+                appliedCandidate, transactionPointerVersion, intents, intentRepo, completionOps);
     if (outcome.status() == TransactionIntentApplierSupport.ApplyStatus.APPLIED) {
       Transaction latest = getTransactionOrThrow(accountId, applyPhaseTxn.getTxId());
       Transaction applied =
           latest.getState() == TransactionState.TS_APPLIED ? latest : appliedCandidate;
       schedulePostCommitCaptureBootstrap(accountId, applied.getTxId(), List.copyOf(intents));
       convergeAfterApply(intents);
-      return applied;
+      return new IdempotencyGuard.CommittedCreate<>(
+          applied,
+          appliedResourceId,
+          committer == null ? txRepo.metaFor(accountId, applied.getTxId(), now) : appliedMeta);
     }
 
     if (outcome.status() == TransactionIntentApplierSupport.ApplyStatus.CONFLICT) {
@@ -804,7 +909,7 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
         Transaction applied = latest;
         schedulePostCommitCaptureBootstrap(accountId, applied.getTxId(), List.copyOf(intents));
         convergeAfterApply(intents);
-        return applied;
+        return completeTransactionReceipt(accountId, applied, now, committer);
       }
       annotateIntentApplyFailure(intents, outcome, now);
       Transaction failed =
@@ -819,10 +924,10 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
       if (failed.getState() == TransactionState.TS_APPLIED) {
         schedulePostCommitCaptureBootstrap(accountId, failed.getTxId(), List.copyOf(intents));
         convergeAfterApply(intents);
-        return failed;
+        return completeTransactionReceipt(accountId, failed, now, committer);
       }
       logCommitFailure(accountId, failed, outcome, intents);
-      return failed;
+      return completeTransactionReceipt(accountId, failed, now, committer);
     }
 
     annotateIntentApplyFailure(intents, outcome, now);
@@ -838,10 +943,15 @@ public class TransactionsServiceImpl extends BaseServiceImpl implements Transact
     if (failed.getState() == TransactionState.TS_APPLIED) {
       schedulePostCommitCaptureBootstrap(accountId, failed.getTxId(), List.copyOf(intents));
       convergeAfterApply(intents);
-      return failed;
+      return completeTransactionReceipt(accountId, failed, now, committer);
     }
     logCommitFailure(accountId, failed, outcome, intents);
-    return failed;
+    return completeTransactionReceipt(accountId, failed, now, committer);
+  }
+
+  private Transaction commitTransaction(
+      String accountId, CommitTransactionRequest request, Timestamp now) {
+    return commitTransaction(accountId, request, now, null).resource();
   }
 
   private Transaction transitionApplyFailureOrReturnApplied(

--- a/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/account/impl/AccountServiceImplTest.java
@@ -24,6 +24,7 @@ import ai.floedb.floecat.account.rpc.CreateAccountRequest;
 import ai.floedb.floecat.account.rpc.DeleteAccountRequest;
 import ai.floedb.floecat.account.rpc.UpdateAccountRequest;
 import ai.floedb.floecat.common.rpc.ErrorCode;
+import ai.floedb.floecat.common.rpc.IdempotencyKey;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.Precondition;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
@@ -422,6 +423,36 @@ class AccountServiceImplTest {
     assertEquals(ErrorCode.MC_PRECONDITION_FAILED, decoded.errorCode());
     assertEquals("account.deletion.in.progress", decoded.messageKey());
     assertEquals("acct", decoded.params().get("account_id"));
+  }
+
+  @Test
+  void idempotentCreateNameRaceUsesAccountAlreadyExistsContract() {
+    when(service.accountRepo.getByName("alpha")).thenReturn(Optional.empty());
+    when(service.idempotencyStore.get(any())).thenReturn(Optional.empty());
+    when(service.idempotencyStore.createPending(
+            any(), any(), any(), any(), any(ResourceId.class), any(), any()))
+        .thenReturn(true);
+    doThrow(new BaseResourceRepository.NameConflictException("concurrent account"))
+        .when(service.accountRepo)
+        .createWithCompletion(any(Account.class), any());
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                service
+                    .createAccount(
+                        CreateAccountRequest.newBuilder()
+                            .setAccountId(accountId)
+                            .setSpec(AccountSpec.newBuilder().setDisplayName("alpha"))
+                            .setIdempotency(IdempotencyKey.newBuilder().setKey("idem"))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    FloecatStatus decoded = FloecatStatus.fromThrowable(failure);
+    assertEquals(Status.Code.ALREADY_EXISTS, decoded.canonicalCode());
+    assertEquals("account.already.exists", decoded.messageKey());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImplSystemCatalogTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/CatalogServiceImplSystemCatalogTest.java
@@ -25,16 +25,21 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.rpc.Catalog;
 import ai.floedb.floecat.catalog.rpc.CatalogSpec;
+import ai.floedb.floecat.catalog.rpc.CreateCatalogRequest;
 import ai.floedb.floecat.catalog.rpc.DeleteCatalogRequest;
 import ai.floedb.floecat.catalog.rpc.UpdateCatalogRequest;
+import ai.floedb.floecat.common.rpc.IdempotencyKey;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.scanner.spi.CatalogGraphView;
 import ai.floedb.floecat.service.context.EngineContextProvider;
+import ai.floedb.floecat.service.error.impl.FloecatStatus;
 import ai.floedb.floecat.service.metagraph.overlay.user.UserGraph;
+import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.CatalogRepository;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.MarkerStore;
@@ -56,6 +61,7 @@ class CatalogServiceImplSystemCatalogTest {
   private EngineContextProvider engineContext;
   private MarkerStore markerStore;
   private UserGraph metadataGraph;
+  private IdempotencyRepository idempotencyStore;
 
   @BeforeEach
   void setup() {
@@ -68,6 +74,7 @@ class CatalogServiceImplSystemCatalogTest {
     graphView = mock(CatalogGraphView.class);
     markerStore = mock(MarkerStore.class);
     metadataGraph = mock(UserGraph.class);
+    idempotencyStore = mock(IdempotencyRepository.class);
 
     svc.catalogRepo = catalogRepo;
     svc.principal = principal;
@@ -76,6 +83,7 @@ class CatalogServiceImplSystemCatalogTest {
     svc.graphView = graphView;
     svc.markerStore = markerStore;
     svc.metadataGraph = metadataGraph;
+    svc.idempotencyStore = idempotencyStore;
 
     var pc = mock(PrincipalContext.class);
     when(principal.get()).thenReturn(pc);
@@ -142,6 +150,41 @@ class CatalogServiceImplSystemCatalogTest {
 
     assertEquals(0L, response.getMeta().getPointerVersion());
     verify(metadataGraph).invalidate(id);
+  }
+
+  @Test
+  void idempotentCreateNameRaceUsesCatalogAlreadyExistsContract() {
+    when(catalogRepo.getByName("acct", "alpha")).thenReturn(Optional.empty());
+    when(idempotencyStore.get(anyString())).thenReturn(Optional.empty());
+    when(idempotencyStore.createPending(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(ResourceId.class),
+            any(),
+            any()))
+        .thenReturn(true);
+    org.mockito.Mockito.doThrow(
+            new BaseResourceRepository.NameConflictException("concurrent catalog"))
+        .when(catalogRepo)
+        .createWithCompletion(any(Catalog.class), any());
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                svc.createCatalog(
+                        CreateCatalogRequest.newBuilder()
+                            .setSpec(CatalogSpec.newBuilder().setDisplayName("alpha"))
+                            .setIdempotency(IdempotencyKey.newBuilder().setKey("idem"))
+                            .build())
+                    .await()
+                    .indefinitely());
+
+    FloecatStatus decoded = FloecatStatus.fromThrowable(failure);
+    assertEquals(Status.Code.ALREADY_EXISTS, decoded.canonicalCode());
+    assertEquals("catalog.already.exists", decoded.messageKey());
   }
 
   private static ResourceId systemCatalogId() {

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/CurrentSnapshotPointerServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/CurrentSnapshotPointerServiceTest.java
@@ -29,6 +29,7 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository;
 import ai.floedb.floecat.service.repo.impl.SnapshotRepository.CurrentSnapshotPointerUpdateResult;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.service.repo.util.TableBlobReachabilityGuard;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -82,6 +83,17 @@ class CurrentSnapshotPointerServiceTest {
   }
 
   @Test
+  void pointerConflictUsesTheTypedRetryableException() {
+    var candidate = Snapshot.newBuilder().setTableId(tableId).setSnapshotId(7L).build();
+    when(service.snapshotRepo.maybeAdvanceCurrentSnapshotPointer(tableId, candidate))
+        .thenReturn(CurrentSnapshotPointerUpdateResult.CONFLICT);
+
+    assertThrows(
+        BaseResourceRepository.AbortRetryableException.class,
+        () -> service.maybeAdvance(tableId, candidate, "corr"));
+  }
+
+  @Test
   void advanceReconcilesRootCurrencyWhenThePointerMoves() {
     // The committed pointer moved onto `candidate`. If it is an already-finalized snapshot (an
     // in-place UpdateSnapshot that re-ordered currency), no later finalize runs, so root currency
@@ -122,6 +134,7 @@ class CurrentSnapshotPointerServiceTest {
             new TableRootCommitter(roots, new TableBlobReachabilityGuard()),
             tableRepo,
             service.snapshotRepo,
+            null,
             null,
             null);
     when(service.snapshotRepo.maybeAdvanceCurrentSnapshotPointer(tableId, candidate))
@@ -193,6 +206,7 @@ class CurrentSnapshotPointerServiceTest {
             new TableRootCommitter(roots, new TableBlobReachabilityGuard()),
             tableRepo,
             service.snapshotRepo,
+            null,
             null,
             null);
     when(service.snapshotRepo.maybeAdvanceCurrentSnapshotPointer(tableId, first))

--- a/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootWriterTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/catalog/impl/TableRootWriterTest.java
@@ -17,12 +17,15 @@ package ai.floedb.floecat.service.catalog.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.catalog.rpc.BlobRef;
@@ -54,6 +57,7 @@ class TableRootWriterTest {
   private ConstraintRepository constraintRepo;
   private TableRepository tableRepo;
   private SnapshotRepository snapshotRepo;
+  private RootResyncQueue rootResyncQueue;
   private TableRootWriter writer;
   private ResourceId tableId;
 
@@ -71,8 +75,10 @@ class TableRootWriterTest {
     when(tableRepo.metaForSafe(any())).thenReturn(MutationMeta.getDefaultInstance());
     snapshotRepo = mock(SnapshotRepository.class);
     when(snapshotRepo.latestRegisteredSnapshotPointer(any())).thenReturn(Optional.empty());
+    rootResyncQueue = mock(RootResyncQueue.class);
     writer =
-        new TableRootWriter(roots, committer, tableRepo, snapshotRepo, constraintRepo, statsStore);
+        new TableRootWriter(
+            roots, committer, tableRepo, snapshotRepo, constraintRepo, statsStore, rootResyncQueue);
 
     tableId =
         ResourceId.newBuilder()
@@ -383,7 +389,13 @@ class TableRootWriterTest {
     var cCommitter = new TableRootCommitter(cRoots, new TableBlobReachabilityGuard());
     var cWriter =
         new TableRootWriter(
-            cRoots, cCommitter, tableRepo, snapshotRepo, constraintRepo, statsStore);
+            cRoots,
+            cCommitter,
+            tableRepo,
+            snapshotRepo,
+            constraintRepo,
+            statsStore,
+            rootResyncQueue);
     cCommitter.commit(
         tableId, TableRootMutations.upsertSnapshot(cRoots, tableId, finalizedEntry(7), null, true));
     updateFailures[0] = 1;
@@ -415,7 +427,13 @@ class TableRootWriterTest {
     var cCommitter = new TableRootCommitter(cRoots, new TableBlobReachabilityGuard());
     var cWriter =
         new TableRootWriter(
-            cRoots, cCommitter, tableRepo, snapshotRepo, constraintRepo, statsStore);
+            cRoots,
+            cCommitter,
+            tableRepo,
+            snapshotRepo,
+            constraintRepo,
+            statsStore,
+            rootResyncQueue);
     cCommitter.commit(
         tableId, TableRootMutations.upsertSnapshot(cRoots, tableId, finalizedEntry(7), null, true));
     updateFailures[0] = 1;
@@ -451,7 +469,13 @@ class TableRootWriterTest {
     var stubbornCommitter = new TableRootCommitter(stubbornRoots, new TableBlobReachabilityGuard());
     var stubbornWriter =
         new TableRootWriter(
-            stubbornRoots, stubbornCommitter, tableRepo, snapshotRepo, constraintRepo, statsStore);
+            stubbornRoots,
+            stubbornCommitter,
+            tableRepo,
+            snapshotRepo,
+            constraintRepo,
+            statsStore,
+            rootResyncQueue);
     stubbornCommitter.commit(
         tableId,
         TableRootMutations.upsertSnapshot(stubbornRoots, tableId, finalizedEntry(7), null, true));
@@ -477,12 +501,30 @@ class TableRootWriterTest {
   void commitFailuresPropagateAndFailTheCallingWrite() {
     // Reads resolve through the root, so the root commit IS the publication: a failure must fail
     // the write before it is acknowledged, never be silently absorbed.
-    when(statsStore.activeStatsGeneration(tableId, 7L))
-        .thenThrow(new IllegalStateException("store down"));
+    var publicationFailure = new IllegalStateException("store down");
+    when(statsStore.activeStatsGeneration(tableId, 7L)).thenThrow(publicationFailure);
 
-    org.junit.jupiter.api.Assertions.assertThrows(
-        IllegalStateException.class, () -> writer.commitStatsGeneration(tableId, 7L));
+    var thrown =
+        assertThrows(IllegalStateException.class, () -> writer.commitStatsGeneration(tableId, 7L));
+
+    assertSame(publicationFailure, thrown);
+    verify(rootResyncQueue).enqueue(tableId);
     assertFalse(entry(7).hasStatsGenerationRef());
+  }
+
+  @Test
+  void markerFailureIsSuppressedWithoutMaskingThePublicationFailure() {
+    var publicationFailure = new IllegalStateException("root publication failed");
+    var markerFailure = new IllegalStateException("marker write failed");
+    when(statsStore.activeStatsGeneration(tableId, 7L)).thenThrow(publicationFailure);
+    org.mockito.Mockito.doThrow(markerFailure).when(rootResyncQueue).enqueue(tableId);
+
+    var thrown =
+        assertThrows(IllegalStateException.class, () -> writer.commitStatsGeneration(tableId, 7L));
+
+    assertSame(publicationFailure, thrown);
+    assertEquals(1, thrown.getSuppressed().length);
+    assertSame(markerFailure, thrown.getSuppressed()[0]);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/common/BaseServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/common/BaseServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import ai.floedb.floecat.common.rpc.Error;
 import ai.floedb.floecat.common.rpc.ErrorCode;
+import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -30,6 +31,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class BaseServiceImplTest {
@@ -79,13 +81,94 @@ class BaseServiceImplTest {
     }
   }
 
+  @Test
+  void runWithRetryDoesNotRetryAnActiveIdempotencyClaim() {
+    TestServiceImpl service = new TestServiceImpl();
+    AtomicInteger attempts = new AtomicInteger();
+
+    Throwable failure =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            IdempotencyInProgressException.class,
+            () ->
+                service
+                    .withRetry(
+                        () -> {
+                          attempts.incrementAndGet();
+                          throw new IdempotencyInProgressException("pending");
+                        })
+                    .await()
+                    .indefinitely());
+
+    assertEquals("pending", failure.getMessage());
+    assertEquals(1, attempts.get());
+  }
+
+  @Test
+  void runWithRetryRetriesTypedTransientConflicts() {
+    TestServiceImpl service = new TestServiceImpl();
+    AtomicInteger attempts = new AtomicInteger();
+
+    String result =
+        service
+            .withRetry(
+                () -> {
+                  if (attempts.getAndIncrement() == 0) {
+                    throw new BaseResourceRepository.AbortRetryableException("pointer conflict");
+                  }
+                  return "ok";
+                })
+            .await()
+            .indefinitely();
+
+    assertEquals("ok", result);
+    assertEquals(2, attempts.get());
+  }
+
+  @Test
+  void runWithRetryDoesNotRetryAnAbortedStatus() {
+    TestServiceImpl service = new TestServiceImpl();
+    AtomicInteger attempts = new AtomicInteger();
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            service
+                .withRetry(
+                    () -> {
+                      attempts.incrementAndGet();
+                      throw io.grpc.Status.ABORTED.asRuntimeException();
+                    })
+                .await()
+                .indefinitely());
+
+    assertEquals(1, attempts.get());
+  }
+
+  @Test
+  void inProgressMapsToAbortedAtTheRpcBoundary() {
+    TestServiceImpl service = new TestServiceImpl();
+
+    StatusRuntimeException mapped =
+        service.map(new IdempotencyInProgressException("pending"), CORRELATION_ID);
+
+    assertEquals(io.grpc.Status.Code.ABORTED, mapped.getStatus().getCode());
+  }
+
   private static final class TestServiceImpl extends BaseServiceImpl {
     StatusRuntimeException repack(StatusRuntimeException ex, String corrId) {
       return toStatus(ex, corrId);
     }
 
+    StatusRuntimeException map(Throwable failure, String corrId) {
+      return toStatus(failure, corrId);
+    }
+
     Uni<Boolean> bodyRunsOnEventLoop() {
       return run(Context::isOnEventLoopThread);
+    }
+
+    <T> Uni<T> withRetry(java.util.function.Supplier<T> supplier) {
+      return runWithRetry(supplier);
     }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImplRootCommitTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/constraints/impl/TableConstraintsServiceImplRootCommitTest.java
@@ -32,6 +32,7 @@ import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.scanner.spi.CatalogGraphView;
+import ai.floedb.floecat.service.catalog.impl.RootResyncQueue;
 import ai.floedb.floecat.service.catalog.impl.TableRootWriter;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.impl.ConstraintRepository;
@@ -60,6 +61,7 @@ class TableConstraintsServiceImplRootCommitTest {
     service.idempotencyStore = mock(IdempotencyRepository.class);
     service.graphView = mock(CatalogGraphView.class);
     service.rootWriter = mock(TableRootWriter.class);
+    service.rootResyncQueue = mock(RootResyncQueue.class);
     TestPrincipals.stubPrincipal(service.principal, service.authz);
 
     tableId =
@@ -80,6 +82,16 @@ class TableConstraintsServiceImplRootCommitTest {
         .thenReturn(MutationMeta.getDefaultInstance());
     when(service.constraints.metaForSafe(any(), anyLong()))
         .thenReturn(MutationMeta.getDefaultInstance());
+    when(service.rootWriter.commitConstraintsFromCommittedState(any(), anyLong())).thenReturn(true);
+  }
+
+  @Test
+  void absorbedConstraintRootCommitLeavesDurableResyncMarker() {
+    when(service.rootWriter.commitConstraintsFromCommittedState(tableId, 5L)).thenReturn(false);
+
+    service.publishCommittedConstraintsToRoot(tableId, 5L);
+
+    verify(service.rootResyncQueue).enqueue(tableId);
   }
 
   @Test
@@ -98,7 +110,7 @@ class TableConstraintsServiceImplRootCommitTest {
         .await()
         .indefinitely();
 
-    verify(service.rootWriter).commitConstraints(tableId, 5L);
+    verify(service.rootWriter).commitConstraintsFromCommittedState(tableId, 5L);
   }
 
   @Test
@@ -117,7 +129,7 @@ class TableConstraintsServiceImplRootCommitTest {
         .await()
         .indefinitely();
 
-    verify(service.rootWriter).commitConstraints(tableId, 5L);
+    verify(service.rootWriter).commitConstraintsFromCommittedState(tableId, 5L);
   }
 
   @Test
@@ -136,7 +148,7 @@ class TableConstraintsServiceImplRootCommitTest {
         .await()
         .indefinitely();
 
-    verify(service.rootWriter).commitConstraints(tableId, 5L);
+    verify(service.rootWriter).commitConstraintsFromCommittedState(tableId, 5L);
   }
 
   @Test
@@ -159,6 +171,6 @@ class TableConstraintsServiceImplRootCommitTest {
                 .await()
                 .indefinitely());
 
-    verify(service.rootWriter).commitConstraints(tableId, 5L);
+    verify(service.rootWriter).commitConstraintsFromCommittedState(tableId, 5L);
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/constraints/it/ConstraintsIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/constraints/it/ConstraintsIT.java
@@ -434,6 +434,10 @@ class ConstraintsIT {
 
     var first = constraintsService.putTableConstraints(request);
     var second = constraintsService.putTableConstraints(request);
+    assertTrue(first.getChanged());
+    assertEquals(first.getChanged(), second.getChanged());
+    assertEquals(first.getConstraints(), second.getConstraints());
+    assertEquals(first.getMeta(), second.getMeta());
     assertNotNull(first.getMeta().getPointerKey());
     assertNotNull(second.getMeta().getPointerKey());
 

--- a/service/src/test/java/ai/floedb/floecat/service/it/ReconcileLaneIsolationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ReconcileLaneIsolationIT.java
@@ -40,7 +40,7 @@ import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobRequest;
 import ai.floedb.floecat.reconciler.rpc.LeaseReconcileJobResponse;
 import ai.floedb.floecat.reconciler.rpc.ReconcileExecutorControlGrpc;
 import ai.floedb.floecat.service.bootstrap.impl.SeedRunner;
-import ai.floedb.floecat.service.it.profiles.ReconcileJobStoreControlPlaneProfile;
+import ai.floedb.floecat.service.it.profiles.ReconcileLaneIsolationProfile;
 import ai.floedb.floecat.service.util.TestDataResetter;
 import ai.floedb.floecat.service.util.TestSupport;
 import io.quarkus.grpc.GrpcClient;
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@TestProfile(ReconcileJobStoreControlPlaneProfile.class)
+@TestProfile(ReconcileLaneIsolationProfile.class)
 class ReconcileLaneIsolationIT {
   private static final String EXPECTED_LANE = "ci-run-a";
   private static final String OTHER_LANE = "ci-run-b";

--- a/service/src/test/java/ai/floedb/floecat/service/it/ViewMutationIT.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/ViewMutationIT.java
@@ -377,7 +377,12 @@ class ViewMutationIT {
             .addOutputColumns(defaultCol)
             .build();
 
-    view.createView(CreateViewRequest.newBuilder().setSpec(specA).setIdempotency(key).build());
+    var idempotentRequest =
+        CreateViewRequest.newBuilder().setSpec(specA).setIdempotency(key).build();
+    var first = view.createView(idempotentRequest);
+    var replay = view.createView(idempotentRequest);
+    assertEquals(first.getView(), replay.getView());
+    assertEquals(first.getMeta(), replay.getMeta());
 
     var ex =
         assertThrows(

--- a/service/src/test/java/ai/floedb/floecat/service/it/profiles/ReconcileLaneIsolationProfile.java
+++ b/service/src/test/java/ai/floedb/floecat/service/it/profiles/ReconcileLaneIsolationProfile.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.floedb.floecat.service.it.profiles;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ReconcileLaneIsolationProfile extends ReconcileJobStoreControlPlaneProfile {
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    Map<String, String> overrides = new HashMap<>(super.getConfigOverrides());
+    overrides.put("floecat.reconciler.execution-lane", "ci-run-a");
+    return Map.copyOf(overrides);
+  }
+}

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/ConstraintProviderFactoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/ConstraintProviderFactoryTest.java
@@ -158,7 +158,7 @@ class ConstraintProviderFactoryTest {
       long snapshotId) {
     TableRootRepository roots = new TableRootRepository(pointers, blobs);
     TableRootCommitter committer = new TableRootCommitter(roots, new TableBlobReachabilityGuard());
-    new TableRootWriter(roots, committer, tables, snapshots, null, null)
+    new TableRootWriter(roots, committer, tables, snapshots, null, null, null)
         .commitSnapshotEntry(tableId, snapshotId);
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/query/catalog/StatsProviderFactoryTest.java
@@ -692,7 +692,7 @@ class StatsProviderFactoryTest {
       long snapshotId) {
     TableRootRepository roots = new TableRootRepository(pointers, blobs);
     TableRootCommitter committer = new TableRootCommitter(roots, new TableBlobReachabilityGuard());
-    new TableRootWriter(roots, committer, tables, snapshots, null, null)
+    new TableRootWriter(roots, committer, tables, snapshots, null, null, null)
         .commitSnapshotEntry(tableId, snapshotId);
   }
 

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedSnapshotFinalizeExecutionServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedSnapshotFinalizeExecutionServiceTest.java
@@ -73,6 +73,7 @@ import ai.floedb.floecat.stats.identity.StatsTargetIdentity;
 import ai.floedb.floecat.stats.spi.StatsStore;
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
 import ai.floedb.floecat.storage.errors.StorageNotFoundException;
+import ai.floedb.floecat.storage.errors.StorageTransactionConflictException;
 import ai.floedb.floecat.storage.spi.BlobStore;
 import com.google.protobuf.ByteString;
 import java.security.MessageDigest;
@@ -476,7 +477,7 @@ class LeasedSnapshotFinalizeExecutionServiceTest {
     doAnswer(
             invocation -> {
               if (finalizeAttempts.getAndIncrement() == 0) {
-                throw new StorageAbortRetryableException("idempotency write aborted");
+                throw new StorageTransactionConflictException("idempotency write aborted", null);
               }
               return null;
             })
@@ -491,6 +492,18 @@ class LeasedSnapshotFinalizeExecutionServiceTest {
             any(byte[].class),
             any(),
             any());
+
+    assertThrows(
+        StorageTransactionConflictException.class,
+        () ->
+            service.persistFailure(
+                principal,
+                FINALIZE_JOB_ID,
+                LEASE_EPOCH,
+                "result-1",
+                "append-only base is incompatible",
+                ai.floedb.floecat.reconciler.rpc.SubmitLeasedSnapshotFinalizeResultRequest
+                    .FailureKind.SFFK_APPEND_ONLY_BASE_INCOMPATIBLE));
 
     assertTrue(
         service.persistFailure(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizePersistenceServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/SnapshotFinalizePersistenceServiceTest.java
@@ -81,7 +81,8 @@ class SnapshotFinalizePersistenceServiceTest {
         new TableRootCommitter(
             roots, new ai.floedb.floecat.service.repo.util.TableBlobReachabilityGuard());
     persistence.rootWriter =
-        new TableRootWriter(roots, committer, null, snapshotRepo, null, persistence.statsStore);
+        new TableRootWriter(
+            roots, committer, null, snapshotRepo, null, persistence.statsStore, null);
 
     committer.commit(
         tableId,

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/jobs/DurableReconcileJobStoreTest.java
@@ -230,6 +230,28 @@ class DurableReconcileJobStoreTest {
   }
 
   @Test
+  void deploymentLaneConstrainsLeasesIndependentlyOfWorkerRequest() {
+    String jobId =
+        store.enqueue(
+            ACCOUNT_ID,
+            CONNECTOR_ID,
+            false,
+            CaptureMode.METADATA_AND_CAPTURE,
+            ReconcileScope.empty());
+
+    System.setProperty("floecat.reconciler.execution-lane", "ci-run");
+    try {
+      store.init();
+      assertTrue(store.leaseNext(ReconcileJobStore.LeaseRequest.all()).isEmpty());
+    } finally {
+      System.clearProperty("floecat.reconciler.execution-lane");
+      store.init();
+    }
+
+    assertEquals(jobId, store.leaseNext(ReconcileJobStore.LeaseRequest.all()).orElseThrow().jobId);
+  }
+
+  @Test
   void enqueueDedupesWhileJobIsActive() {
     ReconcileScope scope = ReconcileScope.of(List.of(), "tbl");
 
@@ -3703,35 +3725,42 @@ class DurableReconcileJobStoreTest {
 
   @Test
   void leaseNextRespectsPinnedExecutorAndExecutionClass() {
-    String jobId =
-        store.enqueue(
-            ACCOUNT_ID,
-            CONNECTOR_ID,
-            false,
-            CaptureMode.METADATA_AND_CAPTURE,
-            ReconcileScope.empty(),
-            ReconcileJobKind.PLAN_CONNECTOR,
-            ReconcileTableTask.empty(),
-            ReconcileViewTask.empty(),
-            ReconcileSnapshotTask.empty(),
-            ReconcileFileGroupTask.empty(),
-            ReconcileExecutionPolicy.of(
-                ReconcileExecutionClass.HEAVY, "remote", Map.of("worker", "remote")),
-            "",
-            "remote-executor");
+    System.setProperty("floecat.reconciler.execution-lane", "remote");
+    try {
+      store.init();
+      String jobId =
+          store.enqueue(
+              ACCOUNT_ID,
+              CONNECTOR_ID,
+              false,
+              CaptureMode.METADATA_AND_CAPTURE,
+              ReconcileScope.empty(),
+              ReconcileJobKind.PLAN_CONNECTOR,
+              ReconcileTableTask.empty(),
+              ReconcileViewTask.empty(),
+              ReconcileSnapshotTask.empty(),
+              ReconcileFileGroupTask.empty(),
+              ReconcileExecutionPolicy.of(
+                  ReconcileExecutionClass.HEAVY, "remote", Map.of("worker", "remote")),
+              "",
+              "remote-executor");
 
-    var lease =
-        store
-            .leaseNext(
-                ReconcileJobStore.LeaseRequest.of(
-                    java.util.EnumSet.of(ReconcileExecutionClass.HEAVY),
-                    Set.of("remote"),
-                    Set.of("remote-executor")))
-            .orElseThrow();
+      var lease =
+          store
+              .leaseNext(
+                  ReconcileJobStore.LeaseRequest.of(
+                      java.util.EnumSet.of(ReconcileExecutionClass.HEAVY),
+                      Set.of("remote"),
+                      Set.of("remote-executor")))
+              .orElseThrow();
 
-    assertEquals(jobId, lease.jobId);
-    assertEquals("remote-executor", lease.pinnedExecutorId);
-    assertEquals(ReconcileExecutionClass.HEAVY, lease.executionPolicy.executionClass());
+      assertEquals(jobId, lease.jobId);
+      assertEquals("remote-executor", lease.pinnedExecutorId);
+      assertEquals(ReconcileExecutionClass.HEAVY, lease.executionPolicy.executionClass());
+    } finally {
+      System.clearProperty("floecat.reconciler.execution-lane");
+      store.init();
+    }
   }
 
   @Test
@@ -3769,47 +3798,54 @@ class DurableReconcileJobStoreTest {
 
   @Test
   void leaseNextFilteredRequestsDoNotScanGlobalReadyRows() throws Exception {
-    String jobId =
-        store.enqueue(
-            ACCOUNT_ID,
-            CONNECTOR_ID,
-            false,
-            CaptureMode.METADATA_AND_CAPTURE,
-            ReconcileScope.empty(),
-            ReconcileJobKind.PLAN_CONNECTOR,
-            ReconcileTableTask.empty(),
-            ReconcileViewTask.empty(),
-            ReconcileSnapshotTask.empty(),
-            ReconcileFileGroupTask.empty(),
-            ReconcileExecutionPolicy.of(
-                ReconcileExecutionClass.HEAVY, "remote", Map.of("worker", "remote")),
-            "",
-            "");
+    System.setProperty("floecat.reconciler.execution-lane", "remote");
+    try {
+      store.init();
+      String jobId =
+          store.enqueue(
+              ACCOUNT_ID,
+              CONNECTOR_ID,
+              false,
+              CaptureMode.METADATA_AND_CAPTURE,
+              ReconcileScope.empty(),
+              ReconcileJobKind.PLAN_CONNECTOR,
+              ReconcileTableTask.empty(),
+              ReconcileViewTask.empty(),
+              ReconcileSnapshotTask.empty(),
+              ReconcileFileGroupTask.empty(),
+              ReconcileExecutionPolicy.of(
+                  ReconcileExecutionClass.HEAVY, "remote", Map.of("worker", "remote")),
+              "",
+              "");
 
-    StoredReconcileJob queued = readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, jobId));
-    @SuppressWarnings("unchecked")
-    List<String> readyKeys =
-        (List<String>)
-            invokePrivateMethod(
-                store, "readyPointerKeys", new Class<?>[] {StoredReconcileJob.class}, queued);
-    for (String readyKey : readyKeys) {
-      if (readyKey.equals(queued.readyPointerKey)) {
-        continue;
+      StoredReconcileJob queued = readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, jobId));
+      @SuppressWarnings("unchecked")
+      List<String> readyKeys =
+          (List<String>)
+              invokePrivateMethod(
+                  store, "readyPointerKeys", new Class<?>[] {StoredReconcileJob.class}, queued);
+      for (String readyKey : readyKeys) {
+        if (readyKey.equals(queued.readyPointerKey)) {
+          continue;
+        }
+        assertTrue(findAndDeleteReadyEntry(queued, readyKey));
       }
-      assertTrue(findAndDeleteReadyEntry(queued, readyKey));
+
+      var filteredLease =
+          store.leaseNext(
+              ReconcileJobStore.LeaseRequest.of(
+                  java.util.EnumSet.of(ReconcileExecutionClass.HEAVY), Set.of("remote")));
+
+      assertTrue(filteredLease.isEmpty());
+
+      var lease = store.leaseNext(ReconcileJobStore.LeaseRequest.all()).orElseThrow();
+      assertEquals(jobId, lease.jobId);
+      assertEquals(ReconcileExecutionClass.HEAVY, lease.executionPolicy.executionClass());
+      assertEquals("remote", lease.executionPolicy.lane());
+    } finally {
+      System.clearProperty("floecat.reconciler.execution-lane");
+      store.init();
     }
-
-    var filteredLease =
-        store.leaseNext(
-            ReconcileJobStore.LeaseRequest.of(
-                java.util.EnumSet.of(ReconcileExecutionClass.HEAVY), Set.of("remote")));
-
-    assertTrue(filteredLease.isEmpty());
-
-    var lease = store.leaseNext(ReconcileJobStore.LeaseRequest.all()).orElseThrow();
-    assertEquals(jobId, lease.jobId);
-    assertEquals(ReconcileExecutionClass.HEAVY, lease.executionPolicy.executionClass());
-    assertEquals("remote", lease.executionPolicy.lane());
   }
 
   @Test
@@ -3879,59 +3915,66 @@ class DurableReconcileJobStoreTest {
 
   @Test
   void pinnedJobsOnlyCreatePinnedReadyIndexRows() throws Exception {
-    String jobId =
-        store.enqueue(
-            ACCOUNT_ID,
-            CONNECTOR_ID,
-            false,
-            CaptureMode.METADATA_AND_CAPTURE,
-            ReconcileScope.empty(),
-            ReconcileJobKind.PLAN_CONNECTOR,
-            ReconcileTableTask.empty(),
-            ReconcileViewTask.empty(),
-            ReconcileSnapshotTask.empty(),
-            ReconcileFileGroupTask.empty(),
-            ReconcileExecutionPolicy.of(
-                ReconcileExecutionClass.HEAVY, "remote", Map.of("worker", "remote")),
-            "",
-            "remote-executor");
+    System.setProperty("floecat.reconciler.execution-lane", "remote");
+    try {
+      store.init();
+      String jobId =
+          store.enqueue(
+              ACCOUNT_ID,
+              CONNECTOR_ID,
+              false,
+              CaptureMode.METADATA_AND_CAPTURE,
+              ReconcileScope.empty(),
+              ReconcileJobKind.PLAN_CONNECTOR,
+              ReconcileTableTask.empty(),
+              ReconcileViewTask.empty(),
+              ReconcileSnapshotTask.empty(),
+              ReconcileFileGroupTask.empty(),
+              ReconcileExecutionPolicy.of(
+                  ReconcileExecutionClass.HEAVY, "remote", Map.of("worker", "remote")),
+              "",
+              "remote-executor");
 
-    StoredReconcileJob queued = readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, jobId));
-    ReconcileWorkerAffinity workerAffinity =
-        ReconcileWorkerAffinity.fromPolicy(queued.executionPolicy());
-    @SuppressWarnings("unchecked")
-    List<String> readyKeys =
-        (List<String>)
-            invokePrivateMethod(
-                store, "readyPointerKeys", new Class<?>[] {StoredReconcileJob.class}, queued);
+      StoredReconcileJob queued = readStoredRecord(Keys.reconcileJobPointerById(ACCOUNT_ID, jobId));
+      ReconcileWorkerAffinity workerAffinity =
+          ReconcileWorkerAffinity.fromPolicy(queued.executionPolicy());
+      @SuppressWarnings("unchecked")
+      List<String> readyKeys =
+          (List<String>)
+              invokePrivateMethod(
+                  store, "readyPointerKeys", new Class<?>[] {StoredReconcileJob.class}, queued);
 
-    assertEquals(1, readyKeys.size());
-    assertTrue(
-        readyKeys
-            .get(0)
-            .startsWith(
-                Keys.reconcileReadyByPinnedExecutorPointerPrefix(
-                    workerAffinity.indexFilterValue("remote-executor"))));
-    assertEquals("remote-executor", queued.pinnedExecutorId());
+      assertEquals(1, readyKeys.size());
+      assertTrue(
+          readyKeys
+              .get(0)
+              .startsWith(
+                  Keys.reconcileReadyByPinnedExecutorPointerPrefix(
+                      workerAffinity.indexFilterValue("remote-executor"))));
+      assertEquals("remote-executor", queued.pinnedExecutorId());
 
-    var otherExecutorLease =
-        store.leaseNext(
-            ReconcileJobStore.LeaseRequest.of(
-                java.util.EnumSet.of(ReconcileExecutionClass.HEAVY),
-                Set.of("remote"),
-                Set.of("other-executor")));
-    assertTrue(otherExecutorLease.isEmpty());
+      var otherExecutorLease =
+          store.leaseNext(
+              ReconcileJobStore.LeaseRequest.of(
+                  java.util.EnumSet.of(ReconcileExecutionClass.HEAVY),
+                  Set.of("remote"),
+                  Set.of("other-executor")));
+      assertTrue(otherExecutorLease.isEmpty());
 
-    var lease =
-        store
-            .leaseNext(
-                ReconcileJobStore.LeaseRequest.of(
-                    java.util.EnumSet.of(ReconcileExecutionClass.HEAVY),
-                    Set.of("remote"),
-                    Set.of("remote-executor")))
-            .orElseThrow();
-    assertEquals(jobId, lease.jobId);
-    assertEquals("remote-executor", lease.pinnedExecutorId);
+      var lease =
+          store
+              .leaseNext(
+                  ReconcileJobStore.LeaseRequest.of(
+                      java.util.EnumSet.of(ReconcileExecutionClass.HEAVY),
+                      Set.of("remote"),
+                      Set.of("remote-executor")))
+              .orElseThrow();
+      assertEquals(jobId, lease.jobId);
+      assertEquals("remote-executor", lease.pinnedExecutorId);
+    } finally {
+      System.clearProperty("floecat.reconciler.execution-lane");
+      store.init();
+    }
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/ConstraintRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/ConstraintRepositoryTest.java
@@ -121,7 +121,7 @@ class ConstraintRepositoryTest {
                                 payload,
                                 resource -> {
                                   String response = "changed=" + resource.changed();
-                                  return committer.prepareOps(
+                                  return committer.prepareSuccessOps(
                                       new IdempotencyGuard.CommittedCreate<>(
                                           response, tableId, resource.meta()));
                                 });

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/ConstraintRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/ConstraintRepositoryTest.java
@@ -30,8 +30,17 @@ import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
+import ai.floedb.floecat.service.common.IdempotencyGuard;
+import ai.floedb.floecat.service.common.IdempotencyInProgressException;
+import ai.floedb.floecat.service.repo.IdempotencyRepository;
+import ai.floedb.floecat.service.repo.model.Keys;
+import ai.floedb.floecat.storage.errors.StorageTransactionConflictException;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
+import ai.floedb.floecat.storage.spi.PointerStore;
+import com.google.protobuf.Timestamp;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -39,7 +48,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -75,6 +86,79 @@ class ConstraintRepositoryTest {
     assertTrue(repo.deleteSnapshotConstraints(tableId, 101L));
     assertTrue(repo.getSnapshotConstraints(tableId, 101L).isEmpty());
     assertEquals(0, repo.countSnapshotConstraints(tableId));
+  }
+
+  @Test
+  void parallelReconcileConflictDoesNotPoisonConstraintIdempotencyKey() throws Exception {
+    var rawPointers = new InMemoryPointerStore();
+    var conflictingPointers = new ConflictFirstBatchPointerStore(rawPointers);
+    var rawBlobs = new InMemoryBlobStore();
+    var constraints = new ConstraintRepository(conflictingPointers, rawBlobs);
+    IdempotencyRepository idempotency =
+        new IdempotencyRepositoryImpl(conflictingPointers, rawBlobs);
+    long snapshotId = 777L;
+    var payload =
+        constraintsForSnapshot(
+            tableId, snapshotId, List.of(definition("pk_incident", ConstraintType.CT_PRIMARY_KEY)));
+    byte[] request = payload.toByteArray();
+    Timestamp now = Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build();
+
+    java.util.concurrent.Callable<String> attempt =
+        () -> {
+          for (int retry = 0; retry < 1000; retry++) {
+            try {
+              return IdempotencyGuard.runOnceCommitted(
+                      tableId.getAccountId(),
+                      "PutTableConstraints",
+                      "parallel-reconcile-key",
+                      request,
+                      tableId,
+                      committer -> {
+                        var put =
+                            constraints.putSnapshotConstraintsWithCompletion(
+                                tableId,
+                                snapshotId,
+                                payload,
+                                resource -> {
+                                  String response = "changed=" + resource.changed();
+                                  return committer.prepareOps(
+                                      new IdempotencyGuard.CommittedCreate<>(
+                                          response, tableId, resource.meta()));
+                                });
+                        return new IdempotencyGuard.CommittedCreate<>(
+                            "changed=" + put.changed(), tableId, put.meta());
+                      },
+                      value -> value.getBytes(StandardCharsets.UTF_8),
+                      bytes -> new String(bytes, StandardCharsets.UTF_8),
+                      idempotency,
+                      60,
+                      now,
+                      () -> "corr")
+                  .resource();
+            } catch (IdempotencyInProgressException | StorageTransactionConflictException e) {
+              LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+            }
+          }
+          throw new AssertionError("reconcile retry budget exhausted");
+        };
+
+    try (ExecutorService pool = Executors.newFixedThreadPool(2)) {
+      var first = pool.submit(attempt);
+      var second = pool.submit(attempt);
+      assertEquals("changed=true", first.get(5, TimeUnit.SECONDS));
+      assertEquals("changed=true", second.get(5, TimeUnit.SECONDS));
+    }
+
+    assertTrue(constraints.getSnapshotConstraints(tableId, snapshotId).isPresent());
+    var receipt =
+        idempotency
+            .get(
+                Keys.idempotencyKey(
+                    tableId.getAccountId(), "PutTableConstraints", "parallel-reconcile-key"))
+            .orElseThrow();
+    assertEquals(
+        ai.floedb.floecat.storage.rpc.IdempotencyRecord.Status.SUCCEEDED, receipt.getStatus());
+    assertEquals("changed=true", receipt.getPayload().toStringUtf8());
   }
 
   @Test
@@ -469,5 +553,22 @@ class ConstraintRepositoryTest {
               .build());
     }
     return builder.build();
+  }
+
+  private static final class ConflictFirstBatchPointerStore
+      extends RepoTestPointerStores.DelegatingPointerStore {
+    private final AtomicBoolean conflict = new AtomicBoolean(true);
+
+    private ConflictFirstBatchPointerStore(PointerStore delegate) {
+      super(delegate);
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<PointerStore.CasOp> ops) {
+      if (conflict.compareAndSet(true, false)) {
+        throw new StorageTransactionConflictException("injected reconcile conflict", null);
+      }
+      return super.compareAndSetBatch(ops);
+    }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
@@ -108,7 +108,7 @@ public class IdempotencyGuardTest {
             () -> id,
             (reserved, committer) -> {
               var committed = new IdempotencyGuard.CommittedCreate<>("R1", reserved, meta(1));
-              assertThat(committer.prepareOps(committed)).isEmpty();
+              assertThat(committer.prepareSuccessOps(committed)).isEmpty();
               return committed;
             },
             strSer(),
@@ -197,7 +197,7 @@ public class IdempotencyGuardTest {
             () -> reservedId,
             (id, committer) -> {
               var committed = new IdempotencyGuard.CommittedCreate<>("RESOURCE", id, createdMeta);
-              PointerStore.CasOp receipt = committer.prepareOps(committed).getFirst();
+              PointerStore.CasOp receipt = committer.prepareSuccessOps(committed).getFirst();
               String blobUri = "blob://thing/" + id.getId();
               blobs.put(
                   blobUri, "RESOURCE".getBytes(StandardCharsets.UTF_8), "application/x-protobuf");
@@ -465,6 +465,56 @@ public class IdempotencyGuardTest {
   }
 
   @Test
+  void convergentEffectRetryableAbortReleasesOwnedClaimAndRetrySucceeds() {
+    AtomicInteger callbacks = new AtomicInteger();
+    byte[] request = "request".getBytes(StandardCharsets.UTF_8);
+    String idempotencyKey = "convergent-retryable-abort";
+
+    assertThatThrownBy(
+            () ->
+                IdempotencyGuard.runOnceConvergentEffects(
+                    ACCOUNT,
+                    OP,
+                    idempotencyKey,
+                    request,
+                    () -> {
+                      callbacks.incrementAndGet();
+                      throw new BaseResourceRepository.AbortRetryableException("retry effect");
+                    },
+                    metaOfVersion(1),
+                    strSer(),
+                    strParser(),
+                    repo,
+                    60,
+                    NOW,
+                    () -> "corr"))
+        .isInstanceOf(BaseResourceRepository.AbortRetryableException.class);
+
+    assertThat(repo.get(Keys.idempotencyKey(ACCOUNT, OP, idempotencyKey))).isEmpty();
+
+    var retried =
+        IdempotencyGuard.runOnceConvergentEffects(
+            ACCOUNT,
+            OP,
+            idempotencyKey,
+            request,
+            () -> {
+              callbacks.incrementAndGet();
+              return new IdempotencyGuard.CreateResult<>("R1", resourceId("rid1"));
+            },
+            metaOfVersion(1),
+            strSer(),
+            strParser(),
+            repo,
+            60,
+            NOW,
+            () -> "corr");
+
+    assertThat(retried.resource()).isEqualTo("R1");
+    assertThat(callbacks).hasValue(2);
+  }
+
+  @Test
   void committedConflictPoisonsNeitherBusinessStateNorReceiptAndRetryReplaysExactResponse() {
     var underlying = new InMemoryPointerStore();
     var conflicting = new ConfirmedAbortOncePointerStore(underlying);
@@ -483,7 +533,7 @@ public class IdempotencyGuardTest {
               if (!conflicting.compareAndSetBatch(
                   List.of(
                       new PointerStore.CasUpsert(businessKey, 0L, pointer),
-                      committer.prepareOps(committed).getFirst()))) {
+                      committer.prepareSuccessOps(committed).getFirst()))) {
                 throw new BaseResourceRepository.AbortRetryableException("lost business CAS");
               }
               return committed;

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IdempotencyGuardTest.java
@@ -25,12 +25,14 @@ import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.service.common.IdempotencyGuard;
+import ai.floedb.floecat.service.common.IdempotencyInProgressException;
 import ai.floedb.floecat.service.common.MutationOps;
 import ai.floedb.floecat.service.repo.IdempotencyRepository;
 import ai.floedb.floecat.service.repo.model.Keys;
 import ai.floedb.floecat.service.repo.model.PointerReferences;
 import ai.floedb.floecat.service.repo.util.BaseResourceRepository;
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
+import ai.floedb.floecat.storage.errors.StorageTransactionConflictException;
 import ai.floedb.floecat.storage.memory.InMemoryBlobStore;
 import ai.floedb.floecat.storage.memory.InMemoryPointerStore;
 import ai.floedb.floecat.storage.rpc.IdempotencyRecord;
@@ -77,13 +79,38 @@ public class IdempotencyGuardTest {
   @Test
   void runOnceEmptyKey() {
     var out =
-        IdempotencyGuard.runOnce(
+        IdempotencyGuard.runOnceConvergentEffects(
             ACCOUNT,
             OP,
             "",
             "req".getBytes(StandardCharsets.UTF_8),
             () -> new IdempotencyGuard.CreateResult<>("R1", resourceId("rid1")),
             metaOfVersion(1),
+            strSer(),
+            strParser(),
+            repo,
+            300,
+            NOW,
+            () -> "corr");
+
+    assertThat(out.resource()).isEqualTo("R1");
+  }
+
+  @Test
+  void reservedCreateWithoutKeyRunsWithoutPreparingAReceipt() {
+    var id = resourceId("rid1");
+    var out =
+        IdempotencyGuard.runOnceReserved(
+            ACCOUNT,
+            OP,
+            "",
+            "req".getBytes(StandardCharsets.UTF_8),
+            () -> id,
+            (reserved, committer) -> {
+              var committed = new IdempotencyGuard.CommittedCreate<>("R1", reserved, meta(1));
+              assertThat(committer.prepareOps(committed)).isEmpty();
+              return committed;
+            },
             strSer(),
             strParser(),
             repo,
@@ -170,7 +197,7 @@ public class IdempotencyGuardTest {
             () -> reservedId,
             (id, committer) -> {
               var committed = new IdempotencyGuard.CommittedCreate<>("RESOURCE", id, createdMeta);
-              PointerStore.CasUpsert receipt = committer.prepare(committed);
+              PointerStore.CasOp receipt = committer.prepareOps(committed).getFirst();
               String blobUri = "blob://thing/" + id.getId();
               blobs.put(
                   blobUri, "RESOURCE".getBytes(StandardCharsets.UTF_8), "application/x-protobuf");
@@ -321,7 +348,7 @@ public class IdempotencyGuardTest {
     byte[] req = "same".getBytes(StandardCharsets.UTF_8);
 
     var r1 =
-        IdempotencyGuard.runOnce(
+        IdempotencyGuard.runOnceConvergentEffects(
             ACCOUNT,
             OP,
             idemKey,
@@ -342,7 +369,7 @@ public class IdempotencyGuardTest {
         .isEqualTo(IdempotencyRecord.Status.SUCCEEDED);
 
     var r2 =
-        IdempotencyGuard.runOnce(
+        IdempotencyGuard.runOnceConvergentEffects(
             ACCOUNT,
             OP,
             idemKey,
@@ -356,6 +383,205 @@ public class IdempotencyGuardTest {
             NOW,
             () -> "corr");
     assertThat(r2.resource()).isEqualTo("R1");
+  }
+
+  @Test
+  void runOncePendingDoesNotInvokeCreator() throws Exception {
+    String idemKey = "active-claim";
+    byte[] request = "request".getBytes(StandardCharsets.UTF_8);
+    String key = Keys.idempotencyKey(ACCOUNT, OP, idemKey);
+    assertThat(repo.createPending(ACCOUNT, key, OP, sha256B64(request), NOW, expiresFrom(NOW, 60)))
+        .isTrue();
+
+    assertThatThrownBy(
+            () ->
+                IdempotencyGuard.runOnceConvergentEffects(
+                    ACCOUNT,
+                    OP,
+                    idemKey,
+                    request,
+                    () -> {
+                      throw new AssertionError("active pending claim must not invoke creator");
+                    },
+                    metaOfVersion(1),
+                    strSer(),
+                    strParser(),
+                    repo,
+                    60,
+                    NOW,
+                    () -> "corr"))
+        .isInstanceOf(IdempotencyInProgressException.class);
+  }
+
+  @Test
+  void receiptOnlyConfirmedAbortReleasesOwnedClaimAndRetrySucceeds() {
+    var underlying = new InMemoryPointerStore();
+    var conflicting = new ConfirmedAbortOncePointerStore(underlying);
+    repo = new IdempotencyRepositoryImpl(conflicting, blobs);
+    AtomicInteger callbacks = new AtomicInteger();
+
+    assertThatThrownBy(
+            () ->
+                IdempotencyGuard.runOnceReceiptOnly(
+                    ACCOUNT,
+                    OP,
+                    "receipt-only-conflict",
+                    "request".getBytes(StandardCharsets.UTF_8),
+                    () -> {
+                      callbacks.incrementAndGet();
+                      return new IdempotencyGuard.CreateResult<>("R1", resourceId("rid1"));
+                    },
+                    metaOfVersion(1),
+                    strSer(),
+                    strParser(),
+                    repo,
+                    60,
+                    NOW,
+                    () -> "corr"))
+        .isInstanceOf(StorageTransactionConflictException.class);
+
+    assertThat(repo.get(Keys.idempotencyKey(ACCOUNT, OP, "receipt-only-conflict"))).isEmpty();
+
+    var retried =
+        IdempotencyGuard.runOnceReceiptOnly(
+            ACCOUNT,
+            OP,
+            "receipt-only-conflict",
+            "request".getBytes(StandardCharsets.UTF_8),
+            () -> {
+              callbacks.incrementAndGet();
+              return new IdempotencyGuard.CreateResult<>("R1", resourceId("rid1"));
+            },
+            metaOfVersion(1),
+            strSer(),
+            strParser(),
+            repo,
+            60,
+            NOW,
+            () -> "corr");
+
+    assertThat(retried.resource()).isEqualTo("R1");
+    assertThat(callbacks).hasValue(2);
+  }
+
+  @Test
+  void committedConflictPoisonsNeitherBusinessStateNorReceiptAndRetryReplaysExactResponse() {
+    var underlying = new InMemoryPointerStore();
+    var conflicting = new ConfirmedAbortOncePointerStore(underlying);
+    repo = new IdempotencyRepositoryImpl(conflicting, blobs);
+    var callbacks = new AtomicInteger();
+    var id = resourceId("known");
+    var key = Keys.idempotencyKey(ACCOUNT, OP, "committed-conflict");
+    var businessKey = "acct/" + ACCOUNT + "/things/known";
+
+    Function<IdempotencyGuard.SuccessCommitter<String>, IdempotencyGuard.CommittedCreate<String>>
+        mutation =
+            committer -> {
+              callbacks.incrementAndGet();
+              var committed = new IdempotencyGuard.CommittedCreate<>("changed=true", id, meta(1));
+              var pointer = PointerReferences.blobPointer(businessKey, "blob://things/known", 1L);
+              if (!conflicting.compareAndSetBatch(
+                  List.of(
+                      new PointerStore.CasUpsert(businessKey, 0L, pointer),
+                      committer.prepareOps(committed).getFirst()))) {
+                throw new BaseResourceRepository.AbortRetryableException("lost business CAS");
+              }
+              return committed;
+            };
+
+    assertThatThrownBy(
+            () ->
+                IdempotencyGuard.runOnceCommitted(
+                    ACCOUNT,
+                    OP,
+                    "committed-conflict",
+                    "request".getBytes(StandardCharsets.UTF_8),
+                    id,
+                    mutation,
+                    strSer(),
+                    strParser(),
+                    repo,
+                    60,
+                    NOW,
+                    () -> "corr"))
+        .isInstanceOf(StorageTransactionConflictException.class);
+    assertThat(underlying.get(businessKey)).isEmpty();
+    assertThat(repo.get(key)).isEmpty();
+
+    var first =
+        IdempotencyGuard.runOnceCommitted(
+            ACCOUNT,
+            OP,
+            "committed-conflict",
+            "request".getBytes(StandardCharsets.UTF_8),
+            id,
+            mutation,
+            strSer(),
+            strParser(),
+            repo,
+            60,
+            NOW,
+            () -> "corr");
+    assertThat(first.resource()).isEqualTo("changed=true");
+    assertThat(underlying.get(businessKey)).isPresent();
+    assertThat(repo.get(key))
+        .get()
+        .extracting(IdempotencyRecord::getStatus)
+        .isEqualTo(IdempotencyRecord.Status.SUCCEEDED);
+
+    var replay =
+        IdempotencyGuard.runOnceCommitted(
+            ACCOUNT,
+            OP,
+            "committed-conflict",
+            "request".getBytes(StandardCharsets.UTF_8),
+            id,
+            ignored -> {
+              throw new AssertionError("replay must not recompute the response");
+            },
+            strSer(),
+            strParser(),
+            repo,
+            60,
+            NOW,
+            () -> "corr");
+    assertThat(replay.resource()).isEqualTo("changed=true");
+    assertThat(callbacks).hasValue(2);
+  }
+
+  @Test
+  void committedPendingInvokesNoCallback() throws Exception {
+    byte[] request = "request".getBytes(StandardCharsets.UTF_8);
+    String key = Keys.idempotencyKey(ACCOUNT, OP, "committed-pending");
+    assertThat(
+            repo.createPending(
+                ACCOUNT,
+                key,
+                OP,
+                sha256B64(request),
+                resourceId("known"),
+                NOW,
+                expiresFrom(NOW, 60)))
+        .isTrue();
+
+    assertThatThrownBy(
+            () ->
+                IdempotencyGuard.runOnceCommitted(
+                    ACCOUNT,
+                    OP,
+                    "committed-pending",
+                    request,
+                    resourceId("known"),
+                    ignored -> {
+                      throw new AssertionError("pending claim must not invoke callback");
+                    },
+                    strSer(),
+                    strParser(),
+                    repo,
+                    60,
+                    NOW,
+                    () -> "corr"))
+        .isInstanceOf(IdempotencyInProgressException.class);
   }
 
   @Test
@@ -392,7 +618,7 @@ public class IdempotencyGuardTest {
         assertThrows(
             StatusRuntimeException.class,
             () ->
-                IdempotencyGuard.runOnce(
+                IdempotencyGuard.runOnceConvergentEffects(
                     ACCOUNT,
                     OP,
                     idemKey,
@@ -446,7 +672,7 @@ public class IdempotencyGuardTest {
         meta(1));
 
     var out =
-        IdempotencyGuard.runOnce(
+        IdempotencyGuard.runOnceConvergentEffects(
             ACCOUNT,
             OP,
             idemKey,
@@ -490,7 +716,7 @@ public class IdempotencyGuardTest {
 
     assertThatThrownBy(
             () ->
-                MutationOps.<ResourceId>createProto(
+                MutationOps.<ResourceId>createProtoConvergentEffects(
                     ACCOUNT,
                     OP,
                     idemKey,
@@ -523,7 +749,7 @@ public class IdempotencyGuardTest {
         meta(1));
 
     var out =
-        IdempotencyGuard.runOnce(
+        IdempotencyGuard.runOnceConvergentEffects(
             ACCOUNT,
             OP,
             idemKey,
@@ -755,6 +981,23 @@ public class IdempotencyGuardTest {
         beforeDelete.run();
       }
       return super.compareAndDelete(key, expectedVersion);
+    }
+  }
+
+  private static final class ConfirmedAbortOncePointerStore
+      extends RepoTestPointerStores.DelegatingPointerStore {
+    private final AtomicBoolean conflict = new AtomicBoolean(true);
+
+    private ConfirmedAbortOncePointerStore(PointerStore delegate) {
+      super(delegate);
+    }
+
+    @Override
+    public boolean compareAndSetBatch(List<PointerStore.CasOp> ops) {
+      if (conflict.compareAndSet(true, false)) {
+        throw new StorageTransactionConflictException("injected confirmed abort", null);
+      }
+      return super.compareAndSetBatch(ops);
     }
   }
 }

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
@@ -124,6 +124,61 @@ class IndexArtifactRepositoryTest {
   }
 
   @Test
+  void atomicDirectArtifactWriteFencesConcurrentGenerationFinalization() {
+    InMemoryPointerStore delegate = new InMemoryPointerStore();
+    InMemoryBlobStore blobs = new InMemoryBlobStore();
+    long snapshotId = 725L;
+    String activeKey =
+        Keys.snapshotIndexArtifactActiveGenerationPointer(
+            TABLE_ID.getAccountId(), TABLE_ID.getId(), snapshotId);
+    String directPrefix =
+        Keys.snapshotIndexArtifactGenerationPrefix(
+            TABLE_ID.getAccountId(), TABLE_ID.getId(), snapshotId, "direct");
+    AtomicBoolean finalizeBeforeArtifactCommit = new AtomicBoolean(true);
+    AtomicBoolean discardedCompletion = new AtomicBoolean();
+    var pointers =
+        new RepoTestPointerStores.DelegatingPointerStore(delegate) {
+          @Override
+          public boolean compareAndSetBatch(List<CasOp> ops) {
+            boolean writesDirectArtifact =
+                ops.stream().anyMatch(op -> op.key().startsWith(directPrefix));
+            if (writesDirectArtifact && finalizeBeforeArtifactCommit.compareAndSet(true, false)) {
+              var active = delegate.get(activeKey).orElseThrow();
+              assertThat(
+                      delegate.compareAndSet(
+                          activeKey,
+                          active.getVersion(),
+                          PointerReferences.opaqueMarkerPointer(
+                              activeKey, "final-generation", active.getVersion() + 1L)))
+                  .isTrue();
+              delegate.deleteByPrefix(directPrefix);
+            }
+            return super.compareAndSetBatch(ops);
+          }
+        };
+    IndexArtifactRepository repository = createRepository(pointers, blobs);
+    IndexArtifactRecord record = indexRecord(snapshotId, "s3://bucket/file.parquet");
+
+    assertThatThrownBy(
+            () ->
+                repository.putIndexArtifactWithCompletion(
+                    record,
+                    com.google.protobuf.util.Timestamps.fromMillis(1L),
+                    ignored -> List.of(new PointerStore.CasCheckAbsent("/receipt")),
+                    ignored -> discardedCompletion.set(true)))
+        .isInstanceOf(BaseResourceRepository.AbortRetryableException.class);
+
+    assertThat(discardedCompletion).isTrue();
+    assertThat(pointers.countByPrefix(directPrefix)).isZero();
+    assertThat(repository.getIndexArtifact(TABLE_ID, snapshotId, record.getTarget())).isEmpty();
+    assertThat(
+            blobs
+                .list(Keys.tableBlobPrefix(TABLE_ID.getAccountId(), TABLE_ID.getId()), 100, "")
+                .keys())
+        .isEmpty();
+  }
+
+  @Test
   void bundledIndexWrappersResolveAllTargetsWithOneBlobRead() {
     InMemoryPointerStore pointers = new InMemoryPointerStore();
     InMemoryBlobStore blobs = spy(new InMemoryBlobStore());

--- a/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionGcTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/transaction/TransactionGcTest.java
@@ -443,7 +443,8 @@ class TransactionGcTest {
             tables,
             snapshots,
             mock(ai.floedb.floecat.service.repo.impl.ConstraintRepository.class),
-            statsStore);
+            statsStore,
+            null);
 
     var gc = newGc(pointers, blobs);
     inject(gc, "rootWriter", writer);
@@ -486,7 +487,8 @@ class TransactionGcTest {
             tables,
             mock(ai.floedb.floecat.service.repo.impl.SnapshotRepository.class),
             mock(ai.floedb.floecat.service.repo.impl.ConstraintRepository.class),
-            mock(ai.floedb.floecat.stats.spi.StatsStore.class));
+            mock(ai.floedb.floecat.stats.spi.StatsStore.class),
+            null);
 
     var gc = newGc(pointers, blobs);
     inject(gc, "rootWriter", writer);

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -16,6 +16,7 @@
 package ai.floedb.floecat.storage.kv.dynamodb;
 
 import ai.floedb.floecat.storage.errors.StorageAbortRetryableException;
+import ai.floedb.floecat.storage.errors.StorageTransactionConflictException;
 import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.AttrWriteRules;
 import ai.floedb.floecat.storage.kv.KvAttributes;
@@ -35,12 +36,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import org.jboss.logging.Logger;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
 public final class DynamoDbKvStore implements KvStore, KvAttributes {
+  private static final Logger LOG = Logger.getLogger(DynamoDbKvStore.class);
   static final int DELETE_BATCH_LIMIT = Integer.getInteger("floedb.floecat.delete.batch.size", 25);
+  static final int TRANSACTION_CONFLICT_MAX_RETRIES =
+      Integer.getInteger("floedb.floecat.transaction-conflict.max-retries", 2);
+  private static final long TRANSACTION_CONFLICT_BASE_DELAY_MS = 10L;
+  private static final long TRANSACTION_CONFLICT_MAX_DELAY_MS = 250L;
   private final AsyncDynamoCaller ddb;
   private final BlockingDynamoCaller blockingDdb;
   private final String table;
@@ -682,32 +689,70 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
 
     var req = TransactWriteItemsRequest.builder().transactItems(tx).build();
 
+    return transactWriteWithConflictRetry(req, 0);
+  }
+
+  private Uni<Boolean> transactWriteWithConflictRetry(
+      TransactWriteItemsRequest req, int conflictAttempt) {
     return dynamo(client -> client.transactWriteItems(req))
         .replaceWith(true)
         .onFailure(TransactionCanceledException.class)
-        .recoverWithItem(
+        .recoverWithUni(
             t -> {
-              // Return false for retryable conflicts; throw on unexpected reasons.
               TransactionCanceledException ex = (TransactionCanceledException) t;
-              boolean sawRetryable = false;
+              boolean sawConditionalFailure = false;
+              boolean sawTransactionConflict = false;
               if (ex.cancellationReasons() != null) {
                 for (var r : ex.cancellationReasons()) {
                   if (r == null || "None".equals(r.code())) {
                     continue;
                   }
-                  if ("ConditionalCheckFailed".equals(r.code())
-                      || "TransactionConflict".equals(r.code())) {
-                    sawRetryable = true;
+                  if ("ConditionalCheckFailed".equals(r.code())) {
+                    sawConditionalFailure = true;
                     continue;
                   }
-                  // Non-retryable reason — abort immediately
-                  throw ex;
+                  if ("TransactionConflict".equals(r.code())) {
+                    sawTransactionConflict = true;
+                    continue;
+                  }
+                  return Uni.createFrom().failure(ex);
                 }
               }
-              if (sawRetryable) {
-                return false;
+              if (sawConditionalFailure) {
+                LOG.debugf(
+                    "DynamoDB transaction cancelled by conditional check table=%s outcome=stale_version",
+                    table);
+                return Uni.createFrom().item(false);
               }
-              throw ex;
+              if (!sawTransactionConflict) {
+                return Uni.createFrom().failure(ex);
+              }
+              if (conflictAttempt >= TRANSACTION_CONFLICT_MAX_RETRIES) {
+                LOG.warnf(
+                    "DynamoDB transaction cancelled by transaction conflict table=%s attempts=%d outcome=confirmed_abort",
+                    table, conflictAttempt + 1);
+                return Uni.createFrom()
+                    .failure(
+                        new StorageTransactionConflictException(
+                            "DynamoDB transaction conflict; transaction was cancelled and no mutation was applied",
+                            ex));
+              }
+
+              long exponentialDelayMs =
+                  Math.min(
+                      TRANSACTION_CONFLICT_MAX_DELAY_MS,
+                      TRANSACTION_CONFLICT_BASE_DELAY_MS * (1L << Math.min(conflictAttempt, 10)));
+              long delayMs =
+                  ThreadLocalRandom.current()
+                      .nextLong(TRANSACTION_CONFLICT_BASE_DELAY_MS, exponentialDelayMs + 1L);
+              return Uni.createFrom()
+                  .voidItem()
+                  .onItem()
+                  .delayIt()
+                  .by(Duration.ofMillis(delayMs))
+                  .onItem()
+                  .transformToUni(
+                      ignored -> transactWriteWithConflictRetry(req, conflictAttempt + 1));
             });
   }
 

--- a/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
+++ b/storage/aws/src/main/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStore.java
@@ -45,7 +45,7 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
   private static final Logger LOG = Logger.getLogger(DynamoDbKvStore.class);
   static final int DELETE_BATCH_LIMIT = Integer.getInteger("floedb.floecat.delete.batch.size", 25);
   static final int TRANSACTION_CONFLICT_MAX_RETRIES =
-      Integer.getInteger("floedb.floecat.transaction-conflict.max-retries", 2);
+      Math.max(0, Integer.getInteger("floedb.floecat.transaction-conflict.max-retries", 8));
   private static final long TRANSACTION_CONFLICT_BASE_DELAY_MS = 10L;
   private static final long TRANSACTION_CONFLICT_MAX_DELAY_MS = 250L;
   private final AsyncDynamoCaller ddb;
@@ -745,6 +745,9 @@ public final class DynamoDbKvStore implements KvStore, KvAttributes {
               long delayMs =
                   ThreadLocalRandom.current()
                       .nextLong(TRANSACTION_CONFLICT_BASE_DELAY_MS, exponentialDelayMs + 1L);
+              LOG.debugf(
+                  "DynamoDB transaction conflict; retrying table=%s failed_attempt=%d max_attempts=%d backoff_ms=%d",
+                  table, conflictAttempt + 1, TRANSACTION_CONFLICT_MAX_RETRIES + 1, delayMs);
               return Uni.createFrom()
                   .voidItem()
                   .onItem()

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
@@ -694,14 +694,14 @@ public class DynamoDbKvStoreTest {
   @Test
   void txnWriteCas_retries_transaction_conflict_inside_budget_then_succeeds() {
     FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
-    handler.setTransactionConflictFailures(1);
+    handler.setTransactionConflictFailures(DynamoDbKvStore.TRANSACTION_CONFLICT_MAX_RETRIES);
     DynamoDbKvStore store = newStore(handler);
 
     var ops =
         List.<KvStore.TxnOp>of(
             new KvStore.TxnPut(record("pk1", "sk1", "K", "v", 1L, Map.of()), 0L));
     assertTrue(store.txnWriteCas(ops).await().indefinitely());
-    assertEquals(2, handler.transactWriteCalls);
+    assertEquals(DynamoDbKvStore.TRANSACTION_CONFLICT_MAX_RETRIES + 1, handler.transactWriteCalls);
   }
 
   @Test

--- a/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
+++ b/storage/aws/src/test/java/ai/floedb/floecat/storage/kv/dynamodb/DynamoDbKvStoreTest.java
@@ -17,6 +17,7 @@ package ai.floedb.floecat.storage.kv.dynamodb;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import ai.floedb.floecat.storage.errors.StorageTransactionConflictException;
 import ai.floedb.floecat.storage.kv.AttrValue;
 import ai.floedb.floecat.storage.kv.KvAttributes;
 import ai.floedb.floecat.storage.kv.KvStore;
@@ -678,7 +679,33 @@ public class DynamoDbKvStoreTest {
   }
 
   @Test
-  void txnWriteCas_returns_false_on_transaction_conflict() {
+  void txnWriteCas_retries_transaction_conflict_then_succeeds() {
+    FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
+    handler.setTransactionConflictFailures(2);
+    DynamoDbKvStore store = newStore(handler);
+
+    var ops =
+        List.<KvStore.TxnOp>of(
+            new KvStore.TxnPut(record("pk1", "sk1", "K", "v", 1L, Map.of()), 0L));
+    assertTrue(store.txnWriteCas(ops).await().indefinitely());
+    assertEquals(3, handler.transactWriteCalls);
+  }
+
+  @Test
+  void txnWriteCas_retries_transaction_conflict_inside_budget_then_succeeds() {
+    FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
+    handler.setTransactionConflictFailures(1);
+    DynamoDbKvStore store = newStore(handler);
+
+    var ops =
+        List.<KvStore.TxnOp>of(
+            new KvStore.TxnPut(record("pk1", "sk1", "K", "v", 1L, Map.of()), 0L));
+    assertTrue(store.txnWriteCas(ops).await().indefinitely());
+    assertEquals(2, handler.transactWriteCalls);
+  }
+
+  @Test
+  void txnWriteCas_reports_confirmed_abort_when_transaction_conflict_budget_is_exhausted() {
     FakeDynamoDbHandler handler = new FakeDynamoDbHandler();
     handler.setCancellationReasonCodes(List.of("TransactionConflict"));
     DynamoDbKvStore store = newStore(handler);
@@ -686,7 +713,10 @@ public class DynamoDbKvStoreTest {
     var ops =
         List.<KvStore.TxnOp>of(
             new KvStore.TxnPut(record("pk1", "sk1", "K", "v", 1L, Map.of()), 0L));
-    assertFalse(store.txnWriteCas(ops).await().indefinitely());
+    assertThrows(
+        StorageTransactionConflictException.class,
+        () -> store.txnWriteCas(ops).await().indefinitely());
+    assertEquals(DynamoDbKvStore.TRANSACTION_CONFLICT_MAX_RETRIES + 1, handler.transactWriteCalls);
   }
 
   @Test
@@ -724,6 +754,7 @@ public class DynamoDbKvStoreTest {
         List.<KvStore.TxnOp>of(
             new KvStore.TxnPut(record("pk1", "sk1", "K", "v", 1L, Map.of()), 0L));
     assertFalse(store.txnWriteCas(ops).await().indefinitely());
+    assertEquals(1, handler.transactWriteCalls);
   }
 
   @Test
@@ -822,6 +853,7 @@ public class DynamoDbKvStoreTest {
     private QueryRequest lastQueryRequest;
     private ScanRequest lastScanRequest;
     private int batchWriteCalls;
+    private int transactWriteCalls;
     private boolean tableExists = true;
     private boolean tableActive = true;
     private boolean failScan;
@@ -829,6 +861,7 @@ public class DynamoDbKvStoreTest {
     private boolean failTxnWithNullReasons;
     private boolean wrapTxnFailureInCompletionException;
     private List<String> cancellationReasonCodes;
+    private int transactionConflictFailuresRemaining;
     private int createTableCalls;
     private int deleteTableCalls;
     private int unprocessedCount;
@@ -847,6 +880,10 @@ public class DynamoDbKvStoreTest {
 
     private void setCancellationReasonCodes(List<String> codes) {
       this.cancellationReasonCodes = codes;
+    }
+
+    private void setTransactionConflictFailures(int count) {
+      this.transactionConflictFailuresRemaining = count;
     }
 
     private void setPendingGetFuture(CompletableFuture<GetItemResponse> pendingGetFuture) {
@@ -1053,6 +1090,11 @@ public class DynamoDbKvStoreTest {
 
     private CompletableFuture<TransactWriteItemsResponse> handleTransactWrite(
         TransactWriteItemsRequest req) {
+      transactWriteCalls++;
+      if (transactionConflictFailuresRemaining > 0) {
+        transactionConflictFailuresRemaining--;
+        return failedTransaction("TransactionConflict");
+      }
       if (cancellationReasonCodes != null) {
         return wrapTxnFailureInCompletionException
             ? failedTransactionWrapped(cancellationReasonCodes)


### PR DESCRIPTION
## Summary

Make every Floecat operation carrying an idempotency key commit its business pointer mutation and exact success receipt atomically, or use a named mechanism whose effects are independently repeatable.

This fixes the reconcile failure where a DynamoDB transaction conflict aborted a constraints mutation but left its separately committed `PENDING` claim behind. Retries then observed `PENDING`, skipped the callback, and remained blocked for the full idempotency TTL.

The PR:

- propagates a confirmed transaction abort from DynamoDB instead of flattening it into an ordinary failed CAS;
- adds the update-shaped `runOnceCommitted` protocol and repository completion hooks;
- migrates every keyed create and update onto atomic receipt helpers;
- gives receipt-only, planner enqueue, and connector credential effects explicit repeatable mechanisms;
- removes the generic non-atomic `IdempotencyGuard.runOnce`, `MutationOps.create`, and `MutationOps.createProto` entry points;
- records derived constraints and statistics root-publication failures for durable `RootResyncQueue` re-drive while preserving their acknowledgement semantics.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

- [ ] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

## Deployment and Compatibility

- [ ] No breaking changes
- [x] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

The removed non-atomic helpers are an intentional internal source-compatibility break: new keyed operations must choose an atomic or explicitly repeatable mechanism. There are no RPC, persisted-format, configuration, or environment-variable changes.

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

Reviewer map:

1. `7e90abd3d` preserves the distinction between stale preconditions and confirmed transaction aborts.
2. `b6217d003` adds the atomic protocols, migrates all keyed operations, removes the unsafe APIs, and covers derived root convergence.

The regression deliberately injects a transaction conflict into parallel constraints reconcile and verifies that neither business state nor receipt commits, the idempotency key is not poisoned, retry succeeds, and replay returns the exact recorded `changed` response.

Known follow-ups, intentionally outside this PR:

- `CurrentSnapshotPointerService` still publishes a stats generation synchronously only when currency reports `UPDATED`; after a failed first attempt, an `UNCHANGED` retry may rely on the durable marker and GC cadence. Removing that guard is a separate measurable hot-path tradeoff.
- Query-side validation of `constraints_ref_version` remains a separate consistency task.

Successful stats re-drive markers may remain briefly after an immediate caller retry succeeds. They are keyed per table and idempotent, so queue depth can reflect contention as well as persistent divergence.
