### PR TITLE
feat: vend Iceberg integration storage credentials

### DIFF
--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClient.java
@@ -25,6 +25,7 @@ import ai.floedb.floecat.catalog.access.CatalogView;
 import ai.floedb.floecat.catalog.access.CatalogViewDefinition;
 import ai.floedb.floecat.catalog.access.ExternalObjectIdentity;
 import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.access.StorageLocations;
 import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -34,6 +35,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.SchemaParser;
@@ -52,16 +55,30 @@ import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewVersion;
 
 final class IcebergRestCatalogClient implements CatalogClient {
+  private static final Logger LOG = Logger.getLogger(IcebergRestCatalogClient.class.getName());
+
   private static final List<String> VENDED_STORAGE_KEYS =
       List.of(
           "s3.access-key-id",
           "s3.secret-access-key",
           "s3.session-token",
           "s3.region",
+          "client.region",
           "s3.endpoint",
           "s3.path-style-access");
+
+  /**
+   * Non-secret routing carried out of the catalog's own answer.
+   *
+   * <p>{@code client.region} belongs here as well as {@code s3.region}: it is Iceberg's own AWS
+   * region property, so a catalog is free to report its region under that name in the {@code
+   * /v1/config} response, and the consumer already reads either spelling. Dropping it left the
+   * region at floecat's configured default, which signs storage requests for the wrong region -- a
+   * signing failure if the caller is lucky, and a read against an unintended region if not.
+   */
   private static final List<String> STORAGE_ROUTING_KEYS =
-      List.of("s3.region", "s3.endpoint", "s3.path-style-access");
+      List.of("s3.region", "client.region", "s3.endpoint", "s3.path-style-access");
+
   private static final String VENDED_EXPIRY_KEY = "s3.session-token-expires-at-ms";
   private static final CatalogCapabilities CAPABILITIES =
       CatalogCapabilities.of(
@@ -81,6 +98,17 @@ final class IcebergRestCatalogClient implements CatalogClient {
   private final Runnable closeHook;
   private final Map<String, String> storageRoutingProperties;
   private final Function<VendedStorageCredentials, FileIO> validationFileIoFactory;
+
+  /**
+   * Used only to prefer a live session over an expired one when ranking candidates.
+   *
+   * <p>Deliberately not used to refuse anything. The consumer owns the expiry policy -- its skew
+   * tolerance, and which paths may read a just-expired credential -- so a provider that filtered on
+   * liveness would refuse credentials the consumer would have read, and the two ends would disagree
+   * about the same rule. Package-visible so a test can fix it.
+   */
+  java.time.Clock clock = java.time.Clock.systemUTC();
+
   private final AtomicBoolean closed = new AtomicBoolean(false);
 
   IcebergRestCatalogClient(
@@ -230,6 +258,19 @@ final class IcebergRestCatalogClient implements CatalogClient {
         });
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Credentials come from {@code SupportsStorageCredentials.credentials()} and nowhere else.
+   * There is deliberately no fall-back to the table's FileIO properties, which is what {@code
+   * IcebergConnector} does for a catalog predating the credential channel: those properties cannot
+   * say whether a key was vended for this table or merged into every table's FileIO from the
+   * client's own configuration, which is why the connector path has to cross-check what it finds
+   * against what the connector was configured with. A Catalog Integration has no configured storage
+   * credential to cross-check against, and the ambiguity would be resolved by guessing. A server
+   * that answers access delegation by putting keys in the load-table config map rather than the
+   * credentials list therefore does not vend through this path.
+   */
   @Override
   public Optional<VendedStorageCredentials> vendStorageCredentials(CatalogObjectName name) {
     Objects.requireNonNull(name, "name");
@@ -249,15 +290,54 @@ final class IcebergRestCatalogClient implements CatalogClient {
     }
 
     String tableLocation = Optional.ofNullable(table.location()).orElse("");
+    // Sampled once for the whole pass. Read per candidate, two credentials carrying the same expiry
+    // could be ranked against different instants and land on opposite sides of it.
+    Instant rankedAt = clock.instant();
     StorageCredential selected = null;
     int selectedPrefixLength = -1;
+    StorageCredential covering = null;
+    int coveringPrefixLength = -1;
+    StorageCredential expired = null;
+    int expiredPrefixLength = -1;
     for (StorageCredential candidate : credentials) {
       if (candidate == null || !hasVendedKeyMaterial(candidate.config())) {
         continue;
       }
       String prefix = Optional.ofNullable(candidate.prefix()).orElse("");
-      String normalizedPrefix = normalizeS3Scheme(prefix);
-      if (!coversLocation(tableLocation, normalizedPrefix)) {
+      if (!StorageLocations.covers(prefix, tableLocation)) {
+        continue;
+      }
+      // Length of the normalized form, so "most specific wins" is not decided by whether a catalog
+      // spelled the same scope with a trailing slash or an s3a:// scheme.
+      String normalizedPrefix =
+          StorageLocations.stripTrailingSlash(StorageLocations.normalizeScheme(prefix.trim()));
+      // The best covering candidate whatever its shape, kept only to describe the response when
+      // nothing renewable covers the table. Ranking happens twice rather than once because the two
+      // questions are different: which credential to use, and what to say when there is none.
+      if (covering == null || normalizedPrefix.length() > coveringPrefixLength) {
+        covering = candidate;
+        coveringPrefixLength = normalizedPrefix.length();
+      }
+      // Renewability decides candidacy, not just the final answer. Iceberg returns a list so a
+      // catalog can scope per prefix, and during a rotation or a reconfiguration that list can hold
+      // a narrow unrenewable pair beside a broad complete session. Ranking on specificity alone
+      // picked the narrow one and then refused the whole response, with a usable credential sitting
+      // in it.
+      if (!missingSessionFields(candidate.config()).isEmpty()) {
+        continue;
+      }
+      // Liveness ranks, it does not exclude. The same rotation leaves a narrow expired session
+      // beside a broad live one, and specificity alone picks the expired one -- which the consumer
+      // then rejects, failing a read the response could have served. An expired candidate is still
+      // kept as the fallback below, because refusing it here would take the skew tolerance and the
+      // per-path decisions away from the consumer that owns them.
+      Instant candidateExpiry = parseVendedExpiry(candidate.config());
+      boolean live = candidateExpiry != null && candidateExpiry.isAfter(rankedAt);
+      if (!live) {
+        if (expired == null || normalizedPrefix.length() > expiredPrefixLength) {
+          expired = candidate;
+          expiredPrefixLength = normalizedPrefix.length();
+        }
         continue;
       }
       if (selected == null || normalizedPrefix.length() > selectedPrefixLength) {
@@ -265,14 +345,71 @@ final class IcebergRestCatalogClient implements CatalogClient {
         selectedPrefixLength = normalizedPrefix.length();
       }
     }
+    // Nothing live covers the table, but something expired does: hand that one on so the consumer
+    // reports the expiry with its own rules rather than seeing "no credentials at all".
+    if (selected == null && expired != null) {
+      selected = expired;
+    }
     if (selected == null) {
+      // A catalog that answered with key material but not a usable pair is a deterministic fault,
+      // not a "did not vend". Returning empty here would hand the caller its no-delegation path and
+      // land as a missing-authority error, which reads as a configuration gap and hides the real
+      // cause; a retry cannot change it either. There is no opt-in that lets an integration fall
+      // back to a storage authority, so the honest answer is to fail with the reason.
+      //
+      // Restricted to credentials that cover this table: a half tuple offered for some other prefix
+      // says nothing about this read, and letting it decide would turn an ordinary "nothing for
+      // this table" into a terminal failure.
+      Optional<Map<String, String>> partialCredential =
+          credentials.stream()
+              .filter(Objects::nonNull)
+              // No null guard, unlike the scope check above: an absent prefix covers every
+              // location by contract, and the selection loop spells the same thing as "". Guarding
+              // it here would drop the single unscoped half-tuple -- the clearest case of the fault
+              // this check exists to name -- back onto the missing-authority path.
+              .filter(candidate -> StorageLocations.covers(candidate.prefix(), tableLocation))
+              .map(StorageCredential::config)
+              .filter(IcebergRestCatalogClient::hasPartialVendedKeyMaterial)
+              .findFirst();
+      if (partialCredential.isPresent()) {
+        // The fields actually absent, not a fixed pair. A partial credential is any incomplete
+        // combination -- a lone session token with neither key is one -- and this message is
+        // terminal, so it is the last thing an operator reads. Naming two fields when neither was
+        // sent, or when the anomaly is the token, sends them to the wrong end of the response.
+        throw new ai.floedb.floecat.catalog.access.CatalogAccessException(
+            ai.floedb.floecat.catalog.access.CatalogAccessException.Code.INVALID_CONFIGURATION,
+            "Vended storage credentials are incomplete: missing "
+                + String.join(", ", missingKeyMaterialFields(partialCredential.get())));
+      }
+      // Something covers the table, it just cannot be renewed. A catalog integration vends only
+      // when the credential it holds is itself a temporary session, and floecat does not scope one
+      // down with STS, so what arrives is what would travel to a reader. Reported rather than
+      // returned so validation and the vend reach the same answer -- both come through this method,
+      // and a bare pair reads storage perfectly well, so accepting it here let an integration pass
+      // every validation check and then fail terminally on first use.
+      if (covering != null) {
+        throw new ai.floedb.floecat.catalog.access.CatalogAccessException(
+            ai.floedb.floecat.catalog.access.CatalogAccessException.Code.INVALID_CONFIGURATION,
+            "Vended storage credentials are not a renewable session: missing "
+                + String.join(", ", missingSessionFields(covering.config())));
+      }
+      // Scope last, once nothing that covers the table has been found. It describes the response as
+      // a whole -- "some credential here is for a different prefix" -- while the two checks above
+      // describe the credential meant for this table. When a response holds both, saying the
+      // credentials do not cover the table is simply untrue: one of them does, and the operator
+      // needs to hear that it is not a session rather than go looking at catalog scoping.
+      //
+      // The order used to run the other way, when scope-invalid fell back to storage-authority
+      // handling and these two were terminal, so an ambiguous response took the recoverable answer.
+      // An Integration no longer falls back, so all three are refusals with the same disposition
+      // and the order decides nothing but which sentence is printed.
       boolean hasOutOfScopeCredential =
           credentials.stream()
               .filter(Objects::nonNull)
               .filter(candidate -> hasVendedKeyMaterial(candidate.config()))
               .map(StorageCredential::prefix)
               .filter(Objects::nonNull)
-              .anyMatch(prefix -> !coversLocation(tableLocation, prefix));
+              .anyMatch(prefix -> !StorageLocations.covers(prefix, tableLocation));
       if (hasOutOfScopeCredential) {
         throw new ai.floedb.floecat.catalog.access.CatalogAccessException(
             ai.floedb.floecat.catalog.access.CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
@@ -281,16 +418,68 @@ final class IcebergRestCatalogClient implements CatalogClient {
       return Optional.empty();
     }
 
+    // Catalog-wide routing first, then whatever this table overrode, then the credential. The
+    // middle layer is the one a catalog uses to put a table in a different region or bucket from
+    // its own default: RESTSessionCatalog.tableFileIO builds the table's FileIO from
+    // RESTUtil.merge(properties(), response.config()), so a LoadTableResponse config reaches
+    // table.io() but never reaches the map captured from /v1/config at client construction.
+    // Dropping it signed reads for the catalog's region against a table that does not live there.
     Map<String, String> vended = new LinkedHashMap<>(storageRoutingProperties);
+    vended.putAll(perTableRoutingProperties(table));
     vended.putAll(filterVendedStorageProperties(selected.config()));
+    // Not a classification: selection required both keys non-blank, VENDED_STORAGE_KEYS carries
+    // both, the filter keeps every non-blank value, and the routing merge only adds -- so this
+    // cannot fire. Kept as an invariant so a future change to any of those three surfaces here
+    // rather than as a credential that reaches storage missing half its key material.
     if (!vended.containsKey("s3.access-key-id") || !vended.containsKey("s3.secret-access-key")) {
-      return Optional.empty();
+      // Typed, not an IllegalStateException: IcebergRestCatalogErrors.translate returns anything it
+      // does not recognise unwrapped, so a raw one would leave this SPI as an untyped
+      // RuntimeException -- escaping CatalogIntegrationDiscovery's catch of CatalogAccessException,
+      // where it would propagate out of ValidateCatalogIntegration instead of reporting a failed
+      // check, and reaching the vendor as a null accessFailure. The guard exists to be seen, and
+      // untyped is the one shape that loses it.
+      throw new ai.floedb.floecat.catalog.access.CatalogAccessException(
+          ai.floedb.floecat.catalog.access.CatalogAccessException.Code.INTERNAL,
+          "Selected vended credential lost its key material during filtering");
     }
+    // Non-null by selection, which only ranks candidates whose session fields are all present.
+    // Optional.ofNullable rather than Optional.of so a future change to that filter degrades to an
+    // absent expiry -- which requireUsableCredentials still refuses -- instead of an NPE here.
     return Optional.of(
         new VendedStorageCredentials(
             Map.copyOf(vended),
             Optional.ofNullable(selected.prefix()).orElse(""),
             Optional.ofNullable(parseVendedExpiry(selected.config()))));
+  }
+
+  /** Which half of the key pair a partial credential did not carry. Never empty for one. */
+  private static List<String> missingKeyMaterialFields(Map<String, String> config) {
+    List<String> missing = new java.util.ArrayList<>();
+    if (isBlank(config.get("s3.access-key-id"))) {
+      missing.add("s3.access-key-id");
+    }
+    if (isBlank(config.get("s3.secret-access-key"))) {
+      missing.add("s3.secret-access-key");
+    }
+    return missing;
+  }
+
+  /**
+   * The renewal fields a vended credential is missing, empty when it is a complete session.
+   *
+   * <p>Both are required together: the token is what makes the credential a session, and the expiry
+   * is what makes it renewable. A credential missing either cannot be re-vended before it lapses,
+   * and the reconcile path would embed it statically and read until it did.
+   */
+  private static List<String> missingSessionFields(Map<String, String> config) {
+    List<String> missing = new java.util.ArrayList<>();
+    if (isBlank(config.get("s3.session-token"))) {
+      missing.add("s3.session-token");
+    }
+    if (parseVendedExpiry(config) == null) {
+      missing.add(VENDED_EXPIRY_KEY);
+    }
+    return missing;
   }
 
   @Override
@@ -310,8 +499,7 @@ final class IcebergRestCatalogClient implements CatalogClient {
                               ai.floedb.floecat.catalog.access.CatalogAccessException.Code
                                   .UNSUPPORTED,
                               "Upstream table does not expose a metadata location"));
-          String scopePrefix = vendedStorageCredentials.scopePrefix();
-          if (!coversLocation(metadataLocation, scopePrefix)) {
+          if (!vendedStorageCredentials.covers(metadataLocation)) {
             throw new ai.floedb.floecat.catalog.access.CatalogAccessException(
                 ai.floedb.floecat.catalog.access.CatalogAccessException.Code
                     .CREDENTIAL_SCOPE_INVALID,
@@ -391,6 +579,22 @@ final class IcebergRestCatalogClient implements CatalogClient {
     return Map.copyOf(filtered);
   }
 
+  /**
+   * Whether a credential carries some S3 key material without carrying a usable pair.
+   *
+   * <p>Distinguishes a catalog that vended nothing for this table -- a normal answer -- from one
+   * that vended half a tuple, which is a fault worth reporting rather than falling back on. A
+   * session token on its own counts: it is only meaningful beside the pair.
+   */
+  private static boolean hasPartialVendedKeyMaterial(Map<String, String> properties) {
+    if (properties == null || properties.isEmpty() || hasVendedKeyMaterial(properties)) {
+      return false;
+    }
+    return !isBlank(properties.get("s3.access-key-id"))
+        || !isBlank(properties.get("s3.secret-access-key"))
+        || !isBlank(properties.get("s3.session-token"));
+  }
+
   private static boolean hasVendedKeyMaterial(Map<String, String> properties) {
     return properties != null
         && !properties.isEmpty()
@@ -398,26 +602,32 @@ final class IcebergRestCatalogClient implements CatalogClient {
         && !isBlank(properties.get("s3.secret-access-key"));
   }
 
-  private static String normalizeS3Scheme(String location) {
-    int schemeEnd = location.indexOf("://");
-    if (schemeEnd < 0) {
-      return location;
-    }
-    String scheme = location.substring(0, schemeEnd);
-    if ("s3".equalsIgnoreCase(scheme)
-        || "s3a".equalsIgnoreCase(scheme)
-        || "s3n".equalsIgnoreCase(scheme)) {
-      return "s3" + location.substring(schemeEnd);
-    }
-    return location;
-  }
-
-  private static boolean coversLocation(String location, String prefix) {
-    return prefix.isEmpty() || normalizeS3Scheme(location).startsWith(normalizeS3Scheme(prefix));
-  }
-
   private static boolean isBlank(String value) {
     return value == null || value.isBlank();
+  }
+
+  /**
+   * Routing this table overrode, empty when it overrode none.
+   *
+   * <p>{@code FileIO.properties()} is a default method that throws unless the implementation
+   * chooses to expose its configuration -- {@code S3FileIO} does, a custom one need not -- so a
+   * refusal here means "no per-table routing to read", not a failure to vend. The catalog-wide map
+   * still applies either way, which is what this path had before.
+   *
+   * <p>Every runtime failure is absorbed, not just the {@code UnsupportedOperationException} the
+   * default method declares: an implementation is free to throw something else for the same "I do
+   * not expose this" reason, and this runs on the success path with a usable credential already
+   * selected. Letting one escape would trade a working vend for a missing region hint -- and for an
+   * Integration that is a failed read, because there is no storage authority behind it.
+   */
+  private static Map<String, String> perTableRoutingProperties(Table table) {
+    try {
+      Map<String, String> properties = table.io().properties();
+      return properties == null ? Map.of() : storageRoutingProperties(properties);
+    } catch (RuntimeException e) {
+      LOG.log(Level.FINE, "Table FileIO did not expose per-table storage routing", e);
+      return Map.of();
+    }
   }
 
   static Map<String, String> storageRoutingProperties(Map<String, String> source) {
@@ -439,6 +649,14 @@ final class IcebergRestCatalogClient implements CatalogClient {
    */
   private static final long MAX_EXPIRY_EPOCH_MILLIS = 253402300799999L;
 
+  /**
+   * Mirrors {@code FloecatConnector.VendedStorageCredentials.MIN_EXPIRY_EPOCH_MILLIS},
+   * 2000-01-01T00:00:00Z. A value below it is in the wrong unit rather than early: seconds read as
+   * milliseconds land in January 1970, deterministically stale, which the refresh path re-vends on
+   * every resolveCredentials. Folding it to absent gets it refused once with the field named.
+   */
+  private static final long MIN_EXPIRY_EPOCH_MILLIS = 946684800000L;
+
   private static Instant parseVendedExpiry(Map<String, String> properties) {
     String raw = properties.get(VENDED_EXPIRY_KEY);
     if (raw == null || raw.isBlank()) {
@@ -446,13 +664,14 @@ final class IcebergRestCatalogClient implements CatalogClient {
     }
     try {
       long epochMillis = Long.parseLong(raw.trim());
-      // Same rule as FloecatConnector.VendedStorageCredentials.expiryFromEpochMillis, which this
-      // module cannot call: catalog-access depends on the catalog-access SPI, not the connector
-      // one. Both bounds, because both paths parse the same field of the same response and a
-      // comment claiming parity is what makes the next reader widen the gap. A non-positive value
-      // is an absent expiry, not an instant in 1970 that every consumer reads as already expired;
-      // anything past MAX_EXPIRY_EPOCH_MILLIS is a unit mismatch, not a date.
-      return epochMillis <= 0 || epochMillis > MAX_EXPIRY_EPOCH_MILLIS
+      // Nearly the rule FloecatConnector.VendedStorageCredentials.expiryFromEpochMillis applies,
+      // which this module cannot call: catalog-access depends on the catalog-access SPI, not the
+      // connector one. The ceiling is shared. The floor is deliberately only here: folding an
+      // out-of-unit value to absent is safe on this path, because a vend that reaches it without a
+      // parseable expiry is refused by missingSessionFields with the field named, and nothing here
+      // infers permanence from an absent expiry. The connector record cannot afford that -- see the
+      // note on expiryFromEpochMillis -- so the asymmetry is the point rather than drift.
+      return epochMillis < MIN_EXPIRY_EPOCH_MILLIS || epochMillis > MAX_EXPIRY_EPOCH_MILLIS
           ? null
           : Instant.ofEpochMilli(epochMillis);
     } catch (NumberFormatException ignored) {

--- a/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
+++ b/catalog-access/iceberg-rest/src/main/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientProvider.java
@@ -100,7 +100,14 @@ public final class IcebergRestCatalogClientProvider implements CatalogClientProv
           namespaces,
           viewCatalog,
           () -> closeCatalog(sessionCatalog),
-          IcebergRestCatalogClient.storageRoutingProperties(properties));
+          // Read back from the catalog, not from what we sent it. RESTSessionCatalog.initialize
+          // ends with super.initialize(name, config.merge(props)), so properties() is the
+          // /v1/config
+          // response merged over ours -- and /v1/config is how an Iceberg REST catalog tells a
+          // client which region and endpoint to reach its storage on. Sourcing routing from the
+          // pre-initialization map dropped s3.endpoint and left the region at floecat's default for
+          // every integration whose operator did not happen to type them into the record.
+          IcebergRestCatalogClient.storageRoutingProperties(sessionCatalog.properties()));
     } catch (RuntimeException | Error e) {
       closeCatalog(sessionCatalog);
       if (e instanceof RuntimeException runtimeException) {

--- a/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
+++ b/catalog-access/iceberg-rest/src/test/java/ai/floedb/floecat/catalog/iceberg/rest/IcebergRestCatalogClientTest.java
@@ -36,6 +36,7 @@ import ai.floedb.floecat.catalog.access.NamespacePath;
 import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -203,13 +204,427 @@ class IcebergRestCatalogClientTest {
   }
 
   @Test
+  void perTableRoutingOverridesTheCatalogWideDefaultAndTheCredentialStillWins() {
+    // The layering a multi-region catalog depends on. RESTSessionCatalog.tableFileIO builds the
+    // table's FileIO from RESTUtil.merge(properties(), response.config()), so a LoadTableResponse
+    // config reaches table.io() and never reaches the map captured from /v1/config at construction.
+    // Reading only the latter signs requests for the catalog's own region against a table that
+    // lives somewhere else.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(io.properties())
+        .thenReturn(
+            Map.of(
+                "s3.endpoint", "https://frankfurt.example.invalid",
+                "client.region", "eu-central-1",
+                // Not routing, and not key material: it must not ride along into the vend.
+                "warehouse", "must-not-leak"));
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "table-access",
+                        "s3.secret-access-key", "table-secret",
+                        "s3.session-token", "table-token",
+                        "s3.session-token-expires-at-ms", "1786000000000"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+    IcebergRestCatalogClient client =
+        new IcebergRestCatalogClient(
+            catalog,
+            namespaces,
+            views,
+            () -> {},
+            Map.of("client.region", "us-east-1", "s3.path-style-access", "true"));
+
+    var vended = client.vendStorageCredentials(name).orElseThrow();
+
+    // The table's own region beats the catalog default.
+    assertEquals("eu-central-1", vended.properties().get("client.region"));
+    assertEquals("https://frankfurt.example.invalid", vended.properties().get("s3.endpoint"));
+    // A catalog-wide key the table did not override still applies.
+    assertEquals("true", vended.properties().get("s3.path-style-access"));
+    // Only allowlisted routing crosses over.
+    assertFalse(vended.properties().containsKey("warehouse"));
+    // The credential still overlays everything.
+    assertEquals("table-access", vended.properties().get("s3.access-key-id"));
+  }
+
+  @Test
+  void aFileIoThatWillNotExposeItsPropertiesStillVends() {
+    // Reading per-table routing is enrichment, and it runs after a usable credential is already
+    // selected, so nothing it throws may cost the vend. UnsupportedOperationException is what the
+    // FileIO.properties() default method declares; the rest is what a concrete implementation is
+    // free to throw for the same "I do not expose this" reason -- and for an Integration a lost
+    // vend is a failed read, since there is no storage authority behind it to fall back to.
+    for (RuntimeException refusal :
+        List.of(
+            new UnsupportedOperationException("does not expose config"),
+            new IllegalStateException("io is closed"),
+            new NullPointerException("properties were never populated"))) {
+      CatalogObjectName name =
+          new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+      TableIdentifier identifier =
+          TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+      Catalog scopedCatalog = mock(Catalog.class);
+      Table table = mock(Table.class);
+      FileIO io =
+          mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+      when(table.io()).thenReturn(io);
+      when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+      when(io.properties()).thenThrow(refusal);
+      when(((SupportsStorageCredentials) io).credentials())
+          .thenReturn(
+              List.of(
+                  StorageCredential.create(
+                      "s3://warehouse/sales/orders/",
+                      Map.of(
+                          "s3.access-key-id", "table-access",
+                          "s3.secret-access-key", "table-secret",
+                          "s3.session-token", "table-token",
+                          "s3.session-token-expires-at-ms", "1786000000000"))));
+      when(scopedCatalog.loadTable(identifier)).thenReturn(table);
+      IcebergRestCatalogClient client =
+          new IcebergRestCatalogClient(
+              scopedCatalog, namespaces, views, () -> {}, Map.of("client.region", "us-east-1"));
+
+      var vended = client.vendStorageCredentials(name).orElseThrow();
+
+      assertEquals("table-access", vended.properties().get("s3.access-key-id"), refusal.toString());
+      // The catalog-wide default still applies, which is what this path had before.
+      assertEquals("us-east-1", vended.properties().get("client.region"), refusal.toString());
+    }
+  }
+
+  @Test
+  void anIncompleteCredentialNamesTheFieldsItActuallyLacks() {
+    // A lone session token with neither key. The message is terminal, so it is the last thing an
+    // operator reads -- a fixed "one of access-key-id or secret-access-key" would point them at
+    // half the truth when in fact neither arrived.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/", Map.of("s3.session-token", "orphan-token"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> client().vendStorageCredentials(name));
+
+    assertEquals(CatalogAccessException.Code.INVALID_CONFIGURATION, error.code());
+    assertTrue(error.getMessage().contains("s3.access-key-id"), error.getMessage());
+    assertTrue(error.getMessage().contains("s3.secret-access-key"), error.getMessage());
+  }
+
+  @Test
+  void aRegionReportedAsClientRegionSurvivesToTheVendedCredential() {
+    // Iceberg's own AWS region property, so a catalog may report its region under this name in the
+    // /v1/config response rather than as s3.region. Filtering it out left the consumer to fall back
+    // to floecat's configured default and sign for the wrong region.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "vended-access",
+                        "s3.secret-access-key", "vended-secret",
+                        "s3.session-token", "vended-token",
+                        "s3.session-token-expires-at-ms", "4102444800000"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+    var client =
+        new IcebergRestCatalogClient(
+            catalog, namespaces, views, () -> {}, Map.of("client.region", "eu-west-1"));
+
+    var vended = client.vendStorageCredentials(name).orElseThrow();
+
+    assertEquals("eu-west-1", vended.properties().get("client.region"));
+  }
+
+  @Test
+  void anUnrelatedCredentialDoesNotHijackTheDiagnosisForThisTable() {
+    // Both faults in one response: a complete session scoped somewhere else, and a bare pair that
+    // does cover this table. Reporting "credentials do not cover the upstream table location" is
+    // simply untrue here -- one of them does -- and it sends the operator to catalog scoping when
+    // the actual defect is that the Integration is not holding a session.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://other-warehouse/",
+                    Map.of(
+                        "s3.access-key-id", "elsewhere-access",
+                        "s3.secret-access-key", "elsewhere-secret",
+                        "s3.session-token", "elsewhere-token",
+                        "s3.session-token-expires-at-ms", "4102444800000")),
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "static-access",
+                        "s3.secret-access-key", "static-secret"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> client().vendStorageCredentials(name));
+
+    assertEquals(CatalogAccessException.Code.INVALID_CONFIGURATION, error.code());
+    assertTrue(error.getMessage().contains("s3.session-token"), error.getMessage());
+  }
+
+  @Test
+  void anOutOfScopeResponseStillReportsScopeWhenNothingCoversTheTable() {
+    // The scope check is not gone, just last: with nothing covering the table, "does not cover the
+    // upstream table location" is the accurate answer.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://other-warehouse/",
+                    Map.of(
+                        "s3.access-key-id", "elsewhere-access",
+                        "s3.secret-access-key", "elsewhere-secret",
+                        "s3.session-token", "elsewhere-token",
+                        "s3.session-token-expires-at-ms", "4102444800000"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> client().vendStorageCredentials(name));
+
+    assertEquals(CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID, error.code());
+  }
+
+  @Test
+  void aBroadLiveSessionBeatsANarrowerExpiredOne() {
+    // The same rotation that leaves a narrow unrenewable pair can leave a narrow expired session.
+    // Ranking on specificity alone picked it, and the consumer then rejected the vend -- failing a
+    // read this response could have served from the broader credential.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/",
+                    Map.of(
+                        "s3.access-key-id", "live-access",
+                        "s3.secret-access-key", "live-secret",
+                        "s3.session-token", "live-token",
+                        "s3.session-token-expires-at-ms", "4102444800000")),
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "expired-access",
+                        "s3.secret-access-key", "expired-secret",
+                        "s3.session-token", "expired-token",
+                        "s3.session-token-expires-at-ms", "1580000000000"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+    var client = new IcebergRestCatalogClient(catalog, namespaces, views, () -> {}, Map.of());
+    client.clock = java.time.Clock.fixed(Instant.parse("2026-09-04T00:00:00Z"), ZoneOffset.UTC);
+
+    var vended = client.vendStorageCredentials(name).orElseThrow();
+
+    assertEquals("live-access", vended.properties().get("s3.access-key-id"));
+    assertEquals("s3://warehouse/", vended.scopePrefix());
+  }
+
+  @Test
+  void anExpiredSessionIsStillHandedOnWhenNothingLiveCoversTheTable() {
+    // Liveness ranks, it does not exclude. The consumer owns the expiry policy -- its skew
+    // tolerance, and whether a query may read a just-expired credential -- so refusing here would
+    // take that decision away and report "no credentials" for a response that had one.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "expired-access",
+                        "s3.secret-access-key", "expired-secret",
+                        "s3.session-token", "expired-token",
+                        "s3.session-token-expires-at-ms", "1580000000000"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+    var client = new IcebergRestCatalogClient(catalog, namespaces, views, () -> {}, Map.of());
+    client.clock = java.time.Clock.fixed(Instant.parse("2026-09-04T00:00:00Z"), ZoneOffset.UTC);
+
+    var vended = client.vendStorageCredentials(name).orElseThrow();
+
+    assertEquals("expired-access", vended.properties().get("s3.access-key-id"));
+  }
+
+  @Test
+  void aBroadRenewableSessionBeatsANarrowerUnrenewablePair() {
+    // The reverse of the longest-prefix case. Iceberg returns a list so a catalog can scope per
+    // prefix, and a rotation or a reconfiguration can leave a narrow unrenewable pair beside a
+    // broad complete session. Ranking on specificity alone picked the narrow one and then refused
+    // the whole response, with a usable credential sitting in it.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/",
+                    Map.of(
+                        "s3.access-key-id", "session-access",
+                        "s3.secret-access-key", "session-secret",
+                        "s3.session-token", "session-token",
+                        "s3.session-token-expires-at-ms", "4102444800000")),
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "static-access",
+                        "s3.secret-access-key", "static-secret"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    var vended = client().vendStorageCredentials(name).orElseThrow();
+
+    assertEquals("session-access", vended.properties().get("s3.access-key-id"));
+    assertEquals("s3://warehouse/", vended.scopePrefix());
+  }
+
+  @Test
+  void aBareKeyPairIsRefusedRatherThanVendedAsALongLivedCredential() {
+    // The shape that made validation and the vend disagree. A bare pair reads storage perfectly
+    // well, so every validation check passed -- including the storage-access probe -- and then the
+    // first capture or query of every table an overlay had materialized failed terminally. Refusing
+    // it here means both paths reach the same answer, because both come through this method.
+    //
+    // There is no scoping-down step that could rescue it: floecat does not mint a narrower
+    // credential with STS, so a pair that arrives is a pair that would travel to a reader.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "static-access",
+                        "s3.secret-access-key", "static-secret"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> client().vendStorageCredentials(name));
+
+    assertEquals(CatalogAccessException.Code.INVALID_CONFIGURATION, error.code());
+    assertTrue(error.getMessage().contains("s3.session-token"));
+  }
+
+  @Test
+  void aSessionWithNoExpiryIsRefusedForTheSameReason() {
+    // Half the requirement is not the requirement: an expiry is what makes the session renewable,
+    // and without one the reconcile path embeds the credential statically and never re-vends.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/sales/orders/",
+                    Map.of(
+                        "s3.access-key-id", "session-access",
+                        "s3.secret-access-key", "session-secret",
+                        "s3.session-token", "session-token"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> client().vendStorageCredentials(name));
+
+    assertEquals(CatalogAccessException.Code.INVALID_CONFIGURATION, error.code());
+    assertTrue(error.getMessage().contains("s3.session-token-expires-at-ms"));
+  }
+
+  @Test
   void aNonPositiveExpiryIsAbsentRatherThanNineteenSeventy() {
     // Both bounds the connector-side parser applies, because a comment here claims parity with it
     // and nothing else pins the two together. Non-positive would otherwise hand back an instant
     // every consumer reads as already expired; out of range is a unit mismatch -- microseconds in
     // a field documented as milliseconds lands in year 62178 -- from the same field of the same
     // response.
-    for (String raw : new String[] {"0", "-1", "1900000000000000", "253402300800000"}) {
+    //
+    // Observed through the refusal rather than through an empty expiry: a value that does not parse
+    // leaves the credential with no renewal point, which is one of the two things this provider now
+    // declines to vend. The parse is still what is being pinned -- a value inside the bounds would
+    // not reach this branch.
+    // "1790000000" is the case that matters most: a plausible expiry reported in seconds, which
+    // as milliseconds lands in January 1970. Positive and inside the ceiling, so only the floor
+    // catches it -- and uncaught it is deterministically stale, which the refresh path re-vends on
+    // every resolveCredentials instead of failing once with the field named.
+    for (String raw :
+        new String[] {
+          "0", "-1", "1790000000", "946684799999", "1900000000000000", "253402300800000"
+        }) {
       CatalogObjectName name =
           new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
       TableIdentifier identifier =
@@ -231,10 +646,105 @@ class IcebergRestCatalogClientTest {
                           "s3.session-token-expires-at-ms", raw))));
       when(catalog.loadTable(identifier)).thenReturn(table);
 
-      var vended = client().vendStorageCredentials(name).orElseThrow();
+      CatalogAccessException error =
+          assertThrows(
+              CatalogAccessException.class, () -> client().vendStorageCredentials(name), raw);
 
-      assertTrue(vended.expiresAt().isEmpty(), raw + " -> " + vended.expiresAt());
+      assertEquals(CatalogAccessException.Code.INVALID_CONFIGURATION, error.code(), raw);
+      assertTrue(error.getMessage().contains("s3.session-token-expires-at-ms"), raw);
     }
+  }
+
+  @Test
+  void anOutOfScopeCredentialIsReportedAsScopeInvalidEvenBesideStrayKeyMaterial() {
+    // The two classifications are not interchangeable: scope-invalid is a fall-back the caller
+    // handles, while an incomplete tuple is terminal. A half tuple offered for some unrelated
+    // prefix must not decide the answer for this table, or a response the code deliberately falls
+    // back on would permanently fail the job.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                // A complete pair, but for another bucket.
+                StorageCredential.create(
+                    "s3://other-bucket/",
+                    Map.of(
+                        "s3.access-key-id", "vended-access",
+                        "s3.secret-access-key", "vended-secret")),
+                // Stray half tuple, also for another bucket.
+                StorageCredential.create(
+                    "s3://third-bucket/", Map.of("s3.access-key-id", "half"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+    var client = new IcebergRestCatalogClient(catalog, namespaces, views, () -> {}, Map.of());
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> client.vendStorageCredentials(name));
+
+    assertEquals(CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID, error.code());
+  }
+
+  @Test
+  void anUnscopedPartialCredentialIsAFaultToo() {
+    // A catalog that vends one credential with no prefix at all and half a tuple in it. An absent
+    // prefix covers every location by contract, so this is the clearest case of the fault the
+    // partial check names -- and the case a null-prefix guard on that filter silently dropped back
+    // onto the missing-authority path.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    StorageCredential unscoped = mock(StorageCredential.class);
+    when(unscoped.prefix()).thenReturn(null);
+    when(unscoped.config()).thenReturn(Map.of("s3.access-key-id", "vended-access"));
+    when(((SupportsStorageCredentials) io).credentials()).thenReturn(List.of(unscoped));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+    var client = new IcebergRestCatalogClient(catalog, namespaces, views, () -> {}, Map.of());
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> client.vendStorageCredentials(name));
+
+    assertEquals(CatalogAccessException.Code.INVALID_CONFIGURATION, error.code());
+  }
+
+  @Test
+  void aPartialVendedCredentialIsAFaultRatherThanNoDelegation() {
+    // Half a tuple is not "this catalog does not vend for this table". Returning empty would hand
+    // the caller its no-delegation path, and since an integration has no storage-authority
+    // fall-back to opt into, that surfaces as a missing-authority error -- which reads as a
+    // configuration gap and hides the real cause. A retry cannot change it either, so it is
+    // reported as an invalid configuration.
+    CatalogObjectName name =
+        new CatalogObjectName(NamespacePath.of("production", "sales"), "orders");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("production", "sales"), "orders");
+    Table table = mock(Table.class);
+    FileIO io =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsStorageCredentials.class));
+    when(table.io()).thenReturn(io);
+    when(table.location()).thenReturn("s3://warehouse/sales/orders/data");
+    when(((SupportsStorageCredentials) io).credentials())
+        .thenReturn(
+            List.of(
+                StorageCredential.create(
+                    "s3://warehouse/", Map.of("s3.access-key-id", "vended-access"))));
+    when(catalog.loadTable(identifier)).thenReturn(table);
+    var client = new IcebergRestCatalogClient(catalog, namespaces, views, () -> {}, Map.of());
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> client.vendStorageCredentials(name));
+
+    assertEquals(CatalogAccessException.Code.INVALID_CONFIGURATION, error.code());
+    assertTrue(error.getMessage().contains("incomplete"), error.getMessage());
   }
 
   @Test
@@ -254,7 +764,9 @@ class IcebergRestCatalogClientTest {
                     "s3://warehouse/",
                     Map.of(
                         "s3.access-key-id", "vended-access",
-                        "s3.secret-access-key", "vended-secret"))));
+                        "s3.secret-access-key", "vended-secret",
+                        "s3.session-token", "vended-token",
+                        "s3.session-token-expires-at-ms", "4102444800000"))));
     when(catalog.loadTable(identifier)).thenReturn(table);
     var client =
         new IcebergRestCatalogClient(
@@ -292,7 +804,9 @@ class IcebergRestCatalogClientTest {
                     "s3://warehouse/",
                     Map.of(
                         "s3.access-key-id", "usable-access",
-                        "s3.secret-access-key", "usable-secret")),
+                        "s3.secret-access-key", "usable-secret",
+                        "s3.session-token", "usable-token",
+                        "s3.session-token-expires-at-ms", "4102444800000")),
                 StorageCredential.create(
                     "s3://warehouse/sales/orders/", Map.of("s3.region", "us-west-2"))));
     when(catalog.loadTable(identifier)).thenReturn(table);
