### PR TITLE
Persist canonical column identity maps for Delta snapshots

### DIFF
--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaCanonicalIdentity.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaCanonicalIdentity.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.connector.delta.uc.impl;
+
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityEntry;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMode;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityPathElement;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityPathElementKind;
+import ai.floedb.floecat.connector.delta.identity.DeltaResolvedSchema;
+import ai.floedb.floecat.schema.identity.ColumnPath;
+import ai.floedb.floecat.schema.identity.IdentityMode;
+import ai.floedb.floecat.schema.identity.LegacyDottedKeyIndex;
+import ai.floedb.floecat.schema.identity.SchemaIdentityReconciler;
+import ai.floedb.floecat.schema.identity.SchemaIdentityState;
+import io.delta.kernel.Snapshot;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Converts Delta schema identity reconciliation state to and from the snapshot wire contract. */
+final class DeltaCanonicalIdentity {
+  private static final int FORMAT_VERSION = 1;
+
+  private DeltaCanonicalIdentity() {}
+
+  static Reconciled reconcile(
+      Snapshot snapshot, long sourceVersion, ColumnIdentityMap previousIdentityMap) {
+    Objects.requireNonNull(snapshot, "snapshot");
+    DeltaResolvedSchema resolved = DeltaColumnMapping.resolveSchema(snapshot);
+    IdentityMode mode = identityMode(resolved, previousIdentityMap);
+    Optional<SchemaIdentityState> previous =
+        previousIdentityMap == null
+                || previousIdentityMap.equals(ColumnIdentityMap.getDefaultInstance())
+            ? Optional.empty()
+            : Optional.of(fromProto(previousIdentityMap));
+    SchemaIdentityReconciler.Result result =
+        SchemaIdentityReconciler.reconcile(resolved.schema(), sourceVersion, mode, previous);
+    return new Reconciled(resolved, result, toProto(result.state()));
+  }
+
+  /** Starts a new generation after unavailable history while preserving ID monotonicity. */
+  static Reconciled reset(
+      Snapshot snapshot, long sourceVersion, ColumnIdentityMap previousIdentityMap) {
+    Objects.requireNonNull(snapshot, "snapshot");
+    DeltaResolvedSchema resolved = DeltaColumnMapping.resolveSchema(snapshot);
+    IdentityMode mode = identityMode(resolved, previousIdentityMap);
+    long previousHighWaterMark =
+        previousIdentityMap == null
+                || previousIdentityMap.equals(ColumnIdentityMap.getDefaultInstance())
+            ? 0L
+            : fromProto(previousIdentityMap).highWaterMark();
+    SchemaIdentityReconciler.Result result =
+        SchemaIdentityReconciler.reset(
+            resolved.schema(), sourceVersion, mode, previousHighWaterMark);
+    return new Reconciled(resolved, result, toProto(result.state()));
+  }
+
+  /**
+   * The identity mode this table reconciles under.
+   *
+   * <p>Column mapping alone is not enough to use native IDs. PROTOCOL.md assigns an id to every
+   * column "nested or leaf", but gives array elements and map keys/values nowhere to record one --
+   * only StructField carries {@code metadata}. Delta-Spark works around that with {@code
+   * delta.columnMapping.nested.ids}, which is an extension rather than protocol, so a conformant
+   * third-party writer may produce a mapped table whose collection interiors have no native ID at
+   * all. Native-ID reconciliation needs one for every node, so such a table falls back to
+   * structured-path identity instead of being refused.
+   *
+   * <p>The choice is sticky: once a table reconciles by path it keeps doing so, even if a later
+   * writer starts emitting nested IDs. Switching modes mid-history is a reset, and silently
+   * triggering one on a writer upgrade would reissue live IDs.
+   */
+  static IdentityMode identityMode(
+      DeltaResolvedSchema resolved, ColumnIdentityMap previousIdentityMap) {
+    if (previousIdentityMap != null
+        && !previousIdentityMap.equals(ColumnIdentityMap.getDefaultInstance())) {
+      return previousIdentityMap.getMode()
+              == ColumnIdentityMode.COLUMN_IDENTITY_MODE_NATIVE_FIELD_ID
+          ? IdentityMode.NATIVE_FIELD_ID
+          : IdentityMode.STRUCTURED_PATH;
+    }
+    if (!resolved.effectiveMappingMode().isEnabled()) {
+      return IdentityMode.STRUCTURED_PATH;
+    }
+    boolean everyNodeHasNativeId =
+        resolved.schema().nodes().stream()
+            .allMatch(
+                node -> node.nativeFieldId().isPresent() && node.nativeFieldId().getAsInt() > 0);
+    return everyNodeHasNativeId ? IdentityMode.NATIVE_FIELD_ID : IdentityMode.STRUCTURED_PATH;
+  }
+
+  static SchemaIdentityState fromProto(ColumnIdentityMap value) {
+    Objects.requireNonNull(value, "value");
+    if (value.getFormatVersion() != FORMAT_VERSION) {
+      throw new IllegalArgumentException(
+          "Unsupported column identity map format " + value.getFormatVersion());
+    }
+    IdentityMode mode =
+        switch (value.getMode()) {
+          case COLUMN_IDENTITY_MODE_NATIVE_FIELD_ID -> IdentityMode.NATIVE_FIELD_ID;
+          case COLUMN_IDENTITY_MODE_STRUCTURED_PATH -> IdentityMode.STRUCTURED_PATH;
+          default -> throw new IllegalArgumentException("Column identity map has no mode");
+        };
+    List<ai.floedb.floecat.schema.identity.SchemaIdentityEntry> entries = new ArrayList<>();
+    for (ColumnIdentityEntry entry : value.getEntriesList()) {
+      entries.add(
+          new ai.floedb.floecat.schema.identity.SchemaIdentityEntry(
+              pathFromProto(entry.getPathList()),
+              entry.hasNativeFieldId()
+                  ? OptionalInt.of(entry.getNativeFieldId())
+                  : OptionalInt.empty(),
+              entry.getColumnId()));
+    }
+    return SchemaIdentityState.restore(
+        value.getSourceVersion(), value.getHighWaterMark(), mode, entries, value.getFingerprint());
+  }
+
+  static void validateSnapshot(Snapshot snapshot, ColumnIdentityMap identityMap) {
+    SchemaIdentityState state = fromProto(identityMap);
+    if (state.sourceVersion() != snapshot.getVersion()) {
+      throw new IllegalArgumentException(
+          "Column identity map version "
+              + state.sourceVersion()
+              + " does not match Delta snapshot "
+              + snapshot.getVersion());
+    }
+    DeltaResolvedSchema resolved = DeltaColumnMapping.resolveSchema(snapshot);
+    // Only one direction is an inconsistency. A native-ID map over a snapshot that is not column
+    // mapped names IDs the source cannot govern. The converse is legitimate: a mapped table whose
+    // collection interiors carry no native IDs reconciles by path (see identityMode), so a
+    // structured-path map over a mapped snapshot is the expected outcome, not a mismatch.
+    if (state.mode() == IdentityMode.NATIVE_FIELD_ID
+        && !resolved.effectiveMappingMode().isEnabled()) {
+      throw new IllegalArgumentException("Snapshot and column identity map use different modes");
+    }
+    Set<ColumnPath> sourcePaths =
+        resolved.schema().nodes().stream().map(node -> node.path()).collect(Collectors.toSet());
+    Set<ColumnPath> mappedPaths =
+        state.entries().stream().map(entry -> entry.path()).collect(Collectors.toSet());
+    if (!sourcePaths.equals(mappedPaths)) {
+      throw new IllegalArgumentException("Snapshot schema does not match its column identity map");
+    }
+    if (state.mode() == IdentityMode.NATIVE_FIELD_ID) {
+      resolved
+          .schema()
+          .nodes()
+          .forEach(
+              node -> {
+                var mapped = state.byPath(node.path()).orElseThrow();
+                long mappedId = mapped.canonicalId();
+                if (node.nativeFieldId().isEmpty()
+                    || mapped.nativeFieldId().isEmpty()
+                    || node.nativeFieldId().getAsInt() != mappedId
+                    || mapped.nativeFieldId().getAsInt() != node.nativeFieldId().getAsInt()) {
+                  throw new IllegalArgumentException(
+                      "Mapped Delta identity changed for " + node.path().display());
+                }
+              });
+    }
+  }
+
+  /** Returns canonical IDs keyed by the unambiguous logical names used by the stats engine. */
+  static java.util.Map<String, Long> canonicalIdsByStatsKey(
+      Snapshot snapshot, ColumnIdentityMap identityMap) {
+    validateSnapshot(snapshot, identityMap);
+    SchemaIdentityState state = fromProto(identityMap);
+    DeltaResolvedSchema resolved = DeltaColumnMapping.resolveSchema(snapshot);
+    LegacyDottedKeyIndex<Long> index = LegacyDottedKeyIndex.create();
+    resolved
+        .schema()
+        .nodes()
+        .forEach(
+            node -> index.add(node.path(), state.byPath(node.path()).orElseThrow().canonicalId()));
+    return new LinkedHashMap<>(index.values());
+  }
+
+  /** Returns canonical IDs keyed by unambiguous logical dotted paths from persisted state. */
+  static java.util.Map<String, Long> canonicalIdsByLogicalKey(ColumnIdentityMap identityMap) {
+    fromProto(identityMap);
+    LegacyDottedKeyIndex<Long> index = LegacyDottedKeyIndex.create();
+    identityMap
+        .getEntriesList()
+        .forEach(entry -> index.add(pathFromProto(entry.getPathList()), entry.getColumnId()));
+    return new LinkedHashMap<>(index.values());
+  }
+
+  /** Returns source ordinals keyed by the same unambiguous logical names as stats. */
+  static java.util.Map<String, Integer> ordinalsByStatsKey(Snapshot snapshot) {
+    LegacyDottedKeyIndex<Integer> index = LegacyDottedKeyIndex.create();
+    DeltaColumnMapping.resolveSchema(snapshot)
+        .schema()
+        .nodes()
+        .forEach(node -> index.add(node.path(), node.ordinal()));
+    return new LinkedHashMap<>(index.values());
+  }
+
+  static ColumnIdentityMap toProto(SchemaIdentityState state) {
+    ColumnIdentityMap.Builder out =
+        ColumnIdentityMap.newBuilder()
+            .setFormatVersion(FORMAT_VERSION)
+            .setSourceVersion(state.sourceVersion())
+            .setHighWaterMark(state.highWaterMark())
+            .setMode(
+                state.mode() == IdentityMode.NATIVE_FIELD_ID
+                    ? ColumnIdentityMode.COLUMN_IDENTITY_MODE_NATIVE_FIELD_ID
+                    : ColumnIdentityMode.COLUMN_IDENTITY_MODE_STRUCTURED_PATH)
+            .setFingerprint(state.fingerprint());
+    for (ai.floedb.floecat.schema.identity.SchemaIdentityEntry entry : state.entries()) {
+      ColumnIdentityEntry.Builder mapped =
+          ColumnIdentityEntry.newBuilder()
+              .setColumnId(entry.canonicalId())
+              .addAllPath(pathToProto(entry.path()));
+      entry.nativeFieldId().ifPresent(mapped::setNativeFieldId);
+      out.addEntries(mapped);
+    }
+    return out.build();
+  }
+
+  private static List<ColumnIdentityPathElement> pathToProto(ColumnPath path) {
+    return path.elements().stream()
+        .map(
+            element -> {
+              ColumnIdentityPathElement.Builder out =
+                  ColumnIdentityPathElement.newBuilder()
+                      .setKind(
+                          switch (element.kind()) {
+                            case FIELD ->
+                                ColumnIdentityPathElementKind
+                                    .COLUMN_IDENTITY_PATH_ELEMENT_KIND_FIELD;
+                            case ARRAY_ELEMENT ->
+                                ColumnIdentityPathElementKind
+                                    .COLUMN_IDENTITY_PATH_ELEMENT_KIND_ARRAY_ELEMENT;
+                            case MAP_KEY ->
+                                ColumnIdentityPathElementKind
+                                    .COLUMN_IDENTITY_PATH_ELEMENT_KIND_MAP_KEY;
+                            case MAP_VALUE ->
+                                ColumnIdentityPathElementKind
+                                    .COLUMN_IDENTITY_PATH_ELEMENT_KIND_MAP_VALUE;
+                          });
+              if (element.name() != null) {
+                out.setName(element.name());
+              }
+              return out.build();
+            })
+        .toList();
+  }
+
+  private static ColumnPath pathFromProto(List<ColumnIdentityPathElement> elements) {
+    ColumnPath path = ColumnPath.ROOT;
+    for (ColumnIdentityPathElement element : elements) {
+      path =
+          switch (element.getKind()) {
+            case COLUMN_IDENTITY_PATH_ELEMENT_KIND_FIELD -> path.field(element.getName());
+            case COLUMN_IDENTITY_PATH_ELEMENT_KIND_ARRAY_ELEMENT -> path.arrayElement();
+            case COLUMN_IDENTITY_PATH_ELEMENT_KIND_MAP_KEY -> path.mapKey();
+            case COLUMN_IDENTITY_PATH_ELEMENT_KIND_MAP_VALUE -> path.mapValue();
+            default ->
+                throw new IllegalArgumentException("Column identity path has no element kind");
+          };
+    }
+    if (path.isRoot()) {
+      throw new IllegalArgumentException("Column identity path cannot be empty");
+    }
+    return path;
+  }
+
+  record Reconciled(
+      DeltaResolvedSchema resolvedSchema,
+      SchemaIdentityReconciler.Result identity,
+      ColumnIdentityMap identityMap) {}
+}

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
@@ -358,7 +358,8 @@ abstract class DeltaConnector implements FloecatConnector {
       long snapshotId,
       Set<String> includeColumns,
       Set<StatsTargetKind> includeTargetKinds,
-      ColumnSelectorPolicy columnSelectorPolicy) {
+      ColumnSelectorPolicy columnSelectorPolicy,
+      ColumnIdentityMap columnIdentityMap) {
     if (snapshotId < 0) {
       return Optional.empty();
     }
@@ -486,7 +487,8 @@ abstract class DeltaConnector implements FloecatConnector {
       Set<String> indexColumns,
       Set<StatsTargetKind> includeTargetKinds,
       boolean captureIndexes,
-      ColumnSelectorPolicy columnSelectorPolicy) {
+      ColumnSelectorPolicy columnSelectorPolicy,
+      ColumnIdentityMap columnIdentityMap) {
     if (snapshotId < 0 || plannedFilePaths == null || plannedFilePaths.isEmpty()) {
       return FileGroupCaptureResult.empty();
     }
@@ -551,7 +553,8 @@ abstract class DeltaConnector implements FloecatConnector {
       ColumnSelectorPolicy columnSelectorPolicy,
       Set<String> plannedFilePaths,
       List<ParquetPageIndexEntry> entries,
-      List<ParquetRowGroup> rowGroups) {
+      List<ParquetRowGroup> rowGroups,
+      ColumnIdentityMap columnIdentityMap) {
     Snapshot snapshot =
         loadTable(storageLocation(namespaceFq, tableName))
             .getSnapshotAsOfVersion(engine, snapshotId);

--- a/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
+++ b/connectors/catalogs/delta/src/main/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnector.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.connector.delta.uc.impl;
 
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
 import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
 import ai.floedb.floecat.catalog.rpc.ConstraintEnforcement;
@@ -183,9 +184,21 @@ abstract class DeltaConnector implements FloecatConnector {
     if (versions.isEmpty()) {
       return List.of();
     }
+    Set<Long> selectedVersions = new LinkedHashSet<>(versions);
     List<SnapshotBundle> bundles = new ArrayList<>(versions.size());
+    ColumnIdentityMap previousIdentityMap =
+        options == null
+            ? ColumnIdentityMap.getDefaultInstance()
+            : options.previousColumnIdentityMap();
+    boolean resetIdentityGeneration =
+        fullRescan && !previousIdentityMap.equals(ColumnIdentityMap.getDefaultInstance());
+    boolean sequentialIdentity =
+        previousIdentityMap.equals(ColumnIdentityMap.getDefaultInstance())
+            || previousIdentityMap.getMode()
+                == ai.floedb.floecat.catalog.rpc.ColumnIdentityMode
+                    .COLUMN_IDENTITY_MODE_STRUCTURED_PATH;
     long earliestAvailableVersion = 0L;
-    for (long version : versions) {
+    for (long version : identityVersionsToWalk(versions, previousIdentityMap, fullRescan)) {
       if (version < earliestAvailableVersion) {
         continue;
       }
@@ -198,11 +211,76 @@ abstract class DeltaConnector implements FloecatConnector {
       }
       Snapshot snapshot = snapshotResult.snapshot();
       if (snapshot == null) {
+        resetIdentityGeneration |= sequentialIdentity;
         continue;
       }
-      bundles.add(buildSnapshotBundle(storageLocation, version, snapshot));
+      long previousIdentityVersion =
+          previousIdentityMap.equals(ColumnIdentityMap.getDefaultInstance())
+              ? -1L
+              : previousIdentityMap.getSourceVersion();
+      if (version < previousIdentityVersion && !resetIdentityGeneration) {
+        LOG.warnf(
+            "Cannot backfill Delta snapshot version %d below persisted identity version %d for %s",
+            Long.valueOf(version), Long.valueOf(previousIdentityVersion), storageLocation);
+        continue;
+      }
+      if (!resetIdentityGeneration && version == previousIdentityVersion) {
+        DeltaCanonicalIdentity.validateSnapshot(snapshot, previousIdentityMap);
+        if (selectedVersions.contains(version)) {
+          bundles.add(buildSnapshotBundle(storageLocation, version, snapshot, previousIdentityMap));
+        }
+        continue;
+      }
+      DeltaCanonicalIdentity.Reconciled identity =
+          resetIdentityGeneration
+              ? DeltaCanonicalIdentity.reset(snapshot, version, previousIdentityMap)
+              : DeltaCanonicalIdentity.reconcile(snapshot, version, previousIdentityMap);
+      previousIdentityMap = identity.identityMap();
+      resetIdentityGeneration = false;
+      sequentialIdentity =
+          identity.identity().state().mode()
+              == ai.floedb.floecat.schema.identity.IdentityMode.STRUCTURED_PATH;
+      if (selectedVersions.contains(version)) {
+        bundles.add(
+            buildSnapshotBundle(storageLocation, version, snapshot, identity.identityMap()));
+      }
     }
     return List.copyOf(bundles);
+  }
+
+  static List<Long> identityVersionsToWalk(
+      List<Long> selectedVersions, ColumnIdentityMap previousIdentityMap, boolean fullRescan) {
+    if (selectedVersions == null || selectedVersions.isEmpty()) {
+      return List.of();
+    }
+    long firstSelected = selectedVersions.stream().mapToLong(Long::longValue).min().orElseThrow();
+    long lastSelected = selectedVersions.stream().mapToLong(Long::longValue).max().orElseThrow();
+    boolean hasPrevious =
+        previousIdentityMap != null
+            && !previousIdentityMap.equals(ColumnIdentityMap.getDefaultInstance());
+    boolean structured =
+        !hasPrevious
+            || previousIdentityMap.getMode()
+                == ai.floedb.floecat.catalog.rpc.ColumnIdentityMode
+                    .COLUMN_IDENTITY_MODE_STRUCTURED_PATH;
+    if (!structured) {
+      return List.copyOf(selectedVersions);
+    }
+    long firstVersion =
+        hasPrevious && !fullRescan
+            ? Math.max(0L, previousIdentityMap.getSourceVersion() + 1L)
+            : firstSelected;
+    if (firstVersion > lastSelected) {
+      return List.copyOf(selectedVersions);
+    }
+    List<Long> versions = new ArrayList<>();
+    for (long version = firstVersion; version <= lastSelected; version++) {
+      versions.add(version);
+      if (version == Long.MAX_VALUE) {
+        break;
+      }
+    }
+    return List.copyOf(versions);
   }
 
   @Override
@@ -1475,7 +1553,10 @@ abstract class DeltaConnector implements FloecatConnector {
   }
 
   private SnapshotBundle buildSnapshotBundle(
-      String storageLocation, long version, Snapshot snapshot) {
+      String storageLocation,
+      long version,
+      Snapshot snapshot,
+      ColumnIdentityMap columnIdentityMap) {
     final long createdMs = snapshot.getTimestamp(engine);
     final long parent = version > 0L ? version - 1L : -1L;
 
@@ -1483,7 +1564,17 @@ abstract class DeltaConnector implements FloecatConnector {
     final String schemaJson = snapshotSchemaJson(snapshot);
     final PartitionSpecInfo partitionSpec = toPartitionSpecInfo(snapshot);
     return new SnapshotBundle(
-        version, parent, createdMs, schemaJson, partitionSpec, 0L, null, Map.of(), 0, null);
+        version,
+        parent,
+        createdMs,
+        schemaJson,
+        partitionSpec,
+        0L,
+        null,
+        Map.of(),
+        0,
+        null,
+        columnIdentityMap);
   }
 
   private List<TargetStatsRecord> buildTargetStats(

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/DeltaConnectorTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.ConstraintType;
 import ai.floedb.floecat.catalog.rpc.SnapshotConstraints;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -446,7 +447,8 @@ class DeltaConnectorTest {
                 7L,
                 Set.of("#" + stableColumnId),
                 FloecatConnector.ColumnSelectorPolicy.defaults(),
-                List.of(entry))
+                List.of(entry),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
 
     assertEquals(1, selected.size());
@@ -461,7 +463,8 @@ class DeltaConnectorTest {
                 7L,
                 Set.of(),
                 FloecatConnector.ColumnSelectorPolicy.defaults(),
-                List.of(entry))
+                List.of(entry),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
     assertEquals(
         Set.of("#" + stableColumnId, "id"), selectedByDefault.getFirst().selectorAliases());
@@ -514,7 +517,8 @@ class DeltaConnectorTest {
                 List.of(
                     pageIndexEntry(oldFile, "id"),
                     pageIndexEntry(newFile, "id"),
-                    pageIndexEntry(newFile, "added")))
+                    pageIndexEntry(newFile, "added")),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
 
     assertEquals(
@@ -540,7 +544,8 @@ class DeltaConnectorTest {
                 8L,
                 Set.of("#" + addedColumnId),
                 FloecatConnector.ColumnSelectorPolicy.defaults(),
-                List.of(pageIndexEntry(oldFile, "id")))
+                List.of(pageIndexEntry(oldFile, "id")),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
     assertEquals(1, schemaOnlyAddition.size());
     assertEquals("added", schemaOnlyAddition.getFirst().columnName());
@@ -556,7 +561,8 @@ class DeltaConnectorTest {
                 FloecatConnector.ColumnSelectorPolicy.defaults(),
                 Set.of(oldFile),
                 List.of(),
-                List.of(new FloecatConnector.ParquetRowGroup(oldFile, 0, 17)))
+                List.of(new FloecatConnector.ParquetRowGroup(oldFile, 0, 17)),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
     assertEquals(1, noDecodedColumns.size());
     assertEquals(17, noDecodedColumns.getFirst().rowCount());
@@ -603,7 +609,8 @@ class DeltaConnectorTest {
                 9L,
                 Set.of("logical_id"),
                 FloecatConnector.ColumnSelectorPolicy.defaults(),
-                List.of(physicalEntry))
+                List.of(physicalEntry),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
 
     assertEquals(1, selected.size());
@@ -749,7 +756,17 @@ class DeltaConnectorTest {
   private static FloecatConnector.SnapshotBundle snapshotBundle(
       long snapshotId, String schemaJson) {
     return new FloecatConnector.SnapshotBundle(
-        snapshotId, 0L, 0L, schemaJson, null, 0L, null, Map.of(), 0, null);
+        snapshotId,
+        0L,
+        0L,
+        schemaJson,
+        null,
+        0L,
+        null,
+        Map.of(),
+        0,
+        null,
+        ColumnIdentityMap.getDefaultInstance());
   }
 
   private static FloecatConnector.ParquetPageIndexEntry pageIndexEntry(

--- a/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/FloecatConnectorDefaultChainTest.java
+++ b/connectors/catalogs/delta/src/test/java/ai/floedb/floecat/connector/delta/uc/impl/FloecatConnectorDefaultChainTest.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.connector.delta.uc.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.spi.ConnectorFormat;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
@@ -94,7 +95,8 @@ class FloecatConnectorDefaultChainTest {
         Set<String> indexColumns,
         Set<StatsTargetKind> includeTargetKinds,
         boolean captureIndexes,
-        ColumnSelectorPolicy columnSelectorPolicy) {
+        ColumnSelectorPolicy columnSelectorPolicy,
+        ColumnIdentityMap columnIdentityMap) {
       return FileGroupCaptureResult.empty();
     }
 

--- a/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
+++ b/connectors/catalogs/iceberg/src/main/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnector.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.connector.iceberg.impl;
 
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.ConstraintColumnRef;
 import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
 import ai.floedb.floecat.catalog.rpc.ConstraintEnforcement;
@@ -329,7 +330,8 @@ public abstract class IcebergConnector implements FloecatConnector {
               manifestList,
               summary,
               schemaId,
-              metadataLocation));
+              metadataLocation,
+              ColumnIdentityMap.getDefaultInstance()));
     }
     return out;
   }
@@ -410,7 +412,8 @@ public abstract class IcebergConnector implements FloecatConnector {
       Set<String> indexColumns,
       Set<StatsTargetKind> includeTargetKinds,
       boolean captureIndexes,
-      ColumnSelectorPolicy columnSelectorPolicy) {
+      ColumnSelectorPolicy columnSelectorPolicy,
+      ColumnIdentityMap columnIdentityMap) {
     if (snapshotId < 0 || plannedFilePaths == null || plannedFilePaths.isEmpty()) {
       return FileGroupCaptureResult.empty();
     }
@@ -478,7 +481,8 @@ public abstract class IcebergConnector implements FloecatConnector {
       ColumnSelectorPolicy columnSelectorPolicy,
       Set<String> plannedFilePaths,
       List<ParquetPageIndexEntry> entries,
-      List<ParquetRowGroup> rowGroups) {
+      List<ParquetRowGroup> rowGroups,
+      ColumnIdentityMap columnIdentityMap) {
     Table table = loadTable(namespaceFq, tableName);
     Snapshot snapshot = table.snapshot(snapshotId);
     if (snapshot == null) {

--- a/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorIssuesTest.java
+++ b/connectors/catalogs/iceberg/src/test/java/ai/floedb/floecat/connector/iceberg/impl/IcebergConnectorIssuesTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.FileContent;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
 import ai.floedb.floecat.common.rpc.ResourceId;
@@ -165,7 +166,8 @@ class IcebergConnectorIssuesTest {
                 123L,
                 Set.of("#1"),
                 FloecatConnector.ColumnSelectorPolicy.defaults(),
-                List.of(oldFileEntry, newFileEntry))
+                List.of(oldFileEntry, newFileEntry),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
 
     assertEquals(
@@ -182,7 +184,8 @@ class IcebergConnectorIssuesTest {
                 Set.of(),
                 new FloecatConnector.ColumnSelectorPolicy(
                     FloecatConnector.DefaultColumnScope.FIRST_N, 1),
-                List.of(oldFileEntry, newFileEntry))
+                List.of(oldFileEntry, newFileEntry),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
     assertEquals(2, selectedByDefault.size());
     assertTrue(
@@ -201,7 +204,8 @@ class IcebergConnectorIssuesTest {
                 123L,
                 Set.of("#2"),
                 FloecatConnector.ColumnSelectorPolicy.defaults(),
-                List.of(oldFileEntry, newFileEntry))
+                List.of(oldFileEntry, newFileEntry),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
     assertEquals(2, selectedAddedColumn.size());
     assertTrue(
@@ -223,7 +227,8 @@ class IcebergConnectorIssuesTest {
                 Set.of("s3://bucket/unsupported.parquet"),
                 List.of(),
                 List.of(
-                    new FloecatConnector.ParquetRowGroup("s3://bucket/unsupported.parquet", 0, 19)))
+                    new FloecatConnector.ParquetRowGroup("s3://bucket/unsupported.parquet", 0, 19)),
+                ColumnIdentityMap.getDefaultInstance())
             .orElseThrow();
     assertEquals(1, noDecodedColumns.size());
     assertEquals(19, noDecodedColumns.getFirst().rowCount());
@@ -239,7 +244,8 @@ class IcebergConnectorIssuesTest {
                     123L,
                     Set.of("#3"),
                     FloecatConnector.ColumnSelectorPolicy.defaults(),
-                    List.of(oldFileEntry)));
+                    List.of(oldFileEntry),
+                    ColumnIdentityMap.getDefaultInstance()));
     assertTrue(initialDefaultError.getMessage().contains("non-null initial default"));
   }
 
@@ -583,7 +589,8 @@ class IcebergConnectorIssuesTest {
                   FloecatConnector.StatsTargetKind.COLUMN,
                   FloecatConnector.StatsTargetKind.FILE),
               false,
-              FloecatConnector.ColumnSelectorPolicy.defaults());
+              FloecatConnector.ColumnSelectorPolicy.defaults(),
+              ColumnIdentityMap.getDefaultInstance());
 
       assertTrue(
           captured.statsRecords().stream()

--- a/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/ConnectorStatsViewBuilder.java
+++ b/core/connectors/common/src/main/java/ai/floedb/floecat/connector/common/ConnectorStatsViewBuilder.java
@@ -88,7 +88,11 @@ public final class ConnectorStatsViewBuilder {
       // Populate ref as fully as we can.
       var ref =
           new FloecatConnector.ColumnRef(
-              name == null ? "" : name, physicalPath == null ? "" : physicalPath, ordinal, fieldId);
+              name == null ? "" : name,
+              physicalPath == null ? "" : physicalPath,
+              ordinal,
+              fieldId,
+              0L);
 
       String logicalTypeStr = (lt == null) ? "" : LogicalTypeProtoAdapter.encodeLogicalType(lt);
 

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/DeltaNestedColumnStatsTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/DeltaNestedColumnStatsTest.java
@@ -71,7 +71,7 @@ public class DeltaNestedColumnStatsTest {
   private static FloecatConnector.ColumnRef ref(
       String name, String physicalPath, int ordinal, int fieldId) {
     return new FloecatConnector.ColumnRef(
-        name == null ? "" : name, physicalPath == null ? "" : physicalPath, ordinal, fieldId);
+        name == null ? "" : name, physicalPath == null ? "" : physicalPath, ordinal, fieldId, 0L);
   }
 
   private static FloecatConnector.ColumnStatsView view(

--- a/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/StatsProtoEmitterTest.java
+++ b/core/connectors/common/src/test/java/ai/floedb/floecat/connector/common/resolver/StatsProtoEmitterTest.java
@@ -60,7 +60,7 @@ public class StatsProtoEmitterTest {
   private static FloecatConnector.ColumnRef ref(
       String name, String physicalPath, int ordinal, int fieldId) {
     return new FloecatConnector.ColumnRef(
-        name == null ? "" : name, physicalPath == null ? "" : physicalPath, ordinal, fieldId);
+        name == null ? "" : name, physicalPath == null ? "" : physicalPath, ordinal, fieldId, 0L);
   }
 
   private static FloecatConnector.ColumnStatsView view(

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
@@ -278,49 +278,13 @@ public interface FloecatConnector extends Closeable {
       ResourceId destinationTableId,
       long snapshotId,
       Set<String> includeColumns,
-      Set<StatsTargetKind> includeTargetKinds) {
-    return captureSnapshotTargetStatsDirect(
-        namespaceFq,
-        tableName,
-        destinationTableId,
-        snapshotId,
-        includeColumns,
-        includeTargetKinds,
-        ColumnSelectorPolicy.defaults());
-  }
-
-  default Optional<DirectSnapshotStatsCapture> captureSnapshotTargetStatsDirect(
-      String namespaceFq,
-      String tableName,
-      ResourceId destinationTableId,
-      long snapshotId,
-      Set<String> includeColumns,
-      Set<StatsTargetKind> includeTargetKinds,
-      ColumnSelectorPolicy columnSelectorPolicy) {
-    return Optional.empty();
-  }
-
-  /** Captures direct stats using the snapshot's authoritative column identity map. */
-  default Optional<DirectSnapshotStatsCapture> captureSnapshotTargetStatsDirect(
-      String namespaceFq,
-      String tableName,
-      ResourceId destinationTableId,
-      long snapshotId,
-      Set<String> includeColumns,
       Set<StatsTargetKind> includeTargetKinds,
       ColumnSelectorPolicy columnSelectorPolicy,
       ColumnIdentityMap columnIdentityMap) {
-    return captureSnapshotTargetStatsDirect(
-        namespaceFq,
-        tableName,
-        destinationTableId,
-        snapshotId,
-        includeColumns,
-        includeTargetKinds,
-        columnSelectorPolicy);
+    return Optional.empty();
   }
 
-  /** Captures requested outputs for one planned file-group within a snapshot. */
+  /** Captures a planned group using the snapshot's authoritative column identity map. */
   FileGroupCaptureResult capturePlannedFileGroup(
       String namespaceFq,
       String tableName,
@@ -331,33 +295,8 @@ public interface FloecatConnector extends Closeable {
       Set<String> indexColumns,
       Set<StatsTargetKind> includeTargetKinds,
       boolean captureIndexes,
-      ColumnSelectorPolicy columnSelectorPolicy);
-
-  /** Captures a planned group using the snapshot's authoritative column identity map. */
-  default FileGroupCaptureResult capturePlannedFileGroup(
-      String namespaceFq,
-      String tableName,
-      ResourceId destinationTableId,
-      long snapshotId,
-      Set<String> plannedFilePaths,
-      Set<String> includeColumns,
-      Set<String> indexColumns,
-      Set<StatsTargetKind> includeTargetKinds,
-      boolean captureIndexes,
       ColumnSelectorPolicy columnSelectorPolicy,
-      ColumnIdentityMap columnIdentityMap) {
-    return capturePlannedFileGroup(
-        namespaceFq,
-        tableName,
-        destinationTableId,
-        snapshotId,
-        plannedFilePaths,
-        includeColumns,
-        indexColumns,
-        includeTargetKinds,
-        captureIndexes,
-        columnSelectorPolicy);
-  }
+      ColumnIdentityMap columnIdentityMap);
 
   /**
    * Applies connector-specific selector semantics to decoded Parquet page-index entries.
@@ -366,27 +305,6 @@ public interface FloecatConnector extends Closeable {
    * return a present value for explicit selectors whose stable IDs or logical names need
    * format-specific resolution.
    */
-  default Optional<List<ParquetPageIndexEntry>> selectPageIndexEntries(
-      String namespaceFq,
-      String tableName,
-      long snapshotId,
-      Set<String> selectors,
-      ColumnSelectorPolicy columnSelectorPolicy,
-      List<ParquetPageIndexEntry> entries) {
-    Set<String> plannedFilePaths = pageIndexPlannedFilePaths(entries);
-    List<ParquetRowGroup> rowGroups = pageIndexRowGroups(entries);
-    return selectPageIndexEntries(
-        namespaceFq,
-        tableName,
-        snapshotId,
-        selectors,
-        columnSelectorPolicy,
-        plannedFilePaths,
-        entries,
-        rowGroups);
-  }
-
-  /** Applies connector-specific selector semantics using the authoritative column identity map. */
   default Optional<List<ParquetPageIndexEntry>> selectPageIndexEntries(
       String namespaceFq,
       String tableName,
@@ -444,25 +362,9 @@ public interface FloecatConnector extends Closeable {
   }
 
   /**
-   * Applies connector-specific selector semantics with complete planned-file and row-group
-   * metadata, including files for which no decodable page-index entry was produced.
-   */
-  default Optional<List<ParquetPageIndexEntry>> selectPageIndexEntries(
-      String namespaceFq,
-      String tableName,
-      long snapshotId,
-      Set<String> selectors,
-      ColumnSelectorPolicy columnSelectorPolicy,
-      Set<String> plannedFilePaths,
-      List<ParquetPageIndexEntry> entries,
-      List<ParquetRowGroup> rowGroups) {
-    return Optional.empty();
-  }
-
-  /**
    * Applies connector-specific selector semantics using the authoritative column identity map.
    *
-   * <p>Connectors without canonical identity requirements retain the legacy selection behavior.
+   * <p>Connectors without canonical identity requirements may ignore the identity map.
    */
   default Optional<List<ParquetPageIndexEntry>> selectPageIndexEntries(
       String namespaceFq,
@@ -474,15 +376,7 @@ public interface FloecatConnector extends Closeable {
       List<ParquetPageIndexEntry> entries,
       List<ParquetRowGroup> rowGroups,
       ColumnIdentityMap columnIdentityMap) {
-    return selectPageIndexEntries(
-        namespaceFq,
-        tableName,
-        snapshotId,
-        selectors,
-        columnSelectorPolicy,
-        plannedFilePaths,
-        entries,
-        rowGroups);
+    return Optional.empty();
   }
 
   record FileGroupCaptureResult(
@@ -661,75 +555,118 @@ public interface FloecatConnector extends Closeable {
               : previousColumnIdentityMap;
     }
 
-    public SnapshotEnumerationOptions(
-        boolean fullRescan,
-        Set<Long> knownSnapshotIds,
-        Set<Long> targetSnapshotIds,
-        SnapshotSelectionKind selectionKind,
-        Set<Long> selectionSnapshotIds,
-        int latestN) {
-      this(
-          fullRescan,
-          knownSnapshotIds,
-          targetSnapshotIds,
-          selectionKind,
-          selectionSnapshotIds,
-          latestN,
-          ColumnIdentityMap.getDefaultInstance());
-    }
-
     public static SnapshotEnumerationOptions full(boolean fullRescan) {
       return new SnapshotEnumerationOptions(
-          fullRescan, Set.of(), Set.of(), SnapshotSelectionKind.ALL, Set.of(), 0);
+          fullRescan,
+          Set.of(),
+          Set.of(),
+          SnapshotSelectionKind.ALL,
+          Set.of(),
+          0,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions full(boolean fullRescan, Set<Long> targetSnapshotIds) {
       return new SnapshotEnumerationOptions(
-          fullRescan, Set.of(), targetSnapshotIds, SnapshotSelectionKind.ALL, Set.of(), 0);
+          fullRescan,
+          Set.of(),
+          targetSnapshotIds,
+          SnapshotSelectionKind.ALL,
+          Set.of(),
+          0,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions incremental(Set<Long> knownSnapshotIds) {
       return new SnapshotEnumerationOptions(
-          false, knownSnapshotIds, Set.of(), SnapshotSelectionKind.ALL, Set.of(), 0);
+          false,
+          knownSnapshotIds,
+          Set.of(),
+          SnapshotSelectionKind.ALL,
+          Set.of(),
+          0,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions incremental(
         Set<Long> knownSnapshotIds, Set<Long> targetSnapshotIds) {
       return new SnapshotEnumerationOptions(
-          false, knownSnapshotIds, targetSnapshotIds, SnapshotSelectionKind.ALL, Set.of(), 0);
+          false,
+          knownSnapshotIds,
+          targetSnapshotIds,
+          SnapshotSelectionKind.ALL,
+          Set.of(),
+          0,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions fullCurrent(boolean fullRescan) {
       return new SnapshotEnumerationOptions(
-          fullRescan, Set.of(), Set.of(), SnapshotSelectionKind.CURRENT, Set.of(), 0);
+          fullRescan,
+          Set.of(),
+          Set.of(),
+          SnapshotSelectionKind.CURRENT,
+          Set.of(),
+          0,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions incrementalCurrent(Set<Long> knownSnapshotIds) {
       return new SnapshotEnumerationOptions(
-          false, knownSnapshotIds, Set.of(), SnapshotSelectionKind.CURRENT, Set.of(), 0);
+          false,
+          knownSnapshotIds,
+          Set.of(),
+          SnapshotSelectionKind.CURRENT,
+          Set.of(),
+          0,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions fullLatestN(boolean fullRescan, int latestN) {
       return new SnapshotEnumerationOptions(
-          fullRescan, Set.of(), Set.of(), SnapshotSelectionKind.LATEST_N, Set.of(), latestN);
+          fullRescan,
+          Set.of(),
+          Set.of(),
+          SnapshotSelectionKind.LATEST_N,
+          Set.of(),
+          latestN,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions incrementalLatestN(
         Set<Long> knownSnapshotIds, int latestN) {
       return new SnapshotEnumerationOptions(
-          false, knownSnapshotIds, Set.of(), SnapshotSelectionKind.LATEST_N, Set.of(), latestN);
+          false,
+          knownSnapshotIds,
+          Set.of(),
+          SnapshotSelectionKind.LATEST_N,
+          Set.of(),
+          latestN,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions fullExplicit(
         boolean fullRescan, Set<Long> snapshotIds) {
       return new SnapshotEnumerationOptions(
-          fullRescan, Set.of(), Set.of(), SnapshotSelectionKind.EXPLICIT, snapshotIds, 0);
+          fullRescan,
+          Set.of(),
+          Set.of(),
+          SnapshotSelectionKind.EXPLICIT,
+          snapshotIds,
+          0,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions incrementalExplicit(
         Set<Long> knownSnapshotIds, Set<Long> snapshotIds) {
       return new SnapshotEnumerationOptions(
-          false, knownSnapshotIds, Set.of(), SnapshotSelectionKind.EXPLICIT, snapshotIds, 0);
+          false,
+          knownSnapshotIds,
+          Set.of(),
+          SnapshotSelectionKind.EXPLICIT,
+          snapshotIds,
+          0,
+          ColumnIdentityMap.getDefaultInstance());
     }
   }
 
@@ -820,11 +757,7 @@ public interface FloecatConnector extends Closeable {
       int ordinal, // 1-based within parent struct, or 0 if unknown
       int fieldId, // 0 if unknown
       long canonicalId // authoritative snapshot identity, or 0 if unavailable
-      ) {
-    public ColumnRef(String name, String physicalPath, int ordinal, int fieldId) {
-      this(name, physicalPath, ordinal, fieldId, 0L);
-    }
-  }
+      ) {}
 
   record ColumnStatsView(
       ColumnRef ref,
@@ -864,31 +797,6 @@ public interface FloecatConnector extends Closeable {
       int schemaId,
       String metadataLocation,
       ColumnIdentityMap columnIdentityMap) {
-    public SnapshotBundle(
-        long snapshotId,
-        long parentId,
-        long upstreamCreatedAtMs,
-        String schemaJson,
-        PartitionSpecInfo partitionSpec,
-        long sequenceNumber,
-        String manifestList,
-        Map<String, String> summary,
-        int schemaId,
-        String metadataLocation) {
-      this(
-          snapshotId,
-          parentId,
-          upstreamCreatedAtMs,
-          schemaJson,
-          partitionSpec,
-          sequenceNumber,
-          manifestList,
-          summary,
-          schemaId,
-          metadataLocation,
-          ColumnIdentityMap.getDefaultInstance());
-    }
-
     public SnapshotBundle {
       columnIdentityMap =
           columnIdentityMap == null ? ColumnIdentityMap.getDefaultInstance() : columnIdentityMap;

--- a/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
+++ b/core/connectors/spi/src/main/java/ai/floedb/floecat/connector/spi/FloecatConnector.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.connector.spi;
 
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.FileContent;
 import ai.floedb.floecat.catalog.rpc.Ndv;
 import ai.floedb.floecat.catalog.rpc.PartitionSpecInfo;
@@ -299,6 +300,26 @@ public interface FloecatConnector extends Closeable {
     return Optional.empty();
   }
 
+  /** Captures direct stats using the snapshot's authoritative column identity map. */
+  default Optional<DirectSnapshotStatsCapture> captureSnapshotTargetStatsDirect(
+      String namespaceFq,
+      String tableName,
+      ResourceId destinationTableId,
+      long snapshotId,
+      Set<String> includeColumns,
+      Set<StatsTargetKind> includeTargetKinds,
+      ColumnSelectorPolicy columnSelectorPolicy,
+      ColumnIdentityMap columnIdentityMap) {
+    return captureSnapshotTargetStatsDirect(
+        namespaceFq,
+        tableName,
+        destinationTableId,
+        snapshotId,
+        includeColumns,
+        includeTargetKinds,
+        columnSelectorPolicy);
+  }
+
   /** Captures requested outputs for one planned file-group within a snapshot. */
   FileGroupCaptureResult capturePlannedFileGroup(
       String namespaceFq,
@@ -311,6 +332,32 @@ public interface FloecatConnector extends Closeable {
       Set<StatsTargetKind> includeTargetKinds,
       boolean captureIndexes,
       ColumnSelectorPolicy columnSelectorPolicy);
+
+  /** Captures a planned group using the snapshot's authoritative column identity map. */
+  default FileGroupCaptureResult capturePlannedFileGroup(
+      String namespaceFq,
+      String tableName,
+      ResourceId destinationTableId,
+      long snapshotId,
+      Set<String> plannedFilePaths,
+      Set<String> includeColumns,
+      Set<String> indexColumns,
+      Set<StatsTargetKind> includeTargetKinds,
+      boolean captureIndexes,
+      ColumnSelectorPolicy columnSelectorPolicy,
+      ColumnIdentityMap columnIdentityMap) {
+    return capturePlannedFileGroup(
+        namespaceFq,
+        tableName,
+        destinationTableId,
+        snapshotId,
+        plannedFilePaths,
+        includeColumns,
+        indexColumns,
+        includeTargetKinds,
+        captureIndexes,
+        columnSelectorPolicy);
+  }
 
   /**
    * Applies connector-specific selector semantics to decoded Parquet page-index entries.
@@ -326,14 +373,53 @@ public interface FloecatConnector extends Closeable {
       Set<String> selectors,
       ColumnSelectorPolicy columnSelectorPolicy,
       List<ParquetPageIndexEntry> entries) {
-    Set<String> plannedFilePaths =
-        entries == null
-            ? Set.of()
-            : entries.stream()
-                .filter(java.util.Objects::nonNull)
-                .map(ParquetPageIndexEntry::filePath)
-                .filter(path -> path != null && !path.isBlank())
-                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+    Set<String> plannedFilePaths = pageIndexPlannedFilePaths(entries);
+    List<ParquetRowGroup> rowGroups = pageIndexRowGroups(entries);
+    return selectPageIndexEntries(
+        namespaceFq,
+        tableName,
+        snapshotId,
+        selectors,
+        columnSelectorPolicy,
+        plannedFilePaths,
+        entries,
+        rowGroups);
+  }
+
+  /** Applies connector-specific selector semantics using the authoritative column identity map. */
+  default Optional<List<ParquetPageIndexEntry>> selectPageIndexEntries(
+      String namespaceFq,
+      String tableName,
+      long snapshotId,
+      Set<String> selectors,
+      ColumnSelectorPolicy columnSelectorPolicy,
+      List<ParquetPageIndexEntry> entries,
+      ColumnIdentityMap columnIdentityMap) {
+    Set<String> plannedFilePaths = pageIndexPlannedFilePaths(entries);
+    List<ParquetRowGroup> rowGroups = pageIndexRowGroups(entries);
+    return selectPageIndexEntries(
+        namespaceFq,
+        tableName,
+        snapshotId,
+        selectors,
+        columnSelectorPolicy,
+        plannedFilePaths,
+        entries,
+        rowGroups,
+        columnIdentityMap);
+  }
+
+  private static Set<String> pageIndexPlannedFilePaths(List<ParquetPageIndexEntry> entries) {
+    return entries == null
+        ? Set.of()
+        : entries.stream()
+            .filter(java.util.Objects::nonNull)
+            .map(ParquetPageIndexEntry::filePath)
+            .filter(path -> path != null && !path.isBlank())
+            .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static List<ParquetRowGroup> pageIndexRowGroups(List<ParquetPageIndexEntry> entries) {
     Map<String, Map<Integer, Integer>> rowGroupsByFile = new LinkedHashMap<>();
     if (entries != null) {
       for (ParquetPageIndexEntry entry : entries) {
@@ -354,15 +440,7 @@ public interface FloecatConnector extends Closeable {
             groups.forEach(
                 (rowGroup, rowCount) ->
                     rowGroups.add(new ParquetRowGroup(filePath, rowGroup, rowCount))));
-    return selectPageIndexEntries(
-        namespaceFq,
-        tableName,
-        snapshotId,
-        selectors,
-        columnSelectorPolicy,
-        plannedFilePaths,
-        entries,
-        rowGroups);
+    return List.copyOf(rowGroups);
   }
 
   /**
@@ -379,6 +457,32 @@ public interface FloecatConnector extends Closeable {
       List<ParquetPageIndexEntry> entries,
       List<ParquetRowGroup> rowGroups) {
     return Optional.empty();
+  }
+
+  /**
+   * Applies connector-specific selector semantics using the authoritative column identity map.
+   *
+   * <p>Connectors without canonical identity requirements retain the legacy selection behavior.
+   */
+  default Optional<List<ParquetPageIndexEntry>> selectPageIndexEntries(
+      String namespaceFq,
+      String tableName,
+      long snapshotId,
+      Set<String> selectors,
+      ColumnSelectorPolicy columnSelectorPolicy,
+      Set<String> plannedFilePaths,
+      List<ParquetPageIndexEntry> entries,
+      List<ParquetRowGroup> rowGroups,
+      ColumnIdentityMap columnIdentityMap) {
+    return selectPageIndexEntries(
+        namespaceFq,
+        tableName,
+        snapshotId,
+        selectors,
+        columnSelectorPolicy,
+        plannedFilePaths,
+        entries,
+        rowGroups);
   }
 
   record FileGroupCaptureResult(
@@ -538,7 +642,8 @@ public interface FloecatConnector extends Closeable {
       Set<Long> targetSnapshotIds,
       SnapshotSelectionKind selectionKind,
       Set<Long> selectionSnapshotIds,
-      int latestN) {
+      int latestN,
+      ColumnIdentityMap previousColumnIdentityMap) {
     public SnapshotEnumerationOptions {
       knownSnapshotIds =
           knownSnapshotIds == null ? Set.of() : Set.copyOf(new LinkedHashSet<>(knownSnapshotIds));
@@ -550,6 +655,27 @@ public interface FloecatConnector extends Closeable {
               ? Set.of()
               : Set.copyOf(new LinkedHashSet<>(selectionSnapshotIds));
       latestN = Math.max(0, latestN);
+      previousColumnIdentityMap =
+          previousColumnIdentityMap == null
+              ? ColumnIdentityMap.getDefaultInstance()
+              : previousColumnIdentityMap;
+    }
+
+    public SnapshotEnumerationOptions(
+        boolean fullRescan,
+        Set<Long> knownSnapshotIds,
+        Set<Long> targetSnapshotIds,
+        SnapshotSelectionKind selectionKind,
+        Set<Long> selectionSnapshotIds,
+        int latestN) {
+      this(
+          fullRescan,
+          knownSnapshotIds,
+          targetSnapshotIds,
+          selectionKind,
+          selectionSnapshotIds,
+          latestN,
+          ColumnIdentityMap.getDefaultInstance());
     }
 
     public static SnapshotEnumerationOptions full(boolean fullRescan) {
@@ -692,8 +818,13 @@ public interface FloecatConnector extends Closeable {
       String name, // leaf name (required for many engines)
       String physicalPath, // canonical leaf path (recommended; may be blank)
       int ordinal, // 1-based within parent struct, or 0 if unknown
-      int fieldId // 0 if unknown
-      ) {}
+      int fieldId, // 0 if unknown
+      long canonicalId // authoritative snapshot identity, or 0 if unavailable
+      ) {
+    public ColumnRef(String name, String physicalPath, int ordinal, int fieldId) {
+      this(name, physicalPath, ordinal, fieldId, 0L);
+    }
+  }
 
   record ColumnStatsView(
       ColumnRef ref,
@@ -722,7 +853,7 @@ public interface FloecatConnector extends Closeable {
 
   record SnapshotBundle(
       long snapshotId,
-      /** The explicit predecessor snapshot ID, or {@code -1} when there is no predecessor. */
+      // The explicit predecessor snapshot ID, or -1 when there is no predecessor.
       long parentId,
       long upstreamCreatedAtMs,
       String schemaJson,
@@ -731,7 +862,38 @@ public interface FloecatConnector extends Closeable {
       String manifestList,
       Map<String, String> summary,
       int schemaId,
-      String metadataLocation) {}
+      String metadataLocation,
+      ColumnIdentityMap columnIdentityMap) {
+    public SnapshotBundle(
+        long snapshotId,
+        long parentId,
+        long upstreamCreatedAtMs,
+        String schemaJson,
+        PartitionSpecInfo partitionSpec,
+        long sequenceNumber,
+        String manifestList,
+        Map<String, String> summary,
+        int schemaId,
+        String metadataLocation) {
+      this(
+          snapshotId,
+          parentId,
+          upstreamCreatedAtMs,
+          schemaJson,
+          partitionSpec,
+          sequenceNumber,
+          manifestList,
+          summary,
+          schemaId,
+          metadataLocation,
+          ColumnIdentityMap.getDefaultInstance());
+    }
+
+    public SnapshotBundle {
+      columnIdentityMap =
+          columnIdentityMap == null ? ColumnIdentityMap.getDefaultInstance() : columnIdentityMap;
+    }
+  }
 
   record SnapshotFileEntry(
       String filePath,

--- a/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/capture/CaptureEngineRequest.java
+++ b/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/capture/CaptureEngineRequest.java
@@ -47,47 +47,6 @@ public record CaptureEngineRequest(
     Optional<String> executionLeaseEpoch,
     BooleanSupplier shouldStop,
     ColumnIdentityMap columnIdentityMap) {
-  public CaptureEngineRequest(
-      Connector sourceConnector,
-      String sourceNamespace,
-      String sourceTable,
-      ResourceId tableId,
-      long snapshotId,
-      String planId,
-      String groupId,
-      List<String> plannedFilePaths,
-      Set<String> statsColumns,
-      Set<String> indexColumns,
-      FloecatConnector.ColumnSelectorPolicy columnSelectorPolicy,
-      Set<FloecatConnector.StatsTargetKind> requestedStatsTargetKinds,
-      boolean capturePageIndex,
-      Optional<String> storageLocation,
-      Optional<String> authorizationToken,
-      Optional<String> executionJobId,
-      Optional<String> executionLeaseEpoch,
-      BooleanSupplier shouldStop) {
-    this(
-        sourceConnector,
-        sourceNamespace,
-        sourceTable,
-        tableId,
-        snapshotId,
-        planId,
-        groupId,
-        plannedFilePaths,
-        statsColumns,
-        indexColumns,
-        columnSelectorPolicy,
-        requestedStatsTargetKinds,
-        capturePageIndex,
-        storageLocation,
-        authorizationToken,
-        executionJobId,
-        executionLeaseEpoch,
-        shouldStop,
-        ColumnIdentityMap.getDefaultInstance());
-  }
-
   public CaptureEngineRequest {
     sourceNamespace = sourceNamespace == null ? "" : sourceNamespace.trim();
     sourceTable = sourceTable == null ? "" : sourceTable.trim();

--- a/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/capture/CaptureEngineRequest.java
+++ b/core/reconciler-spi/src/main/java/ai/floedb/floecat/reconciler/spi/capture/CaptureEngineRequest.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.reconciler.spi.capture;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.rpc.Connector;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
@@ -44,7 +45,49 @@ public record CaptureEngineRequest(
     Optional<String> authorizationToken,
     Optional<String> executionJobId,
     Optional<String> executionLeaseEpoch,
-    BooleanSupplier shouldStop) {
+    BooleanSupplier shouldStop,
+    ColumnIdentityMap columnIdentityMap) {
+  public CaptureEngineRequest(
+      Connector sourceConnector,
+      String sourceNamespace,
+      String sourceTable,
+      ResourceId tableId,
+      long snapshotId,
+      String planId,
+      String groupId,
+      List<String> plannedFilePaths,
+      Set<String> statsColumns,
+      Set<String> indexColumns,
+      FloecatConnector.ColumnSelectorPolicy columnSelectorPolicy,
+      Set<FloecatConnector.StatsTargetKind> requestedStatsTargetKinds,
+      boolean capturePageIndex,
+      Optional<String> storageLocation,
+      Optional<String> authorizationToken,
+      Optional<String> executionJobId,
+      Optional<String> executionLeaseEpoch,
+      BooleanSupplier shouldStop) {
+    this(
+        sourceConnector,
+        sourceNamespace,
+        sourceTable,
+        tableId,
+        snapshotId,
+        planId,
+        groupId,
+        plannedFilePaths,
+        statsColumns,
+        indexColumns,
+        columnSelectorPolicy,
+        requestedStatsTargetKinds,
+        capturePageIndex,
+        storageLocation,
+        authorizationToken,
+        executionJobId,
+        executionLeaseEpoch,
+        shouldStop,
+        ColumnIdentityMap.getDefaultInstance());
+  }
+
   public CaptureEngineRequest {
     sourceNamespace = sourceNamespace == null ? "" : sourceNamespace.trim();
     sourceTable = sourceTable == null ? "" : sourceTable.trim();
@@ -84,6 +127,8 @@ public record CaptureEngineRequest(
             ? Optional.empty()
             : executionLeaseEpoch.map(String::trim).filter(leaseEpoch -> !leaseEpoch.isBlank());
     shouldStop = shouldStop == null ? () -> false : shouldStop;
+    columnIdentityMap =
+        columnIdentityMap == null ? ColumnIdentityMap.getDefaultInstance() : columnIdentityMap;
   }
 
   private static Set<String> normalizeSelectors(Set<String> selectors) {

--- a/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogGraphView.java
+++ b/core/scanner/src/main/java/ai/floedb/floecat/scanner/spi/CatalogGraphView.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.scanner.spi;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
@@ -314,5 +315,10 @@ public interface CatalogGraphView {
 
   record QualifiedRelation(NameRef name, ResourceId resourceId) {}
 
-  record SchemaResolution(UserTableNode table, String schemaJson) {}
+  record SchemaResolution(
+      UserTableNode table, String schemaJson, ColumnIdentityMap columnIdentityMap) {
+    public SchemaResolution(UserTableNode table, String schemaJson) {
+      this(table, schemaJson, ColumnIdentityMap.getDefaultInstance());
+    }
+  }
 }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.CreateNamespaceRequest;
 import ai.floedb.floecat.catalog.rpc.CreateSnapshotRequest;
 import ai.floedb.floecat.catalog.rpc.CreateTableRequest;
@@ -636,7 +637,8 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
                       ctx.authorizationToken(),
                       ctx.executionJobId(),
                       ctx.executionLeaseEpoch(),
-                      () -> false),
+                      () -> false,
+                      ColumnIdentityMap.getDefaultInstance()),
                   (completedFileStats, completedPageIndexEntries) -> {
                     fileStats.addAll(completedFileStats);
                     pageIndexEntries.addAll(completedPageIndexEntries);

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/GrpcReconcilerBackend.java
@@ -686,7 +686,10 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
                 includeTargetKinds == null ? Set.of() : Set.copyOf(includeTargetKinds),
                 columnSelectorPolicy == null
                     ? FloecatConnector.ColumnSelectorPolicy.defaults()
-                    : columnSelectorPolicy));
+                    : columnSelectorPolicy,
+                fetchSnapshot(ctx, tableId, snapshotId)
+                    .map(Snapshot::getColumnIdentityMap)
+                    .orElse(ai.floedb.floecat.catalog.rpc.ColumnIdentityMap.getDefaultInstance())));
   }
 
   private boolean hasAnyCapturedStats(ReconcileContext ctx, ResourceId tableId, long snapshotId) {
@@ -1488,6 +1491,11 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
     if (snapshot.hasMetadataLocation() && !snapshot.getMetadataLocation().isBlank()) {
       builder.setMetadataLocation(snapshot.getMetadataLocation());
     }
+    if (snapshot.hasColumnIdentityMap()) {
+      builder
+          .setColumnIdentityMap(snapshot.getColumnIdentityMap())
+          .setColumnIdentityFingerprint(snapshot.getColumnIdentityFingerprint());
+    }
     return builder.build();
   }
 
@@ -1516,6 +1524,9 @@ public class GrpcReconcilerBackend implements ReconcilerBackend {
     }
     if (spec.hasMetadataLocation()) {
       mask.addPaths("metadata_location");
+    }
+    if (spec.hasColumnIdentityMap()) {
+      mask.addPaths("column_identity_map").addPaths("column_identity_fingerprint");
     }
     return mask.build();
   }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/JavaConnectorFileGroupCaptureAdapter.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/JavaConnectorFileGroupCaptureAdapter.java
@@ -59,7 +59,8 @@ final class JavaConnectorFileGroupCaptureAdapter {
             request.indexColumns(),
             request.requestedStatsTargetKinds(),
             request.capturePageIndex(),
-            request.columnSelectorPolicy());
+            request.columnSelectorPolicy(),
+            request.columnIdentityMap());
     List<TargetStatsRecord> capturedFileStats =
         uniqueFileStats(captured.statsRecords(), publishedFileTargets);
     realizedStatsSelectors.addAll(captured.realizedStatsSelectors());
@@ -76,7 +77,8 @@ final class JavaConnectorFileGroupCaptureAdapter {
                         request.columnSelectorPolicy(),
                         new java.util.LinkedHashSet<>(request.plannedFilePaths()),
                         captured.pageIndexEntries(),
-                        captured.pageIndexRowGroups())
+                        captured.pageIndexRowGroups(),
+                        request.columnIdentityMap())
                     .orElseGet(
                         () ->
                             filterPageIndexEntries(

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/QueuedReconcileWorkerSupport.java
@@ -1088,8 +1088,12 @@ class QueuedReconcileWorkerSupport {
             ? tableScopedCaptureRequestsBySnapshot.keySet()
             : Set.of();
     boolean captureOnly = captureMode == CaptureMode.CAPTURE_ONLY;
-    Set<Long> knownSnapshotIds =
-        (captureOnly || !fullRescan) ? backend.existingSnapshotIds(ctx, tableId) : Set.of();
+    // Identity continuity is deliberately NOT tied to rescan semantics. A full rescan forgets which
+    // snapshots are known precisely so it re-ingests all of them, but the canonical ID counter must
+    // still advance from whatever was last persisted: restarting it at zero would reissue IDs that
+    // already name different columns in stats and artifacts written before the rescan.
+    Set<Long> existingSnapshotIds = backend.existingSnapshotIds(ctx, tableId);
+    Set<Long> knownSnapshotIds = (captureOnly || !fullRescan) ? existingSnapshotIds : Set.of();
     // Capture modes still require a policy even though durable content state now decides
     // completeness.
     ReconcilerService.effectiveCapturePolicy(scope, captureMode);
@@ -1123,6 +1127,7 @@ class QueuedReconcileWorkerSupport {
                     enumerationFullRescan,
                     includeCoreMetadata,
                     knownSnapshotIds,
+                    existingSnapshotIds,
                     enumerationKnownSnapshotIds,
                     enumerationTargetSnapshotIds,
                     cancelRequested,
@@ -1146,6 +1151,7 @@ class QueuedReconcileWorkerSupport {
                   enumerationFullRescan,
                   includeCoreMetadata,
                   knownSnapshotIds,
+                  existingSnapshotIds,
                   enumerationKnownSnapshotIds,
                   enumerationTargetSnapshotIds,
                   cancelRequested,
@@ -1379,6 +1385,7 @@ class QueuedReconcileWorkerSupport {
       boolean enumerationFullRescan,
       boolean includeCoreMetadata,
       Set<Long> knownSnapshotIds,
+      Set<Long> identitySnapshotIds,
       Set<Long> enumerationKnownSnapshotIds,
       Set<Long> targetSnapshotIds,
       BooleanSupplier cancelRequested,
@@ -1388,16 +1395,25 @@ class QueuedReconcileWorkerSupport {
       long errors,
       long snapshotsProcessedBase,
       long statsProcessedBase) {
+    FloecatConnector.SnapshotEnumerationOptions baseEnumerationOptions =
+        ReconcilerService.snapshotEnumerationOptions(
+            enumerationSelection,
+            enumerationFullRescan,
+            enumerationKnownSnapshotIds,
+            targetSnapshotIds);
+    ai.floedb.floecat.catalog.rpc.ColumnIdentityMap previousColumnIdentityMap =
+        previousColumnIdentityMap(ctx, tableId, identitySnapshotIds);
+    FloecatConnector.SnapshotEnumerationOptions enumerationOptions =
+        new FloecatConnector.SnapshotEnumerationOptions(
+            baseEnumerationOptions.fullRescan(),
+            baseEnumerationOptions.knownSnapshotIds(),
+            baseEnumerationOptions.targetSnapshotIds(),
+            baseEnumerationOptions.selectionKind(),
+            baseEnumerationOptions.selectionSnapshotIds(),
+            baseEnumerationOptions.latestN(),
+            previousColumnIdentityMap);
     List<FloecatConnector.SnapshotBundle> upstreamBundles =
-        connector.enumerateSnapshots(
-            sourceNs,
-            sourceTable,
-            tableId,
-            ReconcilerService.snapshotEnumerationOptions(
-                enumerationSelection,
-                enumerationFullRescan,
-                enumerationKnownSnapshotIds,
-                targetSnapshotIds));
+        connector.enumerateSnapshots(sourceNs, sourceTable, tableId, enumerationOptions);
     List<FloecatConnector.SnapshotBundle> bundles =
         filterBundlesForMode(
             filterBundlesForSnapshotScope(upstreamBundles, targetSnapshotIds, progress),
@@ -1430,6 +1446,30 @@ class QueuedReconcileWorkerSupport {
             .toList();
     return new MetadataPassOutcome(
         ingestCounts, ingestCounts.tableChanged, enumeratedSnapshotIds, List.copyOf(bundles));
+  }
+
+  /**
+   * The most recent persisted column identity map for this table, taken from the highest-numbered
+   * snapshot that carries one.
+   *
+   * <p>Takes every snapshot that exists, not the rescan-filtered "known" set: on a full rescan the
+   * known set is empty by design, and returning no map there would restart the canonical ID counter
+   * at zero.
+   */
+  ai.floedb.floecat.catalog.rpc.ColumnIdentityMap previousColumnIdentityMap(
+      ReconcileContext ctx, ResourceId tableId, Set<Long> identitySnapshotIds) {
+    if (identitySnapshotIds == null || identitySnapshotIds.isEmpty()) {
+      return ai.floedb.floecat.catalog.rpc.ColumnIdentityMap.getDefaultInstance();
+    }
+    return identitySnapshotIds.stream()
+        .filter(java.util.Objects::nonNull)
+        .sorted(java.util.Comparator.reverseOrder())
+        .map(snapshotId -> backend.fetchSnapshot(ctx, tableId, snapshotId).orElse(null))
+        .filter(java.util.Objects::nonNull)
+        .filter(ai.floedb.floecat.catalog.rpc.Snapshot::hasColumnIdentityMap)
+        .map(ai.floedb.floecat.catalog.rpc.Snapshot::getColumnIdentityMap)
+        .findFirst()
+        .orElse(ai.floedb.floecat.catalog.rpc.ColumnIdentityMap.getDefaultInstance());
   }
 
   private boolean maybeIngestSnapshotConstraints(
@@ -1679,6 +1719,18 @@ class QueuedReconcileWorkerSupport {
             .setTableId(tableId)
             .setSnapshotId(bundle.snapshotId())
             .setUpstreamCreatedAt(upstreamTimestamp);
+    if (bundle.columnIdentityMap() != null
+        && !bundle
+            .columnIdentityMap()
+            .equals(ai.floedb.floecat.catalog.rpc.ColumnIdentityMap.getDefaultInstance())) {
+      builder
+          .setColumnIdentityMap(bundle.columnIdentityMap())
+          .setColumnIdentityFingerprint(bundle.columnIdentityMap().getFingerprint());
+    } else if (existing != null && existing.hasColumnIdentityMap()) {
+      builder
+          .setColumnIdentityMap(existing.getColumnIdentityMap())
+          .setColumnIdentityFingerprint(existing.getColumnIdentityFingerprint());
+    }
     if (hasParentSnapshotId) {
       builder.setParentSnapshotId(parentSnapshotId);
     }

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/ReconcilerService.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.reconciler.impl;
 
 import static ai.floedb.floecat.reconciler.util.NameParts.split;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.StatsTarget;
 import ai.floedb.floecat.common.rpc.NameRef;
 import ai.floedb.floecat.common.rpc.PrincipalContext;
@@ -300,7 +301,8 @@ public class ReconcilerService {
               targets,
               FloecatConnector.SnapshotSelectionKind.CURRENT,
               Set.of(),
-              0);
+              0,
+              ColumnIdentityMap.getDefaultInstance());
       case LATEST_N ->
           new FloecatConnector.SnapshotEnumerationOptions(
               fullRescan,
@@ -308,7 +310,8 @@ public class ReconcilerService {
               targets,
               FloecatConnector.SnapshotSelectionKind.LATEST_N,
               Set.of(),
-              effective.latestN());
+              effective.latestN(),
+              ColumnIdentityMap.getDefaultInstance());
       case EXPLICIT ->
           new FloecatConnector.SnapshotEnumerationOptions(
               fullRescan,
@@ -316,7 +319,8 @@ public class ReconcilerService {
               targets,
               FloecatConnector.SnapshotSelectionKind.EXPLICIT,
               Set.copyOf(effective.snapshotIds()),
-              0);
+              0,
+              ColumnIdentityMap.getDefaultInstance());
       case ALL, UNSPECIFIED ->
           fullRescan
               ? FloecatConnector.SnapshotEnumerationOptions.full(true, targets)

--- a/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/StandaloneJavaFileGroupExecutionRunner.java
+++ b/reconciler/src/main/java/ai/floedb/floecat/reconciler/impl/StandaloneJavaFileGroupExecutionRunner.java
@@ -16,6 +16,7 @@
 
 package ai.floedb.floecat.reconciler.impl;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.IndexArtifactRecord;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
 import ai.floedb.floecat.reconciler.auth.ReconcileWorkerAuthProvider;
@@ -157,7 +158,8 @@ public class StandaloneJavaFileGroupExecutionRunner {
                     authorizationHeader,
                     java.util.Optional.of(payload.jobId()),
                     java.util.Optional.of(payload.leaseEpoch()),
-                    stop),
+                    stop,
+                    ColumnIdentityMap.getDefaultInstance()),
                 (fileStats, pageIndexEntries) -> {
                   List<TargetStatsRecord> completedFileStats =
                       fileStats == null ? List.of() : fileStats;

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/AbstractReconcilerServiceTestBase.java
@@ -507,7 +507,8 @@ abstract class AbstractReconcilerServiceTestBase {
         Set<String> indexColumns,
         Set<StatsTargetKind> includeTargetKinds,
         boolean captureIndexes,
-        ColumnSelectorPolicy columnSelectorPolicy) {
+        ColumnSelectorPolicy columnSelectorPolicy,
+        ai.floedb.floecat.catalog.rpc.ColumnIdentityMap columnIdentityMap) {
       return FileGroupCaptureResult.empty();
     }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FloecatConnectorCompatibilityTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/FloecatConnectorCompatibilityTest.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.reconciler.impl;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.connector.spi.ConnectorFormat;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
@@ -37,7 +38,17 @@ class FloecatConnectorCompatibilityTest {
 
     FloecatConnector.SnapshotBundle bundle =
         new FloecatConnector.SnapshotBundle(
-            10L, 0L, 0L, "", null, 0L, null, java.util.Map.of(), 0, null);
+            10L,
+            0L,
+            0L,
+            "",
+            null,
+            0L,
+            null,
+            java.util.Map.of(),
+            0,
+            null,
+            ColumnIdentityMap.getDefaultInstance());
     Optional<?> fromBundle = connector.snapshotConstraints("ns", "tbl", tableId, bundle);
     assertTrue(fromBundle.isEmpty());
   }
@@ -100,7 +111,8 @@ class FloecatConnectorCompatibilityTest {
         Set<String> indexColumns,
         Set<StatsTargetKind> includeTargetKinds,
         boolean captureIndexes,
-        ColumnSelectorPolicy columnSelectorPolicy) {
+        ColumnSelectorPolicy columnSelectorPolicy,
+        ColumnIdentityMap columnIdentityMap) {
       return FileGroupCaptureResult.empty();
     }
 

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/JavaConnectorCaptureEngineTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/JavaConnectorCaptureEngineTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.FileColumnStats;
 import ai.floedb.floecat.catalog.rpc.FileContent;
 import ai.floedb.floecat.catalog.rpc.FileStatsTarget;
@@ -106,7 +107,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     assertThat(engine.supports(missingPlannedFiles)).isFalse();
   }
@@ -137,12 +139,13 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     assertThat(engine.capture(request, (fileStats, pageIndexEntries) -> {})).isEmpty();
     verify(connector, never())
         .capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any());
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any());
     verify(connector, never())
         .captureSnapshotTargetStats(any(), any(), any(), anyLong(), any(), any());
   }
@@ -175,7 +178,7 @@ class JavaConnectorCaptureEngineTest {
         .thenReturn(
             new ServerSideStorageConfigResolver.ResolvedConnectorConfig(resolvedConfig, () -> {}));
     when(connector.capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any()))
         .thenReturn(FloecatConnector.FileGroupCaptureResult.of(List.of(), List.of()));
 
     ResourceId tableId = ResourceId.newBuilder().setAccountId("acct").setId("table-1").build();
@@ -198,7 +201,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.of("worker-token"),
             Optional.of("job-1"),
             Optional.of("lease-1"),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     assertThat(engine.capture(request, (fileStats, pageIndexEntries) -> {})).isPresent();
     verify(storageResolver)
@@ -238,7 +242,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     S3Exception expiredToken =
         (S3Exception)
@@ -249,7 +254,7 @@ class JavaConnectorCaptureEngineTest {
                     AwsErrorDetails.builder().serviceName("S3").errorCode("ExpiredToken").build())
                 .build();
     when(connector.capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any()))
         .thenThrow(expiredToken);
 
     assertThatThrownBy(() -> engine.capture(request, (fileStats, pageIndexEntries) -> {}))
@@ -314,7 +319,8 @@ class JavaConnectorCaptureEngineTest {
                     FloecatConnector.StatsTargetKind.COLUMN,
                     FloecatConnector.StatsTargetKind.FILE)),
             eq(false),
-            eq(FloecatConnector.ColumnSelectorPolicy.defaults())))
+            eq(FloecatConnector.ColumnSelectorPolicy.defaults()),
+            eq(ColumnIdentityMap.getDefaultInstance())))
         .thenReturn(FloecatConnector.FileGroupCaptureResult.of(List.of(fileRecord), List.of()));
 
     CaptureEngineRequest request =
@@ -339,7 +345,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     var result = engine.capture(request, outputs::accept);
@@ -360,7 +367,7 @@ class JavaConnectorCaptureEngineTest {
         .captureSnapshotTargetStats(any(), any(), any(), anyLong(), any(), any());
     verify(connector)
         .capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any());
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any());
   }
 
   @Test
@@ -398,7 +405,8 @@ class JavaConnectorCaptureEngineTest {
             eq(Set.of()),
             eq(Set.of(FloecatConnector.StatsTargetKind.FILE)),
             eq(false),
-            eq(FloecatConnector.ColumnSelectorPolicy.defaults())))
+            eq(FloecatConnector.ColumnSelectorPolicy.defaults()),
+            eq(ColumnIdentityMap.getDefaultInstance())))
         .thenReturn(FloecatConnector.FileGroupCaptureResult.of(List.of(fileRecord), List.of()));
 
     CaptureEngineRequest request =
@@ -420,7 +428,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     var result = engine.capture(request, outputs::accept);
@@ -432,7 +441,7 @@ class JavaConnectorCaptureEngineTest {
         .captureSnapshotTargetStats(any(), any(), any(), anyLong(), any(), any());
     verify(connector)
         .capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any());
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any());
   }
 
   @Test
@@ -455,7 +464,8 @@ class JavaConnectorCaptureEngineTest {
             eq(Set.of()),
             eq(Set.of(FloecatConnector.StatsTargetKind.COLUMN)),
             eq(false),
-            eq(FloecatConnector.ColumnSelectorPolicy.defaults())))
+            eq(FloecatConnector.ColumnSelectorPolicy.defaults()),
+            eq(ColumnIdentityMap.getDefaultInstance())))
         .thenReturn(
             FloecatConnector.FileGroupCaptureResult.of(
                 List.of(
@@ -482,7 +492,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     var result = engine.capture(request, outputs::accept);
@@ -512,7 +523,7 @@ class JavaConnectorCaptureEngineTest {
     AtomicBoolean shouldStop = new AtomicBoolean();
 
     when(connector.capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any()))
         .thenAnswer(
             ignored -> {
               shouldStop.set(true);
@@ -538,7 +549,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            shouldStop::get);
+            shouldStop::get,
+            ColumnIdentityMap.getDefaultInstance());
 
     assertThatThrownBy(() -> engine.capture(request, (fileStats, pageIndexEntries) -> {}))
         .isInstanceOf(CancellationException.class)
@@ -554,6 +566,7 @@ class JavaConnectorCaptureEngineTest {
             any(),
             any(),
             anyBoolean(),
+            any(),
             any());
   }
 
@@ -592,7 +605,8 @@ class JavaConnectorCaptureEngineTest {
             eq(Set.of("index_only")),
             eq(Set.of(FloecatConnector.StatsTargetKind.FILE)),
             eq(true),
-            eq(FloecatConnector.ColumnSelectorPolicy.defaults())))
+            eq(FloecatConnector.ColumnSelectorPolicy.defaults()),
+            eq(ColumnIdentityMap.getDefaultInstance())))
         .thenReturn(
             FloecatConnector.FileGroupCaptureResult.of(
                 List.of(fileRecord),
@@ -657,7 +671,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     var result = engine.capture(request, outputs::accept);
@@ -682,7 +697,7 @@ class JavaConnectorCaptureEngineTest {
     var selectedEntry =
         pageIndexEntry(plannedFile, "customer_id").withSelectorAliases(Set.of("#1", "customer_id"));
     when(connector.capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any()))
         .thenReturn(
             FloecatConnector.FileGroupCaptureResult.of(
                 List.of(),
@@ -699,7 +714,8 @@ class JavaConnectorCaptureEngineTest {
             List.of(
                 pageIndexEntry(plannedFile, "customer_id"),
                 pageIndexEntry(plannedFile, "unrequested")),
-            List.of()))
+            List.of(),
+            ColumnIdentityMap.getDefaultInstance()))
         .thenReturn(Optional.of(List.of(selectedEntry)));
     CaptureEngineRequest request =
         new CaptureEngineRequest(
@@ -720,7 +736,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     engine.capture(request, outputs::accept);
@@ -742,7 +759,7 @@ class JavaConnectorCaptureEngineTest {
     String plannedFile = "s3://bucket/path/file-1.parquet";
     var availableEntry = pageIndexEntry(plannedFile, "customer_id");
     when(connector.capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any()))
         .thenReturn(FloecatConnector.FileGroupCaptureResult.of(List.of(), List.of(availableEntry)));
     when(connector.selectPageIndexEntries(
             "db",
@@ -752,7 +769,8 @@ class JavaConnectorCaptureEngineTest {
             FloecatConnector.ColumnSelectorPolicy.defaults(),
             Set.of(plannedFile),
             List.of(availableEntry),
-            List.of()))
+            List.of(),
+            ColumnIdentityMap.getDefaultInstance()))
         .thenReturn(Optional.of(List.of()));
     CaptureEngineRequest request =
         new CaptureEngineRequest(
@@ -773,7 +791,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     engine.capture(request, outputs::accept);
@@ -791,7 +810,7 @@ class JavaConnectorCaptureEngineTest {
     String plannedFile = "s3://bucket/path/file-1.parquet";
     var selectedEntry = pageIndexEntry(plannedFile, "customer_id");
     when(connector.capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any()))
         .thenReturn(
             FloecatConnector.FileGroupCaptureResult.ofSelectedPageIndexes(
                 List.of(), List.of(selectedEntry), List.of(), List.of()));
@@ -814,14 +833,15 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     engine.capture(request, outputs::accept);
 
     assertThat(outputs.pageIndexEntries).containsExactly(selectedEntry);
     verify(connector, never())
-        .selectPageIndexEntries(any(), any(), anyLong(), any(), any(), any(), any(), any());
+        .selectPageIndexEntries(any(), any(), anyLong(), any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -833,7 +853,7 @@ class JavaConnectorCaptureEngineTest {
     ResourceId tableId = ResourceId.newBuilder().setAccountId("acct").setId("table-1").build();
     String plannedFile = "s3://bucket/path/file-1.parquet";
     when(connector.capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any()))
         .thenReturn(
             FloecatConnector.FileGroupCaptureResult.of(
                 List.of(),
@@ -861,7 +881,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     engine.capture(request, outputs::accept);
@@ -880,7 +901,7 @@ class JavaConnectorCaptureEngineTest {
     ResourceId tableId = ResourceId.newBuilder().setAccountId("acct").setId("table-1").build();
     String plannedFile = "s3://bucket/path/file-1.parquet";
     when(connector.capturePlannedFileGroup(
-            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), anyLong(), any(), any(), any(), any(), anyBoolean(), any(), any()))
         .thenReturn(
             FloecatConnector.FileGroupCaptureResult.of(
                 List.of(), List.of(pageIndexEntry(plannedFile, "first"))));
@@ -904,7 +925,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     engine.capture(request, outputs::accept);
@@ -1082,7 +1104,8 @@ class JavaConnectorCaptureEngineTest {
                     FloecatConnector.StatsTargetKind.COLUMN,
                     FloecatConnector.StatsTargetKind.FILE)),
             eq(false),
-            eq(FloecatConnector.ColumnSelectorPolicy.defaults())))
+            eq(FloecatConnector.ColumnSelectorPolicy.defaults()),
+            eq(ColumnIdentityMap.getDefaultInstance())))
         .thenReturn(
             FloecatConnector.FileGroupCaptureResult.of(
                 List.of(fileRecordOne, fileRecordTwo), List.of()));
@@ -1109,7 +1132,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     var result = engine.capture(request, outputs::accept);
@@ -1152,7 +1176,8 @@ class JavaConnectorCaptureEngineTest {
             eq(Set.of()),
             eq(Set.of(FloecatConnector.StatsTargetKind.FILE)),
             eq(false),
-            eq(FloecatConnector.ColumnSelectorPolicy.defaults())))
+            eq(FloecatConnector.ColumnSelectorPolicy.defaults()),
+            eq(ColumnIdentityMap.getDefaultInstance())))
         .thenReturn(
             FloecatConnector.FileGroupCaptureResult.of(
                 List.of(dataRecord, deleteRecord), List.of()));
@@ -1175,7 +1200,8 @@ class JavaConnectorCaptureEngineTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     var outputs = new CapturedFileOutputs();
     engine.capture(request, outputs::accept);

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/PreviousColumnIdentityMapTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/PreviousColumnIdentityMapTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Yellowbrick Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.floedb.floecat.reconciler.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMode;
+import ai.floedb.floecat.catalog.rpc.Snapshot;
+import ai.floedb.floecat.common.rpc.ResourceId;
+import ai.floedb.floecat.reconciler.spi.ReconcileContext;
+import ai.floedb.floecat.reconciler.spi.ReconcilerBackend;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The canonical ID counter must keep advancing across a full rescan.
+ *
+ * <p>A full rescan deliberately reports an empty "known snapshots" set so every snapshot is
+ * re-ingested. Feeding that same set to identity resolution would restart the counter at zero and
+ * reissue IDs that already name different columns in previously captured statistics — so identity
+ * resolution reads the snapshots that exist, independent of rescan filtering.
+ */
+class PreviousColumnIdentityMapTest {
+
+  private static final ResourceId TABLE =
+      ResourceId.newBuilder().setAccountId("acct").setId("table-1").build();
+
+  @Test
+  void picksTheHighestNumberedSnapshotThatCarriesAMap() {
+    QueuedReconcileWorkerSupport support = support();
+    ReconcileContext ctx = mock(ReconcileContext.class);
+
+    when(support.backend.fetchSnapshot(any(), eq(TABLE), eq(3L)))
+        .thenReturn(Optional.of(snapshotWithMap(3L, "sha256:newest", 9L)));
+    when(support.backend.fetchSnapshot(any(), eq(TABLE), eq(1L)))
+        .thenReturn(Optional.of(snapshotWithMap(1L, "sha256:older", 4L)));
+
+    ColumnIdentityMap resolved = support.previousColumnIdentityMap(ctx, TABLE, Set.of(1L, 3L));
+
+    assertThat(resolved.getFingerprint()).isEqualTo("sha256:newest");
+    assertThat(resolved.getHighWaterMark()).isEqualTo(9L);
+  }
+
+  @Test
+  void skipsSnapshotsWithoutAMapRatherThanGivingUp() {
+    QueuedReconcileWorkerSupport support = support();
+    ReconcileContext ctx = mock(ReconcileContext.class);
+
+    when(support.backend.fetchSnapshot(any(), eq(TABLE), eq(5L)))
+        .thenReturn(Optional.of(Snapshot.newBuilder().setSnapshotId(5L).build()));
+    when(support.backend.fetchSnapshot(any(), eq(TABLE), eq(2L)))
+        .thenReturn(Optional.of(snapshotWithMap(2L, "sha256:carried", 7L)));
+
+    ColumnIdentityMap resolved = support.previousColumnIdentityMap(ctx, TABLE, Set.of(2L, 5L));
+
+    assertThat(resolved.getFingerprint()).isEqualTo("sha256:carried");
+    assertThat(resolved.getHighWaterMark()).isEqualTo(7L);
+  }
+
+  @Test
+  void yieldsNoMapWhenTheTableHasNoSnapshotsAtAll() {
+    QueuedReconcileWorkerSupport support = support();
+
+    assertThat(support.previousColumnIdentityMap(mock(ReconcileContext.class), TABLE, Set.of()))
+        .isEqualTo(ColumnIdentityMap.getDefaultInstance());
+  }
+
+  private static QueuedReconcileWorkerSupport support() {
+    QueuedReconcileWorkerSupport support = new QueuedReconcileWorkerSupport();
+    support.backend = mock(ReconcilerBackend.class);
+    return support;
+  }
+
+  private static Snapshot snapshotWithMap(long snapshotId, String fingerprint, long highWaterMark) {
+    ColumnIdentityMap map =
+        ColumnIdentityMap.newBuilder()
+            .setFormatVersion(1)
+            .setSourceVersion(snapshotId)
+            .setHighWaterMark(highWaterMark)
+            .setMode(ColumnIdentityMode.COLUMN_IDENTITY_MODE_STRUCTURED_PATH)
+            .setFingerprint(fingerprint)
+            .build();
+    return Snapshot.newBuilder()
+        .setSnapshotId(snapshotId)
+        .setColumnIdentityMap(map)
+        .setColumnIdentityFingerprint(fingerprint)
+        .build();
+  }
+}

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalLogicTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
@@ -67,7 +68,8 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
             null,
             Map.of("new-key", "new-val"),
             0,
-            "s3://bucket/new.metadata.json");
+            "s3://bucket/new.metadata.json",
+            ColumnIdentityMap.getDefaultInstance());
 
     ReconcileContext ctx =
         new ReconcileContext("ctx", principal, "svc-test", Instant.now(), Optional.<String>empty());
@@ -86,7 +88,17 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
     ResourceId tableId = ResourceId.newBuilder().setAccountId("acct").setId("tbl").build();
     var bundle =
         new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
-            1L, 0L, Instant.now().toEpochMilli(), "{}", null, 0L, null, Map.of(), 0, null);
+            1L,
+            0L,
+            Instant.now().toEpochMilli(),
+            "{}",
+            null,
+            0L,
+            null,
+            Map.of(),
+            0,
+            null,
+            ColumnIdentityMap.getDefaultInstance());
     ReconcileContext ctx =
         new ReconcileContext("ctx", principal, "svc-test", Instant.now(), Optional.empty());
 
@@ -101,11 +113,41 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> bundles =
         List.of(
             new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
-                10L, 0L, 1L, "", null, 0L, null, Map.of(), 0, null),
+                10L,
+                0L,
+                1L,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()),
             new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
