### PR TITLE
fix(reconciler): stabilize checkpoint artifact reuse and finalization

### DIFF
--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
@@ -46,8 +46,8 @@ import ai.floedb.floecat.reconciler.jobs.ReconcileFileGroupTask;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobKind;
 import ai.floedb.floecat.reconciler.jobs.ReconcileJobStore;
 import ai.floedb.floecat.reconciler.jobs.ReconcileSnapshotTask;
-import ai.floedb.floecat.reconciler.jobs.ReusableArtifactBundleSelection;
 import ai.floedb.floecat.reconciler.jobs.ReusableArtifactBundleUris;
+import ai.floedb.floecat.reconciler.jobs.ReusableArtifactBundles;
 import ai.floedb.floecat.reconciler.rpc.CommitLeasedFileGroupResultRequest;
 import ai.floedb.floecat.reconciler.rpc.CommitLeasedFileGroupResultResponse;
 import ai.floedb.floecat.reconciler.rpc.FileGroupArtifactBundleDescriptor;
@@ -642,11 +642,9 @@ public class LeasedFileGroupExecutionService extends BaseServiceImpl {
 
   private Set<Keys.GenerationKey> inheritedIndexSidecarGenerations(
       ResourceId tableId, ReconcileFileGroupTask plannedTask) {
-    List<ReusableArtifactBundleSelection> selections = new ArrayList<>();
-    for (ReconcileFileExecutionPlan executionPlan : plannedTask.fileExecutionPlans()) {
-      selections.addAll(executionPlan.reusableArtifactBundleSelections());
-    }
-    return indexArtifactRepository.inheritedManagedSidecarGenerations(tableId, selections);
+    return indexArtifactRepository.inheritedManagedSidecarGenerations(
+        tableId,
+        ReusableArtifactBundles.inheritedIndexArtifactBundleSelections(List.of(plannedTask)));
   }
 
   private void stageArtifactReferences(StagedArtifactReferences staged) {

--- a/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
+++ b/service/src/main/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionService.java
@@ -358,6 +358,7 @@ public class LeasedFileGroupExecutionService extends BaseServiceImpl {
             validated,
             artifactBundle,
             publishesFileStats(lease.scope.capturePolicy()));
+    stageArtifactReferences(staged);
     boolean accepted =
         jobs.completeFileGroupSuccess(
             lease.jobId,
@@ -366,7 +367,6 @@ public class LeasedFileGroupExecutionService extends BaseServiceImpl {
             System.currentTimeMillis(),
             "Executed file group " + plannedTask.groupId());
     requireAcceptedLeaseOutcome(accepted, lease.jobId);
-    stageArtifactReferences(staged);
     return true;
   }
 

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
@@ -357,6 +357,10 @@ public class IndexArtifactRepository {
           throw new BaseResourceRepository.CorruptionException(
               "managed reusable index record belongs to another table: " + bundleUri);
         }
+        boolean selected =
+            record.hasTarget()
+                && record.getTarget().hasFile()
+                && requiredPaths.remove(record.getTarget().getFile().getFilePath());
         String sidecarUri = record.getArtifactUri();
         if (!sidecarUri.startsWith("/accounts/") || !sidecarUri.contains(Keys.SEG_INDEX_SIDECARS)) {
           continue;
@@ -366,9 +370,7 @@ public class IndexArtifactRepository {
           throw new BaseResourceRepository.CorruptionException(
               "managed reusable index sidecar is outside the owning table generation");
         }
-        if (record.hasTarget()
-            && record.getTarget().hasFile()
-            && requiredPaths.remove(record.getTarget().getFile().getFilePath())) {
+        if (selected) {
           generations.add(sidecarGeneration);
         }
       }

--- a/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
+++ b/service/src/main/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepository.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.repo.impl;
 
 import ai.floedb.floecat.catalog.rpc.IndexArtifactRecord;
 import ai.floedb.floecat.catalog.rpc.IndexTarget;
+import ai.floedb.floecat.common.rpc.BlobHeader;
 import ai.floedb.floecat.common.rpc.MutationMeta;
 import ai.floedb.floecat.common.rpc.Pointer;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -52,6 +53,7 @@ import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -111,9 +113,9 @@ public class IndexArtifactRepository {
       TableBlobReachabilityGuard reachabilityGuard) {
     this.pointerStore = pointerStore;
     this.blobStore = blobStore;
-    this.blobCache = blobCache;
+    this.blobCache = Objects.requireNonNull(blobCache, "blobCache");
     this.reachabilityGuard = reachabilityGuard;
-    this.generationArtifactMap = new GenerationArtifactMap(pointerStore, blobStore, blobCache);
+    this.generationArtifactMap = new GenerationArtifactMap(pointerStore, blobStore, this.blobCache);
   }
 
   public void putIndexArtifact(IndexArtifactRecord value) {
@@ -325,24 +327,21 @@ public class IndexArtifactRepository {
         throw new BaseResourceRepository.CorruptionException(
             "managed reusable index bundle is outside the owning table generation");
       }
-      byte[] bytes;
+      ReusableArtifactBundlePayload bundle;
       try {
-        bytes = blobStore.get(bundleUri);
+        BlobHeader header =
+            blobStore.head(bundleUri).orElseThrow(() -> new StorageNotFoundException(bundleUri));
+        if (header.getContentLength() != selection.payloadBytes()) {
+          throw new BaseResourceRepository.CorruptionException(
+              "managed reusable index bundle metadata does not match: " + bundleUri);
+        }
+        bundle =
+            loadImmutableReusableArtifactBundle(bundleUri)
+                .orElseThrow(() -> new StorageNotFoundException(bundleUri));
       } catch (StorageNotFoundException error) {
         throw new BaseResourceRepository.CorruptionException(
             "managed reusable index bundle is missing: " + bundleUri, error);
-      }
-      if (bytes == null
-          || bytes.length != selection.payloadBytes()
-          || !Hashing.sha256Hex(bytes)
-              .equals(HexFormat.of().formatHex(selection.payloadSha256()))) {
-        throw new BaseResourceRepository.CorruptionException(
-            "managed reusable index bundle metadata does not match: " + bundleUri);
-      }
-      ReusableArtifactBundlePayload bundle;
-      try {
-        bundle = ReusableArtifactBundles.parse(bytes);
-      } catch (InvalidProtocolBufferException error) {
+      } catch (IllegalStateException error) {
         throw new BaseResourceRepository.CorruptionException(
             "managed reusable index bundle is invalid: " + bundleUri, error);
       } catch (IllegalArgumentException error) {
@@ -660,9 +659,7 @@ public class IndexArtifactRepository {
   }
 
   private Optional<SnapshotCaptureManifest> loadCaptureManifest(String uri) {
-    return blobCache == null
-        ? loadCaptureManifestUncached(uri)
-        : blobCache.get(uri, this::loadCaptureManifestUncached);
+    return blobCache.get(uri, this::loadCaptureManifestUncached);
   }
 
   private Optional<SnapshotCaptureManifest> loadCaptureManifestUncached(String uri) {
@@ -1005,10 +1002,15 @@ public class IndexArtifactRepository {
   private Optional<ReusableArtifactBundlePayload> loadCachedReusableArtifactBundle(
       String bundleUri) {
     Optional<ReusableArtifactBundlePayload> bundle = loadReusableArtifactBundle(bundleUri);
-    if (blobCache != null && blobCache.enabled()) {
+    if (blobCache.enabled()) {
       bundle.ifPresent(value -> blobCache.put(bundleUri, value));
     }
     return bundle;
+  }
+
+  private Optional<ReusableArtifactBundlePayload> loadImmutableReusableArtifactBundle(
+      String bundleUri) {
+    return blobCache.get(bundleUri, this::loadReusableArtifactBundle);
   }
 
   private static void requirePrewrittenRecordMatches(
@@ -1204,9 +1206,8 @@ public class IndexArtifactRepository {
             snapshotId);
       }
       ReusableArtifactBundlePayload bundle =
-          (blobCache == null
-                  ? loadReusableArtifactBundle(pointer.getBlobUri())
-                  : blobCache.get(pointer.getBlobUri(), this::loadReusableArtifactBundle))
+          blobCache
+              .get(pointer.getBlobUri(), this::loadReusableArtifactBundle)
               .orElseThrow(
                   () ->
                       new IllegalStateException(

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionServiceTest.java
@@ -808,7 +808,7 @@ class LeasedFileGroupExecutionServiceTest {
                 "stats-signature",
                 "index-signature",
                 Map.of(),
-                List.of(inheritedSelection));
+                List.of(inheritedSelection, inheritedSelection));
     ReconcileFileGroupTask plannedGroup =
         ReconcileFileGroupTask.of("plan-1", "group-1", TABLE_ID, SNAPSHOT_ID, List.of(filePath))
             .withFileExecutionPlans(List.of(executionPlan));
@@ -876,6 +876,17 @@ class LeasedFileGroupExecutionServiceTest {
                 .addFileStatsTargetStorageIds(fileStats.getTargetStorageId())
                 .addIndexArtifactTargetStorageIds(indexArtifact.getTargetStorageId())
                 .build()));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Iterable<ReusableArtifactBundleSelection>> inheritedSelections =
+        ArgumentCaptor.forClass(Iterable.class);
+    verify(indexArtifactRepository)
+        .inheritedManagedSidecarGenerations(eq(tableId()), inheritedSelections.capture());
+    List<ReusableArtifactBundleSelection> aggregatedSelections =
+        java.util.stream.StreamSupport.stream(inheritedSelections.getValue().spliterator(), false)
+            .toList();
+    assertEquals(1, aggregatedSelections.size());
+    assertEquals(List.of(filePath), aggregatedSelections.getFirst().indexFilePaths());
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<List<StatsStore.PrewrittenStatsObject>> objects =

--- a/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionServiceTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/reconciler/impl/LeasedFileGroupExecutionServiceTest.java
@@ -372,14 +372,6 @@ class LeasedFileGroupExecutionServiceTest {
             eq(resultDescriptor(List.of()).artifactReferencesSha256()));
     var order = inOrder(jobs, statsStore, indexArtifactRepository);
     order
-        .verify(jobs)
-        .completeFileGroupSuccess(
-            eq(CHILD_JOB_ID),
-            eq(LEASE_EPOCH),
-            any(ReconcileFileGroupResultDescriptor.class),
-            anyLong(),
-            eq("Executed file group group-1"));
-    order
         .verify(statsStore)
         .protectPrewrittenStatsObjectsInGeneration(
             any(), anyLong(), anyString(), anyString(), any());
@@ -387,6 +379,14 @@ class LeasedFileGroupExecutionServiceTest {
         .verify(statsStore)
         .markPreparedFileGroup(
             any(), anyLong(), anyString(), anyString(), anyString(), anyString());
+    order
+        .verify(jobs)
+        .completeFileGroupSuccess(
+            eq(CHILD_JOB_ID),
+            eq(LEASE_EPOCH),
+            any(ReconcileFileGroupResultDescriptor.class),
+            anyLong(),
+            eq("Executed file group group-1"));
     verify(idempotencyStore, never())
         .createPending(anyString(), anyString(), anyString(), anyString(), any(), any());
     verify(idempotencyStore, never())
@@ -972,12 +972,14 @@ class LeasedFileGroupExecutionServiceTest {
                     artifactBundle(List.of(), List.of())));
 
     assertEquals(Status.Code.FAILED_PRECONDITION, error.getStatus().getCode());
-    verify(statsStore, never())
-        .protectPrewrittenStatsObjectsInGeneration(
-            any(), anyLong(), anyString(), anyString(), any());
-    verify(indexArtifactRepository, never())
-        .registerPrewrittenIndexArtifactReferencesInGeneration(
-            any(), anyLong(), anyString(), anyString(), anyString(), any(), any());
+    verify(statsStore)
+        .markPreparedFileGroup(
+            eq(tableId()),
+            eq(SNAPSHOT_ID),
+            eq("full-rescan-" + PARENT_JOB_ID),
+            eq(CHILD_JOB_ID),
+            eq(LEASE_EPOCH),
+            eq(resultDescriptor(List.of()).artifactReferencesSha256()));
     verify(idempotencyStore, never())
         .finalizeSuccess(
             anyString(), anyString(), anyString(), anyString(), any(), any(), any(), any(), any());

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
@@ -557,6 +557,40 @@ class IndexArtifactRepositoryTest {
   }
 
   @Test
+  void selectedBundleAllowsExternalIndexSidecarsWithoutAnInheritedGeneration() {
+    InMemoryBlobStore blobs = new InMemoryBlobStore();
+    IndexArtifactRepository repository = createRepository(new InMemoryPointerStore(), blobs);
+    String filePath = "s3://bucket/file.parquet";
+    IndexArtifactRecord record =
+        indexRecord(714L, filePath).toBuilder()
+            .setArtifactUri("s3://external-indexes/file.parquet")
+            .build();
+    byte[] bundle =
+        ReusableArtifactBundlePayload.newBuilder()
+            .setFormatVersion(1)
+            .addIndexArtifacts(record)
+            .build()
+            .toByteArray();
+    byte[] digest = HexFormat.of().parseHex(Hashing.sha256Hex(bundle));
+    String bundleUri =
+        workerStatsPrefix(715L) + "reuse-bundles/" + Hashing.sha256Hex(bundle) + ".pb";
+    blobs.put(bundleUri, bundle, "application/x-protobuf");
+
+    assertThat(
+            repository.inheritedManagedSidecarGenerations(
+                TABLE_ID,
+                List.of(
+                    new ReusableArtifactBundleSelection(
+                        "reuse-bundle:prior-group",
+                        bundleUri,
+                        bundle.length,
+                        digest,
+                        List.of(),
+                        List.of(filePath)))))
+        .isEmpty();
+  }
+
+  @Test
   void selectedBundleRejectsASidecarGenerationOwnedByAnotherTable() {
     InMemoryBlobStore blobs = new InMemoryBlobStore();
     IndexArtifactRepository repository = createRepository(new InMemoryPointerStore(), blobs);

--- a/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/repo/impl/IndexArtifactRepositoryTest.java
@@ -68,9 +68,12 @@ class IndexArtifactRepositoryTest {
 
   private static final ResourceId TABLE_ID =
       ResourceId.newBuilder().setAccountId("a").setId("t").setKind(ResourceKind.RK_TABLE).build();
+  private static final ImmutableBlobCache DISABLED_BLOB_CACHE =
+      new ImmutableBlobCache(false, 1L, Duration.ZERO);
 
   private static IndexArtifactRepository createRepository(PointerStore pointers, BlobStore blobs) {
-    return new IndexArtifactRepository(pointers, blobs, null, new TableBlobReachabilityGuard());
+    return new IndexArtifactRepository(
+        pointers, blobs, DISABLED_BLOB_CACHE, new TableBlobReachabilityGuard());
   }
 
   private static IndexArtifactRepository createRepository(
@@ -90,6 +93,19 @@ class IndexArtifactRepositoryTest {
               shardKey, 0L, PointerReferences.opaqueMarkerPointer(shardKey, "deleting", 1L)));
     }
     assertThat(pointers.compareAndSetBatch(creates)).isTrue();
+  }
+
+  @Test
+  void requiresBlobCacheDependency() {
+    assertThatThrownBy(
+            () ->
+                new IndexArtifactRepository(
+                    new InMemoryPointerStore(),
+                    new InMemoryBlobStore(),
+                    null,
+                    new TableBlobReachabilityGuard()))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("blobCache");
   }
 
   @Test
@@ -588,6 +604,109 @@ class IndexArtifactRepositoryTest {
                         List.of(),
                         List.of(filePath)))))
         .isEmpty();
+  }
+
+  @Test
+  void selectedBundleValidationUsesTheImmutableBlobCache() {
+    BlobStore blobs = mock(BlobStore.class);
+    ImmutableBlobCache cache = new ImmutableBlobCache(true, 1024 * 1024, Duration.ZERO);
+    IndexArtifactRepository repository = createRepository(new InMemoryPointerStore(), blobs, cache);
+    String filePath = "s3://bucket/file.parquet";
+    String targetStorageId = "file:" + filePath;
+    String sidecar = managedSidecar(714L, targetStorageId, new byte[] {1});
+    byte[] bundle =
+        ReusableArtifactBundlePayload.newBuilder()
+            .setFormatVersion(1)
+            .addIndexArtifacts(indexRecord(714L, filePath).toBuilder().setArtifactUri(sidecar))
+            .build()
+            .toByteArray();
+    byte[] digest = HexFormat.of().parseHex(Hashing.sha256Hex(bundle));
+    String bundleUri =
+        workerStatsPrefix(715L) + "reuse-bundles/" + Hashing.sha256Hex(bundle) + ".pb";
+    when(blobs.get(bundleUri)).thenReturn(bundle);
+    when(blobs.head(bundleUri))
+        .thenReturn(Optional.of(BlobHeader.newBuilder().setContentLength(bundle.length).build()));
+    ReusableArtifactBundleSelection selection =
+        new ReusableArtifactBundleSelection(
+            "reuse-bundle:prior-group",
+            bundleUri,
+            bundle.length,
+            digest,
+            List.of(),
+            List.of(filePath));
+
+    repository.inheritedManagedSidecarGenerations(TABLE_ID, List.of(selection));
+    repository.inheritedManagedSidecarGenerations(TABLE_ID, List.of(selection));
+
+    verify(blobs, times(1)).get(bundleUri);
+    verify(blobs, times(2)).head(bundleUri);
+  }
+
+  @Test
+  void selectedBundleRejectsDeclaredLengthThatDiffersFromStoredLength() {
+    BlobStore blobs = mock(BlobStore.class);
+    IndexArtifactRepository repository = createRepository(new InMemoryPointerStore(), blobs);
+    String filePath = "s3://bucket/file.parquet";
+    byte[] bundle =
+        ReusableArtifactBundlePayload.newBuilder()
+            .setFormatVersion(1)
+            .addIndexArtifacts(indexRecord(714L, filePath))
+            .build()
+            .toByteArray();
+    byte[] digest = HexFormat.of().parseHex(Hashing.sha256Hex(bundle));
+    String bundleUri =
+        workerStatsPrefix(715L) + "reuse-bundles/" + Hashing.sha256Hex(bundle) + ".pb";
+    when(blobs.head(bundleUri))
+        .thenReturn(
+            Optional.of(BlobHeader.newBuilder().setContentLength(bundle.length + 1).build()));
+
+    assertThatThrownBy(
+            () ->
+                repository.inheritedManagedSidecarGenerations(
+                    TABLE_ID,
+                    List.of(
+                        new ReusableArtifactBundleSelection(
+                            "reuse-bundle:prior-group",
+                            bundleUri,
+                            bundle.length,
+                            digest,
+                            List.of(),
+                            List.of(filePath)))))
+        .isInstanceOf(BaseResourceRepository.CorruptionException.class)
+        .hasMessageContaining("metadata does not match");
+    verify(blobs, never()).get(bundleUri);
+  }
+
+  @Test
+  void selectedBundleWrapsUnsupportedFormatAsCorruption() {
+    InMemoryBlobStore blobs = new InMemoryBlobStore();
+    IndexArtifactRepository repository = createRepository(new InMemoryPointerStore(), blobs);
+    String filePath = "s3://bucket/file.parquet";
+    byte[] bundle =
+        ReusableArtifactBundlePayload.newBuilder()
+            .setFormatVersion(2)
+            .addIndexArtifacts(indexRecord(714L, filePath))
+            .build()
+            .toByteArray();
+    byte[] digest = HexFormat.of().parseHex(Hashing.sha256Hex(bundle));
+    String bundleUri =
+        workerStatsPrefix(715L) + "reuse-bundles/" + Hashing.sha256Hex(bundle) + ".pb";
+    blobs.put(bundleUri, bundle, "application/x-protobuf");
+
+    assertThatThrownBy(
+            () ->
+                repository.inheritedManagedSidecarGenerations(
+                    TABLE_ID,
+                    List.of(
+                        new ReusableArtifactBundleSelection(
+                            "reuse-bundle:prior-group",
+                            bundleUri,
+                            bundle.length,
+                            digest,
+                            List.of(),
+                            List.of(filePath)))))
+        .isInstanceOf(BaseResourceRepository.CorruptionException.class)
+        .hasMessageContaining("unsupported format");
   }
 
   @Test


### PR DESCRIPTION
## Summary

This fixes issues that have shaken out of the production environment runs yesterday and today. This does not break the contract with Floe:

- Deduplicate reusable artifact bundle selections and cache immutable bundle reads to avoid repeated validation and excessive memory use during checkpoint reconciliation.
- Accept external sidecars while retaining generation references only for Floecat-managed artifacts.
- Validate bundle length from blob metadata and consistently report invalid bundles as corruption.
- Stage artifact references before committing file-group success, preventing snapshot finalizers from observing completed groups before their artifacts are available.
- Add coverage for bundle caching, external sidecars, validation failures, deduplication, and commit ordering.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [ ] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Additional Notes

No contract-breaking behaviour vs floe.