@@ -320,7 +834,9 @@ class IcebergRestCatalogClientTest {
                     "s3://warehouse/sales/orders/",
                     Map.of(
                         "s3.access-key-id", "vended-access",
-                        "s3.secret-access-key", "vended-secret"))));
+                        "s3.secret-access-key", "vended-secret",
+                        "s3.session-token", "vended-token",
+                        "s3.session-token-expires-at-ms", "4102444800000"))));
     when(catalog.loadTable(identifier)).thenReturn(table);
 
     var vended = client().vendStorageCredentials(name).orElseThrow();

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogAccessException.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogAccessException.java
@@ -19,6 +19,14 @@ public final class CatalogAccessException extends RuntimeException {
     UNAVAILABLE,
     TIMEOUT,
     CREDENTIAL_EXPIRED,
+    /**
+     * The credentials this catalog needs are configured but not resolvable right now -- typically
+     * the window while a stored secret generation is superseded. Distinct from {@link
+     * #INVALID_CONFIGURATION}, which says the configuration itself is wrong and will stay wrong:
+     * this one clears on its own, so a caller that retries recovers where a caller that gives up
+     * permanently fails work that would have succeeded.
+     */
+    CREDENTIAL_UNAVAILABLE,
     CREDENTIAL_SCOPE_INVALID,
     UNSUPPORTED,
     INTERNAL

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogClient.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/CatalogClient.java
@@ -39,6 +39,15 @@ public interface CatalogClient extends AutoCloseable {
    * Re-loads the table through the upstream protocol and returns only credentials from its
    * dedicated vending channel. Call again when credentials expire; an absent expiry must not be
    * treated as non-expiring.
+   *
+   * <p>An implementation must return credentials whose {@link VendedStorageCredentials#scopePrefix}
+   * covers the table's own storage location, or raise {@link
+   * CatalogAccessException.Code#CREDENTIAL_SCOPE_INVALID}. It must never widen the scope it reports
+   * to make a credential look usable, and nothing downstream will catch it if it does: a caller
+   * takes the reported scope as the narrowest bound it knows, stamps the location it was authorized
+   * for, and hands the credentials on. An over-stated scope is therefore not refused anywhere -- it
+   * surfaces as a 403 from the object store partway through a read, far from the provider that
+   * mis-reported it.
    */
   Optional<VendedStorageCredentials> vendStorageCredentials(CatalogObjectName table);
 

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/StorageLocations.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/StorageLocations.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+/**
+ * Prefix comparison for object-store locations.
+ *
+ * <p>One implementation, shared by the providers that pick a vended credential by scope and by the
+ * callers that check a vended scope against the location they are about to read. A second copy is
+ * how the two ends come to disagree about what a credential covers, and that disagreement only
+ * shows up as a 403 partway through a scan.
+ *
+ * <p>Deliberately <em>not</em> the same rule as {@code
+ * StorageAuthorityResolver.matchesLocationPrefix}, which looks like it answers the same question
+ * and does not. That one decides what floecat authorizes or advertises, so it demands a path
+ * boundary: {@code s3://w/orders} must not reach {@code s3://w/orders-archive}. This one decides
+ * whether a credential the upstream catalog already minted applies to a location, and there the
+ * catalog's own consumer sets the contract -- Iceberg's {@code S3FileIO.clientForStoragePath}
+ * selects the longest {@code storagePath.startsWith(storagePrefix)}, with no boundary at all.
+ *
+ * <p>The rule that keeps the two apart is directional: <b>never be stricter than the component that
+ * will actually use the credential.</b> Being stricter throws away a credential that would have
+ * read, and on the vend path there is nothing to fall back to -- it is reached only once no storage
+ * authority matched -- so a refusal here is a guaranteed failure where the catalog's own client
+ * would have tried and either succeeded or been told no by S3, which enforces the real grant
+ * whatever we believed. Being <em>more</em> permissive costs nothing for the same reason, which is
+ * why the normalizations below are safe and a boundary check is not.
+ */
+public final class StorageLocations {
+  private StorageLocations() {}
+
+  /**
+   * Whether {@code prefix} covers {@code location}.
+   *
+   * <p>Coverage is textual, as the upstream contract defines it: {@code s3://warehouse/orders}
+   * covers {@code s3://warehouse/orders/data/p0}, the prefix itself, and also the sibling {@code
+   * s3://warehouse/orders-archive/p0}. That last one is not an oversight -- Iceberg would select
+   * this credential for that path, and if the credential does not actually reach it, S3 says so.
+   * Refusing here instead would only turn a read that might have worked into one that cannot.
+   *
+   * <p>Two deviations, both deliberately more permissive than a literal comparison, because a
+   * catalog's spelling of its own scope varies and a spelling mismatch costs a whole read: leading
+   * and trailing whitespace is ignored, and a scope written with a trailing slash still names its
+   * own root, so {@code s3://b/tbl/} covers {@code s3://b/tbl}. Neither widens the scope onto a
+   * sibling: {@code s3://b/tbl/} still does not cover {@code s3://b/tblX}.
+   *
+   * <p>An absent or blank prefix covers every location, an absent one included: that is what a
+   * catalog means by vending a credential with no scope, and there is no narrower answer to give.
+   * Under any other prefix an absent location is covered by nothing, since there is nothing to
+   * compare.
+   */
+  public static boolean covers(String prefix, String location) {
+    if (prefix == null) {
+      return true;
+    }
+    String normalizedPrefix = normalizeScheme(prefix.trim());
+    if (normalizedPrefix.isEmpty()) {
+      return true;
+    }
+    if (location == null) {
+      return false;
+    }
+    String normalizedLocation = normalizeScheme(location.trim());
+    // The upstream rule, verbatim.
+    if (normalizedLocation.startsWith(normalizedPrefix)) {
+      return true;
+    }
+    // Plus the one case a literal comparison gets wrong for our purposes: a catalog that scopes to
+    // "s3://b/tbl/" means the table, and the table's own location is spelled without the slash.
+    // Compared by equality rather than by stripping the slash and matching a prefix, which would
+    // reach "s3://b/tblX" as well.
+    return normalizedLocation.equals(stripTrailingSlash(normalizedPrefix));
+  }
+
+  /**
+   * Rewrites s3a:// and s3n:// to s3://.
+   *
+   * <p>They address the same object store, so a credential scoped with one scheme covers a location
+   * written with another. Any other scheme is returned untouched, and {@code null} in gives {@code
+   * null} out -- callers hand this raw provider values, and the sibling {@link #covers} accepts a
+   * null on either side.
+   */
+  public static String normalizeScheme(String location) {
+    if (location == null) {
+      return null;
+    }
+    int schemeEnd = location.indexOf("://");
+    if (schemeEnd < 0) {
+      return location;
+    }
+    String scheme = location.substring(0, schemeEnd);
+    if ("s3".equalsIgnoreCase(scheme)
+        || "s3a".equalsIgnoreCase(scheme)
+        || "s3n".equalsIgnoreCase(scheme)) {
+      return "s3" + location.substring(schemeEnd);
+    }
+    return location;
+  }
+
+  /**
+   * The value without trailing slashes.
+   *
+   * <p>A catalog that scopes a credential to {@code s3://bucket/db/tbl/} and one that scopes it to
+   * {@code s3://bucket/db/tbl} mean the same thing, and both spellings occur -- so a comparison
+   * that keeps the slash silently covers nothing at all.
+   */
+  public static String stripTrailingSlash(String value) {
+    if (value == null || value.isEmpty()) {
+      return "";
+    }
+    int end = value.length();
+    while (end > 0 && value.charAt(end - 1) == '/') {
+      end--;
+    }
+    return value.substring(0, end);
+  }
+}

--- a/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/VendedStorageCredentials.java
+++ b/core/catalog-access-spi/src/main/java/ai/floedb/floecat/catalog/access/VendedStorageCredentials.java
@@ -37,6 +37,23 @@ public record VendedStorageCredentials(
   }
 
   /**
+   * Whether these credentials reach {@code location}.
+   *
+   * <p>The scope is what the catalog authorized, and it is not necessarily the location a caller
+   * wants to read: a table can hold data outside its own table prefix.
+   *
+   * <p>Not a guard every caller applies. The one that hands these credentials on for a specific
+   * location deliberately does not: it stamps the location the caller was authorized for and logs a
+   * disjoint scope rather than refusing, because that vend is reached only once no storage
+   * authority covers the read, so refusing guarantees failure while proceeding lets the object
+   * store -- which enforces the real grant -- decide. Its only use today is a provider checking its
+   * own answer before a validation read.
+   */
+  public boolean covers(String location) {
+    return StorageLocations.covers(scopePrefix, location);
+  }
+
+  /**
    * Key names only. The properties carry live storage credentials and the generated form prints
    * them.
    *

--- a/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/StorageLocationsTest.java
+++ b/core/catalog-access-spi/src/test/java/ai/floedb/floecat/catalog/access/StorageLocationsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.catalog.access;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class StorageLocationsTest {
+  @Test
+  void aPrefixCoversLocationsBeneathIt() {
+    assertTrue(StorageLocations.covers("s3://warehouse/orders", "s3://warehouse/orders/data/p0"));
+    assertTrue(StorageLocations.covers("s3://warehouse/orders", "s3://warehouse/orders"));
+    assertFalse(StorageLocations.covers("s3://warehouse/orders", "s3://warehouse/returns/p0"));
+    assertFalse(StorageLocations.covers("s3://warehouse/orders", "s3://other/orders/p0"));
+  }
+
+  @Test
+  void coverageIsTextualLikeTheUpstreamContract() {
+    // Not a path-boundary rule, on purpose. Iceberg's S3FileIO.clientForStoragePath selects the
+    // longest storagePath.startsWith(storagePrefix), so it would use this credential for these
+    // paths -- and a credential that does not really reach them gets a 403 from S3, which knows the
+    // real grant. Refusing here would instead guarantee failure: the vend path is reached only once
+    // no storage authority matched, so there is nothing left to fall back to.
+    //
+    // The path-boundary rule belongs to StorageAuthorityResolver.matchesLocationPrefix, which
+    // decides what floecat authorizes rather than what an upstream credential applies to.
+    assertTrue(
+        StorageLocations.covers("s3://warehouse/orders", "s3://warehouse/orders-archive/2025/p0"));
+    assertTrue(StorageLocations.covers("s3://warehouse/tpch", "s3://warehouse/tpch_10/customer"));
+    assertTrue(StorageLocations.covers("s3://bucket/db/tbl", "s3://bucket/db/tblX"));
+  }
+
+  @Test
+  void aTrailingSlashOnTheScopeStillNamesItsOwnRoot() {
+    // S3 Tables and Unity routinely vend the slashed form, and the table's own location is spelled
+    // without it, so a literal comparison would make the scope cover nothing at all.
+    assertTrue(StorageLocations.covers("s3://bucket/db/tbl/", "s3://bucket/db/tbl"));
+    assertTrue(StorageLocations.covers("s3://bucket/db/tbl/", "s3://bucket/db/tbl/data/p0"));
+    // Handled by equality rather than by stripping the slash and matching a prefix: stripping would
+    // reach the sibling, which the slashed spelling plainly does not name.
+    assertFalse(StorageLocations.covers("s3://bucket/db/tbl/", "s3://bucket/db/tblX"));
+  }
+
+  @Test
+  void surroundingWhitespaceDoesNotChangeWhatIsCovered() {
+    assertTrue(StorageLocations.covers("  s3://bucket/db/tbl  ", "s3://bucket/db/tbl/p0"));
+    assertTrue(StorageLocations.covers("s3://bucket/db/tbl", " s3://bucket/db/tbl/p0 "));
+    assertFalse(StorageLocations.covers(" s3://bucket/db/tbl ", "s3://other/db/tbl/p0"));
+  }
+
+  @Test
+  void s3SchemeAliasesAddressTheSameStore() {
+    assertTrue(StorageLocations.covers("s3a://warehouse/orders", "s3://warehouse/orders/p0"));
+    assertTrue(StorageLocations.covers("s3://warehouse/orders", "s3n://warehouse/orders/p0"));
+    // A different store is a different store, however similar the path looks.
+    assertFalse(StorageLocations.covers("gs://warehouse/orders", "s3://warehouse/orders/p0"));
+  }
+
+  @Test
+  void anEmptyPrefixCoversEverythingAndAnAbsentLocationIsCoveredByNothing() {
+    assertTrue(StorageLocations.covers("", "s3://warehouse/orders/p0"));
+    assertTrue(StorageLocations.covers("   ", "s3://warehouse/orders/p0"));
+    assertTrue(StorageLocations.covers(null, "s3://warehouse/orders/p0"));
+    // "no scope" means blank, not a bare slash: Iceberg keeps only prefixes starting with "s3", so
+    // a "/" scope is not a scope any credential arrives with, and reading it as "everything" would
+    // be inventing a meaning for a malformed value.
+    assertFalse(StorageLocations.covers("/", "s3://warehouse/orders/p0"));
+    // A blank prefix covers an absent location too: there is no narrower answer available.
+    assertTrue(StorageLocations.covers("", null));
+    assertTrue(StorageLocations.covers(null, null));
+    assertFalse(StorageLocations.covers("s3://warehouse/orders", null));
+  }
+
+  @Test
+  void normalizeSchemeToleratesAnAbsentValueLikeItsSibling() {
+    assertNull(StorageLocations.normalizeScheme(null));
+    assertEquals("s3://bucket/k", StorageLocations.normalizeScheme("s3a://bucket/k"));
+    assertEquals("gs://bucket/k", StorageLocations.normalizeScheme("gs://bucket/k"));
+    assertEquals("no-scheme", StorageLocations.normalizeScheme("no-scheme"));
+  }
+
+  @Test
+  void stripTrailingSlashIsTotal() {
+    assertEquals("s3://b/k", StorageLocations.stripTrailingSlash("s3://b/k//"));
+    assertEquals("", StorageLocations.stripTrailingSlash("///"));
+    assertEquals("", StorageLocations.stripTrailingSlash(null));
+  }
+
+  @Test
+  void vendedCredentialsAnswerForTheirOwnScope() {
+    var credentials =
+        new VendedStorageCredentials(
+            Map.of("s3.access-key-id", "ASIA", "s3.secret-access-key", "secret"),
+            "s3://warehouse/orders",
+            Optional.of(Instant.parse("2026-09-01T15:00:00Z")));
+
+    assertTrue(credentials.covers("s3://warehouse/orders/metadata/v1.metadata.json"));
+    assertFalse(credentials.covers("s3://external-data/orders/p0"));
+  }
+}

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
@@ -1289,6 +1289,15 @@ public interface FloecatConnector extends Closeable {
      * depends on the catalog-access SPI, not this one -- and repeats the rule rather than
      * diverging.
      *
+     * <p>Deliberately does not reject a value in the wrong unit, unlike the Iceberg REST provider's
+     * copy of this rule. Seconds read as milliseconds land in 1970, and folding that to null would
+     * be the honest answer -- except that this record carries its expiry as a parsed field
+     * independent of the property map, so a rejected value is indistinguishable from an absent one
+     * by the time anything reads it, and {@code SourceCatalogCredentialVendor} reads an absent
+     * expiry on the connector path as "long-lived static key, no renewal needed". Rejecting here
+     * would turn a loud refusal into a credential embedded statically and never renewed. The
+     * provider's copy can reject because nothing on that path infers permanence from absence.
+     *
      * <p>Null (absent, blank, out of range, or unparseable) is deliberately not "never expires":
      * callers that cache must treat it as "do not cache", and the reconcile path refuses a
      * credential with no expiry because it cannot schedule a renewal for one. A malformed value is

--- a/core/storage-spi/src/main/java/ai/floedb/floecat/storage/errors/SourceCatalogVendingGrpcStatus.java
+++ b/core/storage-spi/src/main/java/ai/floedb/floecat/storage/errors/SourceCatalogVendingGrpcStatus.java
@@ -24,13 +24,14 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import java.util.HashSet;
+import java.util.Map;
 
 /**
  * Structured discriminators for the source-catalog vending path, so callers can act on a specific
  * condition instead of a status code.
  *
- * <p>Both conditions here previously travelled as bare status codes, and both were ambiguous.
- * {@code INVALID_ARGUMENT} is also what {@code vendStorageCredentials} returns for account_id,
+ * <p>These conditions otherwise travel as bare status codes, which are ambiguous. {@code
+ * INVALID_ARGUMENT} is also what {@code vendStorageCredentials} returns for account_id,
  * execution_binding and location_prefix validation failures, so a delegating connector matching on
  * the code alone turned real configuration errors into a silent fallback. {@code
  * FAILED_PRECONDITION} is shared with lease-precondition failures, which have their own retry
@@ -55,13 +56,72 @@ public final class SourceCatalogVendingGrpcStatus {
       "VENDED_CREDENTIALS_NOT_REFRESHABLE";
 
   /**
-   * The source catalog permanently refused to vend for this table for a reason that is neither
-   * authentication nor authorization -- Databricks' HTTP 400 for a table without external access,
-   * or a 404 for a table id it no longer knows. Terminal: the answer will not change on retry.
+   * The source catalog will not vend, for a reason a retry cannot change: it rejected floecat's
+   * credentials, the upstream table is gone, it vended credentials that do not cover the table, or
+   * -- on the Catalog Integration path -- it cannot vend at all. Terminal.
+   *
+   * <p>That last group is this reason only for an Integration, which has no storage authority to
+   * fall back to and refuses instead. The same condition on a legacy Connector is answered by
+   * returning no credentials, so the caller uses the authority configured for it and nothing is
+   * raised. A condition the next attempt could clear is not this reason either; those stay
+   * retryable.
+   *
+   * <p>Carried under whichever status code fits the refusal, so a consumer reads the reason to know
+   * it came from a source catalog and the code to know what kind of refusal it was.
    */
   public static final String SOURCE_CATALOG_VEND_REFUSED_REASON = "SOURCE_CATALOG_VEND_REFUSED";
 
+  /**
+   * The source catalog could not vend right now, and a later attempt could succeed: it vended a
+   * credential that had already expired, or its stored credentials were momentarily unresolvable.
+   * Retryable, and distinct from the storage service itself being unreachable, which is what a bare
+   * {@code UNAVAILABLE} would be indistinguishable from.
+   */
+  public static final String SOURCE_CATALOG_VEND_UNAVAILABLE_REASON =
+      "SOURCE_CATALOG_VEND_UNAVAILABLE";
+
   private static final String REASON_PARAM = "reason";
+
+  /**
+   * Names this class as the author of a reason on the floecat {@code Error} detail, which -- unlike
+   * {@code ErrorInfo} -- has no domain field of its own. Without it the reason string alone
+   * decides, and a {@code params["reason"]} written by any other subsystem would read as one of
+   * these conditions. That matters most for the refusal, which is classified terminal.
+   */
+  private static final String DOMAIN_PARAM = "domain";
+
+  /**
+   * Where the diagnostic travels, because {@code Status.message} does not survive the trip.
+   *
+   * <p>{@code LocalizeErrorsInterceptor} rewrites every outgoing status with {@code
+   * MessageCatalog.render(error)}, which builds the text from the error code and message key and
+   * never reads {@code Error.message}. Without a keyed template these conditions reached a caller
+   * as "Precondition failed." -- the reason param still classified them, but nothing named the
+   * cause, which is the whole point of refusing instead of relabelling. Each factory below names a
+   * template whose body is this parameter, so the rendered message is the diagnostic.
+   */
+  private static final String DETAIL_PARAM = "detail";
+
+  /**
+   * Message-key suffixes, one per code-and-reason pair.
+   *
+   * <p>Distinct even where the reason repeats: the generator normalizes a suffix into an enum
+   * constant and fails the build when two collide, so {@code SOURCE_CATALOG_VEND_REFUSED} cannot
+   * reuse one suffix across the three codes it is raised under.
+   */
+  private static final String NO_AUTHORITY_KEY = "source.catalog.no.matching.storage.authority";
+
+  private static final String NOT_REFRESHABLE_KEY =
+      "source.catalog.vended.credentials.not.refreshable";
+
+  private static final String VEND_REFUSED_KEY = "source.catalog.vend.refused";
+
+  private static final String VEND_REFUSED_UNAUTHENTICATED_KEY =
+      "source.catalog.vend.refused.unauthenticated";
+
+  private static final String VEND_REFUSED_FORBIDDEN_KEY = "source.catalog.vend.refused.forbidden";
+
+  private static final String VEND_UNAVAILABLE_KEY = "source.catalog.vend.unavailable";
 
   private SourceCatalogVendingGrpcStatus() {}
 
@@ -74,7 +134,7 @@ public final class SourceCatalogVendingGrpcStatus {
   }
 
   public static boolean isNoMatchingStorageAuthority(Throwable error) {
-    return hasReason(error, Status.Code.INVALID_ARGUMENT, NO_MATCHING_STORAGE_AUTHORITY_REASON);
+    return hasReason(error, NO_MATCHING_STORAGE_AUTHORITY_REASON, Status.Code.INVALID_ARGUMENT);
   }
 
   public static StatusRuntimeException vendedCredentialsNotRefreshable(String description) {
@@ -87,7 +147,7 @@ public final class SourceCatalogVendingGrpcStatus {
 
   public static boolean isVendedCredentialsNotRefreshable(Throwable error) {
     return hasReason(
-        error, Status.Code.FAILED_PRECONDITION, VENDED_CREDENTIALS_NOT_REFRESHABLE_REASON);
+        error, VENDED_CREDENTIALS_NOT_REFRESHABLE_REASON, Status.Code.FAILED_PRECONDITION);
   }
 
   public static StatusRuntimeException sourceCatalogVendRefused(String description) {
@@ -98,12 +158,90 @@ public final class SourceCatalogVendingGrpcStatus {
         description);
   }
 
+  /**
+   * The same refusal, carrying the status code the upstream catalog's answer deserves.
+   *
+   * <p>An authentication or authorization refusal from a source catalog is still a source-catalog
+   * vending refusal, and it has to say so: the alternative is a bare {@code UNAUTHENTICATED} that
+   * no consumer can tell apart from floecat's own service-level auth failing. The reason is what
+   * identifies the condition; the code only conveys what kind of failure it was.
+   */
+  public static StatusRuntimeException sourceCatalogVendRefused(
+      Status.Code code, ErrorCode errorCode, String description, Throwable cause) {
+    StatusRuntimeException refusal =
+        withReason(code, errorCode, SOURCE_CATALOG_VEND_REFUSED_REASON, description);
+    if (cause == null) {
+      return refusal;
+    }
+    // Keep the originating exception attached: the detail carries only a message safe to return to
+    // a caller, and server-side logs still need the stack that produced it.
+    return new StatusRuntimeException(refusal.getStatus().withCause(cause), refusal.getTrailers());
+  }
+
+  /**
+   * The retryable counterpart of {@link #sourceCatalogVendRefused(String)}.
+   *
+   * <p>{@code UNAVAILABLE} because the caller should come back, and structured because the code
+   * alone does not distinguish "the source catalog's vending is temporarily unusable" from
+   * "floecat's storage service is unreachable" -- and because {@code BaseServiceImpl.toStatus}
+   * passes a status through untouched only when it carries a floecat error detail, so a bare status
+   * is rebuilt with a synthesized message and loses this description.
+   */
+  public static StatusRuntimeException sourceCatalogVendUnavailable(
+      String description, Throwable cause) {
+    StatusRuntimeException unavailable =
+        withReason(
+            Status.Code.UNAVAILABLE,
+            ErrorCode.MC_UNAVAILABLE,
+            SOURCE_CATALOG_VEND_UNAVAILABLE_REASON,
+            description);
+    if (cause == null) {
+      return unavailable;
+    }
+    return new StatusRuntimeException(
+        unavailable.getStatus().withCause(cause), unavailable.getTrailers());
+  }
+
+  public static boolean isSourceCatalogVendUnavailable(Throwable error) {
+    return hasReason(error, SOURCE_CATALOG_VEND_UNAVAILABLE_REASON, Status.Code.UNAVAILABLE);
+  }
+
+  /**
+   * Whether {@code error} is a source-catalog vending refusal.
+   *
+   * <p>Matched on the domain-scoped reason alone, across every status code a refusal can carry. The
+   * reason is unambiguous on its own -- it names this domain and this condition -- whereas the code
+   * is not, which is the whole point of raising a reason rather than a bare status.
+   */
   public static boolean isSourceCatalogVendRefused(Throwable error) {
-    return hasReason(error, Status.Code.FAILED_PRECONDITION, SOURCE_CATALOG_VEND_REFUSED_REASON);
+    return hasReason(error, SOURCE_CATALOG_VEND_REFUSED_REASON, null);
   }
 
   private static StatusRuntimeException withReason(
       Status.Code code, ErrorCode errorCode, String reason, String description) {
+    return withReason(code, errorCode, messageKey(errorCode, reason), reason, description);
+  }
+
+  /** The suffix for a code-and-reason pair; see the key constants for why it is not just reason. */
+  private static String messageKey(ErrorCode errorCode, String reason) {
+    if (NO_MATCHING_STORAGE_AUTHORITY_REASON.equals(reason)) {
+      return NO_AUTHORITY_KEY;
+    }
+    if (VENDED_CREDENTIALS_NOT_REFRESHABLE_REASON.equals(reason)) {
+      return NOT_REFRESHABLE_KEY;
+    }
+    if (SOURCE_CATALOG_VEND_UNAVAILABLE_REASON.equals(reason)) {
+      return VEND_UNAVAILABLE_KEY;
+    }
+    return switch (errorCode) {
+      case MC_UNAUTHENTICATED -> VEND_REFUSED_UNAUTHENTICATED_KEY;
+      case MC_PERMISSION_DENIED -> VEND_REFUSED_FORBIDDEN_KEY;
+      default -> VEND_REFUSED_KEY;
+    };
+  }
+
+  private static StatusRuntimeException withReason(
+      Status.Code code, ErrorCode errorCode, String messageKey, String reason, String description) {
     String message = description == null ? "" : description;
     com.google.rpc.Status status =
         com.google.rpc.Status.newBuilder()
@@ -114,7 +252,10 @@ public final class SourceCatalogVendingGrpcStatus {
                     Error.newBuilder()
                         .setCode(errorCode)
                         .setMessage(message)
+                        .setMessageKey(messageKey)
                         .putParams(REASON_PARAM, reason)
+                        .putParams(DOMAIN_PARAM, ERROR_DOMAIN)
+                        .putParams(DETAIL_PARAM, message)
                         .build()))
             .addDetails(
                 Any.pack(ErrorInfo.newBuilder().setDomain(ERROR_DOMAIN).setReason(reason).build()))
@@ -122,18 +263,46 @@ public final class SourceCatalogVendingGrpcStatus {
     return StatusProto.toStatusRuntimeException(status);
   }
 
-  private static boolean hasReason(Throwable error, Status.Code expectedCode, String reason) {
+  /** {@code expectedCode} narrows the match; {@code null} accepts the reason under any code. */
+  private static boolean hasReason(Throwable error, String reason, Status.Code expectedCode) {
     Throwable current = error;
     var seen = new HashSet<Throwable>();
     while (current != null && seen.add(current)) {
       if (current instanceof StatusRuntimeException statusError
-          && statusError.getStatus().getCode() == expectedCode
+          && (expectedCode == null || statusError.getStatus().getCode() == expectedCode)
           && hasReasonDetail(statusError, reason)) {
         return true;
       }
       current = current.getCause();
     }
     return false;
+  }
+
+  /**
+   * The ErrorCode a reason was raised with before the domain param existed, or empty when no node
+   * could have emitted it that way.
+   *
+   * <p>Three can arrive domain-less, and which three is a function of the stack's merge order
+   * rather than of {@code main} alone: {@code NO_MATCHING_STORAGE_AUTHORITY} and {@code
+   * VENDED_CREDENTIALS_NOT_REFRESHABLE} are in {@code main}, and {@code
+   * SOURCE_CATALOG_VEND_REFUSED} is in the branch this one is stacked on, which ships first. {@code
+   * SOURCE_CATALOG_VEND_UNAVAILABLE} arrives with this change, so a domain-less detail claiming it
+   * is not an older node -- it is something else, and matching it would reopen exactly the gap the
+   * domain param closes.
+   */
+  private static java.util.Optional<ErrorCode> legacyErrorCode(String reason) {
+    if (NO_MATCHING_STORAGE_AUTHORITY_REASON.equals(reason)) {
+      return java.util.Optional.of(ErrorCode.MC_INVALID_ARGUMENT);
+    }
+    if (VENDED_CREDENTIALS_NOT_REFRESHABLE_REASON.equals(reason)
+        || SOURCE_CATALOG_VEND_REFUSED_REASON.equals(reason)) {
+      return java.util.Optional.of(ErrorCode.MC_PRECONDITION_FAILED);
+    }
+    // Everything else is newer than the domain param, so no node can have emitted it without one
+    // and there is no legacy shape to accept. Empty rather than a default: a reason added later --
+    // under MC_NOT_FOUND, say -- would otherwise be told its historical code was
+    // MC_PRECONDITION_FAILED and quietly match the wrong details, or fail to match its own.
+    return java.util.Optional.empty();
   }
 
   private static boolean hasReasonDetail(StatusRuntimeException error, String reason) {
@@ -149,8 +318,29 @@ public final class SourceCatalogVendingGrpcStatus {
             return true;
           }
         } else if (detail.is(Error.class)) {
+          // Not a backstop, whatever it looks like. LocalizeErrorsInterceptor is a
+          // @GlobalInterceptor
+          // that rebuilds every outgoing status with clearDetails().addDetails(the localized
+          // Error),
+          // so the ErrorInfo above never survives an RPC -- this branch is the only one a remote
+          // consumer, the reconciler included, ever matches on.
           Error floecatError = detail.unpack(Error.class);
-          if (reason.equals(floecatError.getParamsMap().get(REASON_PARAM))) {
+          Map<String, String> params = floecatError.getParamsMap();
+          if (!reason.equals(params.get(REASON_PARAM))) {
+            continue;
+          }
+          if (ERROR_DOMAIN.equals(params.get(DOMAIN_PARAM))) {
+            return true;
+          }
+          // Emitted before the domain param existed. A node still running the older build sends the
+          // reason with no domain, and refusing it here would make a new reconciler read an old
+          // service's answers as "not this condition" for the length of a rolling deploy: the
+          // delegation fall-back would stop being absorbed for existing connectors, and terminal
+          // vending failures would retry until the attempt budget was spent. Narrowed to the
+          // ErrorCode that reason was historically raised with, which is as much as a legacy detail
+          // carries. Removable once no node emits the older shape.
+          if (!params.containsKey(DOMAIN_PARAM)
+              && legacyErrorCode(reason).filter(floecatError.getCode()::equals).isPresent()) {
             return true;
           }
         }

--- a/core/storage-spi/src/test/java/ai/floedb/floecat/storage/errors/SourceCatalogVendingGrpcStatusTest.java
+++ b/core/storage-spi/src/test/java/ai/floedb/floecat/storage/errors/SourceCatalogVendingGrpcStatusTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.storage.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.floedb.floecat.common.rpc.ErrorCode;
+import io.grpc.Status;
+import io.grpc.protobuf.StatusProto;
+import org.junit.jupiter.api.Test;
+
+class SourceCatalogVendingGrpcStatusTest {
+  @Test
+  void aRefusalIsRecognizedUnderEveryStatusCodeItCanCarry() {
+    var precondition = SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused("upstream gone");
+    var unauthenticated =
+        SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+            Status.Code.UNAUTHENTICATED, ErrorCode.MC_UNAUTHENTICATED, "catalog rejected us", null);
+    var forbidden =
+        SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+            Status.Code.PERMISSION_DENIED, ErrorCode.MC_PERMISSION_DENIED, "no grant", null);
+
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(precondition));
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(unauthenticated));
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(forbidden));
+
+    // The code still says what kind of refusal it was; only the reason says where it came from.
+    assertEquals(Status.Code.UNAUTHENTICATED, unauthenticated.getStatus().getCode());
+    assertEquals(Status.Code.PERMISSION_DENIED, forbidden.getStatus().getCode());
+  }
+
+  @Test
+  void aServiceLevelAuthFailureIsNotAVendingRefusal() {
+    var serviceAuthFailure =
+        Status.UNAUTHENTICATED.withDescription("caller token expired").asRuntimeException();
+
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(serviceAuthFailure));
+  }
+
+  @Test
+  void theOriginatingFailureStaysAttachedForServerSideLogs() {
+    var upstream = new IllegalStateException("401 from https://catalog.example/v1/oauth/tokens");
+
+    var refusal =
+        SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+            Status.Code.UNAUTHENTICATED,
+            ErrorCode.MC_UNAUTHENTICATED,
+            "catalog rejected us",
+            upstream);
+
+    assertSame(upstream, refusal.getStatus().getCause());
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(refusal));
+    // The wire-visible description carries only the safe detail, never the upstream's own text.
+    assertEquals("catalog rejected us", refusal.getStatus().getDescription());
+  }
+
+  @Test
+  void theRetryableConditionIsIdentifiableAndNotARefusal() {
+    var unavailable =
+        SourceCatalogVendingGrpcStatus.sourceCatalogVendUnavailable("credential expired", null);
+
+    assertEquals(Status.Code.UNAVAILABLE, unavailable.getStatus().getCode());
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendUnavailable(unavailable));
+    // Retryable: the reconciler classifies only the refusal reasons terminally.
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(unavailable));
+    // Carries a floecat error detail, so BaseServiceImpl.toStatus passes it through untouched
+    // instead of rebuilding it with a synthesized message.
+    assertTrue(StatusProto.fromThrowable(unavailable).getDetailsCount() > 0);
+  }
+
+  @Test
+  void aReasonFromANodeThatPredatesTheDomainParamStillMatches() {
+    // What an older service node puts on the wire. LocalizeErrorsInterceptor rebuilds every status
+    // with clearDetails().addDetails(the localized Error), so the ErrorInfo never survives the RPC
+    // and this shape is all a reconciler sees. Refusing it would, for the length of a rolling
+    // deploy, stop the delegation fall-back being absorbed for existing connectors and turn
+    // terminal vending failures into retries until the attempt budget was spent.
+    for (String reason :
+        new String[] {
+          SourceCatalogVendingGrpcStatus.SOURCE_CATALOG_VEND_REFUSED_REASON,
+          SourceCatalogVendingGrpcStatus.VENDED_CREDENTIALS_NOT_REFRESHABLE_REASON
+        }) {
+      var legacy =
+          legacyStatus(Status.Code.FAILED_PRECONDITION, ErrorCode.MC_PRECONDITION_FAILED, reason);
+
+      assertTrue(
+          SourceCatalogVendingGrpcStatus.SOURCE_CATALOG_VEND_REFUSED_REASON.equals(reason)
+              ? SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(legacy)
+              : SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(legacy),
+          reason);
+    }
+
+    var legacyNoAuthority =
+        legacyStatus(
+            Status.Code.INVALID_ARGUMENT,
+            ErrorCode.MC_INVALID_ARGUMENT,
+            SourceCatalogVendingGrpcStatus.NO_MATCHING_STORAGE_AUTHORITY_REASON);
+
+    assertTrue(SourceCatalogVendingGrpcStatus.isNoMatchingStorageAuthority(legacyNoAuthority));
+  }
+
+  @Test
+  void aReasonNewerThanTheDomainParamHasNoLegacyShape() {
+    // SOURCE_CATALOG_VEND_UNAVAILABLE arrives with this change, so a domain-less detail claiming it
+    // is not an older node that predates the param -- there is no such node. Accepting it would
+    // reopen the gap the param closes, and it would tell a reason added later that its historical
+    // code was MC_PRECONDITION_FAILED whether or not it was ever raised under one.
+    var impostor =
+        legacyStatus(
+            Status.Code.UNAVAILABLE,
+            ErrorCode.MC_PRECONDITION_FAILED,
+            SourceCatalogVendingGrpcStatus.SOURCE_CATALOG_VEND_UNAVAILABLE_REASON);
+
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendUnavailable(impostor));
+
+    // The three that do predate it still match, so the rolling-deploy compatibility is intact.
+    assertTrue(
+        SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(
+            legacyStatus(
+                Status.Code.FAILED_PRECONDITION,
+                ErrorCode.MC_PRECONDITION_FAILED,
+                SourceCatalogVendingGrpcStatus.SOURCE_CATALOG_VEND_REFUSED_REASON)));
+  }
+
+  @Test
+  void aLegacyDetailUnderTheWrongErrorCodeIsNotAccepted() {
+    // The ErrorCode is all a domain-less detail carries to narrow with, so it has to carry weight.
+    var mismatched =
+        legacyStatus(
+            Status.Code.FAILED_PRECONDITION,
+            ErrorCode.MC_INTERNAL,
+            SourceCatalogVendingGrpcStatus.SOURCE_CATALOG_VEND_REFUSED_REASON);
+
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(mismatched));
+  }
+
+  /** A status shaped the way a node emitted it before the domain param existed. */
+  private static io.grpc.StatusRuntimeException legacyStatus(
+      Status.Code code, ErrorCode errorCode, String reason) {
+    return StatusProto.toStatusRuntimeException(
+        com.google.rpc.Status.newBuilder()
+            .setCode(code.value())
+            .setMessage("legacy")
+            .addDetails(
+                com.google.protobuf.Any.pack(
+                    ai.floedb.floecat.common.rpc.Error.newBuilder()
+                        .setCode(errorCode)
+                        .setMessage("legacy")
+                        .putParams("reason", reason)
+                        .build()))
+            .build());
+  }
+
+  @Test
+  void aDetailClaimingAnotherDomainCannotImpersonateAVendingReason() {
+    // What the domain param can and cannot do. It rejects a detail that names a different domain,
+    // which is the case it was added for. It cannot reject a detail that names no domain at all:
+    // that shape is byte-identical to what a node predating the param emits, and refusing it would
+    // break a rolling deploy -- see aReasonFromANodeThatPredatesTheDomainParamStillMatches. Those
+    // fall back to the historical ErrorCode, which is all such a detail carries.
+    var foreign =
+        com.google.rpc.Status.newBuilder()
+            .setCode(Status.Code.FAILED_PRECONDITION.value())
+            .setMessage("unrelated subsystem failure")
+            .addDetails(
+                com.google.protobuf.Any.pack(
+                    ai.floedb.floecat.common.rpc.Error.newBuilder()
+                        .setCode(ErrorCode.MC_PRECONDITION_FAILED)
+                        .setMessage("unrelated subsystem failure")
+                        .putParams(
+                            "reason",
+                            SourceCatalogVendingGrpcStatus.SOURCE_CATALOG_VEND_REFUSED_REASON)
+                        .putParams("domain", "ai.floedb.floecat.someone.else")
+                        .build()))
+            .build();
+
+    var impostor = StatusProto.toStatusRuntimeException(foreign);
+
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(impostor));
+  }
+
+  @Test
+  void otherVendingReasonsStayDistinct() {
+    var notRefreshable =
+        SourceCatalogVendingGrpcStatus.vendedCredentialsNotRefreshable("missing session token");
+    var noAuthority = SourceCatalogVendingGrpcStatus.noMatchingStorageAuthority("none matches");
+
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(notRefreshable));
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(noAuthority));
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendUnavailable(notRefreshable));
+    assertTrue(SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(notRefreshable));
+    assertTrue(SourceCatalogVendingGrpcStatus.isNoMatchingStorageAuthority(noAuthority));
+  }
+}