-                11L, 10L, 2L, "", null, 0L, null, Map.of(), 0, null),
+                11L,
+                10L,
+                2L,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()),
             new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
-                12L, 11L, 3L, "", null, 0L, null, Map.of(), 0, null));
+                12L,
+                11L,
+                3L,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
 
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
         QueuedReconcileWorkerSupport.filterBundlesForMode(
@@ -121,9 +163,29 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> bundles =
         List.of(
             new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
-                10L, 0L, 1L, "", null, 0L, null, Map.of(), 0, null),
+                10L,
+                0L,
+                1L,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()),
             new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
-                11L, 10L, 2L, "", null, 0L, null, Map.of(), 0, null));
+                11L,
+                10L,
+                2L,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
 
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
         QueuedReconcileWorkerSupport.filterBundlesForMode(
@@ -139,11 +201,41 @@ class ReconcilerServiceInternalLogicTest extends AbstractReconcilerServiceTestBa
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> bundles =
         List.of(
             new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
-                10L, 0L, 1L, "", null, 0L, null, Map.of(), 0, null),
+                10L,
+                0L,
+                1L,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()),
             new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
-                11L, 10L, 2L, "", null, 0L, null, Map.of(), 0, null),
+                11L,
+                10L,
+                2L,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()),
             new ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle(
-                12L, 11L, 3L, "", null, 0L, null, Map.of(), 0, null));
+                12L,
+                11L,
+                3L,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
 
     List<ai.floedb.floecat.connector.spi.FloecatConnector.SnapshotBundle> filtered =
         QueuedReconcileWorkerSupport.filterBundlesForMode(

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalsTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceInternalsTest.java
@@ -102,7 +102,17 @@ class ReconcilerServiceInternalsTest {
   private static FloecatConnector.SnapshotBundle bundle(
       long snapshotId, long parentId, long createdAtMs) {
     return new FloecatConnector.SnapshotBundle(
-        snapshotId, parentId, createdAtMs, "", null, 0L, null, Map.of(), 0, null);
+        snapshotId,
+        parentId,
+        createdAtMs,
+        "",
+        null,
+        0L,
+        null,
+        Map.of(),
+        0,
+        null,
+        ai.floedb.floecat.catalog.rpc.ColumnIdentityMap.getDefaultInstance());
   }
 
   private static QueuedReconcileWorkerSupport.ProgressListener noopProgress() {

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/ReconcilerServiceTest.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.reconciler.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.ConstraintDefinition;
 import ai.floedb.floecat.catalog.rpc.ConstraintType;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
@@ -1250,7 +1251,17 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                42L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null));
+                42L,
+                0L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
 
       @Override
