### PR TITLE
fix(delta): make column mapping stats identity-safe

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaColumnMapping.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaColumnMapping.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.delta.uc.impl;
+
+import ai.floedb.floecat.connector.delta.identity.ColumnMappingMode;
+import ai.floedb.floecat.connector.delta.identity.DeltaResolvedSchema;
+import ai.floedb.floecat.connector.delta.identity.DeltaSchemaResolver;
+import ai.floedb.floecat.schema.identity.SchemaNode;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.types.FieldMetadata;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The bridge between Delta Kernel and Floecat's format-neutral column identity.
+ *
+ * <p>Column mapping splits a Delta table into two namespaces: the logical names users and the
+ * catalog speak, and the physical names that data files, checkpoints and file statistics carry.
+ * This class is the only place in the connector that knows which namespace a given Kernel artifact
+ * is expressed in, so planners can work in logical names throughout.
+ *
+ * <p>Everything here is a thin Kernel adapter. The decisions themselves live in {@link
+ * ColumnMappingMode} and {@link DeltaResolvedSchema}, which are Kernel-free and directly testable.
+ */
+final class DeltaColumnMapping {
+
+  private DeltaColumnMapping() {}
+
+  /** Resolves a snapshot's schema together with the mapping mode its readers may trust. */
+  static DeltaResolvedSchema resolveSchema(Snapshot snapshot) {
+    Objects.requireNonNull(snapshot, "snapshot");
+    return DeltaSchemaResolver.resolve(snapshot.getSchema(), effectiveMode(snapshot));
+  }
+
+  /**
+   * The mapping mode a reader may act on, which is the configured mode only when the table protocol
+   * actually supports the feature.
+   */
+  static ColumnMappingMode effectiveMode(Snapshot snapshot) {
+    return ColumnMappingMode.effectiveFromTableProperties(
+        snapshot.getTableProperties(), () -> supportsColumnMapping(protocolOf(snapshot)));
+  }
+
+  static boolean supportsColumnMapping(Protocol protocol) {
+    Objects.requireNonNull(protocol, "protocol");
+    return protocol.supportsFeature(TableFeatures.COLUMN_MAPPING_RW_FEATURE);
+  }
+
+  /**
+   * The schema that Delta writes file statistics against, which column mapping makes physical.
+   *
+   * <p>Reading statistics against the logical schema of a mapped table would match nothing, so a
+   * mapped snapshot that cannot produce its physical schema is an error rather than a silent
+   * fallback.
+   */
+  static StructType statsDataSchema(Snapshot snapshot, DeltaResolvedSchema resolvedSchema) {
+    if (!resolvedSchema.effectiveMappingMode().isEnabled()) {
+      return snapshot.getSchema();
+    }
+    if (snapshot instanceof SnapshotImpl snapshotImpl && snapshotImpl.getMetadata() != null) {
+      return snapshotImpl.getMetadata().getPhysicalSchema();
+    }
+    throw new IllegalArgumentException(
+        "A column-mapped Delta snapshot must expose its physical schema");
+  }
+
+  /**
+   * Narrows a statistics schema to the requested columns, keeping the parents of any selected
+   * nested column so the surviving struct stays reachable.
+   *
+   * <p>Names are matched in the namespace of {@code schema}, so callers must pass keys already
+   * translated by {@link DeltaResolvedSchema#statsKeysFor(Set)}. Selecting nothing yields an empty
+   * struct rather than the whole schema, so an empty selection cannot widen into reading every
+   * column's statistics.
+   */
+  static StructType projectedStatsDataSchema(StructType schema, Set<String> includeColumns) {
+    if (schema == null || includeColumns == null) {
+      return schema;
+    }
+    if (includeColumns.isEmpty()) {
+      return new StructType();
+    }
+    return projectedStatsDataSchema(schema, "", includeColumns);
+  }
+
+  private static StructType projectedStatsDataSchema(
+      StructType schema, String prefix, Set<String> includeColumns) {
+    StructType projected = new StructType();
+    for (StructField field : schema.fields()) {
+      String path = prefix.isEmpty() ? field.getName() : prefix + "." + field.getName();
+      if (includeColumns.contains(path)) {
+        projected = projected.add(field);
+      } else if (field.getDataType() instanceof StructType nested) {
+        StructType projectedNested = projectedStatsDataSchema(nested, path, includeColumns);
+        if (projectedNested.length() > 0) {
+          projected = projected.add(field.withDataType(projectedNested));
+        }
+      }
+    }
+    return projected;
+  }
+
+  /**
+   * Maps a column named by Delta log statistics back to the logical key the planner reports, or
+   * {@code null} when it resolves to no column the caller asked for.
+   */
+  static String logicalNameForStats(
+      Column statsColumn, DeltaResolvedSchema schema, Set<String> columnSet) {
+    String[] names = statsColumn == null ? null : statsColumn.getNames();
+    if (names == null || names.length == 0) {
+      return null;
+    }
+    return logicalName(schema.nodeForStatsNames(Arrays.asList(names)), columnSet);
+  }
+
+  /**
+   * Maps a Parquet footer column back to the logical key the planner reports, or {@code null} when
+   * it resolves to no column the caller asked for.
+   */
+  static String logicalNameForFooter(
+      List<String> parquetPath,
+      Integer fieldId,
+      DeltaResolvedSchema schema,
+      Set<String> columnSet) {
+    return logicalName(schema.nodeForFooterColumn(parquetPath, fieldId), columnSet);
+  }
+
+  private static String logicalName(Optional<SchemaNode> node, Set<String> columnSet) {
+    return node.map(value -> value.path().legacyDottedKey())
+        .filter(columnSet::contains)
+        .orElse(null);
+  }
+
+  /** The key Delta stores a field's physical name under. */
+  static final String PHYSICAL_NAME_KEY = DeltaSchemaResolver.PHYSICAL_NAME;
+
+  /**
+   * Reads a field's physical name from its Kernel metadata, or {@code null} when the field carries
+   * none. Absence is normal for an unmapped table, where logical and physical names coincide.
+   */
+  static String physicalName(FieldMetadata metadata) {
+    return metadata == null ? null : metadata.getString(PHYSICAL_NAME_KEY);
+  }
+
+  private static Protocol protocolOf(Snapshot snapshot) {
+    if (snapshot instanceof SnapshotImpl snapshotImpl) {
+      return snapshotImpl.getProtocol();
+    }
+    throw new IllegalArgumentException(
+        "A Delta snapshot with column mapping configured must expose its protocol");
+  }
+}

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
@@ -301,7 +301,7 @@ abstract class DeltaConnector implements FloecatConnector {
     }
 
     final StructType kernelSchema = snapshot.getSchema();