--- a/docs/catalog-access-spi.md
+++ b/docs/catalog-access-spi.md
@@ -56,12 +56,33 @@ The Iceberg REST provider currently supports:
   exact vended credentials returned to the caller, without ambient credential fallback; and
 - idempotent ownership of the underlying REST session.
 
-`vendStorageCredentials` performs a fresh `loadTable` request on every call, selects the
-longest-prefix credential matching the table location, and copies only the S3 storage credential
-allowlist. Callers reacquire credentials at the returned expiry. A missing or invalid expiry means
-the result must not be cached. Catalog tokens and ordinary FileIO properties are never treated as
-vended storage credentials, so a server that does not vend returns an empty result instead of
-falling back to catalog authentication, configured storage keys, or Connector behavior.
+`vendStorageCredentials` performs a fresh `loadTable` request on every call and copies only the S3
+storage credential allowlist. Among the credentials covering the table location it selects the
+longest prefix, but only complete renewable sessions are candidates: a longer-prefix credential
+missing a session token or a parseable expiry loses to a shorter complete one. A Catalog Integration
+vends only when what it holds is itself a temporary session, and Floecat does not narrow a
+credential with STS, so a bare key pair is refused rather than returned. Callers reacquire
+credentials at the returned expiry, which this provider always supplies; the SPI itself still
+permits an absent expiry and `CatalogClient.vendStorageCredentials` requires callers to handle one.
+
+A response the provider cannot use is reported rather than returned empty, because an Integration
+has no storage authority to fall back to. `INVALID_CONFIGURATION` covers an incomplete tuple, a
+covering credential that is not a renewable session, and an expiry that does not parse;
+`CREDENTIAL_SCOPE_INVALID` covers a response whose credentials cover no part of the table location.
+An empty result still means "this catalog does not vend", and catalog tokens and ordinary FileIO
+properties are never treated as vended storage credentials -- there is deliberately no fall-back to
+the table's FileIO properties, which cannot distinguish a credential vended for the table from one
+merged in from the client's own configuration.
+
+Two pieces of SPI surface support this. `StorageLocations` holds the one prefix-comparison rule
+shared by providers and callers; it is textual, matching Iceberg's own
+`S3FileIO.clientForStoragePath`, and deliberately differs from
+`StorageAuthorityResolver.matchesLocationPrefix`, which is path-boundary strict because it decides
+what Floecat authorizes rather than what an upstream credential applies to. Never be stricter than
+the component that will use the credential. `CatalogAccessException.Code.CREDENTIAL_UNAVAILABLE`
+separates "the credentials are configured but momentarily unresolvable" -- the window while a stored
+secret generation is superseded, which a retry clears -- from `INVALID_CONFIGURATION`, which will
+stay wrong until someone changes it.
 
 ### Renewable AWS credentials
 

--- a/docs/catalog-integrations.md
+++ b/docs/catalog-integrations.md
@@ -40,6 +40,29 @@ directly into an Overlay's `include_namespaces` or `exclude_namespaces` selectio
 These operations require `catalog-integration.read` and `catalog-integration.use`. They use the
 catalog-access SPI directly and never call or fall back to the legacy Connector path.
 
+Tables materialized by an Iceberg REST overlay retain their source Catalog Integration identity.
+When no storage authority covers a table read, Floecat reopens that Integration through the
+catalog-access SPI and asks the upstream catalog for table-scoped storage credentials. The query
+path therefore does not reconstruct or depend on a legacy Connector.
+
+A storage authority is not an alternative for an Integration-backed table, and Floecat does not fall
+back to one. Pairing an authority with an Integration is the split-brain this feature removes --
+authenticate to the catalog here, obtain storage credentials somewhere else -- and the Integration
+record has no way to express it: nothing on it names an authority, and `ValidateCatalogIntegration`
+reports an Integration whose provider cannot vend as invalid rather than as configured differently.
+Anything that means "this Integration cannot vend" therefore fails the read naming the cause: a
+provider that does not advertise storage-credential vending, an authentication mode the
+catalog-access SPI does not implement, a provider reporting that what it can vend does not cover the
+upstream table, or a catalog that returns no credentials for it.
+
+One case is not a refusal. When the catalog vends a scope that does not reach the location Floecat
+asked about, the credential is returned stamped with the location the caller was authorized for and
+the mismatch is logged, because the read may still succeed and the object store enforces the real
+grant either way. A scope merely narrower than the request is stamped as itself rather than widened.
+
+A legacy Connector still behaves as it did: it opts in to vending, so one that does not is left to
+the storage authority the operator configured for it.
+
 ## Shell workflow
 
 Create the integration record, then map its selected namespaces into an existing destination