@@ -1451,7 +1462,17 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                42L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null));
+                42L,
+                0L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
     }
 
@@ -1606,11 +1627,41 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
         backend.capturedKnownSnapshotIds = options.knownSnapshotIds();
         return List.of(
             new SnapshotBundle(
-                42L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null),
+                42L,
+                0L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()),
             new SnapshotBundle(
-                43L, 42L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null),
+                43L,
+                42L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()),
             new SnapshotBundle(
-                44L, 43L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null));
+                44L,
+                43L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
     }
 
@@ -1751,9 +1802,29 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                201L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null),
+                201L,
+                0L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()),
             new SnapshotBundle(
-                202L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null));
+                202L,
+                0L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
     }
 
@@ -2063,7 +2134,18 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           ResourceId destinationTableId,
           SnapshotEnumerationOptions options) {
         return List.of(
-            new SnapshotBundle(201L, -1L, createdAtMs, "", null, 0L, null, Map.of(), 0, null));
+            new SnapshotBundle(
+                201L,
+                -1L,
+                createdAtMs,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
     }
 
@@ -2189,7 +2271,8 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
                         null,
                         Map.of(),
                         0,
-                        null));
+                        null,
+                        ColumnIdentityMap.getDefaultInstance()));
               }
             };
 
@@ -2356,7 +2439,8 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
                         null,
                         Map.of(),
                         0,
