### PR TITLE
fix: restore telemetry tracing error contract

### DIFF
--- a/telemetry-hub/backend-micrometer/src/main/java/ai/floedb/floecat/telemetry/micrometer/MicrometerObservability.java
+++ b/telemetry-hub/backend-micrometer/src/main/java/ai/floedb/floecat/telemetry/micrometer/MicrometerObservability.java
@@ -656,13 +656,13 @@ public final class MicrometerObservability implements Observability {
     }
 
     @Override
-    public void error(Class<? extends Throwable> errorType) {
+    public void error(Throwable throwable) {
       if (span.isRecording()) {
         span.addEvent(
             "exception",
             Attributes.of(
                 AttributeKey.stringKey("exception.type"),
-                Objects.requireNonNull(errorType, "errorType").getName()));
+                Objects.requireNonNull(throwable, "throwable").getClass().getName()));
         span.setStatus(StatusCode.ERROR);
       }
     }

--- a/telemetry-hub/backend-micrometer/src/test/java/ai/floedb/floecat/telemetry/micrometer/MicrometerObservabilityTest.java
+++ b/telemetry-hub/backend-micrometer/src/test/java/ai/floedb/floecat/telemetry/micrometer/MicrometerObservabilityTest.java
@@ -609,7 +609,7 @@ class MicrometerObservabilityTest {
           new IllegalStateException("s3://sensitive-bucket/private/object-key");
       try (Scope ignored = parent.makeCurrent()) {
         StoreTraceScope scope = observability.storeTraceScope("svc", "store-op");
-        scope.error(failure.getClass());
+        scope.error(failure);
         scope.close();
       } finally {
         parent.end();

--- a/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/StoreTraceScope.java
+++ b/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/StoreTraceScope.java
@@ -25,7 +25,7 @@ public interface StoreTraceScope extends AutoCloseable {
         public void success() {}
 
         @Override
-        public void error(Class<? extends Throwable> errorType) {}
+        public void error(Throwable throwable) {}
 
         @Override
         public void close() {}
@@ -34,8 +34,8 @@ public interface StoreTraceScope extends AutoCloseable {
   /** Marks the span as a success. */
   void success();
 
-  /** Records the non-sensitive error type and marks the span as failed. */
-  void error(Class<? extends Throwable> errorType);
+  /** Records an error and marks the span as failed. */
+  void error(Throwable throwable);
 
   @Override
   default void close() {}

--- a/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/TestObservability.java
+++ b/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/TestObservability.java
@@ -410,8 +410,8 @@ public final class TestObservability implements Observability {
     }
 
     @Override
-    public void error(Class<? extends Throwable> errorType) {
-      this.errorType = Objects.requireNonNull(errorType, "errorType");
+    public void error(Throwable throwable) {
+      this.errorType = Objects.requireNonNull(throwable, "throwable").getClass();
       success = false;
     }
 

--- a/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/helpers/StoreMetrics.java
+++ b/telemetry-hub/core/src/main/java/ai/floedb/floecat/telemetry/helpers/StoreMetrics.java
@@ -98,7 +98,7 @@ public final class StoreMetrics extends BaseMetrics {
     public void error(Throwable throwable) {
       error = throwable;
       metricsScope.error(throwable);
-      traceScope.error(throwable.getClass());
+      traceScope.error(throwable);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Restore StoreTraceScope.error(Throwable) to preserve compatibility with core and floecat-runtime, while retaining the privacy behavior introduced in #490 by recording only the exception class name - never its message or stack trace. This resolves the downstream core TracingKvStore compilation failure caused by changing the public API to accept Class<? extends Throwable>.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