--- a/docs/fixed-roles.md
+++ b/docs/fixed-roles.md
@@ -6,9 +6,16 @@ Source of truth: `service/src/main/java/ai/floedb/floecat/service/security/RoleP
 
 ## Role Matrix
 
+`catalog-integration.use` is granted to `default` because reading a table an overlay materialized
+from a Catalog Integration is what asks that Integration's catalog to vend storage credentials: no
+storage authority covers such a table, so withholding the permission would leave those tables
+readable only by `administrator`. It is wider than that vend alone --
+`ValidateCatalogIntegration`, `ListUpstreamNamespaces` and `ListUpstreamObjects` require it too --
+and is expected to split into a narrower vend permission later.
+
 | Role name | Purpose | Granted permissions |
 |-----------|---------|---------------------|
-| `default` | Baseline read-only tenant access. Used when no roles are provided in normal (`oidc`) mode. | `account.read`, `catalog.read`, `namespace.read`, `table.read`, `view.read`, `catalog-integration.read`, `catalog-overlay.read` |
+| `default` | Baseline read-only tenant access. Used when no roles are provided in normal (`oidc`) mode. | `account.read`, `catalog.read`, `namespace.read`, `table.read`, `view.read`, `catalog-integration.read`, `catalog-integration.use`, `catalog-overlay.read` |
 | `administrator` | Full tenant-scoped administration of metadata, catalog integrations, catalog overlays, and legacy connectors. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write`, `catalog-overlay.reconcile`, `catalog-overlay.delete`, `system-objects.read`, `account.delete` |
 | `developer` | Development-role equivalent of `administrator`. | `account.read`, `catalog.read`, `catalog.write`, `namespace.read`, `namespace.write`, `table.read`, `table.write`, `view.read`, `view.write`, `connector.manage`, `catalog-integration.read`, `catalog-integration.write`, `catalog-integration.use`, `catalog-overlay.read`, `catalog-overlay.write`, `catalog-overlay.reconcile`, `catalog-overlay.delete`, `system-objects.read`, `account.delete` |
 | `platform-admin` (or configured value of `floecat.auth.platform-admin.role`) | Platform-level account management role from IdP. | `account.read`, `account.write`, `account.delete` |

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileFailureClassifier.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcileFailureClassifier.java
@@ -44,15 +44,20 @@ final class ReconcileFailureClassifier {
         return terminalInternal(terminalRefresh.getMessage(), terminalRefresh);
       }
       if (cur instanceof StatusRuntimeException sre) {
+        // Any auth failure, wherever it came from -- floecat's own services included, which is why
+        // this stays a raw-code rule rather than folding into the structured check below. A
+        // source-catalog refusal additionally carries SOURCE_CATALOG_VEND_REFUSED under these same
+        // codes, so a consumer that needs to tell the two apart reads the reason, not the code.
         Status.Code code = sre.getStatus().getCode();
         if (code == Status.Code.UNAUTHENTICATED || code == Status.Code.PERMISSION_DENIED) {
           return terminalInternal(sre.getMessage(), sre);
         }
         // Matched by structured reason, not by status code: FAILED_PRECONDITION is shared with
         // lease-precondition failures, which are retryable by design. A catalog that vends an
-        // incomplete session tuple or no expiry will keep doing so, and one that refuses to vend
-        // for this table at all (external access disabled, unknown table id) will keep refusing --
-        // so retrying either only loops.
+        // incomplete session tuple, or refuses for a reason a retry cannot change -- a vanished
+        // upstream table, credentials outside the table's location -- will keep producing the same
+        // answer, so retrying only loops. The vending path deliberately keeps everything a later
+        // attempt could clear off these two reasons.
         if (SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(sre)
             || SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(sre)) {
           return terminalInternal(sre.getMessage(), sre);

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccess.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccess.java
@@ -25,11 +25,51 @@ import java.util.Map;
 /** Resolves one persisted Catalog Integration into a short-lived catalog-access client. */
 @ApplicationScoped
 public class CatalogIntegrationAccess {
+  private static final org.jboss.logging.Logger LOG =
+      org.jboss.logging.Logger.getLogger(CatalogIntegrationAccess.class);
+
   @FunctionalInterface
   interface ClientOpener {
     CatalogClient open(
         CatalogConnectionConfig config, ResolvedCatalogCredentials resolvedCredentials);
   }
+
+  /**
+   * Integration-and-generation pairs already reported at WARN.
+   *
+   * <p>This vend runs once per file group on reconcile and once per scan session on query, so an
+   * integration whose secret is genuinely gone would otherwise write a WARN per group per attempt
+   * per table -- the flood {@code catalogIntegrationFailureStatus} drops to DEBUG for its own
+   * retryable answers, and for the same reason.
+   *
+   * <p>Damped by interval rather than reported once, which is what makes the generation readable as
+   * a signal. Reporting a pair once would give permanent loss and a supersede window the same
+   * shape: one WARN and then silence, with the repeats at DEBUG, which production does not enable.
+   * Re-reporting past {@link #CREDENTIAL_GAP_REPORT_INTERVAL} leaves a supersede window writing the
+   * line about once before its generation moves on, while genuine loss keeps writing it at that
+   * interval against the same generation. The interval is far longer than the per-file-group vend
+   * rate this exists to damp, so the flood is still bounded.
+   *
+   * <p>Bounded and access-synchronized: the key is tenant-supplied, so an unbounded map would be a
+   * slow leak, and eviction only costs a repeated WARN rather than correctness.
+   */
+  private static final int MAX_REPORTED_CREDENTIAL_GAPS = 64;
+
+  private static final java.time.Duration CREDENTIAL_GAP_REPORT_INTERVAL =
+      java.time.Duration.ofMinutes(2);
+
+  private final java.util.Map<String, java.time.Instant> reportedCredentialGaps =
+      java.util.Collections.synchronizedMap(
+          new java.util.LinkedHashMap<>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(
+                java.util.Map.Entry<String, java.time.Instant> eldest) {
+              return size() > MAX_REPORTED_CREDENTIAL_GAPS;
+            }
+          });
+
+  // Package-visible so a test can advance past CREDENTIAL_GAP_REPORT_INTERVAL without sleeping.
+  java.time.Clock clock = java.time.Clock.systemUTC();
 
   @Inject CatalogIntegrationCredentialStore credentialStore;
 
@@ -88,7 +128,10 @@ public class CatalogIntegrationAccess {
           authenticationProperties.put("scope", String.join(" ", oauth.getScopesList()));
         }
         String secret =
-            requireStored(stored, CatalogIntegrationCredentials.CredentialCase.OAUTH_CLIENT_SECRET)
+            requireStored(
+                    integration,
+                    stored,
+                    CatalogIntegrationCredentials.CredentialCase.OAUTH_CLIENT_SECRET)
                 .getOauthClientSecret()
                 .getValue();
         credentialProperties.put("credential", oauth.getClientId() + ":" + secret);
@@ -96,7 +139,8 @@ public class CatalogIntegrationAccess {
       case BEARER -> {
         scheme = CatalogAuthenticationScheme.OAUTH2;
         String token =
-            requireStored(stored, CatalogIntegrationCredentials.CredentialCase.BEARER_TOKEN)
+            requireStored(
+                    integration, stored, CatalogIntegrationCredentials.CredentialCase.BEARER_TOKEN)
                 .getBearerToken()
                 .getValue();
         credentialProperties.put("token", token);
@@ -116,7 +160,10 @@ public class CatalogIntegrationAccess {
               "Ambient and assumed AWS Catalog Integration credentials are not supported");
         }
         var secret =
-            requireStored(stored, CatalogIntegrationCredentials.CredentialCase.AWS_ACCESS_KEY)
+            requireStored(
+                    integration,
+                    stored,
+                    CatalogIntegrationCredentials.CredentialCase.AWS_ACCESS_KEY)
                 .getAwsAccessKey();
         credentialProperties.put("rest.access-key-id", sigv4.getAwsAccessKey().getAccessKeyId());
         credentialProperties.put("rest.secret-access-key", secret.getSecretAccessKey());
@@ -149,21 +196,87 @@ public class CatalogIntegrationAccess {
         config, new ResolvedCatalogCredentials(Map.copyOf(credentialProperties), Map.of(), null));
   }
 
-  private static CatalogIntegrationCredentials requireStored(
+  private CatalogIntegrationCredentials requireStored(
+      CatalogIntegration integration,
       java.util.Optional<CatalogIntegrationCredentials> stored,
       CatalogIntegrationCredentials.CredentialCase expected) {
-    var credentials =
-        stored.orElseThrow(
-            () ->
-                new CatalogAccessException(
-                    CatalogAccessException.Code.INVALID_CONFIGURATION,
-                    "Catalog Integration credentials are not configured"));
+    var credentials = stored.orElseThrow(() -> credentialsAbsent(integration));
     if (credentials.getCredentialCase() != expected) {
       throw new CatalogAccessException(
           CatalogAccessException.Code.INVALID_CONFIGURATION,
           "Catalog Integration credentials do not match authentication configuration");
     }
     return credentials;
+  }
+
+  /**
+   * Why {@code resolve} came back empty, which decides whether a caller should retry.
+   *
+   * <p>Two structurally different conditions reach the same empty Optional, and callers act on the
+   * difference. The record saying no credentials were ever attached is permanent until someone
+   * configures them, so a retry only hides the cause behind an exhausted budget. A generation the
+   * record does carry but the store cannot read is the window {@code
+   * CatalogIntegrationCredentialCleanup} opens while a secret is superseded, and it closes on the
+   * next attempt.
+   *
+   * <p>A rotation whose secret write was lost after the generation was recorded would land in the
+   * second branch and retry forever, which is the one case this split does not separate. It is not
+   * reachable as written -- {@code CatalogIntegrationsImpl} stores the secret before it persists
+   * the generation -- so distinguishing it would mean guarding against an ordering the code does
+   * not have.
+   */
+  private CatalogAccessException credentialsAbsent(CatalogIntegration integration) {
+    if (!CatalogIntegrationCredentialStore.hasStoredCredentials(integration)) {
+      return new CatalogAccessException(
+          CatalogAccessException.Code.INVALID_CONFIGURATION,
+          "Catalog Integration credentials are not configured");
+    }
+    // Logged because the classification cannot tell the two apart. hasStoredCredentials reads the
+    // record, not the store, so every empty resolve against a configured record is retryable -- and
+    // an empty resolve means the store holds no entry, which a superseded generation and a secret
+    // deleted out of band, lost in a restore, or left behind by a backend migration all produce.
+    // The retryable answer is right for the first and wrong forever for the rest.
+    //
+    // The generation is what separates them in the log: a supersede window writes this line about
+    // once and stops as the generation moves on, while permanent loss keeps writing it at
+    // CREDENTIAL_GAP_REPORT_INTERVAL against the same generation. That is visible without reading
+    // the secret store, which is the part an operator cannot do. Bounding the retryable
+    // classification to a window after the record's last update would separate them in the
+    // classification too, at the cost of carrying that state.
+    String integrationId = integration.getResourceId().getId();
+    long generation = integration.getAuthentication().getCredentialGeneration();
+    String gap = integrationId + "@" + generation;
+    if (shouldReportCredentialGap(gap, clock.instant())) {
+      LOG.warnf(
+          "Catalog Integration %s has credentials configured at generation %d that the store cannot"
+              + " resolve; retrying assumes a superseded generation, which repeats if the secret is"
+              + " gone for good",
+          integrationId, generation);
+    } else {
+      LOG.debugf(
+          "Catalog Integration %s still cannot resolve generation %d", integrationId, generation);
+    }
+    return new CatalogAccessException(
+        CatalogAccessException.Code.CREDENTIAL_UNAVAILABLE,
+        "Catalog Integration credentials are not currently resolvable");
+  }
+
+  /**
+   * Whether this integration-and-generation pair is due a WARN, recording it when it is.
+   *
+   * <p>Package-visible so the interval is asserted without capturing log output or sleeping through
+   * it. Read and write share one mutex so a burst of concurrent vends reports once rather than once
+   * per thread; {@code synchronizedMap} locks on the map it returned, which is this reference.
+   */
+  boolean shouldReportCredentialGap(String gap, java.time.Instant now) {
+    synchronized (reportedCredentialGaps) {
+      java.time.Instant reported = reportedCredentialGaps.get(gap);
+      if (reported != null && reported.isAfter(now.minus(CREDENTIAL_GAP_REPORT_INTERVAL))) {
+        return false;
+      }
+      reportedCredentialGaps.put(gap, now);
+      return true;
+    }
   }
 
   record ResolvedAccess(CatalogConnectionConfig config, ResolvedCatalogCredentials credentials) {}

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscovery.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationDiscovery.java
@@ -19,7 +19,6 @@ import ai.floedb.floecat.integration.rpc.CatalogIntegrationValidationCheck;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationValidationCheckType;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationValidationIssue;
 import ai.floedb.floecat.integration.rpc.CatalogIntegrationValidationStatus;
-import ai.floedb.floecat.service.context.PropagatedContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Clock;
@@ -31,14 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
 import java.util.function.LongSupplier;
-import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 
 /** Read-only discovery and validation against one persisted Catalog Integration. */
@@ -56,7 +48,7 @@ public class CatalogIntegrationDiscovery {
   LongSupplier nanoTime = System::nanoTime;
 
   ValidationResult validate(CatalogIntegration integration) {
-    ValidationBudget budget = ValidationBudget.start(validationTimeout, nanoTime);
+    CatalogUpstreamBudget budget = CatalogUpstreamBudget.start(validationTimeout, nanoTime);
     CatalogClient client;
     try {
       client = open(integration, budget);
@@ -73,7 +65,7 @@ public class CatalogIntegrationDiscovery {
     }
   }
 
-  private ValidationResult validate(CatalogClient client, ValidationBudget budget) {
+  private ValidationResult validate(CatalogClient client, CatalogUpstreamBudget budget) {
     List<CatalogIntegrationValidationCheck> checks = new ArrayList<>();
     CatalogCapabilities capabilities = client.capabilities();
     if (!capabilities.supports(CatalogCapability.VALIDATE)) {
@@ -240,7 +232,7 @@ public class CatalogIntegrationDiscovery {
   }
 
   List<NamespacePath> listNamespaces(CatalogIntegration integration, NamespacePath parent) {
-    ValidationBudget budget = ValidationBudget.start(listTimeout, nanoTime);
+    CatalogUpstreamBudget budget = CatalogUpstreamBudget.start(listTimeout, nanoTime);
     try (CatalogClient client = open(integration, budget)) {
       require(client.capabilities(), CatalogCapability.LIST_NAMESPACES);
       return budget.call(() -> client.listNamespaces(parent)).stream().distinct().sorted().toList();
@@ -249,7 +241,7 @@ public class CatalogIntegrationDiscovery {
 
   List<DiscoveredObject> listObjects(
       CatalogIntegration integration, NamespacePath namespace, Set<ObjectKind> requestedKinds) {
-    ValidationBudget budget = ValidationBudget.start(listTimeout, nanoTime);
+    CatalogUpstreamBudget budget = CatalogUpstreamBudget.start(listTimeout, nanoTime);
     try (CatalogClient client = open(integration, budget)) {
       CatalogCapabilities capabilities = client.capabilities();
       Set<ObjectKind> kinds =
@@ -272,7 +264,7 @@ public class CatalogIntegrationDiscovery {
   }
 
   private static Optional<CatalogObjectName> findFirstTable(
-      CatalogClient client, ValidationBudget budget) {
+      CatalogClient client, CatalogUpstreamBudget budget) {
     List<CatalogObjectName> rootTables;
     try {
       rootTables = budget.call(() -> client.listTables(NamespacePath.root()));
@@ -325,7 +317,7 @@ public class CatalogIntegrationDiscovery {
     throw failure;
   }
 
-  private CatalogClient open(CatalogIntegration integration, ValidationBudget budget) {
+  private CatalogClient open(CatalogIntegration integration, CatalogUpstreamBudget budget) {
     return budget.call(() -> access.open(integration), CatalogIntegrationDiscovery::closeClient);
   }
 
@@ -467,135 +459,6 @@ public class CatalogIntegrationDiscovery {
         notRun(
             CatalogIntegrationValidationCheckType.CIVCT_STORAGE_ACCESS,
             "Storage access was not tested because credential vending did not pass."));
-  }
-
-  private record ValidationBudget(long deadlineNanos, LongSupplier nanoTime) {
-    private static ValidationBudget start(Duration timeout, LongSupplier nanoTime) {
-      long timeoutNanos = Math.max(0L, timeout.toNanos());
-      return new ValidationBudget(nanoTime.getAsLong() + timeoutNanos, nanoTime);
-    }
-
-    private void check() {
-      remainingNanos();
-    }
-
-    private <T> T call(Supplier<T> operation) {
-      return call(operation, null);
-    }
-
-    private <T> T call(Supplier<T> operation, Consumer<T> abandonedResult) {
-      long remainingNanos = remainingNanos();
-      PropagatedContext context = PropagatedContext.capture();
-      AbandonedResult<T> result = new AbandonedResult<>(context, abandonedResult);
-      FutureTask<T> task =
-          new FutureTask<>(() -> context.supply(() -> result.publish(operation.get())));
-      Thread.ofVirtual().name("catalog-integration-upstream").start(task);
-      try {
-        T value = task.get(remainingNanos, TimeUnit.NANOSECONDS);
-        result.claim();
-        return value;
-      } catch (TimeoutException failure) {
-        result.abandon();
-        task.cancel(true);
-        throw timeout(failure);
-      } catch (InterruptedException failure) {
-        result.abandon();
-        task.cancel(true);
-        Thread.currentThread().interrupt();
-        CancellationException cancelled =
-            new CancellationException("Catalog upstream operation was cancelled");
-        cancelled.initCause(failure);
-        throw cancelled;
-      } catch (ExecutionException failure) {
-        Throwable cause = failure.getCause();
-        if (cause instanceof RuntimeException runtimeFailure) {
-          throw runtimeFailure;
-        }
-        if (cause instanceof Error error) {
-          throw error;
-        }
-        throw new CatalogAccessException(
-            CatalogAccessException.Code.INTERNAL, "Catalog provider operation failed", cause);
-      }
-    }
-
-    private void run(Runnable operation) {
-      call(
-          () -> {
-            operation.run();
-            return null;
-          });
-    }
-
-    private long remainingNanos() {
-      long remaining = deadlineNanos - nanoTime.getAsLong();
-      if (remaining <= 0L) {
-        throw timeout(null);
-      }
-      return remaining;
-    }
-
-    private static CatalogAccessException timeout(Throwable cause) {
-      return new CatalogAccessException(
-          CatalogAccessException.Code.TIMEOUT,
-          "Catalog upstream operation exceeded the time limit",
-          cause);
-    }
-  }
-
-  private static final class AbandonedResult<T> {
-    private final PropagatedContext context;
-    private final Consumer<T> cleanup;
-    private boolean abandoned;
-    private boolean published;
-    private T value;
-
-    private AbandonedResult(PropagatedContext context, Consumer<T> cleanup) {
-      this.context = context;
-      this.cleanup = cleanup;
-    }
-
-    private T publish(T publishedValue) {
-      synchronized (this) {
-        if (!abandoned) {
-          published = true;
-          value = publishedValue;
-          return publishedValue;
-        }
-      }
-      cleanup(publishedValue);
-      return publishedValue;
-    }
-
-    private synchronized void claim() {
-      published = false;
-      value = null;
-    }
-
-    private void abandon() {
-      T abandonedValue;
-      synchronized (this) {
-        abandoned = true;
-        if (!published) {
-          return;
-        }
-        published = false;
-        abandonedValue = value;
-        value = null;
-      }
-      if (cleanup != null) {
-        Thread.ofVirtual()
-            .name("catalog-integration-cleanup")
-            .start(() -> context.supply(() -> cleanup(abandonedValue)));
-      }
-    }
-
-    private Void cleanup(T abandonedValue) {
-      if (cleanup != null) {
-        cleanup.accept(abandonedValue);
-      }
-      return null;
-    }
   }
 
   enum ObjectKind {

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogIntegrationsImpl.java
@@ -1206,7 +1206,9 @@ public class CatalogIntegrationsImpl extends BaseServiceImpl implements CatalogI
           CREDENTIAL_SCOPE_INVALID ->
           GrpcErrors.preconditionFailed(corr, null, Map.of());
       case NOT_FOUND -> GrpcErrors.notFound(corr, null, Map.of());
-      case UNAVAILABLE -> GrpcErrors.unavailable(corr, null, Map.of());
+      // A credential the store cannot resolve yet is a "come back", not a configuration error: the
+      // caller sees the same UNAVAILABLE it gets for an upstream that is briefly unreachable.
+      case CREDENTIAL_UNAVAILABLE, UNAVAILABLE -> GrpcErrors.unavailable(corr, null, Map.of());
       case TIMEOUT -> GrpcErrors.timeout(corr, null, Map.of());
       case INTERNAL -> GrpcErrors.internal(corr, null, Map.of());
     };

--- a/service/src/main/java/ai/floedb/floecat/service/integration/CatalogUpstreamBudget.java
+++ b/service/src/main/java/ai/floedb/floecat/service/integration/CatalogUpstreamBudget.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package ai.floedb.floecat.service.integration;
+
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.service.context.PropagatedContext;
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+/**
+ * A wall-clock deadline spanning every call one request makes to an upstream catalog.
+ *
+ * <p>An upstream that accepts the connection and then stalls is not bounded by socket timeouts: an
+ * Iceberg REST client alone makes a config round trip, an OAuth exchange and a loadTable, each with
+ * its own timeout and no limit on the total. Whatever holds the caller's thread -- a gRPC handler,
+ * scan planning -- is held for the sum. Sharing one budget across those calls is what stops any of
+ * them being the one that blocks indefinitely.
+ *
+ * <p>Used by validation, discovery and storage-credential vending. {@code CatalogOverlayReconciler}
+ * is deliberately not on it yet: it walks an entire catalog, so it needs a per-call budget like the
+ * listing paths rather than one window over the whole walk, and giving it a single deadline would
+ * cap a legitimately long reconcile.
+ *
+ * <p>The window is this budget's alone. It deliberately does not consult the caller's own gRPC
+ * deadline: see {@link #remainingNanos()} for why reading one here is unsafe.
+ *
+ * <p>The operation runs on a virtual thread so the deadline can be enforced on a provider that
+ * ignores interruption. An abandoned call may still produce a value that owns resources -- a client
+ * holding an HTTP connection pool -- so callers that hand back such a value pass a cleanup
+ * consumer, and a result that arrives after the deadline is closed rather than leaked.
+ */
+public record CatalogUpstreamBudget(long deadlineNanos, LongSupplier nanoTime) {
+  public static CatalogUpstreamBudget start(Duration timeout, LongSupplier nanoTime) {
+    long timeoutNanos = Math.max(0L, timeout.toNanos());
+    return new CatalogUpstreamBudget(nanoTime.getAsLong() + timeoutNanos, nanoTime);
+  }
+
+  /** Fails if the budget is already spent, without starting another upstream call. */
+  public void check() {
+    remainingNanos();
+  }
+
+  public <T> T call(Supplier<T> operation) {
+    return call(operation, null);
+  }
+
+  public <T> T call(Supplier<T> operation, Consumer<T> abandonedResult) {
+    long remainingNanos = remainingNanos();
+    PropagatedContext context = PropagatedContext.capture();
+    AbandonedResult<T> result = new AbandonedResult<>(context, abandonedResult);
+    FutureTask<T> task =
+        new FutureTask<>(() -> context.supply(() -> result.publish(operation.get())));
+    Thread.ofVirtual().name("catalog-integration-upstream").start(task);
+    try {
+      T value = task.get(remainingNanos, TimeUnit.NANOSECONDS);
+      result.claim();
+      return value;
+    } catch (TimeoutException failure) {
+      result.abandon();
+      task.cancel(true);
+      throw timeout(failure);
+    } catch (InterruptedException failure) {
+      result.abandon();
+      task.cancel(true);
+      Thread.currentThread().interrupt();
+      CancellationException cancelled =
+          new CancellationException("Catalog upstream operation was cancelled");
+      cancelled.initCause(failure);
+      throw cancelled;
+    } catch (ExecutionException failure) {
+      Throwable cause = failure.getCause();
+      if (cause instanceof RuntimeException runtimeFailure) {
+        throw runtimeFailure;
+      }
+      if (cause instanceof Error error) {
+        throw error;
+      }
+      throw new CatalogAccessException(
+          CatalogAccessException.Code.INTERNAL, "Catalog provider operation failed", cause);
+    }
+  }
+
+  public void run(Runnable operation) {
+    call(
+        () -> {
+          operation.run();
+          return null;
+        });
+  }
+
+  /**
+   * Time left in this budget.
+   *
+   * <p>Deliberately not shortened by the caller's inbound gRPC deadline, and not for want of
+   * wanting it: {@code io.grpc.Context} cannot be read safely here. {@code ResolvedCallContexts}
+   * documents why -- under Quarkus, attach/detach on a duplicated context is one shared
+   * last-writer-wins slot that several threads of the same call race, so a key can read back empty
+   * or, on a reused worker, stale via the thread-local fallback. An empty read would be harmless
+   * here, but a stale one is not: a deadline left behind by a finished call yields a negative
+   * remaining time and would cancel this call's upstream request immediately, for no reason the
+   * operator can see. That failure mode is what {@code PrincipalProvider} exists to avoid
+   * (eng-floe/floecat#361).
+   *
+   * <p>Do not reintroduce a caller-deadline ceiling by reading the ambient context. If the ceiling
+   * is wanted, the deadline has to arrive the way every other per-call value does -- passed in, or
+   * off the duplicated-context channel -- not sampled from a thread-local.
+   */
+  private long remainingNanos() {
+    long remaining = deadlineNanos - nanoTime.getAsLong();
+    if (remaining <= 0L) {
+      throw timeout(null);
+    }
+    return remaining;
+  }
+
+  private static CatalogAccessException timeout(Throwable cause) {
+    return new CatalogAccessException(
+        CatalogAccessException.Code.TIMEOUT,
+        "Catalog upstream operation exceeded the time limit",
+        cause);
+  }
+
+  private static final class AbandonedResult<T> {
+    private final PropagatedContext context;
+    private final Consumer<T> cleanup;
+    private boolean abandoned;
+    private boolean published;
+    private T value;
+
+    private AbandonedResult(PropagatedContext context, Consumer<T> cleanup) {
+      this.context = context;
+      this.cleanup = cleanup;
+    }
+
+    private T publish(T publishedValue) {
+      synchronized (this) {
+        if (!abandoned) {
+          published = true;
+          value = publishedValue;
+          return publishedValue;
+        }
+      }
+      cleanup(publishedValue);
+      return publishedValue;
+    }
+
+    private synchronized void claim() {
+      published = false;
+      value = null;
+    }
+
+    private void abandon() {
+      T abandonedValue;
+      synchronized (this) {
+        abandoned = true;
+        if (!published) {
+          return;
+        }
+        published = false;
+        abandonedValue = value;
+        value = null;
+      }
+      if (cleanup != null) {
+        Thread.ofVirtual()
+            .name("catalog-integration-cleanup")
+            .start(() -> context.supply(() -> cleanup(abandonedValue)));
+      }
+    }
+
+    private Void cleanup(T abandonedValue) {
+      if (cleanup != null) {
+        cleanup.accept(abandonedValue);
+      }
+      return null;
+    }
+  }
+}

--- a/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
+++ b/service/src/main/java/ai/floedb/floecat/service/security/RolePermissions.java
@@ -41,6 +41,17 @@ public final class RolePermissions {
   public static final String CATALOG_OVERLAY_WRITE = "catalog-overlay.write";
   public static final String CATALOG_OVERLAY_RECONCILE = "catalog-overlay.reconcile";
   public static final String CATALOG_OVERLAY_DELETE = "catalog-overlay.delete";
+
+  /**
+   * What an ordinary reader gets, and the fallback for a role this service does not recognise.
+   *
+   * <p>{@link #CATALOG_INTEGRATION_USE} is in here because reading a table an overlay materialized
+   * from an Iceberg REST Integration <em>is</em> using that Integration's credential: no storage
+   * authority covers such a table, so the scan asks the upstream catalog to vend one. Withholding
+   * the permission does not protect anything a reader cannot already reach -- the vend is reached
+   * only after table authorization has admitted the caller, and for one table's location -- it just
+   * makes those tables unreadable for every role except administrator.
+   */
   private static final List<String> READ_PERMS =
       List.of(
           "account.read",
@@ -49,7 +60,9 @@ public final class RolePermissions {
           "table.read",
           "view.read",
           CATALOG_INTEGRATION_READ,
+          CATALOG_INTEGRATION_USE,
           CATALOG_OVERLAY_READ);
+
   private static final List<String> FULL_PERMS =
       List.of(
           "account.read",

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/ServerSideFileIoPropertiesResolver.java
@@ -85,8 +85,11 @@ public class ServerSideFileIoPropertiesResolver {
       if (vended != null) {
         return mergeStorageAuthorityFileIoConfig(vended);
       }
-      // Nothing vended either: fall through so buildResponse raises the structured
-      // no-matching-authority error rather than silently returning no credentials.
+      // Null only where a fall-back means something: a table with no upstream reference, or a
+      // Connector that did not opt in to vending. Fall through so buildResponse raises the
+      // structured no-matching-authority error rather than silently returning no credentials. An
+      // Integration that cannot vend does not reach here -- it throws, naming the cause, because
+      // there is no authority for it to fall back to.
     }
     ResolveStorageAuthorityResponse response =
         resolver.buildResponse(authority, tableId.getAccountId(), true);

--- a/service/src/main/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendor.java
+++ b/service/src/main/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendor.java
@@ -16,8 +16,15 @@
 
 package ai.floedb.floecat.service.storage.impl;
 
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.access.StorageLocations;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.UpstreamRef;
+import ai.floedb.floecat.common.rpc.ErrorCode;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.common.auth.CredentialResolverSupport;
 import ai.floedb.floecat.connector.rpc.AuthConfig;
@@ -31,20 +38,32 @@ import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.connector.spi.LogSafeText;
 import ai.floedb.floecat.connector.spi.SourceCatalogAccessException;
 import ai.floedb.floecat.connector.spi.SourceCatalogVending;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
 import ai.floedb.floecat.service.credentials.AuthResolutionContexts;
+import ai.floedb.floecat.service.integration.CatalogIntegrationAccess;
+import ai.floedb.floecat.service.integration.CatalogUpstreamBudget;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
+import ai.floedb.floecat.service.security.RolePermissions;
+import ai.floedb.floecat.service.security.impl.Authorizer;
+import ai.floedb.floecat.service.security.impl.PrincipalProvider;
+import ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus;
 import ai.floedb.floecat.storage.rpc.ResolveStorageAuthorityResponse;
 import ai.floedb.floecat.storage.rpc.VendedStorageCredential;
 import com.google.protobuf.util.Timestamps;
 import io.grpc.StatusRuntimeException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import java.util.stream.Stream;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -61,9 +80,29 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
  * what capture had just written.
  *
  * <p>Callers own admission: this class assumes the caller has already authorized access to the
- * table and decided that no storage authority covers the location. It returns {@code null} for
- * every "this catalog cannot or will not vend" condition so the caller can fall back, and throws
- * only when the catalog actively refused or answered unusably.
+ * table and decided that no storage authority covers the location.
+ *
+ * <p>The two upstream kinds answer differently, and deliberately. A legacy Connector opts in to
+ * vending -- {@code IcebergAccessDelegation.declaresVendedCredentials} is the switch -- so a
+ * connector that does not, or cannot, is answered with {@code null} and the caller falls back to
+ * the storage authority the operator configured instead. A Catalog Integration has no such switch
+ * and no such alternative: nothing on the record names an authority, and {@code
+ * ValidateCatalogIntegration} reports an Integration whose provider cannot vend as invalid rather
+ * than as configured some other way. Reaching for an authority beside an Integration is the
+ * split-brain this feature exists to remove, so every "cannot vend" condition on that path is a
+ * refusal naming the cause, not a fall-back.
+ *
+ * <p>Nothing was lost by that. This vend is reached only once no authority covers the location, so
+ * a {@code null} from the Integration path landed on {@code
+ * StorageAuthorityResolver.buildResponse(null, ...)}, which raises no-matching-authority -- the one
+ * consumer that absorbs that error gates on a {@code ConnectorConfig}. The fall-back could only
+ * ever relabel a specific cause as "you configured no storage authority".
+ *
+ * <p>What it throws is classified, because the reconcile path acts on it: only a condition a retry
+ * cannot change -- an authorization refusal, a vanished upstream table, an incomplete credential
+ * tuple -- travels as a terminal refusal reason. Anything a later attempt could clear stays
+ * retryable, since a wrongly terminal answer permanently fails a capture job while a wrongly
+ * retried one costs time.
  */
 @ApplicationScoped
 public class SourceCatalogCredentialVendor {
@@ -77,10 +116,10 @@ public class SourceCatalogCredentialVendor {
    * A catalog-supplied table identifier, flattened and bounded for a status or a log line.
    *
    * <p>Both halves come off the persisted {@code UpstreamRef}, so neither has a length or character
-   * bound. A status description becomes percent-encoded grpc-message trailer metadata that travels
-   * to every consumer and competes with HTTP/2 header limits, and {@code withReason} copies the
-   * same text into two {@code Any} details -- three carriages of whatever the catalog named its
-   * table. Flattening matters for the log line too: a name containing a newline would forge one.
+   * bound, and a refusal carries this text off the node twice: once in the {@code Error} detail's
+   * {@code detail} parameter, and again as the grpc-message {@code LocalizeErrorsInterceptor}
+   * renders from it -- percent-encoded trailer metadata competing with HTTP/2 header limits.
+   * Flattening matters for the log line too: a name containing a newline would forge one.
    */
   private static String boundedTable(String namespaceFq, String tableName) {
     return LogSafeText.bounded(namespaceFq + "." + tableName, MAX_LOGGED_PREFIX_CHARS);
@@ -116,6 +155,17 @@ public class SourceCatalogCredentialVendor {
       Stream.concat(REGION_KEYS.stream(), Stream.of("aws.region")).toList();
 
   /**
+   * How far a vended expiry may sit in the past before it stops looking like a race.
+   *
+   * <p>Wide enough to absorb the two things that legitimately produce a just-expired credential --
+   * transit time between the catalog issuing it and us reading it, and ordinary NTP-scale
+   * disagreement between floecat's clock and the catalog's -- and far narrower than any credential
+   * lifetime worth vending, so a timestamp that is genuinely stale still reads as stale. See {@link
+   * #requireLiveExpiry}, which is the only reader.
+   */
+  private static final Duration EXPIRY_SKEW_TOLERANCE = Duration.ofSeconds(60);
+
+  /**
    * What the caller will do with the credentials. Selects how strictly they are validated: only the
    * reconcile path renews them, so only it requires a renewable session tuple.
    */
@@ -126,18 +176,61 @@ public class SourceCatalogCredentialVendor {
     QUERY
   }
 
+  /**
+   * Which vend path produced a credential, where the two differ in what shapes are legitimate.
+   *
+   * <p>Separate from {@link CredentialUse}, which says what the caller will do with the credential.
+   * This says where it came from, and only one rule turns on it today: whether a key pair with no
+   * session token and no expiry is acceptable for capture. It retires with the connector path.
+   */
+  enum VendSource {
+    /** A connector's own catalog. Unity vends a long-lived key pair for some external locations. */
+    CONNECTOR,
+    /** A catalog integration, whose contract is delegated temporary credentials. */
+    CATALOG_INTEGRATION
+  }
+
+  @Inject PrincipalProvider principal;
+  @Inject Authorizer authz;
   @Inject ConnectorRepository connectorRepo;
   @Inject CredentialResolver credentialResolver;
   Function<ConnectorConfig, FloecatConnector> connectorFactory = ConnectorFactory::create;
+  @Inject CatalogIntegrationRepository catalogIntegrationRepo;
+  @Inject CatalogIntegrationAccess catalogIntegrationAccess;
 
   @ConfigProperty(name = "floecat.storage.aws.region", defaultValue = "us-east-1")
   String defaultRegion;
 
   /**
-   * Vends credentials for {@code table} from the catalog it was captured from, or returns {@code
-   * null} when that catalog does not delegate and the caller should fall back.
+   * Wall-clock limit on everything one vend asks of an upstream catalog. Matches the default the
+   * validation and discovery paths use for the same calls.
    *
-   * @param table a persisted table, carrying the upstream connector reference
+   * <p>One value for both callers, which is a compromise rather than a preference: the reconcile
+   * vend RPC can afford to wait on a slow catalog, while the query path holds scan planning and
+   * would rather give up and fall back. Nothing shortens it per caller -- {@code
+   * CatalogUpstreamBudget} deliberately does not read the caller's gRPC deadline, for the reason
+   * documented there -- so this default is what a stalled upstream costs a scan.
+   */
+  @ConfigProperty(name = "floecat.storage.source-catalog.upstream-timeout", defaultValue = "PT30S")
+  Duration upstreamTimeout;
+
+  /**
+   * How long a vend waits for its own client to close. Short because teardown is not the answer the
+   * caller is waiting for, and unbounded is what this replaces.
+   */
+  private static final Duration CLOSE_TIMEOUT = Duration.ofSeconds(5);
+
+  Clock clock = Clock.systemUTC();
+  LongSupplier nanoTime = System::nanoTime;
+
+  /**
+   * Vends credentials for {@code table} from the catalog it was captured from.
+   *
+   * <p>Returns {@code null} only where a fall-back is meaningful: a table with no upstream
+   * reference, or a Connector that did not opt in to vending. An Integration-backed table is
+   * answered with credentials or with a refusal naming why not.
+   *
+   * @param table a persisted table, carrying its upstream catalog reference
    * @param responseLocationPrefix prefix to stamp on the returned credential
    * @param use how the caller will use the credentials, which sets how strictly they are validated
    */
@@ -147,10 +240,30 @@ public class SourceCatalogCredentialVendor {
       return null;
     }
     UpstreamRef upstream = table.getUpstream();
-    String tableId = table.getResourceId().getId();
-    if (!upstream.hasConnectorId() || upstream.getTableDisplayName().isBlank()) {
+    ResourceId tableId = table.getResourceId();
+    // The Integration branch first, so its invariant holds for this condition too: every "cannot
+    // vend" on that path names the cause rather than falling through to a missing authority the
+    // operator was never asked to configure. Reachable outside the overlay reconciler --
+    // TableServiceImpl.validateUpstreamRef checks the integration id's resource kind and the
+    // namespace segments but never requires a display name -- and by any record written before the
+    // field was populated.
+    if (upstream.hasCatalogIntegrationId()) {
+      if (upstream.getTableDisplayName().isBlank()) {
+        throw integrationCannotVend(
+            "table " + tableId.getId() + " has no upstream table reference");
+      }
+      return vendFromCatalogIntegration(tableId, upstream, responseLocationPrefix, use);
+    }
+    if (upstream.getTableDisplayName().isBlank()) {
       LOG.infof(
-          "source-catalog vending skipped: table %s has no upstream connector reference", tableId);
+          "source-catalog vending skipped: table %s has no upstream table reference",
+          tableId.getId());
+      return null;
+    }
+    if (!upstream.hasConnectorId()) {
+      LOG.infof(
+          "source-catalog vending skipped: table %s has no upstream catalog reference",
+          tableId.getId());
       return null;
     }
     // Scoped to the table's own account rather than trusting the reference. The upstream ref is
@@ -167,7 +280,7 @@ public class SourceCatalogCredentialVendor {
     if (connector == null) {
       LOG.infof(
           "source-catalog vending skipped: upstream connector %s of table %s not found",
-          LogSafeText.bounded(connectorId.getId(), MAX_LOGGED_PREFIX_CHARS), tableId);
+          LogSafeText.bounded(connectorId.getId(), MAX_LOGGED_PREFIX_CHARS), tableId.getId());
       return null;
     }
 
@@ -230,21 +343,149 @@ public class SourceCatalogCredentialVendor {
       return null;
     }
 
-    noteIgnoredAccessPoint(vended.get(), namespaceFq, upstream.getTableDisplayName());
-    requireUsableCredentials(vended.get(), namespaceFq, upstream.getTableDisplayName(), use);
+    return credentialResponse(
+        vended.get().properties(),
+        vended.get().expiresAt(),
+        resolvedConfig.options(),
+        responsePrefix(
+            vended.get(), responseLocationPrefix, namespaceFq, upstream.getTableDisplayName()),
+        "connector=" + connector.getResourceId().getId(),
+        namespaceFq,
+        upstream.getTableDisplayName(),
+        use,
+        VendSource.CONNECTOR);
+  }
 
-    // A delegating catalog vends credentials, not routing. Polaris returns the session triple and
-    // no region at all, which left every consumer to supply its own: the reconcile worker has a
-    // default and survived, the query scan engine has none and fails the whole scan with "region
-    // is missing" after planning has already succeeded. Region is resolved here so both paths see
-    // the same answer, and written under every alias the authority path emits -- consumers read
-    // different ones, and an authority-backed response has always carried all three.
-    Map<String, String> routing =
-        routingProperties(vended.get().properties(), resolvedConfig.options());
+  private ResolveStorageAuthorityResponse vendFromCatalogIntegration(
+      ResourceId tableId, UpstreamRef upstream, String responseLocationPrefix, CredentialUse use) {
+    ResourceId integrationId =
+        upstream.getCatalogIntegrationId().toBuilder().setAccountId(tableId.getAccountId()).build();
+    CatalogIntegration integration = catalogIntegrationRepo.getById(integrationId).orElse(null);
+    if (integration == null) {
+      throw integrationCannotVend(
+          "upstream Catalog Integration "
+              + LogSafeText.bounded(integrationId.getId(), MAX_LOGGED_PREFIX_CHARS)
+              + " of table "
+              + tableId.getId()
+              + " not found");
+    }
+    if (integration.getType() != CatalogIntegrationType.CIT_ICEBERG_REST) {
+      throw integrationCannotVend(
+          "Catalog Integration "
+              + integration.getResourceId().getId()
+              + " is of a type that does not vend storage credentials");
+    }
+
+    // After the two checks above, not before. Opening an integration resolves its stored secret and
+    // spends an OAuth exchange against the upstream on the caller's behalf, so it takes the same
+    // permission every other site that opens one requires -- CatalogIntegrationsImpl's validate and
+    // upstream listings, and the overlay reconcile. Table authorization admits the caller to this
+    // vend; it does not admit them to the integration's own credential.
+    //
+    // Ordered last of the three because the other two describe the Integration rather than the
+    // caller: a missing record or a type that cannot vend means this vend was never going to
+    // happen, and answering PERMISSION_DENIED there would blame the caller for the configuration.
+    authz.require(principal.get(), RolePermissions.CATALOG_INTEGRATION_USE);
+
+    String namespaceFq = String.join(".", upstream.getNamespacePathList());
+    CatalogObjectName tableName =
+        new CatalogObjectName(
+            new NamespacePath(upstream.getNamespacePathList()), upstream.getTableDisplayName());
+    Optional<ai.floedb.floecat.catalog.access.VendedStorageCredentials> vended;
+    // One deadline across the whole conversation with the upstream catalog: opening the client is
+    // itself a config round trip and an OAuth exchange, and loadTable is a third. A catalog that
+    // accepts the connection and then stalls would otherwise hold this thread -- a gRPC handler on
+    // the vend path, scan planning on the query path -- for the sum of three socket timeouts.
+    CatalogUpstreamBudget budget = CatalogUpstreamBudget.start(upstreamTimeout, nanoTime);
+    // Not try-with-resources: the close has to run bounded and exception-swallowing. A close hook
+    // throws would otherwise replace credentials already in hand with an INTERNAL failure, and the
+    // suppression rules make that happen only on the success path, where it is least expected.
+    CatalogClient source = null;
+    try {
+      source =
+          budget.call(
+              () -> catalogIntegrationAccess.open(integration),
+              SourceCatalogCredentialVendor::closeQuietly);
+      // Budgeted like the calls either side of it. It is local for the Iceberg REST provider, but
+      // nothing in the CatalogClient contract says a provider cannot ask the catalog what it
+      // supports, and one that does would sit outside the deadline this method exists to impose.
+      CatalogClient opened = source;
+      if (!budget.call(opened::capabilities).supports(CatalogCapability.VEND_STORAGE_CREDENTIALS)) {
+        throw integrationCannotVend(
+            "Catalog Integration "
+                + integration.getResourceId().getId()
+                + " does not support storage credential vending");
+      }
+      vended = budget.call(() -> opened.vendStorageCredentials(tableName));
+    } catch (StatusRuntimeException e) {
+      throw e;
+    } catch (java.util.concurrent.CancellationException e) {
+      // The budget raises this when the wait is interrupted, and BaseServiceImpl.toStatus maps it
+      // to CANCELLED. Folding it into the classification below would report a caller who went away
+      // as a server fault, and put a cancelled reconcile attempt on the retry path.
+      throw e;
+    } catch (RuntimeException e) {
+      throw catalogIntegrationFailureStatus(
+          e, findCatalogAccessFailure(e), integration, namespaceFq, tableName.name(), use);
+    } finally {
+      closeWithinBudget(source);
+    }
+    if (vended.isEmpty()) {
+      throw integrationCannotVend(
+          "Catalog Integration "
+              + integration.getResourceId().getId()
+              + " vended no storage credentials for "
+              + boundedTable(namespaceFq, tableName.name()));
+    }
+
+    var credentials = vended.get();
+    // The same helper the connector path uses, rather than a second rule beside it. It resolves all
+    // three relations between the vended scope and the location the caller was authorized for: a
+    // broader scope narrows to the request, a narrower one is stamped as itself, and a disjoint one
+    // returns the request with a warning. An earlier inline check here admitted only the first,
+    // which turned a catalog that legitimately scoped to a subtree of the request -- vend
+    // s3://b/db/tbl/data for request s3://b/db/tbl -- into a missing-authority error.
+    //
+    // Nothing is gained by refusing the disjoint case either: this path is reached only once no
+    // storage authority matched, so falling back means failing, while stamping the request lets the
+    // read attempt proceed and lets S3 -- which knows the real grant -- have the final say.
+    String stampedPrefix =
+        responsePrefix(
+            credentials.scopePrefix(), responseLocationPrefix, namespaceFq, tableName.name());
+    return credentialResponse(
+        credentials.properties(),
+        credentials.expiresAt().orElse(null),
+        integration.getPropertiesMap(),
+        stampedPrefix,
+        "catalog-integration=" + integration.getResourceId().getId(),
+        namespaceFq,
+        tableName.name(),
+        use,
+        VendSource.CATALOG_INTEGRATION);
+  }
+
+  private ResolveStorageAuthorityResponse credentialResponse(
+      Map<String, String> properties,
+      Instant expiresAt,
+      Map<String, String> sourceOptions,
+      String responseLocationPrefix,
+      String sourceDescription,
+      String namespaceFq,
+      String tableName,
+      CredentialUse use,
+      VendSource source) {
+    noteIgnoredAccessPoint(properties, namespaceFq, tableName);
+    requireUsableCredentials(
+        properties, expiresAt, clock.instant(), namespaceFq, tableName, use, source);
+
+    // A delegating catalog vends credentials, not necessarily routing. Polaris, for example,
+    // returns the session triple and no region. Resolve non-secret routing once so reconcile and
+    // query consumers receive the same usable answer.
+    Map<String, String> routing = routingProperties(properties, sourceOptions);
 
     LinkedHashMap<String, String> storageConfig = new LinkedHashMap<>();
     storageConfig.put("type", "s3");
-    storageConfig.putAll(vended.get().properties());
+    storageConfig.putAll(properties);
     storageConfig.putAll(routing);
     // Dropped rather than forwarded: the ARN is not acted on anywhere here, and advertising a
     // routing key no consumer honours invites one to start honouring it inconsistently. Same
@@ -252,28 +493,16 @@ public class SourceCatalogCredentialVendor {
     storageConfig.remove("s3.access-point");
     VendedStorageCredential.Builder credential =
         VendedStorageCredential.newBuilder()
-            .setPrefix(
-                responsePrefix(
-                    vended.get(),
-                    responseLocationPrefix,
-                    namespaceFq,
-                    upstream.getTableDisplayName()))
+            .setPrefix(responseLocationPrefix == null ? "" : responseLocationPrefix)
             .putAllConfig(Map.copyOf(storageConfig));
-    Instant expiresAt = vended.get().expiresAt();
     if (expiresAt != null) {
       credential.setExpiresAt(Timestamps.fromMillis(expiresAt.toEpochMilli()));
     }
     LOG.infof(
-        "vended storage credentials from source catalog connector=%s table=%s expiresAt=%s",
-        connector.getResourceId().getId(),
-        boundedTable(namespaceFq, upstream.getTableDisplayName()),
-        expiresAt);
-    // Non-secret routing properties must also travel in client_safe_config. The reconcile worker's
-    // execution-bound (refreshable) merge path applies client_safe_config plus the refreshed
-    // credential triple and never reads storage_credentials[0].config, so region and endpoint
-    // placed only there are silently dropped on the path that matters -- leaving the worker to
-    // guess the endpoint for any non-default region or custom-endpoint bucket. Authority-backed
-    // responses carry routing in client-safe config for exactly this reason.
+        "vended storage credentials from source catalog %s table=%s expiresAt=%s",
+        sourceDescription, boundedTable(namespaceFq, tableName), expiresAt);
+    // Routing must also travel in client_safe_config: the refreshable reconcile path consumes it
+    // separately from the secret credential tuple.
     return ResolveStorageAuthorityResponse.newBuilder()
         .putAllClientSafeConfig(routing)
         .addStorageCredentials(credential)
@@ -303,6 +532,12 @@ public class SourceCatalogCredentialVendor {
       String requestedPrefix,
       String namespaceFq,
       String tableName) {
+    return responsePrefix(
+        vended == null ? null : vended.scopePrefix(), requestedPrefix, namespaceFq, tableName);
+  }
+
+  static String responsePrefix(
+      String vendedScope, String requestedPrefix, String namespaceFq, String tableName) {
     // Both sides normalized, not just the vended one: three of the four exits below return the
     // requested prefix, and that is the common path. The trailing-slash hazard described for the
     // scope applies identically -- credentialScope.location() resolves from table properties or a
@@ -318,7 +553,7 @@ public class SourceCatalogCredentialVendor {
     // travels back and that consumers key a client cache on, so " s3://x " and "s3://x" naming two
     // different scopes is this method's problem to prevent. Trimming cannot widen past the
     // authorization: what is returned still had to clear the containment check below.
-    String raw = vended == null ? null : vended.scopePrefix();
+    String raw = vendedScope;
     // Trailing slash normalized alongside the whitespace, for the same reason: this value travels
     // back as storage_credentials[].prefix, and TableLoadService keys a merged map on it, so
     // "s3://bucket/table/" and "s3://bucket/table" would become two entries and two client FileIO
@@ -333,8 +568,22 @@ public class SourceCatalogCredentialVendor {
     // and is narrower than the unbounded alternative. Otherwise containment is decided by the same
     // path-boundary rule the authority resolver uses -- a plain startsWith would accept
     // "s3://warehouse/tpch_other" as inside "s3://warehouse/tpch".
-    if (requested.isBlank() || StorageAuthorityResolver.matchesLocationPrefix(scope, requested)) {
-      return scope;
+    // Compared with the s3 scheme aliases folded. matchesLocationPrefix normalizes whitespace and
+    // the trailing slash but not the scheme, so an ordinarily-configured catalog reporting
+    // "s3a://warehouse/orders" against an "s3://warehouse/orders/..." request failed both
+    // containment tests and landed in the disjoint branch below -- firing, once per file group, the
+    // WARN that branch reserves for something actually being wrong.
+    String scopeCompared = StorageLocations.normalizeScheme(scope);
+    String requestedCompared = StorageLocations.normalizeScheme(requested);
+    if (requested.isBlank()
+        || StorageAuthorityResolver.matchesLocationPrefix(scopeCompared, requestedCompared)) {
+      // Spelled the way the request spells it, not the way the catalog did. This value is what a
+      // client vend and an Iceberg loadTable hand to the reader, and S3FileIO selects a credential
+      // with a raw storagePath.startsWith(storagePrefix) -- so an "s3a://" prefix is invisible to
+      // an "s3://" data path, which silently falls through to the root client and reads with
+      // ambient credentials or none. Folding the aliases for the comparison without folding what is
+      // returned is what made an unmatchable prefix reachable in the first place.
+      return withSchemeOf(scope, requested);
     }
     // WARN here, unlike the access-point line below, and the difference is the point: a vended
     // access point is benign and common, while a disjoint scope means the credential travels
@@ -347,7 +596,7 @@ public class SourceCatalogCredentialVendor {
     // the credential travels stamped for a location it does not cover and the worker finds out at
     // storage. Still returns the requested prefix, because it is the only bound the caller was
     // authorized for; the log is what turns an opaque 403 into something traceable to the catalog.
-    if (!StorageAuthorityResolver.matchesLocationPrefix(requested, scope)) {
+    if (!StorageAuthorityResolver.matchesLocationPrefix(requestedCompared, scopeCompared)) {
       LOG.warnf(
           "source catalog vended a scope disjoint from the requested location for %s:"
               + " vended=%s requested=%s; returning the requested prefix",
@@ -408,6 +657,31 @@ public class SourceCatalogCredentialVendor {
     return Map.copyOf(routing);
   }
 
+  /**
+   * {@code value} rewritten to carry {@code template}'s scheme, when the two are s3 aliases.
+   *
+   * <p>Only the aliases: {@code s3}, {@code s3a} and {@code s3n} name one store, so choosing
+   * between them is spelling. Anything else is a different store and is left alone -- rewriting
+   * there would not be normalization, it would be pointing the caller somewhere else.
+   */
+  private static String withSchemeOf(String value, String template) {
+    if (template == null || template.isBlank()) {
+      return value;
+    }
+    int valueScheme = value.indexOf("://");
+    int templateScheme = template.indexOf("://");
+    if (valueScheme < 0 || templateScheme < 0) {
+      return value;
+    }
+    String templatePrefix = template.substring(0, templateScheme);
+    // Both sides have to fold to the same store before the spelling is interchangeable.
+    if (!StorageLocations.normalizeScheme(value.substring(0, valueScheme) + "://")
+        .equals(StorageLocations.normalizeScheme(templatePrefix + "://"))) {
+      return value;
+    }
+    return templatePrefix + value.substring(valueScheme);
+  }
+
   private static String firstNonBlank(String... values) {
     if (values == null) {
       return null;
@@ -444,29 +718,74 @@ public class SourceCatalogCredentialVendor {
    * credentials statically and never re-vends, so they expire mid-read with no recovery. Failing at
    * vend time makes that visible here instead of as an opaque 403 partway through a file group.
    *
-   * <p>{@link CredentialUse#QUERY} hands credentials straight to the scan engine's FileIO for reads
-   * that happen now, and registers no refresh provider, so the renewal requirement has no meaning
-   * there. Enforcing it anyway would reject credentials that read perfectly well -- and reject them
-   * with a terminal classification, on a path where nothing is retrying and there is no job to fail
-   * terminally.
+   * <p>Which of those apply is decided by {@link VendSource} first and {@link CredentialUse}
+   * second, because the two sources hold different things. An integration vends only from a
+   * temporary session, so it owes the full triple on either path -- see the reasoning at the {@code
+   * requireSessionTriple} assignment. A connector can legitimately hold a long-lived static key,
+   * and for one of those {@link CredentialUse#QUERY} hands credentials straight to the scan
+   * engine's FileIO for reads that happen now and registers no refresh provider, so the renewal
+   * requirement has no meaning there: enforcing it would reject credentials that read perfectly
+   * well, and reject them terminally on a path where nothing is retrying.
+   *
+   * <p>An expiry that has already passed is the third requirement, split out into {@link
+   * #requireLiveExpiry} because it is the one condition here whose answer depends on how far past
+   * it is.
    */
   static void requireUsableCredentials(
       FloecatConnector.VendedStorageCredentials vended,
+      Instant now,
       String namespaceFq,
       String tableName,
-      CredentialUse use) {
-    Map<String, String> props = vended.properties();
+      CredentialUse use,
+      VendSource source) {
+    requireUsableCredentials(
+        vended.properties(), vended.expiresAt(), now, namespaceFq, tableName, use, source);
+  }
+
+  private static void requireUsableCredentials(
+      Map<String, String> props,
+      Instant expiresAt,
+      Instant now,
+      String namespaceFq,
+      String tableName,
+      CredentialUse use,
+      VendSource source) {
     // A tuple with neither a session token nor an expiry is a long-lived static key, not a session
     // credential missing its renewal fields, and reconcile can use one: it fails
-    // isRefreshableExecutionCredential, so the merge path embeds it statically -- which is the
-    // right answer for a credential that never expires. Unity returns this shape for an external
-    // location backed by long-lived keys, and refusing it here would leave such a table queryable
-    // but never capturable.
+    // isRefreshableExecutionCredential, so the merge path embeds it statically -- the right answer
+    // for a credential that never expires. Unity vends this shape for an external location backed
+    // by long-lived keys, so refusing it would leave such a table queryable but never capturable.
+    //
+    // Connector only, and the reason is what the two sources hold rather than a matter of taste.
+    //
+    // A catalog integration vends only when the credential it holds is itself a temporary session,
+    // and an AWS temporary credential is always the triple. A pair arriving without a session token
+    // therefore does not mean "long-lived and fine": it means the integration is not holding what
+    // it is supposed to. Accepting it would also publish a credential floecat cannot bound -- the
+    // authority path refuses to mint a client-facing credential with no known expiry for the same
+    // reason -- and it would travel into worker payloads and loadTable responses, where a consumer
+    // cannot tell an absent expiry from "never expires".
+    // Reads a null expiry as "permanent", which is only sound while null means the catalog said
+    // nothing. It cannot be tightened by inspecting the raw property instead: this record carries
+    // its expiry as a parsed field independent of the property map -- connectors populate one
+    // without the other -- so by the time the value arrives here, "absent" and "rejected" are the
+    // same null. That is why the connector-side parser deliberately does not reject an out-of-unit
+    // expiry; see FloecatConnector.VendedStorageCredentials.expiryFromEpochMillis.
     String sessionToken = props.get("s3.session-token");
     boolean longLivedStaticKey =
-        (sessionToken == null || sessionToken.isBlank()) && vended.expiresAt() == null;
+        source == VendSource.CONNECTOR
+            && (sessionToken == null || sessionToken.isBlank())
+            && expiresAt == null;
+    // An integration always needs the full triple, on either path. The reason a token-less pair is
+    // refused is what it says about the integration -- it vends only from a temporary session, so a
+    // missing token means it is not holding one -- and that does not depend on what the caller
+    // intends to do with the result. A query vend travels into scan payloads and back over the RPC
+    // just as a reconcile one does, so "read once" is not a reason to publish something unbounded.
+    boolean requireSessionTriple =
+        source == VendSource.CATALOG_INTEGRATION
+            || (use == CredentialUse.RECONCILE && !longLivedStaticKey);
     List<String> required =
-        use == CredentialUse.RECONCILE && !longLivedStaticKey
+        requireSessionTriple
             ? List.of("s3.access-key-id", "s3.secret-access-key", "s3.session-token")
             : List.of("s3.access-key-id", "s3.secret-access-key");
     List<String> missing = new java.util.ArrayList<>();
@@ -476,37 +795,96 @@ public class SourceCatalogCredentialVendor {
         missing.add(key);
       }
     }
-    // Already-expired counts as missing, not as present. RefreshingAwsCredentialsProviderRegistry
-    // reads a past expiry as "refresh now" -- computeRefreshSkew returns Duration.ZERO and
-    // shouldRefresh is then true on every resolveCredentials call -- so a catalog that keeps
-    // returning the same stale timestamp is re-vended once per credential resolution and still
-    // hands back credentials S3 will refuse. Failing here instead names the field once, terminally.
-    // Skipped for the static key above, which has nothing to expire. What stays terminal is the
-    // dangerous middle case: a session token present with an expiry missing or already past. That
-    // one is a session credential floecat cannot renew, so it would lapse mid-capture with nothing
-    // to recover it.
-    if (use == CredentialUse.RECONCILE
-        && !longLivedStaticKey
-        && (vended.expiresAt() == null || !vended.expiresAt().isAfter(Instant.now()))) {
+    // Exempts the static key above, which has nothing to expire. What stays terminal is a
+    // session token whose expiry is absent: that one cannot be renewed and would lapse
+    // mid-capture. Only absent, not past -- the two are disjoint, and an expiry already in the
+    // past belongs to requireLiveExpiry at the end of this method, which weighs it against the
+    // skew tolerance and the calling path instead of folding it in here as a missing field.
+    if (requireSessionTriple && expiresAt == null) {
       missing.add("s3.session-token-expires-at-ms");
     }
-    if (missing.isEmpty()) {
+    if (!missing.isEmpty()) {
+      // The whole tuple, not just the expiry. An access key and secret with an expiry but no
+      // session token satisfies isExecutionBoundStorageCredential yet fails
+      // isRefreshableExecutionCredential, so the reconciler embeds it statically and never renews
+      // -- recreating exactly the defect the expiry check was added to close.
+      //
+      // Structured and terminal: a catalog that omits a field will keep omitting it, and a bare
+      // FAILED_PRECONDITION is classified retryable, so the job would loop forever rather than
+      // fail mid-read.
+      throw SourceCatalogVendingGrpcStatus.vendedCredentialsNotRefreshable(
+          "source catalog vended unusable storage credentials for "
+              + boundedTable(namespaceFq, tableName)
+              + "; missing "
+              + String.join(", ", missing));
+    }
+    requireLiveExpiry(expiresAt, now, namespaceFq, tableName, use, source);
+  }
+
+  /**
+   * Rejects an expiry that has already passed, always as a retryable failure.
+   *
+   * <p>{@link #EXPIRY_SKEW_TOLERANCE} decides whether the timestamp is evidence at all. Inside it,
+   * it is not: a credential can expire between the catalog issuing it and us reading it, and
+   * floecat's clock is not the catalog's. {@link CredentialUse#QUERY} therefore reads it -- it
+   * registers no refresh provider, the credential is almost certainly live, and refusing would fail
+   * a scan that would have worked. {@link CredentialUse#RECONCILE} still asks for a retry, because
+   * it cannot register a refresh provider against an expiry already in the past.
+   *
+   * <p>Outside the tolerance the credential is dead, and both paths fail -- but retryably, not
+   * terminally. A past expiry is a temporal condition: the next vend mints a new credential, which
+   * is why {@code integrationStatus} lists an expired credential among the failures a retry clears.
+   * Terminal belongs to what will not change, such as a tuple missing a field the catalog never
+   * sends, and {@link #requireUsableCredentials} already covers that. The asymmetry decides the
+   * rest: an over-eager terminal permanently fails a capture job, an over-eager retry only costs
+   * time, and the reconciler's own attempt budget bounds the retrying.
+   *
+   * <p>Failing here rather than at S3 still matters. {@code ServerSideFileIoPropertiesResolver}
+   * consults this vendor only once no storage authority covers the location, so there is no
+   * fall-back to lose, and handing a credential known to be dead to the scan engine converts a
+   * diagnosable failure into an opaque 403 partway through a file group.
+   */
+  private static void requireLiveExpiry(
+      Instant expiresAt,
+      Instant now,
+      String namespaceFq,
+      String tableName,
+      CredentialUse use,
+      VendSource source) {
+    // A connector read is exempt, which is where this check started: before the vend paths were
+    // shared it was gated on RECONCILE, and a scan that reads a connector-vended tuple once
+    // registers no refresh provider and has nothing to renew. Sharing the method quietly extended
+    // it to connector queries, failing scans that had been reading fine -- an integration is the
+    // one this branch deliberately made stricter, so the exemption is written by source rather
+    // than left to the shared path.
+    if (source == VendSource.CONNECTOR && use == CredentialUse.QUERY) {
       return;
     }
-    // The whole tuple, not just the expiry. An access key and secret with an expiry but no session
-    // token satisfies isExecutionBoundStorageCredential yet fails isRefreshableExecutionCredential,
-    // so the reconciler embeds it statically and never renews -- recreating exactly the defect the
-    // expiry check was added to close.
-    //
-    // Structured and terminal: a catalog that omits a field will keep omitting it, and a bare
-    // FAILED_PRECONDITION is classified retryable, so the job would loop forever rather than fail
-    // mid-read.
-    throw ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus
-        .vendedCredentialsNotRefreshable(
-            "source catalog vended unusable storage credentials for "
-                + boundedTable(namespaceFq, tableName)
-                + "; missing "
-                + String.join(", ", missing));
+    if (expiresAt == null || expiresAt.isAfter(now)) {
+      return;
+    }
+    boolean race = expiresAt.isAfter(now.minus(EXPIRY_SKEW_TOLERANCE));
+    if (race && use == CredentialUse.QUERY) {
+      return;
+    }
+    String detail =
+        "source catalog vended expired storage credentials for "
+            + boundedTable(namespaceFq, tableName)
+            + "; s3.session-token-expires-at-ms is "
+            + expiresAt
+            + ", now "
+            + now;
+    // Retryable regardless of path, and deliberately so even when the timestamp is old. The
+    // mechanism that argues for terminal -- Entry.resolveCredentials swallowing a retryable refusal
+    // while its snapshot is still live, re-vending once per signed request -- only exists once a
+    // provider is registered. It does not reach the first vend, which has no snapshot behind it and
+    // no evidence that re-vending returns the same timestamp, and whose failure the reconciler's
+    // attempt budget does bound. Terminal there would permanently fail a capture job on one stale
+    // or cached response, and on any clock disagreement past the tolerance it would fail every
+    // table at once. The asymmetry decides it: an over-eager terminal is unrecoverable, an
+    // over-eager retry only costs time. Bounding the refresh-path loop belongs in the registry
+    // that swallows the failure, not here.
+    throw retryableVendFailure(detail, null);
   }
 
   /**
@@ -528,8 +906,8 @@ public class SourceCatalogCredentialVendor {
    * is not retargeted, and Iceberg has no property for it at all -- see the enhancement issue.
    */
   private static void noteIgnoredAccessPoint(
-      FloecatConnector.VendedStorageCredentials vended, String namespaceFq, String tableName) {
-    String accessPoint = vended.properties().get("s3.access-point");
+      Map<String, String> properties, String namespaceFq, String tableName) {
+    String accessPoint = properties.get("s3.access-point");
     if (accessPoint == null || accessPoint.isBlank()) {
       return;
     }
@@ -576,7 +954,19 @@ public class SourceCatalogCredentialVendor {
     // bounding an already-bounded string makes the marker describe the intermediate truncation
     // instead of the original -- understating what was dropped, and cutting away the accurate
     // marker to do it.
-    String description = LogSafeText.bounded(raw, MAX_STATUS_DESCRIPTION);
+    // Deliberately not built from raw. Once these refusals carry a keyed template whose body is
+    // the detail parameter, whatever is here becomes the message a client reads -- and raw
+    // interpolates cause.toString(), which is upstream-controlled: a proxy's HTML, an internal host
+    // name, the shape of somebody else's stack. The class name is as much of the throwable as a
+    // caller needs to tell one failure from another; the whole of it stays in the log line below.
+    String description =
+        LogSafeText.bounded(
+            String.format(
+                "source catalog %s failed to vend credentials for %s: %s",
+                connector.getResourceId().getId(),
+                boundedTable(namespaceFq, tableName),
+                cause.getClass().getSimpleName()),
+            MAX_STATUS_DESCRIPTION);
 
     StatusRuntimeException terminal = terminalStatus(cause, description);
     if (terminal != null) {
@@ -625,16 +1015,15 @@ public class SourceCatalogCredentialVendor {
     java.util.Set<Throwable> seen = new java.util.HashSet<>();
     for (Throwable c = cause; c != null && seen.add(c); c = c.getCause()) {
       if (c instanceof org.apache.iceberg.exceptions.NotAuthorizedException) {
-        return io.grpc.Status.UNAUTHENTICATED
-            .withDescription(description)
-            .withCause(cause)
-            .asRuntimeException();
+        return SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+            io.grpc.Status.Code.UNAUTHENTICATED, ErrorCode.MC_UNAUTHENTICATED, description, cause);
       }
       if (c instanceof org.apache.iceberg.exceptions.ForbiddenException) {
-        return io.grpc.Status.PERMISSION_DENIED
-            .withDescription(description)
-            .withCause(cause)
-            .asRuntimeException();
+        return SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+            io.grpc.Status.Code.PERMISSION_DENIED,
+            ErrorCode.MC_PERMISSION_DENIED,
+            description,
+            cause);
       }
       // Format-neutral refusal for connectors that do not speak Iceberg REST (e.g. Unity Catalog
       // over HTTP): they raise a typed SourceCatalogAccessException rather than an Iceberg
@@ -642,15 +1031,17 @@ public class SourceCatalogCredentialVendor {
       if (c instanceof SourceCatalogAccessException access) {
         return switch (access.denial()) {
           case UNAUTHENTICATED ->
-              io.grpc.Status.UNAUTHENTICATED
-                  .withDescription(description)
-                  .withCause(cause)
-                  .asRuntimeException();
+              SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+                  io.grpc.Status.Code.UNAUTHENTICATED,
+                  ErrorCode.MC_UNAUTHENTICATED,
+                  description,
+                  cause);
           case PERMISSION_DENIED ->
-              io.grpc.Status.PERMISSION_DENIED
-                  .withDescription(description)
-                  .withCause(cause)
-                  .asRuntimeException();
+              SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+                  io.grpc.Status.Code.PERMISSION_DENIED,
+                  ErrorCode.MC_PERMISSION_DENIED,
+                  description,
+                  cause);
           // Terminal, but not a denial, so it must not travel as one: PERMISSION_DENIED here would
           // report "you may not read this table" for a catalog that simply cannot vend for it. It
           // goes back as the structured vend-refused reason, which the reconciler matches by reason
@@ -659,6 +1050,227 @@ public class SourceCatalogCredentialVendor {
               ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus
                   .sourceCatalogVendRefused(description);
         };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Classifies a Catalog Integration vending failure.
+   *
+   * <p>Three outcomes, chosen by whether a retry or a fall-back could produce a better answer.
+   * Terminal where neither can: an authorization refusal, a vanished upstream table, a
+   * configuration that is wrong and will stay wrong. Retryable where the next attempt could
+   * succeed: {@code CREDENTIAL_UNAVAILABLE}, the window while an integration's stored secret is
+   * superseded, and an expired credential, which re-vending replaces. The asymmetry is what decides
+   * the boundary -- an over-eager terminal permanently fails a capture job, an over-eager retry
+   * only costs time -- but it is not a licence to demote a whole code: {@code
+   * INVALID_CONFIGURATION} also covers an upstream 400 and an unrecognised auth configuration,
+   * neither of which any number of retries changes.
+   *
+   * <p>Nothing here falls back. Every {@code CatalogAccessException} from the vend reaches this
+   * method, and an Integration has no storage authority to be handed to instead -- see the class
+   * javadoc for why. So {@code UNSUPPORTED} and {@code CREDENTIAL_SCOPE_INVALID} are refusals like
+   * the rest: they describe the Integration rather than this attempt, and no number of retries
+   * changes an auth mode the SPI does not implement or a scope that does not reach the table.
+   */
+  private static StatusRuntimeException catalogIntegrationFailureStatus(
+      RuntimeException cause,
+      CatalogAccessException accessFailure,
+      CatalogIntegration integration,
+      String namespaceFq,
+      String tableName,
+      CredentialUse use) {
+    String safeCause =
+        accessFailure == null
+            ? cause.getClass().getSimpleName()
+            : accessFailure.code() + ": " + accessFailure.getMessage();
+    // Bounded and flattened exactly as catalogFailureStatus does it, and for the same reasons: both
+    // identifiers come off the persisted UpstreamRef with no length or character limit, a newline
+    // in either forges a log entry, and the text leaves the node as the Error detail's parameter
+    // and as the grpc-message rendered from it. safeCause is already a summary rather than the raw
+    // throwable, so the split here is narrower than the sibling's -- but the long form still
+    // belongs in the log rather than in a trailer.
+    String raw =
+        String.format(
+            "source Catalog Integration %s could not vend credentials for %s: %s",
+            integration.getResourceId().getId(), boundedTable(namespaceFq, tableName), safeCause);
+    String detail = LogSafeText.bounded(raw, MAX_LOGGED_DETAIL_CHARS);
+    // From raw rather than from detail, so the elision marker describes what was actually dropped
+    // instead of an intermediate truncation.
+    String description = LogSafeText.bounded(raw, MAX_STATUS_DESCRIPTION);
+
+    StatusRuntimeException status = integrationStatus(accessFailure, cause, description);
+    // Same split as the connector path, on both axes. A terminal refusal is worth a stack trace. A
+    // retryable one is not on the reconcile path -- vending runs per file group, so a catalog
+    // outage would write one per group per attempt, all describing the same outage, and the
+    // reconciler reports the classified failure anyway. A query vend has neither property: it runs
+    // once per scan session and nothing else reports it, so at debug a transient outage would
+    // leave the caller a bare INTERNAL and the server log empty.
+    //
+    // An INTERNAL carries a third reason, and it is the log or nothing. It is the one answer here
+    // with no floecat Error detail, so BaseServiceImpl rebuilds it -- containsFloecatError is false
+    // -- and GrpcErrors.shouldHideMessage hides every code it does not list, INTERNAL among them,
+    // replacing this description with "Internal error. correlation_id=...". Attaching a detail to
+    // keep the text would be arguing with that rule rather than applying it: the message is hidden
+    // on purpose, and the correlation id is what joins it to the server side. So the server side
+    // has to hold the cause. It also does not flood the way a retryable answer does -- the SPI
+    // raises INTERNAL for a provider that broke its own contract, and an unclassified one is an
+    // exception IcebergRestCatalogErrors.translate did not recognise, neither of which is the
+    // repeating per-group outage the debug branch exists for.
+    if (warrantsWarn(status, use)) {
+      LOG.warnf(cause, "%s", detail);
+    } else {
+      LOG.debugf(cause, "%s", detail);
+    }
+    return status;
+  }
+
+  /**
+   * Whether this vending failure is worth a stack trace, or belongs at debug.
+   *
+   * <p>Package-visible so the matrix is asserted directly rather than by capturing log output. See
+   * the call site for why each arm is where it is.
+   */
+  static boolean warrantsWarn(StatusRuntimeException status, CredentialUse use) {
+    return SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(status)
+        || use == CredentialUse.QUERY
+        || status.getStatus().getCode() == io.grpc.Status.Code.INTERNAL;
+  }
+
+  private static StatusRuntimeException integrationStatus(
+      CatalogAccessException accessFailure, RuntimeException cause, String detail) {
+    if (accessFailure == null) {
+      return io.grpc.Status.INTERNAL.withDescription(detail).withCause(cause).asRuntimeException();
+    }
+    return switch (accessFailure.code()) {
+      case UNAUTHENTICATED ->
+          SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+              io.grpc.Status.Code.UNAUTHENTICATED, ErrorCode.MC_UNAUTHENTICATED, detail, cause);
+      case PERMISSION_DENIED ->
+          SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+              io.grpc.Status.Code.PERMISSION_DENIED, ErrorCode.MC_PERMISSION_DENIED, detail, cause);
+      case NOT_FOUND, INVALID_CONFIGURATION ->
+          SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(detail);
+      // Deterministic descriptions of the Integration, not of this attempt: an auth mode the SPI
+      // does not implement, or a provider reporting that what it holds does not cover the table.
+      case UNSUPPORTED, CREDENTIAL_SCOPE_INVALID ->
+          SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(detail);
+      case CREDENTIAL_UNAVAILABLE, CREDENTIAL_EXPIRED -> retryableVendFailure(detail, cause);
+      // The upstream stalled or fell over: a 503, a RESTException, a socket timeout, this path's
+      // own
+      // budget deadline. Exactly what the retryable reason exists to name, and saying it as a bare
+      // INTERNAL costs the caller the description too -- GrpcErrors hides an INTERNAL message, so
+      // the integration and table named in the detail never reach whoever has to act on it.
+      case UNAVAILABLE, TIMEOUT -> retryableVendFailure(detail, cause);
+      // Not the upstream's fault and not a retry's business: the SPI raises this when a provider
+      // broke its own contract.
+      case INTERNAL ->
+          io.grpc.Status.INTERNAL.withDescription(detail).withCause(cause).asRuntimeException();
+    };
+  }
+
+  /**
+   * A vending failure a later attempt could clear.
+   *
+   * <p>Structured, for the same reason the refusals are: the reconciler classifies only the refusal
+   * reasons terminally, so this keeps the retry behaviour, and {@code UNAVAILABLE} alone cannot be
+   * told apart from floecat's own storage service being unreachable.
+   */
+  private static StatusRuntimeException retryableVendFailure(String detail, Throwable cause) {
+    return SourceCatalogVendingGrpcStatus.sourceCatalogVendUnavailable(detail, cause);
+  }
+
+  /**
+   * Closes a catalog client without letting the close itself become the caller's answer.
+   *
+   * <p>Used on both the abandoned client a timed-out open hands back and the ordinary close, which
+   * try-with-resources would otherwise let escape: a provider whose close hook throws -- an HTTP
+   * pool already shut down, an interrupted keep-alive -- would turn credentials already in hand
+   * into an INTERNAL failure and discard them.
+   */
+  private static void closeQuietly(CatalogClient client) {
+    if (client == null) {
+      return;
+    }
+    try {
+      client.close();
+    } catch (RuntimeException e) {
+      LOG.debugf(e, "closing a catalog client failed");
+    }
+  }
+
+  /**
+   * Closes the client the vend opened, waiting only so long.
+   *
+   * <p>{@link #closeQuietly} bounds exceptions, not time, and it used to run on the request thread
+   * outside the budget that bounds open, capabilities and the vend -- so a provider whose teardown
+   * blocked would hold a gRPC handler or a scan-planning thread past the deadline the budget exists
+   * to impose, and nothing in the {@code CatalogClient} contract says close returns promptly.
+   *
+   * <p>Bounded rather than handed off. Firing it at a virtual thread and not waiting removes the
+   * hold, but nothing then guarantees the client is released before the vend returns, so a burst
+   * holds more of them open than it used to and the release is unobservable. A fresh budget keeps
+   * the ordinary case inline and deterministic while capping the wait; when it lapses the close
+   * carries on where it is and this stops watching.
+   *
+   * <p>A fresh budget, not the vend's: that one may already be spent, and {@code remainingNanos}
+   * refuses to start work on an exhausted budget -- which would leak the client rather than close
+   * it late.
+   */
+  private void closeWithinBudget(CatalogClient client) {
+    if (client == null) {
+      return;
+    }
+    try {
+      CatalogUpstreamBudget.start(CLOSE_TIMEOUT, nanoTime)
+          .call(
+              () -> {
+                client.close();
+                return null;
+              },
+              ignored -> {});
+    } catch (RuntimeException e) {
+      LOG.debugf(e, "closing a catalog client failed or outlasted its budget");
+    }
+  }
+
+  /**
+   * A Catalog Integration that cannot vend for this read.
+   *
+   * <p>Terminal, and deliberately not a {@code null} fall-back. A storage authority is not a second
+   * way for an Integration-backed table to reach its data -- it is the split-brain arrangement this
+   * feature replaces, where floecat authenticates to the catalog and something else supplies the
+   * storage credential. The Integration model has no way to express the alternative: there is no
+   * authority field on the record, and {@code ValidateCatalogIntegration} reports an Integration
+   * whose provider cannot vend as invalid rather than as configured differently.
+   *
+   * <p>So falling back here was never recovery. This vend is reached only once no authority covers
+   * the location, and {@code StorageAuthorityResolver.buildResponse} raises no-matching-authority
+   * for a null one -- the only consumer that absorbs that error gates on a {@code ConnectorConfig},
+   * which an Integration does not have. Returning null therefore replaced a specific cause with
+   * "you configured no storage authority", which is neither true nor actionable.
+   */
+  private static StatusRuntimeException integrationCannotVend(String detail) {
+    String message =
+        LogSafeText.bounded("source-catalog vending refused: " + detail, MAX_STATUS_DESCRIPTION);
+    // Warned, not thrown silently, by the same rule catalogIntegrationFailureStatus applies: a
+    // refusal warns, a retryable answer does not. Every status this helper builds is a refusal, so
+    // the rule always says warn here. It does not flood for the reason it does not there -- a
+    // refusal is terminal, so the reconcile job ends rather than repeating the line per file group
+    // -- and on the query path the caller sees a scan failure and the server log otherwise sees
+    // nothing at all, which is the case these conditions are most likely to be read from.
+    LOG.warnf("%s", message);
+    return SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(message);
+  }
+
+  private static CatalogAccessException findCatalogAccessFailure(Throwable cause) {
+    java.util.Set<Throwable> seen = new java.util.HashSet<>();
+    for (Throwable current = cause;
+        current != null && seen.add(current);
+        current = current.getCause()) {
+      if (current instanceof CatalogAccessException failure) {
+        return failure;
       }
     }
     return null;

--- a/service/src/main/resources/errors_en.properties
+++ b/service/src/main/resources/errors_en.properties
@@ -182,3 +182,12 @@ MC_INVALID_ARGUMENT.system.scan.not.system.table=This scan only works for system
 MC_INVALID_ARGUMENT.system.table.id.required=System table id is required.
 MC_CONFLICT.snapshot.already.exists=Snapshot already exists for id "{snapshot_id}".
 MC_INVALID_ARGUMENT.snapshot.schema.json.required=Snapshot schema JSON is required.
+
+# Source-catalog credential vending. The body is the diagnostic the vend already composed and
+# bounded; without a keyed template these reach a caller as the bare code's message and name nothing.
+MC_INVALID_ARGUMENT.source.catalog.no.matching.storage.authority={detail}
+MC_PRECONDITION_FAILED.source.catalog.vended.credentials.not.refreshable={detail}
+MC_PRECONDITION_FAILED.source.catalog.vend.refused={detail}
+MC_UNAUTHENTICATED.source.catalog.vend.refused.unauthenticated={detail}
+MC_PERMISSION_DENIED.source.catalog.vend.refused.forbidden={detail}
+MC_UNAVAILABLE.source.catalog.vend.unavailable={detail}

--- a/service/src/test/java/ai/floedb/floecat/service/error/impl/MessageCatalogTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/error/impl/MessageCatalogTest.java
@@ -16,16 +16,89 @@
 
 package ai.floedb.floecat.service.error.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import ai.floedb.floecat.common.rpc.ErrorCode;
+import ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import org.junit.jupiter.api.Test;
 
 class MessageCatalogTest {
+  @Test
+  void aVendingDiagnosticSurvivesRendering() {
+    // The gap that let two interceptor surprises through: every assertion on these statuses was
+    // made on the pre-interceptor exception, and LocalizeErrorsInterceptor rewrites the message
+    // with MessageCatalog.render, which never reads Error.message. Rendered here through the real
+    // catalog, so a keyed template going missing fails a test rather than reaching an operator as
+    // "Precondition failed."
+    String diagnostic =
+        "source-catalog vending refused: Catalog Integration integration-1 does not support"
+            + " storage credential vending";
+    var refusal = SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(diagnostic);
+    var detail = errorDetailOf(refusal);
+
+    assertEquals(diagnostic, new MessageCatalog(Locale.ENGLISH).render(detail));
+  }
+
+  @Test
+  void everyVendingReasonRendersItsDiagnosticRatherThanTheBareCode() {
+    record Case(String name, io.grpc.StatusRuntimeException error) {}
+    for (var c :
+        java.util.List.of(
+            new Case(
+                "refused",
+                SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused("refused-detail")),
+            new Case(
+                "unauthenticated",
+                SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+                    io.grpc.Status.Code.UNAUTHENTICATED,
+                    ErrorCode.MC_UNAUTHENTICATED,
+                    "unauthenticated-detail",
+                    null)),
+            new Case(
+                "forbidden",
+                SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused(
+                    io.grpc.Status.Code.PERMISSION_DENIED,
+                    ErrorCode.MC_PERMISSION_DENIED,
+                    "forbidden-detail",
+                    null)),
+            new Case(
+                "unavailable",
+                SourceCatalogVendingGrpcStatus.sourceCatalogVendUnavailable(
+                    "unavailable-detail", null)),
+            new Case(
+                "not-refreshable",
+                SourceCatalogVendingGrpcStatus.vendedCredentialsNotRefreshable(
+                    "not-refreshable-detail")),
+            new Case(
+                "no-authority",
+                SourceCatalogVendingGrpcStatus.noMatchingStorageAuthority(
+                    "no-authority-detail")))) {
+      String rendered = new MessageCatalog(Locale.ENGLISH).render(errorDetailOf(c.error()));
+
+      assertTrue(rendered.endsWith("-detail"), c.name() + " rendered as: " + rendered);
+    }
+  }
+
+  private static ai.floedb.floecat.common.rpc.Error errorDetailOf(
+      io.grpc.StatusRuntimeException error) {
+    var status = io.grpc.protobuf.StatusProto.fromThrowable(error);
+    for (var any : status.getDetailsList()) {
+      if (any.is(ai.floedb.floecat.common.rpc.Error.class)) {
+        try {
+          return any.unpack(ai.floedb.floecat.common.rpc.Error.class);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw new AssertionError(e);
+        }
+      }
+    }
+    throw new AssertionError("no floecat Error detail on " + error.getStatus());
+  }
+
   @Test
   void everyMessageKeyExistsInBundle() {
     final ResourceBundle bundle;

--- a/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccessTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/integration/CatalogIntegrationAccessTest.java
@@ -8,7 +8,9 @@
 package ai.floedb.floecat.service.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -145,6 +147,68 @@ class CatalogIntegrationAccessTest {
             CatalogAccessException.class, () -> access.resolve(integration(authentication)));
 
     assertEquals(CatalogAccessException.Code.UNSUPPORTED, error.code());
+  }
+
+  @Test
+  void aRecordedGenerationThatIsMomentarilyUnreadableIsRetryable() {
+    // The window CatalogIntegrationCredentialCleanup opens while a secret generation is superseded.
+    // It closes on the next attempt, so a caller that gives up here permanently fails work that
+    // would have succeeded.
+    var authentication =
+        CatalogAuthentication.newBuilder()
+            .setBearer(BearerAuthentication.getDefaultInstance())
+            .setCredentialsConfigured(true)
+            .setCredentialGeneration(1L)
+            .build();
+    CatalogIntegration integration = integration(authentication);
+    when(credentials.resolve(integration)).thenReturn(java.util.Optional.empty());
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> access.open(integration));
+
+    assertEquals(CatalogAccessException.Code.CREDENTIAL_UNAVAILABLE, error.code());
+  }
+
+  @Test
+  void permanentCredentialLossKeepsReportingWhileASupersedeWindowGoesQuiet() {
+    // The distinction the WARN exists to make. Reporting a pair once gave both conditions the same
+    // shape -- one line, then DEBUG forever, which production does not enable -- so an operator
+    // could not tell a superseded generation from a secret that is gone. What separates them is
+    // that loss keeps failing at one generation while a supersede window moves to the next.
+    java.time.Instant t0 = java.time.Instant.parse("2026-09-04T12:00:00Z");
+
+    assertTrue(access.shouldReportCredentialGap("integration-1@7", t0));
+    // The flood this damps: a vend per file group, all inside the interval.
+    assertFalse(access.shouldReportCredentialGap("integration-1@7", t0.plusSeconds(1)));
+    assertFalse(access.shouldReportCredentialGap("integration-1@7", t0.plusSeconds(119)));
+
+    // Still the same generation after the interval, which is what permanent loss looks like.
+    assertTrue(access.shouldReportCredentialGap("integration-1@7", t0.plusSeconds(120)));
+    assertFalse(access.shouldReportCredentialGap("integration-1@7", t0.plusSeconds(121)));
+
+    // A supersede window instead moves the generation on, so it reports once and stops rather than
+    // repeating at the interval.
+    assertTrue(access.shouldReportCredentialGap("integration-1@8", t0.plusSeconds(121)));
+  }
+
+  @Test
+  void credentialsThatWereNeverConfiguredAreNotRetryable() {
+    // Same empty Optional, opposite answer, and the record is what separates them: this one says
+    // no credentials were ever attached, so nothing is coming. Reporting "come back" makes a
+    // reconcile job spend its whole budget and report exhaustion instead of the cause, and tells
+    // an operator validating the integration that it is temporarily unavailable, indefinitely.
+    var authentication =
+        CatalogAuthentication.newBuilder()
+            .setBearer(BearerAuthentication.getDefaultInstance())
+            .setCredentialsConfigured(false)
+            .build();
+    CatalogIntegration integration = integration(authentication);
+    when(credentials.resolve(integration)).thenReturn(java.util.Optional.empty());
+
+    CatalogAccessException error =
+        assertThrows(CatalogAccessException.class, () -> access.open(integration));
+
+    assertEquals(CatalogAccessException.Code.INVALID_CONFIGURATION, error.code());
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/security/RolePermissionsTest.java
@@ -31,6 +31,7 @@ class RolePermissionsTest {
           "table.read",
           "view.read",
           RolePermissions.CATALOG_INTEGRATION_READ,
+          RolePermissions.CATALOG_INTEGRATION_USE,
           RolePermissions.CATALOG_OVERLAY_READ);
   private static final List<String> FULL_PERMS =
       List.of(
@@ -95,6 +96,25 @@ class RolePermissionsTest {
     var permissions = RolePermissions.permissionsForRoles(List.of("default"), false);
 
     assertThat(permissions).containsExactlyInAnyOrderElementsOf(READ_PERMS);
+  }
+
+  @Test
+  void anOrdinaryReaderCanVendFromTheIntegrationBehindATable() {
+    // Reading a table an overlay materialized from an Iceberg REST Integration reaches
+    // SourceCatalogCredentialVendor, which requires this permission: no storage authority covers
+    // such a table, so the scan asks the upstream catalog to vend one. Without it every role but
+    // administrator gets PERMISSION_DENIED on exactly the read-back path the Integration exists to
+    // provide.
+    var permissions = RolePermissions.permissionsForRoles(List.of("default"), false);
+
+    assertThat(permissions).contains(RolePermissions.CATALOG_INTEGRATION_USE);
+  }
+
+  @Test
+  void anUnrecognizedRoleAlsoGetsTheVendPermission() {
+    var permissions = RolePermissions.permissionsForRoles(List.of("data-analyst"), false);
+
+    assertThat(permissions).contains(RolePermissions.CATALOG_INTEGRATION_USE);
   }
 
   @Test

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendorTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/SourceCatalogCredentialVendorTest.java
@@ -18,9 +18,27 @@ package ai.floedb.floecat.service.storage.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.access.CatalogAccessException;
+import ai.floedb.floecat.catalog.access.CatalogCapabilities;
+import ai.floedb.floecat.catalog.access.CatalogCapability;
+import ai.floedb.floecat.catalog.access.CatalogClient;
+import ai.floedb.floecat.catalog.access.CatalogObjectName;
+import ai.floedb.floecat.catalog.access.NamespacePath;
+import ai.floedb.floecat.catalog.access.VendedStorageCredentials;
 import ai.floedb.floecat.catalog.rpc.Table;
 import ai.floedb.floecat.catalog.rpc.UpstreamRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -31,20 +49,819 @@ import ai.floedb.floecat.connector.rpc.ConnectorState;
 import ai.floedb.floecat.connector.spi.DatabricksAccessDelegation;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
 import ai.floedb.floecat.connector.spi.SourceCatalogAccessException;
+import ai.floedb.floecat.integration.rpc.CatalogIntegration;
+import ai.floedb.floecat.integration.rpc.CatalogIntegrationType;
+import ai.floedb.floecat.service.integration.CatalogIntegrationAccess;
+import ai.floedb.floecat.service.repo.impl.CatalogIntegrationRepository;
 import ai.floedb.floecat.service.repo.impl.ConnectorRepository;
 import ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SourceCatalogCredentialVendorTest {
 
   private static final Connector CONNECTOR =
       Connector.newBuilder().setResourceId(ResourceId.newBuilder().setId("c1")).build();
+  private static final ResourceId INTEGRATION_ID =
+      ResourceId.newBuilder()
+          .setAccountId("acct")
+          .setKind(ResourceKind.RK_CATALOG_INTEGRATION)
+          .setId("integration-1")
+          .build();
+  private static final Instant EXPIRY = Instant.parse("2026-09-01T15:00:00Z");
+
+  private SourceCatalogCredentialVendor vendor;
+  private CatalogIntegrationRepository integrations;
+  private CatalogIntegrationAccess access;
+  private CatalogClient client;
+  private CatalogIntegration integration;
+
+  @BeforeEach
+  void setUp() {
+    vendor = new SourceCatalogCredentialVendor();
+    integrations = mock(CatalogIntegrationRepository.class);
+    access = mock(CatalogIntegrationAccess.class);
+    client = mock(CatalogClient.class);
+    integration =
+        CatalogIntegration.newBuilder()
+            .setResourceId(INTEGRATION_ID)
+            .setDisplayName("warehouse")
+            .setType(CatalogIntegrationType.CIT_ICEBERG_REST)
+            .setCatalogUri("https://glue.us-east-1.amazonaws.com/iceberg")
+            .putProperties("s3.region", "us-west-2")
+            .build();
+
+    // Opening an integration requires catalog-integration.use; a real Authorizer over a principal
+    // that carries it keeps these tests exercising the same admission the service does.
+    vendor.principal = mock(ai.floedb.floecat.service.security.impl.PrincipalProvider.class);
+    when(vendor.principal.get())
+        .thenReturn(
+            ai.floedb.floecat.common.rpc.PrincipalContext.newBuilder()
+                .setAccountId("acct")
+                .setCorrelationId("corr")
+                .addPermissions(
+                    ai.floedb.floecat.service.security.RolePermissions.CATALOG_INTEGRATION_USE)
+                .build());
+    vendor.authz = new ai.floedb.floecat.service.security.impl.Authorizer();
+    vendor.catalogIntegrationRepo = integrations;
+    vendor.catalogIntegrationAccess = access;
+    vendor.connectorRepo = mock(ConnectorRepository.class);
+    vendor.defaultRegion = "us-east-1";
+    vendor.upstreamTimeout = Duration.ofSeconds(30);
+    vendor.clock = Clock.fixed(Instant.parse("2026-09-01T14:00:00Z"), ZoneOffset.UTC);
+    when(integrations.getById(INTEGRATION_ID)).thenReturn(Optional.of(integration));
+    when(access.open(integration)).thenReturn(client);
+  }
+
+  @Test
+  void vendsForAnIcebergCatalogIntegrationOrigin() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(new CatalogObjectName(NamespacePath.of("sales"), "orders")))
+        .thenReturn(
+            Optional.of(
+                new VendedStorageCredentials(
+                    Map.of(
+                        "s3.access-key-id", "ASIA-VENDED",
+                        "s3.secret-access-key", "secret-vended",
+                        "s3.session-token", "session-vended"),
+                    "s3://warehouse/orders",
+                    Optional.of(EXPIRY))));
+
+    var response =
+        vendor.vendForTable(
+            integrationTable(),
+            "s3://warehouse/orders/metadata/v1.metadata.json",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertEquals(1, response.getStorageCredentialsCount());
+    var credential = response.getStorageCredentials(0);
+    // The already-authorized requested location, never the catalog's broader table prefix:
+    // widening it here would widen the caller's grant from one object to the whole table.
+    assertEquals("s3://warehouse/orders/metadata/v1.metadata.json", credential.getPrefix());
+    assertEquals("ASIA-VENDED", credential.getConfigMap().get("s3.access-key-id"));
+    assertEquals("secret-vended", credential.getConfigMap().get("s3.secret-access-key"));
+    assertEquals("session-vended", credential.getConfigMap().get("s3.session-token"));
+    assertTrue(credential.hasExpiresAt());
+    assertEquals("us-west-2", response.getClientSafeConfigMap().get("s3.region"));
+    assertFalse(response.getClientSafeConfigMap().containsKey("s3.secret-access-key"));
+    verify(client).close();
+  }
+
+  @Test
+  void refusesWhenTheCatalogProviderDoesNotVend() {
+    // Not a fall-back. A storage authority is not a second way for an Integration-backed table to
+    // reach its data -- it is the split-brain this feature replaces -- and the Integration model
+    // has no way to express one anyway. Naming the cause beats relabelling it as a missing
+    // authority the operator was never asked to configure.
+    when(client.capabilities()).thenReturn(CatalogCapabilities.of(CatalogCapability.LOAD_TABLE));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.QUERY));
+
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(failure));
+    assertTrue(
+        failure.getStatus().getDescription().contains("vending"),
+        failure.getStatus().getDescription());
+    verify(client, never()).vendStorageCredentials(any());
+    verify(client).close();
+  }
+
+  @Test
+  void aMissingIntegrationIsRefusedRatherThanBlamedOnTheCaller() {
+    // The permission gates opening the integration. A record that is not there was never going to
+    // be opened, so answering PERMISSION_DENIED would blame the caller for the configuration. The
+    // refusal names the record instead.
+    when(vendor.principal.get())
+        .thenReturn(
+            ai.floedb.floecat.common.rpc.PrincipalContext.newBuilder()
+                .setAccountId("acct")
+                .setCorrelationId("corr")
+                .addPermissions("table.read")
+                .build());
+    when(integrations.getById(INTEGRATION_ID)).thenReturn(Optional.empty());
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.QUERY));
+
+    assertEquals(io.grpc.Status.Code.FAILED_PRECONDITION, failure.getStatus().getCode());
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(failure));
+  }
+
+  @Test
+  void openingAnIntegrationStillRequiresTheVendPermission() {
+    when(vendor.principal.get())
+        .thenReturn(
+            ai.floedb.floecat.common.rpc.PrincipalContext.newBuilder()
+                .setAccountId("acct")
+                .setCorrelationId("corr")
+                .addPermissions("table.read")
+                .build());
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.QUERY));
+
+    assertEquals(io.grpc.Status.Code.PERMISSION_DENIED, failure.getStatus().getCode());
+    verify(access, never()).open(any());
+  }
+
+  @Test
+  void scopesTheIntegrationLookupToTheTableAccount() {
+    ResourceId foreignIntegrationId = INTEGRATION_ID.toBuilder().setAccountId("foreign").build();
+    when(client.capabilities()).thenReturn(CatalogCapabilities.of(CatalogCapability.LOAD_TABLE));
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            vendor.vendForTable(
+                integrationTable(foreignIntegrationId),
+                "s3://warehouse/orders",
+                SourceCatalogCredentialVendor.CredentialUse.QUERY));
+
+    verify(integrations).getById(INTEGRATION_ID);
+    verify(integrations, never()).getById(foreignIntegrationId);
+  }
+
+  @Test
+  void mapsTypedCatalogAuthorizationFailures() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.PERMISSION_DENIED, "Catalog access denied"));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.QUERY));
+
+    assertEquals(io.grpc.Status.Code.PERMISSION_DENIED, failure.getStatus().getCode());
+    assertTrue(failure.getStatus().getDescription().contains("integration-1"));
+    // The code alone cannot be told apart from floecat's own auth failing; the reason names the
+    // source catalog as the refuser.
+    assertTrue(
+        ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(
+            failure));
+    verify(client).close();
+  }
+
+  @Test
+  void mapsDeterministicCatalogFailuresToATerminalVendingReason() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.NOT_FOUND, "Upstream table does not exist"));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE));
+
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(failure));
+  }
+
+  @Test
+  void aProviderThatHoldsNothingForTheTableIsRefused() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.CREDENTIAL_SCOPE_INVALID,
+                "Vended storage credentials do not cover the upstream table location"));
+
+    // Not the disjoint-scope case responsePrefix handles: this is the provider reporting that what
+    // it holds does not cover the table at all, so there is no scope to narrow and no credential to
+    // stamp. Deterministic, and there is no authority to fall back to for an Integration, so it is
+    // refused with the reason rather than relabelled as a missing authority.
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE));
+
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(failure));
+  }
+
+  @Test
+  void aWrongConfigurationIsTerminalRatherThanRetriedForever() {
+    when(access.open(integration))
+        .thenThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.INVALID_CONFIGURATION,
+                "Catalog Integration authentication is not recognized"));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE));
+
+    // An unrecognised auth configuration, an upstream 400 and a malformed catalog URI all arrive as
+    // this code, and no number of retries changes any of them.
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(failure));
+  }
+
+  /**
+   * A just-expired expiry is a race, not an answer: transit time between the catalog issuing the
+   * credential and us reading it, or floecat's clock sitting seconds from the catalog's. The next
+   * vend mints a new one, so it must not carry a terminal reason -- the reconciler would stop
+   * retrying a job that self-heals on the first credential refresh.
+   */
+  @Test
+  void aJustExpiredVendStaysRetryableForReconcile() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(Optional.of(vendedAt(Instant.parse("2026-09-01T13:59:59Z"))));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE));
+
+    // Structured, so it is not mistaken for floecat's own storage service being unreachable.
+    assertEquals(io.grpc.Status.Code.UNAVAILABLE, failure.getStatus().getCode());
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendUnavailable(failure));
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(failure));
+    assertFalse(SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(failure));
+  }
+
+  /**
+   * A blank upstream display name on the Integration path names its cause instead of returning
+   * null. Null means "no source-catalog answer here", which sends the caller to a storage authority
+   * -- and an Integration is configured without one, so the operator would read a missing-authority
+   * error for a table whose record is simply incomplete. Reachable: validateUpstreamRef never
+   * requires the field, and records written before it was populated carry it empty.
+   */
+  @Test
+  void anUnclassifiedVendFailureWarnsRatherThanVanishingAtDebug() {
+    // INTERNAL is the one answer here that carries no floecat Error detail, so BaseServiceImpl
+    // rebuilds it and GrpcErrors.shouldHideMessage replaces the description with the bare
+    // correlation id. If it also logged at debug on the reconcile path, a provider that broke its
+    // contract -- or any exception IcebergRestCatalogErrors.translate returned unwrapped -- would
+    // fail the job with nothing anywhere to say why.
+    record Case(
+        String name,
+        StatusRuntimeException status,
+        SourceCatalogCredentialVendor.CredentialUse use,
+        boolean warns) {}
+    StatusRuntimeException refusal = SourceCatalogVendingGrpcStatus.sourceCatalogVendRefused("no");
+    StatusRuntimeException retryable =
+        SourceCatalogVendingGrpcStatus.sourceCatalogVendUnavailable("later", null);
+    StatusRuntimeException internal =
+        io.grpc.Status.INTERNAL.withDescription("broke its contract").asRuntimeException();
+
+    for (var c :
+        java.util.List.of(
+            new Case(
+                "a refusal on reconcile",
+                refusal,
+                SourceCatalogCredentialVendor.CredentialUse.RECONCILE,
+                true),
+            new Case(
+                "a refusal on query",
+                refusal,
+                SourceCatalogCredentialVendor.CredentialUse.QUERY,
+                true),
+            // The flood this exists to damp: one per file group per attempt, all the same outage,
+            // and the reconciler reports the classified failure anyway.
+            new Case(
+                "a retryable outage on reconcile",
+                retryable,
+                SourceCatalogCredentialVendor.CredentialUse.RECONCILE,
+                false),
+            new Case(
+                "a retryable outage on query",
+                retryable,
+                SourceCatalogCredentialVendor.CredentialUse.QUERY,
+                true),
+            new Case(
+                "an unclassified failure on reconcile",
+                internal,
+                SourceCatalogCredentialVendor.CredentialUse.RECONCILE,
+                true),
+            new Case(
+                "an unclassified failure on query",
+                internal,
+                SourceCatalogCredentialVendor.CredentialUse.QUERY,
+                true))) {
+      assertEquals(
+          c.warns(), SourceCatalogCredentialVendor.warrantsWarn(c.status(), c.use()), c.name());
+    }
+  }
+
+  @Test
+  void aBlankUpstreamNameOnTheIntegrationPathIsRefusedRatherThanSkipped() {
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTableNamed("  "),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE));
+
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(failure));
+    assertThat(failure.getStatus().getDescription()).contains("no upstream table reference");
+    // Refused before any upstream call, so no client is opened for a request that cannot be built.
+    verifyNoInteractions(client);
+  }
+
+  /**
+   * Far enough in the past and it is no longer a race but an answer, and the same answer every
+   * time. RefreshingAwsCredentialsProviderRegistry reads a past expiry as "refresh now" on every
+   * resolveCredentials call, so a catalog that keeps reporting it has the job re-vend once per
+   * resolution and still hand S3 credentials it refuses. Retryable even so, because that loop needs
+   * a registered provider to exist: the first vend has no snapshot behind it, and its failure is
+   * bounded by the reconciler's attempt budget. Terminal here would permanently fail the job on one
+   * stale response, and the next vend may well mint a live credential.
+   */
+  @Test
+  void aStaleVendExpiryIsRetryableForReconcile() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(Optional.of(vendedAt(Instant.parse("2026-09-01T13:00:00Z"))));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE));
+
+    assertEquals(io.grpc.Status.Code.UNAVAILABLE, failure.getStatus().getCode());
+    assertFalse(SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(failure));
+    assertThat(failure.getStatus().getDescription()).contains("s3.session-token-expires-at-ms");
+  }
+
+  /**
+   * Inside the tolerance the query path reads the credential rather than refusing it. It registers
+   * no refresh provider, the tuple is almost certainly live, and a second of clock disagreement is
+   * not a reason to fail a scan that would have worked.
+   */
+  @Test
+  void theQueryPathReadsAJustExpiredVend() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(Optional.of(vendedAt(Instant.parse("2026-09-01T13:59:59Z"))));
+
+    var response =
+        vendor.vendForTable(
+            integrationTable(),
+            "s3://warehouse/orders",
+            SourceCatalogCredentialVendor.CredentialUse.QUERY);
+
+    assertEquals(1, response.getStorageCredentialsCount());
+    assertEquals(
+        "ASIA-VENDED", response.getStorageCredentials(0).getConfigMap().get("s3.access-key-id"));
+  }
+
+  /**
+   * Past the tolerance the query path fails here rather than at S3. There is no fall-back to
+   * preserve -- ServerSideFileIoPropertiesResolver consults the vendor only once no storage
+   * authority covers the location, so its null branch raises the no-matching-authority error
+   * instead of producing credentials -- and handing the scan engine a credential known to be dead
+   * only turns a diagnosable failure into an opaque 403 partway through a file group.
+   */
+  @Test
+  void theQueryPathRefusesAStaleVendRatherThanFailingAtS3() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(Optional.of(vendedAt(Instant.parse("2026-09-01T13:00:00Z"))));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.QUERY));
+
+    // Retryable, not terminal: nothing retries on this path, and the caller is being told the
+    // catalog's answer was stale rather than that its table is unreadable.
+    assertEquals(io.grpc.Status.Code.UNAVAILABLE, failure.getStatus().getCode());
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendUnavailable(failure));
+    assertFalse(SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(failure));
+    assertThat(failure.getStatus().getDescription()).contains("s3.session-token-expires-at-ms");
+  }
+
+  /** A complete session tuple scoped to the requested location, expiring when the caller says. */
+  private static VendedStorageCredentials vendedAt(Instant expiresAt) {
+    return new VendedStorageCredentials(
+        Map.of(
+            "s3.access-key-id", "ASIA-VENDED",
+            "s3.secret-access-key", "secret-vended",
+            "s3.session-token", "session-vended"),
+        "s3://warehouse/orders",
+        Optional.of(expiresAt));
+  }
+
+  @Test
+  void retriesRatherThanRefusingWhileIntegrationCredentialsAreUnresolvable() {
+    when(access.open(integration))
+        .thenThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.CREDENTIAL_UNAVAILABLE,
+                "Catalog Integration credentials are not currently resolvable"));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE));
+
+    // The window while a stored secret is superseded looks exactly like this, and it closes on its
+    // own -- a terminal refusal here permanently fails every job on the integration.
+    assertEquals(io.grpc.Status.Code.UNAVAILABLE, failure.getStatus().getCode());
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendUnavailable(failure));
+    assertFalse(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(failure));
+  }
+
+  @Test
+  void aFailingClientCloseDoesNotDiscardCredentialsAlreadyVended() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(
+            Optional.of(
+                new VendedStorageCredentials(
+                    Map.of(
+                        "s3.access-key-id", "ASIA-VENDED",
+                        "s3.secret-access-key", "secret-vended",
+                        "s3.session-token", "session-vended"),
+                    "s3://warehouse/orders",
+                    Optional.of(EXPIRY))));
+    // An HTTP pool already shut down, an interrupted keep-alive. The credentials are in hand by
+    // then, so letting the close decide the answer throws away work that succeeded.
+    doThrow(new IllegalStateException("connection pool already closed")).when(client).close();
+
+    var response =
+        vendor.vendForTable(
+            integrationTable(),
+            "s3://warehouse/orders/metadata/v1.metadata.json",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertEquals(1, response.getStorageCredentialsCount());
+    assertEquals(
+        "ASIA-VENDED", response.getStorageCredentials(0).getConfigMap().get("s3.access-key-id"));
+  }
+
+  @Test
+  void refusesWhenTheIntegrationAuthModeCannotVend() {
+    when(access.open(integration))
+        .thenThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.UNSUPPORTED,
+                "Ambient and assumed AWS Catalog Integration credentials are not supported"));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.QUERY));
+
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendRefused(failure));
+  }
+
+  @Test
+  void aDisjointVendedScopeStampsTheAuthorizedPrefixRatherThanRefusing() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(
+            Optional.of(
+                new VendedStorageCredentials(
+                    Map.of(
+                        "s3.access-key-id", "ASIA-VENDED",
+                        "s3.secret-access-key", "secret-vended",
+                        "s3.session-token", "session-vended"),
+                    "s3://warehouse/orders",
+                    Optional.of(EXPIRY))));
+
+    // The scope and the requested location have no intersection. Refusing would guarantee failure:
+    // this path is reached only once no storage authority matched, so there is nothing to fall back
+    // to. The requested prefix is the only bound the caller was authorized for, so it travels, the
+    // read is attempted, and S3 -- which knows the real grant -- decides. Same policy as the
+    // connector path, which is now the same code.
+    var response =
+        vendor.vendForTable(
+            integrationTable(),
+            "s3://external-data/orders/part-0.parquet",
+            SourceCatalogCredentialVendor.CredentialUse.QUERY);
+
+    assertEquals(
+        "s3://external-data/orders/part-0.parquet", response.getStorageCredentials(0).getPrefix());
+  }
+
+  @Test
+  void aScopeNarrowerThanTheRequestIsStampedAsItself() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(
+            Optional.of(
+                new VendedStorageCredentials(
+                    Map.of(
+                        "s3.access-key-id", "ASIA-VENDED",
+                        "s3.secret-access-key", "secret-vended",
+                        "s3.session-token", "session-vended"),
+                    "s3://warehouse/orders/data",
+                    Optional.of(EXPIRY))));
+
+    // A catalog that scoped to a subtree of what floecat asked for is a legitimately narrowed
+    // credential, not a fault. The earlier inline check admitted only a scope containing the
+    // request, so this ended as a missing-authority error.
+    var response =
+        vendor.vendForTable(
+            integrationTable(),
+            "s3://warehouse/orders",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertEquals("s3://warehouse/orders/data", response.getStorageCredentials(0).getPrefix());
+  }
+
+  @Test
+  void acceptsAScopeCoveringTheRequestedLocationAcrossS3SchemeAliases() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(
+            Optional.of(
+                new VendedStorageCredentials(
+                    Map.of(
+                        "s3.access-key-id", "ASIA-VENDED",
+                        "s3.secret-access-key", "secret-vended",
+                        "s3.session-token", "session-vended"),
+                    "s3a://warehouse/orders",
+                    Optional.of(EXPIRY))));
+
+    var response =
+        vendor.vendForTable(
+            integrationTable(),
+            "s3://warehouse/orders/data/part-0.parquet",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertEquals(1, response.getStorageCredentialsCount());
+    // Spelled the way the caller spells it. A client vend hands this prefix to the Iceberg reader,
+    // and S3FileIO matches it against a storage path with a raw startsWith -- an "s3a://" prefix is
+    // simply invisible to an "s3://" path, and the reader falls through to the root client.
+    assertEquals(
+        "s3://warehouse/orders/data/part-0.parquet", response.getStorageCredentials(0).getPrefix());
+  }
+
+  @Test
+  void aNarrowerScopeIsStampedInTheRequestedSchemeSpelling() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(
+            Optional.of(
+                new VendedStorageCredentials(
+                    Map.of(
+                        "s3.access-key-id", "ASIA-VENDED",
+                        "s3.secret-access-key", "secret-vended",
+                        "s3.session-token", "session-vended"),
+                    "s3a://warehouse/orders/data",
+                    Optional.of(EXPIRY))));
+
+    // The narrower scope is the one returned, so this is the case where the catalog's own spelling
+    // would otherwise travel back and be unmatchable against the reader's s3:// paths.
+    var response =
+        vendor.vendForTable(
+            integrationTable(),
+            "s3://warehouse/orders",
+            SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    assertEquals("s3://warehouse/orders/data", response.getStorageCredentials(0).getPrefix());
+  }
+
+  @Test
+  void boundsTheWholeUpstreamConversationWithOneDeadline() {
+    vendor.upstreamTimeout = Duration.ofMillis(50);
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenAnswer(
+            invocation -> {
+              new CountDownLatch(1).await();
+              return Optional.empty();
+            });
+
+    StatusRuntimeException failure =
+        assertTimeoutPreemptively(
+            Duration.ofSeconds(2),
+            () ->
+                assertThrows(
+                    StatusRuntimeException.class,
+                    () ->
+                        vendor.vendForTable(
+                            integrationTable(),
+                            "s3://warehouse/orders",
+                            SourceCatalogCredentialVendor.CredentialUse.QUERY)));
+
+    // A stalled upstream is a come-back-later condition, so it carries the retryable reason rather
+    // than a bare INTERNAL whose description the gateway would hide.
+    assertEquals(io.grpc.Status.Code.UNAVAILABLE, failure.getStatus().getCode());
+    assertTrue(SourceCatalogVendingGrpcStatus.isSourceCatalogVendUnavailable(failure));
+    assertTrue(failure.getStatus().getDescription().contains("TIMEOUT"));
+    verify(client).close();
+  }
+
+  @Test
+  void closesAClientReturnedAfterTheOpenDeadline() throws InterruptedException {
+    vendor.upstreamTimeout = Duration.ofMillis(50);
+    CountDownLatch closed = new CountDownLatch(1);
+    when(access.open(integration))
+        .thenAnswer(
+            invocation -> {
+              try {
+                new CountDownLatch(1).await();
+              } catch (InterruptedException ignored) {
+                // An HTTP layer that consumes interruption before handing back its client.
+              }
+              return client;
+            });
+    doAnswer(
+            invocation -> {
+              closed.countDown();
+              return null;
+            })
+        .when(client)
+        .close();
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(2),
+        () ->
+            assertThrows(
+                StatusRuntimeException.class,
+                () ->
+                    vendor.vendForTable(
+                        integrationTable(),
+                        "s3://warehouse/orders",
+                        SourceCatalogCredentialVendor.CredentialUse.QUERY)));
+
+    assertTrue(closed.await(2, java.util.concurrent.TimeUnit.SECONDS));
+  }
+
+  @Test
+  void aCallerWithoutIntegrationUsePermissionCannotOpenTheIntegration() {
+    // Table authorization admits a caller to this vend; it does not admit them to the integration's
+    // own credential. Opening one resolves its stored secret and spends an OAuth exchange upstream,
+    // so it takes the same permission every other site that opens an integration requires -- and
+    // the read role carries table.read without it.
+    when(vendor.principal.get())
+        .thenReturn(
+            ai.floedb.floecat.common.rpc.PrincipalContext.newBuilder()
+                .setAccountId("acct")
+                .setCorrelationId("corr")
+                .addPermissions("table.read")
+                .addPermissions("catalog.read")
+                .build());
+
+    assertThrows(
+        StatusRuntimeException.class,
+        () ->
+            vendor.vendForTable(
+                integrationTable(),
+                "s3://warehouse/orders",
+                SourceCatalogCredentialVendor.CredentialUse.QUERY));
+
+    verifyNoInteractions(access);
+  }
+
+  @Test
+  void rejectsNonRefreshableIntegrationCredentialsForReconcile() {
+    // Not merely "unusual shape": an integration vends only when the credential it holds is itself
+    // a temporary session, and an AWS temporary credential always carries a session token. A pair
+    // without one means the integration is not holding what it should, so this is a fault to
+    // report rather than a long-lived credential to pass along -- and passing it along would
+    // publish something floecat cannot bound, which the authority path refuses to do for its own
+    // credentials. The connector path accepts this shape deliberately; see VendSource.
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(
+            Optional.of(
+                new VendedStorageCredentials(
+                    Map.of(
+                        "s3.access-key-id", "ASIA-VENDED",
+                        "s3.secret-access-key", "secret-vended"),
+                    "s3://warehouse/orders",
+                    Optional.empty())));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTable(),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE));
+
+    assertTrue(SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(failure));
+  }
 
   @Test
   void routingPropertiesKeepConnectorEndpointAndRegionAlias() {
@@ -140,9 +957,8 @@ class SourceCatalogCredentialVendorTest {
   @Test
   void catalogSuppliedTextCannotForgeALogLineOrOverrunTheStatus() {
     // Both identifiers come off a persisted UpstreamRef and the cause message is whatever the
-    // catalog returned, so all three are attacker-influenced. This status is built with
-    // withDescription directly -- GrpcErrors.clampDetail is not on this path -- so an unflattened
-    // newline here would travel as-is into trailer metadata and forge an entry in the server log.
+    // catalog returned, so all three are attacker-influenced -- and since these refusals gained a
+    // keyed template whose body is the detail parameter, the description is what a client reads.
     String forged = "orders\nWARN  [floecat] credentials vended successfully";
     StatusRuntimeException status =
         SourceCatalogCredentialVendor.catalogFailureStatus(
@@ -153,16 +969,72 @@ class SourceCatalogCredentialVendorTest {
             SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
 
     String description = status.getStatus().getDescription();
+    // The table name still reaches it, so flattening and bounding still matter: an unflattened
+    // newline would travel into trailer metadata and forge a server log entry.
     assertThat(description).doesNotContain("\n").doesNotContain("\r");
-    // Bounded, and the elision is marked rather than silent.
     assertThat(description.length()).isLessThan(1_024);
-    // The elision marker must report the size of the original text, not of an intermediate
-    // truncation: bounding an already-bounded string makes it describe the 8k log form instead of
-    // the 20k original, and cuts the accurate marker away in the process.
-    var elision =
-        java.util.regex.Pattern.compile("\\.\\.\\.\\((\\d+) chars\\)$").matcher(description);
-    assertThat(elision.find()).as(description).isTrue();
-    assertThat(Integer.parseInt(elision.group(1))).isGreaterThan(20_000);
+    // The throwable's own text does not reach it at all. It is upstream-controlled -- a proxy's
+    // HTML, an internal host name, somebody else's stack -- and it used to be dropped because these
+    // statuses had no keyed template; now that they render from the detail, excluding it is the
+    // only
+    // thing keeping it off the wire. The full cause still goes to the log.
+    assertThat(description).doesNotContain("<html>").doesNotContain("xxxxxxxx");
+    // The class name stays, which is as much of the throwable as a caller needs to tell one
+    // failure from another.
+    assertThat(description).contains("RuntimeException");
+  }
+
+  @Test
+  void catalogSuppliedTextIsBoundedOnTheIntegrationPathToo() {
+    // Same attacker-influenced inputs as the connector path: the table name comes off a persisted
+    // UpstreamRef, and the status description becomes percent-encoded grpc-message trailer metadata
+    // that withReason copies into two packed details. The Integration path had neither the flatten
+    // nor the bound.
+    String forged = "orders\nWARN  [floecat] credentials vended successfully" + "x".repeat(20_000);
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenThrow(
+            new CatalogAccessException(
+                CatalogAccessException.Code.NOT_FOUND, "Upstream table does not exist"));
+
+    StatusRuntimeException failure =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                vendor.vendForTable(
+                    integrationTableNamed(forged),
+                    "s3://warehouse/orders",
+                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE));
+
+    String description = failure.getStatus().getDescription();
+    assertThat(description).doesNotContain("\n").doesNotContain("\r");
+    assertThat(description.length()).isLessThan(1_024);
+  }
+
+  @Test
+  void aBlankRequestedPrefixIsStampedWithTheVendedScopeRatherThanUnrestricted() {
+    when(client.capabilities())
+        .thenReturn(CatalogCapabilities.of(CatalogCapability.VEND_STORAGE_CREDENTIALS));
+    when(client.vendStorageCredentials(any()))
+        .thenReturn(
+            Optional.of(
+                new VendedStorageCredentials(
+                    Map.of(
+                        "s3.access-key-id", "ASIA-VENDED",
+                        "s3.secret-access-key", "secret-vended",
+                        "s3.session-token", "session-vended"),
+                    "s3://warehouse/orders/",
+                    Optional.of(EXPIRY))));
+
+    var response =
+        vendor.vendForTable(
+            integrationTable(), "", SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+
+    // An empty prefix is what every consumer reads as unrestricted, so passing the blank through
+    // would advertise more than the catalog granted. The trailing slash is normalized away because
+    // consumers key a FileIO cache on this value.
+    assertEquals("s3://warehouse/orders", response.getStorageCredentials(0).getPrefix());
   }
 
   @Test
@@ -383,56 +1255,6 @@ class SourceCatalogCredentialVendorTest {
   }
 
   @Test
-  void anAlreadyExpiredVendIsAsUnusableAsOneWithNoExpiry() {
-    // A past expiry is non-null, so a null check alone lets it through.
-    // RefreshingAwsCredentialsProviderRegistry then
-    // reads it as "refresh now" on every resolveCredentials call, so a catalog that keeps sending
-    // the same stale timestamp is re-vended once per resolution and still yields credentials S3
-    // refuses. Terminal here instead, naming the field.
-    Map<String, String> tuple =
-        Map.of(
-            "s3.access-key-id",
-            "key",
-            "s3.secret-access-key",
-            "secret",
-            "s3.session-token",
-            "token");
-
-    assertThatThrownBy(
-            () ->
-                SourceCatalogCredentialVendor.requireUsableCredentials(
-                    new FloecatConnector.VendedStorageCredentials(
-                        tuple, "s3://warehouse/orders", Instant.parse("1970-01-01T00:00:01Z")),
-                    "cat.schema",
-                    "orders",
-                    SourceCatalogCredentialVendor.CredentialUse.RECONCILE))
-        .isInstanceOfSatisfying(
-            StatusRuntimeException.class,
-            failure -> {
-              assertThat(SourceCatalogVendingGrpcStatus.isVendedCredentialsNotRefreshable(failure))
-                  .isTrue();
-              assertThat(failure.getStatus().getDescription())
-                  .contains("s3.session-token-expires-at-ms");
-            });
-
-    // The two sides of the boundary this narrows: a live expiry still passes, and the query path is
-    // deliberately unchanged -- it never renews, so a stale expiry there is a read that fails at S3
-    // either way and rejecting it would only move the error earlier.
-    SourceCatalogCredentialVendor.requireUsableCredentials(
-        new FloecatConnector.VendedStorageCredentials(
-            tuple, "s3://warehouse/orders", Instant.now().plusSeconds(600)),
-        "cat.schema",
-        "orders",
-        SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
-    SourceCatalogCredentialVendor.requireUsableCredentials(
-        new FloecatConnector.VendedStorageCredentials(
-            tuple, "s3://warehouse/orders", Instant.parse("1970-01-01T00:00:01Z")),
-        "cat.schema",
-        "orders",
-        SourceCatalogCredentialVendor.CredentialUse.QUERY);
-  }
-
-  @Test
   void anAccessPointScopedVendIsUsedAgainstTheBucketRatherThanRefused() {
     // Unity returns access_point for any external location that has one configured, and the grant
     // behind it commonly still permits addressing the bucket. Refusing on the field's presence
@@ -497,6 +1319,33 @@ class SourceCatalogCredentialVendorTest {
             UpstreamRef.newBuilder()
                 .setConnectorId(connectorId)
                 .addAllNamespacePath(List.of("cat", "schema"))
+                .setTableDisplayName("orders"))
+        .build();
+  }
+
+  private static Table integrationTable() {
+    return integrationTable(INTEGRATION_ID);
+  }
+
+  /** A table whose upstream display name is whatever the catalog called it. */
+  private static Table integrationTableNamed(String tableDisplayName) {
+    Table base = integrationTable();
+    return base.toBuilder()
+        .setUpstream(base.getUpstream().toBuilder().setTableDisplayName(tableDisplayName))
+        .build();
+  }
+
+  private static Table integrationTable(ResourceId integrationId) {
+    return Table.newBuilder()
+        .setResourceId(
+            ResourceId.newBuilder()
+                .setAccountId("acct")
+                .setKind(ResourceKind.RK_TABLE)
+                .setId("table-1"))
+        .setUpstream(
+            UpstreamRef.newBuilder()
+                .setCatalogIntegrationId(integrationId)
+                .addNamespacePath("sales")
                 .setTableDisplayName("orders"))
         .build();
   }

--- a/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/storage/impl/StorageAuthorityServiceImplTest.java
@@ -790,10 +790,10 @@ class StorageAuthorityServiceImplTest {
         props, null, expiry);
   }
 
-  // Relative, not a literal: requireUsableCredentials now rejects an expiry that has already
-  // passed, so a hardcoded "future" epoch becomes a test that starts failing on a calendar date.
-  private static final java.time.Instant EXPIRY =
-      java.time.Instant.now().plus(java.time.Duration.ofHours(1));
+  // Fixed, with every expiry stated relative to it: requireUsableCredentials takes the instant to
+  // compare against, so neither a calendar date nor the suite's own runtime decides these cases.
+  private static final java.time.Instant NOW = java.time.Instant.parse("2026-09-01T14:00:00Z");
+  private static final java.time.Instant EXPIRY = NOW.plus(java.time.Duration.ofHours(1));
 
   /**
    * Every field of the session tuple is required, not just the expiry. Access key plus secret plus
@@ -819,9 +819,11 @@ class StorageAuthorityServiceImplTest {
               () ->
                   SourceCatalogCredentialVendor.requireUsableCredentials(
                       vendedTuple(c.ak(), c.sk(), c.token(), c.expiry()),
+                      NOW,
                       "tpch_10",
                       "customer",
-                      SourceCatalogCredentialVendor.CredentialUse.RECONCILE),
+                      SourceCatalogCredentialVendor.CredentialUse.RECONCILE,
+                      SourceCatalogCredentialVendor.VendSource.CONNECTOR),
               c.name());
       assertEquals(io.grpc.Status.Code.FAILED_PRECONDITION, error.getStatus().getCode(), c.name());
       // Terminal by structured reason, so the reconciler stops instead of retrying forever.
@@ -836,9 +838,11 @@ class StorageAuthorityServiceImplTest {
   void completeVendedCredentialsAreAccepted() {
     SourceCatalogCredentialVendor.requireUsableCredentials(
         vendedTuple("ASIA", "secret", "token", EXPIRY),
+        NOW,
         "tpch_10",
         "customer",
-        SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+        SourceCatalogCredentialVendor.CredentialUse.RECONCILE,
+        SourceCatalogCredentialVendor.VendSource.CONNECTOR);
   }
 
   @Test
@@ -850,21 +854,26 @@ class StorageAuthorityServiceImplTest {
     // keys, and refusing it would leave such a table queryable but never capturable.
     SourceCatalogCredentialVendor.requireUsableCredentials(
         vendedTuple("AKIA", "secret", null, null),
+        NOW,
         "tpch_10",
         "customer",
-        SourceCatalogCredentialVendor.CredentialUse.RECONCILE);
+        SourceCatalogCredentialVendor.CredentialUse.RECONCILE,
+        SourceCatalogCredentialVendor.VendSource.CONNECTOR);
 
-    // The middle case stays terminal: a session token floecat cannot renew because the expiry is
-    // absent or already past would lapse mid-capture with nothing to recover it.
-    for (java.time.Instant expiry : new java.time.Instant[] {null, java.time.Instant.EPOCH}) {
+    // The middle case stays terminal: a session token with no expiry cannot be renewed and would
+    // lapse mid-capture. An expiry already in the past is not checked here -- that is a retryable
+    // failure raised before this point, since the next vend mints a fresh credential.
+    for (java.time.Instant expiry : new java.time.Instant[] {null}) {
       assertThrows(
           StatusRuntimeException.class,
           () ->
               SourceCatalogCredentialVendor.requireUsableCredentials(
                   vendedTuple("ASIA", "secret", "token", expiry),
+                  NOW,
                   "tpch_10",
                   "customer",
-                  SourceCatalogCredentialVendor.CredentialUse.RECONCILE),
+                  SourceCatalogCredentialVendor.CredentialUse.RECONCILE,
+                  SourceCatalogCredentialVendor.VendSource.CONNECTOR),
           String.valueOf(expiry));
     }
   }
@@ -879,9 +888,117 @@ class StorageAuthorityServiceImplTest {
     // path where nothing retries and there is no job to fail.
     SourceCatalogCredentialVendor.requireUsableCredentials(
         vendedTuple("AKIA", "secret", null, null),
+        NOW,
         "tpch_10",
         "customer",
-        SourceCatalogCredentialVendor.CredentialUse.QUERY);
+        SourceCatalogCredentialVendor.CredentialUse.QUERY,
+        SourceCatalogCredentialVendor.VendSource.CONNECTOR);
+  }
+
+  @Test
+  void aConnectorQueryReadsAStaleExpiryAsItAlwaysHas() {
+    // The gate this check started behind. A scan reading a connector-vended tuple once registers no
+    // refresh provider and has nothing to renew, so how stale the timestamp is says nothing about
+    // whether the read works -- and a catalog reporting its expiry in seconds parses to 1970, which
+    // would fail every query for every table from it rather than one read. Sharing the vend paths
+    // extended the check here silently; an integration is the one this branch made stricter.
+    SourceCatalogCredentialVendor.requireUsableCredentials(
+        vendedTuple("ASIA", "secret", "token", NOW.minus(java.time.Duration.ofDays(365))),
+        NOW,
+        "tpch_10",
+        "customer",
+        SourceCatalogCredentialVendor.CredentialUse.QUERY,
+        SourceCatalogCredentialVendor.VendSource.CONNECTOR);
+  }
+
+  /**
+   * A past expiry is retryable however stale it is. The tolerance still matters -- inside it the
+   * query path reads the credential rather than failing -- but on reconcile every past expiry asks
+   * for a retry, because the next vend mints a new credential. Asserted directly because the width
+   * of the window is not observable through a vend.
+   */
+  @Test
+  void aPastExpiryIsRetryableOnReconcileHoweverStale() {
+    // Asserted well past the tolerance on purpose. The refresh loop that would argue for terminal
+    // needs a registered provider to exist, so it cannot reach the first vend, whose failure the
+    // attempt budget bounds -- and a terminal answer there is unrecoverable for the table.
+    record Case(String name, java.time.Duration age, boolean terminal) {}
+    for (var c :
+        java.util.List.of(
+            new Case("a second stale", java.time.Duration.ofSeconds(1), false),
+            new Case("at the tolerance", java.time.Duration.ofSeconds(60), false),
+            new Case("an hour stale", java.time.Duration.ofHours(1), false))) {
+      StatusRuntimeException error =
+          assertThrows(
+              StatusRuntimeException.class,
+              () ->
+                  SourceCatalogCredentialVendor.requireUsableCredentials(
+                      vendedTuple("ASIA", "secret", "token", NOW.minus(c.age())),
+                      NOW,
+                      "tpch_10",
+                      "customer",
+                      SourceCatalogCredentialVendor.CredentialUse.RECONCILE,
+                      SourceCatalogCredentialVendor.VendSource.CONNECTOR),
+              c.name());
+      assertEquals(
+          c.terminal(),
+          ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus
+              .isVendedCredentialsNotRefreshable(error),
+          c.name());
+      assertEquals(
+          c.terminal() ? io.grpc.Status.Code.FAILED_PRECONDITION : io.grpc.Status.Code.UNAVAILABLE,
+          error.getStatus().getCode(),
+          c.name());
+    }
+  }
+
+  /** A live expiry is not a past one, however close. */
+  @Test
+  void anExpiryStillInTheFutureIsAccepted() {
+    SourceCatalogCredentialVendor.requireUsableCredentials(
+        vendedTuple("ASIA", "secret", "token", NOW.plusMillis(1)),
+        NOW,
+        "tpch_10",
+        "customer",
+        SourceCatalogCredentialVendor.CredentialUse.RECONCILE,
+        SourceCatalogCredentialVendor.VendSource.CONNECTOR);
+  }
+
+  /**
+   * The same tolerance governs an integration's query path, with a milder answer past it. Inside,
+   * the credential is read -- it is almost certainly live and nothing renews it anyway. Outside, it
+   * is refused here rather than at S3, and refused retryably: nothing is retrying on this path, so
+   * the caller is being told the catalog's answer was stale, not that its table is unreadable.
+   *
+   * <p>An integration rather than a connector, because the rule is written by source. A connector
+   * query is exempt entirely -- see {@link #aConnectorQueryReadsAStaleExpiryAsItAlwaysHas}.
+   */
+  @Test
+  void anIntegrationQueryReadsAJustExpiredTupleAndRefusesAStaleOne() {
+    SourceCatalogCredentialVendor.requireUsableCredentials(
+        vendedTuple("ASIA", "secret", "token", NOW.minusSeconds(1)),
+        NOW,
+        "tpch_10",
+        "customer",
+        SourceCatalogCredentialVendor.CredentialUse.QUERY,
+        SourceCatalogCredentialVendor.VendSource.CATALOG_INTEGRATION);
+
+    StatusRuntimeException error =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                SourceCatalogCredentialVendor.requireUsableCredentials(
+                    vendedTuple(
+                        "ASIA", "secret", "token", NOW.minus(java.time.Duration.ofHours(1))),
+                    NOW,
+                    "tpch_10",
+                    "customer",
+                    SourceCatalogCredentialVendor.CredentialUse.QUERY,
+                    SourceCatalogCredentialVendor.VendSource.CATALOG_INTEGRATION));
+    assertEquals(io.grpc.Status.Code.UNAVAILABLE, error.getStatus().getCode());
+    assertFalse(
+        ai.floedb.floecat.storage.errors.SourceCatalogVendingGrpcStatus
+            .isVendedCredentialsNotRefreshable(error));
   }
 
   @Test
@@ -899,9 +1016,11 @@ class StorageAuthorityServiceImplTest {
           () ->
               SourceCatalogCredentialVendor.requireUsableCredentials(
                   vendedTuple(c.ak(), c.sk(), null, null),
+                  NOW,
                   "tpch_10",
                   "customer",
-                  SourceCatalogCredentialVendor.CredentialUse.QUERY),
+                  SourceCatalogCredentialVendor.CredentialUse.QUERY,
+                  SourceCatalogCredentialVendor.VendSource.CONNECTOR),
           c.name());
     }
   }