-                        null));
+                        null,
+                        ColumnIdentityMap.getDefaultInstance()));
               }
             };
 
@@ -2500,7 +2584,18 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           ResourceId destinationTableId,
           SnapshotEnumerationOptions options) {
         return List.of(
-            new SnapshotBundle(501L, 0L, createdAtMs, "", null, 0L, null, Map.of(), 0, null));
+            new SnapshotBundle(
+                501L,
+                0L,
+                createdAtMs,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
 
       @Override
@@ -2650,7 +2745,18 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           ResourceId destinationTableId,
           SnapshotEnumerationOptions options) {
         return List.of(
-            new SnapshotBundle(201L, 0L, createdAtMs, "", null, 0L, null, Map.of(), 0, null));
+            new SnapshotBundle(
+                201L,
+                0L,
+                createdAtMs,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
     }
 
@@ -2792,7 +2898,18 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           ResourceId destinationTableId,
           SnapshotEnumerationOptions options) {
         return List.of(
-            new SnapshotBundle(201L, -1L, createdAtMs, "", null, 0L, null, Map.of(), 0, null));
+            new SnapshotBundle(
+                201L,
+                -1L,
+                createdAtMs,
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
 
       @Override
@@ -2955,7 +3072,17 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                101L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null));
+                101L,
+                0L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
 
       @Override
@@ -3087,7 +3214,17 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                102L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null));
+                102L,
+                0L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
 
       @Override
