### PR TITLE
feat(identity): add structured source column paths

### DIFF
--- a/core/schema-identity/pom.xml
+++ b/core/schema-identity/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Yellowbrick Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>ai.floedb.floecat</groupId>
+    <artifactId>floecat</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>floecat-schema-identity</artifactId>
+  <description>Format-neutral source schema identity</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/core/schema-identity/src/main/java/ai/floedb/floecat/schema/identity/ColumnPath.java
+++ b/core/schema-identity/src/main/java/ai/floedb/floecat/schema/identity/ColumnPath.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.schema.identity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A structured path to a schema node.
+ *
+ * <p>The path itself is the identity: equality is structural, so a field literally named {@code
+ * "a.b"} never equals the nested field {@code a} then {@code b}. Both string renderings below lose
+ * that distinction, and neither is ever parsed back into a path.
+ *
+ * <p>{@link #display()} is for diagnostics. {@link #legacyDottedKey()} is for the string-based
+ * connector contract, where callers must guard against collisions with {@link LegacyDottedKeyIndex}
+ * rather than assuming the rendered key identifies one column.
+ */
+public record ColumnPath(List<Element> elements) {
+
+  public static final ColumnPath ROOT = new ColumnPath(List.of());
+
+  public ColumnPath {
+    elements = List.copyOf(Objects.requireNonNull(elements, "elements"));
+  }
+
+  /** One structural path step. Only fields carry a name. */
+  public record Element(NodeKind kind, String name) {
+    private static final Element ARRAY_ELEMENT = new Element(NodeKind.ARRAY_ELEMENT, null);
+    private static final Element MAP_KEY = new Element(NodeKind.MAP_KEY, null);
+    private static final Element MAP_VALUE = new Element(NodeKind.MAP_VALUE, null);
+
+    public Element {
+      Objects.requireNonNull(kind, "kind");
+      if (kind == NodeKind.FIELD && (name == null || name.isEmpty())) {
+        throw new IllegalArgumentException("A field path element requires a name");
+      }
+      if (kind != NodeKind.FIELD && name != null) {
+        throw new IllegalArgumentException(kind + " path elements cannot carry a name");
+      }
+    }
+
+    private static Element field(String name) {
+      return new Element(NodeKind.FIELD, name);
+    }
+  }
+
+  public ColumnPath field(String name) {
+    return child(Element.field(name));
+  }
+
+  public ColumnPath arrayElement() {
+    return child(Element.ARRAY_ELEMENT);
+  }
+
+  public ColumnPath mapKey() {
+    return child(Element.MAP_KEY);
+  }
+
+  public ColumnPath mapValue() {
+    return child(Element.MAP_VALUE);
+  }
+
+  public boolean isRoot() {
+    return elements.isEmpty();
+  }
+
+  public Element last() {
+    if (isRoot()) {
+      throw new IllegalStateException("The root path has no last element");
+    }
+    return elements.getLast();
+  }
+
+  /** Renders this path for humans, in logs and error messages. */
+  public String display() {
+    return renderDottedPath();
+  }
+
+  /**
+   * Serializes this path for the existing dotted-string connector contract.
+   *
+   * <p>This representation is lossy. Callers must detect when distinct structured paths produce the
+   * same key rather than treating the string as unique identity; {@link LegacyDottedKeyIndex} does
+   * this for them.
+   */
+  public String legacyDottedKey() {
+    return renderDottedPath();
+  }
+
+  private String renderDottedPath() {
+    StringBuilder result = new StringBuilder();
+    for (Element element : elements) {
+      switch (element.kind()) {
+        case FIELD -> {
+          if (!result.isEmpty()) {
+            result.append('.');
+          }
+          result.append(element.name());
+        }
+        case ARRAY_ELEMENT -> result.append("[]");
+        case MAP_KEY -> result.append(".key");
+        case MAP_VALUE -> result.append("{}");
+      }
+    }
+    return result.toString();
+  }
+
+  private ColumnPath child(Element element) {
+    List<Element> result = new ArrayList<>(elements.size() + 1);
+    result.addAll(elements);
+    result.add(Objects.requireNonNull(element, "element"));
+    return new ColumnPath(result);
+  }
+
+  @Override
+  public String toString() {
+    return display();
+  }
+}

--- a/core/schema-identity/src/main/java/ai/floedb/floecat/schema/identity/LegacyDottedKeyIndex.java
+++ b/core/schema-identity/src/main/java/ai/floedb/floecat/schema/identity/LegacyDottedKeyIndex.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.schema.identity;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Projects structured {@link ColumnPath}s onto the lossy dotted keys of the string-based connector
+ * contract, retiring every key that more than one distinct path renders to.
+ *
+ * <p>{@link ColumnPath#legacyDottedKey()} is not injective: a field literally named {@code "a.b"}
+ * and the nested field {@code a} → {@code b} render identically. Any index that treats the
+ * rendering as identity would silently attribute one column's values to another, so this class
+ * drops such keys entirely rather than picking a winner. Dropping loses statistics for the
+ * colliding columns, which only costs planning precision; keeping them would corrupt it.
+ *
+ * <p>Instances are mutable builders and are not thread-safe. Insertion order is preserved.
+ *
+ * @param <V> the value each path carries into the projected map
+ */
+public final class LegacyDottedKeyIndex<V> {
+
+  private final Map<String, ColumnPath> pathsByKey = new LinkedHashMap<>();
+  private final Map<String, V> valuesByKey = new LinkedHashMap<>();
+  private final Set<String> ambiguousKeys = new LinkedHashSet<>();
+
+  private LegacyDottedKeyIndex() {}
+
+  public static <V> LegacyDottedKeyIndex<V> create() {
+    return new LegacyDottedKeyIndex<>();
+  }
+
+  /**
+   * Registers one path under its rendered key.
+   *
+   * <p>Re-adding an equal path is a no-op that keeps the first value. A different path claiming a
+   * key retires that key for good: neither path, nor any later one rendering to it, appears in the
+   * projected map.
+   */
+  public void add(ColumnPath path, V value) {
+    Objects.requireNonNull(path, "path");
+    String key = path.legacyDottedKey();
+    ColumnPath existing = pathsByKey.putIfAbsent(key, path);
+    if (existing == null) {
+      valuesByKey.put(key, value);
+      return;
+    }
+    if (existing.equals(path)) {
+      return;
+    }
+    ambiguousKeys.add(key);
+    valuesByKey.remove(key);
+  }
+
+  /** The values of every path whose rendered key names it unambiguously, in insertion order. */
+  public Map<String, V> values() {
+    return Collections.unmodifiableMap(new LinkedHashMap<>(valuesByKey));
+  }
+
+  /** The keys of {@link #values()}, in insertion order. */
+  public Set<String> keys() {
+    return Collections.unmodifiableSet(new LinkedHashSet<>(valuesByKey.keySet()));
+  }
+}

--- a/core/schema-identity/src/main/java/ai/floedb/floecat/schema/identity/NodeKind.java
+++ b/core/schema-identity/src/main/java/ai/floedb/floecat/schema/identity/NodeKind.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.schema.identity;
+
+/** A named schema field or one of the implicit nodes inside a collection. */
+public enum NodeKind {
+  FIELD,
+  ARRAY_ELEMENT,
+  MAP_KEY,
+  MAP_VALUE
+}

--- a/core/schema-identity/src/test/java/ai/floedb/floecat/schema/identity/ColumnPathTest.java
+++ b/core/schema-identity/src/test/java/ai/floedb/floecat/schema/identity/ColumnPathTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.schema.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ColumnPathTest {
+
+  @Test
+  void structuredPathsRemainDistinctWhenLegacyRenderingCollides() {
+    ColumnPath dottedField = ColumnPath.ROOT.field("a.b");
+    ColumnPath nestedField = ColumnPath.ROOT.field("a").field("b");
+
+    assertThat(dottedField.display()).isEqualTo(nestedField.display());
+    assertThat(dottedField.legacyDottedKey()).isEqualTo(nestedField.legacyDottedKey());
+    assertThat(dottedField).isNotEqualTo(nestedField);
+  }
+
+  @Test
+  void collectionInteriorsAreStructuralPathElements() {
+    ColumnPath path = ColumnPath.ROOT.field("orders").arrayElement().field("attributes").mapValue();
+
+    assertThat(path.display()).isEqualTo("orders[].attributes{}");
+    assertThat(path.last().kind()).isEqualTo(NodeKind.MAP_VALUE);
+  }
+}

--- a/core/schema-identity/src/test/java/ai/floedb/floecat/schema/identity/LegacyDottedKeyIndexTest.java
+++ b/core/schema-identity/src/test/java/ai/floedb/floecat/schema/identity/LegacyDottedKeyIndexTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.schema.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import org.junit.jupiter.api.Test;
+
+class LegacyDottedKeyIndexTest {
+
+  @Test
+  void distinctPathsKeepDistinctKeys() {
+    LegacyDottedKeyIndex<String> index = LegacyDottedKeyIndex.create();
+
+    index.add(ColumnPath.ROOT.field("a"), "first");
+    index.add(ColumnPath.ROOT.field("b"), "second");
+
+    assertThat(index.values()).containsExactly(entry("a", "first"), entry("b", "second"));
+  }
+
+  @Test
+  void collidingPathsRetireTheSharedKeyForBoth() {
+    ColumnPath dotted = ColumnPath.ROOT.field("a.b");
+    ColumnPath nested = ColumnPath.ROOT.field("a").field("b");
+    LegacyDottedKeyIndex<String> index = LegacyDottedKeyIndex.create();
+
+    index.add(dotted, "first");
+    index.add(nested, "second");
+
+    assertThat(index.values()).isEmpty();
+  }
+
+  @Test
+  void aRetiredKeyStaysRetiredForLaterPaths() {
+    LegacyDottedKeyIndex<String> index = LegacyDottedKeyIndex.create();
+    index.add(ColumnPath.ROOT.field("a.b"), "first");
+    index.add(ColumnPath.ROOT.field("a").field("b"), "second");
+
+    index.add(ColumnPath.ROOT.field("a.b"), "third");
+    assertThat(index.values()).isEmpty();
+  }
+
+  @Test
+  void reAddingAnEqualPathKeepsTheFirstValue() {
+    LegacyDottedKeyIndex<String> index = LegacyDottedKeyIndex.create();
+
+    index.add(ColumnPath.ROOT.field("a"), "first");
+    index.add(ColumnPath.ROOT.field("a"), "second");
+
+    assertThat(index.values()).containsExactly(entry("a", "first"));
+  }
+
+  @Test
+  void containerPathsCollapsingOntoTheSameKeyAreRetired() {
+    LegacyDottedKeyIndex<String> index = LegacyDottedKeyIndex.create();
+
+    index.add(ColumnPath.ROOT.field("tags").arrayElement(), "element");
+    index.add(ColumnPath.ROOT.field("tags[]"), "literal");
+
+    assertThat(index.values()).isEmpty();
+  }
+
+  @Test
+  void viewsDoNotAliasLaterMutations() {
+    LegacyDottedKeyIndex<String> index = LegacyDottedKeyIndex.create();
+    index.add(ColumnPath.ROOT.field("a"), "first");
+    var snapshot = index.values();
+
+    index.add(ColumnPath.ROOT.field("b"), "second");
+
+    assertThat(snapshot).containsExactly(entry("a", "first"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
       <module>core/proto</module>
       <module>core/types</module>
       <module>core/cache</module>
+      <module>core/schema-identity</module>
       <module>core/engine-utils</module>
       <module>core/metadata-admission-runtime</module>
       <module>core/stats</module>


### PR DESCRIPTION
## Summary

Introduces the schema-identity foundation: structured paths distinguish fields, array elements, and map keys or values without flattening them into ambiguous dotted strings. It also safely retires legacy dotted keys when distinct schema paths collide.

## Type of Change

- [X] feat (new functionality)
- [] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