### PR DESCRIPTION
## Summary

Allow tables materialized through an Iceberg REST Catalog Integration/Overlay to obtain table-scoped storage credentials from their source catalog when no storage authority matches.

The shared source-catalog vendor now resolves either a Catalog Integration or a legacy Connector, opens integrations through the catalog-access SPI, preserves tenant and requested-location scoping, validates credential completeness and expiry, and maps deterministic vending failures to a structured terminal reason.

## Type of Change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Validated with:

`mvn -q -pl service -am -Dtest=SourceCatalogCredentialVendorTest,ReconcileFailureClassifierTest -Dsurefire.failIfNoSpecifiedTests=false test`

- [ ] `make fmt`
- [ ] `make verify`
- [x] Added/updated tests for changed behavior

Formatting was applied with `mvn -q fmt:format`. The affected modules compile and the focused source-vending and failure-classification tests pass.

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

Legacy Connector vending remains available and its storage-authority fall-back is unchanged. One connector-path behaviour does change: an already-past expiry on a reconcile vend used to be folded into the missing-fields check and raised terminally, and is now retryable on both paths — see the Reviewers note below for why, and #501 for the loop that motivated the old answer. Catalog Integration vending is attempted only after no storage authority matches, and an Integration that cannot vend now fails the read naming the cause rather than falling back.

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