@@ -3223,7 +3360,17 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                103L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null));
+                103L,
+                0L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
 
       @Override
@@ -3356,7 +3503,17 @@ class ReconcilerServiceTest extends AbstractReconcilerServiceTestBase {
           SnapshotEnumerationOptions options) {
         return List.of(
             new SnapshotBundle(
-                104L, 0L, Instant.now().toEpochMilli(), "", null, 0L, null, Map.of(), 0, null));
+                104L,
+                0L,
+                Instant.now().toEpochMilli(),
+                "",
+                null,
+                0L,
+                null,
+                Map.of(),
+                0,
+                null,
+                ColumnIdentityMap.getDefaultInstance()));
       }
 
       @Override

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutorTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/impl/RemoteDefaultReconcileExecutorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
 import ai.floedb.floecat.connector.spi.FloecatConnector;
@@ -57,7 +58,8 @@ class RemoteDefaultReconcileExecutorTest {
             "s3://bucket/manifests/snapshot-42.avro",
             Map.of("operation", "append"),
             3,
-            "s3://bucket/metadata/v7.metadata.json");
+            "s3://bucket/metadata/v7.metadata.json",
+            ColumnIdentityMap.getDefaultInstance());
     var historical =
         new FloecatConnector.SnapshotBundle(
             42L,
@@ -69,7 +71,8 @@ class RemoteDefaultReconcileExecutorTest {
             "s3://bucket/manifests/reported-differently.avro",
             Map.of("operation", "overwrite"),
             4,
-            null);
+            null,
+            ColumnIdentityMap.getDefaultInstance());
 
     assertEquals("42", RemoteDefaultReconcileExecutor.sourceRevision(current, 42L));
     assertEquals(
@@ -91,7 +94,8 @@ class RemoteDefaultReconcileExecutorTest {
             "s3://bucket/manifests/snapshot-42.avro",
             Map.of("operation", "append"),
             3,
-            "s3://bucket/metadata/v7.metadata.json");
+            "s3://bucket/metadata/v7.metadata.json",
+            ColumnIdentityMap.getDefaultInstance());
     var historical =
         new FloecatConnector.SnapshotBundle(
             42L,
@@ -103,7 +107,8 @@ class RemoteDefaultReconcileExecutorTest {
             "s3://bucket/manifests/snapshot-42.avro",
             Map.of("operation", "append"),
             3,
-            null);
+            null,
+            ColumnIdentityMap.getDefaultInstance());
 
     assertEquals(
         RemoteDefaultReconcileExecutor.metadataFingerprint(current, 42L),

--- a/reconciler/src/test/java/ai/floedb/floecat/reconciler/spi/capture/CaptureEngineRegistryTest.java
+++ b/reconciler/src/test/java/ai/floedb/floecat/reconciler/spi/capture/CaptureEngineRegistryTest.java
@@ -19,6 +19,7 @@ package ai.floedb.floecat.reconciler.spi.capture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
 import ai.floedb.floecat.common.rpc.ResourceId;
 import ai.floedb.floecat.common.rpc.ResourceKind;
@@ -185,7 +186,8 @@ class CaptureEngineRegistryTest {
             java.util.Optional.empty(),
             java.util.Optional.empty(),
             java.util.Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
     CaptureEngineRequest columnSelectors =
         new CaptureEngineRequest(
             request(false, Set.of(FloecatConnector.StatsTargetKind.FILE)).sourceConnector(),
@@ -209,7 +211,8 @@ class CaptureEngineRegistryTest {
             java.util.Optional.empty(),
             java.util.Optional.empty(),
             java.util.Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     assertThat(capabilities.supports(missingPlannedFiles)).isFalse();
     assertThat(capabilities.supports(columnSelectors)).isFalse();
@@ -251,7 +254,8 @@ class CaptureEngineRegistryTest {
             java.util.Optional.empty(),
             java.util.Optional.empty(),
             java.util.Optional.empty(),
-            () -> false);
+            () -> false,
+            ColumnIdentityMap.getDefaultInstance());
 
     assertThat(request.statsColumns()).containsExactly("c1");
     assertThat(request.indexColumns()).containsExactly("idx");
@@ -290,7 +294,8 @@ class CaptureEngineRegistryTest {
         java.util.Optional.empty(),
         java.util.Optional.empty(),
         java.util.Optional.empty(),
-        () -> false);
+        () -> false,
+        ColumnIdentityMap.getDefaultInstance());
   }
 
   private record TestCaptureEngine(

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/SnapshotServiceImpl.java
@@ -395,6 +395,7 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
                   if (spec.hasMetadataLocation() && !spec.getMetadataLocation().isBlank()) {
                     snapBuilder.setMetadataLocation(spec.getMetadataLocation());
                   }
+                  applyColumnIdentity(spec, snapBuilder, corr);
                   var snap = snapBuilder.build();
 
                   if (idempotencyKey == null) {
@@ -715,7 +716,9 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
           "manifest_list",
           "summary",
           "schema_id",
-          "metadata_location");
+          "metadata_location",
+          "column_identity_map",
+          "column_identity_fingerprint");
 
   private Snapshot applySnapshotSpecPatch(
       Snapshot current, SnapshotSpec spec, FieldMask mask, String corr) {
@@ -786,6 +789,8 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
           }
           builder.setMetadataLocation(spec.getMetadataLocation());
         }
