### PR TITLE
fix(catalog): report ordinal_position as a position, not a field id

### DIFF
--- a/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScanner.java
+++ b/core/catalog/src/main/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScanner.java
@@ -23,7 +23,6 @@ import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.metagraph.model.CatalogNode;
 import ai.floedb.floecat.metagraph.model.RelationNode;
 import ai.floedb.floecat.metagraph.model.TableNode;
-import ai.floedb.floecat.metagraph.model.UserTableNode;
 import ai.floedb.floecat.metagraph.model.ViewNode;
 import ai.floedb.floecat.query.rpc.SchemaColumn;
 import ai.floedb.floecat.scanner.columnar.AbstractArrowBatchBuilder;
@@ -38,7 +37,6 @@ import ai.floedb.floecat.systemcatalog.util.SchemaColumns;
 import ai.floedb.floecat.types.LogicalTypeProtoAdapter;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -236,42 +234,49 @@ public final class ColumnsScanner implements SystemObjectScanner {
 
     String schemaName = namespace.schemaName();
 
+    return numberedColumns(
+        ctx,
+        table,
+        (col, position) ->
+            new SystemObjectRow(
+                new Object[] {
+                  catalogName,
+                  schemaName,
+                  table.displayName(),
+                  col.getName(),
+                  typeStringOrNull(col),
+                  position
+                }))
+        .stream();
+  }
+
+  /**
+   * A table's user-facing columns paired with their ordinal_position.
+   *
+   * <p>ordinal_position is a POSITION, not an identity: the SQL standard defines it as the column's
+   * 1-based place in the table, so it must not carry a format-native field id. Field ids do not
+   * survive the trip -- Iceberg's have gaps after a drop and need not ascend in declaration order,
+   * and an unmapped Delta table has no field ids at all (every column reports 0). Both rendered a
+   * column list that disagreed with the table's real shape.
+   *
+   * <p>Both the row and the Arrow path number columns here rather than each keeping its own
+   * counter. They answer the same query, so a reader that saw them disagree would have no way to
+   * tell which was right; sharing the walk makes agreement structural instead of a thing tests have
+   * to keep rediscovering.
+   */
+  private static <T> List<T> numberedColumns(
+      SystemObjectScanContext ctx,
+      TableNode table,
+      java.util.function.BiFunction<SchemaColumn, Integer, T> toRow) {
     // Synthetic element/key/value placeholder rows are stats plumbing, not user columns.
     List<SchemaColumn> columns =
         SchemaColumns.withoutSyntheticNodes(ctx.graph().tableSchema(table.id()));
-
-    if (table instanceof UserTableNode) {
-      return columns.stream()
-          .sorted(Comparator.comparingInt(SchemaColumn::getFieldId))
-          .map(
-              col ->
-                  new SystemObjectRow(
-                      new Object[] {
-                        catalogName,
-                        schemaName,
-                        table.displayName(),
-                        col.getName(),
-                        typeStringOrNull(col),
-                        col.getFieldId()
-                      }));
-    }
-
-    // System tables (no field ids) – preserve declared order
-    List<SystemObjectRow> rows = new ArrayList<>(columns.size());
-    int ordinal = 1;
+    List<T> out = new ArrayList<>(columns.size());
+    int position = 1;
     for (SchemaColumn col : columns) {
-      rows.add(
-          new SystemObjectRow(
-              new Object[] {
-                catalogName,
-                schemaName,
-                table.displayName(),
-                col.getName(),
-                typeStringOrNull(col),
-                ordinal++
-              }));
+      out.add(toRow.apply(col, position++));
     }
-    return rows.stream();
+    return out;
   }
 
   private Stream<SystemObjectRow> scanView(
@@ -336,36 +341,17 @@ public final class ColumnsScanner implements SystemObjectScanner {
     String schemaName = namespace.schemaName();
 
     if (node instanceof TableNode table) {
-      // Synthetic element/key/value placeholder rows are stats plumbing, not user columns.
-      List<SchemaColumn> columns =
-          SchemaColumns.withoutSyntheticNodes(ctx.graph().tableSchema(table.id()));
-      if (table instanceof UserTableNode) {
-        return columns.stream()
-            .sorted(Comparator.comparingInt(SchemaColumn::getFieldId))
-            .map(
-                col ->
-                    ColumnEntry.of(
-                        catalogName,
-                        schemaName,
-                        table.displayName(),
-                        col.getName(),
-                        typeStringOrNull(col),
-                        col.getFieldId()))
-            .toList();
-      }
-      List<ColumnEntry> entries = new ArrayList<>(columns.size());
-      int ordinal = 1;
-      for (SchemaColumn col : columns) {
-        entries.add(
-            ColumnEntry.of(
-                catalogName,
-                schemaName,
-                table.displayName(),
-                col.getName(),
-                typeStringOrNull(col),
-                ordinal++));
-      }
-      return entries;
+      return numberedColumns(
+          ctx,
+          table,
+          (col, position) ->
+              ColumnEntry.of(
+                  catalogName,
+                  schemaName,
+                  table.displayName(),
+                  col.getName(),
+                  typeStringOrNull(col),
+                  position));
     }
 
     if (node instanceof ViewNode view) {

--- a/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScannerTest.java
+++ b/core/catalog/src/test/java/ai/floedb/floecat/systemcatalog/informationschema/ColumnsScannerTest.java
@@ -152,6 +152,39 @@ class ColumnsScannerTest {
   }
 
   @Test
+  void scan_numbersUserTableColumnsByPositionNotFieldId() {
+    // Iceberg field ids have gaps after a drop and need not ascend in declaration order; an
+    // unmapped Delta table reports 0 for every column. Neither can stand in for ordinal_position.
+    var builder = TestTableScanContextBuilder.builder("marketing");
+    var ns = builder.addNamespace(List.of("org", "sales"), "sales", "org.sales");
+    builder.addTableWithSchema(
+        ns,
+        "orders",
+        List.of(
+            positionColumn("id", "long", 40),
+            positionColumn("name", "string", 0),
+            positionColumn("amount", "long", 7)));
+
+    var rows =
+        new ColumnsScanner().scan(builder.build()).map(r -> Arrays.asList(r.values())).toList();
+
+    assertThat(rows)
+        .extracting(row -> row.get(3), row -> row.get(5))
+        .containsExactly(tuple("id", 1), tuple("name", 2), tuple("amount", 3));
+  }
+
+  private static SchemaColumn positionColumn(String name, String type, int fieldId) {
+    return SchemaColumn.newBuilder()
+        .setName(name)
+        .setPhysicalPath(name)
+        .setType(LogicalTypeProtoAdapter.parseToProto(type))
+        .setFieldId(fieldId)
+        .setLeaf(true)
+        .setNullable(false)
+        .build();
+  }
+
+  @Test
   void scan_withNoTables_returnsNoRows() {
     var builder = TestTableScanContextBuilder.builder("marketing");
     var ns = builder.addNamespace("finance.sales");
@@ -217,6 +250,45 @@ class ColumnsScannerTest {
               .toList();
 
       assertThat(arrowRows).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  void scanArrow_numbersColumnsByPositionNotFieldId() {
+    // The Arrow path builds its own rows, so the row-path regression does not cover it. Field ids
+    // chosen to fail loudly if either path ever reverts to reporting or sorting by them: 40 and 7
+    // are out of declaration order, and 0 is what an unmapped Delta column carries.
+    var builder = TestTableScanContextBuilder.builder("marketing");
+    var ns = builder.addNamespace(List.of("org", "sales"), "sales", "org.sales");
+    builder.addTableWithSchema(
+        ns,
+        "orders",
+        List.of(
+            positionColumn("id", "long", 40),
+            positionColumn("name", "string", 0),
+            positionColumn("amount", "long", 7)));
+    SystemObjectScanContext ctx = builder.build();
+    var scanner = new ColumnsScanner();
+
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      List<List<String>> arrowRows =
+          scanner
+              .scanArrow(ctx, null, List.of(), allocator)
+              .map(
+                  batch -> {
+                    try (batch) {
+                      return toRows(batch.root());
+                    }
+                  })
+              .flatMap(List::stream)
+              .toList();
+
+      assertThat(arrowRows)
+          .extracting(row -> row.get(3), row -> row.get(5))
+          .containsExactly(tuple("id", "1"), tuple("name", "2"), tuple("amount", "3"));
+      // Both paths answer the same query; a reader cannot tell which is right if they disagree.
+      assertThat(arrowRows)
+          .isEqualTo(scanner.scan(ctx).map(row -> toStringList(row.values())).toList());
     }
   }
 


### PR DESCRIPTION
## Summary

information_schema.columns emitted SchemaColumn.field_id into ordinal_position and ordered user-table columns by it. The SQL standard defines the column as the 1-based position of the column in the table, and a field id cannot serve as one: Iceberg ids have gaps after a drop and need not ascend in declaration order, and an unmapped Delta table reports 0 for every column. Both rendered a column list that disagreed with the table's real shape.

Use declared order with a 1-based counter, matching what the system-table and view branches of the same scanner already emitted.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