- Catalog Integration/Overlay tables require no separate vending opt-in; the Iceberg REST provider requests delegated credentials and reports its capability.
- The returned credential prefix remains the already-authorized requested location rather than the catalog's potentially broader table scope.
- Ambient/default-chain and assume-role Catalog Integration authentication remain an existing follow-up; explicit SigV4 credentials are supported today.

## Reviewers

- This ports runtime Iceberg credential vending to the Catalog Integration/Overlay identity without depending on a reconstructed legacy Connector.
- Deterministically unusable vending responses carry a structured terminal reason so reconcile jobs do not retry indefinitely. An *expired* response is deliberately not one of them: a past expiry is temporal, the next vend mints a new credential, and the reconciler's attempt budget bounds the retrying. Terminal is reserved for what a retry cannot change — a tuple missing a field the catalog never sends.

  **This is a change from the base branch for the connector path, and it was made twice.** `requireUsableCredentials` previously folded an already-past expiry on `RECONCILE` into `missing` and raised `vendedCredentialsNotRefreshable`, citing an unbounded re-vend loop as the reason. That loop is real, but it does not reach the vend this classification governs: the swallow-and-retry lives in `RefreshingAwsCredentialsProviderRegistry.Entry.resolveCredentials` and only exists once a refresh provider is registered. The **first** vend has no snapshot behind it, no evidence that re-vending returns the same timestamp, and its failure *is* counted by the reconciler's attempt budget — while a terminal answer there sets the job to `JS_FAILED` and cancels its children on a single stale or cached response, and on any clock disagreement past the 60s tolerance would do that to every table at once. So the classification is retryable and the loop is tracked separately as #501, which bounds it for every reason rather than only this one. Making the refresh terminal instead was considered and rejected: `SOURCE_CATALOG_VEND_UNAVAILABLE` also carries `UNAVAILABLE`, `TIMEOUT` and `CREDENTIAL_UNAVAILABLE`, so it would make a brief catalog outage mid-capture fatal.