+        case "column_identity_map", "column_identity_fingerprint" ->
+            applyColumnIdentity(spec, builder, corr);
         default ->
             throw GrpcErrors.invalidArgument(corr, UPDATE_MASK_PATH_INVALID, Map.of("path", path));
       }
@@ -841,7 +846,36 @@ public class SnapshotServiceImpl extends BaseServiceImpl implements SnapshotServ
     if (spec.hasMetadataLocation()) {
       c.scalar("metadata_location", spec.getMetadataLocation());
     }
+    if (spec.hasColumnIdentityMap()) {
+      c.scalar(
+          "column_identity_map",
+          java.util.Base64.getEncoder().encodeToString(spec.getColumnIdentityMap().toByteArray()));
+      c.scalar("column_identity_fingerprint", spec.getColumnIdentityFingerprint());
+    }
     return c.bytes();
+  }
+
+  private static void applyColumnIdentity(
+      SnapshotSpec spec, Snapshot.Builder builder, String correlationId) {
+    if (!spec.hasColumnIdentityMap()) {
+      if (!spec.getColumnIdentityFingerprint().isBlank()) {
+        throw GrpcErrors.invalidArgument(
+            correlationId,
+            SNAPSHOT_COLUMN_IDENTITY_INVALID,
+            Map.of("reason", "column identity fingerprint requires a mapping"));
+      }
+      return;
+    }
+    String mapFingerprint = spec.getColumnIdentityMap().getFingerprint();
+    if (mapFingerprint.isBlank() || !mapFingerprint.equals(spec.getColumnIdentityFingerprint())) {
+      throw GrpcErrors.invalidArgument(
+          correlationId,
+          SNAPSHOT_COLUMN_IDENTITY_INVALID,
+          Map.of("reason", "column identity fingerprint does not match its mapping"));
+    }
+    builder
+        .setColumnIdentityMap(spec.getColumnIdentityMap())
+        .setColumnIdentityFingerprint(mapFingerprint);
   }
 
   private static void canonicalResourceId(Canonicalizer c, String key, ResourceId id) {

--- a/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
+++ b/service/src/main/java/ai/floedb/floecat/service/catalog/impl/TableRootWriter.java
@@ -140,7 +140,8 @@ public class TableRootWriter {
             .setSnapshotId(candidate.getSnapshotId())
             .setSnapshotRef(snapshotRef)
             .setSchemaFingerprint(
-                ai.floedb.floecat.service.repo.impl.SnapshotManifests.schemaFingerprint(candidate));
+                ai.floedb.floecat.service.repo.impl.SnapshotManifests.schemaFingerprint(candidate))
+            .setColumnIdentityFingerprint(candidate.getColumnIdentityFingerprint());
     if (candidate.hasUpstreamCreatedAt()) {
       entry.setUpstreamCreatedAt(candidate.getUpstreamCreatedAt());
     }
@@ -393,6 +394,7 @@ public class TableRootWriter {
               }
               builder.setSchemaFingerprint(
                   ai.floedb.floecat.service.repo.impl.SnapshotManifests.schemaFingerprint(s));
+              builder.setColumnIdentityFingerprint(s.getColumnIdentityFingerprint());
               ai.floedb.floecat.service.repo.impl.SnapshotManifests.applyReuseGenerationRef(
                   builder, s);
             });

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/overlay/user/UserGraph.java
@@ -468,10 +468,16 @@ public final class UserGraph {
                             Map.of("id", tblId.getId())))
             : pinnedReads.requirePinnedTableBlob(
                 nodes.tableFromBlob(tblId, tableBlobUri), cid, tblId);
