### PR TITLE
test(smoke): prove Catalog Integration vending

### DIFF
--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/CredentialResolverSupport.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/auth/CredentialResolverSupport.java
@@ -113,17 +113,21 @@ public final class CredentialResolverSupport {
 
     Map<String, String> options = new HashMap<>(base.options());
     Map<String, String> authProps = new HashMap<>(base.auth().props());
-    Map<String, String> headerHints = new HashMap<>(base.auth().headerHints());
+    // Final so the compiler enforces what the branches below used to assert one at a time:
+    // header hints survive every credential shape. Four exchange branches replaced this with
+    // an empty map, which dropped header.X-Iceberg-Access-Delegation and left an Iceberg
+    // connector configured for vended credentials never asking its catalog to vend. Leaving
+    // the variable alone states that in one place rather than seven, and a future change that
+    // populates hints before the switch cannot be silently discarded by a branch.
+    final Map<String, String> headerHints = new HashMap<>(base.auth().headerHints());
 
     switch (credential.getCredentialCase()) {
       case BEARER -> {
         authProps = new HashMap<>(base.auth().props());
-        headerHints = new HashMap<>(base.auth().headerHints());
         putIfNotBlank(authProps, "token", credential.getBearer().getToken());
       }
       case CLIENT -> {
         authProps = new HashMap<>(base.auth().props());
-        headerHints = new HashMap<>(base.auth().headerHints());
         var client = credential.getClient();
         String tokenEndpoint =
             firstNonBlank(client.getEndpoint(), authProps.get("oauth2-server-uri"));
@@ -138,8 +142,14 @@ public final class CredentialResolverSupport {
                   scope,
                   credential.getPropertiesMap(),
                   credential.getHeadersMap());
+          // authProps is replaced so the client id and secret do not travel on to the connector
+          // once they have been exchanged; only the bearer token should. Header hints are not
+          // credential material -- they are the operator's `--head` routing, kept separately from
+          // the credential headers this exchange consumes -- so they survive, as they already do
+          // on the branch below that skips the exchange. Dropping them silently removed
+          // `header.X-Iceberg-Access-Delegation`, so a connector configured for vended
+          // credentials never asked its catalog to vend and fell back to a storage authority.
           authProps = new HashMap<>();
-          headerHints = new HashMap<>();
           putIfNotBlank(authProps, "token", token);
         } else {
           putIfNotBlank(authProps, "client_id", client.getClientId());
@@ -149,7 +159,6 @@ public final class CredentialResolverSupport {
       }
       case CLI -> {
         authProps = new HashMap<>(base.auth().props());
-        headerHints = new HashMap<>(base.auth().headerHints());
         var cli = credential.getCli();
         String provider =
             cli.getProvider() == null ? "" : cli.getProvider().trim().toLowerCase(Locale.ROOT);
@@ -174,8 +183,9 @@ public final class CredentialResolverSupport {
       case AWS, AWS_WEB_IDENTITY, AWS_ASSUME_ROLE ->
           applyAwsStorageCredentials(options, credential);
       case RFC8693_TOKEN_EXCHANGE -> {
+        // Cleared for the same reason as the client-credentials exchange above, and header
+        // hints kept for the same reason: they are routing, not credential material.
         authProps = new HashMap<>();
-        headerHints = new HashMap<>();
         String token =
             exchangeRfc8693(
                 requireBase(credential.getRfc8693TokenExchange()),
@@ -185,8 +195,9 @@ public final class CredentialResolverSupport {
         putIfNotBlank(authProps, "token", token);
       }
       case AZURE_TOKEN_EXCHANGE -> {
+        // Cleared for the same reason as the client-credentials exchange above, and header
+        // hints kept for the same reason: they are routing, not credential material.
         authProps = new HashMap<>();
-        headerHints = new HashMap<>();
         String token =
             exchangeAzureObo(
                 requireBase(credential.getAzureTokenExchange()),
@@ -196,8 +207,9 @@ public final class CredentialResolverSupport {
         putIfNotBlank(authProps, "token", token);
       }
       case GCP_TOKEN_EXCHANGE -> {
+        // Cleared for the same reason as the client-credentials exchange above, and header
+        // hints kept for the same reason: they are routing, not credential material.
         authProps = new HashMap<>();
-        headerHints = new HashMap<>();
         String token =
             exchangeGoogleDwd(
                 credential.getGcpTokenExchange(),

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/auth/CredentialResolverSupportTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/auth/CredentialResolverSupportTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.connector.rpc.AuthCredentials;
 import ai.floedb.floecat.connector.spi.ConnectorConfig;
+import ai.floedb.floecat.connector.spi.IcebergAccessDelegation;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpServer;
 import java.net.InetSocketAddress;
@@ -122,7 +123,8 @@ class CredentialResolverSupportTest {
             "name",
             "uri",
             Map.of(),
-            new ConnectorConfig.Auth("oauth2", Map.of(), Map.of()));
+            new ConnectorConfig.Auth(
+                "oauth2", Map.of(), Map.of("X-Iceberg-Access-Delegation", "vended-credentials")));
 
     ConnectorConfig applied =
         CredentialResolverSupport.apply(
@@ -131,6 +133,9 @@ class CredentialResolverSupportTest {
             new ai.floedb.floecat.connector.spi.AuthResolutionContext("subject-token", ""));
 
     assertEquals("exchanged", applied.auth().props().get("token"));
+    // Operator routing survives the exchange; only the credential material is replaced.
+    assertEquals(
+        "vended-credentials", applied.auth().headerHints().get("X-Iceberg-Access-Delegation"));
     assertNull(applied.auth().props().get("oauth2-server-uri"));
 
     CapturedRequest req = captured.get();
@@ -188,7 +193,8 @@ class CredentialResolverSupportTest {
             "name",
             "uri",
             Map.of(),
-            new ConnectorConfig.Auth("oauth2", Map.of(), Map.of()));
+            new ConnectorConfig.Auth(
+                "oauth2", Map.of(), Map.of("X-Iceberg-Access-Delegation", "vended-credentials")));
 
     ConnectorConfig applied =
         CredentialResolverSupport.apply(
@@ -196,6 +202,9 @@ class CredentialResolverSupportTest {
             creds,
             new ai.floedb.floecat.connector.spi.AuthResolutionContext("subject-token", ""));
     assertEquals("azure-token", applied.auth().props().get("token"));
+    // Operator routing survives the exchange; only the credential material is replaced.
+    assertEquals(
+        "vended-credentials", applied.auth().headerHints().get("X-Iceberg-Access-Delegation"));
 
     CapturedRequest req = captured.get();
     Map<String, String> form = parseForm(req.body);
@@ -253,7 +262,8 @@ class CredentialResolverSupportTest {
             "name",
             "uri",
             Map.of(),
-            new ConnectorConfig.Auth("oauth2", Map.of(), Map.of()));
+            new ConnectorConfig.Auth(
+                "oauth2", Map.of(), Map.of("X-Iceberg-Access-Delegation", "vended-credentials")));
 
     ConnectorConfig applied =
         CredentialResolverSupport.apply(
@@ -261,6 +271,9 @@ class CredentialResolverSupportTest {
             creds,
             new ai.floedb.floecat.connector.spi.AuthResolutionContext("subject-token", ""));
     assertEquals("gcp-token", applied.auth().props().get("token"));
+    // Operator routing survives the exchange; only the credential material is replaced.
+    assertEquals(
+        "vended-credentials", applied.auth().headerHints().get("X-Iceberg-Access-Delegation"));
 
     CapturedRequest req = captured.get();
     Map<String, String> form = parseForm(req.body);
@@ -405,6 +418,62 @@ class CredentialResolverSupportTest {
     assertEquals("scope-x", form.get("scope"));
     assertEquals("value", form.get("extra"));
     assertNull(req.headers.getFirst("X-Test"));
+  }
+
+  @Test
+  void clientCredentialsExchangeKeepsHeaderHints() throws Exception {
+    // The exchange replaces auth props so the client id and secret do not travel on past it. It
+    // must not take header hints with them: those are the operator's routing, not credential
+    // material, and the credential's own headers are a separate map this exchange consumes.
+    //
+    // Concretely, dropping them removed header.X-Iceberg-Access-Delegation from the catalog
+    // properties IcebergConnectorFactory builds, so an Iceberg connector configured for vended
+    // credentials never asked its catalog to vend -- IcebergAccessDelegation still reported it as
+    // declaring delegation, because that reads the stored record rather than the resolved config,
+    // so the vend was attempted, came back empty, and fell through to a storage authority.
+    System.setProperty("floecat.security.allow-loopback-token-endpoints", "true");
+    server = createServer();
+    server.createContext(
+        "/token",
+        exchange -> {
+          byte[] response =
+              "{\"access_token\":\"client-token\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
+                  .getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().set("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, response.length);
+          exchange.getResponseBody().write(response);
+          exchange.close();
+        });
+    server.start();
+
+    String endpoint = "http://localhost:" + server.getAddress().getPort() + "/token";
+    var creds =
+        AuthCredentials.newBuilder()
+            .setClient(
+                AuthCredentials.ClientCredentials.newBuilder()
+                    .setEndpoint(endpoint)
+                    .setClientId("client-id")
+                    .setClientSecret("client-secret"))
+            .build();
+    var cfg =
+        new ConnectorConfig(
+            ConnectorConfig.Kind.ICEBERG,
+            "name",
+            "uri",
+            Map.of(),
+            new ConnectorConfig.Auth(
+                "oauth2",
+                Map.of("scope", "scope-x"),
+                Map.of("X-Iceberg-Access-Delegation", "vended-credentials")));
+
+    ConnectorConfig applied = CredentialResolverSupport.apply(cfg, creds);
+
+    assertEquals("client-token", applied.auth().props().get("token"));
+    assertEquals(
+        "vended-credentials", applied.auth().headerHints().get("X-Iceberg-Access-Delegation"));
+    // The exchanged secret still must not survive.
+    assertNull(applied.auth().props().get("client_secret"));
+    assertTrue(IcebergAccessDelegation.declaresVendedCredentials(applied));
   }
 
   @Test
@@ -689,7 +758,10 @@ class CredentialResolverSupportTest {
                 "name",
                 "uri",
                 Map.of(),
-                new ConnectorConfig.Auth("oauth2", Map.of(), Map.of())),
+                new ConnectorConfig.Auth(
+                    "oauth2",
+                    Map.of(),
+                    Map.of("X-Iceberg-Access-Delegation", "vended-credentials"))),
             creds,
             new ai.floedb.floecat.connector.spi.AuthResolutionContext("subject-token", ""));
 
@@ -699,7 +771,11 @@ class CredentialResolverSupportTest {
     assertFalse(applied.auth().props().containsKey("gcp.service_account_email"));
     assertFalse(applied.auth().props().containsKey("gcp.delegated_user"));
     assertFalse(applied.auth().headerHints().containsKey("Authorization"));
-    assertEquals(Map.of(), applied.auth().headerHints());
+    // Asserted together: the bootstrap Authorization header the exchange consumed does not
+    // reach the connector, and the operator's own routing hint does. With an empty base hint
+    // map the first assertion held whether or not the second did.
+    assertEquals(
+        Map.of("X-Iceberg-Access-Delegation", "vended-credentials"), applied.auth().headerHints());
   }
 
   @Test

--- a/docs/catalog-integrations.md
+++ b/docs/catalog-integrations.md
@@ -136,9 +136,37 @@ COMPOSE_SMOKE_MODES=polaris-integration make compose-smoke
 
 This mode does not create or trigger a legacy Connector resource.
 
+After the Overlay materializes, the Polaris scenario disables **every** storage authority whose
+prefix covers the table location, then loads the Overlay table through Floecat's own Iceberg REST
+gateway with `X-Iceberg-Access-Delegation: vended-credentials` and requires a complete session
+tuple in the response.
+
+Every covering authority matters, not just the one the smoke created. `matchesLocationPrefix`
+strips a trailing slash from the configured prefix and then requires a path boundary, so the
+seeded `fixture-floecat` authority at `s3://floecat` covers `s3://floecat/sales/...` exactly as the
+smoke's own `s3://floecat/` does — and leaving it enabled means the read resolves through it and
+never reaches the vend. The scenario computes coverage with that same rule, disables what it finds,
+and re-lists to confirm nothing still covers before reading. They are disabled rather than deleted
+so re-enabling restores the exact record, which recreating a seeded fixture from guessed arguments
+would not.
+
+With nothing covering the location and the table already asserted to carry no Connector,
+`vendFromCatalogIntegration` is the only code that can put a credential in that response, so the
+response carries the whole assertion. The authorities are re-enabled afterwards for the sections
+that still read through them.
+
+The gateway is used rather than a capture because `overlay reconcile` is metadata-only and capture
+needs `connector trigger`, which an Overlay-materialized table has no Connector for.
+
 The full LocalStack smoke also exercises the Unity Integration and Overlay path against the same
 TLS-backed Unity/Delta fixture used by the Connector migration scenario. It validates discovery,
 credential vending, a storage read with those credentials, and Overlay materialization.
+
+The Unity Integration finishes with the same gateway `loadTable` check as the Polaris one. No
+authority has to be removed there: that fixture is copied to a bucket deliberately absent from
+`COMPOSE_SMOKE_LOCALSTACK_BUCKETS`, which the scenario asserts rather than assumes. Its upstream
+namespace has two levels, so the URL uses the `%1F` separator the gateway's own `/v1/config`
+advertises.
 
 Authentication types and their properties are:
 

--- a/docs/iceberg-rest-gateway.md
+++ b/docs/iceberg-rest-gateway.md
@@ -233,11 +233,12 @@ ETags for load responses are representation-aware and vary by `snapshots` mode.
   view lifecycle checks in LocalStack mode. To exercise split reconciler deployment, run
   `COMPOSE_SMOKE_MODES=localstack-remote make compose-smoke`, which starts the service in
   `reconciler-control` mode and enables the remote `executor` profile. The Trino block creates and
-  replaces an Iceberg view via SQL and verifies both definitions are queryable. The same
-  `localstack-remote` smoke run also exercises upstream Polaris Iceberg REST credential vending by
+  replaces an Iceberg view via SQL and verifies both definitions are queryable. The `localstack` and
+  `localstack-remote` smoke runs also exercise upstream Polaris Iceberg REST credential vending by
   verifying that Polaris `loadTable` returns non-empty `storage-credentials` when sent
   `X-Iceberg-Access-Delegation: vended-credentials`, then importing the upstream table through that
-  vended-credentials path in the same stack. For the OIDC split deployment, run
+  vended-credentials path with every storage authority covering it disabled, so the import cannot
+  resolve through one instead. For the OIDC split deployment, run
   `COMPOSE_SMOKE_MODES=localstack-oidc-remote make compose-smoke`, which adds Keycloak and
   exercises remote executor worker machine auth as well as user-propagated OIDC auth.
 

--- a/tools/compose-smoke.sh
+++ b/tools/compose-smoke.sh
@@ -337,6 +337,171 @@ assert_remote_file_group_worker_activity() {
     "commitLeasedFileGroupResult"
 }
 
+# Ids of enabled storage authorities covering a location, one per line, on stdout only.
+#
+# Mirrors StorageAuthorityResolver.matchesLocationPrefix, which strips a trailing slash and then
+# requires a path boundary. A substring test is wrong both ways: it misses s3://floecat covering
+# s3://floecat/sales/..., and counts s3://floecat-delta as covering s3://floecat-delta-vended/...
+authorities_covering() {
+  local compose_cmd="$1"
+  local location="$2"
+
+  run_cli_script "$compose_cmd" "account t-0001
+storage-authority list
+quit" | COVERED_LOCATION="$location" python3 -c '
+import os
+import re
+import sys
+
+location = os.environ["COVERED_LOCATION"].strip()
+
+
+def covers(prefix):
+    prefix = prefix.strip().rstrip("/")
+    if not prefix or not location.startswith(prefix):
+        return False
+    return len(location) == len(prefix) or location[len(prefix)] == "/"
+
+
+UUID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+rows = 0
+for line in sys.stdin:
+    parts = line.split()
+    # Only the last two fields are at a fixed offset, and the enabled flag reading true or false is
+    # what identifies a row. Keyed on the id rather than the name because the field count is not
+    # fixed either: a blank TYPE collapses to four fields and a multi-word name adds fields in the
+    # middle. storage-authority update takes an id directly.
+    if len(parts) < 4 or parts[-2] not in ("true", "false"):
+        continue
+    identifier = None
+    for part in parts:
+        if UUID.match(part):
+            identifier = part
+            break
+    if identifier is None:
+        continue
+    rows += 1
+    if parts[-2] == "true" and covers(parts[-1]):
+        print(identifier)
+
+# Recognising nothing is a broken parse, not an empty catalog: every caller reads no output as
+# "no authority covers this", so a column change would turn each of them green asserting nothing.
+if rows == 0:
+    print("parsed no storage-authority rows; the list columns may have changed", file=sys.stderr)
+    sys.exit(1)
+'
+}
+
+# Flips the enabled flag on each authority named on stdin.
+#
+# Disabled rather than deleted, so re-enabling restores the exact record; a seeded fixture cannot
+# be recreated from arguments guessed at the call site. Callers use a here-string, not a pipe: as a
+# pipeline sink this runs in a subshell that inherits the ERR trap under set -E, so a failed update
+# would run the mode handler there, destroy the stack, then run it again in the parent.
+set_authorities_enabled() {
+  local compose_cmd="$1"
+  local label="$2"
+  local enabled="$3"
+  local authority_name
+  local -a authority_names=()
+
+  # Drained before the first update runs. run_cli_script pipes its own script into the container
+  # and so leaves this stdin alone, but a reader should not have to confirm that to trust the loop.
+  while IFS= read -r authority_name; do
+    [ -n "$authority_name" ] || continue
+    authority_names+=("$authority_name")
+  done
+
+  if [ "${#authority_names[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  # One shell invocation for the whole set. The CLI takes a multi-command script, as the setup
+  # blocks in this file already rely on, and a container start per authority adds up: two covering
+  # authorities across four disable and re-enable rounds is eight of them per localstack mode.
+  local script="account t-0001"
+  for authority_name in "${authority_names[@]}"; do
+    script="$script
+storage-authority update $authority_name --enabled $enabled"
+  done
+  script="$script
+quit"
+
+  local out
+  out=$(run_cli_script "$compose_cmd" "$script")
+  echo "$out"
+  # The combined output names whichever update failed, so one assertion over all of them keeps the
+  # signal without a label per authority.
+  assert_not_contains "$label storage authority enabled=$enabled" "$out" "! "
+}
+
+# Fails unless no enabled storage authority covers the location.
+assert_no_authority_covers() {
+  local compose_cmd="$1"
+  local label="$2"
+  local location="$3"
+  local still_covering
+
+  still_covering=$(authorities_covering "$compose_cmd" "$location")
+  if [ -n "$still_covering" ]; then
+    echo "[FAIL] $label storage authorities still cover $location"
+    printf '%s\n' "$still_covering"
+    return 1
+  fi
+  echo "[PASS] $label no storage authority covers $location"
+}
+
+# Fails unless a gateway loadTable returns a complete vended session tuple.
+#
+# Shared by the Polaris and Unity checks, which differ only in label and URL. The body is never
+# echoed: it carries live temporary storage credentials, the same reason the Polaris loadTable
+# precondition omits its own. The status is safe and is reported.
+assert_gateway_vends_session_tuple() {
+  local compose_project="$1"
+  local label="$2"
+  local url="$3"
+
+  local resp
+  resp=$(docker run --rm --network "${compose_project}_floecat" \
+    curlimages/curl:8.12.1 -k -sS \
+    -w '\n%{http_code}' \
+    -X GET "$url" \
+    -H "X-Iceberg-Access-Delegation: vended-credentials")
+  local code
+  code=$(printf '%s' "$resp" | tail -n1)
+  local body
+  body=$(printf '%s' "$resp" | sed '$d')
+  echo "$label gateway loadTable http=${code}"
+
+  if ! python3 - "$body" <<'PY'
+import json
+import sys
+
+# Guarded so a non-JSON body exits quietly rather than printing itself in a traceback; it may
+# carry live credentials. The session token is what separates a real vend from a bare key pair.
+try:
+    payload = json.loads(sys.argv[1])
+    creds = payload.get("storage-credentials")
+    if not isinstance(creds, list) or not creds:
+        sys.exit(1)
+    config = creds[0].get("config") or {}
+    for required in ("s3.access-key-id", "s3.secret-access-key", "s3.session-token"):
+        if not config.get(required):
+            sys.exit(1)
+except SystemExit:
+    raise
+except Exception:
+    sys.exit(1)
+PY
+  then
+    echo "[FAIL] $label gateway loadTable returned no vended session tuple (http=${code})"
+    echo "[FAIL] response body omitted because it may contain storage credentials"
+    return 1
+  fi
+  echo "[PASS] $label gateway credential vending"
+}
+
 assert_table_stats_available() {
   local compose_cmd="$1"
   local label="$2"
@@ -650,6 +815,9 @@ run_mode() {
   local executor_scale="${9:-}"
   local smoke_scope="${10:-full}"
 
+  # Disabled by a scenario and not yet re-enabled. Restored from the mode handlers so a failure
+  # inside that window does not leave a preserved stack with fixture-floecat switched off.
+  local disabled_authorities_pending=""
   local compose_project="floecat-smoke-$label"
   local compose_profiles="${compose_profiles_override:-$profile}"
   if [ "$profile" = "localstack" ] && is_truthy "$COMPOSE_SMOKE_UPSTREAM_ICEBERG_IMPORT"; then
@@ -711,6 +879,25 @@ run_mode() {
   done
 
   local compose_cmd="${mode_env}${DOCKER_COMPOSE_MAIN}"
+  # Deliberately assertion-free and failure-tolerant: this runs from an ERR handler, where a
+  # non-zero command would recurse or mask the failure being reported.
+  restore_disabled_authorities() {
+    [ -n "$disabled_authorities_pending" ] || return 0
+    local pending="$disabled_authorities_pending"
+    disabled_authorities_pending=""
+    echo "==> [SMOKE] re-enabling storage authorities disabled for this scenario"
+    local authority_name
+    while IFS= read -r authority_name; do
+      [ -n "$authority_name" ] || continue
+      # Bounded, unlike every other call in this file. Each re-enable is a compose run that starts
+      # the cli service and its dependencies, and this path runs on a stack that has just failed,
+      # so an unbounded wait would postpone the diagnostics that explain the failure.
+      run_cli_script "$compose_cmd" "account t-0001
+storage-authority update $authority_name --enabled true
+quit" 60 || true
+    done <<< "$pending"
+  }
+
   on_mode_error() {
     echo "==> [SMOKE][FAIL] mode=$label"
     eval "$compose_cmd ps" || true
@@ -723,7 +910,11 @@ run_mode() {
     eval "$compose_cmd logs --no-color --tail=120" || true
     save_mode_logs "$compose_cmd" "${label}-fail"
     save_mode_container_diagnostics "$compose_cmd" "${label}-fail"
+    # Only where the stack survives. Against one about to be down -v'd it writes to a doomed
+    # volume, and each re-enable waits on the service being healthy -- so on the failures that
+    # reach here it would burn its timeout first. After the diagnostics, which record the failure.
     if should_keep_on_fail || should_keep_on_exit; then
+      restore_disabled_authorities
       echo "==> [SMOKE][KEEP] preserving compose stack for mode=$label (COMPOSE_SMOKE_KEEP_ON_FAIL=$COMPOSE_SMOKE_KEEP_ON_FAIL)"
     else
       cleanup_mode "$compose_cmd"
@@ -746,6 +937,7 @@ run_mode() {
       save_mode_logs "$compose_cmd" "${label}-fail"
       save_mode_container_diagnostics "$compose_cmd" "${label}-fail"
       if should_keep_on_fail || should_keep_on_exit; then
+        restore_disabled_authorities
         echo "==> [SMOKE][KEEP] preserving compose stack for mode=$label (COMPOSE_SMOKE_KEEP_ON_FAIL=$COMPOSE_SMOKE_KEEP_ON_FAIL)"
       else
         cleanup_mode "$compose_cmd"
@@ -897,7 +1089,6 @@ quit")
     local source_namespace="$COMPOSE_SMOKE_UPSTREAM_ICEBERG_SOURCE_NS"
     local source_table="$COMPOSE_SMOKE_UPSTREAM_ICEBERG_TABLE"
     local localstack_storage_bucket_resource_list=""
-    local localstack_storage_authority_name=""
     local bucket
     for bucket in $COMPOSE_SMOKE_LOCALSTACK_BUCKETS; do
       local storage_authority_name
@@ -912,19 +1103,11 @@ storage-authority create $storage_authority_name --location-prefix s3://$storage
 quit")
         echo "$localstack_authority_setup_out"
         assert_contains "$label upstream iceberg storage authority setup (${storage_bucket})" "$localstack_authority_setup_out" "$storage_authority_name"
-
-        if [ "$storage_bucket" = "floecat" ]; then
-          localstack_storage_authority_name="$storage_authority_name"
-        fi
       fi
 
       localstack_storage_bucket_resource_list+="\\\"arn:aws:s3:::${storage_bucket}\\\",\\\"arn:aws:s3:::${storage_bucket}/*\\\","
     done
     localstack_storage_bucket_resource_list=${localstack_storage_bucket_resource_list%,}
-    if [ "$smoke_scope" = "full" ] && [ -z "$localstack_storage_authority_name" ]; then
-      echo "[FAIL] $label upstream iceberg expected floecat storage authority name not resolved"
-      return 1
-    fi
 
     docker exec "$localstack_container" sh -lc "cat > /tmp/polaris-trust.json <<'JSON'
 {\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"sts:AssumeRole\"}]}
@@ -1029,22 +1212,33 @@ EOF
       local scenario_suffix="$2"
       local access_delegation_header="$3"
       local expect_vended_creds="$4"
-      local scenario_storage_authority_name="$localstack_storage_authority_name"
+      # The table root, not the bucket root: a bucket root cannot see an authority scoped beneath
+      # it, and one at s3://floecat/sales covers this table without covering s3://floecat.
+      # metadata_uri is the registered metadata file, so /metadata/... strips to the table root.
+      local scenario_authority_location="${metadata_uri%/metadata/*}"
       local scenario_connector_name="smoke-upstream-iceberg${scenario_suffix}"
       local scenario_catalog_name="${COMPOSE_SMOKE_UPSTREAM_ICEBERG_DEST_CATALOG}${scenario_suffix}"
       local scenario_expected_table="${scenario_catalog_name}.${COMPOSE_SMOKE_UPSTREAM_ICEBERG_EXPECTED_TABLE#*.}"
       local access_delegation_arg=""
 
       if [ "$expect_vended_creds" = "true" ]; then
-        # The baseline scenario deliberately proves the storage-authority path. Remove that
-        # authority before the delegated scenario so a successful import cannot silently use the
-        # same authority and pass without ever consuming the credentials returned by Polaris.
-        local authority_remove_out
-        authority_remove_out=$(run_cli_script "$compose_cmd" "account t-0001
-storage-authority delete $scenario_storage_authority_name
-quit")
-        echo "$authority_remove_out"
-        assert_contains "$label upstream iceberg ${scenario_key} storage authority removal" "$authority_remove_out" "ok"
+        # The baseline scenario proves the authority path; take it away here so a successful import
+        # cannot pass without consuming Polaris credentials. Every covering authority, not just the
+        # one this smoke created: leaving the seeded fixture-floecat at s3://floecat behind is what
+        # let this scenario pass without ever vending.
+        local scenario_covering_authorities
+        scenario_covering_authorities=$(authorities_covering "$compose_cmd" "$scenario_authority_location")
+        if [ -z "$scenario_covering_authorities" ]; then
+          echo "[FAIL] $label upstream iceberg ${scenario_key} found no authority covering $scenario_authority_location to take away"
+          return 1
+        fi
+        echo "disabling storage authorities covering ${scenario_authority_location}:"
+        printf '%s\n' "$scenario_covering_authorities"
+        disabled_authorities_pending="$scenario_covering_authorities"
+        set_authorities_enabled "$compose_cmd" "$label upstream iceberg ${scenario_key}" false \
+          <<< "$scenario_covering_authorities"
+        assert_no_authority_covers "$compose_cmd" \
+          "$label upstream iceberg ${scenario_key}" "$scenario_authority_location"
 
         local load_table_resp
         load_table_resp=$(docker run --rm --network "${compose_project}_floecat" curlimages/curl:8.12.1 -k -sS \
@@ -1107,22 +1301,19 @@ quit")
         "${COMPOSE_SMOKE_STATS_SLEEP_SECONDS:-2}"
 
       if [ "$expect_vended_creds" = "true" ]; then
-        # Later smoke sections still exercise authority-backed reads. Restore the authority only
-        # after every delegated assertion has completed, keeping the vending scenario honest.
-        local authority_restore_out
-        authority_restore_out=$(run_cli_script "$compose_cmd" "account t-0001
-storage-authority create $scenario_storage_authority_name --location-prefix s3://floecat/ --type s3 --region us-east-1 --endpoint http://localstack:4566 --path-style-access true --assume-role-arn arn:aws:iam::000000000000:role/polaris --duration-seconds 900 --cred-type aws --cred access_key_id=test --cred secret_access_key=test
-quit")
-        echo "$authority_restore_out"
-        assert_contains "$label upstream iceberg ${scenario_key} storage authority restoration" "$authority_restore_out" "$scenario_storage_authority_name"
+        # Later smoke sections still exercise authority-backed reads. Re-enable only after every
+        # delegated assertion has completed, keeping the vending scenario honest.
+        set_authorities_enabled "$compose_cmd" "$label upstream iceberg ${scenario_key}" true \
+          <<< "$scenario_covering_authorities"
+        disabled_authorities_pending=""
       fi
     }
 
     if [ "$smoke_scope" = "full" ]; then
       run_upstream_iceberg_scenario "storage-authority" "" "" "false"
-      if [ "$label" = "localstack-remote" ] || [ "$label" = "localstack-oidc-remote" ]; then
-        run_upstream_iceberg_scenario "polaris-vended-creds" "_vended_creds" "vended-credentials" "true"
-      fi
+      # Both variants, not only -remote. localstack-oidc-remote never reaches this section, so the
+      # old gate left one variant carrying all Connector vending coverage.
+      run_upstream_iceberg_scenario "polaris-vended-creds" "_vended_creds" "vended-credentials" "true"
     fi
 
     echo "==> [SMOKE] upstream iceberg Catalog Integration overlay reconciliation"
@@ -1177,6 +1368,48 @@ quit")
     assert_contains "$label Polaris overlay avoids Connector identity" "$integration_table_out" "connector_id: -"
     assert_contains "$label Polaris overlay carries Integration identity" "$integration_table_out" "floecat.catalog-integration.id ="
     assert_contains "$label Polaris overlay carries Overlay identity" "$integration_table_out" "floecat.catalog-overlay.id ="
+
+    # A read of the Overlay table, which the assertions above do not reach: they resolve through
+    # the covering authority. overlay reconcile is metadata-only and capture needs a Connector, so
+    # the gateway is the only surface that reaches vendForTable here.
+    #
+    # The table root, not the bucket root: a bucket root cannot see an authority scoped beneath it.
+    # metadata_uri is the registered metadata file, so /metadata/... strips to the table root.
+    local integration_table_location="${metadata_uri%/metadata/*}"
+    local integration_covering_authorities
+    integration_covering_authorities=$(authorities_covering "$compose_cmd" "$integration_table_location")
+    echo "==> [SMOKE] upstream iceberg Catalog Integration credential vending"
+    # A failure, not a skip: the proof below matters most when nothing covers, so guarding the body
+    # on having something to disable would drop the assertion exactly when it is free.
+    if [ -z "$integration_covering_authorities" ]; then
+      echo "[FAIL] $label Polaris integration found no enabled authority covering ${integration_table_location}"
+      echo "[FAIL] the fixture is expected to have one; an empty list means the parse or the seed changed"
+      return 1
+    fi
+    echo "disabling storage authorities covering ${integration_table_location}:"
+    printf '%s\n' "$integration_covering_authorities"
+    disabled_authorities_pending="$integration_covering_authorities"
+    set_authorities_enabled "$compose_cmd" "$label Polaris integration" false \
+      <<< "$integration_covering_authorities"
+    assert_no_authority_covers "$compose_cmd" "$label Polaris integration" \
+      "$integration_table_location"
+
+    local integration_ns="${integration_expected_table#*.}"
+    integration_ns="${integration_ns%.*}"
+    # Same Iceberg REST separator the Unity check uses. The default table has a single-level
+    # namespace so dots never appear, but an override with a nested one would 404 and read as a
+    # broken gateway rather than a mis-encoded path.
+    integration_ns="${integration_ns//./%1F}"
+    local integration_table_leaf="${integration_expected_table##*.}"
+
+    assert_gateway_vends_session_tuple "$compose_project" \
+      "$label upstream iceberg Catalog Integration" \
+      "http://iceberg-rest:9200/v1/${integration_catalog_name}/namespaces/${integration_ns}/tables/${integration_table_leaf}"
+
+    # Re-enabled for the sections that follow, which still read through these authorities.
+    set_authorities_enabled "$compose_cmd" "$label Polaris integration" true \
+      <<< "$integration_covering_authorities"
+    disabled_authorities_pending=""
   elif [ "$profile" = "localstack" ]; then
     echo "==> [SMOKE] skipping upstream iceberg rest import (set COMPOSE_SMOKE_UPSTREAM_ICEBERG_IMPORT=false to disable)"
   fi
@@ -1374,6 +1607,12 @@ quit")
     assert_contains "$label upstream delta unity connector setup names the connector" "$unity_setup_out" "smoke-upstream-delta-unity"
     assert_not_contains "$label upstream delta unity connector setup reported no error" "$unity_setup_out" "! "
 
+    # What makes the stats and index assertions below evidence of vending. The fixture bucket is
+    # absent from COMPOSE_SMOKE_LOCALSTACK_BUCKETS, but that is an overridable default, so it is
+    # asserted rather than assumed -- and before the trigger, so it fails fast.
+    assert_no_authority_covers "$compose_cmd" \
+      "$label upstream delta unity fixture bucket" "$unity_storage_location"
+
     run_connector_trigger_and_wait \
       "$compose_cmd" \
       "$label upstream delta unity connector" \
@@ -1473,6 +1712,20 @@ quit")
     assert_contains "$label Unity overlay carries Integration identity" "$unity_integration_table_out" "floecat.catalog-integration.id ="
     assert_contains "$label Unity overlay carries Overlay identity" "$unity_integration_table_out" "floecat.catalog-overlay.id ="
 
+    # The Unity Integration vend. integration validate reports CREDENTIAL_VENDING through
+    # CatalogIntegrationDiscovery, not through vendForTable, so it does not cover this. Nothing has
+    # to be disabled: the fixture bucket has no authority, which is asserted below.
+    assert_no_authority_covers "$compose_cmd" \
+      "$label Unity integration" "$unity_storage_location"
+
+    # A two-level upstream namespace, so the Iceberg REST separator applies: the gateway's own
+    # /v1/config advertises namespace-separator=%1F and NamespacePaths splits on 0x1F.
+    local unity_integration_ns_path="${COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_SOURCE_NS//./%1F}"
+
+    assert_gateway_vends_session_tuple "$compose_project" \
+      "$label upstream delta unity Catalog Integration" \
+      "http://iceberg-rest:9200/v1/${unity_integration_catalog}/namespaces/${unity_integration_ns_path}/tables/${unity_source_table}"
+
     if [ "$label" = "localstack-remote" ]; then
       local unity_query_begin_out
       unity_query_begin_out=$(run_cli_script "$compose_cmd" "account t-0001
@@ -1499,13 +1752,6 @@ quit")
       echo "$unity_scan_out"
       assert_contains "$label upstream delta unity remote scan" "$unity_scan_out" "data_files:"
       assert_contains "$label upstream delta unity remote scan location" "$unity_scan_out" "$unity_storage_location"
-
-      local unity_vending_logs
-      unity_vending_logs=$(eval "$compose_cmd logs --no-color service executor" 2>&1)
-      assert_contains \
-        "$label upstream delta unity source-catalog vending path" \
-        "$unity_vending_logs" \
-        "vended storage credentials from source catalog"
     fi
   elif [ "$smoke_scope" = "full" ] && [ "$profile" = "localstack" ]; then
     echo "==> [SMOKE] skipping upstream delta unity import (set COMPOSE_SMOKE_UPSTREAM_DELTA_UNITY_IMPORT=true to enable)"


### PR DESCRIPTION
## Summary

Fixes a credential-resolution bug that stopped Iceberg connectors from ever asking their catalog to vend, and gives all four credential-vending paths a smoke oracle that cannot pass without vending.

The bug and the missing coverage are the same story. `polaris-vended-creds` was meant to prove floecat can read using credentials Polaris hands out, but it removed only the authority the smoke creates and left the seeded `fixture-floecat` one covering the same location, so it passed by reading through an authority and hid the fact that vending was broken. Making the oracle honest is what surfaced the bug.

Changes:

- Keep operator header hints across a credential token exchange. Every exchange branch replaced them with an empty map alongside auth props, which removed `header.X-Iceberg-Access-Delegation` from the catalog properties the Iceberg connector builds.
- Give the Catalog Integration vend end-to-end coverage for both providers, Polaris and Unity, through a gateway `loadTable` that must return a complete session tuple.
- Make the delegated Connector oracle take away every authority covering the table location, computed with the resolver's own matching rule, and assert none still does before reading.
- Run the delegated Connector scenario in both `localstack` variants rather than only under `-remote`.

## Type of Change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [x] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Full unit suite locally: 2336 service tests, 0 failures. `fmt:check` clean across all modules.

Each of the four exchange branches the fix touches is pinned by its own assertion: reverting the initialiser to an empty map fails five tests, one per branch plus the secret-handling one.

**The compose smoke ran in CI and all four vend paths pass**, in both `localstack` and `localstack-remote`, with zero `[FAIL]` lines in either job:

```
[PASS] upstream iceberg Catalog Integration credential vending
[PASS] upstream delta unity Catalog Integration credential vending
[PASS] Polaris credential vending          [PASS] Unity credential vending
gateway loadTable http=200                 unity integration gateway loadTable http=200
no storage authority covers s3://floecat/sales/us/trino_types
no storage authority covers s3://floecat-delta-vended/call_center
```

Two assumptions that could not be settled by reading were settled by that run: the gateway response shape is as assumed, and the Iceberg REST gateway does serve a Delta-sourced overlay table through `loadTable`. `polaris-vended-creds`, which failed with `catalog does not delegate` before the fix, now passes with every covering authority provably disabled, which it can only do by vending.

A passing smoke job carries no container logs, since the harness dumps them only on failure. So the evidence for the connector vend is the scenario passing with the authority path removed, not a log line, which is the stronger form and the reason these assertions were moved off log scraping.

**One change is verified only by CI.** Names now reach `set_authorities_enabled` through a here-string rather than a pipe, because as a pipeline sink it runs in a subshell that inherits the ERR trap under `set -E`. That mechanism does not reproduce on bash 3.2, which is what this was developed against, so the local checks say nothing about it. Everything else was exercised offline.

## Deployment and Compatibility

- [x] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

**This PR changes production code.** `CredentialResolverSupport` is on the shared connector auth path, and the change affects the client-credentials, RFC8693, Azure OBO and GCP DWD exchanges.

The effect is to stop discarding `auth.header_hints` after an exchange. Behaviour that depended on hints being dropped would change; nothing in the tree does, and the drop was silent rather than deliberate. Catalog Integrations are unaffected: they never call `apply()`, and the Iceberg REST provider sets the delegation header itself rather than relying on a hint surviving.

Auth props are still replaced, so the client id and secret do not travel past the exchange.

## Checklist

- [x] PR is scoped and focused
- [x] Commit messages follow conventional commit style where practical
- [x] Documentation updated where needed
- [x] No credentials, tokens, or secrets are included
- [x] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)

## Reviewers

- **Preserving header hints cannot leak a secret past the exchange, and that is enforced rather than assumed.** `ConnectorsImpl` runs `validateSecretBearingMap(auth.getHeaderHintsMap(), corr, "auth.header_hints")` on every write, so a secret-bearing key cannot be persisted there in the first place. Credential headers are a separate map (`credential.getHeadersMap()`), which the exchange consumes and does not forward. `sensitiveBootstrapSecretsAreNotPropagatedAfterExchange` now starts from a non-empty hint map, so it asserts both halves at once: the bootstrap `Authorization` does not reach the connector, and the operator hint does.

- **`headerHints` is `final`.** The seven in-switch assignments were byte-identical re-copies of the initialiser, so each branch asserted what the variable already held, which is the shape of the bug being fixed. Stating the invariant once lets the compiler keep it, and a future change that populates hints before the switch cannot be silently discarded by a branch.

- **The declaration gate and the factory read different configs, which is why this failed silently.** `IcebergAccessDelegation.declaresVendedCredentials` reads the stored record, so it reported the connector as asking for delegation; `IcebergConnectorFactory` receives the *resolved* config, whose hints had been dropped. The vend therefore ran, asked the catalog nothing, came back empty, and fell through to a storage authority, invisible wherever an authority happened to cover the table. The CI diagnostic that pinned it was `accessDelegationHeader=null headerKeys=[]`.

- **The gateway is used rather than a capture, and that is forced.** `overlay reconcile` is metadata-only and capture needs `connector trigger`, which an Overlay-materialized table has no Connector for, as `describe table` asserting `connector_id: -` establishes a few lines earlier. So `assert_table_stats_available` has nothing to assert against on this path. A gateway `loadTable` is the one surface that reaches `vendForTable` for an Integration table, and it exercises `CredentialUse.QUERY`, the path a reader takes.

- **Coverage is computed with `matchesLocationPrefix`'s own rule, on the table location, and keyed on the authority id.** A substring test is wrong in both directions: it misses `s3://floecat` covering `s3://floecat/sales/...` and wrongly counts `s3://floecat-delta` as covering `s3://floecat-delta-vended/...`. The location matters as much as the rule, since a bucket root cannot see an authority scoped beneath it, so both callers derive the table root from the fixture's registered metadata URI. Rows are identified by the enabled flag plus a UUID rather than by field count, because neither the display name's position nor the field count is fixed: a multi-word name adds fields in the middle and a blank `TYPE` collapses to four. `storage-authority update` takes an id directly, since `resolveId` short-circuits on `looksLikeUuid`.

- **Failing to parse is not the same as finding nothing.** Recognising zero rows exits non-zero rather than reading as "no authority covers this", which every caller would otherwise treat as proof of absence. A missing covering authority likewise fails rather than skipping, since the `loadTable` proof matters most in exactly that state.

- **Authorities are disabled, not deleted, and restored from the mode handlers.** `resolveStorageAuthority` skips a disabled authority, and re-enabling restores the exact record, which a seeded fixture cannot be recreated from since the harness never chose its configuration. The restore also runs from `on_mode_error` and the failure branch of `on_mode_return`, gated on the stack surviving: a failure inside the window would otherwise leave the stack `COMPOSE_SMOKE_KEEP_ON_FAIL` preserves with `fixture-floecat` disabled, covering the whole `floecat` bucket including the seeded `examples` catalog, and producing the same credential-resolution failure whoever kept the stack is investigating. Against a stack about to be `down -v`'d it only costs its own timeout, so it is skipped there.

- **One log-scraping assertion remains and is deliberately untouched.** `assert_remote_file_group_worker_activity` predates this work, added by #280 and modified by #408, and whether it has a non-log alternative was not investigated here.

## Additional Notes

Gateway response bodies are never echoed, on success or failure, because they carry live temporary storage credentials, the same reason the existing Polaris `loadTable` precondition omits its own. The JSON checks are guarded so a non-JSON body exits quietly rather than printing itself in a traceback.

`docs/iceberg-rest-gateway.md` needed a correction too: it scoped the delegated Polaris scenario to `localstack-remote`, which the mode-gating change makes false.

Two follow-ups deliberately not taken. The two gateway `loadTable` checks are a near-copy that should fold into one helper, and they have already drifted in formatting; that was attempted and reverted because the shared version grew the embedded Python well beyond what this file otherwise carries, and `jq` is not used anywhere in it. Separately, `polaris-vended-creds` runs only where `smoke_scope = full`, so the `polaris-integration` mode exercises the Integration vend but not the Connector one.