- **A partial vend is an error on this path, never a fall-back.** If the upstream answers with key material but not a usable pair, the provider raises `INVALID_CONFIGURATION` rather than returning "did not vend". There is no opt-in that lets a catalog integration fall back to a storage authority, so returning empty would surface a missing-authority error that reads as a configuration gap and hides the real cause — and a retry cannot change a half tuple anyway. The connector path still falls back in the equivalent situation; that is left alone deliberately, since the connector architecture is being retired in favour of integrations and overlays, and this PR only changes the integration path.

- **A token-less vend is refused rather than treated as a long-lived credential.** An integration vends only when the credential it holds is itself a temporary session, and an AWS temporary credential always carries a session token — so a pair arriving without one means the integration is not holding what it should. Accepting it would also publish a credential floecat cannot bound, which `StorageAuthorityResolver` refuses to do for its own client vends, and it would travel into worker payloads and `loadTable` responses where a consumer cannot distinguish an absent expiry from "never expires". The connector path accepts this shape on purpose, because Unity really does vend long-lived keys for some external locations; the two are separated by `VendSource`.

- **The integration vend path opens a fresh catalog client per call, with no cache.** Each call does a credential-store resolve, a REST config round trip, an OAuth exchange, and a `loadTable`, then discards the client — and vending runs once per file group, so a large capture mints a token per group against a rate-limited endpoint. Known and not addressed here: the connector path carries the same NOTE, and the cache wants a design (keying on integration and table, bounded by the shortest credential expiry) rather than being bolted onto this change.