-    return new SchemaResolution(tbl, schemaJsonFor(cid, tbl, snapshot, snapshotBlobUri));
+    SchemaResolution resolved =
+        snapshots.schemaFor(cid, tbl, snapshot, snapshotBlobUri, tbl::schemaJson);
+    return new SchemaResolution(
+        resolved.table(), resolved.schemaJson(), resolved.columnIdentityMap());
   }
 
-  public record SchemaResolution(UserTableNode table, String schemaJson) {}
+  public record SchemaResolution(
+      UserTableNode table,
+      String schemaJson,
+      ai.floedb.floecat.catalog.rpc.ColumnIdentityMap columnIdentityMap) {}
 
   // ----------------------------------------------------------------------
   // Name resolution

--- a/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
+++ b/service/src/main/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelper.java
@@ -18,6 +18,7 @@ package ai.floedb.floecat.service.metagraph.snapshot;
 
 import static ai.floedb.floecat.service.error.impl.GeneratedErrorMessages.MessageKey.*;
 
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotManifestEntry;
 import ai.floedb.floecat.catalog.rpc.TableRoot;
@@ -303,6 +304,7 @@ public class SnapshotHelper {
             .setTableBlobVersion(root.getDefinitionRef().getVersion())
             .setSnapshotBlobUri(entry.getSnapshotRef().getUri())
             .setSnapshotBlobVersion(entry.getSnapshotRef().getVersion())
+            .setColumnIdentityFingerprint(entry.getColumnIdentityFingerprint())
             // Read-schema fingerprint for the payload token; empty on pre-fingerprint manifest
             // entries (the token then falls back to snapshot_blob_version — correct, cold on
             // ingest).
@@ -333,7 +335,38 @@ public class SnapshotHelper {
       SnapshotRef ref,
       java.util.function.Supplier<String> supplier) {
 
-    return new SchemaResolution(tbl, schemaJsonFor(cid, tbl, ref, supplier));
+    return schemaFor(cid, tbl, ref, "", supplier);
+  }
+
+  public SchemaResolution schemaFor(
+      String cid,
+      UserTableNode tbl,
+      SnapshotRef ref,
+      String snapshotBlobUri,
+      java.util.function.Supplier<String> supplier) {
+
+    Snapshot snapshot = snapshotForSchema(cid, tbl, ref, snapshotBlobUri);
+    String schemaJson =
+        snapshot == null || snapshot.getSchemaJson().isBlank()
+            ? supplier.get()
+            : snapshot.getSchemaJson();
+    ColumnIdentityMap identityMap =
+        snapshot != null && snapshot.hasColumnIdentityMap()
+            ? snapshot.getColumnIdentityMap()
+            : ColumnIdentityMap.getDefaultInstance();
+
+    return new SchemaResolution(tbl, schemaJson, identityMap);
+  }
+
+  private Snapshot snapshotForSchema(
+      String cid, UserTableNode tbl, SnapshotRef ref, String snapshotBlobUri) {
+    if (snapshotBlobUri != null && !snapshotBlobUri.isEmpty()) {
+      return pins.requirePinnedSnapshotBlob(snapshots.getByBlobUri(snapshotBlobUri), cid, tbl.id());
+    }
+    if (ref == null || ref.getWhichCase() == SnapshotRef.WhichCase.WHICH_NOT_SET) {
+      return null;
+    }
+    return resolveSnapshot(cid, tbl.id(), ref);
   }
 
   public String schemaJsonFor(

--- a/service/src/main/resources/errors_en.properties
+++ b/service/src/main/resources/errors_en.properties
@@ -170,6 +170,7 @@ MC_INVALID_ARGUMENT.query.input.invalid=Query input is invalid for this request.
 MC_INVALID_ARGUMENT.query.input.not.table=Query input must be a table.
 MC_INVALID_ARGUMENT.query.input.view.cannot.use.snapshot.id=Views cannot be resolved with snapshot_id.
 MC_INVALID_ARGUMENT.query.snapshot.required=Query snapshot is required.
+MC_INVALID_ARGUMENT.snapshot.column.identity.invalid=Snapshot column identity mapping is invalid: {reason}.
 MC_INVALID_ARGUMENT.snapshot.iceberg.required=Snapshot iceberg metadata is required.
 MC_INVALID_ARGUMENT.snapshot.manifest.list.required=Snapshot manifest list is required.
 MC_INVALID_ARGUMENT.snapshot.partition.spec.required=Snapshot partition spec is required.

--- a/service/src/test/java/ai/floedb/floecat/connector/dummy/DummyConnector.java
+++ b/service/src/test/java/ai/floedb/floecat/connector/dummy/DummyConnector.java
@@ -17,6 +17,7 @@
 package ai.floedb.floecat.connector.dummy;
 
 import ai.floedb.floecat.catalog.rpc.ColumnIdAlgorithm;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.FileContent;
 import ai.floedb.floecat.catalog.rpc.TableValueStats;
 import ai.floedb.floecat.catalog.rpc.TargetStatsRecord;
@@ -148,7 +149,17 @@ public final class DummyConnector implements FloecatConnector {
     String schemaJson = describe(namespace, table).schemaJson();
     return List.of(
         new SnapshotBundle(
-            snapshotId, 0L, createdAt, schemaJson, null, 0L, null, Map.of(), 0, null));
+            snapshotId,
+            0L,
+            createdAt,
+            schemaJson,
+            null,
+            0L,
+            null,
+            Map.of(),
+            0,
+            null,
+            ColumnIdentityMap.getDefaultInstance()));
   }
 
   @Override