-    final Map<String, LogicalType> nameToType = DeltaTypeMapper.deltaTypeMap(kernelSchema);
+    final Map<String, LogicalType> nameToType = DeltaTypeMapper.deltaStatsTypeMap(kernelSchema);
     final Set<String> includeNames =
         FloecatConnector.resolveIncludedColumns(
             List.copyOf(nameToType.keySet()), includeColumns, columnSelectorPolicy);
@@ -437,7 +437,7 @@ abstract class DeltaConnector implements FloecatConnector {
     List<String> realizedStatsSelectors =
         requestedKinds.contains(StatsTargetKind.COLUMN)
             ? FloecatConnector.resolveIncludedColumns(
-                    List.copyOf(DeltaTypeMapper.deltaTypeMap(snapshot.getSchema()).keySet()),
+                    List.copyOf(DeltaTypeMapper.deltaStatsTypeMap(snapshot.getSchema()).keySet()),
                     includeColumns,
                     columnSelectorPolicy)
                 .stream()
@@ -757,7 +757,7 @@ abstract class DeltaConnector implements FloecatConnector {
     for (StructField field : schema.fields()) {
       String logicalPath =
           logicalPrefix.isEmpty() ? field.getName() : logicalPrefix + "." + field.getName();
-      String physicalName = DeltaPlanner.physicalName(field.getMetadata());
+      String physicalName = DeltaColumnMapping.physicalName(field.getMetadata());
       if (physicalName == null || physicalName.isBlank()) {
         physicalName = field.getName();
       }
@@ -1525,7 +1525,7 @@ abstract class DeltaConnector implements FloecatConnector {
     }
 
     final StructType kernelSchema = snapshot.getSchema();
-    final Map<String, LogicalType> nameToType = DeltaTypeMapper.deltaTypeMap(kernelSchema);
+    final Map<String, LogicalType> nameToType = DeltaTypeMapper.deltaStatsTypeMap(kernelSchema);
     final String schemaJson = snapshotSchemaJson(snapshot);
     final Set<String> includeNames =
         FloecatConnector.resolveIncludedColumns(

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaPlanner.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaPlanner.java
@@ -20,6 +20,7 @@ import ai.floedb.floecat.connector.common.ParquetFooterStats;
 import ai.floedb.floecat.connector.common.PlannedFile;
 import ai.floedb.floecat.connector.common.Planner;
 import ai.floedb.floecat.connector.common.ndv.NdvProvider;
+import ai.floedb.floecat.connector.delta.identity.DeltaResolvedSchema;
 import ai.floedb.floecat.types.LogicalCoercions;
 import ai.floedb.floecat.types.LogicalComparators;
 import ai.floedb.floecat.types.LogicalKind;
@@ -49,13 +50,11 @@ import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.DateType;
 import io.delta.kernel.types.DecimalType;
 import io.delta.kernel.types.DoubleType;
-import io.delta.kernel.types.FieldMetadata;
 import io.delta.kernel.types.FloatType;
 import io.delta.kernel.types.IntegerType;
 import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.ShortType;
 import io.delta.kernel.types.StringType;
-import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.types.TimestampNTZType;
 import io.delta.kernel.types.TimestampType;
@@ -79,7 +78,6 @@ import java.util.stream.Collectors;
 import org.apache.parquet.io.InputFile;
 
 final class DeltaPlanner implements Planner<String> {
-  static final String COLUMN_MAPPING_PHYSICAL_NAME_KEY = "delta.columnMapping.physicalName";
   static final String STATS_PARSED_FIELD = "stats_parsed";
   static final String ADD_FIELD = "add";
   static final String PATH_FIELD = "path";
@@ -89,13 +87,15 @@ final class DeltaPlanner implements Planner<String> {
 
   private final List<PlannedFile<String>> files = new ArrayList<>();
   private final Map<String, LogicalType> nameToLogical = new LinkedHashMap<>();
-  private final Map<String, String> statsNameToLogical = new LinkedHashMap<>();
+  private final DeltaResolvedSchema deltaSchema;
   private final NdvProvider ndvProvider;
   private final Set<String> columnSet;
   private final Set<String> plannedFilePaths;
   private final boolean allowFooterFallback;
   private final Engine engine;
   private final Snapshot snapshot;
+  private final StructType statsDataSchema;
+  private final Set<String> statsColumnSet;
   private final String storageLocation;
   private final List<DeletionVectorDescriptor> diskDeletionVectors = new ArrayList<>();
   private final Map<String, DeletionVectorDescriptor> deletionVectorsByFile = new LinkedHashMap<>();
@@ -136,12 +136,11 @@ final class DeltaPlanner implements Planner<String> {
     this.snapshot = snapshot;
 
     final StructType schema = snapshot.getSchema();
-    if (nameToType == null || nameToType.isEmpty()) {
-      nameToLogical.putAll(DeltaTypeMapper.deltaTypeMap(schema));
-    } else {
+    this.deltaSchema = DeltaColumnMapping.resolveSchema(snapshot);
+    nameToLogical.putAll(DeltaTypeMapper.deltaStatsTypeMap(schema));
+    if (nameToType != null && !nameToType.isEmpty()) {
       nameToLogical.putAll(nameToType);
     }
-    statsNameToLogical.putAll(statsNameMap(schema));
 
     if (includeColumns == null || includeColumns.isEmpty()) {
       this.columnSet = Collections.unmodifiableSet(new LinkedHashSet<>(nameToLogical.keySet()));
@@ -152,6 +151,8 @@ final class DeltaPlanner implements Planner<String> {
               .collect(Collectors.toCollection(LinkedHashSet::new));
       this.columnSet = Collections.unmodifiableSet(filtered);
     }
+    this.statsDataSchema = DeltaColumnMapping.statsDataSchema(snapshot, deltaSchema);
+    this.statsColumnSet = deltaSchema.statsKeysFor(columnSet);
 
     final ScanBuilder sb = snapshot.getScanBuilder();
     final Scan scan = sb.build();
@@ -199,7 +200,7 @@ final class DeltaPlanner implements Planner<String> {
             String partitionJson = encodePartition(add);
 
             if (includeStats) {
-              Optional<DataFileStatistics> optStats = add.getStats(snapshot.getSchema());
+              Optional<DataFileStatistics> optStats = add.getStats(statsDataSchema);
               if (optStats.isEmpty()) {
                 optStats = checkpointStatsForPath(path);
                 if (optStats.isPresent()) {
@@ -216,7 +217,7 @@ final class DeltaPlanner implements Planner<String> {
                 if (nc != null && !nc.isEmpty()) {
                   nullCounts = new LinkedHashMap<>(nc.size());
                   for (var e : nc.entrySet()) {
-                    String colName = resolveStatsColumnName(firstName(e.getKey()));
+                    String colName = resolveStatsColumnName(e.getKey());
                     Long n = e.getValue();
                     if (colName != null && n != null) nullCounts.put(colName, n);
                   }
@@ -233,7 +234,7 @@ final class DeltaPlanner implements Planner<String> {
                 if (minsMap != null && !minsMap.isEmpty()) {
                   mins = new LinkedHashMap<>(minsMap.size());
                   for (var e : minsMap.entrySet()) {
-                    String colName = resolveStatsColumnName(firstName(e.getKey()));
+                    String colName = resolveStatsColumnName(e.getKey());
                     if (colName != null) {
                       var lt = nameToLogical.get(colName);
                       Object raw = (e.getValue() == null) ? null : e.getValue().getValue();
@@ -248,7 +249,7 @@ final class DeltaPlanner implements Planner<String> {
                 if (maxsMap != null && !maxsMap.isEmpty()) {
                   maxs = new LinkedHashMap<>(maxsMap.size());
                   for (var e : maxsMap.entrySet()) {
-                    String colName = resolveStatsColumnName(firstName(e.getKey()));
+                    String colName = resolveStatsColumnName(e.getKey());
                     if (colName != null) {
                       var lt = nameToLogical.get(colName);
                       Object raw = (e.getValue() == null) ? null : e.getValue().getValue();
@@ -267,7 +268,13 @@ final class DeltaPlanner implements Planner<String> {
                 }
                 var in = parquetInput.apply(path);
 
-                var bfs = ParquetFooterStats.read(in, columnSet, nameToLogical);
+                var bfs =
+                    ParquetFooterStats.read(
+                        in,
+                        nameToLogical,
+                        (parquetPath, fieldId) ->
+                            DeltaColumnMapping.logicalNameForFooter(
+                                parquetPath, fieldId, deltaSchema, columnSet));
 
                 rowCount = bfs.rowCount;
                 nullCounts = new LinkedHashMap<>();
@@ -429,7 +436,8 @@ final class DeltaPlanner implements Planner<String> {
       return Map.of();
     }
 
-    StructType projectedSchema = projectedStatsDataSchema(snapshot.getSchema(), columnSet);
+    StructType projectedSchema =
+        DeltaColumnMapping.projectedStatsDataSchema(statsDataSchema, statsColumnSet);
     StructType statsSchema = StatsSchemaHelper.getStatsSchema(projectedSchema, Set.of());
     if (statsSchema.length() == 0) {
       return Map.of();
@@ -462,7 +470,7 @@ final class DeltaPlanner implements Planner<String> {
             if (!plannedFilePaths.isEmpty() && !plannedFilePaths.contains(resolvedPath)) {
               continue;
             }
-            checkpointStructStatsFromAddRow(addRow, statsNameToLogical, columnSet)
+            checkpointStructStatsFromAddRow(addRow)
                 .ifPresent(stats -> byPath.put(resolvedPath, stats));
           }
         }
@@ -473,8 +481,7 @@ final class DeltaPlanner implements Planner<String> {
     return Collections.unmodifiableMap(byPath);
   }
 
-  static Optional<DataFileStatistics> checkpointStructStatsFromAddRow(
-      Row addFileRow, Map<String, String> statsNameToLogical, Set<String> columnSet) {
+  static Optional<DataFileStatistics> checkpointStructStatsFromAddRow(Row addFileRow) {
     if (addFileRow == null) {
       return Optional.empty();
     }
@@ -496,17 +503,11 @@ final class DeltaPlanner implements Planner<String> {
     long numRecords = readLongLike(statsRow, numRecordsOrdinal);
 
     Map<Column, Literal> minValues =
-        readLiteralStruct(
-            statsRow, statsSchema.indexOf(StatsSchemaHelper.MIN), statsNameToLogical, columnSet);
+        readLiteralStruct(statsRow, statsSchema.indexOf(StatsSchemaHelper.MIN));
     Map<Column, Literal> maxValues =
-        readLiteralStruct(
-            statsRow, statsSchema.indexOf(StatsSchemaHelper.MAX), statsNameToLogical, columnSet);
+        readLiteralStruct(statsRow, statsSchema.indexOf(StatsSchemaHelper.MAX));
     Map<Column, Long> nullCounts =
-        readNullCountStruct(
-            statsRow,
-            statsSchema.indexOf(StatsSchemaHelper.NULL_COUNT),
-            statsNameToLogical,
-            columnSet);
+        readNullCountStruct(statsRow, statsSchema.indexOf(StatsSchemaHelper.NULL_COUNT));
 
     return Optional.of(
         new DataFileStatistics(numRecords, minValues, maxValues, nullCounts, Optional.empty()));
@@ -524,19 +525,6 @@ final class DeltaPlanner implements Planner<String> {
     return checkpointRow.getStruct(addOrdinal);
   }
 
-  static StructType projectedStatsDataSchema(StructType schema, Set<String> includeColumns) {
-    if (schema == null || includeColumns == null || includeColumns.isEmpty()) {
-      return schema;
-    }
-    StructType projected = new StructType();
-    for (StructField field : schema.fields()) {
-      if (includeColumns.contains(field.getName())) {
-        projected = projected.add(field);
-      }
-    }
-    return projected;
-  }
-
   static String absoluteDataPath(String storageLocation, String addPath) {
     if (addPath == null || addPath.isBlank()) {
       return addPath;
@@ -548,8 +536,7 @@ final class DeltaPlanner implements Planner<String> {
     return new Path(new Path(storageLocation), candidate).toString();
   }
 
-  private static Map<Column, Literal> readLiteralStruct(
-      Row parentRow, int ordinal, Map<String, String> statsNameToLogical, Set<String> columnSet) {
+  private static Map<Column, Literal> readLiteralStruct(Row parentRow, int ordinal) {
     if (ordinal < 0 || parentRow.isNullAt(ordinal)) {
       return Map.of();
     }
@@ -558,26 +545,30 @@ final class DeltaPlanner implements Planner<String> {
       return Map.of();
     }
     LinkedHashMap<Column, Literal> values = new LinkedHashMap<>();
-    StructType schema = structRow.getSchema();
-    for (int i = 0; i < schema.length(); i++) {
-      if (structRow.isNullAt(i)) {
-        continue;
-      }
-      DataType dataType = schema.at(i).getDataType();
-      if (isContainerStatsType(dataType)) {
-        continue;
-      }
-      String name = resolveStatsColumnName(schema.at(i).getName(), statsNameToLogical, columnSet);
-      if (name == null) {
-        continue;
-      }
-      values.put(new Column(name), toLiteral(structRow, i, dataType));
-    }
+    readLiteralStruct(structRow, List.of(), values);
     return values;
   }
 
-  private static Map<Column, Long> readNullCountStruct(
-      Row parentRow, int ordinal, Map<String, String> statsNameToLogical, Set<String> columnSet) {
+  private static void readLiteralStruct(Row row, List<String> prefix, Map<Column, Literal> values) {
+    StructType schema = row.getSchema();
+    for (int i = 0; i < schema.length(); i++) {
+      if (row.isNullAt(i)) {
+        continue;
+      }
+      DataType dataType = schema.at(i).getDataType();
+      List<String> path = append(prefix, schema.at(i).getName());
+      if (dataType instanceof StructType) {
+        Row nested = row.getStruct(i);
+        if (nested != null) {
+          readLiteralStruct(nested, path, values);
+        }
+      } else if (!dataType.isNested()) {
+        values.put(column(path), toLiteral(row, i, dataType));
+      }
+    }
+  }
+
+  private static Map<Column, Long> readNullCountStruct(Row parentRow, int ordinal) {
     if (ordinal < 0 || parentRow.isNullAt(ordinal)) {
       return Map.of();
     }
@@ -586,64 +577,42 @@ final class DeltaPlanner implements Planner<String> {
       return Map.of();
     }
     LinkedHashMap<Column, Long> values = new LinkedHashMap<>();
-    StructType schema = structRow.getSchema();
-    for (int i = 0; i < schema.length(); i++) {
-      if (structRow.isNullAt(i)) {
-        continue;
-      }
-      if (isContainerStatsType(schema.at(i).getDataType())) {
-        continue;
-      }
-      String name = resolveStatsColumnName(schema.at(i).getName(), statsNameToLogical, columnSet);
-      if (name == null) {
-        continue;
-      }
-      values.put(new Column(name), readLongLike(structRow, i));
-    }
+    readNullCountStruct(structRow, List.of(), values);
     return values;
   }
 
-  private String resolveStatsColumnName(String statsName) {
-    return resolveStatsColumnName(statsName, statsNameToLogical, columnSet);
-  }
-
-  private static String resolveStatsColumnName(
-      String statsName, Map<String, String> statsNameToLogical, Set<String> columnSet) {
-    if (statsName == null || statsName.isBlank()) {
-      return null;
-    }
-    String logicalName = statsNameToLogical.get(statsName);
-    if (logicalName != null && columnSet.contains(logicalName)) {
-      return logicalName;
-    }
-    return columnSet.contains(statsName) ? statsName : null;
-  }
-
-  private static boolean isContainerStatsType(DataType dataType) {
-    return dataType instanceof StructType;
-  }
-
-  static Map<String, String> statsNameMap(StructType schema) {
-    if (schema == null) {
-      return Map.of();
-    }
-    LinkedHashMap<String, String> mapping = new LinkedHashMap<>();
-    for (StructField field : schema.fields()) {
-      String logicalName = field.getName();
-      if (logicalName == null || logicalName.isBlank()) {
+  private static void readNullCountStruct(Row row, List<String> prefix, Map<Column, Long> values) {
+    StructType schema = row.getSchema();
+    for (int i = 0; i < schema.length(); i++) {
+      if (row.isNullAt(i)) {
         continue;
       }
-      mapping.put(logicalName, logicalName);
-      String physicalName = physicalName(field.getMetadata());
-      if (physicalName != null && !physicalName.isBlank()) {
-        mapping.put(physicalName, logicalName);
+      DataType dataType = schema.at(i).getDataType();
+      List<String> path = append(prefix, schema.at(i).getName());
+      if (dataType instanceof StructType) {
+        Row nested = row.getStruct(i);
+        if (nested != null) {
+          readNullCountStruct(nested, path, values);
+        }
+      } else if (!dataType.isNested()) {
+        values.put(column(path), readLongLike(row, i));
       }
     }
-    return Collections.unmodifiableMap(mapping);
   }
 
-  static String physicalName(FieldMetadata metadata) {
-    return metadata == null ? null : metadata.getString(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
+  private String resolveStatsColumnName(Column statsColumn) {
+    return DeltaColumnMapping.logicalNameForStats(statsColumn, deltaSchema, columnSet);
+  }
+
+  private static List<String> append(List<String> prefix, String name) {
+    List<String> path = new ArrayList<>(prefix.size() + 1);
+    path.addAll(prefix);
+    path.add(name);
+    return path;
+  }
+
+  private static Column column(List<String> path) {
+    return new Column(path.toArray(String[]::new));
   }
 
   private static io.delta.kernel.utils.CloseableIterator<io.delta.kernel.utils.FileStatus>
@@ -848,15 +817,6 @@ final class DeltaPlanner implements Planner<String> {
   @Override
   public Set<String> columns() {
     return columnSet;
-  }
-
-  private static String firstName(Column c) {
-    try {
-      String[] names = (c == null) ? null : c.getNames();
-      return (names == null || names.length == 0) ? null : names[0];
-    } catch (Throwable ignore) {
-      return null;
-    }
   }
 
   static Object canonicalizeStatValue(LogicalType logicalType, Object raw) {

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaTypeMapper.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaTypeMapper.java
@@ -17,6 +17,8 @@
 package ai.floedb.floecat.connector.delta.uc.impl;
 
 import ai.floedb.floecat.connector.common.resolver.DecimalPrecisionConstraints;
+import ai.floedb.floecat.schema.identity.ColumnPath;
+import ai.floedb.floecat.schema.identity.LegacyDottedKeyIndex;
 import ai.floedb.floecat.types.LogicalField;
 import ai.floedb.floecat.types.LogicalKind;
 import ai.floedb.floecat.types.LogicalType;
@@ -77,6 +79,27 @@ final class DeltaTypeMapper {
       out.put(f.getName(), lt);
     }
     return out;
+  }
+
+  /**
+   * Maps every field Delta can address in file statistics. Delta descends through structs, but does
+   * not collect scalar min/max statistics inside arrays or maps.
+   */
+  static Map<String, LogicalType> deltaStatsTypeMap(StructType schema) {
+    LegacyDottedKeyIndex<LogicalType> index = LegacyDottedKeyIndex.create();
+    collectStatsTypes(schema, ColumnPath.ROOT, index);
+    return index.values();
+  }
+
+  private static void collectStatsTypes(
+      StructType schema, ColumnPath prefix, LegacyDottedKeyIndex<LogicalType> index) {
+    for (StructField field : schema.fields()) {
+      ColumnPath path = prefix.field(field.getName());
+      index.add(path, toLogical(field.getDataType()));
+      if (field.getDataType() instanceof StructType nested) {
+        collectStatsTypes(nested, path, index);
+      }
+    }
   }
 
   /**

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaColumnMappingTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaColumnMappingTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.delta.uc.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.floedb.floecat.connector.delta.identity.ColumnMappingMode;
+import ai.floedb.floecat.connector.delta.identity.DeltaResolvedSchema;
+import ai.floedb.floecat.connector.delta.identity.DeltaSchemaResolver;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.skipping.StatsSchemaHelper;
+import io.delta.kernel.types.FieldMetadata;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/** Covers the Kernel-facing half of column mapping; the decisions themselves live in core. */
+class DeltaColumnMappingTest {
+
+  @Test
+  void effectiveColumnMappingModeRequiresProtocolSupport() {
+    assertThat(effectiveMode(ColumnMappingMode.NAME, new Protocol(1, 2)))
+        .isEqualTo(ColumnMappingMode.NONE);
+    assertThat(effectiveMode(ColumnMappingMode.NAME, new Protocol(2, 5)))
+        .isEqualTo(ColumnMappingMode.NAME);
+    assertThat(effectiveMode(ColumnMappingMode.NAME, new Protocol(3, 7, Set.of(), Set.of())))
+        .isEqualTo(ColumnMappingMode.NONE);
+    assertThat(
+            effectiveMode(
+                ColumnMappingMode.ID,
+                new Protocol(3, 7, Set.of("columnMapping"), Set.of("columnMapping"))))
+        .isEqualTo(ColumnMappingMode.ID);
+  }
+
+  @Test
+  void physicalNameReadsDeltaColumnMappingMetadata() {
+    FieldMetadata metadata =
+        FieldMetadata.builder().putString(DeltaColumnMapping.PHYSICAL_NAME_KEY, "col-456").build();
+
+    assertThat(DeltaColumnMapping.physicalName(metadata)).isEqualTo("col-456");
+    assertThat(DeltaColumnMapping.physicalName(null)).isNull();
+    assertThat(DeltaColumnMapping.physicalName(FieldMetadata.empty())).isNull();
+  }
+
+  @Test
+  void resolvesNestedPhysicalStatisticsNamesToLogicalPaths() {
+    DeltaResolvedSchema resolved = mappedNestedSchema(ColumnMappingMode.NAME);
+
+    assertThat(
+            DeltaColumnMapping.logicalNameForStats(
+                new Column(new String[] {"col-address", "col-zip"}),
+                resolved,
+                Set.of("address.zip")))
+        .isEqualTo("address.zip");
+  }
+
+  @Test
+  void statisticsColumnsOutsideTheRequestedSetResolveToNothing() {
+    DeltaResolvedSchema resolved = mappedNestedSchema(ColumnMappingMode.NAME);
+
+    assertThat(
+            DeltaColumnMapping.logicalNameForStats(
+                new Column(new String[] {"col-address", "col-zip"}), resolved, Set.of()))
+        .isNull();
+    assertThat(DeltaColumnMapping.logicalNameForStats(null, resolved, Set.of("address.zip")))
+        .isNull();
+  }
+
+  @Test
+  void footerNameMappingResolvesNestedPhysicalPath() {
+    DeltaResolvedSchema resolved = mappedNestedSchema(ColumnMappingMode.NAME);
+
+    assertThat(
+            DeltaColumnMapping.logicalNameForFooter(
+                List.of("col-address", "col-zip"), 999, resolved, Set.of("address.zip")))
+        .isEqualTo("address.zip");
+  }
+
+  @Test
+  void footerIdMappingUsesFieldIdRatherThanPhysicalPath() {
+    DeltaResolvedSchema resolved = mappedNestedSchema(ColumnMappingMode.ID);
+
+    assertThat(
+            DeltaColumnMapping.logicalNameForFooter(
+                List.of("not", "the", "physical", "path"), 2, resolved, Set.of("address.zip")))
+        .isEqualTo("address.zip");
+    assertThat(
+            DeltaColumnMapping.logicalNameForFooter(
+                List.of("col-address", "col-zip"), null, resolved, Set.of("address.zip")))
+        .isNull();
+  }
+
+  @Test
+  void emptyStatsSelectionDoesNotProjectEveryCheckpointColumn() {
+    StructType schema =
+        new StructType()
+            .add("first", IntegerType.INTEGER, true)
+            .add("second", StringType.STRING, true);
+
+    StructType projected = DeltaColumnMapping.projectedStatsDataSchema(schema, Set.of());
+    StructType statsSchema = StatsSchemaHelper.getStatsSchema(projected, Set.of());
+
+    assertThat(projected.length()).isZero();
+    assertThat(statsSchema.fieldNames())
+        .doesNotContain(StatsSchemaHelper.MIN, StatsSchemaHelper.MAX, StatsSchemaHelper.NULL_COUNT);
+  }
+
+  @Test
+  void projectedStatsDataSchemaRetainsTheParentOfANestedSelection() {
+    StructType schema =
+        new StructType()
+            .add(
+                "address",
+                new StructType()
+                    .add("city", StringType.STRING, true)
+                    .add("zip", IntegerType.INTEGER, true),
+                true)
+            .add("unselected", LongType.LONG, true);
+
+    StructType projected =
+        DeltaColumnMapping.projectedStatsDataSchema(schema, Set.of("address.zip"));
+
+    assertThat(projected.fieldNames()).containsExactly("address");
+    assertThat(((StructType) projected.get("address").getDataType()).fieldNames())
+        .containsExactly("zip");
+  }
+
+  private static ColumnMappingMode effectiveMode(
+      ColumnMappingMode configuredMode, Protocol protocol) {
+    return configuredMode.effective(DeltaColumnMapping.supportsColumnMapping(protocol));
+  }
+
+  private static DeltaResolvedSchema mappedNestedSchema(ColumnMappingMode mode) {
+    FieldMetadata addressMetadata =
+        FieldMetadata.builder()
+            .putLong(DeltaSchemaResolver.COLUMN_ID, 1L)
+            .putString(DeltaSchemaResolver.PHYSICAL_NAME, "col-address")
+            .build();
+    FieldMetadata zipMetadata =
+        FieldMetadata.builder()
+            .putLong(DeltaSchemaResolver.COLUMN_ID, 2L)
+            .putString(DeltaSchemaResolver.PHYSICAL_NAME, "col-zip")
+            .build();
+    StructType schema =
+        new StructType()
+            .add(
+                new StructField(
+                    "address",
+                    new StructType()
+                        .add(new StructField("zip", IntegerType.INTEGER, true, zipMetadata)),
+                    true,
+                    addressMetadata));
+    return DeltaSchemaResolver.resolve(schema, mode);
+  }
+}

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
@@ -587,7 +587,7 @@ class DeltaConnectorTest {
                     LongType.LONG,
                     true,
                     FieldMetadata.builder()
-                        .putString(DeltaPlanner.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-123")
+                        .putString(DeltaColumnMapping.PHYSICAL_NAME_KEY, "col-123")
                         .build()));
     Snapshot latest = snapshot(9L, 9000L, mappedSchema);
     TestDeltaConnector connector =

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaPlannerTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaPlannerTest.java
@@ -23,18 +23,15 @@ import ai.floedb.floecat.types.LogicalType;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.statistics.DataFileStatistics;
-import io.delta.kernel.types.FieldMetadata;
 import io.delta.kernel.types.IntegerType;
 import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StringType;
-import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class DeltaPlannerTest {
@@ -66,39 +63,9 @@ class DeltaPlannerTest {
   }
 
   @Test
-  void statsNameMapIncludesPhysicalColumnMappingNames() {
-    StructType schema =
-        new StructType()
-            .add(
-                new StructField(
-                    "logical_id",
-                    IntegerType.INTEGER,
-                    true,
-                    FieldMetadata.builder()
-                        .putString(DeltaPlanner.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-123")
-                        .build()))
-            .add("plain_name", StringType.STRING, true);
-
-    Map<String, String> mapping = DeltaPlanner.statsNameMap(schema);
-
-    assertThat(mapping)
-        .containsEntry("logical_id", "logical_id")
-        .containsEntry("col-123", "logical_id")
-        .containsEntry("plain_name", "plain_name");
-  }
-
-  @Test
-  void physicalNameReadsDeltaColumnMappingMetadata() {
-    FieldMetadata metadata =
-        FieldMetadata.builder()
-            .putString(DeltaPlanner.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-456")
-            .build();
-
-    assertThat(DeltaPlanner.physicalName(metadata)).isEqualTo("col-456");
-  }
-
-  @Test
-  void checkpointStructStatsFromAddRowReadsStatsParsedAndMapsPhysicalNames() {
+  void checkpointStructStatsFromAddRowRecursesAndPreservesMultipartNames() {
+    StructType nestedMinMax = new StructType().add("col-zip", IntegerType.INTEGER, true);
+    StructType nestedNullCount = new StructType().add("col-zip", LongType.LONG, true);
     StructType addSchema =
         new StructType()
             .add("path", StringType.STRING, true)
@@ -109,19 +76,19 @@ class DeltaPlannerTest {
                     .add(
                         "minValues",
                         new StructType()
-                            .add("col-123", IntegerType.INTEGER, true)
+                            .add("col-address", nestedMinMax, true)
                             .add("plain_name", StringType.STRING, true),
                         true)
                     .add(
                         "maxValues",
                         new StructType()
-                            .add("col-123", IntegerType.INTEGER, true)
+                            .add("col-address", nestedMinMax, true)
                             .add("plain_name", StringType.STRING, true),
                         true)
                     .add(
                         "nullCount",
                         new StructType()
-                            .add("col-123", LongType.LONG, true)
+                            .add("col-address", nestedNullCount, true)
                             .add("plain_name", LongType.LONG, true),
                         true),
                 true);
@@ -138,13 +105,22 @@ class DeltaPlannerTest {
             .put("numRecords", 10L)
             .put(
                 "minValues",
-                new RowBuilder(minSchema).put("col-123", 7).put("plain_name", "a").row())
+                new RowBuilder(minSchema)
+                    .put("col-address", new RowBuilder(nestedMinMax).put("col-zip", 7).row())
+                    .put("plain_name", "a")
+                    .row())
             .put(
                 "maxValues",
-                new RowBuilder(maxSchema).put("col-123", 9).put("plain_name", "z").row())
+                new RowBuilder(maxSchema)
+                    .put("col-address", new RowBuilder(nestedMinMax).put("col-zip", 9).row())
+                    .put("plain_name", "z")
+                    .row())
             .put(
                 "nullCount",
-                new RowBuilder(nullCountSchema).put("col-123", 2L).put("plain_name", 1L).row())
+                new RowBuilder(nullCountSchema)
+                    .put("col-address", new RowBuilder(nestedNullCount).put("col-zip", 2L).row())
+                    .put("plain_name", 1L)
+                    .row())
             .row();
 
     GenericRow addRow =
@@ -153,22 +129,22 @@ class DeltaPlannerTest {
             .put(DeltaPlanner.STATS_PARSED_FIELD, statsRow)
             .row();
 
-    Map<String, String> statsNameToLogical =
-        Map.of("col-123", "logical_id", "logical_id", "logical_id", "plain_name", "plain_name");
-    Optional<DataFileStatistics> stats =
-        DeltaPlanner.checkpointStructStatsFromAddRow(
-            addRow, statsNameToLogical, Set.of("logical_id", "plain_name"));
+    Optional<DataFileStatistics> stats = DeltaPlanner.checkpointStructStatsFromAddRow(addRow);
 
     assertThat(stats).isPresent();
     assertThat(stats.get().getNumRecords()).isEqualTo(10L);
     assertThat(stats.get().getMinValues())
-        .containsEntry(new Column("logical_id"), io.delta.kernel.expressions.Literal.ofInt(7))
+        .containsEntry(
+            new Column(new String[] {"col-address", "col-zip"}),
+            io.delta.kernel.expressions.Literal.ofInt(7))
         .containsEntry(new Column("plain_name"), io.delta.kernel.expressions.Literal.ofString("a"));
     assertThat(stats.get().getMaxValues())
-        .containsEntry(new Column("logical_id"), io.delta.kernel.expressions.Literal.ofInt(9))
+        .containsEntry(
+            new Column(new String[] {"col-address", "col-zip"}),
+            io.delta.kernel.expressions.Literal.ofInt(9))
         .containsEntry(new Column("plain_name"), io.delta.kernel.expressions.Literal.ofString("z"));
     assertThat(stats.get().getNullCount())
-        .containsEntry(new Column("logical_id"), 2L)
+        .containsEntry(new Column(new String[] {"col-address", "col-zip"}), 2L)
         .containsEntry(new Column("plain_name"), 1L);
   }
 

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaTypeMapperTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaTypeMapperTest.java
@@ -39,6 +39,7 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.types.TimestampNTZType;
 import io.delta.kernel.types.TimestampType;
 import io.delta.kernel.types.VariantType;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -215,6 +216,33 @@ class DeltaTypeMapperTest {
     assertThat(t.fields().get(0).name()).isEqualTo("sku");
     assertThat(t.fields().get(0).nullable()).isFalse();
     assertThat(t.fields().get(1).type().kind()).isEqualTo(LogicalKind.INT);
+  }
+
+  @Test
+  void statsTypeMapIncludesNestedStructFieldsButStopsAtCollections() {
+    StructType schema =
+        new StructType()
+            .add(
+                "profile",
+                new StructType()
+                    .add("age", IntegerType.INTEGER, true)
+                    .add("tags", new ArrayType(StringType.STRING, true), true),
+                true);
+
+    Map<String, LogicalType> types = DeltaTypeMapper.deltaStatsTypeMap(schema);
+
+    assertThat(types.keySet()).containsExactly("profile", "profile.age", "profile.tags");
+    assertThat(types).doesNotContainKey("profile.tags[]");
+  }
+
+  @Test
+  void statsTypeMapOmitsDistinctPathsWithTheSameLegacyKey() {
+    StructType schema =
+        new StructType()
+            .add("a.b", StringType.STRING, true)
+            .add("a", new StructType().add("b", IntegerType.INTEGER, true), true);
+
+    assertThat(DeltaTypeMapper.deltaStatsTypeMap(schema)).containsKey("a").doesNotContainKey("a.b");
   }
 
   @Test

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/ParquetFooterStats.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/ParquetFooterStats.java
@@ -33,6 +33,7 @@ import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.ParquetFileReader;
@@ -117,8 +118,26 @@ public final class ParquetFooterStats {
     }
   }
 
+  @FunctionalInterface
+  public interface ColumnResolver {
+    /** Returns the logical output name, or {@code null} when the footer column is not selected. */
+    String resolve(List<String> parquetPath, Integer fieldId);
+  }
+
   public static BasicFileStats read(
       InputFile in, Set<String> includeNames, Map<String, LogicalType> nameToLogical) {
+    return read(
+        in,
+        nameToLogical,
+        (parquetPath, fieldId) -> {
+          String name = String.join(".", parquetPath);
+          return includeNames.isEmpty() || includeNames.contains(name) ? name : null;
+        });
+  }
+
+  public static BasicFileStats read(
+      InputFile in, Map<String, LogicalType> nameToLogical, ColumnResolver columnResolver) {
+    Objects.requireNonNull(columnResolver, "columnResolver");
 
     try (ParquetFileReader r = ParquetFileReader.open(new InputFileAdapter(in))) {
       List<BlockMetaData> rowGroups = r.getFooter().getBlocks();
@@ -129,8 +148,11 @@ public final class ParquetFooterStats {
         totalRows += rg.getRowCount();
 
         for (ColumnChunkMetaData c : rg.getColumns()) {
-          String colName = String.join(".", c.getPath().toArray());
-          if (!includeNames.isEmpty() && !includeNames.contains(colName)) {
+          var parquetId = c.getPrimitiveType().getId();
+          String colName =
+              columnResolver.resolve(
+                  List.of(c.getPath().toArray()), parquetId == null ? null : parquetId.intValue());
+          if (colName == null || colName.isBlank()) {
             continue;
           }
 


### PR DESCRIPTION
## Summary

Routes Delta log, checkpoint, and Parquet footer statistics through the resolved identity model. This prevents renamed, physically mapped, nested, or dotted-name columns from being confused and safely excludes ambiguous legacy keys.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (describe below)
- [ ] Config/env var changes (describe below)

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