- **`catalog-integration.use` in `READ_PERMS` is deliberately wider than the vend it admits.** The permission gates the credential vend, but `CatalogIntegrationsImpl` also requires it for `ValidateCatalogIntegration`, `ListUpstreamNamespaces` and `ListUpstreamObjects` — none of which are gated on table authorization — so granting it to the default reader role also admits upstream enumeration of namespaces and tables that were never materialized into Floecat. That is understood and accepted: the product owner is fine with `use` being broader than we will eventually want, on the basis that it is shorthand for what should later split into `catalog-integration.vend` and `catalog-integration.enumerate`. Until that split exists, the alternative is leaving overlay-materialized Iceberg tables unreadable by every role except administrator, which defeats the read-back path this PR delivers.

- **A client vend inherits whatever scope the upstream catalog minted.** `StorageAuthorityServiceImpl` reaches the source-catalog vend for `SCU_CLIENT` as well as `SCU_SERVER` (only `CredentialScope.forLeasedFile` opts out, and it says why), and the prefix stamped on the response is floecat's authorization boundary, not a restriction on the credential itself. A catalog fronting a warehouse-wide role with no session policy would therefore hand a client more reach than the table it asked for. Two things bound this. The vend refuses anything but the full session triad for an integration, so the credential is always short-lived and the exposure is one expiry wide. And a warehouse-wide role with no session policy is not a production configuration form — it cannot be run as a stable setup precisely because the token it mints is always expiring, so what the scenario actually describes is pointing floecat at a catalog to see what it does. Left as is deliberately: scoping down would mean an STS call using a credential we cannot assume is allowed to mint a narrower one, and restricting source-catalog vends to `SCU_SERVER` would remove client-side reads of overlay-materialized tables, which is a product decision rather than a fix.

- **Credential selection is by table root, not by the location the caller asked for.** `CatalogClient.vendStorageCredentials` takes only a `CatalogObjectName`, so a provider cannot know which location the caller wants and `IcebergRestCatalogClient` can only pick the longest credential covering `table.location()`. A catalog that returns one credential per prefix — the case Iceberg's own `credentials()` list and `S3FileIO`'s prefix-keyed clients exist for — therefore loses the tuple covering a file outside the table root, as `write.data.path`, `write.metadata.path` and imported files all produce. `responsePrefix` cannot compensate; it sets the advertised prefix, not the key material. Not fixed here on purpose: the fix is an SPI signature change, and the Unity provider in the branch stacked above this one implements the same interface, so it is held until that lands rather than breaking it mid-flight. The fuller answer — return every usable credential and let the consumer pick per path, which `storage_credentials` being `repeated` already allows — needs more than a signature: `VendedStorageCredentials` carries a single tuple, and the query path flattens the response into one FileIO property map in `mergeStorageAuthorityFileIoConfig`.

- **A lost call context on the vend path is terminal, not retryable.** The vend now requires `catalog-integration.use`, and `Authorizer.denied` deliberately reports the exact default `PrincipalContext` as `UNAUTHENTICATED` rather than `PERMISSION_DENIED`, so that a context-propagation miss stays diagnosable (eng-floe/floecat#361). `ReconcileFailureClassifier` treats a raw `UNAUTHENTICATED` as terminal, so a propagation miss during reconcile permanently fails the table rather than retrying. Not addressed here: both halves are shared behaviour outside this path — the classifier's rule covers every auth failure, and the `Authorizer` mapping is what makes #361-class bugs findable — so narrowing either belongs with them, not with the vend. The permission check is ordered after the missing-record and non-vending-type refusals, which is as far as this PR reduces the window.

- **A Catalog Integration that vends a bare key pair is refused at the provider.** `IcebergRestCatalogClient` now raises `INVALID_CONFIGURATION` when the selected credential has no session token or no parseable expiry, rather than returning it for the vend to reject later. An integration vends only when what it holds is itself a temporary session, and floecat does not scope a credential down with STS, so a pair that arrives is a pair that would travel to a reader. Raising it in the provider is what makes validation and the vend agree: both reach the catalog through this method, but only the vend applied the rule, so a catalog vending a long-lived pair passed every validation check — including the storage-access probe, which reads perfectly well with one — and then failed terminally on the first capture or query of every table an overlay had materialized from it. `requireUsableCredentials` keeps the same rule as a backstop, since it also covers the legacy Connector path.

- **Falling back to a storage authority is opt-in, and only a Connector can opt in.** A legacy Connector declares that it wants vended credentials (`IcebergAccessDelegation.declaresVendedCredentials`), so one that does not is answered with `null` and the caller uses the authority the operator configured for it — unchanged by this PR. A Catalog Integration has no such switch and no alternative to switch to: nothing on the record names an authority, and `ValidateCatalogIntegration` reports an Integration whose provider cannot vend as invalid rather than as configured some other way. Pairing an authority with an Integration is the split-brain this feature removes — authenticate to the catalog here, obtain storage credentials somewhere else — so every "cannot vend" condition on that path is a refusal naming the cause.

  Nothing was lost by dropping it. The vend is reached only once no authority covers the location, so a `null` from the Integration path landed on `StorageAuthorityResolver.buildResponse(null, ...)`, which raises no-matching-authority; the one consumer that absorbs that error gates on a `ConnectorConfig`, which an Integration does not have. The fall-back could only ever relabel a specific cause as "you configured no storage authority", which is neither true nor actionable. One case is deliberately not a refusal: a vended scope disjoint from the requested location is still stamped with the authorized prefix and logged, because the read may succeed and the object store enforces the real grant either way.

- **The Integration vend has no end-to-end coverage, and adding it is larger than it looks.** Every assertion on this path is a unit test against a stubbed `CatalogClient`, `CatalogIntegrationRepository` and `Authorizer`. The Polaris Integration/overlay smoke section stops at `integration validate`, `overlay reconcile` and `describe table` with the storage authority still in place, so a read there resolves through the authority and never reaches `vendForTable`. The delegated *connector* scenario does it correctly — `run_upstream_iceberg_scenario "polaris-vended-creds"` deletes the authority first so a pass cannot come from it — but nothing does the equivalent for an Integration. This matters most for the permission check: the vend requires `catalog-integration.use` read from the ambient call context, and a propagation miss on the `ScanBundleService` → `ServerSideFileIoPropertiesResolver` path would fail every read of every overlay-materialized table as `UNAUTHENTICATED`, terminally, and no unit test can catch it because each injects the principal directly.

  Mirroring the connector scenario is not sufficient, which is why this is a note rather than a change. There is no CLI verb that captures an Integration-materialized table — `overlay reconcile` is metadata-only and capture requires `connector trigger` — so `assert_table_stats_available` has nothing to assert on. The remaining route is a gateway `loadTable` against the overlay table with the authority dropped, which exercises the client vend, but the harness's only gateway call is hardcoded to one catalog and namespace and would need new plumbing plus assumptions about delegation headers and response shape that cannot be validated without running the compose stack. `tools/compose-smoke.sh` is also owned and extended by the branch stacked above this one, which already builds vend-path smoke for Unity — that is the natural place to land it.

- **Floecat cannot yet consume its own vended credentials through an Integration (#502).** The Iceberg REST gateway reports a vended credential's expiry as a top-level `expires-at` on the credential object, but Iceberg's `CredentialParser` reads only `prefix` and `config` and discards the rest, and the config map carries `s3.session-token` without `s3.session-token-expires-at-ms`. So an Integration pointed at another floecat endpoint receives a complete tuple with no parseable expiry — the one shape `missingSessionFields` refuses, since a session token floecat cannot renew is the case that lapses mid-capture. Inert for every other client, because nothing else consumes an expiry from a `StorageCredential`. Pre-existing from #287 and outside this PR's files; this PR only makes it reachable, by letting an Integration consume an upstream Iceberg REST catalog's vended credentials at all. The fix belongs in the gateway: write the expiry into the credential config under Iceberg's own `S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS`, which is where Polaris and Unity put it and where this PR's reader looks.
- **Rolling deployment: these reasons stay matchable against a pre-upgrade node, deliberately.** `LocalizeErrorsInterceptor` is a `@GlobalInterceptor` that rebuilds every outgoing status with `clearDetails().addDetails(the localized Error)`, so the `ErrorInfo` detail never survives an RPC and the floecat `Error` detail's params are the only discriminator a remote consumer — the reconciler included — ever sees. This change adds a `domain` param to those params so a reason cannot be impersonated by another subsystem's `params["reason"]`, which matters because `isSourceCatalogVendRefused` no longer narrows by status code. Requiring that param unconditionally would have made a new reconciler read an older service node's answers as "not this condition" for the length of a deploy: `isNoMatchingStorageAuthority` would stop being absorbed, so existing Connectors would lose their delegation fall-back, and terminal vending failures would retry until the attempt budget was spent.

  So `legacyErrorCode` accepts a domain-less detail under the `ErrorCode` its reason was historically raised with, and returns empty for anything newer — a reason introduced here has no legacy shape and must not fall into that branch. Which reasons qualify is a function of the stack's merge order rather than of `main` alone: `NO_MATCHING_STORAGE_AUTHORITY` and `VENDED_CREDENTIALS_NOT_REFRESHABLE` are in `main`, `SOURCE_CATALOG_VEND_REFUSED` is in the branch this one is stacked on and ships first, and `SOURCE_CATALOG_VEND_UNAVAILABLE` arrives here. The residual trade is worth stating: a domain-less detail carrying a qualifying reason and its historical `ErrorCode` is byte-identical to what an old node emits, so impersonation is only fully closed once this branch is deleted. It is safe to delete as soon as no deployed node emits the pre-domain shape, and nothing else depends on it.