@@ -175,7 +186,8 @@ public final class DummyConnector implements FloecatConnector {
               c.name,
               c.name, // physical path for nested refs in tests (dot-separated)
               c.ordinal, // stable 1-based ordinal for PATH_ORDINAL algorithms
-              c.colId // fieldId for Iceberg-style schemas
+              c.colId, // fieldId for Iceberg-style schemas
+              0L // no authoritative canonical identity map
               );
 
       cstats.add(
@@ -201,7 +213,8 @@ public final class DummyConnector implements FloecatConnector {
                     c.name,
                     c.name, // physical path for nested refs in tests (dot-separated)
                     c.ordinal, // stable 1-based ordinal for PATH_ORDINAL algorithms
-                    c.colId // fieldId for Iceberg-style schemas
+                    c.colId, // fieldId for Iceberg-style schemas
+                    0L // no authoritative canonical identity map
                     );
 
             cols.add(
@@ -284,7 +297,8 @@ public final class DummyConnector implements FloecatConnector {
       Set<String> indexColumns,
       Set<StatsTargetKind> includeTargetKinds,
       boolean captureIndexes,
-      ColumnSelectorPolicy columnSelectorPolicy) {
+      ColumnSelectorPolicy columnSelectorPolicy,
+      ColumnIdentityMap columnIdentityMap) {
     Set<String> effectivePaths =
         plannedFilePaths == null ? Set.of() : Set.copyOf(new LinkedHashSet<>(plannedFilePaths));
     if (effectivePaths.isEmpty()) {

--- a/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
+++ b/service/src/test/java/ai/floedb/floecat/service/metagraph/snapshot/SnapshotHelperTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ai.floedb.floecat.catalog.rpc.BlobRef;
+import ai.floedb.floecat.catalog.rpc.ColumnIdentityMap;
 import ai.floedb.floecat.catalog.rpc.Snapshot;
 import ai.floedb.floecat.catalog.rpc.SnapshotManifestEntry;
 import ai.floedb.floecat.catalog.rpc.TableRoot;
@@ -170,6 +171,34 @@ class SnapshotHelperTest {
             () -> "{}");
 
     assertThat(schema).contains("fields");
+  }
+
+  @Test
+  void schemaResolutionReadsSchemaAndIdentityFromOneSnapshotPayload() {
+    ResourceId tableId = tableId("tbl");
+    ColumnIdentityMap identityMap =
+        ColumnIdentityMap.newBuilder().setFingerprint("sha256:identity").build();
+    Snapshot snapshot =
+        Snapshot.newBuilder()
+            .setTableId(tableId)
+            .setSnapshotId(41L)
+            .setSchemaJson("{\"fields\":[\"pinned\"]}")
+            .setColumnIdentityMap(identityMap)
+            .setUpstreamCreatedAt(ts("2024-04-01T00:00:00Z"))
+            .build();
+    repository.put(tableId, snapshot);
+
+    var resolved =
+        helper.schemaFor(
+            "corr",
+            TestNodes.tableNode(tableId, "{}"),
+            SnapshotRef.newBuilder().setSnapshotId(41L).build(),
+            "s3://tbl/snap-41.pb",
+            () -> "{}");
+
+    assertThat(resolved.schemaJson()).contains("pinned");
+    assertThat(resolved.columnIdentityMap()).isEqualTo(identityMap);
+    assertThat(repository.liveBlobReads()).isZero();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Computes and persists an identity map for every Delta snapshot. Mapped tables use native StructField IDs plus deterministic derived IDs for collection interiors; unmapped tables reconcile only metadata-changing commits, stamp data-only versions, and reset explicitly when bounded history is unavailable. Canonical identity is additive through the `CanonicalIdentityConnector` opt-in, while existing `FloecatConnector` implementations retain their prior source API and behavior.

## Type of Change

- [ ] feat (new functionality)
- [X] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (adds/updates tests)
- [ ] chore (build/tooling/maintenance)

## Testing

Describe how this was validated.

- [X] `make fmt`
- [X] `make verify`
- [X] Added/updated tests for changed behavior

## Deployment and Compatibility

- [X] No breaking changes
- [ ] Breaking changes (described below)
- [ ] Config/env var changes (describe below)

Existing connectors continue to implement the unchanged `FloecatConnector` SPI. Connectors opt into canonical identity by implementing `CanonicalIdentityConnector`; old-arity record constructors remain available and default the identity map.

## Checklist

- [X] PR is scoped and focused
- [X] Commit messages follow conventional commit style where practical
- [X] Documentation updated where needed
- [X] No credentials, tokens, or secrets are included
- [X] This PR does not disclose a security vulnerability publicly (see `SECURITY.md`)
